### PR TITLE
remove call to wolfictl svg in CI

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -113,25 +113,3 @@ jobs:
         with:
           filePath: diff.log
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  dag:
-    name: Dependency analysis
-    runs-on: ubuntu-latest
-
-    permissions:
-      packages: write
-      contents: read
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Generate dependency svg
-        id: svg
-        uses: docker://ghcr.io/wolfi-dev/wolfictl:latest
-        with:
-          entrypoint: wolfictl
-          args: svg
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: dag.svg
-          path: dag.svg


### PR DESCRIPTION
Nothing seems to rely on the output of this command, and it's changing soon in https://github.com/wolfi-dev/wolfictl/pull/174

If we want to keep it, we can add it back after `wolfictl dot` is done, after the [`wolfictl` image includes graphviz](https://github.com/wolfi-dev/tools/pull/11).