### PR TITLE
Add CVE-2022-32221 to the secfixes data for curl 7.86.0.

### DIFF
--- a/curl.yaml
+++ b/curl.yaml
@@ -14,6 +14,7 @@ package:
 secfixes:
   7.86.0-r0:
     - CVE-2022-42916
+    - CVE-2022-32221
 
 environment:
   contents:


### PR DESCRIPTION
This vulnerability was fixed in 7.86.0, but the CVE wasn't filed until after the release went out. Adding this to the secfixes data now for posterity's sake, even though Wolfi has already fixed it.

Signed-off-by: Dan Lorenc <dlorenc@chainguard.dev>