### PR TITLE
Adding pdo-mysql to PHP build to enable LEMP setups

### DIFF
--- a/php.yaml
+++ b/php.yaml
@@ -41,6 +41,7 @@ pipeline:
         --with-openssl \
         --with-readline \
         --with-zlib \
+        --with-pdo-mysql \
         --enable-fpm
 
   - uses: autoconf/make


### PR DESCRIPTION
This PR adds support to MySQL / MariaDB databases in order to enable LEMP setups.