### PR TITLE
Switch pip to use github fetches and updates to fix flakes.

### DIFF
--- a/py3.10-pip.yaml
+++ b/py3.10-pip.yaml
@@ -1,7 +1,7 @@
 # Generated from https://pypi.org/project/pip/
 package:
   name: py3.10-pip
-  version: 23.0.1
+  version: 23.1
   epoch: 0
   description: The PyPA recommended tool for installing Python packages.
   copyright:
@@ -22,10 +22,11 @@ environment:
       - py3.10-setuptools
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: cd015ea1bfb0fcef59d8a286c1f8bebcb983f6317719d415dc5351efb7cd7024
-      uri: https://files.pythonhosted.org/packages/6b/8b/0b16094553ecc680e43ded8f920c3873b01b1da79a54274c98f08cb29fca/pip-${{package.version}}.tar.gz
+      repository: https://github.com/pypa/pip
+      expected-commit: 6424ac4600265490462015c2fc7f9a402dba9ed8
+      tag: ${{package.version}}
 
   - name: Python Build
     runs: python setup.py build
@@ -49,5 +50,6 @@ secfixes:
 update:
   enabled: true
   shared: true
-  release-monitor:
-    identifier: 6529
+  github:
+    identifier: pypa/pip
+    use-tag: true

--- a/py3.11-pip.yaml
+++ b/py3.11-pip.yaml
@@ -1,14 +1,14 @@
 # Generated from https://pypi.org/project/pip/
 package:
   name: py3.11-pip
-  version: 23.0.1
+  version: 23.1
   epoch: 0
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT
   dependencies:
     provides:
-      - py3-pip=23.0.999
+      - py3-pip=23.1.999
     runtime:
       - python-3.11
       - py3.11-setuptools
@@ -24,10 +24,11 @@ environment:
       - py3.11-setuptools
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: cd015ea1bfb0fcef59d8a286c1f8bebcb983f6317719d415dc5351efb7cd7024
-      uri: https://files.pythonhosted.org/packages/6b/8b/0b16094553ecc680e43ded8f920c3873b01b1da79a54274c98f08cb29fca/pip-${{package.version}}.tar.gz
+      repository: https://github.com/pypa/pip
+      expected-commit: 6424ac4600265490462015c2fc7f9a402dba9ed8
+      tag: ${{package.version}}
 
   - name: Python Build
     runs: python setup.py build
@@ -51,5 +52,6 @@ secfixes:
 update:
   enabled: true
   shared: true
-  release-monitor:
-    identifier: 6529
+  github:
+    identifier: pypa/pip
+    use-tag: true


### PR DESCRIPTION
It looks like a new release came out before the tarball was published: https://github.com/wolfi-dev/os/issues/1369

Also bump to 23.1

Fixes:

Related:

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
