### PR TITLE
openldap: only build openldap-backend-all once

### DIFF
--- a/openldap.yaml
+++ b/openldap.yaml
@@ -309,8 +309,7 @@ subpackages:
 
     description: OpenLDAP ${{range.key}} overlay
 
-  - range: backends
-    name: openldap-backend-all
+  - name: openldap-backend-all
     dependencies:
       runtime:
         - openldap-back-asyncmeta


### PR DESCRIPTION
`dag svg` caught this because there were multiple packages named `openldap-backend-all`

I don't believe this requires an epoch bump because it's producing the same package contents, it's just running this subpackage once instead of N times for each backend in the range.