### PR TITLE
Add pax-utils into the OS.

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -74,6 +74,10 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: texinfo
+      
+      - uses: chainguard-dev/actions/inky-build-pkg@main
+        with:
+          package-name: pax-utils
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ OPENSSL_VERSION ?= 3.0.5-r3
 BINUTILS_VERSION ?= 2.39-r1
 FLEX_VERSION ?= 2.6.4-r0
 BISON_VERSION ?= 3.8.2-r1
+PAXUTILS_VERSION ?= 1.3.4-r0
 TEXINFO_VERSION ?= 6.8-r0
 
 
@@ -30,6 +31,8 @@ PACKAGES = \
 	packages/${ARCH}/flex-${FLEX_VERSION}.apk \
 	packages/${ARCH}/bison-${BISON_VERSION}.apk \
 	packages/${ARCH}/texinfo-${TEXINFO_VERSION}.apk \
+	packages/${ARCH}/pax-utils-${PAXUTILS_VERSION}.apk \
+	packages/${ARCH}/scanelf-utils-${PAXUTILS_VERSION}.apk \ # This is provided by pax-utils as a subpackage so the version is the same
 
 all: ${KEY} ${PACKAGES}
 
@@ -65,6 +68,11 @@ packages/${ARCH}/bison-${BISON_VERSION}.apk:
 
 packages/${ARCH}/texinfo-${TEXINFO_VERSION}.apk:
 	${MELANGE} build texinfo.yaml ${MELANGE_OPTS} ${MELANGE_DEFOPTS}
+	apk index -o packages/${ARCH}/APKINDEX.tar.gz packages/${ARCH}/*.apk --allow-untrusted
+	melange sign-index --signing-key ${KEY} packages/${ARCH}/APKINDEX.tar.gz
+
+packages/${ARCH}/pax-utils-${PAXUTILS_VERSION}.apk:
+	${MELANGE} build pax-utils.yaml ${MELANGE_OPTS} ${MELANGE_DEFOPTS}
 	apk index -o packages/${ARCH}/APKINDEX.tar.gz packages/${ARCH}/*.apk --allow-untrusted
 	melange sign-index --signing-key ${KEY} packages/${ARCH}/APKINDEX.tar.gz
 

--- a/pax-utils.yaml
+++ b/pax-utils.yaml
@@ -1,0 +1,46 @@
+package:
+  name: pax-utils
+  version: 1.3.4
+  epoch: 1
+  description: "ELF related utilities for 32-bit and 64-bit binaries"
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+      - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+  dependencies:
+    runtime:
+      - scanelf
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/bootstrap/stage3
+    keyring:
+      - https://packages.wolfi.dev/bootstrap/stage2/wolfi-signing.rsa.pub
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - xz
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://dev.gentoo.org/~xen0n/distfiles/pax-utils-${{package.version}}.tar.xz
+      expected-sha256: 8baed2f9c5ae8e0cda1b9c75990864101afc64fad0a4616e10f3ff8ef891040b
+  - runs: |
+      make -j$(nproc) USE_CAP=no CC="$(uname -m)-pc-linux-gnu-gcc"
+  - uses: autoconf/make-install
+  - runs: |
+      rm -f "${{targets.destdir}}"/usr/bin/lddtree
+
+subpackages:
+  - name: "scanelf"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/scanelf "${{targets.subpkgdir}}"/usr/bin/scanelf


### PR DESCRIPTION
This was copied from stage3, but with the repo changed to stage3 from stage2.

scanelf is a subpackage that is also built, so I added that to the packages list, but I'm not sure if that's necessary.

Signed-off-by: Dan Lorenc <dlorenc@chainguard.dev>