### PR TITLE
Fix wolfi key location

### DIFF
--- a/wolfi-keys.yaml
+++ b/wolfi-keys.yaml
@@ -29,6 +29,6 @@ pipeline:
       install -m644 wolfi-signing.rsa.pub "${{targets.destdir}}"/etc/apk/keys
 
       for i in x86_64 aarch64; do
-        mkdir -p "${{targets.destdir}}"/usr/share/apk/keys
-        install -m644 wolfi-signing.rsa.pub "${{targets.destdir}}"/usr/share/apk/keys/${i}
+        mkdir -p "${{targets.destdir}}"/usr/share/apk/keys/${i}
+        install -m644 wolfi-signing.rsa.pub "${{targets.destdir}}"/usr/share/apk/keys/${i}/wolfi-signing.rsa.pub
       done


### PR DESCRIPTION
This commit updates the wolfi key location to write it inside of the correct arch directory.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>