### PR TITLE
Mark CVE-2020-29509 and CVE-2020-29511 as fixed in our go versions.

### DIFF
--- a/go-1.19.yaml
+++ b/go-1.19.yaml
@@ -16,15 +16,17 @@ package:
     runtime:
       - build-base
       - bash
-      # Needed for cgo linking due to upstream issue #15696 which forces use
-      # of the gold linker.
-      - binutils-gold
+      - binutils-gold # Needed for cgo linking due to upstream issue #15696 which forces use of the gold linker.
+
 secfixes:
+  "0":
+    - CVE-2020-29509
   1.19.3-r0:
     - CVE-2022-41716
   1.19.4-r0:
     - CVE-2022-41717
     - CVE-2022-41720
+
 environment:
   contents:
     packages:
@@ -37,6 +39,7 @@ environment:
       # package using a prebuilt Go toolchain provided by the Go team.
       # After bootstrapping, go can depend on a previously built Go toolchain.
       # - go-stage0
+
 pipeline:
   - uses: fetch
     with:
@@ -78,6 +81,7 @@ pipeline:
       find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*.bat" \) \
         -exec rm -rf \{\} \+
   - uses: strip
+
 subpackages:
   - name: "go-1.19-doc"
     description: "go documentation"
@@ -85,16 +89,25 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
+
 advisories:
+  CVE-2020-29509:
+    - timestamp: 2023-03-04T20:01:40.664098-05:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      fixed-version: "0"
+    - timestamp: 2023-03-04T21:45:55.952053-05:00
+      status: not_affected
+      justification: vulnerable_code_not_in_execute_path
   CVE-2022-41716:
     - timestamp: 2022-11-01T13:39:29-04:00
       status: fixed
       fixed-version: 1.19.3-r0
   CVE-2022-41717:
-    - timestamp: 2022-12-07T08:11:39+00:00
+    - timestamp: 2022-12-07T08:11:39Z
       status: fixed
       fixed-version: 1.19.4-r0
   CVE-2022-41720:
-    - timestamp: 2022-12-07T08:11:39+00:00
+    - timestamp: 2022-12-07T08:11:39Z
       status: fixed
       fixed-version: 1.19.4-r0

--- a/go-1.20.yaml
+++ b/go-1.20.yaml
@@ -16,11 +16,12 @@ package:
     runtime:
       - build-base
       - bash
-      # Needed for cgo linking due to upstream issue #15696 which forces use
-      # of the gold linker.
-      - binutils-gold
+      - binutils-gold # Needed for cgo linking due to upstream issue #15696 which forces use of the gold linker.
 
 secfixes:
+  "0":
+    - CVE-2020-29509
+    - CVE-2020-29511
 
 environment:
   contents:
@@ -80,3 +81,21 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
+
+advisories:
+  CVE-2020-29509:
+    - timestamp: 2023-03-04T20:01:01.646638-05:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      fixed-version: "0"
+    - timestamp: 2023-03-04T20:01:14.615494-05:00
+      status: not_affected
+      justification: vulnerable_code_not_in_execute_path
+  CVE-2020-29511:
+    - timestamp: 2023-03-04T20:01:14.61372-05:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      fixed-version: "0"
+    - timestamp: 2023-03-04T21:45:58.722232-05:00
+      status: not_affected
+      justification: vulnerable_code_not_in_execute_path


### PR DESCRIPTION
I'm not actually sure if this will help, but grype is currently flagging these against our version of Go. The CVE data appears out of date, showing this unfixed in all Go versions.

However, a fix was merged for Go 1.17: https://github.com/golang/go/commit/4d014e723165f28b34458edb4aa9136e0fb4c702

Since grype is finding this with the "binary" scanner, there's a chance we might need VEX for this.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues. 
 -->

Fixes: 

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->

#### For new package PRs only

- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] The package is available under an OSI-approved or FSF-approved license
- [ ] The version of the package is still receiving security updates

#### For security-related PRs

- [ ] The security fix is recorded in `annotations` and `secfixes`

#### For version bump PRs

- [ ] The `epoch` field is reset to 0
