### PR TITLE
Flag two CVEs as fixed in redis and postgres.

### DIFF
--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -5,9 +5,13 @@ package:
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
+
 secfixes:
-  0:
+  "0":
     - CVE-2017-8806
+  15.2-r0:
+    - CVE-2022-41862
+
 environment:
   contents:
     packages:
@@ -24,6 +28,7 @@ environment:
       - flex
       - execline-dev
       - util-linux-dev
+
 pipeline:
   - uses: fetch
     with:
@@ -39,6 +44,7 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
+
 subpackages:
   - name: postgresql-15-dev
     pipeline:
@@ -78,9 +84,14 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/var/lib/postgres/initdb
           cp postgresql-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/
           chmod +x ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
+
 advisories:
   CVE-2017-8806:
-    - timestamp: 2022-11-03T12:41:55+00:00
+    - timestamp: 2022-11-03T12:41:55Z
       status: not_affected
       justification: vulnerable_code_not_present
       impact: This CVE appears to impact only Debian/Ubuntu.
+  CVE-2022-41862:
+    - timestamp: 2023-03-19T17:21:53.344464-04:00
+      status: fixed
+      fixed-version: 15.2-r0

--- a/redis.yaml
+++ b/redis.yaml
@@ -17,6 +17,7 @@ secfixes:
     - CVE-2023-22458
   7.0.9-r0:
     - CVE-2022-36021
+    - CVE-2023-25155
 
 environment:
   contents:
@@ -73,3 +74,7 @@ advisories:
     - timestamp: 2023-02-25T06:54:30.972765-05:00
       status: fixed
       fixed-version: 7.0.8-r0
+  CVE-2023-25155:
+    - timestamp: 2023-03-19T17:23:43.585248-04:00
+      status: fixed
+      fixed-version: 7.0.9-r0


### PR DESCRIPTION
I confirmed these in the release notes:
https://www.postgresql.org/support/security/CVE-2022-41862/ https://github.com/redis/redis/releases/tag/7.0.9

#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in `annotations` and `secfixes`
