### PR TITLE
Fix dotnet checkout version

### DIFF
--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -41,7 +41,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/dotnet/installer
-      tag: v7.0.104
+      tag: v${{package.version}}
       expected-commit: 5c12d17216f411669c0beb40956249ec48bcb818
       destination: /home/build/installer
   - working-directory: /home/build/installer


### PR DESCRIPTION
The checkout tag version had been hardcoded. I think this might be the reason the recent auto-update CI failed, too: https://github.com/wolfi-dev/os/actions/runs/4618298938/jobs/8165576558?pr=1050

Hopefully, this fix lets the update run successfully, which will in turn fix a few vulnerabilities in the dotnet packages.