### PR TITLE
Add a consul package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -531,6 +531,7 @@ $(eval $(call build-package,secrets-store-csi-driver-provider-gcp,1.2.0-r0))
 $(eval $(call build-package,secrets-store-csi-driver,1.3.2-r0))
 $(eval $(call build-package,cluster-autoscaler,9.26.0-r0))
 $(eval $(call build-package,rqlite,7.14.1-r0,rqlite))
+$(eval $(call build-package,consul,1.15.1-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/consul.yaml
+++ b/consul.yaml
@@ -1,0 +1,39 @@
+package:
+  name: consul
+  version: 1.15.1
+  epoch: 0
+  description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
+  copyright:
+    - license: MPL-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hashicorp/consul
+      tag: v${{package.version}}
+      expected-commit: 7c04b6a0dd433619e788617434a4c236b7d4f892
+      destination: consul
+  - runs: |
+      cd consul
+      make linux
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv consul/pkg/bin/linux_* ${{targets.destdir}}/usr/bin/consul
+  - uses: strip
+subpackages:
+  - name: consul-oci-entrypoint
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv consul/.release/docker/docker-entrypoint.sh ${{targets.subpkgdir}}/usr/bin/
+    dependencies:
+      runtime:
+        - busybox
+        - dumb-init


### PR DESCRIPTION
The oci-entrypoint depends on dumb-init.sh.

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
