### PR TITLE
libxml2/2.11.1 package update - also add var transforms to automatica…

### DIFF
--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -1,10 +1,18 @@
 package:
   name: libxml2
-  version: 2.10.4
-  epoch: 1
+  version: 2.11.1
+  epoch: 0
   description: XML parsing library, version 2
   copyright:
     - license: MIT
+
+# creates a new var that contains only the major and minor version to be used in the fetch URL
+# e.g. 2.10.1 will create a new var mangled-package-version=2.10
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d+\.\d+)\.\d+
+    replace: $1
+    to: mangled-package-version
 
 secfixes:
   2.10.3-r0:
@@ -26,8 +34,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: ed0c91c5845008f1936739e4eee2035531c1c94742c6541f44ee66d885948d45
-      uri: https://download.gnome.org/sources/libxml2/2.10/libxml2-${{package.version}}.tar.xz
+      expected-sha256: 3d39b294b856bfe3bafd5fb126e1f8487004261e78eabb8df9513e927915a995
+      uri: https://download.gnome.org/sources/libxml2/${{vars.mangled-package-version}}/libxml2-${{package.version}}.tar.xz
 
   - uses: autoconf/configure
     with:
@@ -85,5 +93,6 @@ advisories:
 
 update:
   enabled: true
+  manual: true # melange bump doesn't work with var-transforms yet
   release-monitor:
     identifier: 1783


### PR DESCRIPTION
…lly use major.minor in fetch URL

fixes #1677

- [x] The `epoch` field is reset to 0
