### PR TITLE
fluent-bit/2.1.2 package update - switch to manual bump as melange bu…

### DIFF
--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -1,6 +1,6 @@
 package:
   name: fluent-bit
-  version: 2.1.1
+  version: 2.1.2
   epoch: 0
   description: Fast and Lightweight Log processor and forwarder
   copyright:
@@ -38,7 +38,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://releases.fluentbit.io/${{vars.mangled-package-version}}/source-${{package.version}}.tar.gz
-      expected-sha256: 111937b42e98e81e0833d53410350ec037d873950fb68439a1d22b78cad78543
+      expected-sha256: c866be8c5a31321c1f61fa0cb51cfb5d8daaa979d30351ffc6f3a1507b4d3218
 
   - runs: |
       cd build
@@ -91,5 +91,6 @@ subpackages:
 
 update:
   enabled: true
+  manual: true # melange bump doesn't work with var-transforms yet
   release-monitor:
     identifier: 267335


### PR DESCRIPTION
…mp doesnt work with var-transforms yet

#### For version bump PRs
- [x] The `epoch` field is reset to 0
