### PR TITLE
Bump haproxy and glib.

### DIFF
--- a/glib.yaml
+++ b/glib.yaml
@@ -1,7 +1,7 @@
 package:
   name: glib
-  version: 2.74.3
-  epoch: 2
+  version: 2.76.1
+  epoch: 0
   description: Common C routines used by Gtk+ and other libs
   copyright:
     - license: LGPL-2.1-or-later
@@ -40,7 +40,7 @@ var-transforms:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: e9bc41ecd9690d9bc6a970cc7380119b828e5b6a4b16c393c638b3dc2b87cbcb
+      expected-sha256: 43dc0f6a126958f5b454136c4398eab420249c16171a769784486e25f2fda19f
       uri: https://download.gnome.org/sources/glib/${{vars.mangled-package-version}}/glib-${{package.version}}.tar.xz
 
   - uses: meson/configure

--- a/haproxy.yaml
+++ b/haproxy.yaml
@@ -1,6 +1,6 @@
 package:
   name: haproxy
-  version: 2.6.12
+  version: 2.7.6
   epoch: 0
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
@@ -38,7 +38,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://www.haproxy.org/download/${{vars.mangled-package-version}}/src/haproxy-${{package.version}}.tar.gz
-      expected-sha256: 58f9edb26bf3288f4b502658399281cc5d6478468bd178eafe579c8f41895854
+      expected-sha256: 133f357ddb3fcfc5ad8149ef3d74cbb5db6bb4a5ab67289ce0b0ab686cdeb74f
 
   - uses: autoconf/make
     with:


### PR DESCRIPTION
These are still manual.

Fixes: https://github.com/wolfi-dev/os/issues/1339
Fixes: https://github.com/wolfi-dev/os/issues/1346

Related:

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
