### PR TITLE
argon2: Make libargon2 discoverable by split/dev

### DIFF
--- a/argon2.yaml
+++ b/argon2.yaml
@@ -23,11 +23,19 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 62358ba2123abd17fccf2a108a301d4b52c01a7c
 
-  - uses: autoconf/make
-  - uses: autoconf/make-install
+  - runs: |
+      make -j$(nproc) OPTTARGET=none ARGON2_VERSION=${{package.version}}
+      make install DESTDIR=${{targets.destdir}} LIBRARY_REL=lib
+      chmod 0755 ${{targets.destdir}}/usr/lib/libargon2.so.1
   - uses: strip
+
 subpackages:
   - name: argon2-dev
     pipeline:
       - uses: split/dev
-        description: argon2 dev
+    dependencies:
+      runtime:
+        - argon2
+    description: argon2 dev
+
+


### PR DESCRIPTION
Fixes: 
Changed permissions on `libargon2.so.1` to 0755 so that `split/dev` discovered the library. 

Related: 
Discussion in https://github.com/chainguard-dev/melange/issues/321

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only 
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
