### PR TITLE
build environ: ensure that full RELRO is always enabled in LDFLAGS

### DIFF
--- a/build-aarch64.env
+++ b/build-aarch64.env
@@ -2,5 +2,5 @@
 export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1 -Wp,-D_FORTIFY_SOURCE=3"
 export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-Wl,--as-needed,-O1,--sort-common"
+export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now"
 export GOFLAGS="-buildmode=pie"

--- a/build-armv7l.env
+++ b/build-armv7l.env
@@ -2,5 +2,5 @@
 export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv7-a+simd -mtune=cortex-a7 -Wp,-D_FORTIFY_SOURCE=3"
 export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-Wl,--as-needed,-O1,--sort-common"
+export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now"
 export GOFLAGS="-buildmode=pie"

--- a/build-x86_64.env
+++ b/build-x86_64.env
@@ -1,5 +1,5 @@
 export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -Wp,-D_FORTIFY_SOURCE=3"
 export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-Wl,--as-needed,-O1,--sort-common"
+export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now"
 export GOFLAGS="-buildmode=pie"


### PR DESCRIPTION
noticed while investigating #556, though ultimately unrelated

Signed-off-by: Ariadne Conill <ariadne@dereferenced.org>