### PR TITLE
Add advisories for gcc-6 vulnerabilities

### DIFF
--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -242,3 +242,30 @@ subpackages:
 update:
   # EOL upstream, needed for Java 8 bootstrap only.
   enabled: false
+
+advisories:
+  CVE-2018-12886:
+    - timestamp: 2023-04-28T14:46:17.894915-04:00
+      status: under_investigation
+    - timestamp: 2023-04-28T15:03:15.115547-04:00
+      status: affected
+      action: We are affected.
+  CVE-2019-15847:
+    - timestamp: 2023-04-28T14:46:17.894922-04:00
+      status: under_investigation
+    - timestamp: 2023-04-28T15:00:50.02253-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: We don't support POWER.
+  CVE-2021-37322:
+    - timestamp: 2023-04-28T14:46:17.894929-04:00
+      status: under_investigation
+    - timestamp: 2023-04-28T15:02:29.41787-04:00
+      status: not_affected
+      justification: vulnerable_code_not_in_execute_path
+      impact: GCC doesn't use the vulnerable code path in libiberty.
+
+secfixes:
+  "0":
+    - CVE-2019-15847
+    - CVE-2021-37322


### PR DESCRIPTION
Creates advisories for `gcc-6` vulnerabilities just found by `wolfictl advisory discover`.

cc: @kaniini 

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in `advisories` and `secfixes`
