### PR TITLE
go: upgrade to 1.19.2

### DIFF
--- a/go.yaml
+++ b/go.yaml
@@ -1,6 +1,6 @@
 package:
   name: go
-  version: 1.19.1
+  version: 1.19.2
   epoch: 0
   description: "bootstrap golang compiler built with Google-provided artifact"
   target-architecture:
@@ -27,8 +27,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://go.dev/dl/go1.19.1.src.tar.gz
-      expected-sha256: 27871baa490f3401414ad793fba49086f6c855b1c584385ed7771e1204c7e179
+      uri: https://go.dev/dl/go${{package.version}}.src.tar.gz
+      expected-sha256: 2ce930d70a931de660fdaf271d70192793b1b240272645bf0275779f6704df6b
       strip-components: 0
 
   - runs: |


### PR DESCRIPTION
1.19.2 was released October 4: https://groups.google.com/g/golang-announce/c/xtuG5faxtaU

1.19.3 will be released Tuesday, November 1: https://groups.google.com/g/golang-announce/c/dRtDK7WS78g

Signed-off-by: Jason Hall <jason@chainguard.dev>