### PR TITLE
lint.sh: remove packages and keyrings using yq

### DIFF
--- a/alsa-lib.yaml
+++ b/alsa-lib.yaml
@@ -12,10 +12,6 @@ package:
       license: LGPL-2.1-or-later
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -39,7 +35,6 @@ pipeline:
         --enable-aload \
         --disable-dependency-tracking \
         --without-versioned
-
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip

--- a/bubblewrap.yaml
+++ b/bubblewrap.yaml
@@ -7,18 +7,13 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: LGPL-2.0-or-later
   dependencies:
     runtime:
-
 environment:
   contents:
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-    repositories:
-      - https://packages.wolfi.dev/os
     packages:
       - ca-certificates-bundle
       - busybox
@@ -26,7 +21,6 @@ environment:
       - bash
       - meson
       - libcap-dev
-
 pipeline:
   - uses: fetch
     with:
@@ -36,7 +30,6 @@ pipeline:
       meson --prefix=/usr -Drequire_userns=true . output
       meson compile -C output
       DESTDIR="${{targets.destdir}}" meson install --no-rebuild -C output
-
 subpackages:
   - name: bubblewrap-bash-completion
     description: bash completion for bubblewrap
@@ -50,7 +43,6 @@ subpackages:
     dependencies:
       runtime:
         - bubblewrap
-
   - name: bubblewrap-zsh-completion
     description: zsh completion for bubblewrap
     pipeline:

--- a/check.yaml
+++ b/check.yaml
@@ -12,10 +12,6 @@ package:
       license: LGPL-2.0-or-later
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/cups.yaml
+++ b/cups.yaml
@@ -10,17 +10,11 @@ package:
         - "*"
       attestation: TODO
       license: GPL-2.0-only
-
 secfixes:
   2.4.2-r0:
     - CVE-2022-26691
-
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -34,12 +28,10 @@ environment:
       - libusb-dev
       - libgcrypt-dev
       - openssl-dev
-
       # - poppler-utils TODO add for CUPS to be useful for printing.
       # - libjpeg-turbo-dev TODO add for CUPS to be useful for printing.
       # - avahi-dev TODO add for CUPS to be useful for printing.
       # - gnutls-dev TODO add for CUPS to be useful for printing.
-
 pipeline:
   - uses: fetch
     with:
@@ -67,7 +59,6 @@ pipeline:
         --enable-libpaper \
         --with-tls=openssl \
         --with-optim="$CFLAGS"
-
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
@@ -76,7 +67,6 @@ subpackages:
     description: cups manpages
     pipeline:
       - uses: split/manpages
-
   - name: cups-libs
     description: CUPS libraries
     pipeline:
@@ -86,14 +76,12 @@ subpackages:
 
           mkdir -p ${{targets.subpkgdir}}/etc
           mv ${{targets.destdir}}/usr/etc/cups ${{targets.subpkgdir}}/etc
-
   - name: ipptool
     description: Perform internet printing protocol requests
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/ipptool ${{targets.subpkgdir}}/usr/bin
-
   - name: cups-client
     description: CUPS command-line client programs
     pipeline:
@@ -107,7 +95,6 @@ subpackages:
           mv ${{targets.destdir}}/usr/sbin/lpc ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/sbin/lpinfo ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/sbin/lpmove ${{targets.subpkgdir}}/usr/bin
-
   - name: cups-dev
     description: cups dev
     pipeline:

--- a/dbus.yaml
+++ b/dbus.yaml
@@ -10,19 +10,13 @@ package:
         - "*"
       attestation: TODO
       license: AFL-2.1 OR GPL-2.0-or-later
-
 secfixes:
   1.14.4-r0:
     - CVE-2022-42010
     - CVE-2022-42011
     - CVE-2022-42012
-
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -48,7 +42,6 @@ pipeline:
         --with-system-pid-file=/run/dbus/dbus.pid \
         --enable-xml-docs=false \
         --enable-doxygen-docs=false
-
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
@@ -64,7 +57,6 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/lib*.so.* ${{targets.subpkgdir}}/usr/lib
-
     description: D-BUS access libraries
   - name: dbus-x11
     pipeline:

