### PR TITLE
workflows: push-production: only pull and modify the x86_64 repos

### DIFF
--- a/.github/workflows/push-production.yaml
+++ b/.github/workflows/push-production.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: 'Sync public package repository'
         run: |
           mkdir -p "${{ github.workspace }}/packages"
-          gsutil -m rsync -x "aarch64/.*" -r gs://wolfi-production-registry-destination/os/ "${{ github.workspace }}/packages/"
+          gsutil -m rsync -r gs://wolfi-production-registry-destination/os/x86_64/ "${{ github.workspace }}/packages/x86_64/"
           find "${{ github.workspace }}/packages" -print -exec touch \{} \;
 
       - name: 'Build Wolfi'
@@ -75,11 +75,11 @@ jobs:
           # Don't cache the APKINDEX.
           gcloud --quiet storage cp \
               --cache-control=no-store \
-              "${{ github.workspace }}/packages/**/APKINDEX.tar.gz" gs://wolfi-production-registry-destination/os/x86_64/
+              "${{ github.workspace }}/packages/x86_64/APKINDEX.tar.gz" gs://wolfi-production-registry-destination/os/x86_64/
 
           # apks will be cached in CDN for an hour by default.
           gcloud --quiet storage cp \
-              "${{ github.workspace }}/packages/**/*.apk" gs://wolfi-production-registry-destination/os/x86_64/
+              "${{ github.workspace }}/packages/x86_64/*.apk" gs://wolfi-production-registry-destination/os/x86_64/
 
   postrun:
     name: Build (arm64)


### PR DESCRIPTION
Previously we were updating and pulling arm packages as well as x86_64 ones.  This caused corruption of the x86_64 indexes.