### PR TITLE
update actions to drop old params

### DIFF
--- a/.github/workflows/push-production.yaml
+++ b/.github/workflows/push-production.yaml
@@ -78,8 +78,6 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: glibc
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/glibc
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -92,14 +90,10 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: busybox
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/busybox
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: binutils
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/binutils
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -168,8 +162,6 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: bzip2
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/bzip2
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -194,8 +186,6 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: readline
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/readline
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -216,8 +206,6 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: linenoise
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/linenoise
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -234,14 +222,10 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: libtool
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/libtool
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: lua5.3
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/lua5.3
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -258,14 +242,10 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: wolfi-keys
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/wolfi-keys
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: wolfi-baselayout
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/wolfi-baselayout
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -286,8 +266,6 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: libev
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/libev
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:

--- a/.github/workflows/push-staging.yaml
+++ b/.github/workflows/push-staging.yaml
@@ -76,8 +76,6 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: glibc
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/glibc
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -86,18 +84,14 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: gcc
-      
+
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: busybox
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/busybox
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: binutils
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/binutils
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -106,7 +100,7 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: texinfo
-      
+
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: pax-utils
@@ -118,7 +112,7 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: gzip
-      
+
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: make
@@ -166,8 +160,6 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: bzip2
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/bzip2
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -192,8 +184,6 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: readline
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/readline
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -214,8 +204,6 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: linenoise
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/linenoise
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -232,14 +220,10 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: libtool
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/libtool
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: lua5.3
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/lua5.3
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -256,14 +240,10 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: wolfi-keys
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/wolfi-keys
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: wolfi-baselayout
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/wolfi-baselayout
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
@@ -284,8 +264,6 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: libev
-          empty-workspace: false
-          source-dir: ${{ github.workspace }}/libev
 
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:


### PR DESCRIPTION
https://github.com/chainguard-dev/actions/commit/7009e6019d84d3eb5a4a32eeb31312781a7131ac dropped `empty-workspace` and `source-dir` inputs from the `inky-build-pkg` action, so these are unused and generate warnings.