### PR TITLE
Run: wolfictl advisory sync-secfixes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,4 +14,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: wolfi-dev/wolfictl/.github/actions@main
     - run: ./lint.sh

--- a/HOW_TO_PATCH_CVES.md
+++ b/HOW_TO_PATCH_CVES.md
@@ -42,7 +42,7 @@ For the ease of explanation, we'll assume we're addressing a single reported vul
         patches: CVE-2018-25032.patch
     ```
 
-    For more information on how `patch` works, see [its definition](https://github.com/chainguard-dev/melange/blob/main/pipelines/patch.yaml).
+    For more information on how `patch` works, see [its definition](https://github.com/chainguard-dev/melange/blob/main/pkg/build/pipelines/patch.yaml).
 
 1. In the [Makefile](./Makefile), find the line that corresponds to this package, and update the package version to our new release version from the Melange file.
 

--- a/HOW_TO_PATCH_CVES.md
+++ b/HOW_TO_PATCH_CVES.md
@@ -24,17 +24,7 @@ For the ease of explanation, we'll assume we're addressing a single reported vul
 
     a. Increment the "epoch" value. (e.g. change from `2` to `3`)
 
-    b. Add the "secfixes" data to denote that the updated package version will fix the vulnerability. If the `secfixes` top-level YAML field doesn't already exist, create it.
-
-    For example, to show that a new version (e.g. `...-r3` if we just incremented "epoch" to `3`) fixes CVE-2022-37434, the YAML might look like this:
-
-    ```yaml
-    secfixes:
-      1.2.12-r3:
-        - CVE-2022-37434
-    ```
-
-    c. For the new patch, add a `patch` pipeline item in the `pipeline` YAML section. For example, if we downloaded a patch called `CVE-2018-25032.patch` to our package directory above, we'd add an item to `pipeline` that looks like this:
+    b. For the new patch, add a `patch` pipeline item in the `pipeline` YAML section. For example, if we downloaded a patch called `CVE-2018-25032.patch` to our package directory above, we'd add an item to `pipeline` that looks like this:
 
     ```yaml
     - uses: patch
@@ -43,6 +33,19 @@ For the ease of explanation, we'll assume we're addressing a single reported vul
     ```
 
     For more information on how `patch` works, see [its definition](https://github.com/chainguard-dev/melange/blob/main/pkg/build/pipelines/patch.yaml).
+
+    c. Add the advisories data to denote that the updated package version will fix the vulnerability. You can do this using [wolfictl](https://github.com/wolfi-dev/wolfictl/):
+
+
+    ```sh
+    wolfictl advisory create <path-to-melange-config.yaml> --vuln <CVE> --status 'fixed' --fixed-version <new-release-version> --sync
+    ```
+
+    For example, if we're patching CVE-2018-25032 in the "zlib" package, where the `version` is `1.2.3` and the `epoch` is 4, we'd run:
+
+    ```sh
+    wolfictl advisory create ./zlib.yaml --vuln 'CVE-2018-25032' --status 'fixed' --fixed-version '1.2.3-r4' --sync
+    ```
 
 1. In the [Makefile](./Makefile), find the line that corresponds to this package, and update the package version to our new release version from the Melange file.
 
@@ -62,12 +65,12 @@ For the ease of explanation, we'll assume we're addressing a single reported vul
 
 ## NACKing a CVE
 
-To NACK a CVE for a given package, we don't add in any patches or increment the package version. Instead, the only thing we do is add a special entry to the `secfixes` section of the Melange YAML file, where we use a `0` in place of a real version of this package. For example:
+To NACK a CVE for a given package, we don't add in any patches or increment the package version. Instead, we just need to update the advisory data to say that this package is not affected by the vulnerability. As we do this, we also need to provide an accurate ["justification"](https://github.com/chainguard-dev/vex/blob/main/pkg/vex/justification.go#L12-L49) value as to why our package isn't affected. (And, if possible, we should also provide an "impact statement" that explains why we believe our package is not affected—but this is optional.)
 
-```yaml
-secfixes:
-  0:
-    - CVE-2019-6293
+For example:
+
+```sh
+wolfictl advisory create ./zlib.yaml --vuln 'CVE-2023-12345' --status 'not_affected' --justification 'vulnerable_code_not_present' --impact 'Fixed upstream prior to Wolfi packaging.' --sync
 ```
 
 This will notify vulnerability scanners that consume our secdb that this vulnerabitiliy doesn't apply to any of the versions of this package that we've published.

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -68,14 +68,14 @@ subpackages:
       - uses: split/dev
 advisories:
   CVE-2022-38126:
-    - timestamp: 2023-01-05T10:57:08.598208-05:00
+    - timestamp: 2022-09-16T16:42:40+00:00
       status: fixed
       fixed-version: 2.39-r1
   CVE-2022-38128:
-    - timestamp: 2023-01-05T10:57:08.600033-05:00
+    - timestamp: 2022-10-11T20:03:51+00:00
       status: fixed
       fixed-version: 2.39-r3
   CVE-2022-38533:
-    - timestamp: 2023-01-05T10:57:08.599476-05:00
+    - timestamp: 2022-09-16T16:42:40+00:00
       status: fixed
       fixed-version: 2.39-r2

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -7,12 +7,11 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: GPL-3.0-or-later
   dependencies:
     runtime:
-
 secfixes:
   2.39-r1:
     - CVE-2022-38126
@@ -20,7 +19,6 @@ secfixes:
     - CVE-2022-38533
   2.39-r3:
     - CVE-2022-38128
-
 environment:
   contents:
     repositories:
@@ -34,7 +32,6 @@ environment:
       - build-base
       - isl
       - texinfo
-
 pipeline:
   - uses: fetch
     with:
@@ -64,9 +61,21 @@ pipeline:
     runs: |
       rm -rf ${{targets.destdir}}/usr/share/info
   - uses: strip
-
 subpackages:
   - name: "binutils-dev"
     description: "binutils development headers"
     pipeline:
       - uses: split/dev
+advisories:
+  CVE-2022-38126:
+    - timestamp: 2023-01-05T10:57:08.598208-05:00
+      status: fixed
+      fixed-version: 2.39-r1
+  CVE-2022-38128:
+    - timestamp: 2023-01-05T10:57:08.600033-05:00
+      status: fixed
+      fixed-version: 2.39-r3
+  CVE-2022-38533:
+    - timestamp: 2023-01-05T10:57:08.599476-05:00
+      status: fixed
+      fixed-version: 2.39-r2

--- a/brotli.yaml
+++ b/brotli.yaml
@@ -59,6 +59,6 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libbrotlidec.so.* "${{targets.subpkgdir}}"/usr/lib/
 advisories:
   CVE-2020-8927:
-    - timestamp: 2023-01-05T10:57:08.600561-05:00
+    - timestamp: 2022-09-15T02:40:18+00:00
       status: fixed
       fixed-version: 1.0.9-r0

--- a/brotli.yaml
+++ b/brotli.yaml
@@ -7,14 +7,12 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: MIT
-
 secfixes:
   1.0.9-r0:
     - CVE-2020-8927
-
 environment:
   contents:
     packages:
@@ -25,7 +23,6 @@ environment:
       - autoconf
       - automake
       - libtool
-
 pipeline:
   - uses: fetch
     with:
@@ -37,7 +34,6 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
-
 subpackages:
   - name: "brotli-dev"
     description: "headers for brotli"
@@ -46,21 +42,23 @@ subpackages:
     dependencies:
       runtime:
         - brotli
-
   - name: "libbrotlicommon1"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libbrotlicommon.so.* "${{targets.subpkgdir}}"/usr/lib/
-
   - name: "libbrotlienc1"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libbrotlienc.so.* "${{targets.subpkgdir}}"/usr/lib/
-
   - name: "libbrotlidec1"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libbrotlidec.so.* "${{targets.subpkgdir}}"/usr/lib/
+advisories:
+  CVE-2020-8927:
+    - timestamp: 2023-01-05T10:57:08.600561-05:00
+      status: fixed
+      fixed-version: 1.0.9-r0

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -7,7 +7,7 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: GPL-2.0-only
   dependencies:
@@ -22,12 +22,10 @@ package:
       script: |
         #!/bin/busybox sh
         /bin/busybox --install -s
-
 secfixes:
   1.35.0-r3:
     - CVE-2022-28391
     - CVE-2022-30065
