### PR TITLE
Switch wasmtime build from source archive to git.

### DIFF
--- a/wasmtime.yaml
+++ b/wasmtime.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasmtime
   version: 7.0.0
-  epoch: 0
+  epoch: 1
   description: "A fast and secure runtime for WebAssembly"
   copyright:
     - license: Apache-2.0
@@ -17,13 +17,15 @@ environment:
       - build-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/bytecodealliance/wasmtime/releases/download/v${{package.version}}/wasmtime-dev-src.tar.gz
-      expected-sha256: 0c0aba14bffc36431a0c6b7d24f69ebb0fb3e6079f9eb2548fb6c320dd4acd6e
+      repository: https://github.com/bytecodealliance/wasmtime
+      tag: v${{package.version}}
+      expected-commit: 0d8b737cbe0d4c8c6a939064995fd03d9afdb2b8
 
   - name: Configure and build
     runs: |
+      git submodule update --init
       cargo build --release -vv
       cargo build --release --manifest-path crates/c-api/Cargo.toml
       mkdir -p ${{targets.destdir}}/usr/bin/


### PR DESCRIPTION
The naming of the source archives broke with v8. Let's just switch to git-checkout.

Fixes: https://github.com/wolfi-dev/os/issues/1486

Related:

### Pre-review Checklist
