### PR TITLE
Add mercurial (and py3-wheel, which is required).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,6 +517,8 @@ $(eval $(call build-package,dotnet-7,7.0.104-r1))
 $(eval $(call build-package,gtest,1.13.0-r0))
 $(eval $(call build-package,libpsl-native,7.3.1-r0))
 $(eval $(call build-package,powershell,7.3.3-r0))
+$(eval $(call build-package,py3-wheel,0.40.0-r0))
+$(eval $(call build-package,mercurial,6.4-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/mercurial.yaml
+++ b/mercurial.yaml
@@ -1,0 +1,51 @@
+package:
+  name: mercurial
+  version: 6.4
+  epoch: 0
+  description: "Scalable distributed SCM tool"
+  copyright:
+    - license: GPL-2.0-or-later
+  dependencies:
+    runtime:
+      - python3
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - python3-dev
+      - py3-gpep517
+      - py3-wheel
+      - py3-setuptools
+      - gettext-dev
+      - zlib-dev
+      - py3-flit-core
+      - build-base
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://www.mercurial-scm.org/release/mercurial-${{package.version}}.tar.gz
+      expected-sha256: e88bfbcb9911e76904a31b972e57f86da8e6ce5892b98c39dd51d3b9599c1347
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      
+      python3 -m installer -d "${{targets.destdir}}" \
+        dist/*.whl
+
+      install -Dm755 contrib/hgk contrib/hg-ssh hgeditor -t "${{targets.destdir}}"/usr/bin
+
+      for man in doc/*.?; do
+        install -Dm644 "$man" \
+          "${{targets.destdir}}"/usr/share/man/man${man##*.}/${man##*/}
+      done
+  - uses: strip
+
+subpackages:
+  - name: "mercurial-doc"
+    description: "mercurial documentation"
+    pipeline:
+      - uses: split/manpages

--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -1,0 +1,30 @@
+package:
+  name: py3-wheel
+  version: "0.40.0"
+  epoch: 0
+  description: "built-package format for Python"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+      - py3-installer
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-flit-core
+      - py3-gpep517
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/pypa/wheel/archive/refs/tags/${{package.version}}.tar.gz
+      expected-sha256: 3ef5fd1a211b34028d72fd3037692db8301dc2bc5e82646fded18cddf5af1ae9
+  - runs: |
+      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 1
+      python3 -m installer -d "${{targets.destdir}}" dist/wheel-${{package.version}}-py3-none-any.whl
+
+  - uses: strip


### PR DESCRIPTION
Mercurial looks required for openjdk8 and a bunch of other packages.

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates

