### PR TITLE
Actually fix perl regexps in grep.

### DIFF
--- a/grep.yaml
+++ b/grep.yaml
@@ -1,7 +1,7 @@
 package:
   name: grep
   version: "3.10"
-  epoch: 1
+  epoch: 2
   description: "GNU grep implementation"
   copyright:
     - license: GPL-3.0-or-later
@@ -18,6 +18,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - build-base
+      - pcre2-dev
 
 pipeline:
   - uses: fetch
@@ -31,8 +32,7 @@ pipeline:
          --host=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
          --prefix=/usr \
-         --datadir=/usr/share \
-         --with-pcre
+         --datadir=/usr/share
 
   - uses: autoconf/make
 


### PR DESCRIPTION
The flag is harmless but the build just silently continues even if it doesn't have the regexp library. Swap it to install the library and remove the flag.

I tested this time in a full container and it actually works now.

Fixes:

Related:

### Pre-review Checklist

