### PR TITLE
add packages: ko, apko, melange

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,5 +290,8 @@ $(eval $(call build-package,py3-sphinx,6.0.0-r0))
 $(eval $(call build-package,heimdal,7.8.0-r0))
 $(eval $(call build-package,cyrus-sasl,2.1.28-r0))
 $(eval $(call build-package,memcached,1.6.17-r0))
+$(eval $(call build-package,ko,0.12.0-r0))
+$(eval $(call build-package,apko,0.6.0-r0))
+$(eval $(call build-package,melange,0.2.0-r0))
 
 .build-packages: ${PACKAGES}

--- a/apko.yaml
+++ b/apko.yaml
@@ -21,4 +21,4 @@ environment:
 pipeline:
   - uses: go/install
     with:
-      package: chainguard.dev/apko@${{package.version}}
+      package: chainguard.dev/apko@v${{package.version}}

--- a/apko.yaml
+++ b/apko.yaml
@@ -1,0 +1,25 @@
+package:
+  name: apko
+  version: 0.6.0
+  description: Build OCI images using APK directly without Dockerfile
+  target-architecture:
+    - all
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+  dependencies:
+    runtime:
+      - apk-tools
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+
+pipeline:
+  - uses: go/install
+    with:
+      package: chainguard.dev/apko@${{package.version}}

--- a/apko.yaml
+++ b/apko.yaml
@@ -1,6 +1,7 @@
 package:
   name: apko
   version: 0.6.0
+  epoch: 0
   description: Build OCI images using APK directly without Dockerfile
   target-architecture:
     - all
@@ -14,10 +15,8 @@ package:
 
 environment:
   contents:
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-    repositories:
-      - https://packages.wolfi.dev/os
+    packages:
+      - git
 
 pipeline:
   - uses: go/install

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,6 +1,7 @@
 package:
   name: ko
   version: 0.12.0
+  epoch: 0
   description: Simple, fast container image builder for Go applications.
   target-architecture:
     - all
@@ -11,10 +12,8 @@ package:
 
 environment:
   contents:
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-    repositories:
-      - https://packages.wolfi.dev/os
+    packages:
+      - git
 
 pipeline:
   - uses: go/install

--- a/ko.yaml
+++ b/ko.yaml
@@ -18,4 +18,4 @@ environment:
 pipeline:
   - uses: go/install
     with:
-      package: github.com/google/ko@${{package.version}}
+      package: github.com/google/ko@v${{package.version}}

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,0 +1,22 @@
+package:
+  name: ko
+  version: 0.12.0
+  description: Simple, fast container image builder for Go applications.
+  target-architecture:
+    - all
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+
+pipeline:
+  - uses: go/install
+    with:
+      package: github.com/google/ko@${{package.version}}

--- a/melange.yaml
+++ b/melange.yaml
@@ -1,0 +1,27 @@
+package:
+  name: melange
+  version: 0.2.0
+  description: build APKs from source code
+  target-architecture:
+    - all
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+  dependencies:
+    runtime:
+      - apk-tools
+      - bubblewrap
+      - busybox
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+
+pipeline:
+  - uses: go/install
+    with:
+      package: chainguard.dev/melange@${{package.version}}

--- a/melange.yaml
+++ b/melange.yaml
@@ -1,6 +1,7 @@
 package:
   name: melange
   version: 0.2.0
+  epoch: 0
   description: build APKs from source code
   target-architecture:
     - all
@@ -16,10 +17,8 @@ package:
 
 environment:
   contents:
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-    repositories:
-      - https://packages.wolfi.dev/os
+    packages:
+      - git
 
 pipeline:
   - uses: go/install

--- a/melange.yaml
+++ b/melange.yaml
@@ -23,4 +23,4 @@ environment:
 pipeline:
   - uses: go/install
     with:
-      package: chainguard.dev/melange@$v{{package.version}}
+      package: chainguard.dev/melange@v${{package.version}}

--- a/melange.yaml
+++ b/melange.yaml
@@ -23,4 +23,4 @@ environment:
 pipeline:
   - uses: go/install
     with:
-      package: chainguard.dev/melange@${{package.version}}
+      package: chainguard.dev/melange@$v{{package.version}}


### PR DESCRIPTION
Updated attempt at #66 

This uses the new `go/install` pipeline.

Signed-off-by: Jason Hall <jason@chainguard.dev>
