### PR TITLE
Revert "Makefile: make mkdir -p step for source dir an explicit step …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,8 @@ $(eval sourcedir = $(call comma-split,$(1),2))
 $(eval sourcedir = $(or $(sourcedir),$(pkgname)))
 $(eval pkgtarget = $(TARGETDIR)/$(shell $(MELANGE) package-version $(pkgname).yaml).apk)
 packages/$(pkgname): $(pkgtarget)
-./${sourcedir}/:
-	mkdir -p ./${sourcedir}/
-$(pkgtarget): ${KEY} ./${sourcedir}/
+$(pkgtarget): ${KEY}
+	mkdir -p ./$(sourcedir)/
 	SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} ${MELANGE} build $(pkgname).yaml ${MELANGE_OPTS} --source-dir ./$(sourcedir)/
 
 endef


### PR DESCRIPTION
…so it can be overridden"

We're getting failed release builds, think it's due to this change. Let's roll back to get green again and reimplement this.

This reverts commit 6e8612ae46f378d66d5efea1e56838bd266afaf9.
