### PR TITLE
add build environment for armv7l

### DIFF
--- a/build-armv7l.env
+++ b/build-armv7l.env
@@ -1,0 +1,6 @@
+# We target the BCM2836 which is Cortex-A7 with the SIMD unit.
+export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv7-a+simd -mtune=cortex-a7 -Wp,-D_FORTIFY_SOURCE=3"
+export CPPFLAGS="$CFLAGS"
+export CXXFLAGS="$CFLAGS"
+export LDFLAGS="-Wl,--as-needed,-O1,--sort-common"
+export GOFLAGS="-buildmode=pie"


### PR DESCRIPTION
Packages are tuned for BCM2836 (CPU in raspberry pi 2), requiring NEON (which is on the rpi2 CPU).  Older armv7 CPUs are not compatible, but rare.