### PR TITLE
withdraw go-1.20-1.20rc1-r{0,1} packages

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -24,3 +24,7 @@ nghttp2-doc-1.52.0-r0.apk
 libnghttp2-14-1.52.0-r0.apk
 rabbitmq-server-3.11.9-r0.apk
 rabbitmq-server-doc-3.11.9-r0.apk
+go-1.20-1.20rc1-r0.apk
+go-1.20-doc-1.20rc1-r0.apk
+go-1.20-1.20rc1-r1.apk
+go-1.20-doc-1.20rc1-r1.apk


### PR DESCRIPTION
They were created with invalid versions.