### PR TITLE
systemd: use posix-libc-utils directly instead of cmd: virtual in build deps

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -381,11 +381,6 @@ subpackages:
     dependencies:
       runtime:
         - bash
-      provides:
-        # melange normally automatically generates all of the cmd: and so: when it builds a package, so this shouldn't be necessary
-        # However, waiting for it to be built means that there is no way to know that others - systemd.yaml - depend upon it, until it is built.
-        # Since we need to know that systemd.yaml depends upon this glibc.yaml, we added it explicitly.
-        - cmd:getent
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: 253
-  epoch: 1
+  epoch: 2
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -17,7 +17,7 @@ environment:
       - meson
       - libcap-dev
       - ninja
-      - cmd:getent
+      - posix-libc-utils
       - clang-15
       - llvm15
       - python3


### PR DESCRIPTION
Implicit virtuals as direct build dependencies are unsolvable at build time, so they should be avoided here.