### PR TITLE
WIP enable so name CI check

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -41,11 +41,20 @@ jobs:
         run: |
           make --debug MELANGE="sudo melange" MELANGE_DIR=/usr/share/melange MELANGE_EXTRA_OPTS="--keyring-append ${{ github.workspace }}/wolfi-signing.rsa.pub" REPO="${{ github.workspace }}/packages" -j1
 
-      - uses: actions/setup-go@v3
-      - name: 'Generate dependency svg'
-        run: |
-          git clone https://github.com/wolfi-dev/wolfictl && cd wolfictl && go install && cd -
-          wolfictl svg
+      - name: Check sonames
+        id: soname
+        uses: docker://ghcr.io/wolfi-dev/wolfictl:latest
+        with:
+          entrypoint: wolfictl
+          args: check so-name
+
+      - name: Check svg
+        id: svg
+        uses: docker://ghcr.io/wolfi-dev/wolfictl:latest
+        with:
+          entrypoint: wolfictl
+          args: svg
+
       - uses: actions/upload-artifact@v3
         with:
           name: dag.svg

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ packages/${ARCH}/$(1)-$(2).apk: ${KEY}
 
 PACKAGES += packages/${ARCH}/$(1)-$(2).apk
 
+# don't use += as it includes a leading space
+PACKAGES_LOG := $(PACKAGES_LOG)"${ARCH}|$(1)|$(2)\n"
+
 endef
 
 all: ${KEY} .build-packages
@@ -497,7 +500,9 @@ $(eval $(call build-package,nats,0.0.35-r0))
 $(eval $(call build-package,nsc,2.7.8-r0))
 $(eval $(call build-package,json-c,0.16-r0))
 
-.build-packages: ${PACKAGES}
 
+.build-packages: ${PACKAGES}
+	# write built packages list to file for wolfictl checks
+	echo ${PACKAGES_LOG} > packages.log
 dev-container:
 	docker run --privileged --rm -it -v "${PWD}:${PWD}" -w "${PWD}" cgr.dev/chainguard/sdk:latest


### PR DESCRIPTION
This enables a CI check from wolfictl which compares proposed apk changes with it's latest version in wolfi to see if there is a breaking ABI change based on `.so` name files.

It also moved `wolfictl svg` to using a container to avoid compiling speed up builds.