### PR TITLE
dgraph: upstream are creating tags but seem to also publish releases …

### DIFF
--- a/dgraph.yaml
+++ b/dgraph.yaml
@@ -33,5 +33,4 @@ update:
   github:
     identifier: dgraph-io/dgraph
     strip-prefix: v
-    use-tag: true
     tag-filter: v


### PR DESCRIPTION
…when they are ready, lets track releases as early tag is breaking CI

see https://github.com/wolfi-dev/os/pull/1913