--- a/fontconfig.yaml
+++ b/fontconfig.yaml
@@ -19,10 +19,6 @@ package:
         fc-cache --system-only > /dev/null
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -56,7 +52,6 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
-
 subpackages:
   - name: fontconfig-static
     description: fontconfig static library

--- a/freetype.yaml
+++ b/freetype.yaml
@@ -10,19 +10,13 @@ package:
         - "*"
       attestation: TODO
       license: FTL GPL-2.0-or-later
-
 secfixes:
   2.12.1-r0:
     - CVE-2022-27404
     - CVE-2022-27405
     - CVE-2022-27406
-
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -47,7 +41,6 @@ pipeline:
         --with-bzip2 \
         --with-png \
         --enable-freetype-config
-
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip

--- a/gperf.yaml
+++ b/gperf.yaml
@@ -12,10 +12,6 @@ package:
       license: GPL-3.0-or-later
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/grype.yaml
+++ b/grype.yaml
@@ -9,18 +9,12 @@ package:
     - license: Apache-2.0
       paths:
         - "*"
-
 environment:
   contents:
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-    repositories:
-      - https://packages.wolfi.dev/os
     packages:
       - ca-certificates-bundle
       - busybox
       - go
-
 pipeline:
   - uses: fetch
     with:

--- a/icu.yaml
+++ b/icu.yaml
@@ -7,25 +7,19 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: MIT
   dependencies:
     runtime:
-
 environment:
   contents:
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-    repositories:
-      - https://packages.wolfi.dev/os
     packages:
       - busybox
       - build-base
       - ca-certificates-bundle
   environment:
     ICU_DATA_FILTER_FILE: "./data-filter-en.json"
-
 pipeline:
   - uses: fetch
     with:
@@ -50,7 +44,6 @@ pipeline:
     with:
       dir: source
   - uses: strip
-
 subpackages:
   - name: icu-dev
     description: icu development headers

--- a/libbsd.yaml
+++ b/libbsd.yaml
@@ -12,10 +12,6 @@ package:
       license: BSD-3-Clause
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -23,7 +19,6 @@ environment:
       - automake
       - autoconf
       - libmd-dev
-
 pipeline:
   - uses: fetch
     with:

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -7,24 +7,18 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: BSD-3-Clause OR GPL-2.0-only
   dependencies:
     runtime:
-
 environment:
   contents:
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-    repositories:
-      - https://packages.wolfi.dev/os
     packages:
       - ca-certificates-bundle
       - busybox
       - build-base
       - perl
-
 pipeline:
   - uses: fetch
     with:
@@ -36,7 +30,6 @@ pipeline:
       make lib=/lib prefix=/usr RAISE_SETFCAP=no DESTDIR="${{targets.destdir}}" install
       chmod 755 "${{targets.destdir}}/usr/lib/libcap.so.${{package.version}}"
   - uses: strip
-
 subpackages:
   - name: libcap-dev
     description: libcap development headers
@@ -46,7 +39,6 @@ subpackages:
       runtime:
         - libcap
         - libcap-utils
-
   - name: libcap-utils
     description: various utilities included with libcap
     pipeline:
@@ -60,7 +52,6 @@ subpackages:
     dependencies:
       runtime:
         - libcap
-
   - name: libcap-doc
     description: libcap documentation
     pipeline:

--- a/libevent.yaml
+++ b/libevent.yaml
@@ -12,10 +12,6 @@ package:
       license: BSD-3-Clause
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -24,7 +20,6 @@ environment:
       - autoconf
       - python3-dev
       - openssl-dev
-
 pipeline:
   - uses: fetch
     with:
@@ -34,7 +29,6 @@ pipeline:
       sed -i '1s|^#!/usr/bin/env python$|#!/usr/bin/python3|' event_rpcgen.py
       # help provides tracing work out correctly
       sed -i -e "s/@VERSION@/${{package.version}}-r${{package.epoch}}/" *.pc.in
-
   - uses: autoconf/configure
   - uses: autoconf/make
   - uses: autoconf/make-install

--- a/libgcrypt.yaml
+++ b/libgcrypt.yaml
@@ -12,10 +12,6 @@ package:
       license: LGPL-2.1-or-later
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libgpg-error.yaml
+++ b/libgpg-error.yaml
@@ -12,10 +12,6 @@ package:
       license: GPL-2.0-or-later LGPL-2.1-or-later
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libice.yaml
+++ b/libice.yaml
@@ -12,10 +12,6 @@ package:
       license: X11
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -29,7 +25,6 @@ environment:
       - autoconf
       - automake
       - bash
