### PR TITLE
fix some packages' provides to match their version

### DIFF
--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,13 +1,13 @@
 package:
   name: nodejs-18
-  version: 18.16.0
-  epoch: 0
+  version: 18.16.0 # When bumping this, also bump the provides below!
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT
   dependencies:
     provides:
-      - nodejs=18.15.999
+      - nodejs=18.16.999
 
 environment:
   contents:

--- a/py3.10-installer.yaml
+++ b/py3.10-installer.yaml
@@ -1,14 +1,14 @@
 # Generated from https://pypi.org/project/installer/
 package:
   name: py3.10-installer
-  version: 0.7.0
-  epoch: 0
+  version: 0.7.0 # When bumping this, also bump the provides below!
+  epoch: 1
   description: A library for installing Python wheels.
   copyright:
     - license: "MIT"
   dependencies:
     provides:
-      - py3-installer=0.5.999
+      - py3-installer=0.7.999
     runtime:
       - python-3.10
 

--- a/py3.11-installer.yaml
+++ b/py3.11-installer.yaml
@@ -1,14 +1,14 @@
 # Generated from https://pypi.org/project/installer/
 package:
   name: py3.11-installer
-  version: 0.7.0
-  epoch: 0
+  version: 0.7.0 # When bumping this, also bump the provides below!
+  epoch: 1
   description: A library for installing Python wheels.
   copyright:
     - license: "MIT"
   dependencies:
     provides:
-      - py3-installer=0.5.999
+      - py3-installer=0.7.999
     runtime:
       - python-3.11
 

--- a/py3.11-setuptools.yaml
+++ b/py3.11-setuptools.yaml
@@ -1,13 +1,13 @@
 package:
   name: py3.11-setuptools
-  version: 67.7.2
-  epoch: 0
+  version: 67.7.2 # When bumping this, also bump the provides below!
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"
   dependencies:
     provides:
-      - py3-setuptools=67.5.999
+      - py3-setuptools=67.7.999
     runtime:
       - python-3.11
 


### PR DESCRIPTION
For example, if a user asked for `- nodejs~18.15` they'd have gotten node 18.16, because it provided 18.15.999.

I found a couple other examples using this and some eyeballing:

```
yq '. | .package.name + "-" + .package.version + " : " + .package.dependencies.provides[]' *.yaml
```

I've added comments to hopefully remind us to bump the version when node 18.17 or whatever comes out and we get an auto-upgrade PR. These should really just be done with variable replacements, I should get around to doing that in melange.
