### PR TITLE
Change the openjdk jre to manually cutdown jdk tools

### DIFF
--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
   version: 11.0.19.5
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-only
@@ -85,18 +85,28 @@ subpackages:
   - name: openjdk-11-jre
     pipeline:
       - runs: |
-          # generate JRE via jlink
-
-          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm
-          ${{targets.destdir}}/usr/lib/jvm/openjdk/bin/jlink \
-            --no-header-files \
-            --no-man-pages \
-            --compress=2 \
-            --add-modules ALL-MODULE-PATH \
-            --output ${{targets.subpkgdir}}/usr/lib/jvm/openjdk-jre
-
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm/openjdk
+          for dir in conf \
+                   include \
+                   jmods \
+                   legal \
+                   lib \
+                   release; do
+                      cp -r ./build/linux-*-server-release/images/jdk/${dir} ${{targets.subpkgdir}}/usr/lib/jvm/openjdk/${dir}
+          done
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm/openjdk/bin
+          for c in java \
+                  jjs \
+                  keytool \
+                  pack200 \
+                  rmid \
+                  rmiregistry \
+                  unpack200; do
+                      cp ./build/linux-*-server-release/images/jdk/bin/${c} ${{targets.subpkgdir}}/usr/lib/jvm/openjdk/bin/${c}
+          done
+    
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -sf /usr/lib/jvm/openjdk-jre/bin/java ${{targets.subpkgdir}}/usr/bin/java
+          ln -sf /usr/lib/jvm/openjdk/bin/java ${{targets.subpkgdir}}/usr/bin/java
     description: OpenJDK 11 (JRE)
     dependencies:
       runtime:


### PR DESCRIPTION
Take 2 of minimizing the JRE image.  

I have concerns that jlink is not the right approach to producing a JRE as current users of JRE images expect.  jlink is tightly couple to the new Java modules system.  When an application has been converted to use modules it can make sense to generate the JRE from the modules required using jdeps and jlink. However producing a jlink based jre with java.se modules is not the same as a standard jdk - tools.  Various libraries are stripped which I don't feel comfortable removing.

