### PR TITLE
Use GITHUB_OUTPUT instead of deprecated set-output

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -17,8 +17,8 @@ jobs:
       - name: Generate snapshot date
         id: snapshot-date
         run: |
-          echo ::set-output name=date::$(date -u +%Y%m%d)
-          echo ::set-output name=epoch::$(date -u +%s)
+          echo "date=$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT
+          echo "epoch=$(date -u +%s)" >> $GITHUB_OUTPUT
         shell: bash
 
       - uses: actions/checkout@v3

--- a/.github/workflows/push-production.yaml
+++ b/.github/workflows/push-production.yaml
@@ -22,8 +22,8 @@ jobs:
       - name: Generate snapshot date
         id: snapshot-date
         run: |
-          echo ::set-output name=date::$(date -u +%Y%m%d)
-          echo ::set-output name=epoch::$(date -u +%s)
+          echo "date=$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT
+          echo "epoch=$(date -u +%s)" >> $GITHUB_OUTPUT
         shell: bash
 
       - uses: actions/checkout@v3

--- a/.github/workflows/push-staging.yaml
+++ b/.github/workflows/push-staging.yaml
@@ -18,8 +18,8 @@ jobs:
       - name: Generate snapshot date
         id: snapshot-date
         run: |
-          echo ::set-output name=date::$(date -u +%Y%m%d)
-          echo ::set-output name=epoch::$(date -u +%s)
+          echo "date=$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT
+          echo "epoch=$(date -u +%s)" >> $GITHUB_OUTPUT
         shell: bash
 
       - uses: actions/checkout@v3


### PR DESCRIPTION

#### Summary
- Use GITHUB_OUTPUT instead of deprecated set-output

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/