### PR TITLE
fix diff comment not working for pull requests from forks

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -112,9 +112,7 @@ jobs:
         continue-on-error: true
         with:
           filePath: diff.log
-          # If a PAT exists use it else fall back to the default github actions secret
-          # This means we get wolfi bot branding on PRs else uses the github actions bot email so actions will run on forks if enabled
-          GITHUB_TOKEN: ${{ secrets.WOLFI_BOT_CLASSIC_PAT != null && secrets.WOLFI_BOT_CLASSIC_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   dag:
     name: Dependency analysis
     runs-on: ubuntu-latest


### PR DESCRIPTION
Initially I wanted to use the wolfi bot to make PR comments and have more wolfi branding, however for good reasons you cannot use these secrets.  Instead we should always use the default GITHUB_TOKEN on presubmit jobs.
