### PR TITLE
new package: openjdk-8 iced tea distribution

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,0 +1,222 @@
+package:
+  name: openjdk-8
+  version: 8u372-b07
+  epoch: 0
+  description: "IcedTea distribution of OpenJDK 8 (UNSUPPORTED)"
+  copyright:
+    - license: GPL-2.0-or-later
+  dependencies:
+    runtime:
+      - openjdk-8-jre
+      - java-cacerts
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - build-base
+      - bash
+      - findutils
+      - zip
+      - file
+      - gawk
+      - util-linux-dev
+      - libxslt-dev
+      - autoconf
+      - automake
+      - libtool
+      - linux-headers
+      - coreutils
+      - ca-certificates
+      - freetype-dev
+      - cups-dev
+      - libx11-dev
+      - libxext-dev
+      - libxrender-dev
+      - libxrandr-dev
+      - libxtst-dev
+      - libice-dev
+      - libxt-dev
+      - alsa-lib-dev
+      - libffi-dev
+      - krb5-dev
+      - pkgconf-dev
+      - attr-dev
+      - expat-dev
+      - fontconfig-dev
+      - libxi-dev
+      - libjpeg-dev
+      - giflib-dev
+      - lcms2-dev
+      - java-gcj-compat-default-jvm
+      - posix-libc-utils
+      - glib-dev
+      - gtk-2.0-dev
+      - libxinerama-dev
+      - libxcomposite-dev
+      - harfbuzz-dev
+      - pango-dev
+      - cairo-dev
+      - libxft-dev
+      - fribidi-dev
+      - gdk-pixbuf-dev
+      - patch
+      - sed
+      - openjdk-7
+      - ca-certificates
+      - libpng-dev
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://icedtea.classpath.org/download/source/icedtea-3.27.0.tar.xz
+      expected-sha512: ee16aeb4f1564a1fb6132ed5165f925ca8edc8cef13b46291589ceaff42e8f9922f0834e4aba899da061e78ea48805e4ac5bba73a73d5389c05ba4efd1663812
+
+  - working-directory: /home/build/icedtea-drops
+    pipeline:
+      - uses: fetch
+        with:
+          uri: https://icedtea.classpath.org/download/drops/icedtea8/3.27.0/openjdk-git.tar.xz
+          expected-sha512: 227fa26be948f4405e3d8c363a7d196b66aa0c00139c2c4cbfda28ba8d554b6f983765eb0499a63bcae3c6166d5fa51499a3558fc5efee35d1d9b14bc1075aa1
+          extract: false
+      - uses: fetch
+        with:
+          uri: https://icedtea.classpath.org/download/drops/icedtea8/hotspot.tar.xz
+          expected-sha512: 5c8e839d2d74b0308f468d8763a69ab06920f43b92659bbac76f53b48d83ce8d7070a091ca36df99629364fc8d05b8272e7c12d04609b969d5e8db6ace6908df
+          extract: false
+
+  - runs: |
+      ./autogen.sh
+
+  - runs: |
+      export EXTRA_CFLAGS="$CFLAGS -std=gnu++98 -Wno-error -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-strict-overflow"
+      export EXTRA_CPP_FLAGS="$CXXFLAGS -std=gnu++98 -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-strict-overflow"
+
+      bash ./configure \
+        --build=${{host.triplet.gnu}} \
+        --host=${{host.triplet.gnu}} \
+        --prefix=/usr/lib/jvm/java-1.8-openjdk \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --infodir=/usr/share/info \
+        --localstatedir=/var \
+        --with-parallel-jobs=$(nproc) \
+        --disable-dependency-tracking \
+        --disable-downloading \
+        --disable-precompiled-headers \
+        --disable-docs \
+        --disable-system-pcsc \
+        --disable-system-sctp \
+        --with-openjdk-src-zip=/home/build/icedtea-drops/openjdk-git.tar.xz \
+        --with-hotspot-src-zip=/home/build/icedtea-drops/hotspot.tar.xz \
+        --with-jdk-home=/usr/lib/jvm/java-1.7-openjdk \
+        --with-curves="nist+" \
+        --with-pkgversion="Wolfi ${{package.version}}-r${{package.epoch}}"
+
+      make icedtea-boot SHELL=/bin/bash
+      make
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk
+      cp -a /home/build/openjdk.build/images/j2sdk-image/* "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/
+      rm "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/src.zip
+
+      # This archive contains absolute paths from the build environment,
+      # so it does not work on the target system. User can generate it
+      # running 'java -Xshare:dump'.
+      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/server/classes.jsa
+
+      # symlink to shared java cacerts store
+      rm -f "${{targets.destdir}}"/usr/lib/jvm/jvm-1.8-openjdk/jre/lib/security/cacerts
+      ln -sf /etc/ssl/certs/java/cacerts \
+        "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre/lib/security/cacerts
+
+  - uses: strip
+
+subpackages:
+  - name: "openjdk-8-jre-lib"
+    description: "OpenJDK 8 Java Runtime (class libraries)"
+    pipeline:
+      - runs: |
+          for file in jre/lib/images \
+                        jre/lib/*.jar \
+                        jre/lib/security \
+                        jre/lib/ext/*.jar \
+                        jre/lib/cmm \
+                        jre/ASSEMBLY_EXCEPTION \
+                        jre/THIRD_PARTY_README \
+                        jre/LICENSE; do
+            dir=${file%/*}
+            mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/$dir
+            mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/$file "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/$dirname
+          done
+
+  - name: "openjdk-8-jre-base"
+    description: "OpenJDK 8 Java Runtime (no GUI support)"
+    dependencies:
+      runtime:
+        - openjdk-8-jre-lib
+        - java-common
+        - java-cacerts
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/bin
+          ln -sf java-1.8-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/java-8-openjdk
+
+          for file in java orbd rmid servertool unpack200 keytool \
+                      pack200 rmiregistry tnameserv; do
+            mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/bin/$file \
+               "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/bin/
+          done
+
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk
+
+          case $(uname -m) in
+          aarch64) _jarch="aarch64" ;;
+          x86_64) _jarch="amd64" ;;
+          *) _jarch="$(uname -m)" ;;
+          esac
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/lib
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/lib/$_jarch \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/lib
+
+  - name: "openjdk-8-jre"
+    description: "OpenJDK 8 Java Runtime"
+    dependencies:
+      runtime:
+        - openjdk-8-jre-base
+    pipeline:
+      - runs: |
+          for file in bin/policytool \
+                      bin/appletviewer; do
+            dir=${file%/*}
+            mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/$dir
+            mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/$file \
+               "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/$dir
+          done
+
+  - name: "openjdk-8-doc"
+    description: "OpenJDK 8 Documentation"
+    pipeline:
+      - uses: split/manpages
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/man \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk
+
+  - name: "openjdk-8-demos"
+    description: "OpenJDK 8 Demos"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/demo \
+             "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/sample \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 17307

--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -2,7 +2,7 @@ package:
   name: openjdk-8
   version: 8u372-b07
   epoch: 0
-  description: "IcedTea distribution of OpenJDK 8 (UNSUPPORTED)"
+  description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later
   dependencies:

--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,6 +1,6 @@
 package:
   name: openjdk-8
-  version: 8u372-b07
+  version: 8.372.07
   epoch: 0
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
@@ -48,7 +48,7 @@ environment:
       - libjpeg-dev
       - giflib-dev
       - lcms2-dev
-      - java-gcj-compat-default-jvm
+      - openjdk-7-default-jvm
       - posix-libc-utils
       - glib-dev
       - gtk-2.0-dev
@@ -63,7 +63,6 @@ environment:
       - patch
       - sed
       - openjdk-7
-      - ca-certificates
       - libpng-dev
       - zlib-dev
 
@@ -215,6 +214,18 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/demo \
              "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/sample \
              "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/
+
+  - name: "openjdk-8-default-jvm"
+    description: "Use the openjdk-8 JVM as the default JVM"
+    dependencies:
+      runtime:
+        - openjdk-8-jre-base
+      provides:
+        - default-jvm=1.8
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-1.8-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
 
 update:
   enabled: true

--- a/packages.txt
+++ b/packages.txt
@@ -608,6 +608,7 @@ gtk-doc
 gtk-2.0
 java-cacerts
 openjdk-7
+openjdk-8
 aws-efs-csi-driver
 prometheus-bind-exporter
 clickhouse


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

new package: openjdk-8

builds off the work done in #1681 to bootstrap openjdk-8 using the icedtea distribution

related: https://github.com/chainguard-dev/internal/issues/1575

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`