### PR TITLE
ci(staging): create unique clusters for each dag run

### DIFF
--- a/.github/workflows/dag-push-staging.yaml
+++ b/.github/workflows/dag-push-staging.yaml
@@ -8,7 +8,6 @@ on:
 
 env:
   PROJECT: staging-images-183e
-  CLUSTER_NAME: tmp-cluster-staging
   CLUSTER_ZONE: us-central1-b
   SERVICE_ACCOUNT: staging-images-ci
   FQ_SERVICE_ACCOUNT: staging-images-ci@staging-images-183e.iam.gserviceaccount.com
@@ -19,12 +18,16 @@ jobs:
   setup-cluster:
     name: Setup build cluster
     runs-on: ubuntu-latest
+    outputs:
+      cluster-name: ${{ steps.cluster-name.outputs.cluster-name }}
 
     permissions:
       id-token: write
       contents: read
 
     steps:
+      - id: cluster-name
+          echo "cluster-name=tmp-cluster-staging-$(date +%s)" >> $GITHUB_OUTPUT
       - uses: google-github-actions/auth@v0
         with:
           workload_identity_provider: "projects/567187841907/locations/global/workloadIdentityPools/staging-shared-9bd2/providers/staging-shared-gha"
@@ -40,7 +43,7 @@ jobs:
       - name: Setup Build Cluster
         working-directory: ${{github.workspace}}/dag
         run: |
-          gcloud container clusters create "${CLUSTER_NAME}" \
+          gcloud container clusters create "${{ steps.cluster-name.outputs.cluster-name }}" \
             --enable-ip-alias \
             --network                       projects/staging-shared-7864/global/networks/staging-shared-a6474a3 \
             --subnetwork                    projects/staging-shared-7864/regions/us-central1/subnetworks/staging-shared-imgs-us-c1-209d340 \
@@ -57,7 +60,7 @@ jobs:
             --num-nodes       1
 
           gcloud container node-pools create arm-nodes \
-            --cluster         "${CLUSTER_NAME}" \
+            --cluster         "${{ steps.cluster-name.outputs.cluster-name }}" \
             --zone            "${CLUSTER_ZONE}" \
             --tags            "egress-inet" \
             --service-account "${FQ_SERVICE_ACCOUNT}" \
@@ -68,7 +71,7 @@ jobs:
         with:
           project: "${PROJECT}"
           location: "${CLUSTER_ZONE}"
-          cluster: "${CLUSTER_NAME}"
+          cluster: ${{ steps.cluster-name.outputs.cluster-name }}
 
       - working-directory: ${{github.workspace}}/dag
         run: ./scripts/setup-cluster.sh ${SERVICE_ACCOUNT}
@@ -111,7 +114,7 @@ jobs:
           project_id: ${{env.PROJECT}}
       - uses: 'google-github-actions/get-gke-credentials@v0'
         with:
-          cluster_name: ${{ env.CLUSTER_NAME }}
+          cluster_name: ${{ needs.setup-cluster.outputs.cluster-name }}
           location: ${{ env.CLUSTER_ZONE }}
       - run: gcloud auth configure-docker --quiet
 
@@ -149,7 +152,7 @@ jobs:
           project_id: ${{env.PROJECT}}
       - uses: 'google-github-actions/get-gke-credentials@v0'
         with:
-          cluster_name: ${{ env.CLUSTER_NAME }}
+          cluster_name: ${{ needs.setup-cluster.outputs.cluster-name }}
           location: ${{ env.CLUSTER_ZONE }}
 
       - name: Collect diagnostics
@@ -172,6 +175,6 @@ jobs:
       - name: Teardown Build Cluster
         if: always()
         run: |
-          gcloud container clusters delete "${CLUSTER_NAME}" \
+          gcloud container clusters delete "${{ needs.setup-cluster.outputs.cluster-name }}" \
             --zone "${CLUSTER_ZONE}" \
             --quiet


### PR DESCRIPTION
Instead of creating and destroying a cluster with a constant name `tmp-cluster-staging`, this will have us create clusters named like `tmp-cluster-staging-1673360663`, which means multiple builds can be ongoing at the same time.

There's a [quota of 100 clusters per zone](https://cloud.google.com/kubernetes-engine/quotas), but something would have to be going wrong to hit that.

Signed-off-by: Jason Hall <jason@chainguard.dev>