### PR TITLE
Add mongo-tools.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -519,6 +519,7 @@ $(eval $(call build-package,libpsl-native,7.3.1-r0))
 $(eval $(call build-package,powershell,7.3.3-r0))
 $(eval $(call build-package,py3-wheel,0.40.0-r0))
 $(eval $(call build-package,mercurial,6.4-r0))
+$(eval $(call build-package,mongo-tools,100.7.0-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/mongo-tools.yaml
+++ b/mongo-tools.yaml
@@ -1,0 +1,25 @@
+package:
+  name: mongo-tools
+  version: 100.7.0
+  epoch: 0
+  description: Tools for MongoDB
+  copyright:
+    - license: Apache-2.0
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - build-base
+      - krb5-dev
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/mongodb/mongo-tools
+      tag: ${{package.version}}
+      expected-commit: 17946f45f5fabfcdd99f8960b9109f976d370631
+  - runs: |
+      ./make build
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv bin/* ${{targets.destdir}}/usr/bin


### PR DESCRIPTION
These utilities are stored and licensed separately from the rest of mongo.

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates