### PR TITLE
gobject-introspection: fix scanning of non-libtool libraries

### DIFF
--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobject-introspection
   version: 1.74.0
-  epoch: 0
+  epoch: 1
   description: Introspection system for GObject-based libraries
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT
@@ -67,6 +67,7 @@ subpackages:
         - python3
         - cairo-dev
         - libtool
+        - posix-libc-utils
     description: gobject-introspection dev
 
 update:

--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobject-introspection
-  version: 1.74.0
-  epoch: 1
+  version: 1.76.1
+  epoch: 0
   description: Introspection system for GObject-based libraries
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT
@@ -39,7 +39,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 347b3a719e68ba4c69ff2d57ee2689233ea8c07fc492205e573386779e42d653
+      expected-sha256: 196178bf64345501dcdc4d8469b36aa6fe80489354efe71cb7cb8ab82a3738bf
       uri: https://download.gnome.org/sources/gobject-introspection/${{vars.mangled-package-version}}/gobject-introspection-${{package.version}}.tar.xz
 
   - uses: meson/configure


### PR DESCRIPTION
ldd is needed, which is provided by posix-libc-utils.

also upgrade to 1.76.1