-
 environment:
   contents:
     repositories:
@@ -38,7 +36,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - build-base
-
 pipeline:
   - uses: fetch
     with:
@@ -72,4 +69,12 @@ pipeline:
       install -m755 busybox "${{targets.destdir}}"/bin/busybox
       install -m644 securetty "${{targets.destdir}}"/etc/securetty
   - uses: strip
-    
+advisories:
+  CVE-2022-28391:
+    - timestamp: 2023-01-05T10:57:08.60102-05:00
+      status: fixed
+      fixed-version: 1.35.0-r3
+  CVE-2022-30065:
+    - timestamp: 2023-01-05T10:57:08.601466-05:00
+      status: fixed
+      fixed-version: 1.35.0-r3

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -71,10 +71,10 @@ pipeline:
   - uses: strip
 advisories:
   CVE-2022-28391:
-    - timestamp: 2023-01-05T10:57:08.60102-05:00
+    - timestamp: 2022-10-11T20:37:21+00:00
       status: fixed
       fixed-version: 1.35.0-r3
   CVE-2022-30065:
-    - timestamp: 2023-01-05T10:57:08.601466-05:00
+    - timestamp: 2022-10-11T20:37:21+00:00
       status: fixed
       fixed-version: 1.35.0-r3

--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -75,4 +75,8 @@ advisories:
   CVE-2016-2781:
     - timestamp: 2023-01-05T10:57:08.601961-05:00
       status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+      justification: vulnerable_code_not_present
+      impact: |
+        Fixed upstream prior to Wolfi packaging.
+
+        See https://git.savannah.gnu.org/cgit/coreutils.git/commit/?h=v9.1&id=8cb06d4b44a67f89f24b25e2394365533f6e5968

--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -73,7 +73,7 @@ subpackages:
       - uses: split/infodir
 advisories:
   CVE-2016-2781:
-    - timestamp: 2023-01-05T10:57:08.601961-05:00
+    - timestamp: 2022-10-11T20:29:31+00:00
       status: not_affected
       justification: vulnerable_code_not_present
       impact: |

--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -7,18 +7,16 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: GPL-3.0-or-later
   scriptlets:
     post-deinstall: |
       #!/bin/busybox sh
       /bin/busybox --install -s
-
 secfixes:
   0:
     - CVE-2016-2781
-
 environment:
   contents:
     packages:
@@ -29,7 +27,6 @@ environment:
       - acl-dev
       - attr-dev
       - texinfo
-
 pipeline:
   - uses: fetch
     with:
@@ -49,7 +46,6 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
-
   # Move things around to match busybox locations
   - runs: |
       cd "${{targets.destdir}}"
@@ -69,10 +65,14 @@ pipeline:
 
       # shouldn't be here, but you never know...
       rm -f usr/bin/groups
-
 subpackages:
   - name: "coreutils-doc"
     description: "documentation for GNU coreutils"
     pipeline:
       - uses: split/manpages
       - uses: split/infodir
+advisories:
+  CVE-2016-2781:
+    - timestamp: 2023-01-05T10:57:08.601961-05:00
+      status: not_affected
+      justification: vulnerable_code_not_in_execute_path

--- a/cups.yaml
+++ b/cups.yaml
@@ -107,6 +107,6 @@ subpackages:
         - zlib-dev
 advisories:
   CVE-2022-26691:
-    - timestamp: 2023-01-05T10:57:08.602414-05:00
+    - timestamp: 2022-10-25T13:38:24-04:00
       status: fixed
       fixed-version: 2.4.2-r0

--- a/cups.yaml
+++ b/cups.yaml
@@ -105,3 +105,8 @@ subpackages:
         - libgcrypt-dev
         # - gnutls-dev
         - zlib-dev
+advisories:
+  CVE-2022-26691:
+    - timestamp: 2023-01-05T10:57:08.602414-05:00
+      status: fixed
+      fixed-version: 2.4.2-r0

--- a/curl.yaml
+++ b/curl.yaml
@@ -7,10 +7,9 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: MIT
-
 secfixes:
   7.87.0-r0:
     - CVE-2022-43551
@@ -18,7 +17,6 @@ secfixes:
   7.86.0-r0:
     - CVE-2022-42916
     - CVE-2022-32221
-
 environment:
   contents:
     packages:
@@ -30,7 +28,6 @@ environment:
       - openssl-dev
       - zlib-dev
       - brotli-dev
-
 pipeline:
   - uses: fetch
     with:
@@ -49,7 +46,6 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
-
 subpackages:
   - name: "curl-dev"
     description: "headers for libcurl"
@@ -58,15 +54,30 @@ subpackages:
     dependencies:
       runtime:
         - libcurl4
-
   - name: "curl-doc"
     description: "documentation for curl"
     pipeline:
       - uses: split/manpages
-
   - name: "libcurl4"
     description: "curl library"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libcurl.so.* "${{targets.subpkgdir}}"/usr/lib/
+advisories:
+  CVE-2022-32221:
+    - timestamp: 2023-01-05T10:57:08.604231-05:00
+      status: fixed
+      fixed-version: 7.86.0-r0
+  CVE-2022-42916:
+    - timestamp: 2023-01-05T10:57:08.603786-05:00
+      status: fixed
+      fixed-version: 7.86.0-r0
+  CVE-2022-43551:
+    - timestamp: 2023-01-05T10:57:08.60301-05:00
+      status: fixed
+      fixed-version: 7.87.0-r0
+  CVE-2022-43552:
+    - timestamp: 2023-01-05T10:57:08.603388-05:00
+      status: fixed
+      fixed-version: 7.87.0-r0

--- a/curl.yaml
+++ b/curl.yaml
@@ -45,7 +45,7 @@ pipeline:
         --with-nghttp2 \
         --with-pic \
         --disable-ldap \
-        --without-libssh2    
+        --without-libssh2
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip

--- a/curl.yaml
+++ b/curl.yaml
@@ -66,18 +66,18 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libcurl.so.* "${{targets.subpkgdir}}"/usr/lib/
 advisories:
   CVE-2022-32221:
-    - timestamp: 2023-01-05T10:57:08.604231-05:00
+    - timestamp: 2022-12-09T12:10:34-05:00
       status: fixed
       fixed-version: 7.86.0-r0
   CVE-2022-42916:
-    - timestamp: 2023-01-05T10:57:08.603786-05:00
+    - timestamp: 2022-11-19T10:37:17-05:00
       status: fixed
       fixed-version: 7.86.0-r0
   CVE-2022-43551:
-    - timestamp: 2023-01-05T10:57:08.60301-05:00
+    - timestamp: 2022-12-21T13:16:36+00:00
       status: fixed
       fixed-version: 7.87.0-r0
   CVE-2022-43552:
-    - timestamp: 2023-01-05T10:57:08.603388-05:00
+    - timestamp: 2022-12-21T13:16:36+00:00
       status: fixed
       fixed-version: 7.87.0-r0

--- a/dbus.yaml
+++ b/dbus.yaml
@@ -74,14 +74,14 @@ subpackages:
     description: dbus dev
 advisories:
   CVE-2022-42010:
-    - timestamp: 2023-01-05T10:57:08.604691-05:00
+    - timestamp: 2022-10-25T13:38:24-04:00
       status: fixed
       fixed-version: 1.14.4-r0
   CVE-2022-42011:
-    - timestamp: 2023-01-05T10:57:08.605266-05:00
+    - timestamp: 2022-10-25T13:38:24-04:00
       status: fixed
       fixed-version: 1.14.4-r0
   CVE-2022-42012:
-    - timestamp: 2023-01-05T10:57:08.605776-05:00
+    - timestamp: 2022-10-25T13:38:24-04:00
       status: fixed
       fixed-version: 1.14.4-r0

--- a/dbus.yaml
+++ b/dbus.yaml
@@ -72,3 +72,16 @@ subpackages:
         - dbus
         # - util-linux-dev todo add when util-linux is packaged
     description: dbus dev
+advisories:
+  CVE-2022-42010:
+    - timestamp: 2023-01-05T10:57:08.604691-05:00
+      status: fixed
+      fixed-version: 1.14.4-r0
+  CVE-2022-42011:
+    - timestamp: 2023-01-05T10:57:08.605266-05:00
+      status: fixed
+      fixed-version: 1.14.4-r0
+  CVE-2022-42012:
+    - timestamp: 2023-01-05T10:57:08.605776-05:00
+      status: fixed
+      fixed-version: 1.14.4-r0

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -47,7 +47,7 @@ pipeline:
       cd envoy
 
       # these patches are only required for 1.24.0, they are already merged upstream but 1.25.0 is not yet available.
