### PR TITLE
create the necessary jre executable symlinks for java-common

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.372.07
-  epoch: 1
+  epoch: 2
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later
@@ -159,6 +159,13 @@ subpackages:
 
           mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/lib/ \
              "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/
+
+          # move jre executables expected by java-common
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/bin
+          for file in java orbd rmid servertool unpack200 keytool \
+                pack200 rmiregistry tnameserv; do
+            mv "${{targets.destdir}}"/usr/lib/jvm/java-1.8-openjdk/bin/$file "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.8-openjdk/bin/
+          done
 
   - name: "openjdk-8-demos"
     description: "OpenJDK 8 Demos"


### PR DESCRIPTION
Fixes: `java-common` expects `java` (and other execuatables) at `bin/`, this ensures the `jre` sub package links them in the right place.

this _should_ be the last pr needed for the image, tested below:

```bash
❯ docker run --rm registry.wolfs.io/jdk8-jre-dev-amd64@sha256:bb52884de83b758337a47d6d5bf9b81c4e54b28dde70ffb310117c4339378037 -version
openjdk version "1.8.0_372"
OpenJDK Runtime Environment (IcedTea 3.27.0) (Wolfi 8.372.07-r2)
OpenJDK 64-Bit Server VM (build 25.372-b07, mixed mode)
```

with the following apko config:

```yaml
contents:
  packages:
    ...
    - openjdk-8-default-jvm

entrypoint:
  command: /usr/bin/java
```