### PR TITLE
gcc-6: new package

### DIFF
--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -1,0 +1,238 @@
+package:
+  name: gcc-6
+  version: 6.5.0
+  epoch: 0
+  description: "the GNU compiler collection"
+  copyright:
+    - license: GPL-3.0-or-later
+  dependencies:
+    runtime:
+      - binutils
+      - libstdc++-6-dev
+
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - build-base
+      - ca-certificates-bundle
+      - texinfo
+      - gawk
+      - bison
+      - flex-dev
+      - gmp-dev
+      - mpfr-dev
+      - mpc-dev
+      - isl-dev
+      - zlib-dev
+      - make
+      - zip
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://ftp.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
+      expected-sha256: 7ef1796ce497e89479183702635b14bb7a46b53249209a5e0f999bebf4740945
+
+  - uses: fetch
+    with:
+      uri: https://sourceware.org/pub/java/ecj-4.9.jar
+      expected-sha256: 9506e75b862f782213df61af67338eb7a23c35ff425d328affc65585477d34cd
+      extract: false
+
+  - uses: patch
+    with:
+      patches: fix-cxxflags-passing.patch
+
+  - uses: patch
+    with:
+      patches: fix-gcj-arm-thumb.patch
+
+  - uses: patch
+    with:
+      patches: fix-gcj-stdgnu14-link.patch
+
+  - uses: patch
+    with:
+      patches: 0017-pr93402.patch
+
+  - uses: patch
+    with:
+      patches: isl-0.22.patch
+
+  # Rename ecj-4.9.jar to ecj.jar because the build system requires it.
+  # https://gcc.gnu.org/ml/java/2008-04/msg00027.html
+  - runs: |
+      mv ecj-*.jar ecj.jar
+
+  - working-directory: /home/build/build
+    pipeline:
+      - name: 'Configure GCC'
+        runs: |
+          # We use generic CFLAGS, because GCC 6 is older than the CFLAGS we normally use.
+          CFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
+          CXXFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
+          CPPFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
+          export CFLAGS CXXFLAGS CPPFLAGS
+
+          ../configure \
+            --prefix=/usr \
+            --program-suffix="-6.5" \
+            --disable-nls \
+            --disable-werror \
+            --with-glibc-version=2.35 \
+            --enable-initfini-array \
+            --disable-nls \
+            --disable-multilib \
+            --disable-libatomic \
+            --disable-libsanitizer \
+            --enable-host-shared \
+            --enable-shared \
+            --enable-threads \
+            --enable-tls \
+            --enable-default-pie \
+            --enable-default-ssp \
+            --with-system-zlib \
+            --enable-languages=c,c++,java \
+            --enable-bootstrap \
+            --enable-gnu-indirect-function \
+            --enable-gnu-unique-object \
+            --enable-version-specific-runtime-libs \
+            --with-linker-hash-style=gnu \
+            --with-jvm-root=/usr/lib/jvm/java-1.5-gcj
+
+          make -j$(nproc)
+          make -j$(nproc) install DESTDIR="${{targets.destdir}}"
+
+  # We don't want to keep the .la files.
+  - runs: |
+      find ${{targets.destdir}} -name '*.la' -print -exec rm \{} \;
+
+  # We don't support static-linking for Java.
+  - runs: |
+      gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+      gcclibexec=/usr/libexec/gcc/${{host.triplet.gnu}}/${{package.version}}
+
+      sed -i -e 's/lib: /&%{static:%eJava programs cannot be linked statically}/' \
+        "${{targets.destdir}}"/$gcclibdir/libgcj.spec
+
+      find "${{targets.destdir}}" -name libgcj.a -o -name libgtkpeer.a \
+        -o -name libgjsmalsa.a -o -name libgcj-tools.a \
+        -o -name libjvm.a -o -name libgij.a -o -name libgcj_bc.a \
+        -o -name libjavamath.a | xargs rm -f
+
+      mv "${{targets.destdir}}"/usr/lib64/libcc1* "${{targets.destdir}}"/$gcclibdir/
+
+  # We don't want libjvm.so or libjavamath.so to have providers generated for it.
+  - runs: |
+      find "${{targets.destdir}}" -name libjvm.so -o -name libjavamath.so | xargs chmod 644
+
+  # Remove libffi
+  - runs: |
+      rm -f "${{targets.destdir}}"/usr/lib/libffi* "${{targets.destdir}}"/usr/share/man/man3/ffi*
+      find "${{targets.destdir}}" -name 'ffi*.h' | xargs rm -f
+
+  - name: 'Clean up documentation'
+    runs: |
+      rm -rf ${{targets.destdir}}/usr/share/info
+
+  - uses: strip
+
+subpackages:
+  - name: 'libstdc++-6'
+    pipeline:
+      - runs: |
+          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+
+          mkdir -p "${{targets.subpkgdir}}"/$gcclibdir
+          mv "${{targets.destdir}}"/$gcclibdir/*++.so.* "${{targets.subpkgdir}}"/$gcclibdir
+    options:
+      no-provides: true
+
+  - name: 'libstdc++-6-dev'
+    pipeline:
+      - runs: |
+          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+
+          mkdir -p "${{targets.subpkgdir}}"/$gcclibdir
+          mkdir -p "${{targets.subpkgdir}}"/$gcclibdir/include
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx
+          mv "${{targets.destdir}}"/$gcclibdir/*++.a "${{targets.subpkgdir}}"/$gcclibdir/
+          mv "${{targets.destdir}}"/$gcclibdir/libstdc++.so "${{targets.subpkgdir}}"/$gcclibdir/
+          mv "${{targets.destdir}}"/$gcclibdir/include/*++* "${{targets.subpkgdir}}"/$gcclibdir/include/
+          mv "${{targets.destdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/* \
+            "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/
+
+  - name: "libgcj-6"
+    description: 'GNU runtime for Java, version 6'
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          cd "${{targets.destdir}}"/usr/bin
+
+          mv aot-compile-* gappletviewer-* gc-analyze-* gij-* \
+             gjar-* gjarsigner-* gkeytool-* gnative2ascii-* gorbd-* \
+             grmic-* grmid-* grmiregistry-* gserialver-* \
+             gtnameserv-* jv-convert-* rebuild-gcj-db-* \
+             "${{targets.subpkgdir}}"/usr/bin/
+
+          cd "${{targets.destdir}}"
+          for i in $(find usr/lib -name jc1 -o -name jvgenmain); do
+            mkdir -p "${{targets.subpkgdir}}"/${i%/*}
+            mv "${{targets.destdir}}"/$i "${{targets.subpkgdir}}"/$i
+          done
+
+          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+          mkdir -p "${{targets.subpkgdir}}"/$gcclibdir
+          mv "${{targets.destdir}}"/$gcclibdir/gcj-* \
+             "${{targets.destdir}}"/$gcclibdir/logging.properties \
+             "${{targets.destdir}}"/$gcclibdir/security \
+             "${{targets.subpkgdir}}"/$gcclibdir
+
+          mv "${{targets.destdir}}"/$gcclibdir/libgcj_bc.so \
+             "${{targets.destdir}}"/$gcclibdir/libgcj*.so.* \
+             "${{targets.destdir}}"/$gcclibdir/libgij.so.* \
+             "${{targets.subpkgdir}}"/usr/lib
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/
+          mv "${{targets.destdir}}"/usr/share/java "${{targets.subpkgdir}}"/usr/share/
+
+  - name: 'gcj-6'
+    description: 'GCC support for Java, version 6'
+    dependencies:
+      runtime:
+        - gcc-6
+        - libgcj-6
+        - zlib-dev
+    pipeline:
+      - runs: |
+          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mkdir -p "${{targets.subpkgdir}}"/$gcclibdir
+
+          cd "${{targets.destdir}}"/usr/bin
+          mv gcj-* gjavah-* gcjh-* jcf-dump-* "${{targets.subpkgdir}}"/usr/bin/
+
+          cd "${{targets.destdir}}"
+
+          for i in $(find usr/ -name ecj1 -o -name jc1 -o -name jvgenmain); do
+            mkdir -p "${{targets.subpkgdir}}"/${i%/*}
+            mv "${{targets.destdir}}"/$i "${{targets.subpkgdir}}"/$i
+          done
+
+          for i in "${{targets.destdir}}"/$gcclibdir/libgcj*.so; do
+            if [ -L "$i" ]; then
+              mv "$i" "${{targets.destdir}}"/usr/lib/
+            fi
+          done
+
+          mv "${{targets.destdir}}"/$gcclibdir/libgij.so \
+             "${{targets.destdir}}"/$gcclibdir/libgcj.spec \
+             "${{targets.subpkgdir}}"/$gcclibdir/
+
+update:
+  # EOL upstream, needed for Java 8 bootstrap only.
+  enabled: false

--- a/gcc-6/0017-pr93402.patch
+++ b/gcc-6/0017-pr93402.patch
@@ -1,0 +1,45 @@
+2020-01-23  Jakub Jelinek  <jakub@redhat.com>
+
+	PR rtl-optimization/93402
+	* postreload.c (reload_combine_recognize_pattern): Don't try to adjust
+	USE insns.
+
+	* gcc.c-torture/execute/pr93402.c: New test.
+
+--- a/gcc/postreload.c.jj	2020-01-12 11:54:36.000000000 +0100
++++ b/gcc/postreload.c	2020-01-23 17:23:25.359929516 +0100
+@@ -1078,6 +1078,10 @@ reload_combine_recognize_pattern (rtx_in
+       struct reg_use *use = reg_state[regno].reg_use + i;
+       if (GET_MODE (*use->usep) != mode)
+ 	return false;
++      /* Don't try to adjust (use (REGX)).  */
++      if (GET_CODE (PATTERN (use->insn)) == USE
++	  && &XEXP (PATTERN (use->insn), 0) == use->usep)
++	return false;
+     }
+ 
+   /* Look for (set (REGX) (CONST_INT))
+--- a/gcc/testsuite/gcc.c-torture/execute/pr93402.c.jj	2020-01-23 17:25:46.496803852 +0100
++++ b/gcc/testsuite/gcc.c-torture/execute/pr93402.c	2020-01-23 17:25:05.221425501 +0100
+@@ -0,0 +1,21 @@
++/* PR rtl-optimization/93402 */
++
++struct S { unsigned int a; unsigned long long b; };
++
++__attribute__((noipa)) struct S
++foo (unsigned long long x)
++{
++  struct S ret;
++  ret.a = 0;
++  ret.b = x * 11111111111ULL + 111111111111ULL;
++  return ret;
++}
++
++int
++main ()
++{
++  struct S a = foo (1);
++  if (a.a != 0 || a.b != 122222222222ULL)
++    __builtin_abort ();
++  return 0;
++}

