### PR TITLE
Add grpc health probe package.

### DIFF
--- a/grpc-health-probe.yaml
+++ b/grpc-health-probe.yaml
@@ -1,0 +1,35 @@
+package:
+  name: grpc-health-probe
+  version: 0.4.18
+  epoch: 0
+  description: A command-line tool to perform health-checks for gRPC applications in Kubernetes and elsewhere
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/grpc-ecosystem/grpc-health-probe
+      tag: v${{package.version}}
+      expected-commit: 89e1a1152440ebaad28bdfd0b17a01500b16ca7f
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      CGO_ENABLED=0 go build -a -tags netgo -ldflags=-w -trimpath -o ${{targets.destdir}}/usr/bin/grpc_health_probe .
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: grpc-ecosystem/grpc-health-probe
+    strip-prefix: v
+    use-tag: true

--- a/packages.txt
+++ b/packages.txt
@@ -618,6 +618,7 @@ pulumi-language-dotnet
 pulumi-language-java
 pulumi-language-yaml
 pulumi-watch
+grpc-health-probe
 prometheus-stackdriver-exporter
 cadvisor
 secrets-store-csi-driver-provider-azure


### PR DESCRIPTION


Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`
