### PR TITLE
Nack CVE-2023-24329 in Python 3.10.

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -10,6 +10,7 @@ package:
 secfixes:
   "0":
     - CVE-2007-4559
+    - CVE-2023-24329
   3.10.9-r0:
     - CVE-2020-10735
 environment:
@@ -103,6 +104,13 @@ advisories:
     - timestamp: 2023-02-07T08:34:29.611707Z
       status: fixed
       fixed-version: 3.10.9-r0
+  CVE-2023-24329:
+    - timestamp: 2023-03-31T18:57:02.344902-04:00
+      status: not_affected
+      justification: component_not_present
+      impact: The upstream issue has been deemed expected behavior, not a security issue. See https://github.com/python/cpython/issues/102153.
+
+
 update:
   enabled: true
   shared: true


### PR DESCRIPTION
This one is an interesting read. The cypython maintainers argue that this is not a security issue in Python itself, but could present vulnerabilities in libraries that use the function in an unsafe manner.

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `annotations` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
