### PR TITLE
Reject CVE-2010-4756 for glibc

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -31,6 +31,7 @@ secfixes:
     - CVE-2019-1010023
     - CVE-2019-1010024
     - CVE-2019-1010025
+    - CVE-2010-4756
   2.36-r1:
     - CVE-2022-39046
   2.37-r1:
@@ -436,6 +437,11 @@ subpackages:
             && mv "${{targets.destdir}}"/usr/lib/locale/${{range.key}} "${{targets.subpkgdir}}"/usr/lib/locale/
 
 advisories:
+  CVE-2010-4756:
+    - timestamp: 2023-03-06T12:47:28.379717-05:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: Not a vulnerability. POSIX does not guarantee memory safety; resource limits should be appropriately set on applications which use untrusted inputs to glob. BSD GLOB_LIMIT extension is unreliable and was rejected by the GNU project.
   CVE-2019-1010022:
     - timestamp: 2023-03-06T08:22:06.931107-05:00
       status: not_affected


### PR DESCRIPTION
Thanks to @kaniini for her analysis!

Command run to generate this diff:

```shell
wolfictl advisory create ./glibc.yaml --sync \
  --status 'not_affected' \
  --justification 'vulnerable_code_not_present' \
  --impact 'Not a vulnerability. POSIX does not guarantee memory safety; resource limits should be appropriately set on applications which use untrusted inputs to glob. BSD GLOB_LIMIT extension is unreliable and was rejected by the GNU project.' \
  --vuln 'CVE-2010-4756'
```