### PR TITLE
Switch the flux packages to build using the go package instead of mai…

### DIFF
--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-helm-controller
   version: 0.32.2
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit Helm reconciler, for declarative Helming
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin
       CGO_ENABLED=0 go build \
-        -trimpath -a -o "${{targets.destdir}}"/usr/bin/helm-controller ./main.go
+        -trimpath -a -o "${{targets.destdir}}"/usr/bin/helm-controller .
 
   - uses: strip
 

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-kustomize-controller
   version: 0.35.1
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit Kustomize reconciler
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin
       CGO_ENABLED=0 go build \
-        -trimpath -a -o "${{targets.destdir}}"/usr/bin/kustomize-controller ./main.go
+        -trimpath -a -o "${{targets.destdir}}"/usr/bin/kustomize-controller .
 
   - uses: strip
 

--- a/flux-notification-controller.yaml
+++ b/flux-notification-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-notification-controller
   version: 0.33.0
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit event forwarded and notification dispatcher
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin
       CGO_ENABLED=0 go build \
-        -trimpath -a -o "${{targets.destdir}}"/usr/bin/notification-controller ./main.go
+        -trimpath -a -o "${{targets.destdir}}"/usr/bin/notification-controller .
 
   - uses: strip
 

--- a/flux-source-controller.yaml
+++ b/flux-source-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-source-controller
   version: 0.36.1
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit source management component
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
       CGO_ENABLED=1 CGO_LDFLAGS="-static -fuse-ld=lld" go build \
         -ldflags "-s -w" \
         -tags 'netgo,osusergo,static_build' \
-        -trimpath -o "${{targets.destdir}}"/usr/bin/source-controller ./main.go
+        -trimpath -o "${{targets.destdir}}"/usr/bin/source-controller .
 
   - uses: strip
 


### PR DESCRIPTION
…n.go.

This was triggering several false positives in grype because building with the file doesn't embed enough information for scanners to properly detect the version.

Fixes:

Related:

### Pre-review Checklist