### PR TITLE
github actions: use packages/* instead of packages when copying data

### DIFF
--- a/.github/workflows/push-production.yaml
+++ b/.github/workflows/push-production.yaml
@@ -73,4 +73,4 @@ jobs:
       - name: 'Upload the repository to a bucket'
         run: |
           cp /etc/apk/keys/wolfi-signing.rsa.pub ${{ github.workspace }}/packages/wolfi-signing.rsa.pub
-          gcloud --quiet alpha storage cp --recursive ${{ github.workspace }}/packages/ gs://wolfi-production-registry-source/os/
+          gcloud --quiet alpha storage cp --recursive "${{ github.workspace }}/packages/*" gs://wolfi-production-registry-source/os/

--- a/.github/workflows/push-staging.yaml
+++ b/.github/workflows/push-staging.yaml
@@ -68,4 +68,4 @@ jobs:
 
       - name: 'Upload the repository to a bucket'
         run: |
-          gcloud --quiet alpha storage cp --recursive ${{ github.workspace }}/packages/ gs://wolfi-registry-source/os/
+          gcloud --quiet alpha storage cp --recursive "${{ github.workspace }}/packages/*" gs://wolfi-registry-source/os/


### PR DESCRIPTION
Sure would be nice if we could use `gsutil -m rsync` here.