### PR TITLE
openjdk-17: Install jdk17 in version specific folder

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins
   version: "2.401"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: MIT
@@ -40,7 +40,7 @@ pipeline:
       patches: ignoreArchiveNotReadableTest.patch
 
   - runs: |
-      export JAVA_HOME=/usr/lib/jvm/openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
       export LANG=en_US.UTF-8
 
       export MAVEN_OPTS="-DforkCount=2"

--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak
   version: 21.1.1
-  epoch: 0
+  epoch: 1
   description:
   target-architecture:
     - all
@@ -37,7 +37,7 @@ pipeline:
 
   - runs: |
       export LANG=en_US.UTF-8
-      export JAVA_HOME=/usr/lib/jvm/openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
       mvn install -DskipTests=true -Dnode.version=$(node --version) -Pdistribution -q
 

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
   version: 17.0.7.7
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only
@@ -9,6 +9,8 @@ package:
     runtime:
       - freetype
       - fontconfig
+  options:
+    no-provides: true
 
 environment:
   contents:
@@ -89,49 +91,53 @@ pipeline:
   - runs: make jdk-image
 
   - runs: |
-      mkdir -p ${{targets.destdir}}/usr/lib/jvm/openjdk
-      cp -r ./build/linux-*-server-release/images/jdk/* ${{targets.destdir}}/usr/lib/jvm/openjdk
+      mkdir -p ${{targets.destdir}}/usr/lib/jvm/java-17-openjdk
+      cp -r ./build/linux-*-server-release/images/jdk/* ${{targets.destdir}}/usr/lib/jvm/java-17-openjdk
 
       mkdir -p ${{targets.destdir}}/usr/bin
-      ln -sf /usr/lib/jvm/openjdk/bin/java ${{targets.destdir}}/usr/bin/java
-      ln -sf /usr/lib/jvm/openjdk/bin/javac ${{targets.destdir}}/usr/bin/javac
+      ln -sf /usr/lib/jvm/java-17-openjdk/bin/java ${{targets.destdir}}/usr/bin/java
+      ln -sf /usr/lib/jvm/java-17-openjdk/bin/javac ${{targets.destdir}}/usr/bin/javac
 
 subpackages:
   - name: openjdk-17-jre
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm/openjdk
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm/java-17-openjdk
           for dir in conf \
                    include \
                    jmods \
                    legal \
                    lib \
                    release; do
-                      cp -r ./build/linux-*-server-release/images/jdk/${dir} ${{targets.subpkgdir}}/usr/lib/jvm/openjdk/${dir}
+                      cp -r ./build/linux-*-server-release/images/jdk/${dir} ${{targets.subpkgdir}}/usr/lib/jvm/java-17-openjdk/${dir}
           done
-          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm/openjdk/bin
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm/java-17-openjdk/bin
           for c in java \
                   jfr \
                   jrunscript \
                   keytool \
                   rmiregistry; do
-                      cp ./build/linux-*-server-release/images/jdk/bin/${c} ${{targets.subpkgdir}}/usr/lib/jvm/openjdk/bin/${c}
+                      cp ./build/linux-*-server-release/images/jdk/bin/${c} ${{targets.subpkgdir}}/usr/lib/jvm/java-17-openjdk/bin/${c}
           done
 
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -sf /usr/lib/jvm/openjdk/bin/java ${{targets.subpkgdir}}/usr/bin/java
+          ln -sf /usr/lib/jvm/java-17-openjdk/bin/java ${{targets.subpkgdir}}/usr/bin/java
     description: OpenJDK 17 (JRE)
     dependencies:
       runtime:
         - freetype
         - fontconfig
+    options:
+      no-provides: true
 
   - name: openjdk-17-doc
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/share
-          mv  ${{targets.destdir}}/usr/lib/jvm/openjdk/man ${{targets.subpkgdir}}/usr/share
+          mv  ${{targets.destdir}}/usr/lib/jvm/java-17-openjdk/man ${{targets.subpkgdir}}/usr/share
     description: OpenJDK 17 manpages
+    options:
+      no-provides: true
 
 update:
   enabled: true

--- a/zookeeper.yaml
+++ b/zookeeper.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper
   version: "3.8.1"
-  epoch: 0
+  epoch: 1
   description:
   target-architecture:
     - all
@@ -22,7 +22,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-17-jre
+      - openjdk-17
 
 pipeline:
   - uses: git-checkout
@@ -33,7 +33,7 @@ pipeline:
 
   - runs: |
       export LANG=en_US.UTF-8
-      export JAVA_HOME=/usr/lib/jvm/openjdk-jre
+      export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
       mvn install -DskipTests
       tar -xf zookeeper-assembly/target/apache-zookeeper-${{package.version}}-bin.tar.gz


### PR DESCRIPTION
WIP towards #1588. I'm thinking the safest thing to do is roll this out to 17 first and wait a few days to be sure there's no user impact before doing the same for 11.