### PR TITLE
maven switch update config to pull from github so we get the expected…

### DIFF
--- a/maven.yaml
+++ b/maven.yaml
@@ -55,5 +55,6 @@ pipeline:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 1894
+  github:
+    identifier: apache/maven
+    strip-prefix: maven-


### PR DESCRIPTION
… commit sha needed but the git-checkout step

This will prevent auto PRs that are missing the expected commit sha https://github.com/wolfi-dev/os/pull/1896