### PR TITLE
Prepare for YAML formatting

### DIFF
--- a/.yam.yaml
+++ b/.yam.yaml
@@ -1,0 +1,6 @@
+gap:
+  - "."
+  - ".subpackages"
+  - ".data"
+
+indent: 2

--- a/.yam.yaml
+++ b/.yam.yaml
@@ -2,5 +2,6 @@ gap:
   - "."
   - ".subpackages"
   - ".data"
+  - ".pipeline"
 
 indent: 2

--- a/py3-yaml.yaml
+++ b/py3-yaml.yaml
@@ -21,13 +21,13 @@ environment:
       - py3-setuptools
       - yaml-dev
       - cython
-      
+
 pipeline:
   - uses: fetch
     with:
       uri: https://github.com/yaml/pyyaml/archive/${{package.version}}.tar.gz
       expected-sha256: f33eaba25d8e0c1a959bbf00655198c287dfc5868f5b7b01e401eaa1796cc778
-# without --with-libyaml for now
+  # without --with-libyaml for now
   - runs: |
       python3 setup.py build
   - runs: |


### PR DESCRIPTION
This PR:

1. Fixes a minor YAML comment issue in `py3-yaml.yaml` to fix how YAML is decoded by our tools.

2. But more importantly, adds the `.yam.yaml` configuration file that governs how `yam`—as well as our tools that are now using yam's encoder (`melange` and `wolfictl`)—will format our package YAML files. This also determines what _the "correct answer" is_ when we add a lint check into our CI process.

Of note is the "gap" section, which specifies yq-style expressions for nodes whose children elements should be separated by gaps (i.e. a blank line).