### PR TITLE
Add lcms2 pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,5 +222,6 @@ $(eval $(call build-package,llvm-libunwind,15.0.5-r0))
 $(eval $(call build-package,llvm-lld,15.0.5-r0))
 $(eval $(call build-package,dumb-init,1.2.5-r0))
 $(eval $(call build-package,envoy,1.24.0-r0))
+$(eval $(call build-package,lcms2,2.14-r0))
 
 .build-packages: ${PACKAGES}

--- a/lcms2.yaml
+++ b/lcms2.yaml
@@ -1,0 +1,71 @@
+package:
+  name: lcms2
+  version: 2.14
+  epoch: 0
+  description: "Color Management Engine"
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+      - "*"
+      attestation: TODO
+      license: MIT GPL-3.0-only
+      
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - wolfi-base
+      - ca-certificates-bundle
+      - build-base
+      - zlib-dev
+      - libjpeg-dev
+      # - tiff-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/mm2/Little-CMS/releases/download/lcms${{package.version}}/lcms2-${{package.version}}.tar.gz
+      expected-sha256: 28474ea6f6591c4d4cee972123587001a4e6e353412a41b3e9e82219818d5740
+  - runs: |
+      ./configure \
+        --build=$CBUILD \
+        --host=$CHOST \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --infodir=/usr/share/info \
+        --localstatedir=/var \
+        --with-jpeg \
+        --with-tiff \
+        --with-zlib \
+        --with-threads
+      make
+      make check
+  - runs: |
+      DESTDIR="${{targets.destdir}}" make install
+  - uses: strip
+
+subpackages:
+  - name: "lcms2-dev"
+    description: "headers for lcms2"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - lcms2
+
+  - name: "lcms2-doc"
+    description: "lcms2 documentation"
+    pipeline:
+      - uses: split/manpages
+
+  - name: "lcms2-utils"
+    description: "Utility applications for lcms2"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/* "${{targets.subpkgdir}}"/usr/bin

--- a/lcms2.yaml
+++ b/lcms2.yaml
@@ -9,7 +9,7 @@ package:
     - paths:
       - "*"
       attestation: TODO
-      license: MIT GPL-3.0-only
+      license: MIT AND GPL-3.0-only
       
 environment:
   contents:
@@ -26,23 +26,15 @@ pipeline:
     with:
       uri: https://github.com/mm2/Little-CMS/releases/download/lcms${{package.version}}/lcms2-${{package.version}}.tar.gz
       expected-sha256: 28474ea6f6591c4d4cee972123587001a4e6e353412a41b3e9e82219818d5740
-  - runs: |
-      ./configure \
-        --build=$CBUILD \
-        --host=$CHOST \
-        --prefix=/usr \
-        --sysconfdir=/etc \
-        --mandir=/usr/share/man \
-        --infodir=/usr/share/info \
-        --localstatedir=/var \
+  - uses: autoconf/configure
+    with:
+      opts: |
         --with-jpeg \
         --with-tiff \
         --with-zlib \
         --with-threads
-      make
-      make check
-  - runs: |
-      DESTDIR="${{targets.destdir}}" make install
+  - uses: autoconf/make
+  - uses: autoconf/make-install
   - uses: strip
 
 subpackages:

--- a/lcms2.yaml
+++ b/lcms2.yaml
@@ -13,10 +13,6 @@ package:
       
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - wolfi-base
       - ca-certificates-bundle


### PR DESCRIPTION
openjdk actually depends on lcms2 instead of lcms package. #55 

Signed-off-by: Tuan Anh Tran <me@tuananh.org>