### PR TITLE
libXt/1.3.0 and switch fetch file extension as .tar.bz2 are no longer…

### DIFF
--- a/libxt.yaml
+++ b/libxt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxt
-  version: 1.2.1
-  epoch: 3
+  version: 1.3.0
+  epoch: 0
   description: X11 toolkit intrinsics library
   copyright:
     - license: custom
@@ -23,8 +23,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 679cc08f1646dbd27f5e48ffe8dd49406102937109130caab02ca32c083a3d60
-      uri: https://www.x.org/releases/individual/lib/libXt-${{package.version}}.tar.bz2
+      expected-sha256: de4a80c4cc7785b9620e572de71026805f68e85a2bf16c386009ef0e50be3f77
+      uri: https://www.x.org/releases/individual/lib/libXt-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
… published

fixes #1183
