### PR TITLE
Add nri-kubernetes and newrelic-infra-operator packages.

### DIFF
--- a/newrelic-infra-operator.yaml
+++ b/newrelic-infra-operator.yaml
@@ -1,0 +1,35 @@
+package:
+  name: newrelic-infra-operator
+  version: 0.10.0
+  epoch: 0
+  description: Newrelic kubernetes operator of infrastructure
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+      - build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/newrelic/newrelic-infra-operator
+      tag: v${{package.version}}
+      expected-commit: 2251318c93d653a497c3c7986e60f779146b520d
+
+  - runs: |
+      make build
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv newrelic-infra-operator ${{targets.destdir}}/usr/bin/newrelic-infra-operator
+
+update:
+  enabled: true
+  github:
+    identifier: newrelic/newrelic-infra-operator
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/nri-kubernetes.yaml
+++ b/nri-kubernetes.yaml
@@ -1,0 +1,37 @@
+package:
+  name: nri-kubernetes
+  version: 3.11.0
+  epoch: 0
+  description: New Relic integration for Kubernetes
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+      - build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/newrelic/nri-kubernetes
+      tag: v${{package.version}}
+      expected-commit: da6df4cfd3f9981802cb5266c05cb50371312cbe
+
+  - runs: |
+      # Our global LDFLAGS conflict with a Makefile parameter
+      unset LDFLAGS
+      make compile
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv bin/nri-kubernetes ${{targets.destdir}}/usr/bin/nri-kubernetes
+
+update:
+  enabled: true
+  github:
+    identifier: newrelic/nri-kubernetes
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/packages.txt
+++ b/packages.txt
@@ -628,3 +628,5 @@ configmap-reload
 k8sgpt
 kubernetes-dashboard
 buildkitd
+nri-kubernetes
+newrelic-infra-operator


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`
