### PR TITLE
re-order checkout and print gcloud auth

### DIFF
--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -25,6 +25,11 @@ jobs:
       contents: read
 
     steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: wolfi-dev/wolfictl
+          path: ${{github.workspace}}/wolfictl
+
       - uses: google-github-actions/auth@v0
         with:
           workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
@@ -32,11 +37,9 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{env.PROJECT}}
+      - name: 'Use gcloud CLI'
+        run: 'gcloud auth list --filter=status:ACTIVE --format="value(account)"'
 
-      - uses: actions/checkout@v3
-        with:
-          repository: wolfi-dev/wolfictl
-          path: ${{github.workspace}}/wolfictl
       - name: Setup Build Cluster
         working-directory: ${{github.workspace}}/wolfictl
         run: |

--- a/.github/workflows/dag-push-staging.yaml
+++ b/.github/workflows/dag-push-staging.yaml
@@ -25,6 +25,11 @@ jobs:
       contents: read
 
     steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: wolfi-dev/wolfictl
+          path: ${{github.workspace}}/wolfictl
+
       - uses: google-github-actions/auth@v0
         with:
           workload_identity_provider: "projects/567187841907/locations/global/workloadIdentityPools/staging-shared-9bd2/providers/staging-shared-gha"
@@ -32,11 +37,9 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{env.PROJECT}}
+      - name: 'Use gcloud CLI'
+        run: 'gcloud auth list --filter=status:ACTIVE --format="value(account)"'
 
-      - uses: actions/checkout@v3
-        with:
-          repository: wolfi-dev/wolfictl
-          path: ${{github.workspace}}/wolfictl
       - name: Setup Build Cluster
         working-directory: ${{github.workspace}}/wolfictl
         run: |


### PR DESCRIPTION
Move the checkout earlier and try to use the gcloud 
- check [here](https://github.com/google-github-actions/auth#prerequisites)
 You must run the actions/checkout@v3 step before this action. Omitting the checkout step or putting it after auth will cause future steps to be unable to authenticate.
 