### PR TITLE
Add a workflow to close stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,30 @@
+name: 'Close stale'
+
+on:
+  schedule:
+  - cron: '0 1 * * *'
+
+jobs:
+  stale:
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+        stale-issue-message: |-
+          This issue is stale because it has been open for 90 days with no
+          activity. It will automatically close after 30 more days of
+          inactivity. Keep fresh with the 'lifecycle/frozen' label.
+        stale-issue-label: 'lifecycle/stale'
+        exempt-issue-labels: 'lifecycle/frozen'
+
+        stale-pr-message: |-
+          This Pull Request is stale because it has been open for 90 days with
+          no activity. It will automatically close after 30 more days of
+          inactivity. Keep fresh with the 'lifecycle/frozen' label.
+        stale-pr-label: 'lifecycle/stale'
+        exempt-pr-labels: 'lifecycle/frozen'
+
+        days-before-stale: 90
+        days-before-close: 30

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,13 +12,6 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-        stale-issue-message: |-
-          This issue is stale because it has been open for 90 days with no
-          activity. It will automatically close after 30 more days of
-          inactivity. Keep fresh with the 'lifecycle/frozen' label.
-        stale-issue-label: 'lifecycle/stale'
-        exempt-issue-labels: 'lifecycle/frozen'
-
         stale-pr-message: |-
           This Pull Request is stale because it has been open for 90 days with
           no activity. It will automatically close after 30 more days of


### PR DESCRIPTION
This will close PRs that haven't had activity after 120 days, warning about this closure after 90 days.

We can tweak these timelines or wording if we want to.
