### PR TITLE
bump epoch for go-1.19/go-1.20 dependents

### DIFF
--- a/gomplate.yaml
+++ b/gomplate.yaml
@@ -1,7 +1,7 @@
 package:
   name: gomplate
   version: 3.11.5
-  epoch: 0
+  epoch: 1
   description: A go templating utility.
   copyright:
     - license: MIT

--- a/thanos.yaml
+++ b/thanos.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos
   version: 0.31.0
-  epoch: 1
+  epoch: 2
   description: Highly available Prometheus setup with long term storage capabilities.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

bumps epochs of packages depending on go(-fips)-1.19.x or 1.20.x

Related: #1750 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->
