### PR TITLE
withdrawn-packages: withdraw openjdk-jre 17.0.7+5 (bad version)

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -80,3 +80,6 @@ thread-1.81.0-r0.apk
 unit_test_framework-1.81.0-r0.apk
 wave-1.81.0-r0.apk
 wserialization-1.81.0-r0.apk
+openjdk-17-17.0.7+5-r0.apk
+openjdk-17-doc-17.0.7+5-r0.apk
+openjdk-17-jre-17.0.7+5-r0.apk


### PR DESCRIPTION
These packages have a non-conformant APK version and should have been removed sooner.