### PR TITLE
Fix double-quoting of ldflags in go/build pipeline.

### DIFF
--- a/docker-credential-ecr-login.yaml
+++ b/docker-credential-ecr-login.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-credential-ecr-login
   version: 0.7.0
-  epoch: 1
+  epoch: 2
   description: Credential helper for Docker to use the AWS Elastic Container Registry
   copyright:
     - license: Apache-2.0
@@ -22,7 +22,7 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cli/docker-credential-ecr-login
-      ldflags: '"-X github.com/awslabs/amazon-ecr-credential-helper/ecr-login/version.Version=${{package.version}}"'
+      ldflags: -X github.com/awslabs/amazon-ecr-credential-helper/ecr-login/version.Version=${{package.version}}
       output: docker-credential-ecr-login
 
   - uses: strip

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubevela
   version: 1.8.1
-  epoch: 0
+  epoch: 1
   description: KubeVela is a modern application delivery platform that makes deploying and operating applications across today's hybrid, multi-cloud environments easier, faster and more reliable
   copyright:
     - license: Apache-2.0
@@ -30,13 +30,13 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cmd/core/main.go
-      ldflags: '"-X github.com/oam-dev/kubevela/version.VelaVersion=${{package.version}}"'
+      ldflags: -X github.com/oam-dev/kubevela/version.VelaVersion=${{package.version}}
       output: manager
 
   - uses: go/build
     with:
       packages: ./references/cmd/cli/main.go
-      ldflags: '"-X github.com/oam-dev/kubevela/version.VelaVersion=${{package.version}}"'
+      ldflags: -X github.com/oam-dev/kubevela/version.VelaVersion=${{package.version}}
       output: vela
 
   - uses: strip

--- a/kyverno-cli.yaml
+++ b/kyverno-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-cli
   version: 1.9.2
-  epoch: 1
+  epoch: 2
   description: Kubernetes Native Policy Management CLI
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cmd/cli/kubectl-kyverno
-      ldflags: '"-X github.com/kyverno/kyverno/pkg/version.BuildVersion=${{package.version}}"'
+      ldflags: -X github.com/kyverno/kyverno/pkg/version.BuildVersion=${{package.version}}
       output: kyverno-cli
 
   - uses: strip


### PR DESCRIPTION
This was spitting out a build-warning at the start like: `sh: github.com/kyverno/kyverno/pkg/version.BuildVersion=1.9.2: unknown operand`

I checked and the variable wasn't actually set either in the binary. Removing this quoting fixes it.

Fixes:

Related:

### Pre-review Checklist
