### PR TITLE
Bump ruby.

### DIFF
--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
-  version: 3.2.1
-  epoch: 1
+  version: 3.2.2
+  epoch: 0
   description: "the Ruby programming language"
   copyright:
     - license: Ruby


### PR DESCRIPTION
The tags don't line up well for our auto-update system yet (_ instead of -).

Fixes:

Related:

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0
