### PR TITLE
Revert "logstash/8.7.1 package update"

### DIFF
--- a/logstash.yaml
+++ b/logstash.yaml
@@ -58,6 +58,7 @@ pipeline:
 
 update:
   enabled: true
+  manual: true # avoid creating PRs while build fails on arm
   github:
     identifier: elastic/logstash
     strip-prefix: v

--- a/logstash.yaml
+++ b/logstash.yaml
@@ -1,6 +1,6 @@
 package:
   name: logstash
-  version: "8.7.0"
+  version: "8.7.0" # 8.7.1-r0 has been withdrawn, when bumping to 8.7.1 bump the epoch to avoid withdrawing the same version again
   epoch: 0
   description: Logstash - transport and process your logs, events, or other data
   target-architecture:

--- a/logstash.yaml
+++ b/logstash.yaml
@@ -1,6 +1,6 @@
 package:
   name: logstash
-  version: 8.7.1
+  version: "8.7.0"
   epoch: 0
   description: Logstash - transport and process your logs, events, or other data
   target-architecture:
@@ -31,7 +31,7 @@ pipeline:
     with:
       repository: https://github.com/elastic/logstash
       tag: v${{package.version}}
-      expected-commit: ddd00672d403b6ea1df4e4225ad2056d19ed9404
+      expected-commit: 82d8400440fea09f84c6e8e549a7a613cb9a5260
 
   - runs: |
       export OSS=true

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -96,3 +96,4 @@ libjpeg-2.1.5-r0.apk
 libjpeg-2.1.5.1-r1.apk
 libjpeg-2.1.91-r0.apk
 libjpeg-2.1.91-r1.apk
+logstash-8.7.1-r0.apk


### PR DESCRIPTION
This is failing on arm
```
ℹ️  aarch64   | Building logstash-core using gradle
⚠️  aarch64   | ./gradlew assemble
ℹ️  aarch64   |
ℹ️  aarch64   | > Task :installDevelopmentGems FAILED
⚠️  aarch64   |
⚠️  aarch64   | FAILURE: Build failed with an exception.
```