### PR TITLE
Allow failure for melange cache update

### DIFF
--- a/.github/workflows/update-cache.yaml
+++ b/.github/workflows/update-cache.yaml
@@ -36,5 +36,5 @@ jobs:
         run: |
           for cfg in $(ls -1 | grep '.*\.yaml'); do
             echo "Updating cache for ${cfg}...";
-            melange update-cache --cache-dir gs://${{env.SOURCE_CACHE_BUCKET}}/ "${cfg}";
+            melange update-cache --cache-dir gs://${{env.SOURCE_CACHE_BUCKET}}/ "${cfg}" || true;
           done


### PR DESCRIPTION
Sometimes updating the cache for a given fetch artifact will fail. Here's an example from a [recent run](https://github.com/wolfi-dev/os/actions/runs/3803432845/jobs/6469832916):

```console
Updating cache for gmp.yaml...
2022/12/29 22:27:20 fetching artifacts relating to gmp-6.2.1
2022/12/29 22:27:20 processing fetch node:
2022/12/29 22:27:20   uri: [https://gmplib.org/download/gmp/gmp-${{package.version}}.tar.xz](https://gmplib.org/download/gmp/gmp-$%7B%7Bpackage.version%7D%7D.tar.xz)
2022/12/29 22:27:20   evaluated: https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz
Error: Get "https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz": x509: certificate has expired or is not yet valid: current time 2022-12-29T22:27:21Z is after 2022-12-27T23:59:59Z
2022/12/29 22:27:21 error during command execution: Get "https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz": x509: certificate has expired or is not yet valid: current time 2022-12-29T22:27:21Z is after 2022-12-27T23:59:59Z
```

This PR adjusts the workflow so that it's okay for individual calls to `melange update-cache` to fail.