### PR TITLE
Add two CVEs that were already fixed to the git package.

### DIFF
--- a/git.yaml
+++ b/git.yaml
@@ -18,6 +18,9 @@ secfixes:
   2.39.2-r0:
     - CVE-2023-22490
     - CVE-2023-23946
+  2.40.1-r0:
+    - CVE-2023-25652
+    - CVE-2023-29007
 
 environment:
   contents:
@@ -131,6 +134,14 @@ advisories:
     - timestamp: 2023-02-15T16:48:52.217204-05:00
       status: fixed
       fixed-version: 2.39.2-r0
+  CVE-2023-25652:
+    - timestamp: 2023-04-28T20:44:11.22969-04:00
+      status: fixed
+      fixed-version: 2.40.1-r0
+  CVE-2023-29007:
+    - timestamp: 2023-04-28T20:44:23.501938-04:00
+      status: fixed
+      fixed-version: 2.40.1-r0
 
 update:
   enabled: true


### PR DESCRIPTION
I saw them here: https://github.blog/2023-04-25-git-security-vulnerabilities-announced-4/

We already bumped to the fixed version, so this updates the feed.

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only

#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in `advisories` and `secfixes`

