### PR TITLE
Split systemd into a library package.

### DIFF
--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-bit
   version: 2.0.11
-  epoch: 1
+  epoch: 2
   description: Fast and Lightweight Log processor and forwarder
   copyright:
     - license: Apache-2.0

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: 253
-  epoch: 0
+  epoch: 1
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -48,6 +48,13 @@ subpackages:
     description: "headers for systemd"
     pipeline:
       - uses: split/dev
+
+  - name: "libsystemd"
+    description: "systemd library"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/lib
+          mv ${{targets.destdir}}/lib/libsystemd.so* ${{targets.subpkgdir}}/lib
 
 update:
   enabled: true


### PR DESCRIPTION
Fluent-bit specifically just needs libsystemd.so, but it's grabbing the entire package today.

Fixes:

Related:

### Pre-review Checklist

