### PR TITLE
Fix two CVEs in minio and add secfixes entries.

### DIFF
--- a/minio.yaml
+++ b/minio.yaml
@@ -1,9 +1,9 @@
 package:
   name: minio
-  # minio uses strange versioning, the upstream version is RELEASE.2023-03-24T21-41-23Z
+  # minio uses strange versioning, the upstream version is RELEASE.2023-04-13T03-08-07Z
   # when bumping this, also bump the tag in git-checkout below
-  version: 0.20230324.214123
-  epoch: 1
+  version: 0.20230413.030807
+  epoch: 0
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0
@@ -21,8 +21,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/minio/minio
-      tag: RELEASE.2023-03-24T21-41-23Z
-      expected-commit: 74040b457b50417b58eae7cb17c63428a0e2dd44
+      tag: RELEASE.2023-04-13T03-08-07Z
+      expected-commit: a42650c065fe22c6a6d3ce526d80c5354d4bceac
   - runs: |
       make build
       mkdir -p ${{targets.destdir}}/usr/bin
@@ -57,6 +57,14 @@ advisories:
     - timestamp: 2023-03-25T17:05:12.402326-04:00
       status: not_affected
       justification: vulnerable_code_not_present
+  CVE-2023-28433:
+    - timestamp: 2023-04-13T17:44:39.707701-04:00
+      status: fixed
+      fixed-version: 0.20230413.030807
+  CVE-2023-28434:
+    - timestamp: 2023-04-13T17:44:43.780465-04:00
+      status: fixed
+      fixed-version: 0.20230413.030807
 
 secfixes:
   "0":
@@ -67,6 +75,9 @@ secfixes:
     - CVE-2021-21390
     - CVE-2021-43858
     - CVE-2022-35919
+  0.20230413.030807:
+    - CVE-2023-28433
+    - CVE-2023-28434
 
 update:
   enabled: false # uses strange versioning


### PR DESCRIPTION
Fixes:

Related:

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0
