### PR TITLE
Add upstream packaged nginx.confs

### DIFF
--- a/nginx.yaml
+++ b/nginx.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx
   version: 1.23.4
-  epoch: 1
+  epoch: 0
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause

--- a/nginx.yaml
+++ b/nginx.yaml
@@ -132,3 +132,10 @@ subpackages:
                 install -m644 -D stream.conf ${{targets.subpkgdir}}/etc/nginx/stream.d/
               ;;
             esac
+    - name: nginx-package-config
+      description: Config supplied in packaged nginx.org bundles at https://hg.nginx.org/pkg-oss/
+      pipeline:
+        - runs: |
+            install -m644 -D nginx.conf ${{targets.subpkgdir}}/etc/nginx/
+            mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
+            install -m644 -D default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d

--- a/nginx.yaml
+++ b/nginx.yaml
@@ -1,6 +1,6 @@
 package:
   name: nginx
-  version: 1.23.3
+  version: 1.23.4
   epoch: 1
   description: HTTP and reverse proxy server (stable version)
   copyright:
@@ -38,10 +38,11 @@ data:
       stream_geoip: "10"
       stream: "10"
 # TODO look at adding extra modules like alpine does https://git.alpinelinux.org/aports/tree/main/nginx/APKBUILD#n149
+# Also note the nginx inc config https://hg.nginx.org/pkg-oss/file/tip/alpine 
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 75cb5787dbb9fae18b14810f91cc4343f64ce4c24e27302136fb52498042ba54
+      expected-sha256: d43300e36bb249a7e6edc60bca1b0fc372a0bafce2f346d76acfb677a8790fc0
       uri: https://nginx.org/download/nginx-${{package.version}}.tar.gz
 
   - name: configure
@@ -100,14 +101,35 @@ pipeline:
 
   - runs: |
       make DESTDIR=${{targets.destdir}} install
-
       # default error logs to standard error
-      echo 'error_log  stderr  notice;' >> ${{targets.destdir}}/etc/nginx/nginx.conf
-      # and access to stdout
-      echo 'access_log  stdout;' >> ${{targets.destdir}}/etc/nginx/nginx.conf
+      sed -i 's/#error_log  logs\/error.log;$/error_log  stderr  notice;/' ${{targets.destdir}}/etc/nginx/nginx.conf
+      # and both access logs to stdout
+      sed -i 's/#access_log.*;$/access_log  \/dev\/stdout;/' ${{targets.destdir}}/etc/nginx/nginx.conf
 
   - uses: strip
 subpackages:
+    - name: nginx-package-config
+      description: Config supplied in packaged nginx.org bundles at https://hg.nginx.org/pkg-oss/
+      dependencies:
+        runtime:
+          - nginx
+      pipeline:
+        - runs: |
+            mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
+            install -m644 -D nginx.conf ${{targets.subpkgdir}}/etc/nginx/
+            install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d
+            # Follow Docker Image and link logs to to stdout/stderr
+            # https://github.com/nginxinc/docker-nginx/blob/73a5acae6945b75b433cafd0c9318e4378e72cbb/mainline/alpine-slim/Dockerfile#L106-L107
+            mkdir -p ${{targets.subpkgdir}}/var/log/nginx
+            ln -sf /dev/stdout ${{targets.subpkgdir}}/var/log/nginx/access.log
+            ln -sf /dev/stderr ${{targets.subpkgdir}}/var/log/nginx/error.log
+            # Package config has a different default location for html files, rather annoyingly
+            # Don't really like using a symlink here, but seems better than copying
+            mkdir -p ${{targets.subpkgdir}}/usr/share/nginx/html
+            ln -sf /var/lib/nginx/html/50x.html ${{targets.subpkgdir}}/usr/share/nginx/html/50x.html
+            ln -sf /var/lib/nginx/html/index.html ${{targets.subpkgdir}}/usr/share/nginx/html/index.html
+
+
     - range: modules
       name: nginx-mod-${{range.key}}
       description: Nginx third-party module ${{range.key}}
@@ -134,15 +156,3 @@ subpackages:
                 install -m644 -D stream.conf ${{targets.subpkgdir}}/etc/nginx/stream.d/
               ;;
             esac
-    - name: nginx-package-config
-      description: Config supplied in packaged nginx.org bundles at https://hg.nginx.org/pkg-oss/
-      pipeline:
-        - runs: |
-            mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
-            install -m644 -D nginx.conf ${{targets.subpkgdir}}/etc/nginx/
-            install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d
-            # Follow Docker Image and link logs to to stdout/stderr
-            mkdir -p ${{targets.subpkgdir}}/var/log/nginx
-            ln -sf /dev/stdout ${{targets.subpkgdir}}/var/log/nginx/access.log
-            ln -sf /dev/stderr ${{targets.subpkgdir}}/var/log/nginx/error.log
-

--- a/nginx.yaml
+++ b/nginx.yaml
@@ -103,6 +103,8 @@ pipeline:
 
       # default error logs to standard error
       echo 'error_log  stderr  notice;' >> ${{targets.destdir}}/etc/nginx/nginx.conf
+      # and access to stdout
+      echo 'access_log  stdout;' >> ${{targets.destdir}}/etc/nginx/nginx.conf
 
   - uses: strip
 subpackages:
@@ -136,6 +138,11 @@ subpackages:
       description: Config supplied in packaged nginx.org bundles at https://hg.nginx.org/pkg-oss/
       pipeline:
         - runs: |
-            install -m644 -D nginx.conf ${{targets.subpkgdir}}/etc/nginx/
             mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
-            install -m644 -D default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d
+            install -m644 -D nginx.conf ${{targets.subpkgdir}}/etc/nginx/
+            install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d
+            # Follow Docker Image and link logs to to stdout/stderr
+            mkdir -p ${{targets.subpkgdir}}/var/log/nginx
+            ln -sf /dev/stdout ${{targets.subpkgdir}}/var/log/nginx/access.log
+            ln -sf /dev/stderr ${{targets.subpkgdir}}/var/log/nginx/error.log
+

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,32 @@
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,4 +1,4 @@
-
+# Based on https://hg.nginx.org/pkg-oss/file/fd9484abcae4/alpine/nginx.conf
 user  nginx;
 worker_processes  auto;
 

--- a/nginx/nginx.default.conf
+++ b/nginx/nginx.default.conf
@@ -1,0 +1,44 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+

--- a/nginx/nginx.default.conf
+++ b/nginx/nginx.default.conf
@@ -1,3 +1,5 @@
+# https://hg.nginx.org/pkg-oss/file/fd9484abcae4/alpine/nginx.default.conf
+
 server {
     listen       80;
     server_name  localhost;


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

Adds configs found in the upstream pacakges, but not in the source repo. See https://hg.nginx.org/pkg-oss/

Related: https://github.com/chainguard-images/images/issues/382


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `annotations` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
