### PR TITLE
Add CVE-2020-29511 to go 1.19 as nacked.

### DIFF
--- a/go-1.19.yaml
+++ b/go-1.19.yaml
@@ -16,6 +16,7 @@ package:
 secfixes:
   "0":
     - CVE-2020-29509
+    - CVE-2020-29511
   1.19.3-r0:
     - CVE-2022-41716
   1.19.4-r0:
@@ -109,6 +110,10 @@ advisories:
     - timestamp: 2023-03-04T21:45:55.952053-05:00
       status: not_affected
       justification: vulnerable_code_not_in_execute_path
+  CVE-2020-29511:
+    - timestamp: 2023-05-03T14:27:20.842639-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
   CVE-2022-41716:
     - timestamp: 2022-11-01T13:39:29-04:00
       status: fixed

--- a/go-fips-1.19.yaml
+++ b/go-fips-1.19.yaml
@@ -18,6 +18,7 @@ package:
 secfixes:
   "0":
     - CVE-2020-29509
+    - CVE-2020-29511
   1.19.3-r0:
     - CVE-2022-41716
   1.19.4-r0:
@@ -121,6 +122,10 @@ advisories:
     - timestamp: 2023-03-04T21:45:55.952053-05:00
       status: not_affected
       justification: vulnerable_code_not_in_execute_path
+  CVE-2020-29511:
+    - timestamp: 2023-05-03T14:27:38.169203-04:00
+      status: not_affected
+      justification: vulnerable_code_not_present
   CVE-2022-41716:
     - timestamp: 2022-11-01T13:39:29-04:00
       status: fixed


### PR DESCRIPTION
We nacked this in 1.20, so nack it back to 1.19.

Fixes:

Related:

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in `advisories` and `secfixes`
