### PR TITLE
first batch of intltool dependencies

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -587,3 +587,4 @@ perl-try-tiny
 perl-encode-locale
 perl-lwp-mediatypes
 perl-clone
+perl-uri

--- a/packages.txt
+++ b/packages.txt
@@ -586,3 +586,4 @@ gdk-pixbuf
 perl-try-tiny
 perl-encode-locale
 perl-lwp-mediatypes
+perl-clone

--- a/packages.txt
+++ b/packages.txt
@@ -585,3 +585,4 @@ libxcursor
 gdk-pixbuf
 perl-try-tiny
 perl-encode-locale
+perl-lwp-mediatypes

--- a/packages.txt
+++ b/packages.txt
@@ -583,3 +583,4 @@ libxinerama
 libxcomposite
 libxcursor
 gdk-pixbuf
+perl-try-tiny

--- a/packages.txt
+++ b/packages.txt
@@ -584,3 +584,4 @@ libxcomposite
 libxcursor
 gdk-pixbuf
 perl-try-tiny
+perl-encode-locale

--- a/perl-clone.yaml
+++ b/perl-clone.yaml
@@ -1,0 +1,46 @@
+package:
+  name: perl-clone
+  version: "0.46"
+  epoch: 0
+  description: Clone perl module
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: aadeed5e4c8bd6bbdf68c0dd0066cb513e16ab9e5b4382dc4a0aafd55890697b
+      uri: https://cpan.metacpan.org/authors/id/G/GA/GARU/Clone-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+subpackages:
+  - name: perl-clone-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-clone manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5875

--- a/perl-encode-locale.yaml
+++ b/perl-encode-locale.yaml
@@ -1,0 +1,46 @@
+package:
+  name: perl-encode-locale
+  version: "1.05"
+  epoch: 0
+  description: Perl module - Determine the locale encoding
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 176fa02771f542a4efb1dbc2a4c928e8f4391bf4078473bd6040d8f11adb0ec1
+      uri: https://cpan.metacpan.org/authors/id/G/GA/GAAS/Encode-Locale-${{package.version}}.tar.gz
+
+  - runs: |
+      PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-encode-locale-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-encode-locale manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2852

--- a/perl-lwp-mediatypes.yaml
+++ b/perl-lwp-mediatypes.yaml
@@ -1,0 +1,47 @@
+package:
+  name: perl-lwp-mediatypes
+  version: "6.04"
+  epoch: 0
+  description: Perl module - guess media type for a file or a URL
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 8f1bca12dab16a1c2a7c03a49c5e58cce41a6fec9519f0aadfba8dad997919d9
+      uri: https://cpan.metacpan.org/authors/id/O/OA/OALDERS/LWP-MediaTypes-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-lwp-mediatypes-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-lwp-mediatypes manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3047

--- a/perl-try-tiny.yaml
+++ b/perl-try-tiny.yaml
@@ -1,0 +1,48 @@
+package:
+  name: perl-try-tiny
+  version: "0.31"
+  epoch: 0
+  description: Minimal try/catch with proper preservation of $@
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 3300d31d8a4075b26d8f46ce864a1d913e0e8467ceeba6655d5d2b2e206c11be
+      uri: https://cpan.metacpan.org/authors/id/E/ET/ETHER/Try-Tiny-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-try-tiny-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-try-tiny manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11921

--- a/perl-uri.yaml
+++ b/perl-uri.yaml
@@ -1,0 +1,48 @@
+package:
+  name: perl-uri
+  version: "5.17"
+  epoch: 0
+  description: Uniform Resource Identifiers (absolute and relative)
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 5f7e42b769cb27499113cfae4b786c37d49e7c7d32dbb469602cd808308568f8
+      uri: https://cpan.metacpan.org/authors/id/O/OA/OALDERS/URI-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-uri-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-uri manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3485


### PR DESCRIPTION
Intltool is a dependency of OpenJDK.

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`