### PR TITLE
update fluent-bit to 2.1.1

### DIFF
--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -1,10 +1,18 @@
 package:
   name: fluent-bit
-  version: 2.0.11
-  epoch: 2
+  version: 2.1.1
+  epoch: 0
   description: Fast and Lightweight Log processor and forwarder
   copyright:
     - license: Apache-2.0
+
+# creates a new var that contains only the major and minor version to be used in the fetch URL
+# e.g. 2.6.11 will create a new var mangled-package-version=2.6
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d+\.\d+)\.\d+
+    replace: $1
+    to: mangled-package-version
 
 environment:
   contents:
@@ -29,8 +37,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://releases.fluentbit.io/2.0/source-${{package.version}}.tar.gz
-      expected-sha256: bb7ce6f5d9d83f1f1d31ea23c2dacda3b5885411dde5ea9f8ff20fa6ed278a94
+      uri: https://releases.fluentbit.io/${{vars.mangled-package-version}}/source-${{package.version}}.tar.gz
+      expected-sha256: 111937b42e98e81e0833d53410350ec037d873950fb68439a1d22b78cad78543
 
   - runs: |
       cd build


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #1491 , Not bumping to 2.1.0 it had missed the podman plugins 
https://fluentbit.io/announcements/v2.1.1/

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
