### PR TITLE
Trim some more extra weight out of gcloud.

### DIFF
--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: google-cloud-sdk
   version: 426.0.0
-  epoch: 1
+  epoch: 2
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0
@@ -40,6 +40,14 @@ pipeline:
       rm -rf google-cloud-sdk/deb
       rm -rf google-cloud-sdk/rpm
       rm google-cloud-sdk/install.bat
+      rm google-cloud-sdk/data/cli/gcloud.json
+      
+      # This is a large binary with vulnerabilities in it, users can add it back later.
+      google-cloud-sdk/bin/gcloud components remove anthoscli
+      
+      # Running gcloud adds a bunch of pyc files, remove those
+      find google-cloud-sdk/ -name "*.pyc" -exec rm -rf '{}' +
+      rm -rf google-cloud-sdk/.install
 
       mv google-cloud-sdk ${{targets.destdir}}/usr/share/
       


### PR DESCRIPTION
I chatted with some folks on the team and they confirmed this is safe to remove.

It cuts the compressed size from 92MB to 50MB!

Fixes:

Related:

### Pre-review Checklist

