### PR TITLE
Add envoy ratelimit package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,6 +542,7 @@ $(eval $(call build-package,exim,4.96-r0,exim))
 $(eval $(call build-package,external-dns,0.13.4-r0))
 $(eval $(call build-package,metrics-server,0.6.3-r0))
 $(eval $(call build-package,k8s-sidecar,1.23.1-r0))
+$(eval $(call build-package,ratelimit,0.0_git20230331-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/ratelimit.yaml
+++ b/ratelimit.yaml
@@ -1,0 +1,15 @@
+package:
+  name: ratelimit
+  # This project doesn't do releases and everything is commit based.
+  # This corresponds to commit 008b66a
+  version: "0.0_git20230331"
+  epoch: 0
+  description: Go/gRPC service designed to enable generic rate limit scenarios from different types of applications.
+  copyright:
+    - license: Apache-2.0
+pipeline:
+  - uses: go/install
+    with:
+      package: github.com/envoyproxy/ratelimit/src/service_cmd@008b66a
+  - runs: |
+      mv ${{targets.destdir}}/usr/bin/service_cmd ${{targets.destdir}}/usr/bin/ratelimit


### PR DESCRIPTION
They don't actually tag upstream releases, so I'm not sure I did the version right. This is the latest commit.

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
