### PR TITLE
Add thin-provisioning-tools and libpfm.

### DIFF
--- a/libpfm.yaml
+++ b/libpfm.yaml
@@ -1,0 +1,38 @@
+package:
+  name: libpfm
+  version: 4.13.0
+  epoch: 0
+  description: "perfmon libraries"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-${{package.version}}.tar.gz
+      expected-sha256: d18b97764c755528c1051d376e33545d0eb60c6ebf85680436813fa5b04cc3d1
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: "libpfm-dev"
+    description: "headers for libpfm"
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 21491

--- a/packages.txt
+++ b/packages.txt
@@ -539,3 +539,5 @@ asciidoc
 asciidoctor
 iniparser
 ndctl
+thin-provisioning-tools
+libpfm

--- a/thin-provisioning-tools.yaml
+++ b/thin-provisioning-tools.yaml
@@ -1,0 +1,49 @@
+package:
+  name: thin-provisioning-tools
+  version: 1.0.3
+  description: "suite of tools for manipulating the metadata of the dm-thin device-mapper target"
+  copyright:
+    - license: GPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - rust
+      - coreutils
+      - gawk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/jthornber/thin-provisioning-tools
+      expected-commit: 2dcafdbe737478f9bab8c588d55862c6a4548b60
+      tag: v${{package.version}}
+
+  - runs: |
+      cargo build --release
+      make install DESTDIR="${{targets.destdir}}"
+
+  - uses: strip
+
+subpackages:
+  - name: "thin-provisioning-tools-dev"
+    description: "headers for thin-provisioning-tools"
+    pipeline:
+      - uses: split/dev
+
+  - name: "thin-provisioning-tools-doc"
+    description: "docs for thin-provisioning-tools"
+    pipeline:
+      - uses: split/manpages
+
+update:
+  enabled: true
+  github:
+    identifier: jthornber/thin-provisioning-tools
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v


### PR DESCRIPTION
Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`
