### PR TITLE
Fix the cross build for the azure secrets-store-csi-driver.

### DIFF
--- a/secrets-store-csi-driver-provider-azure.yaml
+++ b/secrets-store-csi-driver-provider-azure.yaml
@@ -1,7 +1,7 @@
 package:
   name: secrets-store-csi-driver-provider-azure
   version: 1.4.1
-  epoch: 1
+  epoch: 2
   description: Azure Key Vault provider for Secret Store CSI driver
   copyright:
     - license: MIT
@@ -24,10 +24,12 @@ pipeline:
 
   - runs: |
       unset LDFLAGS
-      make build
+      make build ARCH=$(go env GOARCH)
 
   - runs: |
       install -Dm755 _output/*/secrets-store-csi-driver-provider-azure "${{targets.destdir}}"/usr/bin/secrets-store-csi-driver-provider-azure
+
+  - uses: strip
 
 update:
   enabled: true

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -98,3 +98,5 @@ libjpeg-2.1.91-r0.apk
 libjpeg-2.1.91-r1.apk
 logstash-8.7.1-r0.apk
 logstash-8.7.0-r1.apk
+secrets-store-csi-driver-provider-azure-1.4.1-r0.apk
+secrets-store-csi-driver-provider-azure-1.4.1-r1.apk


### PR DESCRIPTION
The strip error was because it was am amd64 binary instead of an arm one. The makefile hardcoded a default ARCH.

Also withdraw the broken package.

Fixes:

Related:

### Pre-review Checklist


