### PR TITLE
openjdk-11: Withdraw bad openjdk-11 version

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -80,6 +80,9 @@ thread-1.81.0-r0.apk
 unit_test_framework-1.81.0-r0.apk
 wave-1.81.0-r0.apk
 wserialization-1.81.0-r0.apk
+openjdk-11-11.0.19+5-r0.apk
+openjdk-11-jre-doc-11.0.19+5-r0.apk
+openjdk-11-jre-11.0.19+5-r0.apk
 openjdk-17-17.0.7+5-r0.apk
 openjdk-17-doc-17.0.7+5-r0.apk
 openjdk-17-jre-17.0.7+5-r0.apk


### PR DESCRIPTION
11.0.19+5-r0 is not a supported version format and results in apk and apko not resolving the latest 11 JDK to add. 