### PR TITLE
Bump Ruby 3.0 and 3.1, and mark several CVEs as fixed.

### DIFF
--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.0
-  version: 3.0.5
-  epoch: 1
+  version: 3.0.6
+  epoch: 0
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -36,7 +36,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://cache.ruby-lang.org/pub/ruby/3.0/ruby-${{package.version}}.tar.gz
-      expected-sha256: 9afc6380a027a4fe1ae1a3e2eccb6b497b9c5ac0631c12ca56f9b7beb4848776
+      expected-sha256: 6e6cbd490030d7910c0ff20edefab4294dfcd1046f0f8f47f78b597987ac683e
   - name: Configure
     runs: |
       ./configure \
@@ -58,8 +58,6 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
-
-  # Remove gem bundler installed with ruby. It's provided by it's own package
   - runs: |-
       # Ignore the patch version of ruby since ruby will install under the
       # version of the latest standard library. Should produce the string 3.0.*
@@ -95,11 +93,24 @@ advisories:
     - timestamp: 2023-03-10T10:57:16.957642-05:00
       status: fixed
       fixed-version: 3.0.5-r0
+  CVE-2023-28755:
+    - timestamp: 2023-04-14T07:20:45.246887-04:00
+      status: fixed
+      fixed-version: 3.0.6-r0
+  CVE-2023-28756:
+    - timestamp: 2023-04-14T07:20:49.582382-04:00
+      status: fixed
+      fixed-version: 3.0.6-r0
 
 secfixes:
   3.0.5-r0:
     - CVE-2021-33621
+  3.0.6-r0:
+    - CVE-2023-28755
+    - CVE-2023-28756
+
 update:
   enabled: false
+  manual: true # be careful with auto updates as we don't want to include 3.3, we currently don't offer a filter on release monitor versions
   release-monitor:
     identifier: 4223

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
-  version: 3.1.3
-  epoch: 5
+  version: 3.1.4
+  epoch: 0
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -36,7 +36,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-${{package.version}}.tar.gz
-      expected-sha256: 5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e
+      expected-sha256: a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6
   - name: Configure
     runs: |
       ./configure \
@@ -58,8 +58,6 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
-
-  # Remove gem bundler installed with ruby. It's provided by it's own package
   - runs: |-
       # Ignore the patch version of ruby since ruby will install under the
       # version of the latest standard library. Should produce the string 3.1.*
@@ -85,12 +83,27 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/share
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
           mv "${{targets.destdir}}"/usr/share/ri "${{targets.subpkgdir}}"/usr/share/
-
   - name: "ruby-3.1-dev"
     description: "ruby development headers"
     pipeline:
       - uses: split/dev
+
 update:
   enabled: false
   release-monitor:
     identifier: 4223
+
+advisories:
+  CVE-2023-28755:
+    - timestamp: 2023-04-14T07:20:17.118678-04:00
+      status: fixed
+      fixed-version: 3.1.4-r0
+  CVE-2023-28756:
+    - timestamp: 2023-04-14T07:20:13.369198-04:00
+      status: fixed
+      fixed-version: 3.1.4-r0
+
+secfixes:
+  3.1.4-r0:
+    - CVE-2023-28756
+    - CVE-2023-28755

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -62,8 +62,6 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
-
-  # Remove gem bundler installed with ruby. It's provided by it's own package
   - runs: |-
       # Ignore the patch version of ruby since ruby will install under the
       # version of the latest standard library. Should produce the string 3.2.*
@@ -89,13 +87,28 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/share
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
           mv "${{targets.destdir}}"/usr/share/ri "${{targets.subpkgdir}}"/usr/share/
-
   - name: "ruby-3.2-dev"
     description: "ruby development headers"
     pipeline:
       - uses: split/dev
+
 update:
   enabled: true
   manual: true # be careful with auto updates as we don't want to include 3.3, we currently don't offer a filter on release monitor versions
   release-monitor:
     identifier: 4223
+
+advisories:
+  CVE-2023-28755:
+    - timestamp: 2023-04-14T07:19:28.944696-04:00
+      status: fixed
+      fixed-version: 3.2.2-r0
+  CVE-2023-28756:
+    - timestamp: 2023-04-14T07:19:41.245348-04:00
+      status: fixed
+      fixed-version: 3.2.2-r0
+
+secfixes:
+  3.2.2-r0:
+    - CVE-2023-28755
+    - CVE-2023-28756


### PR DESCRIPTION
We picked this in up a 3.2 bump, but didn't bump 3.0 and 3.1.

Fixes:

Related:

### Pre-review Checklist


#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0
