### PR TITLE
Set nginx package config to port 8080.

### DIFF
--- a/nginx.yaml
+++ b/nginx.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx
   version: 1.24.0
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause

--- a/nginx/nginx.default.conf
+++ b/nginx/nginx.default.conf
@@ -1,7 +1,7 @@
 # https://hg.nginx.org/pkg-oss/file/fd9484abcae4/alpine/nginx.default.conf
 
 server {
-    listen       80;
+    listen       8080;
     server_name  localhost;
 
     #access_log  /var/log/nginx/host.access.log  main;


### PR DESCRIPTION
Note that this will not affect the image until it uses the package-config package.

This changed is required for nginx to run on k8s.

Related: https://github.com/chainguard-images/images/issues/452
