### PR TITLE
go: 1.20.4 and 1.19.9 to fix CVEs

### DIFF
--- a/go-1.19.yaml
+++ b/go-1.19.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.19
-  version: 1.19.8
-  epoch: 1
+  version: 1.19.9
+  epoch: 0
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -30,6 +30,10 @@ secfixes:
     - CVE-2023-24536
     - CVE-2023-24537
     - CVE-2023-24538
+  1.19.9-r0:
+    - CVE-2023-24539
+    - CVE-2023-24540
+    - CVE-2023-29400
 
 environment:
   contents:
@@ -47,7 +51,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://go.dev/dl/go${{package.version}}.src.tar.gz
-      expected-sha256: 1d7a67929dccafeaf8a29e55985bc2b789e0499cb1a17100039f084e3238da2f
+      expected-sha256: 131190a4697a70c5b1d232df5d3f55a3f9ec0e78e40516196ffb3f09ae6a5744
       strip-components: 0
 
   - runs: |
@@ -141,6 +145,18 @@ advisories:
     - timestamp: 2023-04-05T08:50:56.423606-04:00
       status: fixed
       fixed-version: 1.19.8-r0
+  CVE-2023-24539:
+    - timestamp: 2023-05-02T15:58:58.350831-04:00
+      status: fixed
+      fixed-version: 1.19.9-r0
+  CVE-2023-24540:
+    - timestamp: 2023-05-02T15:59:11.158232-04:00
+      status: fixed
+      fixed-version: 1.19.9-r0
+  CVE-2023-29400:
+    - timestamp: 2023-05-02T15:59:18.977361-04:00
+      status: fixed
+      fixed-version: 1.19.9-r0
 
 update:
   enabled: true

--- a/go-1.20.yaml
+++ b/go-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.20
-  version: 1.20.3
-  epoch: 1
+  version: 1.20.4
+  epoch: 0
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -26,6 +26,10 @@ secfixes:
     - CVE-2023-24536
     - CVE-2023-24537
     - CVE-2023-24538
+  1.20.4-r0:
+    - CVE-2023-29400
+    - CVE-2023-24539
+    - CVE-2023-24540
 
 environment:
   contents:
@@ -43,7 +47,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://go.dev/dl/go${{package.version}}.src.tar.gz
-      expected-sha256: e447b498cde50215c4f7619e5124b0fc4e25fb5d16ea47271c47f278e7aa763a
+      expected-sha256: 9f34ace128764b7a3a4b238b805856cc1b2184304df9e5690825b0710f4202d6
       strip-components: 0
 
   - runs: |
@@ -133,6 +137,18 @@ advisories:
     - timestamp: 2023-04-05T08:50:58.537967-04:00
       status: fixed
       fixed-version: 1.20.3-r0
+  CVE-2023-24539:
+    - timestamp: 2023-05-02T16:01:15.588118-04:00
+      status: fixed
+      fixed-version: 1.20.4-r0
+  CVE-2023-24540:
+    - timestamp: 2023-05-02T16:01:15.623186-04:00
+      status: fixed
+      fixed-version: 1.20.4-r0
+  CVE-2023-29400:
+    - timestamp: 2023-05-02T16:01:15.651143-04:00
+      status: fixed
+      fixed-version: 1.20.4-r0
 
 update:
   enabled: true

--- a/go-fips-1.19.yaml
+++ b/go-fips-1.19.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-fips-1.19
-  version: 1.19.8
-  epoch: 1
+  version: 1.19.9
+  epoch: 0
   description: "the Go programming language with OpenSSL cryptography"
   copyright:
     - license: BSD-3-Clause
@@ -32,6 +32,10 @@ secfixes:
     - CVE-2023-24536
     - CVE-2023-24537
     - CVE-2023-24538
+  1.19.9-r0:
+    - CVE-2023-24540
+    - CVE-2023-29400
+    - CVE-2023-24539
 
 environment:
   contents:
@@ -50,7 +54,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://go.dev/dl/go${{package.version}}.src.tar.gz
-      expected-sha256: 1d7a67929dccafeaf8a29e55985bc2b789e0499cb1a17100039f084e3238da2f
+      expected-sha256: 131190a4697a70c5b1d232df5d3f55a3f9ec0e78e40516196ffb3f09ae6a5744
       strip-components: 0
 
   - working-directory: /home/build/go
@@ -153,6 +157,18 @@ advisories:
     - timestamp: 2023-04-05T08:55:40.609989-04:00
       status: fixed
       fixed-version: 1.19.8-r0
+  CVE-2023-24539:
+    - timestamp: 2023-05-02T15:59:47.675581-04:00
+      status: fixed
+      fixed-version: 1.19.9-r0
+  CVE-2023-24540:
+    - timestamp: 2023-05-02T15:59:58.258052-04:00
+      status: fixed
+      fixed-version: 1.19.9-r0
+  CVE-2023-29400:
+    - timestamp: 2023-05-02T16:00:05.929051-04:00
+      status: fixed
+      fixed-version: 1.19.9-r0
 
 update:
   enabled: true

--- a/go-fips-1.20.yaml
+++ b/go-fips-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-fips-1.20
-  version: 1.20.3
-  epoch: 1
+  version: 1.20.4
+  epoch: 0
   description: "the Go programming language with OpenSSL cryptography"
   copyright:
     - license: BSD-3-Clause
@@ -31,6 +31,10 @@ secfixes:
     - CVE-2023-24536
     - CVE-2023-24537
     - CVE-2023-24538
+  1.20.4-r0:
+    - CVE-2023-24540
+    - CVE-2023-29400
+    - CVE-2023-24539
 
 environment:
   contents:
@@ -46,7 +50,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://go.dev/dl/go${{package.version}}.src.tar.gz
-      expected-sha256: e447b498cde50215c4f7619e5124b0fc4e25fb5d16ea47271c47f278e7aa763a
+      expected-sha256: 9f34ace128764b7a3a4b238b805856cc1b2184304df9e5690825b0710f4202d6
       strip-components: 0
 
   - working-directory: /home/build/go
@@ -145,6 +149,18 @@ advisories:
     - timestamp: 2023-04-05T08:55:05.226339-04:00
       status: fixed
       fixed-version: 1.20.3-r0
+  CVE-2023-24539:
+    - timestamp: 2023-05-02T16:02:29.236055-04:00
+      status: fixed
+      fixed-version: 1.20.4-r0
+  CVE-2023-24540:
+    - timestamp: 2023-05-02T16:02:29.279148-04:00
+      status: fixed
+      fixed-version: 1.20.4-r0
+  CVE-2023-29400:
+    - timestamp: 2023-05-02T16:02:29.308339-04:00
+      status: fixed
+      fixed-version: 1.20.4-r0
 
 update:
   enabled: true


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/MEb0UyuSMsU

#### For security-related PRs
- [x] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
- [x] The `epoch` field is reset to 0