### PR TITLE
Bump some go dependencies to resolve CVEs in pulumi.

### DIFF
--- a/pulumi-language-java.yaml
+++ b/pulumi-language-java.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-java
   version: 0.9.2
-  epoch: 1
+  epoch: 2
   description: Pulumi Language SDK for Java
   copyright:
     - license: Apache-2.0
@@ -19,20 +19,18 @@ pipeline:
     with:
       repository: https://github.com/pulumi/pulumi-java.git
       tag: v${{package.version}}
-      destination: ${{package.name}}
       expected-commit: 9ed55571c504dc26c0a9226f359c5aa0b1d15fdb
 
-  - working-directory: ${{package.name}}
-    pipeline:
-      - runs: |
-          set -x
-          export CGO_ENABLED=0 GO111MODULE=on
-          cd pkg/
-          go build \
-            -o "${{targets.destdir}}/usr/bin/pulumi-language-java" \
-            -ldflags="-X github.com/pulumi/pulumi-java/pkg/version.Version=v${{package.version}}" \
-            ./cmd/pulumi-language-java
-      - uses: strip
+  - uses: go/build
+    with:
+      packages: ./cmd/pulumi-language-java
+      output: pulumi-language-java
+      ldflags: -X github.com/pulumi/pulumi-java/pkg/version.Version=v${{package.version}}
+      # Mitigate GHSA-hw7c-3rfg-p46j
+      deps: google.golang.org/protobuf@v1.29.1
+      modroot: pkg
+
+  - uses: strip
 
 update:
   enabled: true

--- a/pulumi.yaml
+++ b/pulumi.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi
   version: 3.66.0
-  epoch: 1
+  epoch: 2
   description: Infrastructure as Code in any programming language
   copyright:
     - license: Apache-2.0
@@ -41,6 +41,17 @@ pipeline:
           export GOBIN="${PULUMI_ROOT}/bin"
           mkdir -p "${{targets.destdir}}/usr/bin"
 
+          # Mitigate CVE-2022-41723
+          cd pkg/
+          go get golang.org/x/text@v0.9.0
+          go get golang.org/x/net@v0.7.0
+          go mod tidy
+          cd ../sdk
+          go mod edit -dropreplace golang.org/x/text
+          go get golang.org/x/text@v0.9.0
+          go mod tidy
+          cd ..
+
           # Build the Pulumi CLI itself
           make install
           mv -v "${PULUMI_ROOT}"/bin/pulumi* "${{targets.destdir}}/usr/bin"
@@ -49,6 +60,7 @@ pipeline:
           for lang in go nodejs python; do
             cd "sdk/${lang}"
             make build
+
             # "make install_package" is needed for all SDKs except Go
             [[ "${lang}" == "go" ]] || make install_package
             # Remove .cmd files only used on Windows


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
