### PR TITLE
Add CVE-2023-0056 as fixed in haproxy.

### DIFF
--- a/haproxy.yaml
+++ b/haproxy.yaml
@@ -20,6 +20,8 @@ var-transforms:
 secfixes:
   "0":
     - CVE-2016-2102
+  2.6.8-r0:
+    - CVE-2023-0056
   2.6.9-r0:
     - CVE-2023-25725
 
@@ -87,6 +89,10 @@ advisories:
     - timestamp: 2023-02-20T15:12:46.092387-05:00
       status: not_affected
       justification: vulnerable_code_not_in_execute_path
+  CVE-2023-0056:
+    - timestamp: 2023-05-04T10:59:24.549732-04:00
+      status: fixed
+      fixed-version: 2.6.8-r0
   CVE-2023-25725:
     - timestamp: 2023-02-15T16:12:20.024784027+07:00
       status: fixed


### PR DESCRIPTION
It was fixed in 2.6.8 and 2.7.2, according to the changelogs:
* https://www.haproxy.org/download/2.6/src/CHANGELOG
* https://www.haproxy.org/download/2.7/src/CHANGELOG

(search BUG/MEDIUM: mux-h2: Refuse interim responses with end-stream flag set).
The commit itself is here: https://github.com/FireBurn/haproxy/commit/038a7e8aeb1c5b90c18c55d2bcfb3aaa476bce89

We packaged 2.6.7, 2.6.8, 2.6.9, then bumped to 2.7.6.


Fixes:

Related:

### Pre-review Checklist


#### For new package PRs only


#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in `advisories` and `secfixes`
