### PR TITLE
step: fix build by stopping use of go/install

### DIFF
--- a/step.yaml
+++ b/step.yaml
@@ -6,15 +6,17 @@ package:
   copyright:
     - license: Apache-2.0
 
-environment:
-  contents:
-    packages:
-      - git
-
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/smallstep/cli/cmd/step@v${{package.version}}
+      repository: https://github.com/smallstep/cli
+      tag: v${{package.version}}
+      expected-commit: 0ce5911cd5b9dce8ade36f24e3084fc6e4976a30
+
+  - uses: go/build
+    with:
+      packages: ./cmd/step
+      output: step
 
 update:
   enabled: true


### PR DESCRIPTION
The `step.yaml` package had been configured to use `go/install`, which wasn't working because step's `go.mod` contains a `replace` directive.

This PR swaps out `go/install` for an analogous approach of `git-checkout` and `go/build`.
