### PR TITLE
Add prometheus cloudwatch exporter package.

### DIFF
--- a/cloudwatch-exporter.yaml
+++ b/cloudwatch-exporter.yaml
@@ -1,0 +1,44 @@
+package:
+  name: cloudwatch-exporter
+  version: "0.15.3"
+  epoch: 0
+  description: Metrics exporter for Amazon AWS CloudWatch
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - openjdk-17-jre
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - maven
+      - openjdk-17
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/prometheus/cloudwatch_exporter
+      tag: v${{package.version}}
+      expected-commit: eb9f513167eb1bf2efeadbf67e9641b610d3dd4b
+
+  - uses: patch
+    with:
+      patches: 0001-Update-snakeyaml-to-2.0.0-to-address-CVE-2022-1471.patch
+
+  - runs: |
+      mvn package
+      ls target/
+      mkdir -p ${{targets.destdir}}/usr/share/java/cloudwatch_exporter
+      mv target/cloudwatch_exporter-${{package.version}}-jar-with-dependencies.jar  ${{targets.destdir}}/usr/share/java/cloudwatch_exporter/cloudwatch_exporter.jar
+
+update:
+  enabled: true
+  github:
+    tag-filter: v
+    identifier: prometheus/cloudwatch_exporter
+    strip-prefix: v
+    use-tag: true

--- a/cloudwatch-exporter/0001-Update-snakeyaml-to-2.0.0-to-address-CVE-2022-1471.patch
+++ b/cloudwatch-exporter/0001-Update-snakeyaml-to-2.0.0-to-address-CVE-2022-1471.patch
@@ -1,0 +1,26 @@
+From 72fdfa98f1f447aaa0e69fb696032e8b88cedc46 Mon Sep 17 00:00:00 2001
+From: Dan Lorenc <dlorenc@chainguard.dev>
+Date: Sun, 7 May 2023 11:13:16 -0400
+Subject: [PATCH] Update snakeyaml to 2.0.0 to address CVE-2022-1471.
+
+Signed-off-by: Dan Lorenc <dlorenc@chainguard.dev>
+---
+ pom.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pom.xml b/pom.xml
+index 05d8aa0..be9ed59 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -79,7 +79,7 @@
+     <dependency>
+       <groupId>org.yaml</groupId>
+       <artifactId>snakeyaml</artifactId>
+-      <version>1.33</version>
++      <version>2.0</version>
+     </dependency>
+     <dependency>
+       <groupId>io.prometheus</groupId>
+-- 
+2.39.2 (Apple Git-143)
+

--- a/packages.txt
+++ b/packages.txt
@@ -629,3 +629,4 @@ k8sgpt
 kubernetes-dashboard
 buildkitd
 kine
+cloudwatch-exporter


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`
