### PR TITLE
Fix yq package config

### DIFF
--- a/yq.yaml
+++ b/yq.yaml
@@ -7,11 +7,6 @@ package:
     - license: Apache License 2.0
   dependencies:
     runtime:
-environment:
-  contents: {}
-  packages:
-    - busybox
-    - go
 pipeline:
   - uses: go/install
     with:


### PR DESCRIPTION
The existing YAML data structure was incorrect (`packages` should've been under `contents`) — but this also means we can build without any additional packages being added to the build environment.