### PR TITLE
Update coreutils advisory as now affected

### DIFF
--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -9,9 +9,7 @@ package:
     post-deinstall: |
       #!/bin/busybox sh
       /bin/busybox --install -s
-secfixes:
-  0:
-    - CVE-2016-2781
+
 environment:
   contents:
     packages:
@@ -22,6 +20,7 @@ environment:
       - acl-dev
       - attr-dev
       - texinfo
+
 pipeline:
   - uses: fetch
     with:
@@ -60,18 +59,26 @@ pipeline:
 
       # shouldn't be here, but you never know...
       rm -f usr/bin/groups
+
 subpackages:
   - name: "coreutils-doc"
     description: "documentation for GNU coreutils"
     pipeline:
       - uses: split/manpages
       - uses: split/infodir
+
 advisories:
   CVE-2016-2781:
-    - timestamp: 2022-10-11T20:29:31+00:00
+    - timestamp: 2022-10-11T20:29:31Z
       status: not_affected
       justification: vulnerable_code_not_present
       impact: |
         Fixed upstream prior to Wolfi packaging.
 
         See https://git.savannah.gnu.org/cgit/coreutils.git/commit/?h=v9.1&id=8cb06d4b44a67f89f24b25e2394365533f6e5968
+    - timestamp: 2023-03-27T20:52:17.710834-04:00
+      status: affected
+      action: |
+        Prior fix was reverted upstream, standby for future fix.
+
+        See revert at https://git.savannah.gnu.org/cgit/coreutils.git/commit/?id=v8.27-101-gf5d7c0842


### PR DESCRIPTION
A previously present fix in `coreutils` for CVE-2016-2781  was reverted upstream. This PR removes the `secfixes` entry and adds a new update to the corresponding advisory.