### PR TITLE
Add upstream support policy for package versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-wolfi-package-request.yml
+++ b/.github/ISSUE_TEMPLATE/new-wolfi-package-request.yml
@@ -30,5 +30,6 @@ body:
       description: Additional questions to answer
       options:
         - label: This package has an un-restrictive license
-        - label: I am interested in adding this package to Wolfi OS myself.
-        - label: I am willing to help maintain this package.
+        - label: The package/versions proposed are actively maintained upstream
+        - label: I am interested in adding this package to Wolfi OS myself
+        - label: I am willing to help maintain this package

--- a/README.md
+++ b/README.md
@@ -28,4 +28,7 @@ Wolfi is not currently intended to be a general purpose desktop operating system
 that enable containerized and embedded system workflows. Please keep this in mind when proposing adding packages to
 Wolfi. Also note that some packages may not be appropriately licensed for inclusion.  FSF or OSI approved [licenses](https://spdx.org/licenses/) are ideal.
 
+Wolfi also aims to keep its package set as up-to-date with security patches as possible. It is a requirement that any 
+package/version contributed to Wolfi has an actively maintained upstream. 
+
 To request inclusion of a package into Wolfi please use our [New Package Request Template](https://wolfi.dev/os/issues/new/choose).


### PR DESCRIPTION
Adding readme and issue template wording to clarify our package/versions policy as requiring upstream support. 