### PR TITLE
Don't run update cron for forks

### DIFF
--- a/.github/workflows/wolfictl-update-gh.yaml
+++ b/.github/workflows/wolfictl-update-gh.yaml
@@ -14,8 +14,9 @@ env:
   GIT_AUTHOR_EMAIL: 121097084+wolfi-bot@users.noreply.github.com
 
 jobs:
-  lint:
+  update:
     name: Wolfictl Update
+    if: github.repository == 'wolfi-dev/os'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/wolfictl-update-rm.yaml
+++ b/.github/workflows/wolfictl-update-rm.yaml
@@ -14,8 +14,9 @@ env:
   GIT_AUTHOR_EMAIL: 121097084+wolfi-bot@users.noreply.github.com
 
 jobs:
-  lint:
+  update:
     name: Wolfictl Update
+    if: github.repository == 'wolfi-dev/os'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
I noticed when I updated my own fork of Wolfi, I started getting failed job GitHub notifications every hour 😱  (e.g. [this](https://github.com/luhring/wolfi-os/actions/runs/4683324124/jobs/8298280373)). It seems like this shouldn't run on forks.