### PR TITLE
Don't generate index when building packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ MELANGE_OPTS += --arch ${ARCH}
 MELANGE_OPTS += --env-file build-${ARCH}.env
 MELANGE_OPTS += --cache-dir ${CACHE_DIR}
 MELANGE_OPTS += --namespace wolfi
+MELANGE_OPTS += --generate-index false
 MELANGE_OPTS += ${MELANGE_EXTRA_OPTS}
 
 ifeq (${BUILDWORLD}, no)


### PR DESCRIPTION
When we build packages we publish them to the repo where infrastructure generates a signed APKINDEX into the repo. APKINDEXes generated by `melange build` are discarded, so let's just not generate them.

You can override this with `MELANGE_EXTRA_OPTS=--generate-index=true make ...`

Related to https://github.com/chainguard-dev/melange/issues/279

Signed-off-by: Jason Hall <jason@chainguard.dev>