### PR TITLE
Add a Prometheus mysqld exporter package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -462,6 +462,7 @@ $(eval $(call build-package,poetry,1.3.2-r0))
 $(eval $(call build-package,zot,1.4.3-r0))
 $(eval $(call build-package,terraform,1.3.9-r0))
 $(eval $(call build-package,prometheus-node-exporter,1.5.0-r1))
+$(eval $(call build-package,prometheus-mysqld-exporter,0.14.0-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/prometheus-mysqld-exporter.yaml
+++ b/prometheus-mysqld-exporter.yaml
@@ -1,0 +1,35 @@
+package:
+  name: prometheus-mysqld-exporter
+  # When bumping this version you can remove the `go get` line in the build script
+  version: 0.14.0
+  epoch: 0
+  description: Prometheus Exporter for MySQL server metrics
+  target-architecture:
+    - all
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - bash
+      - build-base
+      - go
+      - curl
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/prometheus/mysqld_exporter
+      tag: v${{package.version}}
+      expected-commit: ca1b9af82a471c849c529eb8aadb1aac73e7b68c
+  - runs: |
+      # Mitigate GHSA-vvpx-j8f3-3w6h
+      go get golang.org/x/net@v0.7.0
+      go mod tidy
+      make build
+  - runs: |
+      install -Dm755 mysqld_exporter "${{targets.destdir}}"/usr/bin/mysqld_exporter
+  - uses: strip


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues. 
 -->

Fixes: 

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->

#### For new package PRs only

- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] The package is available under an OSI-approved or FSF-approved license
- [ ] The version of the package is still receiving security updates

#### For security-related PRs

- [ ] The security fix is recorded in `annotations` and `secfixes`

#### For version bump PRs

- [ ] The `epoch` field is reset to 0
