### PR TITLE
aws-cli has no prefix tags with v and update to 1.27.115

### DIFF
--- a/aws-cli.yaml
+++ b/aws-cli.yaml
@@ -1,6 +1,6 @@
 package:
   name: aws-cli
-  version: 1.27.112
+  version: 1.27.115
   epoch: 0
   description: "Universal Command Line Interface for Amazon Web Services"
   copyright:
@@ -33,7 +33,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/aws/aws-cli/archive/${{package.version}}.tar.gz
-      expected-sha256: db5034ba79365fd912872da9ee4e06998870e135a3e7e5b2421560535603f121
+      expected-sha256: b693f12991738cbd65cbe8e3c9077d82e910a9f8015fdbba51066fb94991a048
 
   - runs: |
       python3 setup.py build
@@ -47,6 +47,5 @@ update:
   enabled: true
   github:
     identifier: aws/aws-cli
-    strip-prefix: v
     use-tag: true
     tag-filter: "1.27"


### PR DESCRIPTION
aws-cli has no prefix tags with v and update to 1.27.115
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
