### PR TITLE
libarchive: fix libarchive-dev dependencies

### DIFF
--- a/libarchive.yaml
+++ b/libarchive.yaml
@@ -1,7 +1,7 @@
 package:
   name: libarchive
   version: 3.6.2
-  epoch: 2
+  epoch: 3
   description: "multi-format archive and compression library"
   copyright:
     - license: BSD-2-Clause
@@ -56,7 +56,11 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
-        - libarchive
+        - bzip2-dev
+        - lz4-dev
+        - xz-dev
+        - zlib-dev
+        - zstd-dev
 
   - name: "libarchive-tools"
     description: "bsdtar and bsdcpio programs from libarchive"


### PR DESCRIPTION
Since libarchive was initially packaged, additional features provided by external libraries have been added, but the -dev package was not updated to depend on those libraries.

This fixes building CMake with current libarchive packages for example.