### PR TITLE
new package: hicolor-icon-theme

### DIFF
--- a/hicolor-icon-theme.yaml
+++ b/hicolor-icon-theme.yaml
@@ -1,0 +1,40 @@
+package:
+  name: hicolor-icon-theme
+  version: 0.17
+  epoch: 0
+  description: Freedesktop.org Hicolor icon theme
+  copyright:
+    - license: GPL-2.0-only
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://icon-theme.freedesktop.org/releases/hicolor-icon-theme-${{package.version}}.tar.xz
+      expected-sha512: eca8655930aa7e234f42630041c0053fde067b970fad1f81c55fcd4c5046c03edfdf2ede72a3e78fba2908e7da53e9463d3c5ae12ab9f5ef261e29a49f9c7a8d
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --build=$CHOST \
+        --host=$CHOST \
+        --prefix=/usr
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1316

--- a/packages.txt
+++ b/packages.txt
@@ -602,3 +602,4 @@ perl-http-cookies
 perl-libwww
 perl-xml-parser
 intltool
+hicolor-icon-theme


### PR DESCRIPTION
new package: hicolor-icon-theme

required for `gtk+2.0`

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`