-      # cannot use the melange "patch" pipeline as we fetch a Git repo above and can't clone into a non empty folder  
+      # cannot use the melange "patch" pipeline as we fetch a Git repo above and can't clone into a non empty folder
       patch -p1 < ../update_brotli.patch
       patch -p1 < ../googleurl-1.patch
       patch -p1 < ../googleurl-2.patch
@@ -55,7 +55,6 @@ pipeline:
       patch -p1 < ../googleurl-4.patch
       patch -p1 < ../googleurl-5.patch
       patch -p1 < ../googleurl-6.patch
-
 
       ./bazel/setup_clang.sh /usr
       echo "build --config=clang" >> user.bazelrc

--- a/expat.yaml
+++ b/expat.yaml
@@ -7,18 +7,16 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: MIT
   dependencies:
     runtime:
-
 secfixes:
   2.4.9-r0:
     - CVE-2022-40674
   2.5.0-r0:
     - CVE-2022-43680
-
 environment:
   contents:
     repositories:
@@ -29,7 +27,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - build-base
-
 pipeline:
   - uses: fetch
     with:
@@ -45,7 +42,6 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
-
 subpackages:
   - name: "expat-dev"
     description: "expat headers"
@@ -54,3 +50,12 @@ subpackages:
     dependencies:
       runtime:
         - expat
+advisories:
+  CVE-2022-40674:
+    - timestamp: 2023-01-05T10:57:08.606264-05:00
+      status: fixed
+      fixed-version: 2.4.9-r0
+  CVE-2022-43680:
+    - timestamp: 2023-01-05T10:57:08.606612-05:00
+      status: fixed
+      fixed-version: 2.5.0-r0

--- a/expat.yaml
+++ b/expat.yaml
@@ -52,10 +52,10 @@ subpackages:
         - expat
 advisories:
   CVE-2022-40674:
-    - timestamp: 2023-01-05T10:57:08.606264-05:00
+    - timestamp: 2022-09-21T11:05:50-05:00
       status: fixed
       fixed-version: 2.4.9-r0
   CVE-2022-43680:
-    - timestamp: 2023-01-05T10:57:08.606612-05:00
+    - timestamp: 2022-10-26T11:51:12-04:00
       status: fixed
       fixed-version: 2.5.0-r0

--- a/flex.yaml
+++ b/flex.yaml
@@ -70,4 +70,10 @@ advisories:
   CVE-2019-6293:
     - timestamp: 2023-01-05T10:57:08.60697-05:00
       status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+      justification: vulnerable_code_not_present
+      impact: |
+        The VEX spec should include a better justification value for this scenario: the vulnerability itself is contested or invalid.
+
+        See for more context on CVE-2019-6293:
+        - https://github.com/westes/flex/issues/414#issuecomment-452593828
+        - https://github.com/NixOS/nixpkgs/issues/55386#issuecomment-683792976

--- a/flex.yaml
+++ b/flex.yaml
@@ -7,18 +7,16 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: BSD-2-Clause AND LGPL-2.0-or-later
   dependencies:
     runtime:
       - m4
       - libfl2
-
 secfixes:
   0:
     - CVE-2019-6293
-
 environment:
   contents:
     repositories:
@@ -31,7 +29,6 @@ environment:
       - ca-certificates-bundle
       - build-base
       - bison
-
 pipeline:
   - uses: fetch
     with:
@@ -54,7 +51,6 @@ pipeline:
   - runs: |
       ln -s flex ${{targets.destdir}}/usr/bin/lex
   - uses: strip
-
 subpackages:
   - name: "flex-dev"
     description: "flex development headers"
@@ -64,10 +60,14 @@ subpackages:
       runtime:
         - flex
         - libfl2
-
   - name: "libfl2"
     description: "flex scanner library"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libfl.so* "${{targets.subpkgdir}}"/usr/lib
+advisories:
+  CVE-2019-6293:
+    - timestamp: 2023-01-05T10:57:08.60697-05:00
+      status: not_affected
+      justification: vulnerable_code_not_in_execute_path

--- a/flex.yaml
+++ b/flex.yaml
@@ -68,7 +68,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libfl.so* "${{targets.subpkgdir}}"/usr/lib
 advisories:
   CVE-2019-6293:
-    - timestamp: 2023-01-05T10:57:08.60697-05:00
+    - timestamp: 2022-10-11T19:48:04+00:00
       status: not_affected
       justification: vulnerable_code_not_present
       impact: |

--- a/freetype.yaml
+++ b/freetype.yaml
@@ -64,3 +64,16 @@ subpackages:
     pipeline:
       - uses: split/manpages
     description: freetype manpages
+advisories:
+  CVE-2022-27404:
+    - timestamp: 2023-01-05T10:57:08.607351-05:00
+      status: fixed
+      fixed-version: 2.12.1-r0
+  CVE-2022-27405:
+    - timestamp: 2023-01-05T10:57:08.607733-05:00
+      status: fixed
+      fixed-version: 2.12.1-r0
+  CVE-2022-27406:
+    - timestamp: 2023-01-05T10:57:08.608195-05:00
+      status: fixed
+      fixed-version: 2.12.1-r0

--- a/freetype.yaml
+++ b/freetype.yaml
@@ -66,14 +66,14 @@ subpackages:
     description: freetype manpages
 advisories:
   CVE-2022-27404:
-    - timestamp: 2023-01-05T10:57:08.607351-05:00
+    - timestamp: 2022-10-26T16:28:34-04:00
       status: fixed
       fixed-version: 2.12.1-r0
   CVE-2022-27405:
-    - timestamp: 2023-01-05T10:57:08.607733-05:00
+    - timestamp: 2022-10-26T16:28:34-04:00
       status: fixed
       fixed-version: 2.12.1-r0
   CVE-2022-27406:
-    - timestamp: 2023-01-05T10:57:08.608195-05:00
+    - timestamp: 2022-10-26T16:28:34-04:00
       status: fixed
       fixed-version: 2.12.1-r0

