### PR TITLE
dotnet-7: security upgrade to 7.0.105 (CVE-2023-28260)

### DIFF
--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -1,13 +1,13 @@
 package:
   name: dotnet-7
-  version: 7.0.104
-  epoch: 1
+  version: 7.0.105
+  epoch: 0
   description: ".NET SDK"
   target-architecture:
     - all
   copyright:
     - paths:
-      - "*"
+        - "*"
       attestation: TODO
       license: MIT
   dependencies:
@@ -42,7 +42,7 @@ pipeline:
     with:
       repository: https://github.com/dotnet/installer
       tag: v${{package.version}}
-      expected-commit: 5c12d17216f411669c0beb40956249ec48bcb818
+      expected-commit: e1bc5e001c9b8e87d9f99e06eb7dbf04c508f450
       destination: /home/build/installer
   - working-directory: /home/build/installer
     runs: |
@@ -87,7 +87,6 @@ subpackages:
     dependencies:
       runtime:
         - dotnet-7
-
   - name: aspnet-7-runtime
     description: "The ASP.NET Core Runtime, version 7"
     pipeline:
@@ -97,7 +96,6 @@ subpackages:
     dependencies:
       runtime:
         - dotnet-7-runtime
-
   - name: dotnet-7-targeting-pack
     description: "The .NET Core targeting pack, version 7"
     pipeline:
@@ -105,7 +103,6 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/share/dotnet/packs
           mv "${{targets.destdir}}"/usr/share/dotnet/packs/NETStandard.Library.* "${{targets.subpkgdir}}"/usr/share/dotnet/packs/
           mv "${{targets.destdir}}"/usr/share/dotnet/packs/Microsoft.NETCore.App.* "${{targets.subpkgdir}}"/usr/share/dotnet/packs/
-
   - name: aspnet-7-targeting-pack
     description: "The ASP.NET targeting pack, version 7"
     pipeline:
@@ -115,7 +112,6 @@ subpackages:
     dependencies:
       runtime:
         - dotnet-7-targeting-pack
-
   - name: dotnet-7-sdk
     description: "The .NET Core SDK, version 7"
     pipeline:
@@ -129,6 +125,7 @@ subpackages:
       runtime:
         - dotnet-7-runtime
         - dotnet-7-targeting-pack
+
 update:
   enabled: true
   github:
@@ -136,3 +133,13 @@ update:
     strip-prefix: v
     use-tag: true
     tag-filter: "v7.0.1" # We specifically the 7.0.1xx releases since those are intended for prod.
+
+advisories:
+  CVE-2023-28260:
+    - timestamp: 2023-04-11T10:23:04.494184-07:00
+      status: fixed
+      fixed-version: 7.0.105-r0
+
+secfixes:
+  7.0.105-r0:
+    - CVE-2023-28260


### PR DESCRIPTION
Fixes: CVE-2023-28260

Related:

### Pre-review Checklist

#### For security-related PRs
- [x] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
- [x] The `epoch` field is reset to 0