### PR TITLE
Bump x/net in the prometheus-node-exporter package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -461,7 +461,7 @@ $(eval $(call build-package,wasmtime,6.0.0-r0))
 $(eval $(call build-package,poetry,1.3.2-r0))
 $(eval $(call build-package,zot,1.4.3-r0))
 $(eval $(call build-package,terraform,1.3.9-r0))
-$(eval $(call build-package,prometheus-node-exporter,1.5.0-r0))
+$(eval $(call build-package,prometheus-node-exporter,1.5.0-r1))
 
 .build-packages: ${PACKAGES}
 

--- a/prometheus-node-exporter.yaml
+++ b/prometheus-node-exporter.yaml
@@ -1,7 +1,8 @@
 package:
   name: prometheus-node-exporter
+  # When bumping this version you can remove the `go get` line in the build script
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: Prometheus Exporter for machine metrics
   target-architecture:
     - all
@@ -25,6 +26,9 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 1b48970ffcf5630534fb00bb0687d73c66d1c959
   - runs: |
+      # Mitigate GHSA-vvpx-j8f3-3w6h
+      go get golang.org/x/net@v0.7.0
+      go mod tidy
       make build
   - runs: |
       install -Dm755 node_exporter "${{targets.destdir}}"/usr/bin/node_exporter


### PR DESCRIPTION
I've verified that with this, the image in https://github.com/chainguard-images/images/pull/321 scans clean.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues. 
 -->

Fixes: 

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->

#### For new package PRs only

- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] The package is available under an OSI-approved or FSF-approved license
- [ ] The version of the package is still receiving security updates

#### For security-related PRs

- [ ] The security fix is recorded in `annotations` and `secfixes`

#### For version bump PRs

- [ ] The `epoch` field is reset to 0
