### PR TITLE
Fix erroneous perl-test-pod-doc definition

### DIFF
--- a/perl-yaml-syck.yaml
+++ b/perl-yaml-syck.yaml
@@ -39,6 +39,6 @@ pipeline:
   - runs: find ${{targets.destdir}} \( -name perllocal.pod -o -name .packlist \) -delete
   - uses: strip
 subpackages:
-  - name: perl-test-pod-doc
+  - name: perl-yaml-syck-doc
     pipeline:
       - uses: split/manpages


### PR DESCRIPTION
Resolves the same kind of problem as in #85 but for the `perl-test-pod-doc` package.