### PR TITLE
removes the mavenrc from the package, let apko configs handle defaulu…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,6 @@ $(eval $(call build-package,postgresql-11,11.17-r0))
 $(eval $(call build-package,postgresql-15,15.0-r0))
 $(eval $(call build-package,llvm15,15.0.3-r0))
 $(eval $(call build-package,tzdata,2022f-r0))
-$(eval $(call build-package,maven,3.8.6-r0))
+$(eval $(call build-package,maven,3.8.6-r1))
 
 .build-packages: ${PACKAGES}

--- a/maven.yaml
+++ b/maven.yaml
@@ -1,7 +1,7 @@
 package:
   name: maven
   version: 3.8.6
-  epoch: 0
+  epoch: 1
   description: A Java project management and project comprehension tool.
   target-architecture:
     - all
@@ -47,8 +47,3 @@ pipeline:
 
       install -m755 -Dt ${{targets.destdir}}/usr/share/java/maven/bin ./bin/mvnyjp
       ln -sf /usr/share/java/maven/bin/mvnyjp ${{targets.destdir}}/usr/bin/mvnyjp
-
-      mkdir ${{targets.destdir}}/etc
-      cat > ${{targets.destdir}}/etc/mavenrc <<-EOF
-      M2_HOME="/usr/share/java/maven"
-      EOF


### PR DESCRIPTION
…t env vars

I noticed by including the M2_HOME default env var via the package caused issues running downstream maven tests that have multiple maven versions in unit tests.

Signed-off-by: James Rawlings <jrawlings@chainguard.dev>