### PR TITLE
Fix mariadb formatting.

### DIFF
--- a/mariadb.yaml
+++ b/mariadb.yaml
@@ -113,7 +113,37 @@ pipeline:
     runs: |
       DESTDIR="${{targets.destdir}}" ninja install
   - name: "Remove extras"
-    runs: "rm -rf \"${{targets.destdir}}\"/usr/local/mysql/sql-bench/\nrm -rf \"${{targets.destdir}}\"/usr/local/mysql/mysql-test/\n\nrm -rf \"${{targets.destdir}}\"/usr/bin/mariadb_config \nrm -rf \"${{targets.destdir}}\"/usr/bin/mysql_config \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/errmsg.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/ma_list.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/ma_pvio.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/ma_tls.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/mariadb/ma_io.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/mariadb_com.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/mariadb_ctype.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/mariadb_dyncol.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/mariadb_stmt.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/mariadb_version.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/mysql.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/mysql/client_plugin.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/mysql/plugin_auth.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/mysql/plugin_auth_common.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/mysql_version.h \nrm -rf \"${{targets.destdir}}\"/usr/include/mysql/mysqld_error.h \nrm -rf \"${{targets.destdir}}\"/usr/lib/${{package.name}}/plugin/dialog.so \nrm -rf \"${{targets.destdir}}\"/usr/lib/${{package.name}}/plugin/mysql_clear_password.so \nrm -rf \"${{targets.destdir}}\"/usr/lib/${{package.name}}/plugin/sha256_password.so \nrm -rf \"${{targets.destdir}}\"/usr/lib/${{package.name}}/plugin/caching_sha2_password.so \nrm -rf \"${{targets.destdir}}\"/usr/lib/${{package.name}}/plugin/client_ed25519.so \nrm -rf \"${{targets.destdir}}\"/usr/lib/libmysqlclient.so \nrm -rf \"${{targets.destdir}}\"/usr/lib/libmysqlclient_r.so \nrm -rf \"${{targets.destdir}}\"/usr/lib/libmariadb.so* \nrm -rf \"${{targets.destdir}}\"/usr/lib/pkgconfig/libmariadb.pc\n"
+    runs: |
+      rm -rf "${{targets.destdir}}"/usr/local/mysql/sql-bench/
+      rm -rf "${{targets.destdir}}"/usr/local/mysql/mysql-test/
+  
+      rm -rf "${{targets.destdir}}"/usr/bin/mariadb_config 
+      rm -rf "${{targets.destdir}}"/usr/bin/mysql_config 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/errmsg.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/ma_list.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/ma_pvio.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/ma_tls.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/mariadb/ma_io.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/mariadb_com.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/mariadb_ctype.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/mariadb_dyncol.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/mariadb_stmt.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/mariadb_version.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/mysql.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/mysql/client_plugin.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/mysql/plugin_auth.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/mysql/plugin_auth_common.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/mysql_version.h 
+      rm -rf "${{targets.destdir}}"/usr/include/mysql/mysqld_error.h 
+      rm -rf "${{targets.destdir}}"/usr/lib/${{package.name}}/plugin/dialog.so 
+      rm -rf "${{targets.destdir}}"/usr/lib/${{package.name}}/plugin/mysql_clear_password.so 
+      rm -rf "${{targets.destdir}}"/usr/lib/${{package.name}}/plugin/sha256_password.so 
+      rm -rf "${{targets.destdir}}"/usr/lib/${{package.name}}/plugin/caching_sha2_password.so 
+      rm -rf "${{targets.destdir}}"/usr/lib/${{package.name}}/plugin/client_ed25519.so 
+      rm -rf "${{targets.destdir}}"/usr/lib/libmysqlclient.so 
+      rm -rf "${{targets.destdir}}"/usr/lib/libmysqlclient_r.so 
+      rm -rf "${{targets.destdir}}"/usr/lib/libmariadb.so* 
+      rm -rf "${{targets.destdir}}"/usr/lib/pkgconfig/libmariadb.pc
 
 subpackages:
   - name: "mariadb-dev"
@@ -125,36 +155,36 @@ subpackages:
         - mariadb
   - name: "mariadb-doc"
     pipeline:
-      - uses: split/manpages
+    - uses: split/manpages
   - name: "mariadb-test"
     pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/mysql_client_test \
-            "${{targets.destdir}}"/usr/bin/mysql_client_test_embedded \
-            "${{targets.destdir}}"/usr/bin/mariadb-client-test \
-            "${{targets.destdir}}"/usr/bin/mariadb-client-test-embedded \
-            "${{targets.destdir}}"/usr/bin/mariadb-test \
-            "${{targets.destdir}}"/usr/bin/mariadb-test-embedded \
-            "${{targets.destdir}}"/usr/bin/mysqltest \
-            "${{targets.destdir}}"/usr/bin/mysqltest_embedded \
-            "${{targets.subpkgdir}}"/usr/bin/
+    - runs: |
+        mkdir -p "${{targets.subpkgdir}}"/usr/bin
+        mv "${{targets.destdir}}"/usr/bin/mysql_client_test \
+          "${{targets.destdir}}"/usr/bin/mysql_client_test_embedded \
+          "${{targets.destdir}}"/usr/bin/mariadb-client-test \
+          "${{targets.destdir}}"/usr/bin/mariadb-client-test-embedded \
+          "${{targets.destdir}}"/usr/bin/mariadb-test \
+          "${{targets.destdir}}"/usr/bin/mariadb-test-embedded \
+          "${{targets.destdir}}"/usr/bin/mysqltest \
+          "${{targets.destdir}}"/usr/bin/mysqltest_embedded \
+          "${{targets.subpkgdir}}"/usr/bin/
 
-          mv "${{targets.destdir}}"/usr/mysql-test \
-            "${{targets.subpkgdir}}"/usr/
+        mv "${{targets.destdir}}"/usr/mysql-test \
+          "${{targets.subpkgdir}}"/usr/
   - name: "mariadb-bench"
     pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/share/
-          mv "${{targets.destdir}}"/usr/sql-bench "${{targets.subpkgdir}}"/usr/share
+    - runs: |
+        mkdir -p "${{targets.subpkgdir}}"/usr/share/
+        mv "${{targets.destdir}}"/usr/sql-bench "${{targets.subpkgdir}}"/usr/share
   - name: "mariadb-backup"
     pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/mariabackup \
-            "${{targets.destdir}}"/usr/bin/mariadb-backup \
-            "${{targets.destdir}}"/usr/bin/mbstream \
-            "${{targets.subpkgdir}}"/usr/bin/
+    - runs: |
+        mkdir -p "${{targets.subpkgdir}}"/usr/bin
+        mv "${{targets.destdir}}"/usr/bin/mariabackup \
+          "${{targets.destdir}}"/usr/bin/mariadb-backup \
+          "${{targets.destdir}}"/usr/bin/mbstream \
+          "${{targets.subpkgdir}}"/usr/bin/
   - name: mariadb-oci-entrypoint
     description: Entrypoint for using HAProxy in OCI containers
     dependencies:


### PR DESCRIPTION
The wolfictl advisory command switched one of the multiline commands to a single-line string.

Signed-off-by: Dan Lorenc <dlorenc@chainguard.dev>