### PR TITLE
Fix versioning scheme for cluster-autoscaler packages.

### DIFF
--- a/cluster-autoscaler.yaml
+++ b/cluster-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler
-  version: 9.28.0
-  epoch: 2
+  version: 1.27.1
+  epoch: 0
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -18,8 +18,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/kubernetes/autoscaler
-      tag: cluster-autoscaler-chart-${{package.version}}
-      expected-commit: 70fd890ebc04d28e292ae7920de5f069dec6c701
+      tag: cluster-autoscaler-${{package.version}}
+      expected-commit: 62d9c945786ff0a0b6942af269e8d5d05bee29fa
 
   - uses: go/build
     with:
@@ -33,6 +33,7 @@ update:
   enabled: true
   github:
     identifier: kubernetes/autoscaler
-    strip-prefix: cluster-autoscaler-chart-
+    strip-prefix: cluster-autoscaler-
     use-tag: true
-    tag-filter: cluster-autoscaler-chart-
+    # There are other tags like "cluster-autoscaler-chart-FOO"
+    tag-filter: cluster-autoscaler-1

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -100,3 +100,9 @@ logstash-8.7.1-r0.apk
 logstash-8.7.0-r1.apk
 secrets-store-csi-driver-provider-azure-1.4.1-r0.apk
 secrets-store-csi-driver-provider-azure-1.4.1-r1.apk
+cluster-autoscaler-9.26.0-r0.apk
+cluster-autoscaler-9.26.0-r1.apk
+cluster-autoscaler-9.27.0-r0.apk
+cluster-autoscaler-9.28.0-r0.apk
+cluster-autoscaler-9.28.0-r1.apk
+cluster-autoscaler-9.28.0-r2.apk


### PR DESCRIPTION
This is built out of a monorepo that does a bunch of different separate releases. They release a package for cluster-autoscaler, and then also a chart. And for some reason they use different versioning schemes, and I picked the wrong ones.

This fixes that, then withdraws the old packages so the correct ones can get installed.

Fixes:

Related:

### Pre-review Checklist