### PR TITLE
withdraw libLLVM-15-15.0.7-r0

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -50,3 +50,4 @@ glibc-locale-posix-2.37-r4.apk
 glibc-locale-posix-2.37-r5.apk
 glibc-2.37-r4.apk
 glibc-2.37-r5.apk
+libLLVM-15-15.0.7-r0.apk


### PR DESCRIPTION
This package is defective and was fixed in `-r1`.