### PR TITLE
Add boost.

### DIFF
--- a/boost.yaml
+++ b/boost.yaml
@@ -1,0 +1,114 @@
+package:
+  name: boost
+  version: 1.81.0
+  epoch: 0
+  description: "A library for interacting with the Linux kernel's Berkeley Packet Filter (BPF) facility from user space"
+  copyright:
+    - license: "custom"
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - python3
+      - python3-dev
+data:
+  - name: libs
+    items:
+      atomic: atomic
+      chrono: chrono
+      container: container
+      context: context
+      contract: contract
+      coroutine: coroutine
+      date_time: date_time
+      fiber: fiber
+      filesystem: filesystem
+      graph: graph
+      iostreams: iostreams
+      math: math
+      prg_exec_monitor: prg_exec_monitor
+      program_options: program_options
+      python3: python3
+      random: random
+      regex: regex
+      serialization: serialization
+      system: system
+      thread: thread
+      unit_test_framework: unit_test_framework
+      wave: wave
+      wserialization: wserialization
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://boostorg.jfrog.io/artifactory/main/release/${{package.version}}/source/boost_1_81_0.tar.gz
+      expected-sha256: 205666dea9f6a7cfed87c7a6dfbeb52a2c1b9de55712c9c1a87735d7181452b6
+  - runs: |
+      abiflags="$(python3-config --abiflags)"
+
+      # create user-config.jam
+      PY3_VERSION=$(python3 -c 'import sys; print("%i.%i" % (sys.version_info.major, sys.version_info.minor))')
+      cat > user-config.jam <<-__EOF__
+      using gcc : : $CC : <cxxflags>"${CXXFLAGS}" <linkflags>"${LDFLAGS}" ;
+      using python : ${PY3_VERSION:+$PY3_VERSION }: /usr/bin/python3 : ${PY3_VERSION:+/usr/include/python${PY3_VERSION}${abiflags} }: : : : ${abiflags:+$abiflags };
+      __EOF__
+
+      cd tools/build/src/engine
+      ./build.sh cc gcc
+      cd ../../../../
+
+      cd tools/bcp
+      ../build/src/engine/b2 -j $(nproc)
+      cd ../../
+
+      ./tools/build/src/engine/b2 \
+        --user-config=user-config.jam \
+        --prefix="${{targets.destdir}}/usr" \
+        release \
+        toolset=gcc \
+        debug-symbols=off \
+        threading=single,multi \
+        runtime-link=shared \
+        link=shared,static \
+        cflags=-fno-strict-aliasing \
+        --layout=tagged \
+        -q \
+        -j $(nproc)
+
+      mkdir -p "${{targets.destdir}}"/usr/bin
+      install -Dm755 tools/build/src/engine/b2 "${{targets.destdir}}"/usr/bin/b2
+      install -Dm755 dist/bin/bcp "${{targets.destdir}}"/usr/bin/bcp
+      install -Dm644 LICENSE_1_0.txt \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE_1_0.txt
+
+      "${{targets.destdir}}"/usr/bin/b2 \
+      --includedir="$[{targets.destdir}]"/usr/include \
+      --libdir="${{targets.destdir}}"/usr/lib \
+      install
+  - uses: strip
+subpackages:
+  - name: boost-dev
+    pipeline:
+    - uses: split/dev
+  - name: boost-static
+    pipeline:
+    - uses: split/static
+  - name: boost-docs
+    pipeline:
+    - uses: split/manpages
+  - range: libs
+    name: "${{range.key}}"
+    description: "${{range.key}} boost library"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libboost_${{range.key}}* "${{targets.subpkgdir}}"/usr/lib/
+update:
+  enabled: true
+  github:
+    identifier: boostorg/boost
+    strip-prefix: boost-
+    use-tag: true

--- a/packages.txt
+++ b/packages.txt
@@ -522,3 +522,4 @@ skaffold
 google-cloud-sdk
 task
 ferretdb
+boost


### PR DESCRIPTION
This was "inspired" by Alpine's APKBUILD, with the following notable changes:

* signal was removed in boost 1.69, so I dropped it here.
* I dropped the python2 compat stuff and assumed only python3.

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`

