### PR TITLE
apko: bump go deps to mitigate a GHSA

### DIFF
--- a/apko.yaml
+++ b/apko.yaml
@@ -61,7 +61,7 @@ advisories:
     - timestamp: 2023-04-05T10:22:32.318046-04:00
       status: fixed
       fixed-version: 0.7.3-r1
-  GHSA-2h5h-59f5-c5x9:
+  CVE-2023-30551:
     - timestamp: 2023-05-04T12:30:46.874822-04:00
       status: fixed
       fixed-version: 0.8.0-r1

--- a/apko.yaml
+++ b/apko.yaml
@@ -26,7 +26,7 @@ pipeline:
   - runs: |
       cd apko
 
-      # GHSA-2h5h-59f5-c5x9
+      # GHSA-2h5h-59f5-c5x9 (CVE-2023-30551)
       go get -u github.com/sigstore/rekor@v1.1.1
       go mod tidy
 

--- a/apko.yaml
+++ b/apko.yaml
@@ -1,7 +1,8 @@
 package:
   name: apko
+  # When bumping the version check if the CVE/GHSA mitigations below can be removed.
   version: 0.8.0
-  epoch: 0
+  epoch: 1
   description: Build OCI images using APK directly without Dockerfile
   copyright:
     - license: Apache-2.0
@@ -24,6 +25,11 @@ pipeline:
 
   - runs: |
       cd apko
+
+      # GHSA-2h5h-59f5-c5x9
+      go get -u github.com/sigstore/rekor@1.1.1
+      go mod tidy
+
       make apko
       install -m755 -D ./apko "${{targets.destdir}}"/usr/bin/apko
 
@@ -39,6 +45,8 @@ secfixes:
     - CVE-2023-28840
     - CVE-2023-28841
     - CVE-2023-28842
+  0.8.0-r1:
+    - GHSA-2h5h-59f5-c5x9
 
 advisories:
   CVE-2023-28840:
@@ -53,3 +61,7 @@ advisories:
     - timestamp: 2023-04-05T10:22:32.318046-04:00
       status: fixed
       fixed-version: 0.7.3-r1
+  GHSA-2h5h-59f5-c5x9:
+    - timestamp: 2023-05-04T12:30:46.874822-04:00
+      status: fixed
+      fixed-version: 0.8.0-r1

--- a/apko.yaml
+++ b/apko.yaml
@@ -46,7 +46,7 @@ secfixes:
     - CVE-2023-28841
     - CVE-2023-28842
   0.8.0-r1:
-    - GHSA-2h5h-59f5-c5x9
+    - CVE-2023-30551
 
 advisories:
   CVE-2023-28840:

--- a/apko.yaml
+++ b/apko.yaml
@@ -27,7 +27,7 @@ pipeline:
       cd apko
 
       # GHSA-2h5h-59f5-c5x9
-      go get -u github.com/sigstore/rekor@1.1.1
+      go get -u github.com/sigstore/rekor@v1.1.1
       go mod tidy
 
       make apko


### PR DESCRIPTION
This shows up in `cgr.dev/chainguard/apko`:

```
$ grype registry:cgr.dev/chainguard/apko
 ✔ Cataloged packages      [143 packages]
 ✔ Scanning image...       [3 vulnerabilities]
   ├── 0 critical, 1 high, 2 medium, 0 low, 0 negligible
   └── 1 fixed
NAME                       INSTALLED  FIXED-IN  TYPE       VULNERABILITY        SEVERITY
github.com/sigstore/rekor  v1.1.0     1.1.1     go-module  GHSA-2h5h-59f5-c5x9  Medium
```