### PR TITLE
bazel should not include the JDK used to compile it as a runtime depe…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ $(eval $(call build-package,libfontenc,1.1.6-r0))
 $(eval $(call build-package,mkfontscale,1.2.2-r0))
 $(eval $(call build-package,encodings,1.0.6-r0))
 $(eval $(call build-package,ttf-dejavu,2.37-r0))
-$(eval $(call build-package,bazel-5,5.3.2-r0))
+$(eval $(call build-package,bazel-5,5.3.2-r1))
 $(eval $(call build-package,clang-15,15.0.4-r0))
 $(eval $(call build-package,jenkins,2.378-r0))
 

--- a/bazel-5.yaml
+++ b/bazel-5.yaml
@@ -1,7 +1,7 @@
 package:
   name: bazel-5
   version: 5.3.2
-  epoch: 0
+  epoch: 1
   description: Bazel is an open-source build and test tool
   target-architecture:
     - all
@@ -10,9 +10,6 @@ package:
         - "*"
       attestation: TODO
       license: Apache-2.0
-  dependencies:
-    runtime:
-      - openjdk-11
 environment:
   contents:
     packages:


### PR DESCRIPTION
…ndency, let users chose which JDK they use

Signed-off-by: James Rawlings <jrawlings@chainguard.dev>