### PR TITLE
janitor old clusters more aggressively

### DIFF
--- a/.github/workflows/janitor-clusters.yaml
+++ b/.github/workflows/janitor-clusters.yaml
@@ -2,8 +2,7 @@ name: Janitor Clusters
 
 on:
   schedule:
-    # At the end of every day
-    - cron: "0 0 * * *"
+    - cron: "0 * * * *" # hourly
   workflow_dispatch:
 
 jobs:

--- a/scripts/janitor-clusters.sh
+++ b/scripts/janitor-clusters.sh
@@ -12,9 +12,9 @@ do
   echo "  NAME: ${NAME}"
   echo "  CREATE_TIME: ${CREATE_TIME} / ${FORMATED_CREATE_TIME}"
 
-  YESTERDAY_DATE=$(date -I -d "yesterday")
-  if [[ ${FORMATED_CREATE_TIME} < ${YESTERDAY_DATE} ]]; then
-    echo "Cluster ${NAME}(${FORMATED_CREATE_TIME}) is older than ${YESTERDAY_DATE} will terminate"
+  CUTOFF_DATE=$(date -I -d "7 hours ago")
+  if [[ ${FORMATED_CREATE_TIME} < ${CUTOFF_DATE} ]]; then
+    echo "Cluster ${NAME}(${FORMATED_CREATE_TIME}) is older than ${CUTOFF_DATE} will terminate"
     gcloud container clusters delete "${NAME}" \
     --zone "${ZONE}" \
     --quiet


### PR DESCRIPTION
Instead of janitoring clusters every day and deleting clusters >24 old, run every hour and delete clusters >7 hours old.

Since GitHub jobs are limited to 6 hours, any cluster older than that can be assumed to be dead.

I couldn't test this locally myself since `date -d` doesn't work on macOS, so please let me know if this is wrong.

Signed-off-by: Jason Hall <jason@chainguard.dev>