### PR TITLE
openssl: split out provider and engine modules, configuration

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,12 +1,16 @@
 package:
   name: openssl
   version: 3.1.0
-  epoch: 2
+  epoch: 3
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
+  # For now, continue to install the legacy openssl provider if the parent openssl
+  # package is installed.  This is done because users may be installing the openssl
+  # package to gain that provider.
   dependencies:
     runtime:
+      - openssl-provider-legacy
 
 secfixes:
   3.0.7-r0:
@@ -84,6 +88,13 @@ pipeline:
       rm ${{targets.destdir}}/usr/bin/c_rehash
   - uses: strip
 
+data:
+  - name: engines
+    items:
+      afalg: Linux AF_ALG engine
+      capi: CAPI engine
+      padlock: VIA Padlock engine
+
 subpackages:
   - name: "openssl-doc"
     description: "OpenSSL documentation"
@@ -91,12 +102,24 @@ subpackages:
       - uses: split/manpages
       - runs: |
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share
+  - name: "openssl-config"
+    description: "OpenSSL configuration"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/etc
+          mv "${{targets.destdir}}"/etc/ssl "${{targets.subpkgdir}}"/etc/
   - name: "libcrypto3"
     description: "OpenSSL libcrypto library"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libcrypto.so.3 "${{targets.subpkgdir}}"/usr/lib
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/engines-3
+          mv "${{targets.destdir}}"/usr/lib/engines-3/loader_attic.so "${{targets.subpkgdir}}"/usr/lib/engines-3/
+    dependencies:
+      runtime:
+        - openssl-config
   - name: "libssl3"
     description: "OpenSSL libssl library"
     pipeline:
@@ -107,6 +130,19 @@ subpackages:
     description: "OpenSSL headers"
     pipeline:
       - uses: split/dev
+  - range: engines
+    name: "openssl-engine-${{range.key}}"
+    description: "OpenSSL ${{range.value}}"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/engines-3
+          mv "${{targets.destdir}}"/usr/lib/engines-3/${{range.key}}.so "${{targets.subpkgdir}}"/usr/lib/engines-3/
+  - name: "openssl-provider-legacy"
+    description: "OpenSSL legacy provider"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/ossl-modules
+          mv "${{targets.destdir}}"/usr/lib/ossl-modules/legacy.so "${{targets.subpkgdir}}"/usr/lib/ossl-modules/
 
 advisories:
   CVE-2022-3358:


### PR DESCRIPTION
This introduces some changes I discovered as part of working on a FIPS build of OpenSSL for customers.  It streamlines the configuration of the OpenSSL components, and isolates the ones that are usually not used into subpackages to slim down built image sizes.