### PR TITLE
Add note to patching CVE doas commands about BUILDWORLD=no

### DIFF
--- a/HOW_TO_PATCH_CVES.md
+++ b/HOW_TO_PATCH_CVES.md
@@ -55,12 +55,7 @@ For the ease of explanation, we'll assume we're addressing a single reported vul
     doas make
     ```
 
-    Note that currently, this will build the **entire world**. If you want to build just a single package, first ensure that you have a `doas` configuration line that passes the `BUILDWORLD` variable through similar to this:
-    ```
-    permit setenv { BUILDWORLD=$BUILDWORLD } ...
-    ```
-
-    Then you can run the following to build the package:
+    Note that currently, this will build the **entire world**. If you want to build just a single package, you can run the following to build the package:
 
     ```shell
     BUILDWORLD=no doas make packages/${ARCH}/${PACKAGE_NAME}-${PACKAGE_VERSION}.apk

--- a/HOW_TO_PATCH_CVES.md
+++ b/HOW_TO_PATCH_CVES.md
@@ -52,7 +52,7 @@ For the ease of explanation, we'll assume we're addressing a single reported vul
 1. Verify that our update package will build successfully by running Melange. To do this, run (in a container if you're not already on Linux):
 
     ```shell
-    doas make
+    make
     ```
 
     Note that currently, this will build the **entire world**. If you want to build just a single package, you can run the following to build the package:

--- a/HOW_TO_PATCH_CVES.md
+++ b/HOW_TO_PATCH_CVES.md
@@ -58,7 +58,7 @@ For the ease of explanation, we'll assume we're addressing a single reported vul
     Note that currently, this will build the **entire world**. If you want to build just a single package, you can run the following to build the package:
 
     ```shell
-    BUILDWORLD=no doas make packages/${ARCH}/${PACKAGE_NAME}-${PACKAGE_VERSION}.apk
+    BUILDWORLD=no make packages/${ARCH}/${PACKAGE_NAME}-${PACKAGE_VERSION}.apk
     ```
 
 1. Open a PR.

--- a/HOW_TO_PATCH_CVES.md
+++ b/HOW_TO_PATCH_CVES.md
@@ -55,10 +55,15 @@ For the ease of explanation, we'll assume we're addressing a single reported vul
     doas make
     ```
 
-    Note that currently, this will build the **entire world**. If you want to build just a single package, you can run:
+    Note that currently, this will build the **entire world**. If you want to build just a single package, first ensure that you have a `doas` configuration line that passes the `BUILDWORLD` variable through similar to this:
+    ```
+    permit setenv { BUILDWORLD=$BUILDWORLD } ...
+    ```
+
+    Then you can run the following to build the package:
 
     ```shell
-    doas make packages/${ARCH}/${PACKAGE_NAME}-${PACKAGE_VERSION}.apk
+    BUILDWORLD=no doas make packages/${ARCH}/${PACKAGE_NAME}-${PACKAGE_VERSION}.apk
     ```
 
 1. Open a PR.


### PR DESCRIPTION
This PR adds a little bit of guidance around how to use the `BUILDWORLD=no` flag in the CVE patching guide. There's a bit about how to configure `doas` in general to pass the variable through. And there's I've added the flag itself to the make invocation for single packages.