### PR TITLE
Note advisories for PHP

### DIFF
--- a/php.yaml
+++ b/php.yaml
@@ -13,6 +13,7 @@ package:
   dependencies:
     runtime:
       - libxml2
+
 environment:
   contents:
     packages:
@@ -25,6 +26,7 @@ environment:
       - openssl-dev
       - readline-dev
       - sqlite-dev
+
 pipeline:
   - uses: fetch
     with:
@@ -44,6 +46,7 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
+
 subpackages:
   - name: php-dev
     description: PHP 8.2 development headers
@@ -86,11 +89,29 @@ subpackages:
             echo; \
           	echo 'decorate_workers_output = no'; \
           } | tee ${{targets.subpkgdir}}/etc/php-fpm.d/zz-apko.conf
+
 advisories:
+  CVE-2007-2728:
+    - timestamp: 2023-02-16T11:01:48.943749-05:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+  CVE-2007-3205:
+    - timestamp: 2023-02-16T11:01:59.241092-05:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+  CVE-2007-4596:
+    - timestamp: 2023-02-16T11:02:05.863326-05:00
+      status: not_affected
+      justification: vulnerable_code_not_present
   CVE-2022-31630:
     - timestamp: 2023-02-11T20:12:25.988296-05:00
       status: fixed
       fixed-version: 8.1.13-r0
+
 secfixes:
+  "0":
+    - CVE-2007-2728
+    - CVE-2007-3205
+    - CVE-2007-4596
   8.1.13-r0:
     - CVE-2022-31630


### PR DESCRIPTION
NAKing outdated CVE entries for PHP

Ran commands:

```
wolfictl advisory create ./php.yaml --status not_affected --justification vulnerable_code_not_present --sync --vuln CVE-2007-2728
wolfictl advisory create ./php.yaml --status not_affected --justification vulnerable_code_not_present --sync --vuln CVE-2007-3205
wolfictl advisory create ./php.yaml --status not_affected --justification vulnerable_code_not_present --sync --vuln CVE-2007-4596
```