### PR TITLE
Withdraw libjpeg because it was renamed

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -89,3 +89,10 @@ openjdk-17-jre-17.0.7+5-r0.apk
 libtirpc-dev-1.3.3-r0.apk
 neo4j-5.6.0-r0.apk
 neo4j-oci-entrypoint-5.6.0-r0.apk
+libjpeg-2.1.4-r0.apk
+libjpeg-2.1.4-r1.apk
+libjpeg-2.1.4-r2.apk
+libjpeg-2.1.5-r0.apk
+libjpeg-2.1.5.1-r1.apk
+libjpeg-2.1.91-r0.apk
+libjpeg-2.1.91-r1.apk


### PR DESCRIPTION
...to `libjpeg-turbo` in https://github.com/wolfi-dev/os/pull/1619