### PR TITLE
Add libnetfilter_conntrack and libnfnetlink.

### DIFF
--- a/libnetfilter_conntrack.yaml
+++ b/libnetfilter_conntrack.yaml
@@ -1,0 +1,40 @@
+package:
+  name: libnetfilter_conntrack
+  version: "1.0.9"
+  epoch: 0
+  description: programming interface (API) to the in-kernel connection tracking state table
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - ca-certificates-bundle
+      - busybox
+      - libnfnetlink-dev
+      - libmnl-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://www.netfilter.org/projects/libnetfilter_conntrack/files/libnetfilter_conntrack-${{package.version}}.tar.bz2
+      expected-sha256: 67bd9df49fe34e8b82144f6dfb93b320f384a8ea59727e92ff8d18b5f4b579a8
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+subpackages:
+  - name: libnetfilter_conntrack-dev
+    description: libnetfilter_conntrack development files
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1675

--- a/libnetfilter_cthelper.yaml
+++ b/libnetfilter_cthelper.yaml
@@ -1,0 +1,39 @@
+package:
+  name: libnetfilter_cthelper
+  version: "1.0.1"
+  epoch: 0
+  description: A Netfilter netlink library for connection tracking helpers
+  copyright:
+    - license: GPL-2.0
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - ca-certificates-bundle
+      - busybox
+      - libmnl-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://www.netfilter.org/projects/libnetfilter_cthelper/files/libnetfilter_cthelper-${{package.version}}.tar.bz2
+      expected-sha256: 14073d5487233897355d3ff04ddc1c8d03cc5ba8d2356236aa88161a9f2dc912
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+subpackages:
+  - name: libnetfilter_cthelper-dev
+    description: libnetfilter_cthelper development files
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1677

--- a/libnetfilter_cttimeout.yaml
+++ b/libnetfilter_cttimeout.yaml
@@ -1,0 +1,39 @@
+package:
+  name: libnetfilter_cttimeout
+  version: "1.0.1"
+  epoch: 0
+  description: Library for the connection tracking timeout infrastructure
+  copyright:
+    - license: GPL-2.0
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - ca-certificates-bundle
+      - busybox
+      - libmnl-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://www.netfilter.org/projects/libnetfilter_cttimeout/files/libnetfilter_cttimeout-${{package.version}}.tar.bz2
+      expected-sha256: 0b59da2f3204e1c80cb85d1f6d72285fc07b01a2f5678abf5dccfbbefd650325
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+subpackages:
+  - name: libnetfilter_cttimeout-dev
+    description: libnetfilter_cttimeout development files
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1676

--- a/libnetfilter_queue.yaml
+++ b/libnetfilter_queue.yaml
@@ -1,0 +1,40 @@
+package:
+  name: libnetfilter_queue
+  version: "1.0.5"
+  epoch: 0
+  description: API to packets that have been queued by the kernel packet filter
+  copyright:
+    - license: GPL-2.0
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - ca-certificates-bundle
+      - busybox
+      - libmnl-dev
+      - libnfnetlink-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://www.netfilter.org/projects/libnetfilter_queue/files/libnetfilter_queue-${{package.version}}.tar.bz2
+      expected-sha256: f9ff3c11305d6e03d81405957bdc11aea18e0d315c3e3f48da53a24ba251b9f5
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+subpackages:
+  - name: libnetfilter_queue-dev
+    description: libnetfilter_queue development files
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1679

--- a/libnfnetlink.yaml
+++ b/libnfnetlink.yaml
@@ -1,0 +1,38 @@
+package:
+  name: libnfnetlink
+  version: "1.0.2"
+  epoch: 0
+  description: low-level library for netfilter related kernel/userspace communication
+  copyright:
+    - license: GPL-2.0
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - ca-certificates-bundle
+      - busybox
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://www.netfilter.org/projects/libnfnetlink/files/libnfnetlink-${{package.version}}.tar.bz2
+      expected-sha256: b064c7c3d426efb4786e60a8e6859b82ee2f2c5e49ffeea640cfe4fe33cbc376
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+subpackages:
+  - name: libnfnetlink-dev
+    description: libnftnl development files
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1682

--- a/packages.txt
+++ b/packages.txt
@@ -559,3 +559,8 @@ oauth2-proxy
 step-ca
 aws-ebs-csi-driver
 libsolv
+libnfnetlink
+libnetfilter_conntrack
+libnetfilter_cthelper
+libnetfilter_queue
+libnetfilter_cttimeout


### PR DESCRIPTION


Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`
