### PR TITLE
Fix pcre by removing duplicated packages.

### DIFF
--- a/pcre.yaml
+++ b/pcre.yaml
@@ -21,8 +21,6 @@ environment:
             - autoconf
             - m4
             - libtool
-            - autoconf
-            - automake
 pipeline:
     - uses: fetch
       with:


### PR DESCRIPTION
The new lint rule didn't run against old PRs, but it's now blocking new PRs.

Signed-off-by: Dan Lorenc <dlorenc@chainguard.dev>