### PR TITLE
Enable autoupdate for py3-setuptools

### DIFF
--- a/py3.10-setuptools.yaml
+++ b/py3.10-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.10-setuptools
   version: 67.5.1
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"
@@ -20,7 +20,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 15136a251127da2d2e77ac7a1bc231eb504654f7e3346d93613a13f2e2787535
-      uri: https://files.pythonhosted.org/packages/a4/3a/d60ed296ff8bbc6157ce818765c4c02df8b02fe70c310b7d29127962c5ae/setuptools-${{package.version}}.tar.gz
+      uri: https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-${{package.version}}.tar.gz
   - name: Python Build
     runs: python setup.py build
   - name: Python Install
@@ -28,7 +28,6 @@ pipeline:
   - uses: strip
 update:
   enabled: true
-  manual: true # uses a sha in the fetch URL
   shared: true
   release-monitor:
     identifier: 4021

--- a/py3.10-setuptools.yaml
+++ b/py3.10-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.10-setuptools
-  version: 67.5.1
-  epoch: 1
+  version: 67.6.1
+  epoch: 0
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"

--- a/py3.11-setuptools.yaml
+++ b/py3.11-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.11-setuptools
-  version: 67.5.1
-  epoch: 1
+  version: 67.6.1
+  epoch: 0
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"

--- a/py3.11-setuptools.yaml
+++ b/py3.11-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.11-setuptools
   version: 67.5.1
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"
@@ -22,7 +22,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 15136a251127da2d2e77ac7a1bc231eb504654f7e3346d93613a13f2e2787535
-      uri: https://files.pythonhosted.org/packages/a4/3a/d60ed296ff8bbc6157ce818765c4c02df8b02fe70c310b7d29127962c5ae/setuptools-${{package.version}}.tar.gz
+      uri: https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-${{package.version}}.tar.gz
   - name: Python Build
     runs: python setup.py build
   - name: Python Install
@@ -30,7 +30,6 @@ pipeline:
   - uses: strip
 update:
   enabled: true
-  manual: true # uses a sha in the fetch URL
   shared: true
   release-monitor:
     identifier: 4021


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

we use the following URL which enable auto-update for py3-* packages. It's a 302 redirect but fetch can support following redirect.

```
https://files.pythonhosted.org/packages/source/<first-letter-of-package-name>/<package-name>-<version>.tar.gz
```

```
https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-${{package.version}}.tar.gz
```

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
