### PR TITLE
Add a fixed CVE to the jenkins secdb.

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -8,6 +8,7 @@ package:
   dependencies:
     runtime:
       - ttf-dejavu
+
 environment:
   contents:
     packages:
@@ -27,6 +28,7 @@ environment:
       - git
       - patch
       - ttf-dejavu
+
 pipeline:
   - uses: fetch
     with:
@@ -46,3 +48,13 @@ pipeline:
 
       mkdir -p ${{targets.destdir}}/usr/share/java/jenkins
       mv war/target/jenkins.war ${{targets.destdir}}/usr/share/java/jenkins/
+
+advisories:
+  CVE-2023-27898:
+    - timestamp: 2023-03-11T18:35:43.356601-05:00
+      status: fixed
+      fixed-version: 2.394-r0
+
+secfixes:
+  2.394-r0:
+    - CVE-2023-27898


### PR DESCRIPTION
This was fixed in 2.394.

https://www.jenkins.io/security/advisory/2023-03-08/#SECURITY-3037

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: 

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in `annotations` and `secfixes`

