### PR TITLE
attempt to fix the janitor 2

### DIFF
--- a/.github/workflows/janitor-clusters.yaml
+++ b/.github/workflows/janitor-clusters.yaml
@@ -35,17 +35,13 @@ jobs:
           project_id: ${{ matrix.project }}
 
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-
-      - name: Clean up Clusters
-        working-directory: ./scripts
-        run: ./janitor-clusters.sh ${{ matrix.project }}
-        shell: bash
+      - run: ./scripts/janitor-clusters.sh ${{ matrix.project }}
 
       # Notify on failures
       - uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
         if: failure()
         with:
-          payload: '{"text": "[dag-push-production] failure: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
+          payload: '{"text": "[janitor] failure: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Theory is the auth action creates a creds file in the root of the workspace, so `working-dir` messes that up.

It [failed again](https://github.com/wolfi-dev/os/actions/runs/4213625135/jobs/7313451505) after [the last attempt](https://github.com/wolfi-dev/os/pull/611) and didn't notify Slack...