### PR TITLE
openldap: fix permissions on libldap and liblber

### DIFF
--- a/openldap.yaml
+++ b/openldap.yaml
@@ -1,7 +1,7 @@
 package:
   name: openldap
   version: 2.6.3
-  epoch: 0
+  epoch: 1
   description: LDAP Server
   copyright:
     - license: OLDAP-2.8
@@ -232,7 +232,10 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mkdir -p ${{targets.subpkgdir}}/etc/openldap
+
           mv ${{targets.destdir}}/usr/lib/*.so* ${{targets.subpkgdir}}/usr/lib/
+          chmod 755 ${{targets.subpkgdir}}/usr/lib/*.so*
+
           mv ${{targets.destdir}}/etc/openldap/ldap.conf ${{targets.subpkgdir}}/etc/openldap
   - name: openldap-lloadd
     pipeline:


### PR DESCRIPTION
Otherwise, melange does not scan them as shared library dependencies.  This results in missing provides entries when building `libtirpc` and others.