### PR TITLE
fix arm release build, remove strip for secrets-store-csi-driver-prov…

### DIFF
--- a/secrets-store-csi-driver-provider-azure.yaml
+++ b/secrets-store-csi-driver-provider-azure.yaml
@@ -1,7 +1,7 @@
 package:
   name: secrets-store-csi-driver-provider-azure
   version: 1.4.1
-  epoch: 0
+  epoch: 1
   description: Azure Key Vault provider for Secret Store CSI driver
   copyright:
     - license: MIT
@@ -28,8 +28,6 @@ pipeline:
 
   - runs: |
       install -Dm755 _output/*/secrets-store-csi-driver-provider-azure "${{targets.destdir}}"/usr/bin/secrets-store-csi-driver-provider-azure
-
-  - uses: strip
 
 update:
   enabled: true


### PR DESCRIPTION
…ider-azure

arm release builds are failing with:

```
strip: Unable to recognise the format of the input file `./usr/bin/secrets-store-csi-driver-provider-azure'
```

The gcp provider doesn't use strip either

