### PR TITLE
add #nolint for ruby yajl

### DIFF
--- a/ruby3.2-yajl-ruby.yaml
+++ b/ruby3.2-yajl-ruby.yaml
@@ -1,3 +1,4 @@
+#nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: ruby3.2-yajl-ruby
   version: 1.4.3


### PR DESCRIPTION
This sets us up to be able to merge https://github.com/wolfi-dev/wolfictl/pull/81, which requires a `tag` and `expected-commit` for `git-checkout` pipelines. yajl doesn't use this, for reasons expressed in comments in the config:

```
  # The latest releases of yajl-ruby were released on rubygems.org but a tag
  # was not created in the repo itself. https://github.com/brianmario/yajl-ruby
  #
  # This commit matches the 1.4.3 release on rubygems.org so it's used to check
  # the repository out and build the 1.4.3 version of yajl-ruby
```

...but this shouldn't limit us from enforcing this best practice for other future configs.

With the work in https://github.com/wolfi-dev/wolfictl/pull/81 rebased on top of https://github.com/wolfi-dev/wolfictl/pull/88 the repo fails linting without `#nolint`ing yajl, and passes when this `#nolint` is specified.