### PR TITLE
gradle-8: update to 8.1.1

### DIFF
--- a/gradle-8.yaml
+++ b/gradle-8.yaml
@@ -1,15 +1,13 @@
 package:
   name: gradle-8
-  version: 8.0.2 # When bumping this, also bump the provides below!
-  epoch: 2
+  version: 8.1.1 # When bumping this, also bump the provides below!
+  epoch: 0
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - openjdk-11-jre
     provides:
-      - gradle=8.0.2
+      - gradle=8.1.1
 
 environment:
   contents:
@@ -19,25 +17,27 @@ environment:
       - build-base
       - bash
       - tini
-      - maven
       - git
       - patch
       - zip
+      # note: the comment below is not the case while we evaluate the right way to build gradle we have swapped from
+      # using the boostrap gradle to gradlewrapper.
+      #
       # The first time this is built, it depends on gradle-stage0.yaml being built first,
       # using pre-built gradle binaries, which `provides` a gradle package at an earlier version.
       # Afterwards it depends on previous versions of this package built from source.
-      - gradle
+      - openjdk-11
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/gradle/gradle
       tag: v${{package.version}}
-      expected-commit: 7d6581558e226a580d91d399f7dfb9e3095c2b1d
+      expected-commit: 1cf537a851c635c364a4214885f8b9798051175b
 
   - runs: |
       # Do not use the gradle wrapper, ensure we're using the bootstrap version.
-      /usr/bin/gradle :distributions-full:binDistributionZip
+      ./gradlew :distributions-full:binDistributionZip
 
       unzip subprojects/distributions-full/build/distributions/gradle-${{package.version}}-bin.zip
       cd gradle-${{package.version}}-*


### PR DESCRIPTION
This temporarily swaps build to use gradlew instead of the previous version of Gradle.  Building 8.1.1 with 8.0.1 results in:

```
  x86_64    | * What went wrong:
  x86_64    | Script compilation errors:
  x86_64    |
  x86_64    |   Line 27:         languageVersion = JavaLanguageVersion.of(11)
  x86_64    |                    ^ Val cannot be reassigned
  x86_64    |
  x86_64    |   Line 27:         languageVersion = JavaLanguageVersion.of(11)
  x86_64    |                                      ^ Type mismatch: inferred type is JavaLanguageVersion! but Property<JavaLanguageVersion!>! was expected
  x86_64    |
  x86_64    |   Line 28:         vendor = JvmVendorSpec.ADOPTIUM
  x86_64    |                    ^ Val cannot be reassigned
  x86_64    |
  x86_64    |   Line 28:         vendor = JvmVendorSpec.ADOPTIUM
  x86_64    |                             ^ Type mismatch: inferred type is JvmVendorSpec! but Property<JvmVendorSpec!>! was expected
  x86_64    |
  x86_64    | 4 errors
  x86_64    |
```
