### PR TITLE
fix and simplify java8 subpackages to jre

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.372.07
-  epoch: 0
+  epoch: 1
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later
@@ -127,84 +127,38 @@ pipeline:
       rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/server/classes.jsa
 
       # symlink to shared java cacerts store
-      rm -f "${{targets.destdir}}"/usr/lib/jvm/jvm-1.8-openjdk/jre/lib/security/cacerts
+      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre/lib/security/cacerts
       ln -sf /etc/ssl/certs/java/cacerts \
         "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre/lib/security/cacerts
+
+      case $(uname -m) in
+      aarch64) _jarch="aarch64" ;;
+      x86_64) _jarch="amd64" ;;
+      *) _jarch="$(uname -m)" ;;
+      esac
+
+      # Remove extras not needed for headless installs
+      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre/lib/$_jarch/{libjsound,libjsoundalsa,libsplashscreen,libawt*,libfontmanager}.so
+      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre/bin/policytool
+      rm -f "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/bin/{policytool,appletviewer}
 
   - uses: strip
 
 subpackages:
-  - name: "openjdk-8-jre-lib"
-    description: "OpenJDK 8 Java Runtime (class libraries)"
-    pipeline:
-      - runs: |
-          for file in jre/lib/images \
-                        jre/lib/*.jar \
-                        jre/lib/security \
-                        jre/lib/ext/*.jar \
-                        jre/lib/cmm \
-                        jre/ASSEMBLY_EXCEPTION \
-                        jre/THIRD_PARTY_README \
-                        jre/LICENSE; do
-            dir=${file%/*}
-            mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/$dir
-            mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/$file "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/$dirname
-          done
-
-  - name: "openjdk-8-jre-base"
-    description: "OpenJDK 8 Java Runtime (no GUI support)"
+  - name: "openjdk-8-jre"
+    description: "OpenJDK 8 Java Runtime Environment"
     dependencies:
       runtime:
-        - openjdk-8-jre-lib
         - java-common
         - java-cacerts
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/bin
-          ln -sf java-1.8-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/java-8-openjdk
-
-          for file in java orbd rmid servertool unpack200 keytool \
-                      pack200 rmiregistry tnameserv; do
-            mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/bin/$file \
-               "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/bin/
-          done
-
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/
           mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/jre \
              "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk
 
-          case $(uname -m) in
-          aarch64) _jarch="aarch64" ;;
-          x86_64) _jarch="amd64" ;;
-          *) _jarch="$(uname -m)" ;;
-          esac
-
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/lib
-          mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/lib/$_jarch \
-             "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/lib
-
-  - name: "openjdk-8-jre"
-    description: "OpenJDK 8 Java Runtime"
-    dependencies:
-      runtime:
-        - openjdk-8-jre-base
-    pipeline:
-      - runs: |
-          for file in bin/policytool \
-                      bin/appletviewer; do
-            dir=${file%/*}
-            mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/$dir
-            mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/$file \
-               "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/$dir
-          done
-
-  - name: "openjdk-8-doc"
-    description: "OpenJDK 8 Documentation"
-    pipeline:
-      - uses: split/manpages
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk
-          mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/man \
-             "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/lib/ \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/
 
   - name: "openjdk-8-demos"
     description: "OpenJDK 8 Demos"
@@ -219,7 +173,7 @@ subpackages:
     description: "Use the openjdk-8 JVM as the default JVM"
     dependencies:
       runtime:
-        - openjdk-8-jre-base
+        - openjdk-8-jre
       provides:
         - default-jvm=1.8
     pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

java-8: simplify and fix

Fixes: this fixes [this](https://github.com/chainguard-images/images-private/actions/runs/4883952199/jobs/8716011838?pr=211#step:5:2331) error, and appears to put things into a working state. it also simplifies the provided subpackages into a single `-jre` subpackage. the theory being this eases the burden of maintainers needing to know exactly which files belong where, and faffing with all the linked `lib*.so`'s like I unfortunately did.

```bash
/# cat >HelloWorld.java <<EOF
> class HelloWorld {
>   public static void main(String[] args) {
>     System.out.println("Hello, World!");
>   }
> }
> EOF

/# javac HelloWorld.java
/# java HelloWorld
Hello, World!
```