### PR TITLE
upgrade envoy/1.26.0 package

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -1,6 +1,6 @@
 package:
   name: envoy
-  version: 1.25.5
+  version: 1.26.0
   epoch: 0
   description: Cloud-native high-performance edge/middle/service proxy
   copyright:
@@ -13,7 +13,7 @@ environment:
       - ca-certificates-bundle
       - build-base
       - git
-      - bazel-5
+      - bazel-6
       - openjdk-11
       - bash
       - libtool
@@ -33,12 +33,12 @@ pipeline:
     with:
       repository: https://github.com/envoyproxy/envoy
       tag: v${{package.version}}
-      expected-commit: 4b5f5474f35763423684c0fe25c99cc7b2a01fcf
+      expected-commit: 51964702956d64adcd1df6b8ea132e863fe78e74
       destination: envoy
 
   - runs: |
       export JAVA_HOME=/usr/lib/jvm/openjdk
-      mkdir -p /builder/home/.cache/bazel/_bazel_root
+      mkdir -p .cache/bazel/_bazel_root
 
       cd envoy
 


### PR DESCRIPTION
Includes update of Bazel 6 - build seems to be running longer on my local machine but will take a while. Let's use CI to check as it will be faster.