### PR TITLE
push packages to wolfi-production-registry-destination directly

### DIFF
--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -12,7 +12,7 @@ env:
   CLUSTER_ZONE: us-central1-b
   SERVICE_ACCOUNT: prod-images-ci
   FQ_SERVICE_ACCOUNT: prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com
-  BUCKET: wolfi-production-registry-source/os/
+  BUCKET: wolfi-production-registry-destination/os/
   SRC_BUCKET: gs://wolfi-production-registry-destination/os/
 
 jobs:

--- a/.github/workflows/push-production.yaml
+++ b/.github/workflows/push-production.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: 'Upload the repository to a bucket'
         run: |
           cp /etc/apk/keys/wolfi-signing.rsa.pub ${{ github.workspace }}/packages/wolfi-signing.rsa.pub
-          gcloud --quiet alpha storage cp --recursive "${{ github.workspace }}/packages/*" gs://wolfi-production-registry-source/os/
+          gcloud --quiet alpha storage cp --recursive "${{ github.workspace }}/packages/*" gs://wolfi-production-registry-destination/os/
 
   postrun:
     name: Build (arm64)


### PR DESCRIPTION
the current approach with using a source bucket + reconcilation is not really getting us anything useful, but it *is* getting us a 2 hour waiting period on builds while the repository reconciles.

we should move to using `wolfictl` to reconcile the index and upload artifacts directly, but that requires further discussion.  this provides an immediate quality of life improvement for now.