### PR TITLE
gomplate: depend on latest go

### DIFF
--- a/gomplate.yaml
+++ b/gomplate.yaml
@@ -32,6 +32,11 @@ pipeline:
         -X github.com/hairyhenderson/gomplate/v3/version.GitCommit=$(git rev-parse --short HEAD)" \
         github.com/hairyhenderson/gomplate/v3/cmd/gomplate
 
+      # Test that the binary can be run, since there have been issues with the
+      # Go version used by the tool that only manifest at runtime.
+      ${{targets.destdir}}/usr/bin/gomplate -i 'the answer is: {{ mul 6 7 }}'
+
+
 update:
   enabled: true
   github:

--- a/gomplate.yaml
+++ b/gomplate.yaml
@@ -1,7 +1,7 @@
 package:
   name: gomplate
   version: 3.11.5
-  epoch: 1
+  epoch: 2
   description: A go templating utility.
   copyright:
     - license: MIT
@@ -12,7 +12,7 @@ environment:
       - wolfi-baselayout
       - busybox
       - build-base
-      - go-1.19 # This requires go 1.19 for now
+      - go
       - git
       - ca-certificates-bundle
 

--- a/gomplate.yaml
+++ b/gomplate.yaml
@@ -36,7 +36,6 @@ pipeline:
       # Go version used by the tool that only manifest at runtime.
       ${{targets.destdir}}/usr/bin/gomplate -i 'the answer is: {{ mul 6 7 }}'
 
-
 update:
   enabled: true
   github:


### PR DESCRIPTION
When gomplate was added in [three months ago](https://github.com/wolfi-dev/os/commit/8bdd1e0092448436f9fee86bf95df2dad9091724), it was 3.11.3 and required Go 1.19 specifically for some reason. 

It was bot-updated to 3.11.5 [two weeks ago](https://github.com/wolfi-dev/os/commit/f0b4930f9191862cb54c85eb3eb461f8c753f424) and seems to no longer require Go 1.19.

This PR makes it depend on the floating latest go, which is currently 1.20.4.