### PR TITLE
Nack a CVE in ruby 3.1 and 3.0.

### DIFF
--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -58,7 +58,6 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
-
   # Remove gem bundler installed with ruby. It's provided by it's own package
   - runs: |-
       # Ignore the patch version of ruby since ruby will install under the
@@ -95,10 +94,17 @@ advisories:
     - timestamp: 2023-03-10T10:57:16.957642-05:00
       status: fixed
       fixed-version: 3.0.5-r0
+  CVE-2023-22795:
+    - timestamp: 2023-03-28T20:54:15.650462-04:00
+      status: not_affected
+      justification: component_not_present
 
 secfixes:
+  "0":
+    - CVE-2023-22795
   3.0.5-r0:
     - CVE-2021-33621
+
 update:
   enabled: false
   release-monitor:

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -58,7 +58,6 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
-
   # Remove gem bundler installed with ruby. It's provided by it's own package
   - runs: |-
       # Ignore the patch version of ruby since ruby will install under the
@@ -85,12 +84,22 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/share
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
           mv "${{targets.destdir}}"/usr/share/ri "${{targets.subpkgdir}}"/usr/share/
-
   - name: "ruby-3.1-dev"
     description: "ruby development headers"
     pipeline:
       - uses: split/dev
+
 update:
   enabled: false
   release-monitor:
     identifier: 4223
+
+advisories:
+  CVE-2023-22795:
+    - timestamp: 2023-03-28T20:52:58.257257-04:00
+      status: not_affected
+      justification: component_not_present
+
+secfixes:
+  "0":
+    - CVE-2023-22795


### PR DESCRIPTION
The CVE is actually in rails, not ruby, but the CPE entry is a bit strange in the NVD.

Fixes:

Related:

### Pre-review Checklist


#### For new package PRs only


#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in `annotations` and `secfixes`

#### For version bump PRs
