### PR TITLE
go-1.20: rename go-doc to avoid conflict

### DIFF
--- a/go-1.20.yaml
+++ b/go-1.20.yaml
@@ -69,7 +69,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "go-doc"
+  - name: "go-1.20-doc"
     description: "go documentation"
     pipeline:
       - runs: |


### PR DESCRIPTION
Without this change there are two packages named `go-doc` which `dag` chokes on.

We should probably make this an actual wolfi lint check too.

Signed-off-by: Jason Hall <jason@chainguard.dev>