### PR TITLE
Add a kafka package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,6 +468,7 @@ $(eval $(call build-package,prometheus-alertmanager,0.25.0-r0))
 $(eval $(call build-package,prometheus-mysqld-exporter,0.14.0-r0))
 $(eval $(call build-package,sbt-stage0,1.8.2-r0))
 $(eval $(call build-package,sbt,1.8.2-r0))
+$(eval $(call build-package,kafka,3.4.0-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/kafka.yaml
+++ b/kafka.yaml
@@ -1,0 +1,45 @@
+package:
+  name: kafka
+  version: "3.4.0"
+  epoch: 0
+  description:
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+        - "*"
+      attestation:
+      license: Apache-2.0
+  dependencies:
+    runtime:
+      - bash # some helper scripts use bash
+      - openjdk-11-jre
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - gradle
+      - sbt
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/kafka
+      tag: ${{package.version}}
+      expected-commit: 2e1947d240607d53f071f61c875cfffc3fec47fe
+  - runs: |
+      export LANG=en_US.UTF-8
+      
+      ./gradlew clean releaseTarGz
+
+      tar -xf core/build/distributions/kafka_2.13-${{package.version}}.tgz
+
+      mkdir -p ${{targets.destdir}}/usr/lib/kafka
+      
+      mv kafka_2.13-${{package.version}}/bin ${{targets.destdir}}/usr/lib/kafka
+      mv kafka_2.13-${{package.version}}/libs ${{targets.destdir}}/usr/lib/kafka
+      mv kafka_2.13-${{package.version}}/config ${{targets.destdir}}/usr/lib/kafka
+
+      # Clean up windows
+      rm -rf ${{targets.destdir}}/usr/lib/kafka/bin/*.bat


### PR DESCRIPTION
This builds kafka using gradle and sbt (currently stage0). When that gets merged I can then bootstrap a real sbt from stage-0 and this should be swappable over.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues. 
 -->

Fixes: 

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->

#### For new package PRs only

- [x] This PR is marked as fixing a pre-existing package request bug
- [x] The package is available under an OSI-approved or FSF-approved license
- [x] The version of the package is still receiving security updates