--- a/gcc-6/fix-cxxflags-passing.patch
+++ b/gcc-6/fix-cxxflags-passing.patch
@@ -1,0 +1,10 @@
+--- gcc-4.8.1/Makefile.in.orig
++++ gcc-4.8.1/Makefile.in
+@@ -169,6 +169,7 @@
+ # built for the build system to override those in BASE_FLAGS_TO_PASSS.
+ EXTRA_BUILD_FLAGS = \
+ 	CFLAGS="$(CFLAGS_FOR_BUILD)" \
++	CXXFLAGS="$(CXXFLAGS_FOR_BUILD)" \
+ 	LDFLAGS="$(LDFLAGS_FOR_BUILD)"
+ 
+ # This is the list of directories to built for the host system.

--- a/gcc-6/fix-gcj-arm-thumb.patch
+++ b/gcc-6/fix-gcj-arm-thumb.patch
@@ -1,0 +1,23 @@
+diff -ruN gcc/libjava/configure.host gcc/libjava/configure.host
+--- gcc/libjava/configure.host	2015-05-28 21:13:55.185034000 +0300
++++ gcc/libjava/configure.host	2018-12-27 09:26:16.579326441 +0200
+@@ -407,6 +407,10 @@
+ 	descriptor_h=sysdep/powerpc/descriptor.h
+ 	;;
+ 
++  arm*-*)
++	descriptor_h=sysdep/arm/descriptor.h
++	;;
++
+   *)
+ 	descriptor_h=sysdep/descriptor-n.h
+ 	;;
+diff -ruN gcc/libjava/sysdep/arm/descriptor.h gcc/libjava/sysdep/arm/descriptor.h
+--- gcc/libjava/sysdep/arm/descriptor.h	1970-01-01 02:00:00.000000000 +0200
++++ gcc/libjava/sysdep/arm/descriptor.h	2018-12-27 09:27:38.714979452 +0200
+@@ -0,0 +1,4 @@
++// Given a function pointer, return the code address.
++// Strip out the ARM/Thumb mode indicator bit
++
++#define UNWRAP_FUNCTION_DESCRIPTOR(X)  ((void*)(((unsigned long)X) & ~1UL))
+

