### PR TITLE
The weaviate helm chart expects the binary to be at /bin/weaviate and…

### DIFF
--- a/weaviate.yaml
+++ b/weaviate.yaml
@@ -1,7 +1,7 @@
 package:
   name: weaviate
   version: 1.18.3
-  epoch: 0
+  epoch: 1
   description: Weaviate is an open source vector database that stores both objects and vectors, allowing for combining vector search with structured filtering with the fault-tolerance and scalability of a cloud-native database, all accessible through GraphQL, REST, and various language clients.
   copyright:
     - license: BSD-3-Clause
@@ -21,11 +21,11 @@ pipeline:
       expected-commit: dc17efeb75b28c119d9dd1bd14ba2b4c4dd1fae9
 
   - runs: |
-      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/bin
       GITHASH=$(git rev-parse --short HEAD)
       go build \
         -ldflags '-w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'' \
-        -o ${{targets.destdir}}/usr/bin/weaviate ./cmd/weaviate-server
+        -o ${{targets.destdir}}/bin/weaviate ./cmd/weaviate-server
 
 update:
   enabled: true


### PR DESCRIPTION
… overrides the entrypoint.

Adjust the path in our image to match that.

Fixes:

Related:

### Pre-review Checklist

