### PR TITLE
busybox: add symlink manifest

### DIFF
--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,7 +1,7 @@
 package:
   name: busybox
   version: 1.36.0
-  epoch: 2
+  epoch: 3
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only
@@ -66,6 +66,9 @@ pipeline:
       chmod 1777 "${{targets.destdir}}"/tmp
       install -m755 busybox "${{targets.destdir}}"/bin/busybox
       install -m644 securetty "${{targets.destdir}}"/etc/securetty
+
+      mkdir -p "${{targets.destdir}}"/etc/busybox-paths.d
+      ./busybox --list-path > "${{targets.destdir}}"/etc/busybox-paths.d/busybox
 
   - uses: strip
 


### PR DESCRIPTION
BusyBox symlinks are not tracked by the apkdb, so we need to track them somehow for SBOMs and other tasks like simulating `busybox --install`.