### PR TITLE
Add minio package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -524,6 +524,7 @@ $(eval $(call build-package,clamav,1.0.1-r0))
 $(eval $(call build-package,py3-wheel,0.40.0-r0))
 $(eval $(call build-package,mercurial,6.4-r0))
 $(eval $(call build-package,mongo-tools,100.7.0-r0))
+$(eval $(call build-package,minio,0.20230324.214123-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/minio.yaml
+++ b/minio.yaml
@@ -1,0 +1,69 @@
+package:
+  name: minio
+  # minio uses strange versioning, the upstream version is RELEASE.2023-03-24T21-41-23Z
+  # when bumping this, also bump the tag in git-checkout below
+  version: 0.20230324.214123
+  epoch: 0
+  description: Multi-Cloud Object Storage
+  copyright:
+    - license: AGPL-3.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - build-base
+      - perl
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/minio/minio
+      tag: RELEASE.2023-03-24T21-41-23Z
+      expected-commit: 74040b457b50417b58eae7cb17c63428a0e2dd44
+  - runs: |
+      make build
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv minio ${{targets.destdir}}/usr/bin
+
+advisories:
+  CVE-2018-1000538:
+    - timestamp: 2023-03-25T17:04:18.613256-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+  CVE-2020-11012:
+    - timestamp: 2023-03-25T17:04:39.916688-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+  CVE-2021-21287:
+    - timestamp: 2023-03-25T17:04:51.061715-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+  CVE-2021-21362:
+    - timestamp: 2023-03-25T17:04:58.58436-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+  CVE-2021-21390:
+    - timestamp: 2023-03-25T17:05:03.086934-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+  CVE-2021-43858:
+    - timestamp: 2023-03-25T17:05:08.097081-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+  CVE-2022-35919:
+    - timestamp: 2023-03-25T17:05:12.402326-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+
+secfixes:
+  "0":
+    - CVE-2018-1000538
+    - CVE-2020-11012
+    - CVE-2021-21287
+    - CVE-2021-21362
+    - CVE-2021-21390
+    - CVE-2021-43858
+    - CVE-2022-35919


### PR DESCRIPTION
The versioning is a bit strange, but I borrowed how Alpine handles this.

Minio's versioning also confuses grype, but all of these CVEs were fixed prior to our packaging.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates

