### PR TITLE
java-common: new package

### DIFF
--- a/java-common.yaml
+++ b/java-common.yaml
@@ -1,0 +1,22 @@
+package:
+  name: java-common
+  version: 0.1
+  epoch: 0
+  description: "Compatibility infrastructure for JVM runtimes"
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/bin
+      for exe in jaotc jar jarsigner java javac javadoc javap jcmd jdb jdeprscan jdeps jexec jexec-binfmt jfr jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200; do
+        ln -sf ../lib/jvm/default-jvm/bin/$exe "${{targets.destdir}}"/usr/bin
+      done
+
+update:
+  enable: false

--- a/packages.txt
+++ b/packages.txt
@@ -577,3 +577,4 @@ nvidia-device-plugin
 external-secrets-operator
 gcc-6
 fastjar
+java-common


### PR DESCRIPTION
Add common package which owns all of the JVM-related symlinks for `/usr/bin`.  This allows configuring the "default" JVM via subpackages which set up the `/usr/lib/jvm/default-jvm` symlink.