### PR TITLE
Bump vala.

### DIFF
--- a/vala.yaml
+++ b/vala.yaml
@@ -1,6 +1,6 @@
 package:
   name: vala
-  version: 0.56.3
+  version: 0.56.6
   epoch: 0
   description: Compiler for the GObject type system
   copyright:
@@ -25,7 +25,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: e1066221bf7b89cb1fa7327a3888645cb33b604de3bf45aa81132fd040b699bf
+      expected-sha256: 050e841cbfe2b8e7d0fb350c9506bd7557be1cd86a90c896765f1a09a1870013
       uri: https://download.gnome.org/sources/vala/0.56/vala-${{package.version}}.tar.xz
 
   - uses: autoconf/configure


### PR DESCRIPTION
This failed in ci, but I tried it locally and everything worked.

Fixes: https://github.com/wolfi-dev/os/pull/1172

Related:

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
