### PR TITLE
second batch of dependencies for intltool

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -593,3 +593,4 @@ perl-io-html
 perl-http-message
 perl-http-negotiate
 perl-www-robotrules
+perl-file-listing

--- a/packages.txt
+++ b/packages.txt
@@ -588,3 +588,4 @@ perl-encode-locale
 perl-lwp-mediatypes
 perl-clone
 perl-uri
+perl-http-date

--- a/packages.txt
+++ b/packages.txt
@@ -589,3 +589,4 @@ perl-lwp-mediatypes
 perl-clone
 perl-uri
 perl-http-date
+perl-io-html

--- a/packages.txt
+++ b/packages.txt
@@ -595,3 +595,4 @@ perl-http-negotiate
 perl-www-robotrules
 perl-file-listing
 perl-html-tagset
+perl-html-parser

--- a/packages.txt
+++ b/packages.txt
@@ -594,3 +594,4 @@ perl-http-message
 perl-http-negotiate
 perl-www-robotrules
 perl-file-listing
+perl-html-tagset

--- a/packages.txt
+++ b/packages.txt
@@ -590,3 +590,4 @@ perl-clone
 perl-uri
 perl-http-date
 perl-io-html
+perl-http-message

--- a/packages.txt
+++ b/packages.txt
@@ -591,3 +591,4 @@ perl-uri
 perl-http-date
 perl-io-html
 perl-http-message
+perl-http-negotiate

--- a/packages.txt
+++ b/packages.txt
@@ -592,3 +592,4 @@ perl-http-date
 perl-io-html
 perl-http-message
 perl-http-negotiate
+perl-www-robotrules

--- a/perl-file-listing.yaml
+++ b/perl-file-listing.yaml
@@ -1,0 +1,51 @@
+package:
+  name: perl-file-listing
+  version: "6.15"
+  epoch: 0
+  description: Parse directory listing
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl-http-date
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+      - perl-http-date
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 46c4fb9f9eb9635805e26b7ea55b54455e47302758a10ed2a0b92f392713770c
+      uri: https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/File-Listing-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-file-listing-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-file-listing manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2892

--- a/perl-html-parser.yaml
+++ b/perl-html-parser.yaml
@@ -1,0 +1,54 @@
+package:
+  name: perl-html-parser
+  version: "3.81"
+  epoch: 0
+  description: HTML parser class
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl-html-tagset
+      - perl-http-message
+      - perl-uri
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+      - perl-html-tagset
+      - perl-http-message
+      - perl-uri
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: c0910a5c8f92f8817edd06ccfd224ba1c2ebe8c10f551f032587a1fc83d62ff2
+      uri: https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTML-Parser-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+subpackages:
+  - name: perl-html-parser-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-html-parser manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2967

--- a/perl-html-tagset.yaml
+++ b/perl-html-tagset.yaml
@@ -1,0 +1,48 @@
+package:
+  name: perl-html-tagset
+  version: "3.20"
+  epoch: 0
+  description: data tables useful in parsing HTML
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: adb17dac9e36cd011f5243881c9739417fd102fce760f8de4e9be4c7131108e2
+      uri: https://cpan.metacpan.org/authors/id/P/PE/PETDANCE/HTML-Tagset-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-html-tagset-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-html-tagset manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2971

--- a/perl-http-date.yaml
+++ b/perl-http-date.yaml
@@ -1,0 +1,47 @@
+package:
+  name: perl-http-date
+  version: "6.05"
+  epoch: 0
+  description: Perl module date conversion routines
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 365d6294dfbd37ebc51def8b65b81eb79b3934ecbc95a2ec2d4d827efe6a922b
+      uri: https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Date-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-http-date-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-http-date manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2976

--- a/perl-http-message.yaml
+++ b/perl-http-message.yaml
@@ -1,0 +1,61 @@
+package:
+  name: perl-http-message
+  version: "6.44"
+  epoch: 0
+  description: HTTP style message
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl-clone
+      - perl-http-date
+      - perl-uri
+      - perl-io-html
+      - perl-encode-locale
+      - perl-lwp-mediatypes
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+      - perl-clone
+      - perl-http-date
+      - perl-uri
+      - perl-io-html
+      - perl-encode-locale
+      - perl-lwp-mediatypes
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 398b647bf45aa972f432ec0111f6617742ba32fc773c6612d21f64ab4eacbca1
+      uri: https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Message-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-http-message-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-http-message manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2977

--- a/perl-http-negotiate.yaml
+++ b/perl-http-negotiate.yaml
@@ -1,0 +1,51 @@
+package:
+  name: perl-http-negotiate
+  version: "6.01"
+  epoch: 0
+  description: HTTP::Negotiate perl module
+  copyright:
+    - license: GPL-2.0 or Artistic
+  dependencies:
+    runtime:
+      - perl-http-message
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+      - perl-http-message
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 1c729c1ea63100e878405cda7d66f9adfd3ed4f1d6cacaca0ee9152df728e016
+      uri: https://cpan.metacpan.org/authors/id/G/GA/GAAS/HTTP-Negotiate-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-http-negotiate-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-http-negotiate manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2978

--- a/perl-io-html.yaml
+++ b/perl-io-html.yaml
@@ -1,0 +1,47 @@
+package:
+  name: perl-io-html
+  version: "1.004"
+  epoch: 0
+  description: Open an HTML file with automatic charset detection
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: c87b2df59463bbf2c39596773dfb5c03bde0f7e1051af339f963f58c1cbd8bf5
+      uri: https://cpan.metacpan.org/authors/id/C/CJ/CJM/IO-HTML-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-io-html-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-io-html manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2992

--- a/perl-www-robotrules.yaml
+++ b/perl-www-robotrules.yaml
@@ -1,0 +1,51 @@
+package:
+  name: perl-www-robotrules
+  version: "6.02"
+  epoch: 0
+  description: WWW::RobotRules perl module
+  copyright:
+    - license: GPL-2.0 or Artistic
+  dependencies:
+    runtime:
+      - perl-uri
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+      - perl-uri
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 46b502e7a288d559429891eeb5d979461dd3ecc6a5c491ead85d165b6e03a51e
+      uri: https://cpan.metacpan.org/authors/id/G/GA/GAAS/WWW-RobotRules-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-www-robotrules-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-www-robotrules manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3506


### PR DESCRIPTION
Intltool is an indirect dependency of OpenJDK.

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`