### PR TITLE
Remove version qualifier for openssl in nodejs

### DIFF
--- a/nodejs.yaml
+++ b/nodejs.yaml
@@ -19,7 +19,7 @@ environment:
       - icu-dev
       - linux-headers
       - nghttp2-dev
-      - openssl-dev>3
+      - openssl-dev
       - python3
       - py3-jinja2
       - samurai


### PR DESCRIPTION
This came out of a discussion w/ @imjasonh — with the following understanding:

1. We don't want the dag logic to consider versions for now, since that would add a new dimension of complexity to the logic and we're not sure what value it would provide.
2. Since we haven't published a version of openssl earlier than version 3, this `>3` currently has no effect.

An alternative solution here is to have `dag` just ignore these version qualifiers for now.