### PR TITLE
update pax-utils/1.3.7 switch fetch URL as old one doesnt work with l…

### DIFF
--- a/pax-utils.yaml
+++ b/pax-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: pax-utils
-  version: 1.3.4
-  epoch: 4
+  version: 1.3.7
+  epoch: 0
   description: "ELF related utilities for 32-bit and 64-bit binaries"
   copyright:
     - license: GPL-2.0-only
@@ -25,13 +25,14 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://dev.gentoo.org/~xen0n/distfiles/pax-utils-${{package.version}}.tar.xz
-      expected-sha256: 8baed2f9c5ae8e0cda1b9c75990864101afc64fad0a4616e10f3ff8ef891040b
+      uri: https://gitweb.gentoo.org/proj/pax-utils.git/snapshot/pax-utils-${{package.version}}.tar.gz
+      expected-sha256: 9b5e7d7da71210b47aa3ccdf026bbbcc5d5cf8321be2285ee1ddcb0a761fc7cb
 
-  - runs: |
-      make -j$(nproc) USE_CAP=no CC="${{host.triplet.gnu}}-gcc"
+  - uses: meson/configure
 
-  - uses: autoconf/make-install
+  - uses: meson/compile
+
+  - uses: meson/install
 
   - runs: |
       rm -f "${{targets.destdir}}"/usr/bin/lddtree
@@ -45,6 +46,5 @@ subpackages:
 
 update:
   enabled: true
-  manual: true # fetch url has changed possibly we can use https://gitweb.gentoo.org/proj/pax-utils.git/ but this doesn't compile with melange
   release-monitor:
     identifier: 2601


### PR DESCRIPTION
…atest versions, plus now requires build with meson

fixes #1256
