### PR TITLE
grype and trivy: new packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,5 +132,6 @@ $(eval $(call build-package,execline,2.9.0.1-r0))
 $(eval $(call build-package,s6,2.11.1.2-r0))
 $(eval $(call build-package,libretls,3.5.2-r0))
 $(eval $(call build-package,grype,0.50.2-r0))
+$(eval $(call build-package,trivy,0.32.0-r0))
 
 .build-packages: ${PACKAGES}

--- a/Makefile
+++ b/Makefile
@@ -131,5 +131,6 @@ $(eval $(call build-package,skalibs,2.12.0.0-r0))
 $(eval $(call build-package,execline,2.9.0.1-r0))
 $(eval $(call build-package,s6,2.11.1.2-r0))
 $(eval $(call build-package,libretls,3.5.2-r0))
+$(eval $(call build-package,grype,0.50.2-r0))
 
 .build-packages: ${PACKAGES}

--- a/grype.yaml
+++ b/grype.yaml
@@ -1,0 +1,31 @@
+package:
+  name: grype
+  version: 0.50.2
+  description: Vulnerability scanner for container images, filesystems, and SBOMs
+  target-architecture:
+    - all
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/anchore/grype/archive/v${{package.version}}/grype-${{package.version}}.tar.gz
+      expected-sha512: 528f521282bc952df805d89827bf9b347c3bbca5253e914b600db5aa3022b7d94c21fad37bd47ddc3fc75db8ae612a4cb31a06ec897400e388836fdbab3259ed
+  - runs: |
+      CGO_ENABLED=0 go build \
+        -ldflags "-X github.com/anchore/grype/internal/version.version=${{package.version}}" \
+        -o "${{targets.destdir}}/usr/bin/grype"

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,31 @@
+package:
+  name: trivy
+  version: 0.32.0
+  description: Simple and comprehensive vulnerability scanner for containers
+  target-architecture:
+    - all
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/aquasecurity/trivy/archive/v${{package.version}}/trivy-${{package.version}}.tar.gz
+      expected-sha512: 3a31fea34f9d8f021eb3a1d522ef47e555d7559eba50b7d64bb25aeef9fd99fc4146316f1e176dcc7ce02033b20c1f6cc7cafee563d9c54f9e4301fbf9db0b5c
+  - runs: |
+      CGO_ENABLED=0 go build \
+        -ldflags "-s -w -X=main.version=${{package.version}}" \
+        -o "${{targets.destdir}}/usr/bin/trivy" ./cmd/trivy


### PR DESCRIPTION
Based on:

- https://git.alpinelinux.org/aports/tree/testing/grype/APKBUILD?id=6fe7083ce006ff3fe818461f04749d3020907823
- https://git.alpinelinux.org/aports/tree/testing/trivy/APKBUILD?id=6fe7083ce006ff3fe818461f04749d3020907823
- https://github.com/aquasecurity/trivy/blob/v0.32.0/Makefile

Skipped any make business and just used go build

cc @jspeed-meyers @luhring 