### PR TITLE
Resolve several vulns in envoy

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -1,11 +1,10 @@
 package:
   name: envoy
-  version: 1.25.2
+  version: 1.25.3
   epoch: 0
   description: Cloud-native high-performance edge/middle/service proxy
   copyright:
     - license: Apache-2.0
-
 environment:
   contents:
     packages:
@@ -27,15 +26,13 @@ environment:
       - llvm-lld
       - coreutils
       - patch
-
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/envoyproxy/envoy
       tag: v${{package.version}}
-      expected-commit: afa98867c807dee0d833da701ba3ab0c9ace9ada
+      expected-commit: e99d61c4596573fbea8b8a9def8b160e138a4018
       destination: envoy
-
   - runs: |
       export JAVA_HOME=/usr/lib/jvm/openjdk
       mkdir -p /builder/home/.cache/bazel/_bazel_root
@@ -50,7 +47,6 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv bazel-bin/source/exe/envoy-static ${{targets.destdir}}/usr/bin/envoy
   - uses: strip
-
 subpackages:
   - name: envoy-oci-entrypoint
     description: Entrypoint for using Envoy in OCI containers
@@ -73,3 +69,48 @@ update:
   github:
     identifier: envoyproxy/envoy
     strip-prefix: v
+advisories:
+  CVE-2023-27487:
+    - timestamp: 2023-04-11T16:37:16.620228-04:00
+      status: under_investigation
+    - timestamp: 2023-04-11T16:48:57.416409-04:00
+      status: fixed
+      fixed-version: 1.25.3-r0
+  CVE-2023-27488:
+    - timestamp: 2023-04-11T16:37:16.620174-04:00
+      status: under_investigation
+    - timestamp: 2023-04-11T16:48:57.461209-04:00
+      status: fixed
+      fixed-version: 1.25.3-r0
+  CVE-2023-27491:
+    - timestamp: 2023-04-11T16:37:16.620117-04:00
+      status: under_investigation
+    - timestamp: 2023-04-11T16:48:57.439497-04:00
+      status: fixed
+      fixed-version: 1.25.3-r0
+  CVE-2023-27492:
+    - timestamp: 2023-04-11T16:37:16.620069-04:00
+      status: under_investigation
+    - timestamp: 2023-04-11T16:48:57.394771-04:00
+      status: fixed
+      fixed-version: 1.25.3-r0
+  CVE-2023-27493:
+    - timestamp: 2023-04-11T16:37:16.620021-04:00
+      status: under_investigation
+    - timestamp: 2023-04-11T16:48:57.370639-04:00
+      status: fixed
+      fixed-version: 1.25.3-r0
+  CVE-2023-27496:
+    - timestamp: 2023-04-11T16:37:16.61997-04:00
+      status: under_investigation
+    - timestamp: 2023-04-11T16:48:57.344825-04:00
+      status: fixed
+      fixed-version: 1.25.3-r0
+secfixes:
+  1.25.3-r0:
+    - CVE-2023-27496
+    - CVE-2023-27493
+    - CVE-2023-27492
+    - CVE-2023-27487
+    - CVE-2023-27491
+    - CVE-2023-27488


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

Fixes the following `envoy` vulnerabilities (found via `wolfictl advisory discover`) by upgrading to version `1.25.3`:

- CVE-2023-27487
- CVE-2023-27488
- CVE-2023-27491
- CVE-2023-27492
- CVE-2023-27493
- CVE-2023-27496

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

