### PR TITLE
Revert "jenkins/2.402 package update"

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -88,6 +88,7 @@ secfixes:
 
 update:
   enabled: true
+  manual: true # as of 2.402 arm builds are broken, issue tracking this https://issues.jenkins.io/browse/JENKINS-71147
   github:
     identifier: jenkinsci/jenkins
     strip-prefix: jenkins-

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -1,6 +1,6 @@
 package:
   name: jenkins
-  version: "2.402"
+  version: "2.401"
   epoch: 0
   description:
   copyright:
@@ -33,7 +33,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/jenkinsci/jenkins/archive/refs/tags/jenkins-${{package.version}}.tar.gz
-      expected-sha256: 0f8f9707ea30938599d57a7696a1e472f87c8a797ec26d8add22c11ee2c6d816
+      expected-sha256: 2eb98967d5348473d61fb69a1a91396c99711ebe27e377a9b9afa0773ae2980a
 
   - uses: patch
     with:


### PR DESCRIPTION
error in release building on arm
```
Caused by: java.lang.IllegalArgumentException: Unknown os.arch aarch64'.
```
https://github.com/wolfi-dev/os/actions/runs/4800748594

This reverts commit 7952a2c886005bc553147def5a41a51c332826ae.
