### PR TITLE
libxcursor: new package

### DIFF
--- a/libxcursor.yaml
+++ b/libxcursor.yaml
@@ -1,0 +1,51 @@
+package:
+  name: libxcursor
+  version: 1.2.1
+  epoch: 0
+  description: X cursor management library
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - xorgproto
+      - util-macros
+      - libx11-dev
+      - libxrender-dev
+      - libxfixes-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 46c143731610bafd2070159a844571b287ac26192537d047a39df06155492104
+      uri: https://www.x.org/releases/individual/lib/libXcursor-${{package.version}}.tar.xz
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: libxcursor-dev
+    pipeline:
+      - uses: split/dev
+    description: libxcursor dev
+
+  - name: libxcursor-doc
+    pipeline:
+      - uses: split/manpages
+    description: libxcursor manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1770

--- a/packages.txt
+++ b/packages.txt
@@ -581,3 +581,4 @@ java-common
 java-gcj-compat
 libxinerama
 libxcomposite
+libxcursor


### PR DESCRIPTION
Dependency of GTK, which is a dependency of OpenJDK 7, because it does not have headless mode as a build option yet.

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`