### PR TITLE
don't cache APKINDEX objects in GCS

### DIFF
--- a/.github/workflows/push-production.yaml
+++ b/.github/workflows/push-production.yaml
@@ -72,7 +72,10 @@ jobs:
       - name: 'Upload the repository to a bucket'
         run: |
           cp /etc/apk/keys/wolfi-signing.rsa.pub ${{ github.workspace }}/packages/wolfi-signing.rsa.pub
-          gcloud --quiet alpha storage cp --recursive "${{ github.workspace }}/packages/*" gs://wolfi-production-registry-destination/os/
+          gcloud --quiet storage cp \
+              --recursive \
+              --cache-control="public, max-age=0" \
+              "${{ github.workspace }}/packages/*" gs://wolfi-production-registry-destination/os/
 
   postrun:
     name: Build (arm64)

--- a/.github/workflows/push-production.yaml
+++ b/.github/workflows/push-production.yaml
@@ -69,13 +69,14 @@ jobs:
         run: |
           sudo chown -R $(id -u):$(id -g) "${{ github.workspace }}/packages"
 
-      - name: 'Upload the repository to a bucket'
+      - name: 'Upload the repository to the bucket'
         run: |
           cp /etc/apk/keys/wolfi-signing.rsa.pub ${{ github.workspace }}/packages/wolfi-signing.rsa.pub
           gcloud --quiet storage cp \
-              --recursive \
-              --cache-control=off \
-              "${{ github.workspace }}/packages/*" gs://wolfi-production-registry-destination/os/
+              --cache-control=off \  # Don't cache the APKINDEX.
+              "${{ github.workspace }}/packages/**/APKINDEX.tar.gz" gs://wolfi-production-registry-destination/os/
+          gcloud --quiet storage cp \  # apks will be cached in CDN for an hour by default.
+              "${{ github.workspace }}/packages/**/*.apk" gs://wolfi-production-registry-destination/os/
 
   postrun:
     name: Build (arm64)

--- a/.github/workflows/push-production.yaml
+++ b/.github/workflows/push-production.yaml
@@ -74,7 +74,7 @@ jobs:
           cp /etc/apk/keys/wolfi-signing.rsa.pub ${{ github.workspace }}/packages/wolfi-signing.rsa.pub
           gcloud --quiet storage cp \
               --recursive \
-              --cache-control="public, max-age=0" \
+              --cache-control=off \
               "${{ github.workspace }}/packages/*" gs://wolfi-production-registry-destination/os/
 
   postrun:


### PR DESCRIPTION
Currently when we publish our APKINDEX, it gets cached for up to an hour, meaning that downstream tools like apko trying to install a new package won't see that new package, since they get an older cached index.

This changes our GCS upload to set the `cache-control` header to tell GCS and Cloud CDN not to cache these objects. This will affect both APKINDEX and the apks themselves, even though it should be fine to cache the apks as they don't change.

If we want to target this change better to only the index, we can (either now, or in the future).

Also uses `gcloud storage cp` instead of the `alpha` variant.

When we're done with this change we can do the same to the arm64 builds happening on GKE.