### PR TITLE
Fix the dashboard package by including local files.

### DIFF
--- a/kubernetes-dashboard.yaml
+++ b/kubernetes-dashboard.yaml
@@ -2,7 +2,7 @@ package:
   name: kubernetes-dashboard
   # When bumping, check to see if the GHSA mitigations below can be removed.
   version: 2.7.0
-  epoch: 0
+  epoch: 1
   description: General-purpose web UI for Kubernetes clusters
   copyright:
     - license: Apache-2.0
@@ -41,7 +41,7 @@ pipeline:
 
       # The amd64 path here is hardcoded in the makefile, but this will actually build platform-appropriate binaries.
       # https://github.com/kubernetes/dashboard/blob/v2.7.0/Makefile#L29
-      mv dist/amd64/dashboard "${{targets.destdir}}"/usr/share/kubernetes-dashboard/
+      mv dist/amd64/* "${{targets.destdir}}"/usr/share/kubernetes-dashboard/
 
       mkdir -p "${{targets.destdir}}"/usr/bin
       ln -sf /usr/share/kubernetes-dashboard/dashboard "${{targets.destdir}}"/usr/bin/dashboard


### PR DESCRIPTION
The 2.7.0 release still requires external static files, the 3.0 release won't and I misread the docs.

Fixes:

Related:

### Pre-review Checklist
