### PR TITLE
openssl: add fips build-option

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.1.0
-  epoch: 3
+  epoch: 4
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,14 @@ secfixes:
     - CVE-2023-0464
   3.1.0-r2:
     - CVE-2023-0465
+
+vars:
+  fips-enable: 'no-fips'
+
+options:
+  fips:
+    vars:
+      fips-enable: 'enable-fips'
 
 environment:
   contents:
@@ -67,6 +75,7 @@ pipeline:
          --prefix=/usr \
          --libdir=lib \
          --openssldir=/etc/ssl \
+         ${{vars.fips-enable}} \
          enable-ktls \
          shared \
          no-zlib \
@@ -102,12 +111,6 @@ subpackages:
       - uses: split/manpages
       - runs: |
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share
-  - name: "openssl-config"
-    description: "OpenSSL configuration"
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/etc
-          mv "${{targets.destdir}}"/etc/ssl "${{targets.subpkgdir}}"/etc/
   - name: "libcrypto3"
     description: "OpenSSL libcrypto library"
     pipeline:
@@ -143,6 +146,37 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/ossl-modules
           mv "${{targets.destdir}}"/usr/lib/ossl-modules/legacy.so "${{targets.subpkgdir}}"/usr/lib/ossl-modules/
+  - if: ${{options.fips.enabled}} == 'true'
+    name: "openssl-provider-fips"
+    description: "OpenSSL fips provider"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/ossl-modules
+          mv "${{targets.destdir}}"/usr/lib/ossl-modules/fips.so "${{targets.subpkgdir}}"/usr/lib/ossl-modules/
+
+          mkdir -p "${{targets.subpkgdir}}"/etc/ssl
+          mv "${{targets.destdir}}"/etc/ssl/fipsmodule.cnf "${{targets.subpkgdir}}"/etc/ssl/
+  - if: ${{options.fips.enabled}} == 'true'
+    name: "openssl-config-fips"
+    description: "OpenSSL configuration (FIPS mode)"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/etc/ssl
+          cat fips-preamble.cnf "${{targets.destdir}}"/etc/ssl/openssl.cnf > "${{targets.subpkgdir}}"/etc/ssl/openssl.cnf
+    dependencies:
+      # We overlay the fips mode openssl.cnf on top of the openssl-config package to
+      # enable FIPS mode.  So we require and replace the openssl-config package.
+      runtime:
+        - openssl-config
+        - openssl-provider-fips
+      replaces:
+        - openssl-config
+  - name: "openssl-config"
+    description: "OpenSSL configuration"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/etc
+          mv "${{targets.destdir}}"/etc/ssl "${{targets.subpkgdir}}"/etc/
 
 advisories:
   CVE-2022-3358:


### PR DESCRIPTION
Adds a `fips` build-option to the OpenSSL package.  This build option is disabled in Wolfi, but may be enabled in other builds, by passing it as a `--build-option` to Melange, e.g.

    % make packages/openssl BUILDWORLD=no MELANGE_EXTRA_OPTS="--build-option fips"

To use FIPS mode, the `openssl-config-fips` package may be installed.  Otherwise, to use the FIPS module on a case-by-case basis programatically, the `openssl-provider-fips` package may be installed.

**Any module built using this build option is not considered CMVP-validated.**  Users who wish to use the built FIPS module in a validated setting must obtain validation materials from a designated CMVP testing lab.

Chainguard **does not** provide its validation materials to the general public.  Contact sales if interested in FIPS-validated OpenSSL packages for Wolfi.