### PR TITLE
Add php-fpm subpackage

### DIFF
--- a/php.yaml
+++ b/php.yaml
@@ -40,7 +40,8 @@ pipeline:
         --with-curl \
         --with-openssl \
         --with-readline \
-        --with-zlib
+        --with-zlib \
+        --enable-fpm
 
   - uses: autoconf/make
   - uses: autoconf/make-install
@@ -63,3 +64,28 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/bin/phpdbg ${{targets.subpkgdir}}/usr/bin/
+  - name: php-fpm
+    description: PHP 8.2 FastCGI Process Manager (FPM)
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/sbin/php-fpm ${{targets.subpkgdir}}/usr/bin/
+          mkdir -p ${{targets.subpkgdir}}/etc/php-fpm.d 
+          mv ${{targets.destdir}}/etc/php-fpm.conf.default ${{targets.subpkgdir}}/etc/php-fpm.conf
+          sed -i 's/\/home\/build\/melange-out\/php//g' ${{targets.subpkgdir}}/etc/php-fpm.conf
+          mv ${{targets.destdir}}/etc/php-fpm.d/www.conf.default ${{targets.subpkgdir}}/etc/php-fpm.d/www.conf \
+          && { \
+          	echo '[global]'; \
+          	echo 'error_log = /proc/self/fd/2'; \
+            echo 'daemonize = no'; \
+          	echo; \
+          	echo '[www]'; \
+            echo 'listen = [::]:9000'; \
+          	echo 'access.log = /proc/self/fd/2'; \
+            echo; \
+          	echo 'clear_env = no'; \
+          	echo; \
+          	echo 'catch_workers_output = yes'; \
+            echo; \
+          	echo 'decorate_workers_output = no'; \
+          } | tee ${{targets.subpkgdir}}/etc/php-fpm.d/zz-apko.conf


### PR DESCRIPTION
This PR adds the `php-fpm` subpackage when building `php`. Attending package request #247 .

Tested with our Nginx image using Docker Compose and it works fine 👍🏼 