### PR TITLE
Add pulumi, pulumi-watch, pulumi-kubernetes-operator, pulumi SDKs

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -610,3 +610,9 @@ java-cacerts
 openjdk-7
 aws-efs-csi-driver
 prometheus-bind-exporter
+pulumi
+pulumi-kubernetes-operator
+pulumi-language-dotnet
+pulumi-language-java
+pulumi-language-yaml
+pulumi-watch

--- a/pulumi-kubernetes-operator.yaml
+++ b/pulumi-kubernetes-operator.yaml
@@ -1,0 +1,38 @@
+package:
+  name: pulumi-kubernetes-operator
+  version: 1.11.5
+  epoch: 0
+  description: A Kubernetes Operator that automates the deployment of Pulumi Stacks
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - go
+      - busybox
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pulumi/pulumi-kubernetes-operator.git
+      tag: v${{package.version}}
+      destination: ${{package.name}}
+      expected-commit: e3f9416a288067828cba13813989aa8a6d5cb9eb
+
+  - working-directory: ${{package.name}}
+    pipeline:
+      - runs: |
+          # Original Go build args found in ./scripts/build.sh
+          CGO_ENABLED=0 go build -o "${{targets.destdir}}/usr/bin/${{package.name}}" \
+            -ldflags "-X github.com/pulumi/pulumi-kubernetes-operator/version.Version=v${{package.version}} -w -extldflags \"-static\"" \
+            -tags netgo ./cmd/manager/main.go
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pulumi/pulumi-kubernetes-operator
+    strip-prefix: v

--- a/pulumi-kubernetes-operator.yaml
+++ b/pulumi-kubernetes-operator.yaml
@@ -25,6 +25,10 @@ pipeline:
   - working-directory: ${{package.name}}
     pipeline:
       - runs: |
+          # Address CVE-2022-21698
+          go get github.com/prometheus/client_golang@v1.11.1
+          go mod tidy
+
           # Original Go build args found in ./scripts/build.sh
           CGO_ENABLED=0 go build -o "${{targets.destdir}}/usr/bin/${{package.name}}" \
             -ldflags "-X github.com/pulumi/pulumi-kubernetes-operator/version.Version=v${{package.version}} -w -extldflags \"-static\"" \

--- a/pulumi-language-dotnet.yaml
+++ b/pulumi-language-dotnet.yaml
@@ -1,0 +1,41 @@
+package:
+  name: pulumi-language-dotnet
+  version: 3.54.1
+  epoch: 0
+  description: Pulumi Language SDK for Dotnet
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - go
+      - busybox
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pulumi/pulumi-dotnet.git
+      tag: v${{package.version}}
+      destination: ${{package.name}}
+      expected-commit: da9240106c8f740175922f188462fed6446042b7
+
+  - working-directory: ${{package.name}}
+    pipeline:
+      - runs: |
+          set -x
+          export CGO_ENABLED=0 GO111MODULE=on
+          cd pulumi-language-dotnet/
+          go build \
+            -o "${{targets.destdir}}/usr/bin/pulumi-language-dotnet" \
+            -ldflags="-X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/version.Version=v${{package.version}}" \
+            .
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pulumi/pulumi-dotnet
+    strip-prefix: v

--- a/pulumi-language-java.yaml
+++ b/pulumi-language-java.yaml
@@ -1,0 +1,41 @@
+package:
+  name: pulumi-language-java
+  version: 0.9.2
+  epoch: 0
+  description: Pulumi Language SDK for Java
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - go
+      - busybox
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pulumi/pulumi-java.git
+      tag: v${{package.version}}
+      destination: ${{package.name}}
+      expected-commit: 9ed55571c504dc26c0a9226f359c5aa0b1d15fdb
+
+  - working-directory: ${{package.name}}
+    pipeline:
+      - runs: |
+          set -x
+          export CGO_ENABLED=0 GO111MODULE=on
+          cd pkg/
+          go build \
+            -o "${{targets.destdir}}/usr/bin/pulumi-language-java" \
+            -ldflags="-X github.com/pulumi/pulumi-java/pkg/version.Version=v${{package.version}}" \
+            ./cmd/pulumi-language-java
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pulumi/pulumi-java
+    strip-prefix: v

