### PR TITLE
Remove bsd-compat-headers from libtirpc-dev.

### DIFF
--- a/libtirpc.yaml
+++ b/libtirpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtirpc
   version: 1.3.3
-  epoch: 0
+  epoch: 1
   description: Transport Independent RPC library (SunRPC replacement)
   copyright:
     - license: BSD-3-Clause
@@ -77,7 +77,6 @@ subpackages:
     dependencies:
       runtime:
         - libtirpc
-        - bsd-compat-headers
         - krb5-dev
         - libtirpc-conf
     description: libtirpc dev

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -83,3 +83,4 @@ wserialization-1.81.0-r0.apk
 openjdk-17-17.0.7+5-r0.apk
 openjdk-17-doc-17.0.7+5-r0.apk
 openjdk-17-jre-17.0.7+5-r0.apk
+libtirpc-dev-1.3.3-r0.apk


### PR DESCRIPTION
We don't have this package and never have.

Fixes:

Related:


