### PR TITLE
Enable auto-update for icu pkg

### DIFF
--- a/icu.yaml
+++ b/icu.yaml
@@ -59,6 +59,5 @@ subpackages:
         - icu
 update:
   enabled: true
-  manual: true # maybe use var transforms, until then manual update is needed to handle the version in the fetch URL
   release-monitor:
     identifier: 16134


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Enable auto-update for icu pkg since we're using vars-transform now.

I guess this one doesn't need epoch bump?

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
