### PR TITLE
openjdk-17: change JRE subpackage to remove extra tools 

### DIFF
--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -114,7 +114,7 @@ subpackages:
                   rmiregistry; do
                       cp ./build/linux-*-server-release/images/jdk/bin/${c} ${{targets.subpkgdir}}/usr/lib/jvm/openjdk/bin/${c}
           done
-          
+
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           ln -sf /usr/lib/jvm/openjdk/bin/java ${{targets.subpkgdir}}/usr/bin/java
     description: OpenJDK 17 (JRE)

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
   version: 17.0.7.5
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-only
@@ -97,19 +97,26 @@ subpackages:
   - name: openjdk-17-jre
     pipeline:
       - runs: |
-          # generate JRE via jlink
-
-          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm
-
-          ${{targets.destdir}}/usr/lib/jvm/openjdk/bin/jlink \
-            --no-header-files \
-            --no-man-pages \
-            --compress=2 \
-            --add-modules ALL-MODULE-PATH \
-            --output ${{targets.subpkgdir}}/usr/lib/jvm/openjdk-jre
-
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm/openjdk
+          for dir in conf \
+                   include \
+                   jmods \
+                   legal \
+                   lib \
+                   release; do
+                      cp -r ./build/linux-*-server-release/images/jdk/${dir} ${{targets.subpkgdir}}/usr/lib/jvm/openjdk/${dir}
+          done
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm/openjdk/bin
+          for c in java \
+                  jfr \
+                  jrunscript \
+                  keytool \
+                  rmiregistry; do
+                      cp ./build/linux-*-server-release/images/jdk/bin/${c} ${{targets.subpkgdir}}/usr/lib/jvm/openjdk/bin/${c}
+          done
+          
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -sf /usr/lib/jvm/openjdk-jre/bin/java ${{targets.subpkgdir}}/usr/bin/java
+          ln -sf /usr/lib/jvm/openjdk/bin/java ${{targets.subpkgdir}}/usr/bin/java
     description: OpenJDK 17 (JRE)
     dependencies:
       runtime:


### PR DESCRIPTION
Re-opening on a wolfi branch to see the file diffs.

Related:
https://github.com/wolfi-dev/os/pull/906
https://github.com/chainguard-images/images/issues/297

