### PR TITLE
llvm-libunwind: fix build on ARM

### DIFF
--- a/llvm-libunwind.yaml
+++ b/llvm-libunwind.yaml
@@ -25,14 +25,18 @@ pipeline:
       uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/cmake-${{package.version}}.src.tar.xz
       expected-sha256: 04e62ab7d0168688d9102680adf8eabe7b04275f333fe20eef8ab5a3a8ea9fcc
       strip-components: 0
+  - uses: patch
+    with:
+      patches: mte-fix.patch
   - runs: |
-      mv cmake-${{package.version}}.src ../cmake
+      mv cmake-${{package.version}}.src cmake-src
   - runs: |
       cmake -B build -G Ninja -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCLANG_BUILT_STANDALONE=TRUE \
         -DLLVM_CONFIG=/usr/lib/llvm15/bin/llvm-config \
+        -DCMAKE_MODULE_PATH=/home/build/cmake-src/Modules \
         -DLIBUNWIND_INSTALL_HEADERS=YES
   - runs: |
       cmake --build build

--- a/llvm-libunwind/mte-fix.patch
+++ b/llvm-libunwind/mte-fix.patch
@@ -1,0 +1,28 @@
+From 5d276380b0b45c3f02ef3c8614c3be95ce1bcb1e Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Fri, 17 Mar 2023 09:27:41 +0100
+Subject: [PATCH] [libunwind][AArch64] Unbreak building with GNU assembler
+
+GNU assembler mandates armv8.5-a for memtag instructions. Maybe
+we should remove this restriction in GNU assembler, but let's work
+around it for current GNU Binutils releases.
+
+Differential Revision: https://reviews.llvm.org/D146109
+---
+ src/DwarfInstructions.hpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/DwarfInstructions.hpp b/src/DwarfInstructions.hpp
+index 27432be56133..9962c2ffa0ca 100644
+--- a/src/DwarfInstructions.hpp
++++ b/src/DwarfInstructions.hpp
+@@ -224,7 +224,8 @@ int DwarfInstructions<A, R>::stepWithDwarf(A &addressSpace, pint_t pc,
+         p &= ~0xfULL;
+         // CFA is the bottom of the current stack frame.
+         for (; p < cfa; p += 16) {
+-          __asm__ __volatile__(".arch_extension memtag\n"
++          __asm__ __volatile__(".arch armv8.5-a\n"
++                               ".arch_extension memtag\n"
+                                "stg %[Ptr], [%[Ptr]]\n"
+                                :
+                                : [Ptr] "r"(p)


### PR DESCRIPTION
the memory tagging extension requires ARMv8.5 or later, so the inline assembly needs to be marked with that requirement.

no idea how LLVM release engineering missed that one...