### PR TITLE
fix janitor part 3: return of the janitor

### DIFF
--- a/.github/workflows/janitor-clusters.yaml
+++ b/.github/workflows/janitor-clusters.yaml
@@ -26,6 +26,7 @@ jobs:
             workload_identity_provider: "projects/567187841907/locations/global/workloadIdentityPools/staging-shared-9bd2/providers/staging-shared-gha"
 
     steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: google-github-actions/auth@v0
         with:
           workload_identity_provider: ${{ matrix.workload_identity_provider }}
@@ -34,7 +35,6 @@ jobs:
         with:
           project_id: ${{ matrix.project }}
 
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - run: ./scripts/janitor-clusters.sh ${{ matrix.project }}
 
       # Notify on failures


### PR DESCRIPTION
Since the repo wasn't checked out, it seems the auth workflow didn't actually persist the creds file:

```
Warning: The "create_credentials_file" option is true, but the current GitHub workspace is empty. Did you forget to use "actions/checkout" before this step? If you do not intend to share authentication with future steps in this job, set "create_credentials_file" to false.
```

Move `checkout` first to hopefully fix this.