### PR TITLE
split certmanager into controller subpackages

### DIFF
--- a/cert-manager.yaml
+++ b/cert-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: cert-manager
   version: 1.11.1
-  epoch: 0
+  epoch: 1
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -26,22 +26,44 @@ pipeline:
   # the makefile hardcodes the requirement for some container runtime (CTR), even when we don't need it
   # to workaround, set CTR to anything $(command -v)able
   - runs: |
-      make CTR=touch server-binaries
+      make CTR=make _bin/server/controller-linux-$(go env GOARCH)
+      make CTR=make _bin/server/webhook-linux-$(go env GOARCH)
+      make CTR=make _bin/server/cainjector-linux-$(go env GOARCH)
+      make CTR=make _bin/server/acmesolver-linux-$(go env GOARCH)
 
-  - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
-      mv _bin/server/*-linux-$(go env GOARCH) ${{targets.destdir}}/usr/bin/
+      mv _bin/server/* ${{targets.destdir}}/usr/bin/
 
   - uses: strip
 
 subpackages:
+  - name: ${{package.name}}-controller
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/controller-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/controller
+
+  - name: ${{package.name}}-webhook
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/webhook-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/webhook
+
+  - name: ${{package.name}}-cainjector
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/cainjector-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/cainjector
+
+  - name: ${{package.name}}-acmesolver
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/acmesolver-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/acmesolver
+
   - name: cmctl
-    pipelines:
+    pipeline:
       - runs: |
-          make CTR=touch cmctl-linux
+          make CTR=make cmctl-linux
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv _bin/cmctl/cmctl-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/
+          install -Dm755 _bin/cmctl/cmctl-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/cmctl
+      - uses: strip
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

cert-manager: split controller components into individual subpackages, reducing overall binary sizes and simplifying downstream image(s)
