### PR TITLE
ci: run 'dag svg' to prevent duplicate package entries

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -40,3 +40,13 @@ jobs:
       - name: 'Build Wolfi'
         run: |
           make --debug MELANGE="sudo melange" MELANGE_DIR=/usr/share/melange MELANGE_EXTRA_OPTS="--keyring-append ${{ github.workspace }}/wolfi-signing.rsa.pub" REPO="${{ github.workspace }}/packages" -j1
+
+      - uses: actions/setup-go@v3
+      - name: 'Generate dependency svg'
+        run: |
+          git clone https://github.com/wolfi-dev/dag && cd dag && go install && cd -
+          dag svg
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dag.svg
+          path: dag.svg

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 packages/*
 local-melange.rsa*
+dag.svg


### PR DESCRIPTION
`dag`'s CI also makes sure that it can run `dag svg` on the wolfi-dev/os repo, so hopefully this isn't too noisy.

If we don't want to depend on `dag` for this I can also make it a part of `wolfictl lint`.

Signed-off-by: Jason Hall <jason@chainguard.dev>