### PR TITLE
gcc: rebuild to get rid of unwanted .la files

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 12.2.0
-  epoch: 9
+  epoch: 10
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
gcc 12.2.0-r9 technically changed on ARM because the .la files were removed.  Bump the epoch to make it consistent on both x86_64 and ARM.