### PR TITLE
Add pcre support to our grep package.

### DIFF
--- a/grep.yaml
+++ b/grep.yaml
@@ -1,7 +1,7 @@
 package:
   name: grep
   version: "3.10"
-  epoch: 0
+  epoch: 1
   description: "GNU grep implementation"
   copyright:
     - license: GPL-3.0-or-later
@@ -31,7 +31,8 @@ pipeline:
          --host=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
          --prefix=/usr \
-         --datadir=/usr/share
+         --datadir=/usr/share \
+         --with-pcre
 
   - uses: autoconf/make
 


### PR DESCRIPTION
I was compiling ClickHouse which uses grep to detect some CPU features in the configure script. This failed because our grep isn't compiled with PCRE support.

Fixes:

Related:

### Pre-review Checklist
