### PR TITLE
add janitor job to cleanup old k8s clusters

### DIFF
--- a/.github/workflows/janitor-clusters.yaml
+++ b/.github/workflows/janitor-clusters.yaml
@@ -1,0 +1,43 @@
+name: Janitor Clusters
+
+on:
+  schedule:
+    # At the end of every day
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  clean-cluster:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    strategy:
+      matrix:
+        project: ["prod-images-c6e5", "staging-images-183e"]
+        include:
+          - project: "prod-images-c6e5"
+            fq_service_account: prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com
+            workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
+          - project: "staging-images-183e"
+            fq_service_account: staging-images-ci@staging-images-183e.iam.gserviceaccount.com
+            workload_identity_provider: "projects/567187841907/locations/global/workloadIdentityPools/staging-shared-9bd2/providers/staging-shared-gha"
+
+    steps:
+      - uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
+        with:
+          workload_identity_provider: ${{ matrix.workload_identity_provider }}
+          service_account: ${{ matrix.fq_service_account }}
+
+      - uses: google-github-actions/setup-gcloud@d51b5346f85640ec2aa2fa057354d2b82c2fcbce # v1.0.1
+        with:
+          project_id: ${{ matrix.project }}
+
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - name: Clean up Clusters
+        working-directory: ./scripts
+        run: ./janitor-clusters.sh ${{ matrix.project }}
+        shell: bash

--- a/scripts/janitor-clusters.sh
+++ b/scripts/janitor-clusters.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+for clusters in $(
+  gcloud container clusters list --project="${1}" \
+    --format="csv[no-heading](name,createTime,zone)")
+do
+  IFS=',' read -r -a infoArray<<< "${clusters}"
+  NAME="${infoArray[0]}"
+  CREATE_TIME="${infoArray[1]}"
+  ZONE="${infoArray[2]}"
+  FORMATED_CREATE_TIME=$(date -u -d "${CREATE_TIME}" +"%Y-%m-%d")
+  echo "  NAME: ${NAME}"
+  echo "  CREATE_TIME: ${CREATE_TIME} / ${FORMATED_CREATE_TIME}"
+
+  YESTERDAY_DATE=$(date -I -d "yesterday")
+  if [[ ${FORMATED_CREATE_TIME} < ${YESTERDAY_DATE} ]]; then
+    echo "Cluster ${NAME}(${FORMATED_CREATE_TIME}) is older than ${YESTERDAY_DATE} will terminate"
+    gcloud container clusters delete "${NAME}" \
+    --zone "${ZONE}" \
+    --quiet
+  fi
+done


### PR DESCRIPTION
- add janitor job to cleanup old k8s clusters

Some clusters might be around due to any ci issues, so this will do a cleanup every day if the cluster is older than 1 day


to reduce costs :)