### PR TITLE
Add trust-dns package from prossimo!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -549,6 +549,7 @@ $(eval $(call build-package,prometheus-config-reloader,0.64.0-r0))
 $(eval $(call build-package,prometheus-operator,0.64.0-r0))
 $(eval $(call build-package,ratelimit,0.0_git20230331-r0))
 $(eval $(call build-package,ntpd-rs,0.2.1-r0))
+$(eval $(call build-package,trust-dns,0.22.0-r0))
 
 .build-packages: ${PACKAGES}
 

--- a/trust-dns.yaml
+++ b/trust-dns.yaml
@@ -1,0 +1,37 @@
+package:
+  name: trust-dns
+  version: 0.22.0
+  epoch: 0
+  description: ""
+  copyright:
+    - license: MIT
+environment:
+  contents:
+    packages:
+      - rust
+      - libLLVM-15
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - openssl-dev
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/bluejekyll/trust-dns
+      tag: v${{package.version}}
+      expected-commit: 19b4dc40c046b8d49991bd7b5969333771774f1b
+  - name: Configure and build
+    runs: |
+      cargo build --release -p trust-dns --all-features
+      mkdir -p ${{targets.destdir}}/usr/bin/
+      mv target/release/trust-dns ${{targets.destdir}}/usr/bin/
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: bluejekyll/trust-dns
+    strip-prefix: v
+    tag-filter: v
+  


### PR DESCRIPTION
Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `annotations` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
