### PR TITLE
Update dag-push-production.yaml

### DIFF
--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -53,7 +53,7 @@ jobs:
             --zone            "${CLUSTER_ZONE}" \
             --release-channel rapid \
             --workload-pool   "${PROJECT}.svc.id.goog" \
-            --machine-type    e2-standard-32 \
+            --machine-type    e2-standard-4 \
             --num-nodes       1 \
             --spot  \
             --no-enable-autorepair


### PR DESCRIPTION
Use a 4-CPU x86_64 VM in the GKE cluster, since we're not sending real builds to it anyway.

We might be able to get rid of the VM entirely, but for now at least trimming of 28 VMs worth of $$ seems like an easy win.
