### PR TITLE
fix arm release build, disable strip for secrets-store-csi-driver-pro…

### DIFF
--- a/secrets-store-csi-driver-provider-azure.yaml
+++ b/secrets-store-csi-driver-provider-azure.yaml
@@ -29,7 +29,10 @@ pipeline:
   - runs: |
       install -Dm755 _output/*/secrets-store-csi-driver-provider-azure "${{targets.destdir}}"/usr/bin/secrets-store-csi-driver-provider-azure
 
-  - uses: strip
+  # disable strip as causing arm build to fail
+  # strip: Unable to recognise the format of the input file `./usr/bin/secrets-store-csi-driver-provider-azure'
+  # not deleting as we may want to investigate why this fails, a quick fix for the break in the release pipeline is to disable
+  # - uses: strip 
 
 update:
   enabled: true


### PR DESCRIPTION
…vider-azure

Rather than just removing `strip` I've commented it out as we might want to look at why this failed.  For now we just want to have the release pipeline green again.