--- a/gcc-6/fix-gcj-stdgnu14-link.patch
+++ b/gcc-6/fix-gcj-stdgnu14-link.patch
@@ -1,0 +1,35 @@
+--- gcc-6.1.0/libjava/Makefile.am
++++ gcc-6.1.0/libjava/Makefile.am
+@@ -488,10 +488,14 @@
+ nat_files = $(nat_source_files:.cc=.lo)
+ xlib_nat_files = $(xlib_nat_source_files:.cc=.lo)
+ 
++libgcj_la_CPPFLAGS = \
++        $(AM_CPPFLAGS) \
++        $(LIBSTDCXX_RAW_CXX_CXXFLAGS)
++
+ # Include THREADLIBS here to ensure that the correct version of
+ # certain linuxthread functions get linked:
+ ## The mysterious backslash in the grep pattern is consumed by make.
+-libgcj_la_LDFLAGS = -rpath $(toolexeclibdir) $(THREADLDFLAGS) $(extra_ldflags) $(THREADLIBS) \
++libgcj_la_LDFLAGS = $(LIBSTDCXX_RAW_CXX_LDFLAGS) -rpath $(toolexeclibdir) $(THREADLDFLAGS) $(extra_ldflags) $(THREADLIBS) \
+ 	$(LIBLTDL) $(SYS_ZLIBS) $(LIBJAVA_LDFLAGS_NOUNDEF) \
+ 	-version-info `grep -v '^\#' $(srcdir)/libtool-version` \
+ 	$(LIBGCJ_LD_SYMBOLIC_FUNCTIONS) $(LIBGCJ_LD_EXPORT_ALL)
+--- gcc-6.1.0/libjava/Makefile.in
++++ gcc-6.1.0/libjava/Makefile.in
+@@ -1103,9 +1103,13 @@
+ nat_files = $(nat_source_files:.cc=.lo)
+ xlib_nat_files = $(xlib_nat_source_files:.cc=.lo)
+ 
++libgcj_la_CPPFLAGS = \
++	$(AM_CPPFLAGS) \
++        $(LIBSTDCXX_RAW_CXX_CXXFLAGS)
++
+ # Include THREADLIBS here to ensure that the correct version of
+ # certain linuxthread functions get linked:
+-libgcj_la_LDFLAGS = -rpath $(toolexeclibdir) $(THREADLDFLAGS) $(extra_ldflags) $(THREADLIBS) \
++libgcj_la_LDFLAGS = $(LIBSTDCXX_RAW_CXX_LDFLAGS) -rpath $(toolexeclibdir) $(THREADLDFLAGS) $(extra_ldflags) $(THREADLIBS) \
+ 	$(LIBLTDL) $(SYS_ZLIBS) $(LIBJAVA_LDFLAGS_NOUNDEF) \
+ 	-version-info `grep -v '^\#' $(srcdir)/libtool-version` \
+ 	$(LIBGCJ_LD_SYMBOLIC_FUNCTIONS) $(LIBGCJ_LD_EXPORT_ALL)

