### PR TITLE
Bump the jetty dependency in kafka to pick up CVE fixes.

### DIFF
--- a/kafka.yaml
+++ b/kafka.yaml
@@ -1,7 +1,8 @@
 package:
   name: kafka
+  # When bumping check to see if the CVE mitigation can be removed.
   version: "3.4.0"
-  epoch: 1
+  epoch: 2
   description:
   target-architecture:
     - all
@@ -35,6 +36,9 @@ pipeline:
   - runs: |
       export LANG=en_US.UTF-8
 
+      # Mitigate CVE-2023-26048 and CVE-2023-26049 by bumping jetty
+      sed -i 's/\(jetty:\s*"\)[^"]\+"/\19.4.51.v20230217"/' gradle/dependencies.gradle
+
       ./gradlew clean releaseTarGz
 
       tar -xf core/build/distributions/kafka_2.13-${{package.version}}.tgz
@@ -53,3 +57,18 @@ update:
   github:
     identifier: apache/kafka
     use-tag: true
+
+advisories:
+  CVE-2023-26048:
+    - timestamp: 2023-05-02T08:42:50.301866-04:00
+      status: fixed
+      fixed-version: 3.4.0-r2
+  CVE-2023-26049:
+    - timestamp: 2023-05-02T08:43:01.711354-04:00
+      status: fixed
+      fixed-version: 3.4.0-r2
+
+secfixes:
+  3.4.0-r2:
+    - CVE-2023-26048
+    - CVE-2023-26049


### PR DESCRIPTION
These showed up in our rumble scan. I did a full image build and test for kafka.

Fixes:

Related:

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in `advisories` and `secfixes`
