### PR TITLE
Add an sbt-stage0 and sbt package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,6 +466,8 @@ $(eval $(call build-package,terraform,1.3.9-r0))
 $(eval $(call build-package,prometheus-node-exporter,1.5.0-r1))
 $(eval $(call build-package,prometheus-alertmanager,0.25.0-r0))
 $(eval $(call build-package,prometheus-mysqld-exporter,0.14.0-r0))
+$(eval $(call build-package,sbt-stage0,1.8.2-r0))
+$(eval $(call build-package,sbt,1.8.2-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/sbt-stage0.yaml
+++ b/sbt-stage0.yaml
@@ -1,0 +1,42 @@
+package:
+  name: sbt-stage0
+  version: 1.8.2
+  epoch: 0
+  description: A scala build tool
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: Apache-2.0
+  dependencies:
+    runtime:
+    - openjdk-11-jre
+    - bash
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - build-base
+      - busybox
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 1f65344da074dbd66dfefa93c0eff8d319d772e5cad47fcbeb6ae178bbdf4686
+      uri: https://github.com/sbt/sbt/releases/download/v${{package.version}}/sbt-${{package.version}}.tgz
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/java/sbt/bin
+      mkdir -p ${{targets.destdir}}/usr/share/java/sbt/conf
+
+      install -m644 -Dt ${{targets.destdir}}/usr/share/java/sbt/bin ./bin/sbt-launch.jar
+      install -m755 -Dt ${{targets.destdir}}/usr/share/java/sbt/bin ./bin/sbt
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      ln -sf /usr/share/java/sbt/bin/sbt ${{targets.destdir}}/usr/bin/sbt
+  - if: ${{build.arch}} == 'aarch64'
+    runs: |
+      install -m644 -Dt ${{targets.destdir}}/usr/share/java/sbt/bin ./bin/sbtn-aarch64-pc-linux
+  - if: ${{build.arch}} == 'amd64'
+    runs: |
+      install -m644 -Dt ${{targets.destdir}}/usr/share/java/sbt/bin ./bin/sbtn-x86_64-pc-linux

--- a/sbt.yaml
+++ b/sbt.yaml
@@ -1,0 +1,50 @@
+package:
+  name: sbt
+  version: 1.8.2
+  epoch: 0
+  description: A scala build tool
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: Apache-2.0
+  dependencies:
+    runtime:
+    - openjdk-11-jre
+    - bash
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - build-base
+      - busybox
+      - sbt-stage0
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/sbt/sbt
+      tag: v${{package.version}}
+      expected-commit: 8c1b98f11570047c0dd1411823628fa4342681e2
+  - runs: |
+      cd launcher-package
+
+      sbt -Dsbt.build.version=${{package.version}}  universal:packageZipTarball
+
+      tar -xf target/universal/sbt.tgz
+
+      mkdir -p ${{targets.destdir}}/usr/share/java/sbt/bin
+      mkdir -p ${{targets.destdir}}/usr/share/java/sbt/conf
+
+      install -m644 -Dt ${{targets.destdir}}/usr/share/java/sbt/bin ./sbt/bin/sbt-launch.jar
+      install -m755 -Dt ${{targets.destdir}}/usr/share/java/sbt/bin ./sbt/bin/sbt
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      ln -sf /usr/share/java/sbt/bin/sbt ${{targets.destdir}}/usr/bin/sbt
+  - if: ${{build.arch}} == 'aarch64'
+    runs: |
+      install -m644 -Dt ${{targets.destdir}}/usr/share/java/sbt/bin ./launcher-package/sbt/bin/sbtn-aarch64-pc-linux
+  - if: ${{build.arch}} == 'amd64'
+    runs: |
+      install -m644 -Dt ${{targets.destdir}}/usr/share/java/sbt/bin ./launcher-package/sbt/bin/sbtn-x86_64-pc-linux


### PR DESCRIPTION
SBT is required to build scala, which is required to bulid kafka. sbt bootstraps itself, so we first need a bootstrap version of the compiler.

I've tested and this bootstrap version can build the full scala distribution.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues. 
 -->

Fixes: 

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->

#### For new package PRs only

- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] The package is available under an OSI-approved or FSF-approved license
- [x] The version of the package is still receiving security updates

#### For security-related PRs

- [ ] The security fix is recorded in `annotations` and `secfixes`

#### For version bump PRs

- [ ] The `epoch` field is reset to 0
