### PR TITLE
add argo wokflows

### DIFF
--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -1,0 +1,51 @@
+package:
+  name: argo-workflows
+  version: 3.4.7
+  epoch: 0
+  description: Workflow engine for Kubernetes.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+      - python3
+      - openssl
+      - nodejs-16
+      - yarn
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/argoproj/argo-workflows
+      tag: v${{package.version}}
+      expected-commit: f2292647c5a6be2f888447a1fef71445cc05b8fd
+
+  - runs: |
+      # NODE_OPTIONS has to been set
+      sed -i 's/NODE_OPTIONS='\''[^'\'']*'\''/NODE_OPTIONS='\''--openssl-legacy-provider'\''/g' ui/package.json
+      cp ui/package.json .
+      cp ui/yarn.lock .
+
+      yarn install
+      yarn cache clean
+
+      # Our global LDFLAGS conflict with a Makefile parameter
+      unset LDFLAGS
+      make dist/workflow-controller
+      make dist/argo
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv dist/argo* ${{targets.destdir}}/usr/bin/
+      mv dist/workflow-controller* ${{targets.destdir}}/usr/bin/
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: argoproj/argo-workflows
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -539,3 +539,4 @@ asciidoc
 asciidoctor
 iniparser
 ndctl
+argo-workflows


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_

Had to Override NODE_Options as its is hard code in the make file doesn't take the env variables 

More Context on using the Node 

```
https://github.com/wolfi-dev/os/actions/runs/4710381594/jobs/8353977863#step:6:1439

 $ rm -Rf dist && NODE_OPTIONS='' NODE_ENV=production webpack --mode production --config ./src/app/webpack.config.js
ℹ️  x86_64    | isProd= true
⚠️  x86_64    | Error: error:0308010C:digital envelope routines::unsupported
⚠️  x86_64    |     at new Hash (node:internal/crypto/hash:71:19)
⚠️  x86_64    |     at Object.createHash (node:crypto:130:10)
⚠️  x86_64    |     at module.exports (/home/build/ui/node_modules/webpack/lib/util/createHash.js:135:53)
⚠️  x86_64    |     at NormalModule._initBuildHash (/home/build/ui/node_modules/webpack/lib/NormalModule.js:417:16)
⚠️  x86_64    |     at handleParseError (/home/build/ui/node_modules/webpack/lib/NormalModule.js:471:10)
⚠️  x86_64    |     at /home/build/ui/node_modules/webpack/lib/NormalModule.js:503:5
⚠️  x86_64    |     at /home/build/ui/node_modules/webpack/lib/NormalModule.js:358:12
⚠️  x86_64    |     at /home/build/ui/node_modules/loader-runner/lib/LoaderRunner.js:373:3
⚠️  x86_64    |     at iterateNormalLoaders (/home/build/ui/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
⚠️  x86_64    |     at iterateNormalLoaders (/home/build/ui/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
⚠️  x86_64    |     at /home/build/ui/node_modules/loader-runner/lib/LoaderRunner.js:236:3
⚠️  x86_64    |     at runSyncOrAsync (/home/build/ui/node_modules/loader-runner/lib/LoaderRunner.js:130:11)
⚠️  x86_64    |     at iterateNormalLoaders (/home/build/ui/node_modules/loader-runner/lib/LoaderRunner.js:232:2)
⚠️  x86_64    |     at Array.<anonymous> (/home/build/ui/node_modules/loader-runner/lib/LoaderRunner.js:205:4)
⚠️  x86_64    |     at Storage.finished (/home/build/ui/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:55:16)
⚠️  x86_64    |     at /home/build/ui/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:91:9
⚠️  x86_64    | node:internal/crypto/hash:71
⚠️  x86_64    |   this[kHandle] = new _Hash(algorithm, xofLen);
⚠️  x86_64    |                   ^


⚠️  x86_64    | 
⚠️  x86_64    | Error: error:0308010C:digital envelope routines::unsupported
⚠️  x86_64    |     at new Hash (node:internal/crypto/hash:71:19)
⚠️  x86_64    |     at Object.createHash (node:crypto:130:10)
⚠️  x86_64    |     at module.exports (/home/build/ui/node_modules/webpack/lib/util/createHash.js:135:53)
⚠️  x86_64    |     at NormalModule._initBuildHash (/home/build/ui/node_modules/webpack/lib/NormalModule.js:417:16)
⚠️  x86_64    |     at handleParseError (/home/build/ui/node_modules/webpack/lib/NormalModule.js:471:10)
⚠️  x86_64    |     at /home/build/ui/node_modules/webpack/lib/NormalModule.js:503:5
⚠️  x86_64    |     at /home/build/ui/node_modules/webpack/lib/NormalModule.js:358:12
⚠️  x86_64    |     at /home/build/ui/node_modules/loader-runner/lib/LoaderRunner.js:373:3
⚠️  x86_64    |     at iterateNormalLoaders (/home/build/ui/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
⚠️  x86_64    |     at Array.<anonymous> (/home/build/ui/node_modules/loader-runner/lib/LoaderRunner.js:205:4)
⚠️  x86_64    |     at Storage.finished (/home/build/ui/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:55:16)
⚠️  x86_64    |     at /home/build/ui/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:91:9
⚠️  x86_64    |     at /home/build/ui/node_modules/graceful-fs/graceful-fs.js:123:16
⚠️  x86_64    |     at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:68:3) {
⚠️  x86_64    |   opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
⚠️  x86_64    |   library: 'digital envelope routines',
⚠️  x86_64    |   reason: 'unsupported',
⚠️  x86_64    |   code: 'ERR_OSSL_EVP_UNSUPPORTED'

```
https://stackoverflow.com/questions/69394632/webpack-build-failing-with-err-ossl-evp-unsupported
https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V17.md#openssl-30
