### PR TITLE
haproxy: use libslz instead of zlib for compression implementation

### DIFF
--- a/haproxy.yaml
+++ b/haproxy.yaml
@@ -21,7 +21,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - build-base
-      - zlib-dev
       - lua5.3-dev
       - openssl-dev
       - pcre2-dev
@@ -40,7 +39,6 @@ pipeline:
         USE_PCRE2=1 \
         USE_PCRE2_JIT=1 \
         USE_OPENSSL=1 \
-        USE_ZLIB=1 \
         USE_LUA=1 \
         USE_NS=1 \
         USE_PROMEX=1 \


### PR DESCRIPTION
Refer to: https://github.com/haproxy/haproxy/blob/ac78c4fd9d87c93bfb61c9c15182c9c0e38053f9/INSTALL#L315-L319
> Zlib compresses a bit better than libslz but at the expense of more CPU usage (about 3.5 times more minimum), and a huge memory usage (~260 kB per compressed stream). The only valid reason for uzing Zlib instead of SLZ here usually is to deal with a very limited internet bandwidth while CPU and RAM are abundant so that the last few percent of compression ratio are worth the invested hardware.

Refer to: http://www.libslz.org/
> A side effect from its stateless nature is that it can emit a zlib-compatible stream without being vulnerable to CRIME-like attacks by processing the sensitive and attacker-controlled data in distinct batches. Since no dictionary persists between calls, there is no risk that attacker-controlled data is used to guess sensitive data using dictionary lookups.

To conclude, I think it would be better to switch the default compression implementation to the libslz.