### PR TITLE
mpc/1.3.1 also switch to automatic updates

### DIFF
--- a/mpc.yaml
+++ b/mpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: mpc
-  version: 1.2.1
-  epoch: 5
+  version: 1.3.1
+  epoch: 0
   description: "multiple-precision C library"
   copyright:
     - license: LGPL-3.0-or-later
@@ -26,7 +26,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://ftp.gnu.org/gnu/mpc/mpc-${{package.version}}.tar.gz
-      expected-sha256: 17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459
+      expected-sha256: ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8
 
   - runs: |
       EGREP=egrep ./configure \
@@ -52,6 +52,5 @@ subpackages:
 
 update:
   enabled: true
-  manual: true # originally skipped, lets be careful upgrading this package
   release-monitor:
     identifier: 1667


### PR DESCRIPTION
@kaniini mcp was originally skipping auto updates, I wonder if this was because of possible soname files changed?  If so I've switched it to enable automated updates now but can keep manual if you prefer?