### PR TITLE
Add nats nats-server and nsc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,6 +479,9 @@ $(eval $(call build-package,libnet,1.2-r0))
 $(eval $(call build-package,libpcap,1.10.3-r0))
 $(eval $(call build-package,libssh,0.10.4-r0))
 $(eval $(call build-package,zookeeper,3.8.1-r0))
+$(eval $(call build-package,nats-server,2.9.15-r0))
+$(eval $(call build-package,nats,0.0.35-r0))
+$(eval $(call build-package,nsc,2.7.8-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/nats-server.yaml
+++ b/nats-server.yaml
@@ -1,0 +1,29 @@
+package:
+  name: nats-server
+  version: 2.9.15
+  epoch: 0
+  description: High-Performance server for NATS.io, the cloud and edge native messaging system.
+  copyright:
+    - license: Apache-2.0
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - go
+      - ca-certificates-bundle
+pipeline:
+  # We can't use go/install because this requires a specific go version
+  - uses: git-checkout
+    with:
+      repository: https://github.com/nats-io/nats-server
+      tag: v${{package.version}}
+      expected-commit: b91fa85462d42c2f988170aee27955773e68c56d
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/etc/nats
+      go build \
+        -ldflags "-w -X github.com/nats-io/nats-server/v2/server.gitCommit=$(git rev-parse HEAD)" \
+        -o ${{targets.destdir}}/usr/bin/nats-server \
+        main.go
+      mv docker/nats-server.conf ${{targets.destdir}}/etc/nats/nats-server.conf

--- a/nats.yaml
+++ b/nats.yaml
@@ -1,0 +1,25 @@
+package:
+  name: nats
+  version: 0.0.35
+  epoch: 0
+  description: The NATS Command Line Interface.
+  copyright:
+    - license: Apache-2.0
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - go
+      - ca-certificates-bundle
+pipeline:
+  # We can't use go/install because this requires a specific go version
+  - uses: git-checkout
+    with:
+      repository: https://github.com/nats-io/natscli
+      tag: v${{package.version}}
+      expected-commit: 08972cdf512c4bbe30b45df880a67762d6d0f4d4
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      cd nats
+      go build -ldflags "-w -X main.version=${{package.version}}" -o ${{targets.destdir}}/usr/bin/nats

--- a/nsc.yaml
+++ b/nsc.yaml
@@ -1,0 +1,14 @@
+package:
+  name: nsc
+  version: 2.7.8
+  epoch: 0
+  description: Tool for creating nkey/jwt based configurations
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - go
+pipeline:
+  - uses: go/install
+    with:
+      package: github.com/nats-io/nsc/v2@v${{package.version}}


### PR DESCRIPTION
These are all required to build the full nats image.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: 

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only 
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

