### PR TITLE
libssh2: fix configure invocation, remove explicit libssh2 dep on -dev package

### DIFF
--- a/libssh2.yaml
+++ b/libssh2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libssh2
   version: 1.10.0
-  epoch: 2
+  epoch: 3
   description: "A library implementing the SSH2 protocol as defined by Internet Drafts"
   copyright:
     - license: BSD
@@ -21,17 +21,7 @@ pipeline:
     with:
       uri: https://www.libssh2.org/download/${{package.name}}-${{package.version}}.tar.gz
       expected-sha256: 2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51
-  - name: Build
-    runs: |
-        CC=gcc CXX=g++ ./configure \
-        --disable-python \
-        --disable-static \
-        --disable-resmgr \
-        --enable-rawmidi \
-        --enable-seq \
-        --enable-aload \
-        --disable-dependency-tracking \
-        --without-versioned
+  - uses: autoconf/configure
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
@@ -41,9 +31,7 @@ subpackages:
     description: "headers for libssh2"
     pipeline:
       - uses: split/dev
-    dependencies:
-      runtime:
-        - libssh2
+
 update:
   enabled: true
   release-monitor:


### PR DESCRIPTION
Modernize libssh2 package and fix `./configure` invocation.
Found while doing `.la` file audit.