### PR TITLE
ci: only run jobs against main repo

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -2,6 +2,7 @@ name: CI build action
 
 on:
   pull_request:
+    branches: ['main']
 
 jobs:
   build:

--- a/.github/workflows/push-production.yaml
+++ b/.github/workflows/push-production.yaml
@@ -2,16 +2,15 @@ name: Build Packages Production
 
 on:
   push:
-    branches:
-      - main
-    paths-ignore:
-      - README.md
+    branches: ['main']
+    paths-ignore: ['README.md']
   workflow_dispatch:
 
 jobs:
   build:
     name: Build OS packages
     runs-on: ubuntu-16-core
+    if: github.repository == 'wolfi-dev/os'
 
     permissions:
       id-token: write

--- a/.github/workflows/push-staging.yaml
+++ b/.github/workflows/push-staging.yaml
@@ -8,6 +8,7 @@ jobs:
   build:
     name: Build OS packages (staging)
     runs-on: ubuntu-16-core
+    if: github.repository == 'wolfi-dev/os'
 
     permissions:
       id-token: write

--- a/.github/workflows/secdb-production.yaml
+++ b/.github/workflows/secdb-production.yaml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Build security database
     runs-on: ubuntu-latest
+    if: github.repository == 'wolfi-dev/os'
 
     permissions:
       id-token: write

--- a/.github/workflows/secdb-staging.yaml
+++ b/.github/workflows/secdb-staging.yaml
@@ -7,6 +7,7 @@ jobs:
   build:
     name: Build security database
     runs-on: ubuntu-latest
+    if: github.repository == 'wolfi-dev/os'
 
     permissions:
       id-token: write


### PR DESCRIPTION
The GitHub Actions workflows only make sense, and only remotely work, when run against the main repo, and not against forks.

For example, the job to build and push packages to the prod bucket rely on creds that (should!) only work using the main repo's OIDC token, and would fail if ever run against a fork.

Signed-off-by: Jason Hall <jason@chainguard.dev>