### PR TITLE
make bootstrapping an explicit build configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,12 @@ ifeq (${USE_CACHE}, yes)
 	MELANGE_OPTS += --cache-source ${CACHE_DIR}
 endif
 
+ifeq (${BOOTSTRAP}, yes)
+	MELANGE_OPTS += --repository-append https://packages.wolfi.dev/bootstrap/stage3
+	MELANGE_OPTS += --keyring-append    https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
+
+endif
+
 ifeq (${BUILDWORLD}, no)
 MELANGE_OPTS += -k ${WOLFI_SIGNING_PUBKEY}
 MELANGE_OPTS += -r ${WOLFI_PROD}

--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/autoconf.yaml
+++ b/autoconf.yaml
@@ -12,10 +12,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/automake.yaml
+++ b/automake.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -20,10 +20,6 @@ secfixes:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/bison.yaml
+++ b/bison.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/build-base.yaml
+++ b/build-base.yaml
@@ -16,10 +16,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -23,10 +23,6 @@ secfixes:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/bzip2.yaml
+++ b/bzip2.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - perl

--- a/expat.yaml
+++ b/expat.yaml
@@ -16,10 +16,6 @@ secfixes:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/file.yaml
+++ b/file.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/flex.yaml
+++ b/flex.yaml
@@ -16,10 +16,6 @@ secfixes:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/gawk.yaml
+++ b/gawk.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -12,10 +12,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/gdbm.yaml
+++ b/gdbm.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -34,10 +34,6 @@ secfixes:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/gmp.yaml
+++ b/gmp.yaml
@@ -14,10 +14,6 @@ secfixes:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/grep.yaml
+++ b/grep.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/gzip.yaml
+++ b/gzip.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/help2man.yaml
+++ b/help2man.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/isl.yaml
+++ b/isl.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/libffi.yaml
+++ b/libffi.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libtool.yaml
+++ b/libtool.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/linenoise.yaml
+++ b/linenoise.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/linux-headers.yaml
+++ b/linux-headers.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/lua5.3-lzlib.yaml
+++ b/lua5.3-lzlib.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/lua5.3.yaml
+++ b/lua5.3.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/m4.yaml
+++ b/m4.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/make.yaml
+++ b/make.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/mpc.yaml
+++ b/mpc.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/mpdecimal.yaml
+++ b/mpdecimal.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/mpfr.yaml
+++ b/mpfr.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -15,10 +15,6 @@ secfixes:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -45,10 +45,6 @@ options:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/patch.yaml
+++ b/patch.yaml
@@ -20,10 +20,6 @@ secfixes:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/pax-utils.yaml
+++ b/pax-utils.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/perl.yaml
+++ b/perl.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/pkgconf.yaml
+++ b/pkgconf.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -17,10 +17,6 @@ secfixes:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -17,10 +17,6 @@ secfixes:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -15,10 +15,6 @@ secfixes:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/readline.yaml
+++ b/readline.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/scdoc.yaml
+++ b/scdoc.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/sed.yaml
+++ b/sed.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/sqlite.yaml
+++ b/sqlite.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/texinfo.yaml
+++ b/texinfo.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/wget.yaml
+++ b/wget.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/wolfi-base.yaml
+++ b/wolfi-base.yaml
@@ -13,10 +13,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
 

--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/wolfi-keys.yaml
+++ b/wolfi-keys.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
 

--- a/xz.yaml
+++ b/xz.yaml
@@ -10,10 +10,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -16,10 +16,6 @@ secfixes:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox


### PR DESCRIPTION
This change adds `BOOTSTRAP=yes` as an option in the Makefile. If that option is set to `yes`, the bootstrap-stage3 repo and keychain will be added. Otherwise, they won't be, and packages must already have been bootstrapped and be available in the local package repo.

cc @deitch 