### PR TITLE
Note fix for CVE-2023-1579 in binutils

### DIFF
--- a/binutils.yaml
+++ b/binutils.yaml
@@ -7,6 +7,7 @@ package:
     - license: GPL-3.0-or-later
   dependencies:
     runtime:
+
 secfixes:
   2.39-r1:
     - CVE-2022-38126
@@ -14,6 +15,9 @@ secfixes:
     - CVE-2022-38533
   2.39-r3:
     - CVE-2022-38128
+  2.40-r0:
+    - CVE-2023-1579
+
 environment:
   contents:
     repositories:
@@ -27,11 +31,13 @@ environment:
       - build-base
       - isl
       - texinfo
+
 pipeline:
   - uses: fetch
     with:
       uri: https://ftp.gnu.org/gnu/binutils/binutils-${{package.version}}.tar.gz
       expected-sha256: d7f82c4047decf43a6f769ac32456a92ddb6932409a585c633cdd4e9df23d956
+
   - name: 'Configure binutils'
     runs: |
       ./configure \
@@ -50,36 +56,50 @@ pipeline:
         --enable-default-execstack=no \
         --enable-default-hash-style=gnu \
         --enable-textrel-check=error
+
   - uses: autoconf/make
+
   - uses: autoconf/make-install
+
   - name: 'Clean up documentation'
     runs: |
       rm -rf ${{targets.destdir}}/usr/share/info
+
   - uses: strip
+
 subpackages:
   - name: "binutils-dev"
     description: "binutils development headers"
     pipeline:
       - uses: split/dev
+
   - name: "binutils-gold"
     description: "binutils (gold linker)"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/ld.gold "${{targets.subpkgdir}}"/usr/bin/
+
 advisories:
   CVE-2022-38126:
-    - timestamp: 2022-09-16T16:42:40+00:00
+    - timestamp: 2022-09-16T16:42:40Z
       status: fixed
       fixed-version: 2.39-r1
   CVE-2022-38128:
-    - timestamp: 2022-10-11T20:03:51+00:00
+    - timestamp: 2022-10-11T20:03:51Z
       status: fixed
       fixed-version: 2.39-r3
   CVE-2022-38533:
-    - timestamp: 2022-09-16T16:42:40+00:00
+    - timestamp: 2022-09-16T16:42:40Z
       status: fixed
       fixed-version: 2.39-r2
+  CVE-2023-1579:
+    - timestamp: 2023-04-12T15:06:15.89895-04:00
+      status: under_investigation
+    - timestamp: 2023-04-12T15:46:39.789572-04:00
+      status: fixed
+      fixed-version: 2.40-r0
+
 update:
   enabled: true
   release-monitor:


### PR DESCRIPTION
As far as I could tell, the patch was already applied as of the upstream version `2.40`.