### PR TITLE
Fix py3-ordered set.

### DIFF
--- a/py3-ordered-set.yaml
+++ b/py3-ordered-set.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ordered-set
-  version: 4.0.2
-  epoch: 3
+  version: 4.1.0
+  epoch: 0
   description: "mutableset which remembers its order"
   copyright:
     - license: MIT
@@ -15,24 +15,20 @@ environment:
       - wolfi-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - python3
+      - py3-setuptools
 
 pipeline:
   - uses: fetch
     with:
       uri: https://files.pythonhosted.org/packages/source/o/ordered-set/ordered-set-${{package.version}}.tar.gz
-      expected-sha256: ba93b2df055bca202116ec44b9bead3df33ea63a7d5827ff8e16738b97f33a95
+      expected-sha256: 694a8e44c87657c59292ede72891eb91d34131f6531463aab3009191c77364a8
 
   - runs: |
-      _site_pkgs="$(python3 -c 'import site; print(site.getsitepackages()[0])')"
-      _py3ver=$(python3 -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
+      python3 setup.py build
 
-      mkdir -p "${{targets.destdir}}"/"$_site_pkgs"
-      cp -rv ordered_set.egg-info "${{targets.destdir}}"/"$_site_pkgs"/ordered_set-${{package.version}}-py$_py3ver.egg-info
-      cp -rv ordered_set.py "${{targets.destdir}}"/$_site_pkgs/
-
-      python3 -m compileall -f -q "${{targets.destdir}}"/$_site_pkgs/*.py
+  - runs: |
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
 
   - uses: strip
 


### PR DESCRIPTION
The new version packages like a more traditional python app. It hasn't changed in a few years, so it should be stable now.

https://github.com/rspeer/ordered-set/blob/master/CHANGELOG.md#changelog

Fixes: https://github.com/wolfi-dev/os/pull/1340

Related:

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
