### PR TITLE
gradle-8: Fix broken build

### DIFF
--- a/gradle-8.yaml
+++ b/gradle-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: gradle-8
   version: 8.0.2
-  epoch: 0
+  epoch: 1
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,6 @@ environment:
       - build-base
       - bash
       - tini
-      - openjdk-11
       - maven
       - git
       - patch


### PR DESCRIPTION
Fix gradle build due to openjdk-11 in build deps and coming from transitive runtime deps

Related:
review thread on https://github.com/wolfi-dev/os/pull/1203

I suspect this might be an apko regression as I don't understand how this was working before.

One thing that I'm wondering about is why gradle pulls in JRE as runtime deps while maven doesn't. I don't know what the right thing but it's definitely inconsistent right now.