### PR TITLE
switch openssh and python-3.12 to manual update, we will get an issue created rather than a PR

### DIFF
--- a/openssh.yaml
+++ b/openssh.yaml
@@ -128,6 +128,7 @@ secfixes:
   9.2_p1-r0:
     - CVE-2023-25136
 update:
+  manual: true
   enabled: true
   release-monitor:
     identifier: 2565

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -105,6 +105,7 @@ advisories:
       fixed-version: 3.0.7-r0
 update:
   enabled: true
+  manual: true
   shared: true
   github:
     identifier: python/cpython


### PR DESCRIPTION
- fixes #920 switch python-3.12 to manual update as it is alpha and not currently automatable 
- fixes #923 switch openssh to manual update as the version format is special and not currently automatable
