### PR TITLE
disable auto updates for py3-urllib3 as upstream is releasing pre-rel…

### DIFF
--- a/py3-urllib3.yaml
+++ b/py3-urllib3.yaml
@@ -35,5 +35,6 @@ pipeline:
 
 update:
   enabled: true
+  manual: true # looks like melange and update need a "trim-suffix:" key.  Currently auto updates fail "bot update found newer version 2.0.0a4 compared with package.version 1.26.15 in melange config"
   github:
     identifier: urllib3/urllib3


### PR DESCRIPTION
…eases using a strange version suffix `2.0.0a4`

I'll add a `strip-suffix:` config to melange and update the bot to work with it