--- a/pulumi-language-yaml.yaml
+++ b/pulumi-language-yaml.yaml
@@ -1,0 +1,40 @@
+package:
+  name: pulumi-language-yaml
+  version: 1.1.1
+  epoch: 0
+  description: Pulumi Language SDK for YAML
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - go
+      - busybox
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pulumi/pulumi-yaml.git
+      tag: v${{package.version}}
+      destination: ${{package.name}}
+      expected-commit: 7a48c05395d38ec59663de8907863ec740c489b1
+
+  - working-directory: ${{package.name}}
+    pipeline:
+      - runs: |
+          set -x
+          export CGO_ENABLED=0 GO111MODULE=on
+          go build \
+            -o "${{targets.destdir}}/usr/bin/pulumi-language-yaml" \
+            -ldflags="-s -w -X github.com/pulumi/pulumi-yaml/pkg/version.Version=v${{package.version}}" \
+            ./cmd/pulumi-language-yaml/
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pulumi/pulumi-yaml
+    strip-prefix: v

--- a/pulumi-watch.yaml
+++ b/pulumi-watch.yaml
@@ -1,0 +1,40 @@
+package:
+  name: pulumi-watch
+  version: 0.1.5
+  epoch: 0
+  description: Supports the functionality of the pulumi watch command
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - rust
+      - libLLVM-15
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pulumi/watchutil-rs.git
+      tag: v${{package.version}}
+      destination: ${{package.name}}
+      expected-commit: bae2913e89662fbd0bf3264cb2985ea6b6c73c59
+
+  - working-directory: ${{package.name}}
+    pipeline:
+      - runs: |
+          set -x
+          cargo build --release -vv
+          mkdir -p "${{targets.destdir}}/usr/bin/"
+          mv target/release/pulumi-watch "${{targets.destdir}}/usr/bin/"
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pulumi/watchutil-rs
+    strip-prefix: v

--- a/pulumi.yaml
+++ b/pulumi.yaml
@@ -1,0 +1,85 @@
+package:
+  name: pulumi
+  version: 3.65.1
+  epoch: 0
+  description: Infrastructure as Code in any programming language
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - go
+      - busybox
+      - build-base
+      - yarn
+      - nodejs
+      - python3
+      - python3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pulumi/pulumi.git
+      tag: v${{package.version}}
+      destination: ${{package.name}}
+      expected-commit: f4044dc955009a7da3d58f845ec29a9a7f80ec49
+
+  - working-directory: ${{package.name}}
+    pipeline:
+      - runs: |
+          set -x
+          export CGO_ENABLED=0 GO111MODULE=on
+          export PULUMI_VERSION="v${{package.version}}"
+          export PULUMI_ROOT="$(mktemp -d)"
+          export GOBIN="${PULUMI_ROOT}/bin"
+          mkdir -p "${{targets.destdir}}/usr/bin"
+
+          # Build the Pulumi CLI itself
+          make install
+          mv -v "${PULUMI_ROOT}"/bin/pulumi* "${{targets.destdir}}/usr/bin"
+
+          # Build the Pulumi Language SDKs (Go, Node.js, Python)
+          for lang in go nodejs python; do
+            cd "sdk/${lang}"
+            make build
+            # "make install_package" is needed for all SDKs except Go
+            [[ "${lang}" == "go" ]] || make install_package
+            # Remove .cmd files only used on Windows
+            rm -f "${PULUMI_ROOT}"/bin/*.cmd
+            ls -la "${PULUMI_ROOT}/bin"
+            mv -v "${PULUMI_ROOT}"/bin/pulumi* "${{targets.destdir}}/usr/bin"
+            cd ../..
+          done
+      - uses: strip
+
+subpackages:
+  - name: "pulumi-language-go"
+    description: "Pulumi Language SDK for Go"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/bin"
+          mv -v "${{targets.destdir}}"/usr/bin/pulumi-*go* "${{targets.subpkgdir}}/usr/bin"
+
+  - name: "pulumi-language-nodejs"
+    description: "Pulumi Language SDK for Node.js"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/bin"
+          mv -v "${{targets.destdir}}"/usr/bin/pulumi-*nodejs* "${{targets.subpkgdir}}/usr/bin"
+          # pulumi-analyzer-policy is built by the nodejs sdk even though it doesnt contain the string "nodejs"
+          mv -v "${{targets.destdir}}"/usr/bin/pulumi-analyzer-policy "${{targets.subpkgdir}}/usr/bin"
+
+  - name: "pulumi-language-python"
+    description: "Pulumi Language SDK for Python"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/bin"
+          mv -v "${{targets.destdir}}"/usr/bin/pulumi-*python* "${{targets.subpkgdir}}/usr/bin"
+
+update:
+  enabled: true
+  github:
+    identifier: pulumi/pulumi
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: supercedes #1717 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
