### PR TITLE
bump cluster-autoscaler to 9.27.0

### DIFF
--- a/cluster-autoscaler.yaml
+++ b/cluster-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler
-  version: 9.26.0
-  epoch: 1
+  version: 9.27.0
+  epoch: 0
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ pipeline:
     with:
       repository: https://github.com/kubernetes/autoscaler
       tag: cluster-autoscaler-chart-${{package.version}}
-      expected-commit: 562b9772903e327792634407234214d74b44f907
+      expected-commit: 28a1abf601503c2a13ac732128d8f90b979f89cb
   - runs: |
       cd cluster-autoscaler
       mkdir -p ${{targets.destdir}}/usr/bin


### PR DESCRIPTION
bump cluster-autoscaler to 9.27.0 
9.28.0 is for the kubernetes version > 1.26so holding off upgrading to the latest 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
