### PR TITLE
Add systemd package, and add it as a dependency to fluent-bit.

### DIFF
--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-bit
   version: 2.0.11
-  epoch: 0
+  epoch: 1
   description: Fast and Lightweight Log processor and forwarder
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,7 @@ environment:
       - yaml-dev
       - zlib-dev
       - dpkg
+      - systemd-dev
 
 pipeline:
   - uses: fetch

--- a/packages.txt
+++ b/packages.txt
@@ -358,6 +358,7 @@ helm
 kubescape
 s3cmd
 kubevela
+systemd
 fluent-bit
 sbom-scorecard
 libaio

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,0 +1,56 @@
+package:
+  name: systemd
+  version: 253
+  epoch: 0
+  description: The systemd System and Service Manager
+  copyright:
+    - license: LGPL-2.1-or-later AND GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox-full
+      - ca-certificates-bundle
+      - build-base
+      - gperf
+      - coreutils
+      - meson
+      - libcap-dev
+      - ninja
+      - cmd:getent
+      - clang-15
+      - llvm15
+      - python3
+      - py3-jinja2
+      - libmount
+      - cmake
+      - libbpf
+      - util-linux-dev
+      - libuuid
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/systemd/systemd
+      tag: v${{package.version}}
+      expected-commit: 477fdc5afed0457c43d01f3d7ace7209f81d3995
+
+  - uses: meson/configure
+
+  - runs: |
+      meson setup build/
+      ninja -C build/
+
+  - uses: meson/install
+
+subpackages:
+  - name: "systemd-dev"
+    description: "headers for systemd"
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: systemd/systemd
+    strip-prefix: v


### PR DESCRIPTION
Fluent-bit has a systemd plugin that's required for the default helm chart. We comfigured it in our build, but didn't actually have systemd-dev so it ignored that part, making our fluent-bit image crash in a normal helm install.

I've verified that this fixes our image and the helm tests now pass!

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`
