### PR TITLE
remove id-token from CI workflow

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-16-core
 
     permissions:
-      id-token: write
       packages: write
       contents: read
 


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>