### PR TITLE
Mark CVE-2016-2102 as invalid in haproxy.

### DIFF
--- a/haproxy.yaml
+++ b/haproxy.yaml
@@ -15,6 +15,8 @@ package:
       - libgcc
 
 secfixes:
+  "0":
+    - CVE-2016-2102
   2.6.9-r0:
     - CVE-2023-25725
 
@@ -72,6 +74,14 @@ subpackages:
           chmod +x ${{targets.subpkgdir}}/usr/local/bin/docker-entrypoint.sh
 
 advisories:
+  CVE-2016-2102:
+    - timestamp: 2023-02-20T14:35:07.391236-05:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      fixed-version: "0"
+    - timestamp: 2023-02-20T15:12:46.092387-05:00
+      status: not_affected
+      justification: vulnerable_code_not_in_execute_path
   CVE-2023-25725:
     - timestamp: 2023-02-15T16:12:20.024784027+07:00
       status: fixed


### PR DESCRIPTION
This vulnerability was actually present in openstack, not haproxy. The CPE appears to be incorrect, but the description indicates another program left haproxy available externally.