--- a/giflib.yaml
+++ b/giflib.yaml
@@ -61,6 +61,6 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/* "${{targets.subpkgdir}}"/usr/bin
 advisories:
   CVE-2022-28506:
-    - timestamp: 2023-01-05T10:57:08.609751-05:00
+    - timestamp: 2022-11-16T18:48:05+07:00
       status: fixed
       fixed-version: 5.2.1-r0

--- a/giflib.yaml
+++ b/giflib.yaml
@@ -7,14 +7,12 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: MIT
-
 secfixes:
   5.2.1-r0:
     - CVE-2022-28506
-      
 environment:
   contents:
     packages:
@@ -27,7 +25,6 @@ environment:
       - libtool
       - xmlto
       - coreutils
-
 pipeline:
   - uses: fetch
     with:
@@ -41,7 +38,6 @@ pipeline:
       make DESTDIR="${{targets.destdir}}" PREFIX=/usr install
       rm -f "${{targets.destdir}}"/usr/lib/*.a
   - uses: strip
-
 subpackages:
   - name: "giflib-dev"
     description: "headers for giflib"
@@ -50,7 +46,6 @@ subpackages:
     dependencies:
       runtime:
         - giflib
-
   - name: "giflib-doc"
     description: "giflib documentation"
     pipeline:
@@ -58,10 +53,14 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/doc/giflib
           mv doc/* "${{targets.subpkgdir}}"/usr/share/doc/giflib
-
   - name: "giflib-utils"
     description: "Programs for manipulating GIF format image files"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/* "${{targets.subpkgdir}}"/usr/bin
+advisories:
+  CVE-2022-28506:
+    - timestamp: 2023-01-05T10:57:08.609751-05:00
+      status: fixed
+      fixed-version: 5.2.1-r0

--- a/git.yaml
+++ b/git.yaml
@@ -81,9 +81,18 @@ subpackages:
       runtime:
         - git-daemon
     pipeline:
-      - runs: |
+      - runs: |-
           mkdir -p "${{targets.subpkgdir}}"/usr/libexec/git-core/mergetools
 
           mv  "${{targets.destdir}}"/usr/libexec/git-core/*p4* "${{targets.subpkgdir}}"/usr/libexec/git-core/
           mv  "${{targets.destdir}}"/usr/libexec/git-core/mergetools/*p4* \
             "${{targets.subpkgdir}}"/usr/libexec/git-core/mergetools/
+advisories:
+  CVE-2022-39253:
+    - timestamp: 2023-01-05T10:57:08.610395-05:00
+      status: fixed
+      fixed-version: 2.38.1-r0
+  CVE-2022-39260:
+    - timestamp: 2023-01-05T10:57:08.610848-05:00
+      status: fixed
+      fixed-version: 2.38.1-r0

--- a/git.yaml
+++ b/git.yaml
@@ -89,10 +89,10 @@ subpackages:
             "${{targets.subpkgdir}}"/usr/libexec/git-core/mergetools/
 advisories:
   CVE-2022-39253:
-    - timestamp: 2023-01-05T10:57:08.610395-05:00
+    - timestamp: 2022-10-19T21:10:17+00:00
       status: fixed
       fixed-version: 2.38.1-r0
   CVE-2022-39260:
-    - timestamp: 2023-01-05T10:57:08.610848-05:00
+    - timestamp: 2022-10-19T21:10:17+00:00
       status: fixed
       fixed-version: 2.38.1-r0

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -427,6 +427,6 @@ subpackages:
             && mv "${{targets.destdir}}"/usr/lib/locale/${{range.key}} "${{targets.subpkgdir}}"/usr/lib/locale/
 advisories:
   CVE-2022-39046:
-    - timestamp: 2023-01-05T10:57:08.61134-05:00
+    - timestamp: 2022-10-11T20:29:19+00:00
       status: fixed
       fixed-version: 2.36-r1

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -7,7 +7,7 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: GPL-3.0-or-later
   dependencies:
@@ -24,11 +24,9 @@ package:
       script: |
         #!/bin/busybox sh
         /sbin/ldconfig
-
 secfixes:
   2.36-r1:
     - CVE-2022-39046
-
 environment:
   contents:
     repositories:
@@ -47,7 +45,6 @@ environment:
       - flex
       - grep
       - python3
-
 pipeline:
   - uses: fetch
     with:
@@ -97,7 +94,6 @@ pipeline:
     runs: |
       make -C build -j$(nproc) localedata/install-locale-files DESTDIR="${{targets.destdir}}"
   - uses: strip
-
 data:
   - name: locales
     items:
@@ -301,7 +297,6 @@ data:
       yuw: Yau
       zh: Mandarin Chinese
       zu: Zulu
-
 subpackages:
   - name: "glibc-dev"
     description: "GLIBC development headers"
@@ -311,11 +306,9 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           [ -f "${{targets.destdir}}"/usr/lib/libc.so ] && mv "${{targets.destdir}}"/usr/lib/libc.so "${{targets.subpkgdir}}"/usr/lib/
           [ -f "${{targets.destdir}}"/usr/lib/libm.so ] && mv "${{targets.destdir}}"/usr/lib/libm.so "${{targets.subpkgdir}}"/usr/lib/
-
     dependencies:
       runtime:
         - linux-headers
-
   - name: "glibc-iconv"
     description: "GLIBC iconv tables"
     pipeline:
@@ -325,7 +318,6 @@ subpackages:
 
           mkdir -p "${{targets.subpkgdir}}"/usr/sbin
           mv "${{targets.destdir}}"/usr/sbin/iconvconfig "${{targets.subpkgdir}}"/usr/sbin
-
   - name: "glibc-locales"
     description: "GLIBC locale data"
     pipeline:
@@ -333,7 +325,6 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share
           mv "${{targets.destdir}}"/usr/share/i18n "${{targets.subpkgdir}}"/usr/share/i18n
-
   - name: "tzutils"
     description: "Timezone utilities"
     pipeline:
@@ -344,7 +335,6 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/tzselect "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/zdump "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/sbin/zic "${{targets.subpkgdir}}"/usr/sbin
-
   - name: "posix-libc-utils"
     description: "POSIX XCU utilities included with the C library"
     pipeline:
@@ -358,14 +348,12 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/locale "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/pldd "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/libexec "${{targets.subpkgdir}}"/usr
-
   - name: "localedef"
     description: "Tool for defining GLIBC locales"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/localedef "${{targets.subpkgdir}}"/usr/bin
-
   - name: "sotruss"
     description: "Shared object tracing tool"
     pipeline:
@@ -375,43 +363,38 @@ subpackages:
 
           mv "${{targets.destdir}}"/usr/bin/sotruss "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/lib/audit/* "${{targets.subpkgdir}}"/usr/lib/audit/
-
   - name: "nscd"
     description: "NSS caching daemon"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/sbin
           mv "${{targets.destdir}}"/usr/sbin/nscd "${{targets.subpkgdir}}"/usr/sbin/
-
   - name: "nss-db"
     description: "NSS module for database lookups"
     pipeline:
-       - runs: |
-           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-           mkdir -p "${{targets.subpkgdir}}"/lib64
-           mkdir -p "${{targets.subpkgdir}}"/var
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mkdir -p "${{targets.subpkgdir}}"/lib64
+          mkdir -p "${{targets.subpkgdir}}"/var
 
-           mv "${{targets.destdir}}"/usr/bin/makedb "${{targets.subpkgdir}}"/usr/bin
-           mv "${{targets.destdir}}"/lib64/libnss_db.so.2 "${{targets.subpkgdir}}"/lib64
-           mv "${{targets.destdir}}"/var/db "${{targets.subpkgdir}}"/var
-
+          mv "${{targets.destdir}}"/usr/bin/makedb "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/lib64/libnss_db.so.2 "${{targets.subpkgdir}}"/lib64
+          mv "${{targets.destdir}}"/var/db "${{targets.subpkgdir}}"/var
   - name: "nss-hesiod"
     description: "NSS module for hesiod lookups"
     pipeline:
       - runs: |
-           mkdir -p "${{targets.subpkgdir}}"/lib64
-           mv "${{targets.destdir}}"/lib64/libnss_hesiod.so.2 "${{targets.subpkgdir}}"/lib64
-
+          mkdir -p "${{targets.subpkgdir}}"/lib64
+          mv "${{targets.destdir}}"/lib64/libnss_hesiod.so.2 "${{targets.subpkgdir}}"/lib64
   - name: "pcprofiledump"
     description: "PC profiling tool"
     pipeline:
       - runs: |
-           mkdir -p "${{targets.subpkgdir}}"/lib64
-           mv "${{targets.destdir}}"/lib64/libpcprofile.so "${{targets.subpkgdir}}"/lib64
+          mkdir -p "${{targets.subpkgdir}}"/lib64
+          mv "${{targets.destdir}}"/lib64/libpcprofile.so "${{targets.subpkgdir}}"/lib64
 
-           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-           mv "${{targets.destdir}}"/usr/bin/pcprofiledump "${{targets.subpkgdir}}"/usr/bin
-
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/pcprofiledump "${{targets.subpkgdir}}"/usr/bin
   - name: "glibc-tracing"
     description: "GLIBC tracing and profiling utilities"
     pipeline:
@@ -420,21 +403,18 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/mtrace "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/xtrace "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/sprof "${{targets.subpkgdir}}"/usr/bin
-
   - name: "sln"
     description: "Staticly-linked symbolic link tool"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/sbin
           mv "${{targets.destdir}}"/sbin/sln "${{targets.subpkgdir}}"/sbin
-
   - name: "glibc-locale-posix"
     description: "POSIX locale data for glibc"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/locale
           mv "${{targets.destdir}}"/usr/lib/locale/C.utf8 "${{targets.subpkgdir}}"/usr/lib/locale/
-
   - range: locales
     name: "glibc-locale-${{range.key}}"
     description: "${{range.value}} locale data for glibc"
@@ -445,3 +425,8 @@ subpackages:
             || mv "${{targets.destdir}}"/usr/lib/locale/${{range.key}}_* "${{targets.subpkgdir}}"/usr/lib/locale/
           [ -d "${{targets.destdir}}"/usr/lib/locale/${{range.key}} ] \
             && mv "${{targets.destdir}}"/usr/lib/locale/${{range.key}} "${{targets.subpkgdir}}"/usr/lib/locale/
+advisories:
+  CVE-2022-39046:
+    - timestamp: 2023-01-05T10:57:08.61134-05:00
+      status: fixed
+      fixed-version: 2.36-r1

--- a/gmp.yaml
+++ b/gmp.yaml
@@ -58,6 +58,6 @@ subpackages:
         - gmp
 advisories:
   CVE-2021-43618:
-    - timestamp: 2023-01-05T10:57:08.613492-05:00
+    - timestamp: 2022-10-11T19:40:48+00:00
       status: fixed
       fixed-version: 6.2.1-r4

--- a/gmp.yaml
+++ b/gmp.yaml
@@ -7,16 +7,14 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: LGPL-3.0-or-later OR GPL-2.0-or-later
   dependencies:
     runtime:
-
 secfixes:
   6.2.1-r4:
     - CVE-2021-43618
-
 environment:
   contents:
     repositories:
@@ -30,7 +28,6 @@ environment:
       - ca-certificates-bundle
       - m4
       - texinfo
-
 pipeline:
   - uses: fetch
     with:
@@ -51,7 +48,6 @@ pipeline:
   - name: 'Clean up documentation'
     runs: |
       rm -rf ${{targets.destdir}}/usr/share/info
-
 subpackages:
   - name: "gmp-dev"
     description: "gmp headers"
@@ -60,3 +56,8 @@ subpackages:
     dependencies:
       runtime:
         - gmp
+advisories:
+  CVE-2021-43618:
+    - timestamp: 2023-01-05T10:57:08.613492-05:00
+      status: fixed
+      fixed-version: 6.2.1-r4

--- a/go.yaml
+++ b/go.yaml
@@ -14,14 +14,12 @@ package:
     runtime:
       - build-base
       - bash
-
 secfixes:
   1.19.3-r0:
     - CVE-2022-41716
   1.19.4-r0:
     - CVE-2022-41717
     - CVE-2022-41720
-
 environment:
   contents:
     packages:
@@ -30,7 +28,6 @@ environment:
       - build-base
       - bash
       - go
-
 pipeline:
   - uses: fetch
     with:
@@ -72,7 +69,6 @@ pipeline:
       find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*.bat" \) \
         -exec rm -rf \{\} \+
   - uses: strip
-
 subpackages:
   - name: "go-doc"
     description: "go documentation"
@@ -80,3 +76,16 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
+advisories:
+  CVE-2022-41716:
+    - timestamp: 2023-01-05T10:57:08.613858-05:00
+      status: fixed
+      fixed-version: 1.19.3-r0
+  CVE-2022-41717:
+    - timestamp: 2023-01-05T10:57:08.614278-05:00
+      status: fixed
+      fixed-version: 1.19.4-r0
+  CVE-2022-41720:
+    - timestamp: 2023-01-05T10:57:08.614702-05:00
+      status: fixed
+      fixed-version: 1.19.4-r0

--- a/go.yaml
+++ b/go.yaml
@@ -78,14 +78,14 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
 advisories:
   CVE-2022-41716:
-    - timestamp: 2023-01-05T10:57:08.613858-05:00
+    - timestamp: 2022-11-01T13:39:29-04:00
       status: fixed
       fixed-version: 1.19.3-r0
   CVE-2022-41717:
-    - timestamp: 2023-01-05T10:57:08.614278-05:00
+    - timestamp: 2022-12-07T08:11:39+00:00
       status: fixed
       fixed-version: 1.19.4-r0
   CVE-2022-41720:
-    - timestamp: 2023-01-05T10:57:08.614702-05:00
+    - timestamp: 2022-12-07T08:11:39+00:00
       status: fixed
       fixed-version: 1.19.4-r0

--- a/libarchive.yaml
+++ b/libarchive.yaml
@@ -7,10 +7,9 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: BSD-2-Clause
-
 environment:
   contents:
     packages:
@@ -27,11 +26,9 @@ environment:
       - attr-dev
       - openssl-dev
       - expat-dev
-
 secfixes:
   3.6.1-r2:
     - CVE-2022-36227
-
 pipeline:
   - uses: fetch
     with:
@@ -49,14 +46,12 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
-
 subpackages:
   - name: "libarchive-doc"
     description: "libarchive documentation"
     pipeline:
       - uses: split/manpages
       - uses: split/infodir
-
   - name: "libarchive-dev"
     description: "libarchive development headers"
     pipeline:
@@ -64,10 +59,14 @@ subpackages:
     dependencies:
       runtime:
         - libarchive
-
   - name: "libarchive-tools"
     description: "bsdtar and bsdcpio programs from libarchive"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/bsd* "${{targets.subpkgdir}}"/usr/bin/
+advisories:
+  CVE-2022-36227:
+    - timestamp: 2023-01-05T10:57:08.615137-05:00
+      status: fixed
+      fixed-version: 3.6.1-r2

--- a/libarchive.yaml
+++ b/libarchive.yaml
@@ -67,6 +67,6 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/bsd* "${{targets.subpkgdir}}"/usr/bin/
 advisories:
   CVE-2022-36227:
-    - timestamp: 2023-01-05T10:57:08.615137-05:00
+    - timestamp: 2022-12-06T16:23:01+00:00
       status: fixed
       fixed-version: 3.6.1-r2

--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -66,3 +66,12 @@ subpackages:
         - xz-dev
         - libxml2-utils
     description: libxml2 dev
+advisories:
+  CVE-2022-40303:
+    - timestamp: 2023-01-05T10:57:08.615556-05:00
+      status: fixed
+      fixed-version: 2.10.3-r0
+  CVE-2022-40304:
+    - timestamp: 2023-01-05T10:57:08.615947-05:00
+      status: fixed
+      fixed-version: 2.10.3-r0

--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -68,10 +68,10 @@ subpackages:
     description: libxml2 dev
 advisories:
   CVE-2022-40303:
-    - timestamp: 2023-01-05T10:57:08.615556-05:00
+    - timestamp: 2022-10-20T22:07:42+01:00
       status: fixed
       fixed-version: 2.10.3-r0
   CVE-2022-40304:
-    - timestamp: 2023-01-05T10:57:08.615947-05:00
+    - timestamp: 2022-10-20T22:07:42+01:00
       status: fixed
       fixed-version: 2.10.3-r0

--- a/lint.sh
+++ b/lint.sh
@@ -24,3 +24,13 @@ for f in *.yaml; do
     yq -i 'del(.environment.contents.keyring)' $f
   fi
 done
+
+# Ensure advisory data and secfixes data are in sync.
+echo "
+
+Looking for files with out-of-sync advisory and secfixes data...
+"
+wolfictl advisory sync-secfixes --warn *.yaml
+
+# And if we make it this far...
+echo "All data is in sync!"

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -7,17 +7,15 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: MIT
   dependencies:
     runtime:
       - ncurses-terminfo-base
-
 secfixes:
   6.3-r0:
     - CVE-2022-29458
-
 environment:
   contents:
     repositories:
@@ -29,31 +27,30 @@ environment:
       - ca-certificates-bundle
       - build-base
       - ncurses
-
 pipeline:
   - uses: fetch
     with:
-#      uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{package.version}}-20220820.tgz
+      #      uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{package.version}}-20220820.tgz
       uri: https://distfiles.alpinelinux.org/distfiles/edge/ncurses-${{package.version}}-20220820.tgz
       expected-sha256: 7b810b01f71609fd31107a0b7794d0940d3ecc10c98ba19e83749419ba0934b9
   - name: Configure
     runs: |
-        ./configure \
-          --prefix=/usr \
-          --host=${{host.triplet.gnu}} \
-          --mandir=/usr/share/man \
-          --without-ada \
-          --without-tests \
-          --disable-termcap \
-          --disable-rpath-hack \
-          --disable-stripping \
-          --with-pkg-config-libdir=/usr/lib/pkgconfig \
-          --without-cxx-binding \
-          --with-terminfo-dirs="/etc/terminfo:/usr/share/terminfo:/lib/terminfo:/usr/lib/terminfo" \
-          --enable-pc-files \
-          --with-shared \
-          --enable-widec \
-          --with-xterm-kbs=DEL
+      ./configure \
+        --prefix=/usr \
+        --host=${{host.triplet.gnu}} \
+        --mandir=/usr/share/man \
+        --without-ada \
+        --without-tests \
+        --disable-termcap \
+        --disable-rpath-hack \
+        --disable-stripping \
+        --with-pkg-config-libdir=/usr/lib/pkgconfig \
+        --without-cxx-binding \
+        --with-terminfo-dirs="/etc/terminfo:/usr/share/terminfo:/lib/terminfo:/usr/lib/terminfo" \
+        --enable-pc-files \
+        --with-shared \
+        --enable-widec \
+        --with-xterm-kbs=DEL
   - uses: autoconf/make
   - uses: autoconf/make-install
   - name: 'Set up development files'
@@ -68,7 +65,6 @@ pipeline:
       ln -s libncurses.so ${{targets.destdir}}/usr/lib/libcurses.so
       echo 'INPUT(-lncursesw)' > ${{targets.destdir}}/usr/lib/libcursesw.so
   - uses: strip
-
 subpackages:
   - name: "ncurses-dev"
     description: "ncurses headers"
@@ -79,12 +75,10 @@ subpackages:
     dependencies:
       runtime:
         - ncurses
-
   - name: "ncurses-doc"
     description: "ncurses documentation"
     pipeline:
       - uses: split/manpages
-
   - name: "ncurses-terminfo-base"
     description: "descriptions of common terminals"
     pipeline:
@@ -128,10 +122,14 @@ subpackages:
 
           mkdir -p "${{targets.subpkgdir}}"/etc/terminfo/x
           mv "${{targets.destdir}}"/usr/share/terminfo/x/xterm* "${{targets.subpkgdir}}"/etc/terminfo/x
-
   - name: "ncurses-terminfo"
     description: "other terminal descriptions"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share
           mv "${{targets.destdir}}"/usr/share/terminfo "${{targets.subpkgdir}}"/usr/share
+advisories:
+  CVE-2022-29458:
+    - timestamp: 2023-01-05T10:57:08.616375-05:00
+      status: fixed
+      fixed-version: 6.3-r0

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -130,6 +130,6 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/terminfo "${{targets.subpkgdir}}"/usr/share
 advisories:
   CVE-2022-29458:
-    - timestamp: 2023-01-05T10:57:08.616375-05:00
+    - timestamp: 2022-10-11T19:49:30+00:00
       status: fixed
       fixed-version: 6.3-r0

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -7,12 +7,11 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: Apache-2.0
   dependencies:
     runtime:
-
 secfixes:
   3.0.7-r1:
     - CVE-2022-3996
@@ -20,7 +19,6 @@ secfixes:
     - CVE-2022-3358
     - CVE-2022-3602
     - CVE-2022-3786
-
 environment:
   contents:
     repositories:
@@ -32,17 +30,14 @@ environment:
       - ca-certificates-bundle
       - perl
       - build-base
-
 pipeline:
   - uses: fetch
     with:
       uri: https://www.openssl.org/source/openssl-${{package.version}}.tar.gz
       expected-sha256: 83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e
-
   - uses: patch
     with:
       patches: CVE-2022-3996.patch
-
   - name: Configure and build
     runs: |
       export CC=${{host.triplet.gnu}}-gcc
@@ -74,7 +69,6 @@ pipeline:
   - runs: |
       rm ${{targets.destdir}}/usr/bin/c_rehash
   - uses: strip
-
 subpackages:
   - name: "openssl-doc"
     description: "OpenSSL documentation"
@@ -82,21 +76,18 @@ subpackages:
       - uses: split/manpages
       - runs: |
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share
-
   - name: "libcrypto3"
     description: "OpenSSL libcrypto library"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libcrypto.so.3 "${{targets.subpkgdir}}"/usr/lib
-
   - name: "libssl3"
     description: "OpenSSL libssl library"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libssl.so.3 "${{targets.subpkgdir}}"/usr/lib
-
   - name: "openssl-dev"
     description: "OpenSSL headers"
     pipeline:
@@ -105,3 +96,20 @@ subpackages:
       runtime:
         - libcrypto3
         - libssl3
+advisories:
+  CVE-2022-3358:
+    - timestamp: 2023-01-05T10:57:08.617657-05:00
+      status: fixed
+      fixed-version: 3.0.7-r0
+  CVE-2022-3602:
+    - timestamp: 2023-01-05T10:57:08.618133-05:00
+      status: fixed
+      fixed-version: 3.0.7-r0
+  CVE-2022-3786:
+    - timestamp: 2023-01-05T10:57:08.61863-05:00
+      status: fixed
+      fixed-version: 3.0.7-r0
+  CVE-2022-3996:
+    - timestamp: 2023-01-05T10:57:08.617117-05:00
+      status: fixed
+      fixed-version: 3.0.7-r1

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -98,18 +98,18 @@ subpackages:
         - libssl3
 advisories:
   CVE-2022-3358:
-    - timestamp: 2023-01-05T10:57:08.617657-05:00
+    - timestamp: 2022-11-01T16:49:56+00:00
       status: fixed
       fixed-version: 3.0.7-r0
   CVE-2022-3602:
-    - timestamp: 2023-01-05T10:57:08.618133-05:00
+    - timestamp: 2022-11-01T16:49:56+00:00
       status: fixed
       fixed-version: 3.0.7-r0
   CVE-2022-3786:
-    - timestamp: 2023-01-05T10:57:08.61863-05:00
+    - timestamp: 2022-11-01T16:49:56+00:00
       status: fixed
       fixed-version: 3.0.7-r0
   CVE-2022-3996:
-    - timestamp: 2023-01-05T10:57:08.617117-05:00
+    - timestamp: 2022-12-22T17:26:45+00:00
       status: fixed
       fixed-version: 3.0.7-r1

--- a/patch.yaml
+++ b/patch.yaml
@@ -75,30 +75,30 @@ pipeline:
   - uses: strip
 advisories:
   CVE-2018-6951:
-    - timestamp: 2023-01-05T10:57:08.621509-05:00
+    - timestamp: 2022-09-28T12:06:03+01:00
       status: fixed
       fixed-version: 2.7.6-r3
   CVE-2018-6952:
-    - timestamp: 2023-01-05T10:57:08.622109-05:00
+    - timestamp: 2022-09-28T12:06:03+01:00
       status: fixed
       fixed-version: 2.7.6-r3
   CVE-2018-20969:
-    - timestamp: 2023-01-05T10:57:08.620456-05:00
+    - timestamp: 2022-09-28T12:06:03+01:00
       status: fixed
       fixed-version: 2.7.6-r3
   CVE-2018-1000156:
-    - timestamp: 2023-01-05T10:57:08.619567-05:00
+    - timestamp: 2022-09-28T12:06:03+01:00
       status: fixed
       fixed-version: 2.7.6-r3
   CVE-2019-13636:
-    - timestamp: 2023-01-05T10:57:08.620946-05:00
+    - timestamp: 2022-09-28T12:06:03+01:00
       status: fixed
       fixed-version: 2.7.6-r3
   CVE-2019-13638:
-    - timestamp: 2023-01-05T10:57:08.61999-05:00
+    - timestamp: 2022-09-28T12:06:03+01:00
       status: fixed
       fixed-version: 2.7.6-r3
   CVE-2019-20633:
-    - timestamp: 2023-01-05T10:57:08.619152-05:00
+    - timestamp: 2022-09-28T12:06:03+01:00
       status: fixed
       fixed-version: 2.7.6-r3

--- a/patch.yaml
+++ b/patch.yaml
@@ -7,12 +7,11 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: GPL-3.0-or-later
   dependencies:
     runtime:
-
 secfixes:
   2.7.6-r3:
     - CVE-2019-20633
@@ -22,7 +21,6 @@ secfixes:
     - CVE-2019-13636
     - CVE-2018-6951
     - CVE-2018-6952
-
 environment:
   contents:
     repositories:
@@ -37,44 +35,34 @@ environment:
       - autoconf
       - automake
       - libtool
-
 pipeline:
   - uses: fetch
     with:
       uri: https://ftp.gnu.org/gnu/patch/patch-${{package.version}}.tar.gz
       expected-sha256: 8cf86e00ad3aaa6d26aca30640e86b0e3e1f395ed99f189b06d4c9f74bc58a4e
-
   - uses: patch
     with:
       patches: CVE-2018-6951.patch
-
   - uses: patch
     with:
       patches: CVE-2018-6952.patch
-
   - uses: patch
     with:
       patches: 0001-Allow-input-files-to-be-missing-for-ed-style-patches.patch
-
   - uses: patch
     with:
       patches: 0002-Fix-arbitrary-command-execution-in-ed-style-patches-.patch
-
   - uses: patch
     with:
       patches: CVE-2019-13636.patch
-
   - uses: patch
     with:
       patches: CVE-2019-13638.patch
-
   - uses: patch
     with:
       patches: CVE-2019-20633.patch
-
   - runs: |
       autoreconf -vfi
-
   - name: Configure
     runs: |
       ./configure \
@@ -85,3 +73,32 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
+advisories:
+  CVE-2018-6951:
+    - timestamp: 2023-01-05T10:57:08.621509-05:00
+      status: fixed
+      fixed-version: 2.7.6-r3
+  CVE-2018-6952:
+    - timestamp: 2023-01-05T10:57:08.622109-05:00
+      status: fixed
+      fixed-version: 2.7.6-r3
+  CVE-2018-20969:
+    - timestamp: 2023-01-05T10:57:08.620456-05:00
+      status: fixed
+      fixed-version: 2.7.6-r3
+  CVE-2018-1000156:
+    - timestamp: 2023-01-05T10:57:08.619567-05:00
+      status: fixed
+      fixed-version: 2.7.6-r3
+  CVE-2019-13636:
+    - timestamp: 2023-01-05T10:57:08.620946-05:00
+      status: fixed
+      fixed-version: 2.7.6-r3
+  CVE-2019-13638:
+    - timestamp: 2023-01-05T10:57:08.61999-05:00
+      status: fixed
+      fixed-version: 2.7.6-r3
+  CVE-2019-20633:
+    - timestamp: 2023-01-05T10:57:08.619152-05:00
+      status: fixed
+      fixed-version: 2.7.6-r3

--- a/pcre2.yaml
+++ b/pcre2.yaml
@@ -80,10 +80,10 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/libpcre2-posix* "${{targets.subpkgdir}}"/usr/lib/
 advisories:
   CVE-2022-1586:
-    - timestamp: 2023-01-05T10:57:08.622743-05:00
+    - timestamp: 2022-09-20T11:15:38+00:00
       status: fixed
       fixed-version: 10.40-r0
   CVE-2022-1587:
-    - timestamp: 2023-01-05T10:57:08.623233-05:00
+    - timestamp: 2022-09-20T11:15:38+00:00
       status: fixed
       fixed-version: 10.40-r0

--- a/pcre2.yaml
+++ b/pcre2.yaml
@@ -78,3 +78,12 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libpcre2-posix* "${{targets.subpkgdir}}"/usr/lib/
+advisories:
+  CVE-2022-1586:
+    - timestamp: 2023-01-05T10:57:08.622743-05:00
+      status: fixed
+      fixed-version: 10.40-r0
+  CVE-2022-1587:
+    - timestamp: 2023-01-05T10:57:08.623233-05:00
+      status: fixed
+      fixed-version: 10.40-r0

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -85,7 +85,7 @@ subpackages:
           chmod +x ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
 advisories:
   CVE-2017-8806:
-    - timestamp: 2023-01-05T10:57:08.623755-05:00
+    - timestamp: 2022-11-03T12:41:55+00:00
       status: not_affected
       justification: vulnerable_code_not_present
       impact: This CVE appears to impact only Debian/Ubuntu.

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -87,4 +87,5 @@ advisories:
   CVE-2017-8806:
     - timestamp: 2023-01-05T10:57:08.623755-05:00
       status: not_affected
-      justification: vulnerable_code_not_in_execute_path
+      justification: vulnerable_code_not_present
+      impact: This CVE appears to impact only Debian/Ubuntu.

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -83,3 +83,8 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/var/lib/postgres/initdb
           cp postgresql-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/
           chmod +x ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
+advisories:
+  CVE-2017-8806:
+    - timestamp: 2023-01-05T10:57:08.623755-05:00
+      status: not_affected
+      justification: vulnerable_code_not_in_execute_path

--- a/python3.yaml
+++ b/python3.yaml
@@ -97,6 +97,6 @@ subpackages:
         - python3
 advisories:
   CVE-2020-10735:
-    - timestamp: 2023-01-05T10:57:08.62425-05:00
+    - timestamp: 2022-09-12T21:06:30+00:00
       status: fixed
       fixed-version: 3.0.7-r0

--- a/python3.yaml
+++ b/python3.yaml
@@ -7,16 +7,14 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: PSF-2.0
   dependencies:
     runtime:
-
 secfixes:
   3.0.7-r0:
     - CVE-2020-10735
-
 environment:
   contents:
     repositories:
@@ -39,7 +37,6 @@ environment:
       - sqlite-dev
       - xz-dev
       - zlib-dev
-
 pipeline:
   - uses: fetch
     with:
@@ -82,7 +79,6 @@ pipeline:
     runs: |
       ln -s python3 "${{targets.destdir}}"/usr/bin/python
   - uses: strip
-
 subpackages:
   - name: "python3-doc"
     description: "python3 documentation"
@@ -92,7 +88,6 @@ subpackages:
     description: "python3 development headers"
     pipeline:
       - uses: split/dev
-
       # pyconfig.h is needed at runtime... ugh.
       - runs: |
           mkdir -p "${{targets.destdir}}"/usr/include/python3.11
@@ -100,3 +95,8 @@ subpackages:
     dependencies:
       runtime:
         - python3
+advisories:
+  CVE-2020-10735:
+    - timestamp: 2023-01-05T10:57:08.62425-05:00
+      status: fixed
+      fixed-version: 3.0.7-r0

--- a/redis.yaml
+++ b/redis.yaml
@@ -1,46 +1,57 @@
 # Generated from https://git.alpinelinux.org/aports/plain/main/redis/APKBUILD
 package:
-    name: redis
-    version: 7.0.7
-    epoch: 0
-    description: Advanced key-value store
-    target-architecture:
-        - all
-    copyright:
-        - paths:
-            - '*'
-          attestation: TODO
-          license: BSD-3-Clause
+  name: redis
+  version: 7.0.7
+  epoch: 0
+  description: Advanced key-value store
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+        - '*'
+      attestation: TODO
+      license: BSD-3-Clause
 secfixes:
-    7.0.7-r0:
-      - CVE-2022-0543
-      - CVE-2022-3734
-      - CVE-2022-3647
-
+  7.0.7-r0:
+    - CVE-2022-0543
+    - CVE-2022-3734
+    - CVE-2022-3647
 environment:
-    contents:
-        packages:
-            - busybox
-            - ca-certificates-bundle
-            - build-base
-            - automake
-            - autoconf
-            - linux-headers
-            - openssl-dev
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - linux-headers
+      - openssl-dev
 pipeline:
-    - uses: fetch
-      with:
-        expected-sha256: 8d327d7e887d1bb308fc37aaf717a0bf79f58129e3739069aaeeae88955ac586
-        uri: https://download.redis.io/releases/redis-${{package.version}}.tar.gz
-    - uses: patch
-      with:
-        patches: 0000-Disable-protected-mode.patch
-    - runs: |
-        export CFLAGS="$CFLAGS -DUSE_MALLOC_USABLE_SIZE"
-          make USE_JEMALLOC=no \
-          MALLOC=libc \
-          BUILD_TLS=yes \
-          all
-        make install PREFIX=/usr INSTALL_BIN="${{targets.destdir}}/usr/bin"
-
-    - uses: strip
+  - uses: fetch
+    with:
+      expected-sha256: 8d327d7e887d1bb308fc37aaf717a0bf79f58129e3739069aaeeae88955ac586
+      uri: https://download.redis.io/releases/redis-${{package.version}}.tar.gz
+  - uses: patch
+    with:
+      patches: 0000-Disable-protected-mode.patch
+  - runs: |
+      export CFLAGS="$CFLAGS -DUSE_MALLOC_USABLE_SIZE"
+        make USE_JEMALLOC=no \
+        MALLOC=libc \
+        BUILD_TLS=yes \
+        all
+      make install PREFIX=/usr INSTALL_BIN="${{targets.destdir}}/usr/bin"
+  - uses: strip
+advisories:
+  CVE-2022-0543:
+    - timestamp: 2023-01-05T10:57:08.624906-05:00
+      status: fixed
+      fixed-version: 7.0.7-r0
+  CVE-2022-3647:
+    - timestamp: 2023-01-05T10:57:08.625651-05:00
+      status: fixed
+      fixed-version: 7.0.7-r0
+  CVE-2022-3734:
+    - timestamp: 2023-01-05T10:57:08.625291-05:00
+      status: fixed
+      fixed-version: 7.0.7-r0

--- a/redis.yaml
+++ b/redis.yaml
@@ -44,14 +44,14 @@ pipeline:
   - uses: strip
 advisories:
   CVE-2022-0543:
-    - timestamp: 2023-01-05T10:57:08.624906-05:00
+    - timestamp: 2022-12-24T13:35:15-05:00
       status: fixed
       fixed-version: 7.0.7-r0
   CVE-2022-3647:
-    - timestamp: 2023-01-05T10:57:08.625651-05:00
+    - timestamp: 2022-12-24T13:35:15-05:00
       status: fixed
       fixed-version: 7.0.7-r0
   CVE-2022-3734:
-    - timestamp: 2023-01-05T10:57:08.625291-05:00
+    - timestamp: 2022-12-24T13:35:15-05:00
       status: fixed
       fixed-version: 7.0.7-r0

--- a/samurai.yaml
+++ b/samurai.yaml
@@ -50,10 +50,10 @@ subpackages:
       - uses: split/infodir
 advisories:
   CVE-2021-30218:
-    - timestamp: 2023-01-05T10:57:08.626037-05:00
+    - timestamp: 2022-09-19T06:57:25+00:00
       status: fixed
       fixed-version: 1.2-r0
   CVE-2021-30219:
-    - timestamp: 2023-01-05T10:57:08.627495-05:00
+    - timestamp: 2022-09-19T06:57:25+00:00
       status: fixed
       fixed-version: 1.2-r0

--- a/samurai.yaml
+++ b/samurai.yaml
@@ -7,18 +7,16 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: Apache-2.0
   dependencies:
     provides:
       - ninja=1.9.0
-
 secfixes:
   1.2-r0:
     - CVE-2021-30218
     - CVE-2021-30219
-
 environment:
   contents:
     packages:
@@ -26,7 +24,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - build-base
-
 pipeline:
   - uses: fetch
     with:
@@ -45,10 +42,18 @@ pipeline:
   - uses: strip
   - runs: |
       ln -s samu "${{targets.destdir}}"/usr/bin/ninja
-
 subpackages:
   - name: "samurai-doc"
     description: "samurai documentation"
     pipeline:
       - uses: split/manpages
       - uses: split/infodir
+advisories:
+  CVE-2021-30218:
+    - timestamp: 2023-01-05T10:57:08.626037-05:00
+      status: fixed
+      fixed-version: 1.2-r0
+  CVE-2021-30219:
+    - timestamp: 2023-01-05T10:57:08.627495-05:00
+      status: fixed
+      fixed-version: 1.2-r0

--- a/sqlite.yaml
+++ b/sqlite.yaml
@@ -83,6 +83,6 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib "${{targets.subpkgdir}}"/usr/
 advisories:
   CVE-2022-46908:
-    - timestamp: 2023-01-05T10:57:08.627974-05:00
+    - timestamp: 2022-12-14T10:26:25+00:00
       status: fixed
       fixed-version: 3.40.0-r1

--- a/sqlite.yaml
+++ b/sqlite.yaml
@@ -23,17 +23,14 @@ environment:
       - ca-certificates-bundle
       - build-base
       - readline
-
 secfixes:
   3.40.0-r1:
     - CVE-2022-46908
-
 pipeline:
   - uses: fetch
     with:
       uri: https://www.sqlite.org/2022/sqlite-autoconf-3400000.tar.gz
       expected-sha256: 0333552076d2700c75352256e91c78bf5cd62491589ba0c69aed0a81868980e7
-
   - name: Configure
     runs: |
       _amalgamation="-DSQLITE_ENABLE_FTS4 \
@@ -84,3 +81,8 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr
           mv "${{targets.destdir}}"/usr/lib "${{targets.subpkgdir}}"/usr/
+advisories:
+  CVE-2022-46908:
+    - timestamp: 2023-01-05T10:57:08.627974-05:00
+      status: fixed
+      fixed-version: 3.40.0-r1

--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -52,14 +52,13 @@ pipeline:
   - uses: autoconf/make-install
 
   - runs: |
-      
       # Move to /bin to overwrite busybox's version.
       mv ${{targets.destdir}}/usr/bin/getopt \
         ${{targets.destdir}}/usr/bin/rev ${{targets.destdir}}/bin
 
 data:
   - name: libs
-    items: 
+    items:
       libblkid: Block device identification library from util-linux
       libfdisk: Partitioning library for fdisk-like programs
       libmount: Block device identification library from util-linux
@@ -67,7 +66,7 @@ data:
       libuuid: DCE compatible Universally Unique Identifier library
 
   - name: bins
-    items: 
+    items:
       agetty: agetty program from util-linux
       blkid: Block device identification tool from util-linux
       cfdisk: Curses based partition table manipulator from util-linux
@@ -118,10 +117,10 @@ subpackages:
           for i in usr/bin usr/sbin bin sbin; do
             if [ -e ${{targets.destdir}}/$i/${{range.key}} ]; then
               mkdir -p ${{targets.subpkgdir}}/$i
-              mv ${{targets.destdir}}/$i/${{range.key}} ${{targets.subpkgdir}}/$i/${{range.key}}              
+              mv ${{targets.destdir}}/$i/${{range.key}} ${{targets.subpkgdir}}/$i/${{range.key}}
             fi
           done
-    
+
   - name: util-linux-login
     description: Login utils from util-linux package newgrp last lastb login lslogins nologin su sulogin
     dependencies:
@@ -138,7 +137,7 @@ subpackages:
           for cmd in newgrp last lastb login lslogins nologin su sulogin; do
             for dir in bin sbin usr/bin usr/sbin; do
               if [ -e $dir/$cmd ] || [ -L $dir/$cmd ]; then
-                pwd 
+                pwd
                 ls -al
                 mkdir -p ${{targets.subpkgdir}}/$dir
                 mv $dir/$cmd ${{targets.subpkgdir}}/$dir/

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -56,10 +56,10 @@ subpackages:
         - zlib
 advisories:
   CVE-2018-25032:
-    - timestamp: 2023-01-05T10:57:08.628823-05:00
+    - timestamp: 2022-10-11T12:16:06+01:00
       status: fixed
       fixed-version: 1.2.12-r0
   CVE-2022-37434:
-    - timestamp: 2023-01-05T10:57:08.628433-05:00
+    - timestamp: 2022-10-11T12:16:06+01:00
       status: fixed
       fixed-version: 1.2.12-r3

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -7,18 +7,16 @@ package:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: MPL-2.0 AND MIT
   dependencies:
     runtime:
-
 secfixes:
   1.2.12-r3:
     - CVE-2022-37434
   1.2.12-r0:
     - CVE-2018-25032
-
 environment:
   contents:
     repositories:
@@ -30,7 +28,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - build-base
-
 pipeline:
   - uses: fetch
     with:
@@ -45,13 +42,11 @@ pipeline:
   - runs: |
       make install pkgconfigdir="/usr/lib/pkgconfig" DESTDIR="${{targets.destdir}}"
   - uses: strip
-
 subpackages:
   - name: "zlib-static"
     description: "zlib static library"
     pipeline:
       - uses: split/static
-
   - name: "zlib-dev"
     description: "zlib development headers"
     pipeline:
@@ -59,3 +54,12 @@ subpackages:
     dependencies:
       runtime:
         - zlib
+advisories:
+  CVE-2018-25032:
+    - timestamp: 2023-01-05T10:57:08.628823-05:00
+      status: fixed
+      fixed-version: 1.2.12-r0
+  CVE-2022-37434:
+    - timestamp: 2023-01-05T10:57:08.628433-05:00
+      status: fixed
+      fixed-version: 1.2.12-r3


### PR DESCRIPTION
This PR adds our initial advisory data (needed for VEX) to the Wolfi distro. In particular, this:

1. Fixes various whitespace mistakes in the YAML files so that the YAML can be re-encoded without any goofiness
2. Adds a new lint check in CI to ensure that there is advisory data for all secfixes data, and vice versa
3. Runs `wolfictl advisory sync-secfixes` to populate advisory data using existing secfixes data
4. Adjusts this particular advisory timestamp data to match the `git blame` data for existing secfixes entries
5. Encodes the correct `justification` and `impact_statement` data via researching previously `nak`-ed vulnerabilities
6. Updates our `HOW_TO_PATCH_CVES.md` based on the new advisory system and `wolfictl advisory` commands