### PR TITLE
busybox: bump to 1.36.0-r2 to disambiguate version

### DIFF
--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,7 +1,7 @@
 package:
   name: busybox
   version: 1.36.0
-  epoch: 0
+  epoch: 2
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only


### PR DESCRIPTION
Otherwise `busybox-full 1.36.0-r1` is selected by default as `busybox` provider due to a bug in apko.  See also: chainguard-dev/apko#632.