### PR TITLE
Fix for pip NAK of CVE-2018-20225

### DIFF
--- a/py3.10-pip.yaml
+++ b/py3.10-pip.yaml
@@ -10,6 +10,7 @@ package:
     runtime:
       - python-3.10
       - py3.10-setuptools
+
 environment:
   contents:
     packages:
@@ -19,6 +20,7 @@ environment:
       - build-base
       - python-3.10
       - py3.10-setuptools
+
 pipeline:
   - uses: fetch
     with:
@@ -29,3 +31,14 @@ pipeline:
   - name: Python Install
     runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
   - uses: strip
+
+advisories:
+  CVE-2018-20225:
+    - timestamp: 2023-03-28T09:38:33.819695-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
+
+secfixes:
+  "0":
+    - CVE-2018-20225

--- a/py3.11-pip.yaml
+++ b/py3.11-pip.yaml
@@ -12,6 +12,7 @@ package:
     runtime:
       - python-3.11
       - py3.11-setuptools
+
 environment:
   contents:
     packages:
@@ -21,6 +22,7 @@ environment:
       - build-base
       - python-3.11
       - py3.11-setuptools
+
 pipeline:
   - uses: fetch
     with:
@@ -31,3 +33,14 @@ pipeline:
   - name: Python Install
     runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
   - uses: strip
+
+advisories:
+  CVE-2018-20225:
+    - timestamp: 2023-03-28T09:38:38.961464-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
+
+secfixes:
+  "0":
+    - CVE-2018-20225

--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -11,7 +11,6 @@ package:
 secfixes:
   "0":
     - CVE-2007-4559
-    - CVE-2018-20225
   3.10.9-r0:
     - CVE-2020-10735
 
@@ -105,11 +104,6 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
-  CVE-2018-20225:
-    - timestamp: 2023-03-27T21:41:07.052074-04:00
-      status: not_affected
-      justification: vulnerable_code_not_present
-      impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
   CVE-2020-10735:
     - timestamp: 2023-02-07T08:34:29.611707Z
       status: fixed

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -12,7 +12,6 @@ package:
 secfixes:
   "0":
     - CVE-2007-4559
-    - CVE-2018-20225
   3.0.7-r0:
     - CVE-2020-10735
 
@@ -105,11 +104,6 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
-  CVE-2018-20225:
-    - timestamp: 2023-03-27T21:42:27.8338-04:00
-      status: not_affected
-      justification: vulnerable_code_not_present
-      impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
   CVE-2020-10735:
     - timestamp: 2022-09-12T21:06:30Z
       status: fixed

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -10,7 +10,6 @@ package:
 secfixes:
   "0":
     - CVE-2007-4559
-    - CVE-2018-20225
   3.0.7-r0:
     - CVE-2020-10735
 
@@ -100,11 +99,6 @@ advisories:
       status: not_affected
       justification: vulnerable_code_not_present
       impact: The upstream issue has been closed, deeming this to be expected behavior, not a security issue. See https://bugs.python.org/issue1044.
-  CVE-2018-20225:
-    - timestamp: 2023-03-27T21:42:35.187417-04:00
-      status: not_affected
-      justification: vulnerable_code_not_present
-      impact: This vulnerability is disputed, and the consensus in the security community is that this is intended behavior, not a security flaw.
   CVE-2020-10735:
     - timestamp: 2022-09-12T21:06:30Z
       status: fixed


### PR DESCRIPTION
My apologies, this fixes the way I handled CVE-2018-20225 in #871 — I thought `pip` was coming from the `python-3.10` package. 🤦 

A future version of our advisories system will require advisories to describe **which individual component** has the reported vulnerability, which I expect to reduce the chance of this sort of error happening.