### PR TITLE
clean up gcc manpages

### DIFF
--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-6
   version: 6.5.0
-  epoch: 1
+  epoch: 2
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later
@@ -142,6 +142,10 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: 'gcc-6-doc'
+    pipeline:
+      - uses: split/manpages
+
   - name: 'libstdc++-6'
     pipeline:
       - runs: |

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 12.2.0
-  epoch: 10
+  epoch: 11
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later
@@ -73,6 +73,10 @@ pipeline:
   - runs: |
       make -C build -j$(nproc) install DESTDIR="${{targets.destdir}}"
 
+  # We don't want to keep the .la files.
+  - runs: |
+      find ${{targets.destdir}} -name '*.la' -print -exec rm \{} \;
+
   - runs: |
       chmod 755 ${{targets.destdir}}/usr/lib64/libgcc_s.*
 
@@ -86,6 +90,10 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: 'gcc-doc'
+    pipeline:
+      - uses: split/manpages
+
   - name: 'libstdc++'
     pipeline:
       - runs: |


### PR DESCRIPTION
The GCC manpages were not split out, we discovered this while making sure GCC 6 and GCC 12 could be installed side by side.