### PR TITLE
Update llvm-lld.yaml

### DIFF
--- a/llvm-lld.yaml
+++ b/llvm-lld.yaml
@@ -66,5 +66,7 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 1830
+  github:
+    identifier: llvm/llvm-project
+    use-tag: true
+    tag-filter: llvmorg-15.

--- a/llvm-lld.yaml
+++ b/llvm-lld.yaml
@@ -70,3 +70,4 @@ update:
     identifier: llvm/llvm-project
     use-tag: true
     tag-filter: llvmorg-15.
+    strip-prefix: llvmorg-


### PR DESCRIPTION
Configure llvm-ld to upgrade to latest major version 15 only, and not try to upgrade to 16, which requires manual work.

There isn't a newer 15 at this time, but this pattern will help us when we do manually upgrade it to 16.
