### PR TITLE
Add a zookeeper package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,6 +478,7 @@ $(eval $(call build-package,libmnl,1.0.5-r0))
 $(eval $(call build-package,libnet,1.2-r0))
 $(eval $(call build-package,libpcap,1.10.3-r0))
 $(eval $(call build-package,libssh,0.10.4-r0))
+$(eval $(call build-package,zookeeper,3.8.1-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/zookeeper.yaml
+++ b/zookeeper.yaml
@@ -1,0 +1,50 @@
+package:
+  name: zookeeper
+  version: "3.8.1"
+  epoch: 0
+  description:
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+        - "*"
+      attestation:
+      license: Apache-2.0
+  dependencies:
+    runtime:
+      - bash # some helper scripts use bash
+      - openjdk-17-jre
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - maven
+      - openjdk-17-jre
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/zookeeper
+      tag: release-${{package.version}}
+      expected-commit: 74db005175a4ec545697012f9069cb9dcc8cdda7
+  - runs: |
+      export LANG=en_US.UTF-8
+      export JAVA_HOME=/usr/lib/jvm/openjdk-jre
+
+      mvn install -DskipTests
+      tar -xf zookeeper-assembly/target/apache-zookeeper-${{package.version}}-bin.tar.gz
+
+      mkdir -p ${{targets.destdir}}/usr/share/java/zookeeper
+      mkdir -p ${{targets.destdir}}/usr/share/java/zookeeper/bin
+      mkdir -p ${{targets.destdir}}/usr/share/java/zookeeper/lib
+      mkdir -p ${{targets.destdir}}/usr/share/java/zookeeper/conf
+
+      # Clean up windows files
+      rm -rf apache-zookeeper-${{package.version}}-bin/bin/*.cmd
+      mv apache-zookeeper-${{package.version}}-bin/lib/* ${{targets.destdir}}/usr/share/java/zookeeper/lib
+      mv apache-zookeeper-${{package.version}}-bin/bin/* ${{targets.destdir}}/usr/share/java/zookeeper/bin
+      mv apache-zookeeper-${{package.version}}-bin/conf/* ${{targets.destdir}}/usr/share/java/zookeeper/conf
+
+      # Setup a sample conf
+      cp ${{targets.destdir}}/usr/share/java/zookeeper/conf/zoo_sample.cfg ${{targets.destdir}}/usr/share/java/zookeeper/conf/zoo.cfg


### PR DESCRIPTION
Our kafka package contains zookeeper too, but this one is standalone.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: 

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only 
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
