### PR TITLE
libmspack: new package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -497,6 +497,7 @@ $(eval $(call build-package,nats-server,2.9.15-r0))
 $(eval $(call build-package,nats,0.0.35-r0))
 $(eval $(call build-package,nsc,2.7.8-r1))
 $(eval $(call build-package,json-c,0.16-r0))
+$(eval $(call build-package,libmspack,0.11_alpha-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/libmspack.yaml
+++ b/libmspack.yaml
@@ -1,0 +1,33 @@
+# Generated from https://git.alpinelinux.org/aports/plain/community/libmspack/APKBUILD
+package:
+  name: libmspack
+  version: 0.11_alpha
+  epoch: 0
+  description: Library for Microsoft CAB compression formats
+  copyright:
+    - license: LGPL-2.1-only
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 70dd1fb2f0aecc36791b71a1e1840e62173079eadaa081192d1c323a0eeea21b
+      uri: https://www.cabextract.org.uk/libmspack/libmspack-0.11alpha.tar.gz
+  - uses: autoconf/configure
+  - uses: autoconf/make
+  - uses: autoconf/make-install
+  - uses: strip
+subpackages:
+  - name: libmspack-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - libmspack
+    description: libmspack dev


### PR DESCRIPTION
dependency for clamav 

Related: #763

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only 
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
- [X] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
