### PR TITLE
Bump opensearch-2 and fix the java build dependency.

### DIFF
--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-2
-  version: "2.6.0"
-  epoch: 2
+  version: "2.7.0"
+  epoch: 0
   description:
   target-architecture:
     - all
@@ -22,13 +22,14 @@ environment:
       - ca-certificates-bundle
       - curl
       - gradle
+      - openjdk-11
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/opensearch-project/OpenSearch
       tag: ${{package.version}}
-      expected-commit: 7203a5af21a8a009aece1474446b437a3c674db6
+      expected-commit: b7a6e09e492b1e965d827525f7863b366ef0e304
 
   - runs: |
       export LANG=en_US.UTF-8


### PR DESCRIPTION
The change to reduce the jre broke this build/update.

Fixes: https://github.com/wolfi-dev/os/pull/1757

Related:


#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0
