### PR TITLE
rust: drop dependency on rust-stage0

### DIFF
--- a/go.yaml
+++ b/go.yaml
@@ -28,6 +28,10 @@ environment:
       - build-base
       - bash
       - go
+      # During bootstrapping, this must depend on go-stage0, which builds a Go
+      # package using a prebuilt Go toolchain provided by the Go team.
+      # After bootstrapping, go can depend on a previously built Go toolchain.
+      # - go-stage0
 pipeline:
   - uses: fetch
     with:

--- a/rust.yaml
+++ b/rust.yaml
@@ -34,11 +34,15 @@ environment:
       - clang-15
       - openssl-dev
       - python3
-      - rust-stage0
       - wasi-libc
       - xz-dev
       - zlib-dev
       - patch
+      - rust
+      # During bootstrapping, this must depend on rust-stage0, which builds a Rust
+      # package using a prebuilt Rust toolchain provided by the Rust team.
+      # After bootstrapping, rust can depend on a previously built Rust toolchain.
+      # - rust-stage0
 
 pipeline:
   - uses: fetch


### PR DESCRIPTION
This had worked because `go` was already built and available in Wolfi's packages.

We might want to keep `go` building using previous `go`s instead of `go-stage0`, in which case we should document this decision and its implications, and make `rust` consistent with that too.

Signed-off-by: Jason Hall <jason@chainguard.dev>