### PR TITLE
Bump Python 3.12 to alpha7.

### DIFF
--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   # When bumping to a real non-prerelease you'll have to change the URL pattern on line 45
-  version: 3.12.0_alpha6
+  version: 3.12.0_alpha7
   epoch: 0
   description: "the Python programming language"
   copyright:
@@ -39,8 +39,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://www.python.org/ftp/python/3.12.0/Python-3.12.0a6.tar.xz
-      expected-sha256: 298440252c4b6b4e120e014c15d729eaf8ab779300dcca61d422c537e4e85eca
+      uri: https://www.python.org/ftp/python/3.12.0/Python-3.12.0a7.tar.xz
+      expected-sha256: a19ae4dc5afebdff5e1312346f160062a11e0dbd5f9e68a6a981ea37b21608e1
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist
