### PR TITLE
Add a nack for CVE-2017-8806 to older postgres's.

### DIFF
--- a/postgresql-11.yaml
+++ b/postgresql-11.yaml
@@ -99,3 +99,14 @@ update:
     strip-prefix: REL_
     tag-filter: REL_11
     use-tag: true
+
+advisories:
+  CVE-2017-8806:
+    - timestamp: 2023-05-03T13:58:34.261264-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This CVE appears to impact only Debian/Ubuntu.
+
+secfixes:
+  "0":
+    - CVE-2017-8806

--- a/postgresql-12.yaml
+++ b/postgresql-12.yaml
@@ -99,3 +99,14 @@ update:
     strip-prefix: REL_
     tag-filter: REL_12
     use-tag: true
+
+advisories:
+  CVE-2017-8806:
+    - timestamp: 2023-05-03T13:58:26.329535-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This CVE appears to impact only Debian/Ubuntu.
+
+secfixes:
+  "0":
+    - CVE-2017-8806

--- a/postgresql-13.yaml
+++ b/postgresql-13.yaml
@@ -99,3 +99,14 @@ update:
     strip-prefix: REL_
     tag-filter: REL_13
     use-tag: true
+
+advisories:
+  CVE-2017-8806:
+    - timestamp: 2023-05-03T13:58:22.118734-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This CVE appears to impact only Debian/Ubuntu.
+
+secfixes:
+  "0":
+    - CVE-2017-8806

--- a/postgresql-14.yaml
+++ b/postgresql-14.yaml
@@ -99,3 +99,14 @@ update:
     strip-prefix: REL_
     tag-filter: REL_14
     use-tag: true
+
+advisories:
+  CVE-2017-8806:
+    - timestamp: 2023-05-03T13:58:17.082446-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
+      impact: This CVE appears to impact only Debian/Ubuntu.
+
+secfixes:
+  "0":
+    - CVE-2017-8806


### PR DESCRIPTION
We nacked this (correctly) for 15, but never added it for 11-14.

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only

#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in `advisories` and `secfixes`

