### PR TITLE
Add ferretdb and task.

### DIFF
--- a/ferretdb.yaml
+++ b/ferretdb.yaml
@@ -1,0 +1,29 @@
+package:
+  name: ferretdb
+  version: 1.0.0
+  epoch: 0
+  description: "A truly Open Source MongoDB alternative"
+  copyright:
+    - license: Apache-2.0
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - go
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/FerretDB/FerretDB
+      tag: v${{package.version}}
+      expected-commit: 6734769da718c9b1b182f9c4ab61fb5e9fa37bd6
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      go build -v -o=${{targets.destdir}}/usr/bin/ferretdb -race=false -tags=ferretdb_tigris ./cmd/ferretdb
+  - uses: strip
+update:
+  enabled: true
+  github:
+    identifier: FerretDB/FerretDB
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -516,3 +516,5 @@ elfutils
 libbpf
 skaffold
 google-cloud-sdk
+task
+ferretdb

--- a/task.yaml
+++ b/task.yaml
@@ -1,0 +1,20 @@
+package:
+  name: task
+  version: 3.23.0
+  epoch: 0
+  description: A task runner / simpler Make alternative written in Go
+  target-architecture:
+    - all
+  copyright:
+    - license: MIT
+      paths:
+        - "*"
+pipeline:
+  - uses: go/install
+    with:
+      package: github.com/go-task/task/v3/cmd/task@v${{package.version}}
+update:
+  enabled: true
+  github:
+    identifier: go-task/task
+    strip-prefix: v


### PR DESCRIPTION
Ferretdb normally uses task to build so I added it, but it doesn't actually require it for release builds.

Fixes:

Related:

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`

