### PR TITLE
Add msmtp to wolfi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,5 +267,6 @@ $(eval $(call build-package,linux-pam,1.5.2-r0))
 $(eval $(call build-package,cython,0.29.32-r0))
 $(eval $(call build-package,util-linux,2.38.1-r0))
 $(eval $(call build-package,jansson,2.14-r0))
+$(eval $(call build-package,msmtp,1.8.22-r0))
 
 .build-packages: ${PACKAGES}

--- a/msmtp.yaml
+++ b/msmtp.yaml
@@ -1,0 +1,60 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/tiff/APKBUILD
+package:
+    name: msmtp
+    version: 1.8.22
+    epoch: 0
+    description: msmtp is an SMTP client with a sendmail interface
+    target-architecture:
+        - all
+    copyright:
+        - paths:
+            - '*'
+          attestation: |
+             Copyright (C) 2018, 2019, 2020, 2021, 2022
+             Martin Lambers <marlam@marlam.de>
+
+               This program is free software; you can redistribute it and/or modify
+               it under the terms of the GNU General Public License as published by
+               the Free Software Foundation; either version 3 of the License, or
+               (at your option) any later version.
+
+               This program is distributed in the hope that it will be useful,
+               but WITHOUT ANY WARRANTY; without even the implied warranty of
+               MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+               GNU General Public License for more details.
+
+               You should have received a copy of the GNU General Public License
+               along with this program.  If not, see <http://www.gnu.org/licenses/>.
+          license: GPL-3.0-or-later
+environment:
+    contents:
+        packages:
+            - busybox
+            - ca-certificates-bundle
+            - build-base
+            - automake
+            - autoconf
+            - cmake
+            # - gnutls-dev # TODO
+            - gettext-dev
+
+pipeline:
+    - uses: fetch
+      with:
+        expected-sha256: 1b04206286a5b82622335e4eb09e17074368b7288e53d134543cbbc6b79ea3e7
+        uri: https://marlam.de/msmtp/releases/msmtp-${{package.version}}.tar.xz
+    - uses: autoconf/configure
+    - uses: autoconf/make
+    - uses: autoconf/make-install
+    - uses: strip
+    - runs: |
+        mkdir -p ${{targets.destdir}}/etc/conf.d
+        echo '# defaut config' > ${{targets.destdir}}/etc/conf.d/msmtp.confd
+        echo '#MSMTP_INTERFACE="127.0.0.1"' >> ${{targets.destdir}}/etc/conf.d/msmtp.confd
+        echo '#MSMTP_PORT="25"' >> ${{targets.destdir}}/etc/conf.d/msmtp.confd
+        echo '#MSMTP_COMMAND="/usr/bin/msmtp -f %F"' >> ${{targets.destdir}}/etc/conf.d/msmtp.confd
+subpackages:
+    - name: msmtp-doc
+      pipeline:
+        - uses: split/manpages
+      description: msmtp manpages


### PR DESCRIPTION
This PR adds msmtp to wolfi, an SMTP client with a sendmail frontend. Useful for sending email without a full sendmail installation.

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>