### PR TITLE
Fix the google-cloud-sdk package on x86 by deleting some unneeded bin…

### DIFF
--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: google-cloud-sdk
   version: 426.0.0
-  epoch: 0
+  epoch: 1
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0
@@ -34,6 +34,13 @@ pipeline:
   - runs: |
       ./google-cloud-sdk/install.sh -q
       mkdir -p ${{targets.destdir}}/usr/share/
+
+      # Trim some extra stuff
+      rm -rf google-cloud-sdk/platform/bundledpythonunix/
+      rm -rf google-cloud-sdk/deb
+      rm -rf google-cloud-sdk/rpm
+      rm google-cloud-sdk/install.bat
+
       mv google-cloud-sdk ${{targets.destdir}}/usr/share/
       
       mkdir -p ${{targets.destdir}}/usr/bin

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -51,3 +51,4 @@ glibc-locale-posix-2.37-r5.apk
 glibc-2.37-r4.apk
 glibc-2.37-r5.apk
 libLLVM-15-15.0.7-r0.apk
+google-cloud-sdk-426.0.0-r0.apk


### PR DESCRIPTION
…aries.

These were confusing melange's auto-detector, and we don't need them anyway. They only seem to be included in the  x86 build, so I missed it on arm.

Fixes:

Related: https://github.com/chainguard-images/images/pull/446

### Pre-review Checklist

