### PR TITLE
gdk-pixbuf: new package

### DIFF
--- a/gdk-pixbuf.yaml
+++ b/gdk-pixbuf.yaml
@@ -1,0 +1,76 @@
+package:
+  name: gdk-pixbuf
+  version: 2.42.10
+  epoch: 0
+  description: GTK+ image loading library
+  copyright:
+    - license: LGPL-2.1-or-later
+  scriptlets:
+    trigger:
+      paths:
+        - '/usr/lib/gdk-pixbuf-2.0/*/loaders'
+      script: |
+        #!/bin/busybox sh
+        gdk-pixbuf-query-loaders --update-cache
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - glib-dev
+      - gobject-introspection-dev
+      - libjpeg-dev
+      - libpng-dev
+      - meson
+      - py3-docutils
+      - tiff-dev
+      - shared-mime-info
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: ee9b6c75d13ba096907a2e3c6b27b61bcd17f5c7ebeab5a5b439d2f2e39fe44b
+      uri: https://download.gnome.org/sources/gdk-pixbuf/2.42/gdk-pixbuf-${{package.version}}.tar.xz
+
+  - uses: meson/configure
+    with:
+      # Tests seem to be broken for some reason.
+      opts: -Dtests=false
+
+  - uses: meson/compile
+
+  - uses: meson/install
+
+  - uses: strip
+
+subpackages:
+  - name: gdk-pixbuf-doc
+    pipeline:
+      - uses: split/manpages
+    description: gdk-pixbuf manpages
+
+  - name: gdk-pixbuf-lang
+    pipeline:
+      - uses: split/locales
+    description: gdk-pixbuf locales
+
+  - name: gdk-pixbuf-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - gdk-pixbuf
+        - shared-mime-info
+    description: gdk-pixbuf dev
+
+  - name: gdk-pixbuf-loaders
+    description: metapackage to pull in gdk-pixbuf loaders
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 9533

--- a/packages.txt
+++ b/packages.txt
@@ -582,3 +582,4 @@ java-gcj-compat
 libxinerama
 libxcomposite
 libxcursor
+gdk-pixbuf


### PR DESCRIPTION
Dependency of OpenJDK.

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`