### PR TITLE
Bump rustls-ffi to v0.10.0 and fix the upgrade check.

### DIFF
--- a/rustls-ffi.yaml
+++ b/rustls-ffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: rustls-ffi
-  version: 0.8.2
-  epoch: 1
+  version: 0.10.0
+  epoch: 0
   description: "C-to-rustls bindings"
   copyright:
     - license: MIT
@@ -18,10 +18,11 @@ environment:
       - bash
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/rustls/rustls-ffi/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: aa627cdd1c8183b9c84e2360641dd8efc7412307aa5451b240058c41357d14fd
+      repository: https://github.com/rustls/rustls-ffi
+      tag: v${{package.version}}
+      expected-commit: 188aa9d5f9872889be48643734464fe171e7fd1d
 
   - uses: autoconf/make
 
@@ -34,3 +35,4 @@ update:
   github:
     identifier: rustls/rustls-ffi
     strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
The project stopped cutting github "releases" but still publishes tags.

Fixes:

Related:

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
