### PR TITLE
fastjar: new package

### DIFF
--- a/fastjar.yaml
+++ b/fastjar.yaml
@@ -1,0 +1,47 @@
+package:
+  name: fastjar
+  version: 0.98
+  epoch: 0
+  description: "fast implementation of Java Archiver"
+  copyright:
+    - license: "GPL-2.0-or-later"
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - build-base
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: http://download.savannah.nongnu.org/releases/fastjar/fastjar-${{package.version}}.tar.gz
+      expected-sha512: c0f9fca7b58d6acd00b90a5184dbde9ba3ffc5bf4d69512743e450649a272baf1f6af98b15d79d2b53990eaf84ef402c986035e6b615a19e35ed424348143903
+
+  - uses: patch
+    with:
+      patches: 0001-Properly-zero-terminate-filename.patch
+
+  - uses: patch
+    with:
+      patches: 0002-Fix-write-return-value-check.patch
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: "fastjar-doc"
+    description: "fast implementation of Java Archiver (documentation)"
+    pipeline:
+      - uses: split/manpages
+
+update:
+  enable: true
+  release-monitor:
+    identifier: 14692

--- a/fastjar/0001-Properly-zero-terminate-filename.patch
+++ b/fastjar/0001-Properly-zero-terminate-filename.patch
@@ -1,0 +1,16 @@
+http://cvs.savannah.gnu.org/viewvc/fastjar/jartool.c?root=fastjar&r1=1.59&r2=1.60&view=patch
+
+2010-03-01  Richard Guenther  <rguenther@suse.de>
+
+	* jartool.c (read_entries): Properly zero-terminate filename.
+
+--- a/jartool.c	2009/09/06 22:16:00	1.59
++++ b/jartool.c	2010/03/01 15:38:43	1.60
+@@ -790,6 +790,7 @@
+ 		   progname, jarfile);
+ 	  return 1;
+ 	}
++      ze->filename[len] = '\0';
+       len = UNPACK_UB4(header, CEN_EFLEN);
+       len += UNPACK_UB4(header, CEN_COMLEN);
+       if (lseek (fd, len, SEEK_CUR) == -1)

--- a/fastjar/0002-Fix-write-return-value-check.patch
+++ b/fastjar/0002-Fix-write-return-value-check.patch
@@ -1,0 +1,17 @@
+http://cvs.savannah.gnu.org/viewvc/fastjar/jartool.c?root=fastjar&r1=1.60&r2=1.61&view=patch
+
+2010-06-10  Chris Ball  <cjb@laptop.org>
+
+	* jartool.c (add_file_to_jar): Fix write return value check.
+
+--- a/jartool.c	2010/03/01 15:38:43	1.60
++++ b/jartool.c	2010/06/10 08:46:10	1.61
+@@ -1258,7 +1258,7 @@
+       exit_on_error("write");
+ 
+   /* write the file name to the zip file */
+-  if (1 == write(jfd, fname, file_name_length))
++  if (-1 == write(jfd, fname, file_name_length))
+     exit_on_error("write");
+ 
+   if(verbose){

--- a/packages.txt
+++ b/packages.txt
@@ -576,3 +576,4 @@ weaviate
 nvidia-device-plugin
 external-secrets-operator
 gcc-6
+fastjar


### PR DESCRIPTION
fastjar is another component, besides GCJ 6.5, that we need to assemble a Java 1.5 JDK for bootstrapping OpenJDK 7, which is needed to bootstrap OpenJDK 8.

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`