### PR TITLE
Mark CVE-2022-35977 as fixed in Redis 7.0.8.

### DIFF
--- a/redis.yaml
+++ b/redis.yaml
@@ -11,11 +11,15 @@ package:
         - '*'
       attestation: TODO
       license: BSD-3-Clause
+
 secfixes:
   7.0.7-r0:
     - CVE-2022-0543
     - CVE-2022-3734
     - CVE-2022-3647
+  7.0.8-r0:
+    - CVE-2022-35977
+
 environment:
   contents:
     packages:
@@ -26,6 +30,7 @@ environment:
       - autoconf
       - linux-headers
       - openssl-dev
+
 pipeline:
   - uses: fetch
     with:
@@ -42,6 +47,7 @@ pipeline:
         all
       make install PREFIX=/usr INSTALL_BIN="${{targets.destdir}}/usr/bin"
   - uses: strip
+
 advisories:
   CVE-2022-0543:
     - timestamp: 2022-12-24T13:35:15-05:00
@@ -55,3 +61,7 @@ advisories:
     - timestamp: 2022-12-24T13:35:15-05:00
       status: fixed
       fixed-version: 7.0.7-r0
+  CVE-2022-35977:
+    - timestamp: 2023-02-20T14:37:55.058122-05:00
+      status: fixed
+      fixed-version: 7.0.8-r0


### PR DESCRIPTION
I confirmed in the release notes that this was fixed in the release of Redis we already have, so marking it as fixed there.

https://github.com/redis/redis/releases/tag/7.0.8