### PR TITLE
Add cluster-autoscaler package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -529,6 +529,7 @@ $(eval $(call build-package,mc,0.20230323.200304-r0))
 $(eval $(call build-package,thanos,0.31.0-r0))
 $(eval $(call build-package,secrets-store-csi-driver-provider-gcp,1.2.0-r0))
 $(eval $(call build-package,secrets-store-csi-driver,1.3.2-r0))
+$(eval $(call build-package,cluster-autoscaler,9.26.0-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/cluster-autoscaler.yaml
+++ b/cluster-autoscaler.yaml
@@ -1,0 +1,26 @@
+package:
+  name: cluster-autoscaler
+  version: 9.26.0
+  epoch: 0
+  description: Autoscaling components for Kubernetes
+  copyright:
+    - license: Apache-2.0
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes/autoscaler
+      tag: cluster-autoscaler-chart-${{package.version}}
+      expected-commit: 562b9772903e327792634407234214d74b44f907
+  - runs: |
+      cd cluster-autoscaler
+      mkdir -p ${{targets.destdir}}/usr/bin
+      go build -o ${{targets.destdir}}/usr/bin/cluster-autoscaler .
+  - uses: strip


### PR DESCRIPTION
Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates

