### PR TITLE
Add libuuid to util-linux.

### DIFF
--- a/libsm.yaml
+++ b/libsm.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsm
   version: 1.2.4
-  epoch: 0
+  epoch: 1
   description: X11 Session Management library
   copyright:
     - license: MIT
@@ -16,7 +16,8 @@ environment:
       - libice-dev
       - xorgproto
       - xtrans
-      # - util-linux-dev TODO let's do util-linux-dev later and enable the configure flag --with-libuuid below
+      - libuuid
+      - util-linux-dev
       - util-macros
       - xmlto
       - bash
@@ -30,8 +31,8 @@ pipeline:
       opts: |
         --enable-docs \
         --with-xmlto \
-        --without-fop
-  # --with-libuuid TODO as above, would rather not build util-linux-dev yet
+        --without-fop \
+        --with-libuuid
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip

--- a/packages.txt
+++ b/packages.txt
@@ -166,7 +166,6 @@ libxtst
 rarian
 check
 libice
-libsm
 icu
 py3-markupsafe
 py3-jinja2
@@ -255,6 +254,7 @@ zig
 linux-pam
 cython
 util-linux
+libsm
 glib
 jansson
 msmtp

--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -1,7 +1,7 @@
 package:
   name: util-linux
   version: 2.38.1
-  epoch: 0
+  epoch: 1
   description: Random collection of Linux utilities
   copyright:
     - license: |-
@@ -33,7 +33,6 @@ pipeline:
       opts: |
         --disable-silent-rules \
         --enable-newgrp \
-        --disable-uuidd \
         --disable-nls \
         --disable-tls \
         --disable-kill \


### PR DESCRIPTION
I noticed this was missing while building another package, and saw we also had a todo in libsm to enable this option later.

Fixes:

Related:

### Pre-review Checklist
