### PR TITLE
Bump the JDK toolchain in logstash without bumping the version.

### DIFF
--- a/logstash.yaml
+++ b/logstash.yaml
@@ -1,7 +1,7 @@
 package:
   name: logstash
   version: "8.7.0" # 8.7.1-r0 has been withdrawn, when bumping to 8.7.1 bump the epoch to avoid withdrawing the same version again
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   target-architecture:
     - all
@@ -13,7 +13,7 @@ package:
   dependencies:
     runtime:
       - bash # some helper scripts use bash
-      - openjdk-11-jre
+      - openjdk-17-jre
 
 environment:
   contents:
@@ -22,7 +22,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - gradle
-      - openjdk-11
+      - openjdk-17
       - ruby-3.1
       - bash
 


### PR DESCRIPTION
The 8.7.1 update failed to build on arm. I wasn't able to reproduce it.

This is somewhat of a test to try changing the toolchain and see if it works, then we can try again to bump the version.

Fixes:

Related: https://github.com/wolfi-dev/os/pull/1769

### Pre-review Checklist
