### PR TITLE
Fix the nsc package by removing the runtime dependency on go.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -495,7 +495,7 @@ $(eval $(call build-package,libssh,0.10.4-r0))
 $(eval $(call build-package,zookeeper,3.8.1-r0))
 $(eval $(call build-package,nats-server,2.9.15-r0))
 $(eval $(call build-package,nats,0.0.35-r0))
-$(eval $(call build-package,nsc,2.7.8-r0))
+$(eval $(call build-package,nsc,2.7.8-r1))
 $(eval $(call build-package,json-c,0.16-r0))
 
 .build-packages: ${PACKAGES}

--- a/nsc.yaml
+++ b/nsc.yaml
@@ -1,13 +1,10 @@
 package:
   name: nsc
   version: 2.7.8
-  epoch: 0
+  epoch: 1
   description: Tool for creating nkey/jwt based configurations
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - go
 pipeline:
   - uses: go/install
     with:


### PR DESCRIPTION
This was a copy/paste error from the apko go/install yaml file, which does actually need go :)

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: 

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only 
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `annotations` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
