### PR TITLE
make stage0 usage more consistent

### DIFF
--- a/busybox-full.yaml
+++ b/busybox-full.yaml
@@ -1,13 +1,10 @@
 package:
   name: busybox-full
   version: 1.36.0
-  epoch: 0
+  epoch: 1
   description: "swiss-army knife for embedded systems, with more applets"
   copyright:
     - license: GPL-2.0-only
-  dependencies:
-    provides:
-      - busybox=${{package.version}}-${{package.epoch}}
 
 secfixes:
   1.35.0-r3:

--- a/busybox-full.yaml
+++ b/busybox-full.yaml
@@ -5,6 +5,9 @@ package:
   description: "swiss-army knife for embedded systems, with more applets"
   copyright:
     - license: GPL-2.0-only
+  dependencies:
+    provides:
+      - busybox=1.36.0
 
 secfixes:
   1.35.0-r3:

--- a/eudev.yaml
+++ b/eudev.yaml
@@ -1,7 +1,7 @@
 package:
   name: eudev
-  version: 3.2.11
-  epoch: 0
+  version: 3.2.11 # When bumping this, also bump the provides below!
+  epoch: 1
   description: init system agnostic fork of systemd-udev
   copyright:
     - license: GPL-2.0-only
@@ -82,7 +82,7 @@ subpackages:
   - name: eudev-hwids
     dependencies:
       provides:
-        - hwids-udev=${{package.version}}-r${{package.epoch}}
+        - hwids-udev=3.2.11-r1
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc/udev/hwdb.d

--- a/eudev.yaml
+++ b/eudev.yaml
@@ -82,7 +82,7 @@ subpackages:
   - name: eudev-hwids
     dependencies:
       provides:
-        - hwids-udev=3.2.11-r1
+        - hwids-udev=3.2.11
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc/udev/hwdb.d

--- a/go-1.19.yaml
+++ b/go-1.19.yaml
@@ -7,7 +7,7 @@ package:
     - license: BSD-3-Clause
   dependencies:
     provides:
-      - go=1.19.999
+      - go=1.19.999 # This should be go=${{package.version}}-${{package.epoch}}
     runtime:
       - build-base
       - bash
@@ -38,11 +38,10 @@ environment:
       - ca-certificates-bundle
       - build-base
       - bash
+      # The first time this is built, it depends on go-stage0.yaml being built first,
+      # using pre-built go binaries, which `provides` a go package at an earlier version.
+      # Afterwards it depends on previous versions of this package built from source.
       - go
-      # During bootstrapping, this must depend on go-stage0, which builds a Go
-      # package using a prebuilt Go toolchain provided by the Go team.
-      # After bootstrapping, go can depend on a previously built Go toolchain.
-      # - go-stage0
 
 pipeline:
   - uses: fetch

--- a/go-1.20.yaml
+++ b/go-1.20.yaml
@@ -7,7 +7,7 @@ package:
     - license: BSD-3-Clause
   dependencies:
     provides:
-      - go=1.20.999
+      - go=1.20.999 # This should be go=${{package.version}}-${{package.epoch}}
     runtime:
       - build-base
       - bash
@@ -34,6 +34,9 @@ environment:
       - ca-certificates-bundle
       - build-base
       - bash
+      # The first time this is built, it depends on go-stage0.yaml being built first,
+      # using pre-built go binaries, which `provides` a go package at an earlier version.
+      # Afterwards it depends on previous versions of this package built from source.
       - go
 
 pipeline:

--- a/go-fips-1.19.yaml
+++ b/go-fips-1.19.yaml
@@ -7,7 +7,7 @@ package:
     - license: BSD-3-Clause
   dependencies:
     provides:
-      - go-fips=1.19.999
+      - go-fips=1.19.999 # This should be go-fips=${{package.version}}-${{package.epoch}}
     runtime:
       - build-base
       - bash
