### PR TITLE
Switch oauth2-proxy to the declarative go dep management.

### DIFF
--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: oauth2-proxy
   version: 7.4.0
-  epoch: 1
+  epoch: 2
   description: Reverse proxy and static file server that provides authentication using various providers to validate accounts by email, domain or group.
   copyright:
     - license: MIT
@@ -22,15 +22,15 @@ pipeline:
       uri: https://github.com/oauth2-proxy/oauth2-proxy/archive/refs/tags/v${{package.version}}.tar.gz
       expected-sha256: f9c5791537b1286b5985b0123f19ad84d390a7fffc1edc1b7c50c5d66c67ebdd
 
+  - uses: go/build
+    with:
+      packages: .
+      output: oauth2-proxy
+      ldflags: -X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.Version=${{package.version}}
+      # GHSA-vvpx-j8f3-3w6h
+      deps: golang.org/x/net@v0.7.0
+
   - runs: |
-      # Mitigate GHSA-vvpx-j8f3-3w6h
-      go get golang.org/x/net@v0.7.0
-      go mod tidy
-
-      # --installsuffix cgo isn't required as of Go 1.10, and Go 1.18 is the minimum version supported by this project
-      # Most packages are already prebuilt with CGO_ENABLED=0, rendering -a (force rebuild) unnecessary, but leaving it in for readability of intent
-      CGO_ENABLED=0 go build -a -ldflags="-X main.VERSION=${{package.version}}" -o "${{targets.destdir}}/bin/"
-
       # Make sure there is at least an empty key file.
       # This is useful for GCP App Engine custom runtime builds, because you cannot use multiline variables in their app.yaml, so you have to build the
       # key into the container and then tell it where it is by setting OAUTH2_PROXY_JWT_KEY_FILE=/etc/ssl/private/jwt_signing_key.pem in app.yaml instead.


### PR DESCRIPTION
We can do this for more packages, but we should test this end to end in a few first.

Fixes:

Related:

### Pre-review Checklist

