### PR TITLE
Note advisories for git

### DIFF
--- a/git.yaml
+++ b/git.yaml
@@ -10,13 +10,18 @@ package:
         - "*"
       attestation: TODO
       license: GPL-2.0-or-later
+
 secfixes:
-  2.39.1-r0:
-    - CVE-2022-23521
-    - CVE-2022-41903
   2.38.1-r0:
     - CVE-2022-39253
     - CVE-2022-39260
+  2.39.1-r0:
+    - CVE-2022-23521
+    - CVE-2022-41903
+  2.39.2-r0:
+    - CVE-2023-22490
+    - CVE-2023-23946
+
 environment:
   contents:
     packages:
@@ -29,6 +34,7 @@ environment:
       - openssl-dev
       - pcre2-dev
       - zlib-dev
+
 pipeline:
   - uses: fetch
     with:
@@ -56,6 +62,7 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/var/git
   - uses: strip
+
 subpackages:
   - name: "git-daemon"
     description: "Git protocol daemon"
@@ -90,6 +97,7 @@ subpackages:
           mv  "${{targets.destdir}}"/usr/libexec/git-core/*p4* "${{targets.subpkgdir}}"/usr/libexec/git-core/
           mv  "${{targets.destdir}}"/usr/libexec/git-core/mergetools/*p4* \
             "${{targets.subpkgdir}}"/usr/libexec/git-core/mergetools/
+
 advisories:
   CVE-2022-23521:
     - timestamp: 2023-01-17T17:17:24.622307-05:00
@@ -107,3 +115,11 @@ advisories:
     - timestamp: 2023-01-17T17:17:24.623244-05:00
       status: fixed
       fixed-version: 2.39.1-r0
+  CVE-2023-22490:
+    - timestamp: 2023-02-15T16:48:32.355662-05:00
+      status: fixed
+      fixed-version: 2.39.2-r0
+  CVE-2023-23946:
+    - timestamp: 2023-02-15T16:48:52.217204-05:00
+      status: fixed
+      fixed-version: 2.39.2-r0


### PR DESCRIPTION
Re: https://github.blog/2023-02-14-git-security-vulnerabilities-announced-3/ (we were already up-to-date)

Ran these commands:

```
wolfictl advisory create ./git.yaml --fixed-version 2.39.2-r0 --status fixed --sync --vuln CVE-2023-22490
wolfictl advisory create ./git.yaml --fixed-version 2.39.2-r0 --status fixed --sync --vuln CVE-2023-23946
```