### PR TITLE
Fix hardcoded version for icu + py3-dateutil

### DIFF
--- a/icu.yaml
+++ b/icu.yaml
@@ -1,7 +1,7 @@
 package:
   name: icu
   version: 71.1
-  epoch: 2
+  epoch: 3
   description: "International Components for Unicode library"
   copyright:
     - license: MIT
@@ -15,11 +15,21 @@ environment:
       - ca-certificates-bundle
   environment:
     ICU_DATA_FILTER_FILE: "./data-filter-en.json"
+
+var-transforms:
+  - from: ${{package.version}}
+    match: \.
+    replace: \-
+    to: dash-package-version
+  - from: ${{package.version}}
+    match: \.
+    replace: \_
+    to: underscore-package-version
+
 pipeline:
   - uses: fetch
     with:
-      # TODO: cannot use package.version here since "71-1"/"71_1" are different from "71.1"
-      uri: https://github.com/unicode-org/icu/releases/download/release-71-1/icu4c-71_1-src.tgz
+      uri: https://github.com/unicode-org/icu/releases/download/release-${{vars.dash-package-version}}/icu4c-${{vars.underscore-package-version}}-src.tgz
       expected-sha512: 1fd2a20aef48369d1f06e2bb74584877b8ad0eb529320b976264ec2db87420bae242715795f372dbc513ea80047bc49077a064e78205cd5e8b33d746fd2a2912
   - runs: |
       # JSON-ified version of https://git.alpinelinux.org/aports/plain/main/icu/data-filter-en.yml?id=8db8f1a746ebc18ac3b56c91ed14224e424f57ec

--- a/py3-dateutil.yaml
+++ b/py3-dateutil.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-dateutil
   version: 2.8.2
-  epoch: 1
+  epoch: 2
   description: "Python3 extensions for datetime module"
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause
@@ -20,7 +20,13 @@ environment:
       - python3
       - py3-setuptools
       - py3-gpep517
-      
+
+var-transforms:
+  - from: ${{package.version}}
+    match: \.
+    replace: \,
+    to: mangled-package-version
+
 pipeline:
   - uses: fetch
     with:
@@ -28,11 +34,10 @@ pipeline:
       expected-sha256: 0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86
   - runs: |
       # Generate _version.py ourselves since we don't use setuptools_scm
-      # TODO (tuananh): hardcode the version tuple for now
       cat <<- EOF >dateutil/_version.py
       # coding: utf-8
       version = '${{package.version}}'
-      version_tuple = (2,8,2)
+      version_tuple = (${{vars.mangled-package-version}})
       EOF
 
       sed -e '/setuptools_scm/d' -i setup.cfg


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