@@ -40,12 +40,11 @@ environment:
       - ca-certificates-bundle
       - build-base
       - bash
-      - go
       - openssl-dev
-      # During bootstrapping, this must depend on go-stage0, which builds a Go
-      # package using a prebuilt Go toolchain provided by the Go team.
-      # After bootstrapping, go can depend on a previously built Go toolchain.
-      # - go-stage0
+      # The first time this is built, it depends on go-stage0.yaml being built first,
+      # using pre-built go binaries, which `provides` a go package at an earlier version.
+      # Afterwards it depends on previous versions of this package built from source.
+      - go
 
 pipeline:
   - uses: fetch

--- a/go-fips-1.20.yaml
+++ b/go-fips-1.20.yaml
@@ -7,12 +7,15 @@ package:
     - license: BSD-3-Clause
   dependencies:
     provides:
-      - go=1.20.999
+      - go-fips=1.20.999 # This should be go-fips=${{package.version}}-${{package.epoch}}
     runtime:
       - build-base
       - bash
       - binutils-gold # Needed for cgo linking due to upstream issue #15696 which forces use of the gold linker.
       - openssl-dev # Needed for building against cryptographic packages.
+      # The first time this is built, it depends on go-stage0.yaml being built first,
+      # using pre-built go binaries, which `provides` a go package at an earlier version.
+      # Afterwards it depends on previous versions of this package built from source.
       - '!go-1.20'
 
 secfixes:

--- a/go-stage0.yaml
+++ b/go-stage0.yaml
@@ -10,7 +10,7 @@ package:
       - build-base
       - bash
     provides:
-      - go=1.19-r0
+      - go=1.19.1-r2
 
 environment:
   contents:

--- a/go-stage0.yaml
+++ b/go-stage0.yaml
@@ -10,7 +10,7 @@ package:
       - build-base
       - bash
     provides:
-      - go=1.19.1-r2
+      - go=1.19.1
 
 environment:
   contents:

--- a/gradle-8.yaml
+++ b/gradle-8.yaml
@@ -9,7 +9,7 @@ package:
     runtime:
       - openjdk-11-jre
     provides:
-      - gradle=8.0.2-r2
+      - gradle=8.0.2
 
 environment:
   contents:

--- a/gradle-8.yaml
+++ b/gradle-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: gradle-8
-  version: 8.0.2
-  epoch: 1
+  version: 8.0.2 # When bumping this, also bump the provides below!
+  epoch: 2
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0
@@ -9,8 +9,7 @@ package:
     runtime:
       - openjdk-11-jre
     provides:
-      # Hack for self bootstrapping
-      - gradle-stage0=8.0.1
+      - gradle=8.0.2-r2
 
 environment:
   contents:
@@ -24,7 +23,10 @@ environment:
       - git
       - patch
       - zip
-      - gradle-stage0
+      # The first time this is built, it depends on gradle-stage0.yaml being built first,
+      # using pre-built gradle binaries, which `provides` a gradle package at an earlier version.
+      # Afterwards it depends on previous versions of this package built from source.
+      - gradle
 
 pipeline:
   - uses: git-checkout

--- a/gradle-stage0.yaml
+++ b/gradle-stage0.yaml
@@ -9,7 +9,7 @@ package:
     runtime:
       - openjdk-11-jre
     provides:
-      - gradle=8.0.1 # hack for self bootstrapping
+      - gradle=8.0.1-r0
 
 environment:
   contents:

--- a/gradle-stage0.yaml
+++ b/gradle-stage0.yaml
@@ -9,7 +9,7 @@ package:
     runtime:
       - openjdk-11-jre
     provides:
-      - gradle=8.0.1-r0
+      - gradle=8.0.1
 
 environment:
   contents:

--- a/maven-stage0.yaml
+++ b/maven-stage0.yaml
@@ -5,6 +5,9 @@ package:
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - maven=3.9.1-r0
 
 environment:
   contents:

