### PR TITLE
json-c: new package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,6 +483,7 @@ $(eval $(call build-package,zookeeper,3.8.1-r0))
 $(eval $(call build-package,nats-server,2.9.15-r0))
 $(eval $(call build-package,nats,0.0.35-r0))
 $(eval $(call build-package,nsc,2.7.8-r0))
+$(eval $(call build-package,json-c,0.16-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/json-c.yaml
+++ b/json-c.yaml
@@ -1,0 +1,41 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/json-c/APKBUILD
+package:
+  name: json-c
+  version: "0.16"
+  epoch: 0
+  description: A JSON implementation in C
+  copyright:
+    - license: MIT
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - cmake
+      - doxygen
+      - samurai
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 8e45ac8f96ec7791eaf3bb7ee50e9c2100bbbc87b8d0f1d030c5ba8a0288d96b
+      uri: https://s3.amazonaws.com/json-c_releases/releases/json-c-${{package.version}}.tar.gz
+  - uses: cmake/configure
+  - uses: cmake/build
+  - uses: cmake/install
+  - uses: strip
+subpackages:
+  - name: json-c-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - json-c
+    description: json-c dev
+  - name: json-c-doc
+    pipeline:
+      - uses: split/manpages
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/doc/json-c
+          mv doc/html "${{targets.subpkgdir}}"/usr/share/doc/json-c
+    description: json-c doc


### PR DESCRIPTION
json-c is a dependency for clamav

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: #763

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only 
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
