### PR TITLE
glibc: add conflict with musl

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ which uses it to provide [lightweight GNU/Linux runtime images][cgi].
    [melange]: https://github.com/chainguard-dev/melange
    [cg]: https://chainguard.dev/
    [cgi]: https://chainguard.dev/chainguard-images
+
+## Mixing packages with other distributions
+
+Mixing packages with other distributions is not supported and can
+create security problems.  If a package is missing from Wolfi that
+your project requires, please open a bug or send a patch adding it.

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.36
-  epoch: 1
+  epoch: 2
   description: "the GNU C library"
   target-architecture:
     - all
@@ -13,6 +13,7 @@ package:
   dependencies:
     runtime:
       - wolfi-baselayout
+      - '!musl'
   scriptlets:
     trigger:
       paths:


### PR DESCRIPTION
Conflict with musl to prevent mixing Alpine and Wolfi packages.

Closes #16.