### PR TITLE
ko: bump go deps to mitigate GHSAs

### DIFF
--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
-  version: 0.13.0
-  epoch: 2
+  version: 0.13.0 # When bumping the version check if the GHSA mitigations below can be removed.
+  epoch: 3
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,21 @@ pipeline:
 
   - runs: |
       cd ko
+
+      # GHSA-232p-vwff-86mp
+      # GHSA-33pg-m6jh-5237
+      # GHSA-6wrf-mxfj-pf5p
+      go get -u github.com/docker/docker@v23.0.3+incompatible
+
+      # GHSA-2h5h-59f5-c5x9
+      go get -u github.com/sigstore/rekor@v1.1.1
+
+      # GHSA-hw7c-3rfg-p46j
+      go get -u google.golang.org/protobuf@v1.29.1
+
+      go mod tidy
+      go mod vendor
+
       CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/google/ko/pkg/commands.Version=${{package.version}}"
       install -m755 -D ./ko "${{targets.destdir}}"/usr/bin/ko
 
@@ -31,3 +46,33 @@ update:
   github:
     identifier: ko-build/ko
     strip-prefix: v
+
+advisories:
+  GHSA-2h5h-59f5-c5x9:
+    - timestamp: 2023-05-04T10:34:34.169879-04:00
+      status: fixed
+      fixed-version: 0.13.0-r3
+  GHSA-6wrf-mxfj-pf5p:
+    - timestamp: 2023-05-04T10:34:34.141361-04:00
+      status: fixed
+      fixed-version: 0.13.0-r3
+  GHSA-33pg-m6jh-5237:
+    - timestamp: 2023-05-04T10:34:34.117098-04:00
+      status: fixed
+      fixed-version: 0.13.0-r3
+  GHSA-232p-vwff-86mp:
+    - timestamp: 2023-05-04T10:34:34.07704-04:00
+      status: fixed
+      fixed-version: 0.13.0-r3
+  GHSA-hw7c-3rfg-p46j:
+    - timestamp: 2023-05-04T10:34:34.199688-04:00
+      status: fixed
+      fixed-version: 0.13.0-r3
+
+secfixes:
+  0.13.0-r3:
+    - GHSA-33pg-m6jh-5237
+    - GHSA-232p-vwff-86mp
+    - GHSA-hw7c-3rfg-p46j
+    - GHSA-2h5h-59f5-c5x9
+    - GHSA-6wrf-mxfj-pf5p


### PR DESCRIPTION
These show up in `grype cgr.dev/chainguard/ko`:

```
$ grype cgr.dev/chainguard/ko
   ├── 0 critical, 2 high, 4 medium, 1 low, 0 negligible
   └── 5 fixed
NAME                        INSTALLED             FIXED-IN  TYPE       VULNERABILITY        SEVERITY
github.com/docker/docker    v23.0.1+incompatible  23.0.3    go-module  GHSA-232p-vwff-86mp  High
github.com/docker/docker    v23.0.1+incompatible  23.0.3    go-module  GHSA-33pg-m6jh-5237  Medium
github.com/docker/docker    v23.0.1+incompatible  23.0.3    go-module  GHSA-6wrf-mxfj-pf5p  Medium
github.com/sigstore/rekor   v1.0.1                1.1.1     go-module  GHSA-2h5h-59f5-c5x9  Medium
google.golang.org/protobuf  v1.29.0               1.29.1    go-module  GHSA-hw7c-3rfg-p46j  Low
```

These are fixed at head, and will be fixed when the next version of ko is released.

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in `advisories` and `secfixes`
