### PR TITLE
on forks don't run the build clusters/dag push to stage and prod

### DIFF
--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -19,6 +19,7 @@ jobs:
   setup-cluster:
     name: Setup build cluster
     runs-on: ubuntu-latest
+    if: github.repository == 'wolfi-dev/os'
 
     permissions:
       id-token: write

--- a/.github/workflows/dag-push-staging.yaml
+++ b/.github/workflows/dag-push-staging.yaml
@@ -19,6 +19,7 @@ jobs:
   setup-cluster:
     name: Setup build cluster
     runs-on: ubuntu-latest
+    if: github.repository == 'wolfi-dev/os'
 
     permissions:
       id-token: write


### PR DESCRIPTION
Fixes:  Forked repo's don't need to run the build clusters as anyway it just fails 

