### PR TITLE
java-gcj-compat: new package

### DIFF
--- a/java-gcj-compat.yaml
+++ b/java-gcj-compat.yaml
@@ -1,0 +1,83 @@
+package:
+  name: java-gcj-compat
+  version: 6.5.0
+  epoch: 1
+  description: 'Compatibility package to present a JDK using GCJ and FastJAR'
+  copyright:
+    - license: GPL-2.0-or-later
+  dependencies:
+    runtime:
+      - build-base
+      - gcj-6
+      - fastjar
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - build-base
+      - gcj-6
+      - fastjar
+
+pipeline:
+  # Build ECJ as `javac`
+  - runs: |
+      gcj-6.5 -Wl,-Bsymbolic -findirect-dispatch -o ecj \
+        --main=org.eclipse.jdt.internal.compiler.batch.Main \
+        /usr/share/java/ecj.jar -lgcj
+
+  - runs: |
+      JVM_DIR="${{targets.destdir}}"/usr/lib/jvm
+      JDK_DIR=$JVM_DIR/java-1.5-gcj
+      JDK_BIN_DIR=$JDK_DIR/bin
+      JDK_LIB_DIR=$JDK_DIR/lib
+      JRE_DIR=$JDK_DIR/jre
+      JRE_BIN_DIR=$JRE_DIR/bin
+      JRE_LIB_DIR=$JRE_DIR/lib
+
+      CPU=$(uname -m | sed -e 's/i.86/i386/g' -e 's/x86_64/amd64/g')
+
+      mkdir -p $JDK_BIN_DIR $JDK_LIB_DIR
+      ln -sf ../../../../bin/gij-6.5 $JDK_BIN_DIR/java
+      ln -sf ../../../../bin/fastjar $JDK_BIN_DIR/fastjar
+      ln -sf ../../../../bin/sinjdoc $JDK_BIN_DIR/javadoc
+      ln -sf ../../../../bin/grmic-6.5 $JDK_BIN_DIR/rmic
+      ln -sf ../../../../bin/gjavah-6.5 $JDK_BIN_DIR/javah
+      install -s /home/build/ecj $JDK_BIN_DIR/javac
+      ln -sf ../../../../bin/gappletviewer-6.5 $JDK_BIN_DIR/appletviewer
+      ln -sf ../../../../bin/gjarsigner-6.5 $JDK_BIN_DIR/jarsigner
+      ln -sf ../../../../bin/grmiregistry-6.5 $JDK_BIN_DIR/rmiregistry
+      ln -sf ../../../../bin/gkeytool-6.5 $JDK_BIN_DIR/keytool
+      ln -sf ../../../../bin/gjar-6.5 $JDK_BIN_DIR/gjar
+      ln -sf ../../../../bin/gnative2ascii-6.5 $JDK_BIN_DIR/gnative2ascii
+      ln -sf ../../../../share/java/libgcj-tools-6.5.0.jar $JDK_LIB_DIR/tools.jar
+
+      gcjrel=$(ls -d /usr/lib/gcc/${{host.triplet.gnu}}/6.5.0/gcj-6.5.0-* | cut -d '-' -f 3)
+
+      mkdir -p $JRE_BIN_DIR $JRE_LIB_DIR/$CPU
+      ln -sf ../../../../../bin/gij-6.5 $JRE_BIN_DIR/java
+      ln -sf ../../../../../bin/grmiregistry-6.5 $JRE_BIN_DIR/rmiregistry
+      ln -sf ../../../../../bin/gkeytool-6.5 $JRE_BIN_DIR/keytool
+      ln -sf ../../../../../share/java/libgcj-6.5.0.jar $JRE_LIB_DIR/rt.jar
+      ln -sf ../../../../../../lib/gcj-$_gccver-$gcjrel/libjvm.so $JRE_LIB_DIR/$CPU
+      ln -sf ../../../../../../lib/gcj-$_gccver-$gcjrel/libjavamath.so $JRE_LIB_DIR/$CPU
+      ln -sf ../../../../../../lib/gcj-$_gccver-$gcjrel/classmap.db $JRE_LIB_DIR/$CPU
+
+  - uses: strip
+
+subpackages:
+  - name: 'java-gcj-compat-default-jvm'
+    description: 'Use the java-gcj-compat JVM as the default JVM'
+    dependencies:
+      runtime:
+        - java-common
+        - java-gcj-compat
+      provides:
+        - default-jvm=1.5
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-1.5-gcj "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+update:
+  enabled: false

--- a/packages.txt
+++ b/packages.txt
@@ -578,3 +578,4 @@ external-secrets-operator
 gcc-6
 fastjar
 java-common
+java-gcj-compat


### PR DESCRIPTION
Provides a fake JDK/JRE built from GCJ and FastJAR, for bootstrapping OpenJDK 7.

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`