### PR TITLE
Mark pip vuln CVE-2018-20225 as invalid

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -11,6 +11,7 @@ package:
 secfixes:
   "0":
     - CVE-2007-4559
+    - CVE-2018-20225
   3.10.9-r0:
     - CVE-2020-10735
 
@@ -104,6 +105,11 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
+  CVE-2018-20225:
+    - timestamp: 2023-03-27T21:41:07.052074-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
   CVE-2020-10735:
     - timestamp: 2023-02-07T08:34:29.611707Z
       status: fixed

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -12,6 +12,7 @@ package:
 secfixes:
   "0":
     - CVE-2007-4559
+    - CVE-2018-20225
   3.0.7-r0:
     - CVE-2020-10735
 
@@ -104,6 +105,11 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
+  CVE-2018-20225:
+    - timestamp: 2023-03-27T21:42:27.8338-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
   CVE-2020-10735:
     - timestamp: 2022-09-12T21:06:30Z
       status: fixed

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -10,6 +10,7 @@ package:
 secfixes:
   "0":
     - CVE-2007-4559
+    - CVE-2018-20225
   3.0.7-r0:
     - CVE-2020-10735
 
@@ -99,6 +100,11 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
+  CVE-2018-20225:
+    - timestamp: 2023-03-27T21:42:35.187417-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
   CVE-2020-10735:
     - timestamp: 2022-09-12T21:06:30Z
       status: fixed


### PR DESCRIPTION
This vulnerability is disputed and appears not to be a vulnerability at all.

Ran:

```console
$ wolfictl advisory create ./python-3.12.yaml --sync --vuln 'CVE-2018-20225' --status 'not_affected' --justification 'vulnerable_code_not_present' --impact 'This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.'
$ # and so on, for each python version...
```