### PR TITLE
Makefile: Specify wolfi namespace in purls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ MELANGE_OPTS += --pipeline-dir ${MELANGE_DIR}/pipelines
 MELANGE_OPTS += --arch ${ARCH}
 MELANGE_OPTS += --env-file build-${ARCH}.env
 MELANGE_OPTS += --cache-dir ${CACHE_DIR}
+MELANGE_OPTS += --namespace wolfi
 MELANGE_OPTS += ${MELANGE_EXTRA_OPTS}
 
 ifeq (${BUILDWORLD}, no)


### PR DESCRIPTION
This commit modifies the main makefile to pass the `wolfi` namespace to the melange invocation. This is required to identify our packages in the melange SBOMs as right now they have `unknown` in the namespace.

/cc @luhring @jdolitsky @imjasonh 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>