### PR TITLE
libpaper: switch fetch URL so we can auto update and bump to 2.1.0

### DIFF
--- a/libpaper.yaml
+++ b/libpaper.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpaper
-  version: 1.1.28
-  epoch: 2
+  version: 2.1.0
+  epoch: 0
   description: Library for handling paper characteristics
   copyright:
     - license: GPL-2.0-only
@@ -14,15 +14,12 @@ environment:
       - build-base
       - automake
       - autoconf
-      - libtool
 
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: c8bb946ec93d3c2c72bbb1d7257e90172a22a44a07a07fb6b802a5bb2c95fddc
-      uri: https://deb.debian.org/debian/pool/main/libp/libpaper/libpaper_${{package.version}}.tar.gz
-
-  - runs: autoreconf -fi
+      expected-sha256: 474e9575e1235a0d8e3661f072de0193bab6ea1023363772f698a2cc39d640cf
+      uri: https://github.com/rrthomas/libpaper/releases/download/v${{package.version}}/libpaper-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:
@@ -50,5 +47,6 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 15136
+  github:
+    identifier: rrthomas/libpaper
+    strip-prefix: v


### PR DESCRIPTION
fixes: #925
