### PR TITLE
Mark a bunch of CVEs as fixed in Jenkins.

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -8,6 +8,7 @@ package:
   dependencies:
     runtime:
       - ttf-dejavu
+
 environment:
   contents:
     packages:
@@ -27,6 +28,7 @@ environment:
       - git
       - patch
       - ttf-dejavu
+
 pipeline:
   - uses: fetch
     with:
@@ -46,11 +48,38 @@ pipeline:
 
       mkdir -p ${{targets.destdir}}/usr/share/java/jenkins
       mv war/target/jenkins.war ${{targets.destdir}}/usr/share/java/jenkins/
+
 advisories:
+  CVE-2023-24998:
+    - timestamp: 2023-03-25T21:19:30.185258-04:00
+      status: fixed
+      fixed-version: 2.394-r0
   CVE-2023-27898:
     - timestamp: 2023-03-11T18:35:43.356601-05:00
       status: fixed
       fixed-version: 2.394-r0
+  CVE-2023-27899:
+    - timestamp: 2023-03-25T21:19:10.610669-04:00
+      status: fixed
+      fixed-version: 2.394-r0
+  CVE-2023-27902:
+    - timestamp: 2023-03-25T21:19:39.717473-04:00
+      status: fixed
+      fixed-version: 2.394-r0
+  CVE-2023-27903:
+    - timestamp: 2023-03-25T21:19:51.085573-04:00
+      status: fixed
+      fixed-version: 2.394-r0
+  CVE-2023-27904:
+    - timestamp: 2023-03-25T21:19:59.68093-04:00
+      status: fixed
+      fixed-version: 2.394-r0
+
 secfixes:
   2.394-r0:
     - CVE-2023-27898
+    - CVE-2023-27899
+    - CVE-2023-24998
+    - CVE-2023-27902
+    - CVE-2023-27903
+    - CVE-2023-27904


### PR DESCRIPTION
These were all fixed in 2.394 according to https://www.openwall.com/lists/oss-security/2023/03/08/3

Fixes:

Related:

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in `annotations` and `secfixes`
