### PR TITLE
fix erroneus libice-static definitions

### DIFF
--- a/freetype.yaml
+++ b/freetype.yaml
@@ -52,8 +52,8 @@ pipeline:
   - uses: autoconf/make-install
   - uses: strip
 subpackages:
-  - name: libice-static
-    description: libice static library
+  - name: freetype-static
+    description: freetype static library
     pipeline:
       - uses: split/static
   - name: freetype-dev

--- a/libpng.yaml
+++ b/libpng.yaml
@@ -42,8 +42,8 @@ subpackages:
     pipeline:
       - uses: split/manpages
     description: libpng manpages
-  - name: libice-static
-    description: libice static library
+  - name: libpng-static
+    description: libpng static library
     pipeline:
       - uses: split/static
   - name: libpng-utils


### PR DESCRIPTION
The real libice-static-1.0.10-r0.apk should be unaffected and not need an epoch bump (AFAIK), but due to this issue there will be packages published that don't make sense:

- libice-static-2.12.1-r0.apk (from freetype.yaml)
- libice-static-1.6.38-r0.apk (from libpng.yaml)