### PR TITLE
mitigate GHSAs in apko and melange

### DIFF
--- a/apko.yaml
+++ b/apko.yaml
@@ -39,3 +39,23 @@ update:
     identifier: chainguard-dev/apko
     strip-prefix: v
     use-tag: true
+
+secfixes:
+  0.7.3-r1:
+    - CVE-2023-28840
+    - CVE-2023-28841
+    - CVE-2023-28842
+
+advisories:
+  CVE-2023-28840:
+    - timestamp: 2023-04-05T10:22:32.316309-04:00
+      status: fixed
+      fixed-version: 0.7.3-r1
+  CVE-2023-28841:
+    - timestamp: 2023-04-05T10:22:32.31759-04:00
+      status: fixed
+      fixed-version: 0.7.3-r1
+  CVE-2023-28842:
+    - timestamp: 2023-04-05T10:22:32.318046-04:00
+      status: fixed
+      fixed-version: 0.7.3-r1

--- a/apko.yaml
+++ b/apko.yaml
@@ -28,7 +28,7 @@ pipeline:
       # Mitigate GHSA-232p-vwff-86mp
       # Mitigate GHSA-33pg-m6jh-5237
       # Mitigate GHSA-6wrf-mxfj-pf5p
-      go get github.com/docker/docker@23.0.3
+      go get github.com/docker/docker@v23.0.3+incompatible
 
       make apko
       install -m755 -D ./apko "${{targets.destdir}}"/usr/bin/apko

--- a/apko.yaml
+++ b/apko.yaml
@@ -1,7 +1,8 @@
 package:
   name: apko
+  # When bumping the version check if the CVE/GHSA mitigations below can be removed.
   version: 0.7.3
-  epoch: 0
+  epoch: 1
   description: Build OCI images using APK directly without Dockerfile
   copyright:
     - license: Apache-2.0
@@ -23,8 +24,15 @@ pipeline:
       destination: apko
   - runs: |
       cd apko
+
+      # Mitigate GHSA-232p-vwff-86mp
+      # Mitigate GHSA-33pg-m6jh-5237
+      # Mitigate GHSA-6wrf-mxfj-pf5p
+      go get github.com/docker/docker@23.0.3
+
       make apko
       install -m755 -D ./apko "${{targets.destdir}}"/usr/bin/apko
+
 update:
   enabled: true
   github:

--- a/melange.yaml
+++ b/melange.yaml
@@ -15,14 +15,16 @@ package:
 environment:
   contents:
     packages:
-      - git
+      - go
+      - busybox
+      - ca-certificates-bundle
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
-      expected-commit: b38d879b8d3866bf2942b8dcd27b0987f7a857f1
+      expected-commit: 4ed1d07ef6955379e936cf237f8dfec382454f47
       destination: melange
   - runs: |
       cd melange

--- a/melange.yaml
+++ b/melange.yaml
@@ -40,3 +40,23 @@ update:
     identifier: chainguard-dev/melange
     strip-prefix: v
     use-tag: true
+
+secfixes:
+  0.3.2-r1:
+    - CVE-2023-28840
+    - CVE-2023-28841
+    - CVE-2023-28842
+
+advisories:
+  CVE-2023-28840:
+    - timestamp: 2023-04-05T10:22:34.321059-04:00
+      status: fixed
+      fixed-version: 0.3.2-r1
+  CVE-2023-28841:
+    - timestamp: 2023-04-05T10:22:34.321895-04:00
+      status: fixed
+      fixed-version: 0.3.2-r1
+  CVE-2023-28842:
+    - timestamp: 2023-04-05T10:22:34.32252-04:00
+      status: fixed
+      fixed-version: 0.3.2-r1

--- a/melange.yaml
+++ b/melange.yaml
@@ -8,6 +8,7 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - apk-tools
       - bubblewrap
       - busybox
 

--- a/melange.yaml
+++ b/melange.yaml
@@ -29,7 +29,7 @@ pipeline:
       # Mitigate GHSA-232p-vwff-86mp
       # Mitigate GHSA-33pg-m6jh-5237
       # Mitigate GHSA-6wrf-mxfj-pf5p
-      go get github.com/docker/docker@23.0.3
+      go get github.com/docker/docker@v23.0.3+incompatible
 
       make melange
       install -m755 -D ./melange "${{targets.destdir}}"/usr/bin/melange

--- a/melange.yaml
+++ b/melange.yaml
@@ -1,13 +1,13 @@
 package:
   name: melange
+  # When bumping the version check if the CVE/GHSA mitigations below can be removed.
   version: 0.3.2
-  epoch: 0
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - apk-tools
       - bubblewrap
       - busybox
 
@@ -17,6 +17,26 @@ environment:
       - git
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: chainguard.dev/melange@v${{package.version}}
+      repository: https://github.com/chainguard-dev/melange
+      tag: v${{package.version}}
+      expected-commit: b38d879b8d3866bf2942b8dcd27b0987f7a857f1
+      destination: melange
+  - runs: |
+      cd melange
+
+      # Mitigate GHSA-232p-vwff-86mp
+      # Mitigate GHSA-33pg-m6jh-5237
+      # Mitigate GHSA-6wrf-mxfj-pf5p
+      go get github.com/docker/docker@23.0.3
+
+      make melange
+      install -m755 -D ./melange "${{targets.destdir}}"/usr/bin/melange
+
+update:
+  enabled: true
+  github:
+    identifier: chainguard-dev/melange
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
Noticed these while scanning `cgr.dev/chainguard/{apko,melange}` with `grype`

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in `annotations` and `secfixes`