Here is the new diff using the manual method. (which is used by every other package manager I've looked at)

```
< usr/bin/javac
11,13d9
< usr/lib/jvm/openjdk/bin/jaotc
< usr/lib/jvm/openjdk/bin/jar
< usr/lib/jvm/openjdk/bin/jarsigner
15,26d10
< usr/lib/jvm/openjdk/bin/javac
< usr/lib/jvm/openjdk/bin/javadoc
< usr/lib/jvm/openjdk/bin/javap
< usr/lib/jvm/openjdk/bin/jcmd
< usr/lib/jvm/openjdk/bin/jconsole
< usr/lib/jvm/openjdk/bin/jdb
< usr/lib/jvm/openjdk/bin/jdeprscan
< usr/lib/jvm/openjdk/bin/jdeps
< usr/lib/jvm/openjdk/bin/jfr
< usr/lib/jvm/openjdk/bin/jhsdb
< usr/lib/jvm/openjdk/bin/jimage
< usr/lib/jvm/openjdk/bin/jinfo
28,36d11
< usr/lib/jvm/openjdk/bin/jlink
< usr/lib/jvm/openjdk/bin/jmap
< usr/lib/jvm/openjdk/bin/jmod
< usr/lib/jvm/openjdk/bin/jps
< usr/lib/jvm/openjdk/bin/jrunscript
< usr/lib/jvm/openjdk/bin/jshell
< usr/lib/jvm/openjdk/bin/jstack
< usr/lib/jvm/openjdk/bin/jstat
< usr/lib/jvm/openjdk/bin/jstatd
39d13
< usr/lib/jvm/openjdk/bin/rmic
42d15
< usr/lib/jvm/openjdk/bin/serialver
64,224d36
< usr/lib/jvm/openjdk/demo
< usr/lib/jvm/openjdk/demo/README
< usr/lib/jvm/openjdk/demo/jfc
< usr/lib/jvm/openjdk/demo/jfc/CodePointIM
< usr/lib/jvm/openjdk/demo/jfc/CodePointIM/CodePointIM.jar
< usr/lib/jvm/openjdk/demo/jfc/CodePointIM/README.html
< usr/lib/jvm/openjdk/demo/jfc/CodePointIM/README_ja.html
< usr/lib/jvm/openjdk/demo/jfc/CodePointIM/README_zh_CN.html
< usr/lib/jvm/openjdk/demo/jfc/CodePointIM/src.zip
< usr/lib/jvm/openjdk/demo/jfc/FileChooserDemo
< usr/lib/jvm/openjdk/demo/jfc/FileChooserDemo/FileChooserDemo.jar
< usr/lib/jvm/openjdk/demo/jfc/FileChooserDemo/README.txt
< usr/lib/jvm/openjdk/demo/jfc/FileChooserDemo/src.zip
< usr/lib/jvm/openjdk/demo/jfc/Font2DTest
< usr/lib/jvm/openjdk/demo/jfc/Font2DTest/Font2DTest.html
< usr/lib/jvm/openjdk/demo/jfc/Font2DTest/Font2DTest.jar
< usr/lib/jvm/openjdk/demo/jfc/Font2DTest/README.txt
< usr/lib/jvm/openjdk/demo/jfc/Font2DTest/src.zip
< usr/lib/jvm/openjdk/demo/jfc/J2Ddemo
< usr/lib/jvm/openjdk/demo/jfc/J2Ddemo/J2Ddemo.jar
< usr/lib/jvm/openjdk/demo/jfc/J2Ddemo/README.txt
< usr/lib/jvm/openjdk/demo/jfc/J2Ddemo/src.zip
< usr/lib/jvm/openjdk/demo/jfc/Metalworks
< usr/lib/jvm/openjdk/demo/jfc/Metalworks/Metalworks.jar
< usr/lib/jvm/openjdk/demo/jfc/Metalworks/README.txt
< usr/lib/jvm/openjdk/demo/jfc/Metalworks/src.zip
< usr/lib/jvm/openjdk/demo/jfc/Notepad
< usr/lib/jvm/openjdk/demo/jfc/Notepad/Notepad.jar
< usr/lib/jvm/openjdk/demo/jfc/Notepad/README.txt
< usr/lib/jvm/openjdk/demo/jfc/Notepad/src.zip
< usr/lib/jvm/openjdk/demo/jfc/SampleTree
< usr/lib/jvm/openjdk/demo/jfc/SampleTree/README.txt
< usr/lib/jvm/openjdk/demo/jfc/SampleTree/SampleTree.jar
< usr/lib/jvm/openjdk/demo/jfc/SampleTree/src.zip
< usr/lib/jvm/openjdk/demo/jfc/Stylepad
< usr/lib/jvm/openjdk/demo/jfc/Stylepad/README.txt
< usr/lib/jvm/openjdk/demo/jfc/Stylepad/Stylepad.jar
< usr/lib/jvm/openjdk/demo/jfc/Stylepad/src.zip
< usr/lib/jvm/openjdk/demo/jfc/SwingSet2
< usr/lib/jvm/openjdk/demo/jfc/SwingSet2/README.txt
< usr/lib/jvm/openjdk/demo/jfc/SwingSet2/SwingSet2.html
< usr/lib/jvm/openjdk/demo/jfc/SwingSet2/SwingSet2.jar
< usr/lib/jvm/openjdk/demo/jfc/SwingSet2/src.zip
< usr/lib/jvm/openjdk/demo/jfc/TableExample
< usr/lib/jvm/openjdk/demo/jfc/TableExample/README.txt
< usr/lib/jvm/openjdk/demo/jfc/TableExample/TableExample.jar
< usr/lib/jvm/openjdk/demo/jfc/TableExample/src.zip
< usr/lib/jvm/openjdk/demo/jfc/TransparentRuler
< usr/lib/jvm/openjdk/demo/jfc/TransparentRuler/README.txt
< usr/lib/jvm/openjdk/demo/jfc/TransparentRuler/TransparentRuler.jar
< usr/lib/jvm/openjdk/demo/jfc/TransparentRuler/src.zip
< usr/lib/jvm/openjdk/demo/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/README.txt
< usr/lib/jvm/openjdk/demo/nbproject/jfc
< usr/lib/jvm/openjdk/demo/nbproject/jfc/FileChooserDemo
< usr/lib/jvm/openjdk/demo/nbproject/jfc/FileChooserDemo/build.properties
< usr/lib/jvm/openjdk/demo/nbproject/jfc/FileChooserDemo/build.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/FileChooserDemo/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/jfc/FileChooserDemo/nbproject/file-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/FileChooserDemo/nbproject/jdk.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/FileChooserDemo/nbproject/netbeans-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/FileChooserDemo/nbproject/project.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Font2DTest
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Font2DTest/build.properties
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Font2DTest/build.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Font2DTest/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Font2DTest/nbproject/file-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Font2DTest/nbproject/jdk.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Font2DTest/nbproject/netbeans-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Font2DTest/nbproject/project.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Metalworks
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Metalworks/build.properties
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Metalworks/build.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Metalworks/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Metalworks/nbproject/file-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Metalworks/nbproject/jdk.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Metalworks/nbproject/netbeans-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Metalworks/nbproject/project.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Notepad
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Notepad/build.properties
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Notepad/build.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Notepad/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Notepad/nbproject/file-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Notepad/nbproject/jdk.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Notepad/nbproject/netbeans-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/Notepad/nbproject/project.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SampleTree
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SampleTree/build.properties
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SampleTree/build.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SampleTree/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SampleTree/nbproject/file-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SampleTree/nbproject/jdk.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SampleTree/nbproject/netbeans-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SampleTree/nbproject/project.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SwingApplet
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SwingApplet/build.properties
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SwingApplet/build.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SwingApplet/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SwingApplet/nbproject/file-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SwingApplet/nbproject/jdk.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SwingApplet/nbproject/netbeans-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/SwingApplet/nbproject/project.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TableExample
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TableExample/build.properties
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TableExample/build.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TableExample/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TableExample/nbproject/file-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TableExample/nbproject/jdk.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TableExample/nbproject/netbeans-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TableExample/nbproject/project.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TransparentRuler
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TransparentRuler/build.properties
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TransparentRuler/build.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TransparentRuler/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TransparentRuler/nbproject/file-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TransparentRuler/nbproject/jdk.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TransparentRuler/nbproject/netbeans-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/jfc/TransparentRuler/nbproject/project.xml
< usr/lib/jvm/openjdk/demo/nbproject/management
< usr/lib/jvm/openjdk/demo/nbproject/management/FullThreadDump
< usr/lib/jvm/openjdk/demo/nbproject/management/FullThreadDump/build.properties
< usr/lib/jvm/openjdk/demo/nbproject/management/FullThreadDump/build.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/FullThreadDump/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/management/FullThreadDump/nbproject/file-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/FullThreadDump/nbproject/jdk.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/FullThreadDump/nbproject/netbeans-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/FullThreadDump/nbproject/project.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/JTop
< usr/lib/jvm/openjdk/demo/nbproject/management/JTop/build.properties
< usr/lib/jvm/openjdk/demo/nbproject/management/JTop/build.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/JTop/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/management/JTop/nbproject/file-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/JTop/nbproject/jdk.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/JTop/nbproject/netbeans-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/JTop/nbproject/project.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/MemoryMonitor
< usr/lib/jvm/openjdk/demo/nbproject/management/MemoryMonitor/build.properties
< usr/lib/jvm/openjdk/demo/nbproject/management/MemoryMonitor/build.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/MemoryMonitor/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/management/MemoryMonitor/nbproject/file-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/MemoryMonitor/nbproject/jdk.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/MemoryMonitor/nbproject/netbeans-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/MemoryMonitor/nbproject/project.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/VerboseGC
< usr/lib/jvm/openjdk/demo/nbproject/management/VerboseGC/build.properties
< usr/lib/jvm/openjdk/demo/nbproject/management/VerboseGC/build.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/VerboseGC/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/management/VerboseGC/nbproject/file-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/VerboseGC/nbproject/jdk.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/VerboseGC/nbproject/netbeans-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/management/VerboseGC/nbproject/project.xml
< usr/lib/jvm/openjdk/demo/nbproject/project.xml
< usr/lib/jvm/openjdk/demo/nbproject/scripting
< usr/lib/jvm/openjdk/demo/nbproject/scripting/jconsole-plugin
< usr/lib/jvm/openjdk/demo/nbproject/scripting/jconsole-plugin/build.properties
< usr/lib/jvm/openjdk/demo/nbproject/scripting/jconsole-plugin/build.xml
< usr/lib/jvm/openjdk/demo/nbproject/scripting/jconsole-plugin/nbproject
< usr/lib/jvm/openjdk/demo/nbproject/scripting/jconsole-plugin/nbproject/file-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/scripting/jconsole-plugin/nbproject/jdk.xml
< usr/lib/jvm/openjdk/demo/nbproject/scripting/jconsole-plugin/nbproject/netbeans-targets.xml
< usr/lib/jvm/openjdk/demo/nbproject/scripting/jconsole-plugin/nbproject/project.xml
690c502
```