### PR TITLE
py3-urllib3/2.0.1 package update - also enable auto updates and inclu…

### DIFF
--- a/py3-urllib3.yaml
+++ b/py3-urllib3.yaml
@@ -12,24 +12,21 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
       - busybox
       - ca-certificates-bundle
       - build-base
-      - python3
-      - py3-setuptools
+      - py3-pip
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/urllib3/urllib3/releases/download/${{package.version}}/urllib3-${{package.version}}.tar.gz
-      expected-sha256: 2ce66a68134be469f5df5d46d724237489b3cd85b2bba2223dbbee1746548826
+      repository: https://github.com/urllib3/urllib3.git
+      tag: ${{package.version}}
+      expected-commit: b85e93d619a323b92c2954da852857e0119d71b8
 
   - runs: |
-      python3 setup.py build
-
-  - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      export SOURCE_DATE_EPOCH=315532800
+      pip install . --prefix=/usr --root=${{targets.destdir}}
 
   - uses: strip
 

--- a/py3-urllib3.yaml
+++ b/py3-urllib3.yaml
@@ -25,6 +25,7 @@ pipeline:
       expected-commit: b85e93d619a323b92c2954da852857e0119d71b8
 
   - runs: |
+      # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
       export SOURCE_DATE_EPOCH=315532800
       pip install . --prefix=/usr --root=${{targets.destdir}}
 

--- a/py3-urllib3.yaml
+++ b/py3-urllib3.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-urllib3
-  version: 1.26.15
+  version: 2.0.1
   epoch: 0
   description: "HTTP library with thread-safe connection pooling, file post, and more"
   copyright:
@@ -23,7 +23,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/urllib3/urllib3/releases/download/${{package.version}}/urllib3-${{package.version}}.tar.gz
-      expected-sha256: 8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305
+      expected-sha256: 2ce66a68134be469f5df5d46d724237489b3cd85b2bba2223dbbee1746548826
 
   - runs: |
       python3 setup.py build
@@ -35,6 +35,7 @@ pipeline:
 
 update:
   enabled: true
-  manual: true # looks like melange and update need a "trim-suffix:" key.  Currently auto updates fail "bot update found newer version 2.0.0a4 compared with package.version 1.26.15 in melange config"
+  ignore-regex-patterns:
+    - (\d+\.\d+)\.\da\d+ # urllib3 releases alpha versions with a suffix "a" followed by a digit, let's ignore these
   github:
     identifier: urllib3/urllib3


### PR DESCRIPTION
…de `ignore-regex-patterns` to ignore strange upstream version pattern for alpha releases

fixes: #1704

#### For version bump PRs
- [x] The `epoch` field is reset to 0