-
 pipeline:
   - uses: fetch
     with:

--- a/libmd.yaml
+++ b/libmd.yaml
@@ -12,10 +12,6 @@ package:
       license: Public Domain
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libpaper.yaml
+++ b/libpaper.yaml
@@ -12,10 +12,6 @@ package:
       license: GPL-2.0-only
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libpng.yaml
+++ b/libpng.yaml
@@ -10,13 +10,8 @@ package:
         - "*"
       attestation: TODO
       license: Libpng
-
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -31,7 +26,6 @@ pipeline:
     with:
       expected-sha256: e2b5e1b4329650992c041996cf1269681b341191dc07ffed816c555769cceb77
       uri: https://downloads.sourceforge.net/libpng/libpng-${{package.version}}.tar.gz
-
   - runs: autoreconf -vif
   - uses: autoconf/configure
   - uses: autoconf/make

--- a/libpthread-stubs.yaml
+++ b/libpthread-stubs.yaml
@@ -12,10 +12,6 @@ package:
       license: X11
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libsm.yaml
+++ b/libsm.yaml
@@ -12,10 +12,6 @@ package:
       license: MIT
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -40,9 +36,7 @@ pipeline:
         --enable-docs \
         --with-xmlto \
         --without-fop
-
   # --with-libuuid TODO as above, would rather not build util-linux-dev yet
-
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
@@ -53,7 +47,6 @@ subpackages:
     dependencies:
       runtime:
         - libsm
-
     description: libsm dev
   - name: libsm-doc
     pipeline:

--- a/libusb.yaml
+++ b/libusb.yaml
@@ -12,10 +12,6 @@ package:
       license: LGPL-2.0-or-later
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libx11.yaml
+++ b/libx11.yaml
@@ -12,10 +12,6 @@ package:
       license: custom:XFREE86
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libxau.yaml
+++ b/libxau.yaml
@@ -12,10 +12,6 @@ package:
       license: MIT
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libxcb.yaml
+++ b/libxcb.yaml
@@ -12,10 +12,6 @@ package:
       license: MIT
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -28,7 +24,6 @@ environment:
       - libxdmcp-dev
       - libxslt
       - python3
-
 pipeline:
   - uses: fetch
     with:

--- a/libxdmcp.yaml
+++ b/libxdmcp.yaml
@@ -12,10 +12,6 @@ package:
       license: MIT
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -41,7 +37,6 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/share"
           mv "${{targets.destdir}}/usr/share/doc" "${{targets.subpkgdir}}/usr/share"
-
     description: libxdmcp manpages
   - name: libxdmcp-dev
     pipeline:

--- a/libxext.yaml
+++ b/libxext.yaml
@@ -12,10 +12,6 @@ package:
       license: MIT
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libxfixes.yaml
+++ b/libxfixes.yaml
@@ -12,10 +12,6 @@ package:
       license: custom
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libxi.yaml
+++ b/libxi.yaml
@@ -12,10 +12,6 @@ package:
       license: MIT AND X11
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -29,7 +25,6 @@ environment:
       - util-macros
       - xmlto
       - bash
-
 pipeline:
   - uses: fetch
     with:

--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -10,18 +10,12 @@ package:
         - "*"
       attestation: TODO
       license: MIT
-
 secfixes:
   2.10.3-r0:
     - CVE-2022-40303
     - CVE-2022-40304
-
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libxrandr.yaml
+++ b/libxrandr.yaml
@@ -12,10 +12,6 @@ package:
       license: MIT
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libxrender.yaml
+++ b/libxrender.yaml
@@ -12,10 +12,6 @@ package:
       license: custom
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libxslt.yaml
+++ b/libxslt.yaml
@@ -12,10 +12,6 @@ package:
       license: custom
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -26,7 +22,6 @@ environment:
       - libxml2-dev
       - libgcrypt-dev
       - libgpg-error-dev
-
 pipeline:
   - uses: fetch
     with:

