### PR TITLE
OpenJDK: Add GA version

### DIFF
--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -1,0 +1,124 @@
+#nolint:bad-version
+package:
+  name: openjdk-19
+  version: 19.0.2.7
+  epoch: 1
+  description:
+  copyright:
+    - license: GPL-2.0-only
+  dependencies:
+    runtime:
+      - freetype
+      - fontconfig
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - file
+      - freetype-dev
+      - cups-dev
+      - libx11-dev
+      - libxext-dev
+      - libxrender-dev
+      - libxrandr-dev
+      - libxtst-dev
+      - libxt-dev
+      - alsa-lib-dev
+      - libffi-dev
+      - bash
+      - zip
+      - fontconfig-dev
+      - libxi-dev
+      - libjpeg-dev
+      - giflib-dev
+      - lcms2-dev
+
+var-transforms:
+  - from: ${{package.version}}
+    match: \.(\d+)$
+    replace: +$1
+    to: mangled-package-version
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/openjdk/jdk19u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
+      expected-sha256: 5903efd527dd08e9c235c8822e3d5699c3d18a8618c3e533307e8d6491ffbbf0
+
+# We need pre-built binaries to use as Boot JDK https://hg.openjdk.org/jdk/jdk12/raw-file/tip/doc/building.html#boot-jdk-requirements
+  - uses: fetch
+    with:
+      uri: https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.2%2B7/OpenJDK19U-jdk_x64_linux_hotspot_19.0.2_7.tar.gz
+      expected-sha256: 3a3ba7a3f8c3a5999e2c91ea1dca843435a0d1c43737bd2f6822b2f02fc52165
+      strip-components: 0
+  - uses: fetch
+    with:
+      uri: https://github.com/google/googletest/archive/release-1.8.1.tar.gz
+      expected-sha256: 9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c
+      strip-components: 0
+  - runs: chmod +x configure
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --with-boot-jdk=./jdk-19.0.2+7/ \
+        --with-vendor-name=wolfi \
+        --with-vendor-url=https://wolfi.dev \
+        --with-vendor-bug-url=https://github.com/wolfi-dev/os/issues \
+        --with-version-opt="wolfi-r${{package.epoch}}" \
+        --with-gtest=./googletest-release-1.8.1 \
+        --with-source-date=version \
+        --enable-reproducible-build \
+        --disable-warnings-as-errors \
+        --disable-precompiled-headers \
+        --enable-dtrace=no \
+        --with-zlib=system \
+        --with-native-debug-symbols=none \
+        --disable-warnings-as-errors \
+        --disable-precompiled-headers \
+        --with-jvm-variants=server \
+        --with-debug-level=release \
+        --with-jtreg=no  \
+        --with-libpng=system \
+        --with-libjpeg=system \
+        --with-giflib=system \
+        --with-lcms=system
+  - runs: make jdk-image
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/lib/jvm/openjdk
+      cp -r ./build/linux-*-server-release/images/jdk/* ${{targets.destdir}}/usr/lib/jvm/openjdk
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      ln -sf /usr/lib/jvm/openjdk/bin/java ${{targets.destdir}}/usr/bin/java
+      ln -sf /usr/lib/jvm/openjdk/bin/javac ${{targets.destdir}}/usr/bin/javac
+subpackages:
+  - name: openjdk-19-jre
+    pipeline:
+      - runs: |
+          # generate JRE via jlink
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm
+
+          ${{targets.destdir}}/usr/lib/jvm/openjdk/bin/jlink \
+            --no-header-files \
+            --no-man-pages \
+            --compress=2 \
+            --add-modules ALL-MODULE-PATH \
+            --output ${{targets.subpkgdir}}/usr/lib/jvm/openjdk-jre
+
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          ln -sf /usr/lib/jvm/openjdk-jre/bin/java ${{targets.subpkgdir}}/usr/bin/java
+    description: OpenJDK 19 (JRE)
+    dependencies:
+      runtime:
+        - freetype
+        - fontconfig
+  - name: openjdk-19-doc
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share
+          mv  ${{targets.destdir}}/usr/lib/jvm/openjdk/man ${{targets.subpkgdir}}/usr/share
+    description: OpenJDK 19 manpages

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -1,0 +1,123 @@
+#nolint:bad-version
+package:
+  name: openjdk-20
+  version: 20.36
+  epoch: 1
+  description:
+  copyright:
+    - license: GPL-2.0-only
+  dependencies:
+    runtime:
+      - freetype
+      - fontconfig
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - file
+      - freetype-dev
+      - cups-dev
+      - libx11-dev
+      - libxext-dev
+      - libxrender-dev
+      - libxrandr-dev
+      - libxtst-dev
+      - libxt-dev
+      - alsa-lib-dev
+      - libffi-dev
+      - bash
+      - zip
+      - fontconfig-dev
+      - libxi-dev
+      - libjpeg-dev
+      - giflib-dev
+      - lcms2-dev
+
+var-transforms:
+  - from: ${{package.version}}
+    match: \.(\d+)$
+    replace: +$1
+    to: mangled-package-version
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/openjdk/jdk20u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
+      expected-sha256: 215767be88a18af00440d5241960a3937237e77b938db4485bdb1c9bb414972e
+
+  - uses: fetch
+    with:
+      uri: https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20%2B36/OpenJDK20U-jdk_x64_linux_hotspot_20_36.tar.gz
+      expected-sha256: fb6000faf47fffcda8caf01f60097d582728a6fffb6c1b85c8075c674f0c9281
+      strip-components: 0
+  - uses: fetch
+    with:
+      uri: https://github.com/google/googletest/archive/release-1.8.1.tar.gz
+      expected-sha256: 9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c
+      strip-components: 0
+  - runs: chmod +x configure
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --with-boot-jdk=./jdk-20+36 \
+        --with-vendor-name=wolfi \
+        --with-vendor-url=https://wolfi.dev \
+        --with-vendor-bug-url=https://github.com/wolfi-dev/os/issues \
+        --with-version-opt="wolfi-r${{package.epoch}}" \
+        --with-gtest=./googletest-release-1.8.1 \
+        --with-source-date=version \
+        --enable-reproducible-build \
+        --disable-warnings-as-errors \
+        --disable-precompiled-headers \
+        --enable-dtrace=no \
+        --with-zlib=system \
+        --with-native-debug-symbols=none \
+        --disable-warnings-as-errors \
+        --disable-precompiled-headers \
+        --with-jvm-variants=server \
+        --with-debug-level=release \
+        --with-jtreg=no  \
+        --with-libpng=system \
+        --with-libjpeg=system \
+        --with-giflib=system \
+        --with-lcms=system
+  - runs: make jdk-image
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/lib/jvm/openjdk
+      cp -r ./build/linux-*-server-release/images/jdk/* ${{targets.destdir}}/usr/lib/jvm/openjdk
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      ln -sf /usr/lib/jvm/openjdk/bin/java ${{targets.destdir}}/usr/bin/java
+      ln -sf /usr/lib/jvm/openjdk/bin/javac ${{targets.destdir}}/usr/bin/javac
+subpackages:
+  - name: openjdk-20-jre
+    pipeline:
+      - runs: |
+          # generate JRE via jlink
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm
+
+          ${{targets.destdir}}/usr/lib/jvm/openjdk/bin/jlink \
+            --no-header-files \
+            --no-man-pages \
+            --compress=2 \
+            --add-modules ALL-MODULE-PATH \
+            --output ${{targets.subpkgdir}}/usr/lib/jvm/openjdk-jre
+
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          ln -sf /usr/lib/jvm/openjdk-jre/bin/java ${{targets.subpkgdir}}/usr/bin/java
+    description: OpenJDK 20 (JRE)
+    dependencies:
+      runtime:
+        - freetype
+        - fontconfig
+  - name: openjdk-20-doc
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share
+          mv  ${{targets.destdir}}/usr/lib/jvm/openjdk/man ${{targets.subpkgdir}}/usr/share
+    description: OpenJDK 20 manpages

--- a/packages.txt
+++ b/packages.txt
@@ -190,6 +190,8 @@ libjpeg
 lcms2
 openjdk-11
 openjdk-17
+openjdk-19
+openjdk-20
 su-exec
 llvm15
 postgresql-11,postgresql


### PR DESCRIPTION
This is copied from openjdk-17 package to release more recent GA release

Fix https://github.com/wolfi-dev/os/issues/598

### Pre-review Checklist

#### For new package PRs only
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security update
