### PR TITLE
gcc-6: skip providers generation for gcc 6

### DIFF
--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -1,10 +1,12 @@
 package:
   name: gcc-6
   version: 6.5.0
-  epoch: 0
+  epoch: 1
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later
+  options:
+    no-provides: true
   dependencies:
     runtime:
       - binutils


### PR DESCRIPTION
Otherwise `gcc-6` conflicts with `build-base`/`gcc`.