### PR TITLE
restic-0.15.1: new package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -534,6 +534,7 @@ $(eval $(call build-package,rqlite,7.14.1-r0,rqlite))
 $(eval $(call build-package,karpenter,0.27.0-r0))
 $(eval $(call build-package,kube-state-metrics,2.8.2-r0))
 $(eval $(call build-package,consul,1.15.1-r0))
+$(eval $(call build-package,restic,0.15.1-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/restic.yaml
+++ b/restic.yaml
@@ -1,0 +1,26 @@
+package:
+  name: restic
+  version: 0.15.1
+  epoch: 0
+  description: restic is a backup program which allows saving multiple revisions of files and directories in an encrypted repository stored on different backends
+  copyright:
+    - license: BSD-2-Clause
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/restic/restic/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-sha256: fce382fdcdac0158a35daa640766d5e8a6e7b342ae2b0b84f2aacdff13990c52
+  - runs: |
+      CGO_ENABLED=0 go build \
+        -trimpath -ldflags \
+        "-buildid= -X main.version=${{package.version}}" \
+        -o "${{targets.destdir}}/usr/bin/restic" ./cmd/restic
+  - uses: strip


### PR DESCRIPTION
Related: #885 

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
