### PR TITLE
glibc subpackage  `posix-libc-utils`: explicitly provide `cmd:getent`

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -381,6 +381,11 @@ subpackages:
     dependencies:
       runtime:
         - bash
+      provides:
+        # melange normally automatically generates all of the cmd: and so: when it builds a package, so this shouldn't be necessary
+        # However, waiting for it to be built means that there is no way to know that others - systemd.yaml - depend upon it, until it is built.
+        # Since we need to know that systemd.yaml depends upon this glibc.yaml, we added it explicitly.
+        - cmd:getent
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin


### PR DESCRIPTION
`systemd.yaml` depends on `cmd:getent`. This is provided by `glibc.yaml` in the subpackage `posix-libc-utils`, but is not explicit. This means that `systemd.yaml` not only can be built only after glibc (which is fine), but cannot even resolve that dependency until glibc is built, and melange automatically generates the provides list.

Which, in turn, makes generating the dependency graph impossible.

This adds it as an explicit `provides` by the subpackage, which allows the graph to build.