### PR TITLE
NAK git-for-windows vulnerability

### DIFF
--- a/git.yaml
+++ b/git.yaml
@@ -12,6 +12,8 @@ package:
       license: GPL-2.0-or-later
 
 secfixes:
+  "0":
+    - CVE-2023-22743
   2.38.1-r0:
     - CVE-2022-39253
     - CVE-2022-39260
@@ -119,6 +121,11 @@ advisories:
     - timestamp: 2023-02-15T16:48:32.355662-05:00
       status: fixed
       fixed-version: 2.39.2-r0
+  CVE-2023-22743:
+    - timestamp: 2023-03-07T21:25:45.597765-05:00
+      status: not_affected
+      justification: component_not_present
+      impact: This vulnerability refers to git-for-windows, not git.
   CVE-2023-23946:
     - timestamp: 2023-02-15T16:48:52.217204-05:00
       status: fixed


### PR DESCRIPTION
Noticed during Grype scan of `cgr.dev/chainguard/go`.

Ran command:

```shell
wolfictl advisory create --sync ./git.yaml --status 'not_affected' --justification 'component_not_present' --impact 'This vulnerability refers to git-for-windows, not git.' --vuln 'CVE-2023-22743'
```