--- a/gcc-6/gcc-4.8-build-args.patch
+++ b/gcc-6/gcc-4.8-build-args.patch
@@ -1,0 +1,41 @@
+When cross compiling a target gcc, target flags may be used on the host
+
+Configure identifies a number of warning flags (WARN_CFLAGS and
+WARN_CXXFLAGS) from the $CC value.  The cross compiler may be different
+from the host compiler and may not support the same set of flags.  This
+leads to problems such as:
+
+cc1plus: error: unrecognized command line option "-Wno-narrowing"
+cc1plus: error: unrecognized command line option "-Wno-overlength-strings"
+
+Work around this problem by removing the warning flags from the
+BUILD_CXXFLAGS value, in a way similar to the BUILD_CFLAGS.
+
+Upstream-Status: Pending
+
+Signed-off-by: Mark Hatle <mark.hatle@windriver.com>
+
+Index: gcc-4.8.0/gcc/configure
+===================================================================
+--- gcc-4.8.0.orig/gcc/configure
++++ gcc-4.8.0/gcc/configure
+@@ -11720,6 +10581,7 @@ STMP_FIXINC=stmp-fixinc
+ if test x$build != x$host || test "x$coverage_flags" != x
+ then
+     BUILD_CFLAGS='$(INTERNAL_CFLAGS) $(T_CFLAGS) $(CFLAGS_FOR_BUILD)'
++    BUILD_CXXFLAGS='$(INTERNAL_CFLAGS) $(T_CFLAGS) $(CFLAGS_FOR_BUILD)'
+     BUILD_LDFLAGS='$(LDFLAGS_FOR_BUILD)'
+ fi
+ 
+Index: gcc-4.8.0/gcc/configure.ac
+===================================================================
+--- gcc-4.8.0.orig/gcc/configure.ac
++++ gcc-4.8.0/gcc/configure.ac
+@@ -1901,6 +1901,7 @@ STMP_FIXINC=stmp-fixinc		AC_SUBST(STMP_F
+ if test x$build != x$host || test "x$coverage_flags" != x
+ then
+     BUILD_CFLAGS='$(INTERNAL_CFLAGS) $(T_CFLAGS) $(CFLAGS_FOR_BUILD)'
++    BUILD_CXXFLAGS='$(INTERNAL_CFLAGS) $(T_CFLAGS) $(CFLAGS_FOR_BUILD)'
+     BUILD_LDFLAGS='$(LDFLAGS_FOR_BUILD)'
+ fi
+ 

--- a/gcc-6/isl-0.22.patch
+++ b/gcc-6/isl-0.22.patch
@@ -1,0 +1,13 @@
+diff -urN gcc-6.4.0.orig/gcc/graphite.h gcc-6.4.0/gcc/graphite.h
+--- gcc-6.4.0.orig/gcc/graphite.h	2023-04-25 21:42:41
++++ gcc-6.4.0/gcc/graphite.h	2023-04-25 21:43:23
+@@ -26,6 +26,9 @@
+ #include <isl/options.h>
+ #include <isl/ctx.h>
+ #include <isl/val_gmp.h>
++#include <isl/id.h>
++#include <isl/space.h>
++#include <isl/val.h>
+ #include <isl/set.h>
+ #include <isl/union_set.h>
+ #include <isl/map.h>

--- a/packages.txt
+++ b/packages.txt
@@ -575,3 +575,4 @@ cue
 weaviate
 nvidia-device-plugin
 external-secrets-operator
+gcc-6


### PR DESCRIPTION
gcc-6 is necessary to bootstrap openjdk 7, which is necessary to bootstrap openjdk 8.

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
  - Exception: The package is needed to bootstrap OpenJDK 8.
- [x] REQUIRED - The package is added to `packages.txt`