### PR TITLE
Remove pinned version of sdk image

### DIFF
--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -127,8 +127,7 @@ jobs:
             --bucket=${BUCKET} \
             --src-bucket=${SRC_BUCKET} \
             --secret-key \
-            --arch=arm64 \
-            --sdk-image="cgr.dev/chainguard/sdk@sha256:cba91e91f91ad11c65e4a4951792cf443a67bbe0699b3f6a7f10e4f7b547219c"
+            --arch=arm64
 
   teardown-cluster:
     name: Teardown build cluster

--- a/.github/workflows/dag-push-staging.yaml
+++ b/.github/workflows/dag-push-staging.yaml
@@ -127,8 +127,7 @@ jobs:
             --bucket=${BUCKET} \
             --src-bucket=${SRC_BUCKET} \
             --secret-key \
-            --arch=arm64 \
-            --sdk-image="cgr.dev/chainguard/sdk@sha256:cba91e91f91ad11c65e4a4951792cf443a67bbe0699b3f6a7f10e4f7b547219c"
+            --arch=arm64
 
   teardown-cluster:
     name: Teardown build cluster


### PR DESCRIPTION
Once the sdk latest image is in a good state, safe to remove this pin