### PR TITLE
add CRON jobs to periodically check packages for new versions

### DIFF
--- a/.github/workflows/wolfictl-update-gh.yaml
+++ b/.github/workflows/wolfictl-update-gh.yaml
@@ -1,0 +1,24 @@
+name: Wolfictl Update From GitHub
+
+on:
+  # Triggers the workflow every hour
+  schedule:
+    - cron: "0 * * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  lint:
+    name: Wolfictl Update
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: wolfi-dev/wolfictl/.github/actions@main
+    - run: |
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+    - run: wolfictl update https://github.com/${{github.repository}} --release-monitoring-query=false
+      env:
+        GITHUB_TOKEN: ${{ secrets.WOLFI_BOT_FINE_GRAINED_PAT }}

--- a/.github/workflows/wolfictl-update-rm.yaml
+++ b/.github/workflows/wolfictl-update-rm.yaml
@@ -1,0 +1,24 @@
+name: Wolfictl Update From Release Monitor
+
+on:
+  # Triggers the workflow daily at 4:30pm UTC
+  schedule:
+    - cron: "30 16 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  lint:
+    name: Wolfictl Update
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: wolfi-dev/wolfictl/.github/actions@main
+    - run: |
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+    - run: wolfictl update https://github.com/${{github.repository}} --github-release-query=false
+      env:
+        GITHUB_TOKEN: ${{ secrets.WOLFI_BOT_FINE_GRAINED_PAT }}


### PR DESCRIPTION
This PR add's two CRON jobs because depending on which service we use to check for new packages the updater performs differently.

When using GitHub to check for updates the updater uses a graphql API and a single query compared with https://release-monitoring.org/ which needs to call their API for every package we are checking.  Therefore, checking via GitHubs API can be done more frequently.

The CRONS from this PR  will query GitHub every hour and https://release-monitoring.org/ daily.

Signed-off-by: James Rawlings <jrawlings@chainguard.dev>