--- a/maven-stage0.yaml
+++ b/maven-stage0.yaml
@@ -7,7 +7,7 @@ package:
     - license: Apache-2.0
   dependencies:
     provides:
-      - maven=3.9.1-r0
+      - maven=3.9.1
 
 environment:
   contents:

--- a/maven.yaml
+++ b/maven.yaml
@@ -12,8 +12,11 @@ environment:
       - ca-certificates-bundle
       - build-base
       - busybox
-      - maven
       - openjdk-11-jre
+      # The first time this is built, it depends on maven-stage0.yaml being built first,
+      # using pre-built maven binaries, which `provides` a maven package at an earlier version.
+      # Afterwards it depends on previous versions of this package built from source.
+      - maven
 
 pipeline:
   - uses: git-checkout

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -36,6 +36,9 @@ environment:
       - libjpeg-dev
       - giflib-dev
       - lcms2-dev
+      # TODO: This should depend on an openjdk-11-stage0.yaml, which is built using
+      # pre-built openjdk-10 binaries and `provides` openjdk-11 at an earlier version.
+      # Afterwards it can depend on previous versions of this package built from source.
       - openjdk-11
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -36,6 +36,9 @@ environment:
       - libjpeg-dev
       - giflib-dev
       - lcms2-dev
+      # TODO: This should depend on an openjdk-17-stage0.yaml, which is built using
+      # pre-built openjdk-16 binaries and `provides` openjdk-17 at an earlier version.
+      # Afterwards it can depend on previous versions of this package built from source.
       - openjdk-17
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL

--- a/sbt-stage0.yaml
+++ b/sbt-stage0.yaml
@@ -15,7 +15,7 @@ package:
       - openjdk-11-jre
       - bash
     provides:
-      - sbt=1.8.2-r0
+      - sbt=1.8.2
 
 environment:
   contents:

--- a/sbt-stage0.yaml
+++ b/sbt-stage0.yaml
@@ -14,6 +14,8 @@ package:
     runtime:
       - openjdk-11-jre
       - bash
+    provides:
+      - sbt=1.8.2-r0
 
 environment:
   contents:

--- a/sbt.yaml
+++ b/sbt.yaml
@@ -1,7 +1,7 @@
 package:
   name: sbt
   version: 1.8.2
-  epoch: 0
+  epoch: 1
   description: A scala build tool
   target-architecture:
     - all
@@ -21,7 +21,10 @@ environment:
       - ca-certificates-bundle
       - build-base
       - busybox
-      - sbt-stage0
+      # The first time this is built, it depends on sbt-stage0.yaml being built first,
+      # using pre-built sbt binaries, which `provides` a sbt package at an earlier version.
+      # Afterwards it depends on previous versions of this package built from source.
+      - sbt
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
⚠️ This PR only bumps epochs for non`-stage0` packages. Please let me know if you disagree that this is what we want to do. ⚠️ 

This aligns usage of stage0 packages across the repo (hopefully correctly 🤞)

When `{package}` depends on itself, there is a `{package}-stage0.yaml` that builds that package from pre-built binaries and `provides: package-${{package.version}}-${{package.epoch}}` at an early version.

Then, when `{package}.yaml` has a dependency on itself, the first time it's built it will use the package `provides`ed by `{package}-stage0.yaml`, and subsequent versions will use the package `provides`ed by `{package}.yaml` _and not the `-stage0`_.

After `{package}` is successfully built, the intention is that the `stage0` packages are never depended on again, except when bootstrapping from scratch (e.g., a new architecture, or someone reproducing and checking our work).

The following packages are `stage0`'ed in this way:

- `go`
- ~`rust`~ (https://github.com/wolfi-dev/os/pull/1485)
- `maven`
- `gradle`
- `sbt`

`openjdk-{11,17}` are not built this way, but should be. This PR adds `TODO`s.

@joshrwolf @rawlingsj @patflynn @deitch