### PR TITLE
fix failures on merge queues, this step is not required so lets make …

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -108,6 +108,8 @@ jobs:
       - name: PR comment diff
         if: steps.diff_file_check.outputs.exists == 'true'
         uses: thollander/actions-comment-pull-request@632cf9ce90574d125be56b5f3405cda41a84e2fd # v2.3.1
+        # We're seeing jobs using merge queues fail
+        continue-on-error: true
         with:
           filePath: diff.log
           # If a PAT exists use it else fall back to the default github actions secret


### PR DESCRIPTION
…it optional

merege queues do not have an associated PR number so the comment step fails, i.e we see this
```
Error: No issue/pull request in input neither in current context.
```
Let's just ignore these failures
