### PR TITLE
Nack CVE-2023-0466 in openssl.

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -9,6 +9,8 @@ package:
     runtime:
 
 secfixes:
+  "0":
+    - CVE-2023-0466
   3.0.7-r0:
     - CVE-2022-3358
     - CVE-2022-3602
@@ -165,6 +167,12 @@ advisories:
     - timestamp: 2023-03-28T07:54:27.093515-07:00
       status: fixed
       fixed-version: 3.1.0-r2
+  CVE-2023-0466:
+    - timestamp: 2023-04-08T12:32:54.797413-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This was a case of documentation not matching function behavior. The upstream maintainers decided to update the documentation rather than change the behavior. See https://www.openssl.org/news/secadv/20230328.txt
+
 update:
   enabled: true
   release-monitor:


### PR DESCRIPTION
The upstream maintainers decide to not change the behavior here and instead update the documentation. Ref: https://www.openssl.org/news/secadv/20230328.txt

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only

#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in `advisories` and `secfixes`

