### PR TITLE
Add a missing advisory entry for CVE-2022-31630.

### DIFF
--- a/php.yaml
+++ b/php.yaml
@@ -90,3 +90,13 @@ subpackages:
             echo; \
           	echo 'decorate_workers_output = no'; \
           } | tee ${{targets.subpkgdir}}/etc/php-fpm.d/zz-apko.conf
+
+advisories:
+  CVE-2022-31630:
+    - timestamp: 2023-02-11T20:12:25.988296-05:00
+      status: fixed
+      fixed-version: 8.1.13-r0
+
+secfixes:
+  8.1.13-r0:
+    - CVE-2022-31630


### PR DESCRIPTION
This was fixed upstream here: https://github.com/php/php-src/commit/d50532be91f054ef9beb1afca2ea94f4a70f7c4d

I manually confirmed that the first release containing that fix was 8.1.13, which does not actually match the NVD - it says "Up to (excluding) 8.1.12".

I did this by cloning the repo locally and running 'git branch -a --contains d50532be91f054ef9beb1afca2ea94f4a70f7c4d' and looking through the branch output.

8.1.13 also happens to be the first version we packaged, so we've never been vulnerable to this: https://github.com/wolfi-dev/os/commit/9045c1944a8f951a1bdc2ab996d7caf705b1ecc7

Signed-off-by: Dan Lorenc <dlorenc@chainguard.dev>