--- a/libxt.yaml
+++ b/libxt.yaml
@@ -12,10 +12,6 @@ package:
       license: custom
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libxtst.yaml
+++ b/libxtst.yaml
@@ -12,10 +12,6 @@ package:
       license: custom
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/maven.yaml
+++ b/maven.yaml
@@ -12,10 +12,6 @@ package:
       license: Apache-2.0
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - ca-certificates-bundle
       - build-base
@@ -26,7 +22,6 @@ pipeline:
       expected-sha256: c7047a48deb626abf26f71ab3643d296db9b1e67f1faa7d988637deac876b5a9
       uri: https://archive.apache.org/dist/maven/maven-3/${{package.version}}/binaries/apache-maven-${{package.version}}-bin.tar.gz
   - runs: |
-
       mkdir -p ${{targets.destdir}}/usr/share/java/maven
       mkdir -p ${{targets.destdir}}/usr/share/java/maven/bin
       mkdir -p ${{targets.destdir}}/usr/share/java/maven/boot

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -14,13 +14,8 @@ package:
     runtime:
       - freetype
       - fontconfig
-
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -42,7 +37,6 @@ environment:
       - zip
       - fontconfig-dev
       - libxi-dev
-
 pipeline:
   - uses: fetch
     with:
@@ -86,7 +80,6 @@ pipeline:
       ln -sf /usr/lib/jvm/openjdk/bin/java ${{targets.destdir}}/usr/bin/java
 subpackages:
   - name: openjdk-11-jre
-
     pipeline:
       - runs: |
           # generate JRE via jlink
@@ -106,7 +99,6 @@ subpackages:
       runtime:
         - freetype
         - fontconfig
-
   - name: openjdk-11-jre-doc
     pipeline:
       - runs: |

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -14,13 +14,8 @@ package:
     runtime:
       - freetype
       - fontconfig
-
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -42,7 +37,6 @@ environment:
       - zip
       - fontconfig-dev
       - libxi-dev
-
 pipeline:
   - uses: fetch
     with:
@@ -90,7 +84,6 @@ pipeline:
 
       mkdir -p ${{targets.destdir}}/usr/bin
       ln -sf /usr/lib/jvm/openjdk/bin/java ${{targets.destdir}}/usr/bin/java
-
 subpackages:
   - name: openjdk-17-jre
     pipeline:
@@ -113,7 +106,6 @@ subpackages:
       runtime:
         - freetype
         - fontconfig
-
   - name: openjdk-17-doc
     pipeline:
       - runs: |

--- a/perl-test-pod.yaml
+++ b/perl-test-pod.yaml
@@ -12,10 +12,6 @@ package:
       license: GPL-1.0-or-later OR Artistic-1.0-Perl
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -23,7 +19,6 @@ environment:
       - automake
       - autoconf
       - perl
-
 pipeline:
   - uses: fetch
     with:

--- a/perl-yaml-syck.yaml
+++ b/perl-yaml-syck.yaml
@@ -12,10 +12,6 @@ package:
       license: MIT
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/postgresql-11.yaml
+++ b/postgresql-11.yaml
@@ -10,13 +10,8 @@ package:
         - "*"
       attestation: TODO
       license: BSD
-
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -31,7 +26,6 @@ environment:
       - flex
       - execline-dev
       # - util-linux-dev TODO add once util-linux is packaged
-
 pipeline:
   - uses: fetch
     with:
@@ -62,28 +56,24 @@ subpackages:
         - postgresql-11-client
         - libpq-11
     description: postgresql dev
-
   - name: postgresql-11-client
     description: PostgreSQL client
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/psql ${{targets.subpkgdir}}/usr/bin/
-
   - name: postgresql-11-contrib
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}
           make DESTDIR=${{targets.subpkgdir}} -C contrib install
     description: Extension modules distributed with PostgreSQL
-
   - name: libpq-11
     description: PostgreSQL libraries
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libpq.so* ${{targets.subpkgdir}}/usr/lib/
-
   - name: postgresql-11-oci-entrypoint
     description: Entrypoint for using PostgreSQL in OCI containers
     dependencies:

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -13,13 +13,8 @@ package:
 secfixes:
   0:
     - CVE-2017-8806
-
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -34,7 +29,6 @@ environment:
       - flex
       - execline-dev
       # - util-linux-dev TODO add once util-linux is packaged
-
 pipeline:
   - uses: fetch
     with:
