### PR TITLE
build: add environment files for x86_64 and aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ MELANGE_OPTS += --keyring-append ${KEY}.pub
 MELANGE_OPTS += --signing-key ${KEY}
 MELANGE_OPTS += --pipeline-dir ${MELANGE_DIR}/pipelines
 MELANGE_OPTS += --arch ${ARCH}
+MELANGE_OPTS += --env-file build-${ARCH}.env
 MELANGE_OPTS += ${MELANGE_EXTRA_OPTS}
 
 define build-package

--- a/build-aarch64.env
+++ b/build-aarch64.env
@@ -1,0 +1,6 @@
+# Ampere Altra, the CPU used by most cloud providers, is Neoverse N1.
+export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1 -D_FORTIFY_SOURCE=3"
+export CPPFLAGS="$CFLAGS"
+export CXXFLAGS="$CFLAGS"
+export LDFLAGS="-Wl,--as-needed,-O1,--sort-common"
+export GOFLAGS="-buildmode=pie"

--- a/build-x86_64.env
+++ b/build-x86_64.env
@@ -1,0 +1,5 @@
+export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -D_FORTIFY_SOURCE=3"
+export CPPFLAGS="$CFLAGS"
+export CXXFLAGS="$CFLAGS"
+export LDFLAGS="-Wl,--as-needed,-O1,--sort-common"
+export GOFLAGS="-buildmode=pie"


### PR DESCRIPTION
Previously we did not do any microarch optimizations, now we target Nehalem-era x86_64, tuned for Broadwell or newer microarchitectures.  This should provide performance numbers in benchmarks similar to those of ClearLinux, while retaining compatibility with most data-center hardware still in deployment.

On the ARM side, we are starting with ARMv8.0-A as baseline, but tuned for Neoverse N1, which the Ampere Altra core, used by most cloud providers, is derived from.

In addition, upgrade to `-D_FORTIFY_SOURCE=3`, which is meaningful in glibc 2.36 and later.