### PR TITLE
Mitigate the x/net and x/text GHSA's in gomplate and dex.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -419,8 +419,8 @@ $(eval $(call build-package,gnutar,1.34-r0))
 $(eval $(call build-package,dpkg,1.20.12-r0))
 $(eval $(call build-package,calicoctl,3.25.0-r0))
 $(eval $(call build-package,container-entrypoint,0.1.0-r0))
-$(eval $(call build-package,gomplate,3.11.3-r0))
-$(eval $(call build-package,dex,2.35.3-r0))
+$(eval $(call build-package,gomplate,3.11.3-r1))
+$(eval $(call build-package,dex,2.35.3-r1))
 
 .build-packages: ${PACKAGES}
 

--- a/dex.yaml
+++ b/dex.yaml
@@ -1,7 +1,8 @@
 package:
   name: dex
+  # When bumping the version check if the GHSA mitigations below can be removed.
   version: 2.35.3
-  epoch: 0
+  epoch: 1
   description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors
   target-architecture:
     - all
@@ -25,6 +26,19 @@ pipeline:
       repository: https://github.com/dexidp/dex
       branch: v${{package.version}}
   - runs: |
+      # Mitigate GHSA-vvpx-j8f3-3w6h and GHSA-69ch-w2m2-3vjp
+      go get golang.org/x/text@v0.3.8
+      go get golang.org/x/net@v0.7.0
+      go mod tidy
+
+      cd api/v2
+      go get golang.org/x/text@v0.3.8
+      go get golang.org/x/net@v0.7.0
+      go mod tidy -compat=1.17
+      cd ../../
+
+      go mod tidy
+
       make release-binary
       mkdir -p ${{targets.destdir}}/usr/bin/
       mkdir -p ${{targets.destdir}}/srv/dex/

--- a/gomplate.yaml
+++ b/gomplate.yaml
@@ -1,7 +1,8 @@
 package:
   name: gomplate
+  # When bumping the version check if the GHSA mitigations below can be removed.
   version: 3.11.3
-  epoch: 0
+  epoch: 1
   description: A go templating utility.
   target-architecture:
     - all
@@ -26,6 +27,12 @@ pipeline:
       branch: v${{package.version}}
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
+      
+      # Mitigate GHSA-vvpx-j8f3-3w6h and GHSA-69ch-w2m2-3vjp
+      go get golang.org/x/text@v0.3.8
+      go get golang.org/x/net@v0.7.0
+      go mod tidy
+
       go build -o ${{targets.destdir}}/usr/bin \
         -ldflags "-w -s -X github.com/hairyhenderson/gomplate/v3/version.Version=${{package.version}} \
         -X github.com/hairyhenderson/gomplate/v3/version.GitCommit=$(git rev-parse --short HEAD)" \


### PR DESCRIPTION
This gives us a clean dex image! Both of these bumps were done upstream but they haven't been released yet.