@@ -61,28 +55,24 @@ subpackages:
         - postgresql-15-client
         - libpq-15
     description: postgresql dev
-
   - name: postgresql-15-client
     description: PostgreSQL client
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/psql ${{targets.subpkgdir}}/usr/bin/
-
   - name: postgresql-15-contrib
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}
           make DESTDIR=${{targets.subpkgdir}} -C contrib install
     description: Extension modules distributed with PostgreSQL
-
   - name: libpq-15
     description: PostgreSQL libraries
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libpq.so* ${{targets.subpkgdir}}/usr/lib/
-
   - name: postgresql-15-oci-entrypoint
     description: Entrypoint for using PostgreSQL in OCI containers
     dependencies:

--- a/su-exec.yaml
+++ b/su-exec.yaml
@@ -4,30 +4,26 @@ package:
   epoch: 0
   description: switch user and group id, setgroups and exec
   target-architecture:
-      - all
+    - all
   copyright:
-      - paths:
-            - "*"
-        attestation: TODO
-        license: MIT
+    - paths:
+        - "*"
+      attestation: TODO
+      license: MIT
 environment:
   contents:
-      repositories:
-          - https://packages.wolfi.dev/os
-      keyring:
-          - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-      packages:
-          - busybox
-          - ca-certificates-bundle
-          - build-base
-          - automake
-          - autoconf
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
 pipeline:
-    - uses: fetch
-      with:
-          expected-sha256: ec4acbd8cde6ceeb2be67eda1f46c709758af6db35cacbcde41baac349855e25
-          uri: https://github.com/ncopa/su-exec/archive/v${{package.version}}.tar.gz
-    - uses: autoconf/make
-    - runs: |
-          mkdir -p ${{targets.destdir}}/sbin
-          install -D su-exec ${{targets.destdir}}/sbin
+  - uses: fetch
+    with:
+      expected-sha256: ec4acbd8cde6ceeb2be67eda1f46c709758af6db35cacbcde41baac349855e25
+      uri: https://github.com/ncopa/su-exec/archive/v${{package.version}}.tar.gz
+  - uses: autoconf/make
+  - runs: |
+      mkdir -p ${{targets.destdir}}/sbin
+      install -D su-exec ${{targets.destdir}}/sbin

--- a/tree.yaml
+++ b/tree.yaml
@@ -12,12 +12,6 @@ package:
       license: GPL-2.0-or-later
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -9,18 +9,12 @@ package:
     - license: Apache-2.0
       paths:
         - "*"
-
 environment:
   contents:
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-    repositories:
-      - https://packages.wolfi.dev/os
     packages:
       - ca-certificates-bundle
       - busybox
       - go
-
 pipeline:
   - uses: fetch
     with:

--- a/util-macros.yaml
+++ b/util-macros.yaml
@@ -12,10 +12,6 @@ package:
       license: MIT
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/xcb-proto.yaml
+++ b/xcb-proto.yaml
@@ -12,10 +12,6 @@ package:
       license: MIT
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/xmlto.yaml
+++ b/xmlto.yaml
@@ -15,13 +15,8 @@ package:
       - libxslt
       - perl-yaml-syck
       - perl-test-pod
-
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
@@ -33,7 +28,6 @@ environment:
       - perl-yaml-syck
       - perl-test-pod
       # - docbook-xsl # TODO used for manpages - skipping for now
-
 pipeline:
   - uses: fetch
     with:

--- a/xorgproto.yaml
+++ b/xorgproto.yaml
@@ -12,10 +12,6 @@ package:
       license: BSD-2-Clause AND MIT AND X11
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/xtrans.yaml
+++ b/xtrans.yaml
@@ -12,10 +12,6 @@ package:
       license: MIT
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/zip.yaml
+++ b/zip.yaml
@@ -12,15 +12,10 @@ package:
       license: Info-ZIP
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle
       - build-base
-
 pipeline:
   - uses: fetch
     with:


### PR DESCRIPTION
This also has the effect of `yq`-formatting only files that specified those elements. In time we probably want to be uniformly formatting everything with `yq`, but there are some minor issues with that, like how `yq` prefers to remove multi-line strings.

Until then, at least having a check that packages/keyring aren't specified should help remove some confusion.

Signed-off-by: Jason Hall <jason@chainguard.dev>