### PR TITLE
Add advisories for disputed glibc vulns

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -26,6 +26,11 @@ package:
         /sbin/ldconfig
 
 secfixes:
+  "0":
+    - CVE-2019-1010022
+    - CVE-2019-1010023
+    - CVE-2019-1010024
+    - CVE-2019-1010025
   2.36-r1:
     - CVE-2022-39046
   2.37-r1:
@@ -431,6 +436,26 @@ subpackages:
             && mv "${{targets.destdir}}"/usr/lib/locale/${{range.key}} "${{targets.subpkgdir}}"/usr/lib/locale/
 
 advisories:
+  CVE-2019-1010022:
+    - timestamp: 2023-03-06T08:22:06.931107-05:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: The CVE itself is disputed and should not be considered a security vulnerability.
+  CVE-2019-1010023:
+    - timestamp: 2023-03-06T08:22:06.962374-05:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: The CVE itself is disputed and should not be considered a security vulnerability.
+  CVE-2019-1010024:
+    - timestamp: 2023-03-06T08:22:06.99195-05:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: The CVE itself is disputed and should not be considered a security vulnerability.
+  CVE-2019-1010025:
+    - timestamp: 2023-03-06T08:22:07.02221-05:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: The CVE itself is disputed and should not be considered a security vulnerability.
   CVE-2022-39046:
     - timestamp: 2022-10-11T20:29:19Z
       status: fixed


### PR DESCRIPTION
Nacks disputed CVEs for `glibc`. Thanks to @westonsteimel for looking into these!

This diff is the result of running:

```shell
wolfictl advisory create ./glibc.yaml --sync --status 'not_affected' --justification 'vulnerable_code_not_present' --impact 'The CVE itself is disputed and should not be considered a security vulnerability.' --vuln 'CVE-2019-1010022';
wolfictl advisory create ./glibc.yaml --sync --status 'not_affected' --justification 'vulnerable_code_not_present' --impact 'The CVE itself is disputed and should not be considered a security vulnerability.' --vuln 'CVE-2019-1010023';
wolfictl advisory create ./glibc.yaml --sync --status 'not_affected' --justification 'vulnerable_code_not_present' --impact 'The CVE itself is disputed and should not be considered a security vulnerability.' --vuln 'CVE-2019-1010024';
wolfictl advisory create ./glibc.yaml --sync --status 'not_affected' --justification 'vulnerable_code_not_present' --impact 'The CVE itself is disputed and should not be considered a security vulnerability.' --vuln 'CVE-2019-1010025';
```