### PR TITLE
{heimdal,krb5,sqlite}: rebuild to get rid of .la files

### DIFF
--- a/heimdal.yaml
+++ b/heimdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: heimdal
   version: 7.8.0
-  epoch: 1
+  epoch: 2
   description: "Implementation of Kerberos 5"
   copyright:
     - license: BSD-3-Clause

--- a/krb5.yaml
+++ b/krb5.yaml
@@ -1,7 +1,7 @@
 package:
   name: krb5
   version: 1.20.1
-  epoch: 1
+  epoch: 2
   description: The Kerberos network authentication system
   copyright:
     - license: MIT

--- a/sqlite.yaml
+++ b/sqlite.yaml
@@ -1,7 +1,7 @@
 package:
   name: sqlite
   version: 3.40.1
-  epoch: 3
+  epoch: 4
   description: "C library which implements an SQL database engine"
   copyright:
     - license: blessing
@@ -90,3 +90,4 @@ update:
   enabled: false
   release-monitor:
     identifier: 4877
+


### PR DESCRIPTION
A more exhaustive search of `.la` files will be done in the near future.