### PR TITLE
add eol java 9

### DIFF
--- a/openjdk-9.yaml
+++ b/openjdk-9.yaml
@@ -1,0 +1,213 @@
+package:
+  name: openjdk-9
+  version: 9.0.4
+  epoch: 0
+  description: "Oracle OpenJDK 9"
+  copyright:
+    - license: GPL-2.0-with-classpath-exception
+  dependencies:
+    runtime:
+      - openjdk-9-jre
+      - java-cacerts
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - build-base
+      - ca-certificates
+      - bash
+      - zip
+      - file
+      - gawk
+      - linux-headers
+      - coreutils
+      - freetype-dev
+      - cups-dev
+      - libx11-dev
+      - libxext-dev
+      - libxrender-dev
+      - libxrandr-dev
+      - libxtst-dev
+      - libxt-dev
+      - alsa-lib-dev
+      - libffi-dev
+      - fontconfig-dev
+      - libjpeg-dev
+      - giflib-dev
+      - lcms2-dev
+      - libpng-dev
+      - zlib-dev
+      - openjdk-8
+      - openjdk-8-default-jvm
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://download.java.net/openjdk/jdk9/ri/openjdk-9_src.zip
+      expected-sha512: 1932e416d7f3164aed6d3590a4d42afdffb35cca6aeeec7146b1cdcbb3ac18e42122cd363b2fb44717ff562842ae1c6ab5645fb3e2a2fa236e753b5379ba7876
+      extract: false
+
+  - runs: |
+      unzip openjdk-9_src.zip
+      cd openjdk
+      mv * ..
+
+  - uses: patch
+    with:
+      patches: JDK-8187578.patch JDK-8241296.patch JDK-8245051.patch gcc10-compilation-fix.patch gcc11.patch int-conversion.patch make-4.3.patch
+
+  - runs: |
+      CFLAGS='' CXXFLAGS='' LDFLAGS='' \
+        bash ./configure \
+        --build=${{host.triplet.gnu}} \
+        --host=${{host.triplet.gnu}} \
+        --prefix=/usr/lib/jvm/java-1.9-openjdk \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --infodir=/usr/share/info \
+        --localstatedir=/var \
+        --with-jobs=$(nproc) \
+        --with-test-jobs=$(nproc) \
+        --disable-precompiled-headers \
+        --with-zlib=system \
+        --with-libjpeg=system \
+        --with-giflib=system \
+        --with-libpng=system \
+        --with-lcms=system \
+        --with-jtreg=no \
+        --with-native-debug-symbols=none \
+        --disable-warnings-as-errors \
+        --enable-dtrace=no \
+        --with-jvm-variants=server \
+        --with-debug-level=release \
+        --with-version-pre= \
+        --with-version-opt="wolfi-r${{package.epoch}}" \
+        --with-version-build="${{package.version}}" \
+        --with-extra-cflags="-fno-lifetime-dse -fno-strict-overflow -fno-delete-null-pointer-checks -fno-strict-aliasing" \
+        --with-extra-cxxflags="-fno-lifetime-dse -fno-strict-overflow -fno-delete-null-pointer-checks -fno-strict-aliasing" \
+        --with-extra-ldflags="$LDFLAGS"
+
+      make images
+
+  # Check we built something valid
+  - runs: |
+      _java_bin="./build/*-normal-server-release/images/jdk/bin"
+
+      $_java_bin/javac -d . HelloWorld.java
+      $_java_bin/java HelloWorld
+
+      # run the gtest unittest suites
+      make test-hotspot-gtest
+
+  - runs: |
+      _java_home="usr/lib/jvm/java-1.9-openjdk"
+
+      mkdir -p "${{targets.destdir}}"/$_java_home
+      cp -r build/*-normal-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
+      rm "${{targets.destdir}}"/$_java_home/lib/src.zip
+
+  - uses: strip
+
+subpackages:
+  - name: "openjdk-9-jre"
+    description: "OpenJDK 9 Java Runtime Environment"
+    dependencies:
+      runtime:
+        - openjdk-9-jre-base
+    pipeline:
+      - runs: |
+          _java_home="usr/lib/jvm/java-1.9-openjdk"
+
+          mkdir -p "${{targets.subpkgdir}}"/$_java_home/lib
+          mv "${{targets.destdir}}"/$_java_home/lib/libawt_xawt.so \
+              "${{targets.destdir}}"/$_java_home/lib/libfontmanager.so \
+              "${{targets.destdir}}"/$_java_home/lib/libjavajpeg.so \
+              "${{targets.destdir}}"/$_java_home/lib/libjsoundalsa.so \
+              "${{targets.destdir}}"/$_java_home/lib/liblcms.so \
+              "${{targets.destdir}}"/$_java_home/lib/libsplashscreen.so \
+              "${{targets.subpkgdir}}"/$_java_home/lib
+
+  - name: "openjdk-9-jre-base"
+    description: "OpenJDK 9 Java Runtime Environment (headless)"
+    dependencies:
+      runtime:
+        - java-common
+        - java-cacerts
+    pipeline:
+      - runs: |
+          _java_home="usr/lib/jvm/java-1.9-openjdk"
+
+          mkdir -p "${{targets.subpkgdir}}"/$_java_home
+          mv "${{targets.destdir}}"/$_java_home/lib \
+             "${{targets.subpkgdir}}"/$_java_home
+
+          mkdir -p "${{targets.subpkgdir}}"/$_java_home/bin
+          for i in appletviewer \
+                    idlj \
+                    java \
+                    jjs \
+                    jrunscript \
+                    keytool \
+                    orbd \
+                    pack200 \
+                    rmid \
+                    rmiregistry \
+                    servertool \
+                    tnameserv \
+                    unpack200; do
+            mv "${{targets.destdir}}"/$_java_home/bin/$i "${{targets.subpkgdir}}"/$_java_home/bin/$i
+          done
+
+          mv "${{targets.destdir}}"/$_java_home/legal "${{targets.subpkgdir}}"/$_java_home
+          mv "${{targets.destdir}}"/$_java_home/conf "${{targets.subpkgdir}}"/$_java_home
+          mv "${{targets.destdir}}"/$_java_home/release "${{targets.subpkgdir}}"/$_java_home
+          cp ASSEMBLY_EXCEPTION \
+              LICENSE \
+              README \
+             "${{targets.subpkgdir}}"/$_java_home
+
+          # symlink to shared java cacerts store
+          rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
+          ln -sf /etc/ssl/certs/java/cacerts \
+            "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
+
+  - name: "openjdk-9-jmods"
+    description: "OpenJDK 9 jmods"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.9-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-1.9-openjdk/jmods \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.9-openjdk
+
+  - name: "openjdk-9-doc"
+    description: "OpenJDK 9 Documentation"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.9-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-1.9-openjdk/man \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.9-openjdk
+
+  - name: "openjdk-9-demos"
+    description: "OpenJDK 9 Demos"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.9-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-1.9-openjdk/demo \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.9-openjdk
+
+  - name: "openjdk-9-default-jvm"
+    description: "Use the openjdk-9 JVM as the default JVM"
+    dependencies:
+      runtime:
+        - openjdk-9-jre
+      provides:
+        - default-jvm=1.9
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-1.9-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+update:
+  # OpenJDK 9 is EOL.
+  enabled: false

--- a/openjdk-9/HelloWorld.java
+++ b/openjdk-9/HelloWorld.java
@@ -1,0 +1,3 @@
+public class HelloWorld {
+  public static void main(String[] args) { System.out.println("Hello World!"); }
+}

--- a/openjdk-9/JDK-8187578.patch
+++ b/openjdk-9/JDK-8187578.patch
@@ -1,0 +1,29 @@
+From b5dd6a9a45b8e9120733798b915eb8111a7c65ef Mon Sep 17 00:00:00 2001
+From: Erik Helin <ehelin@openjdk.org>
+Date: Fri, 15 Sep 2017 14:47:13 +0200
+Subject: [PATCH] 8187578: BitMap::reallocate should check if old_map is NULL
+Origin: https://github.com/openjdk/jdk11u/commit/b5dd6a9a45b8e9120733798b915eb8111a7c65ef
+Modified: File to patch has another location in JDK9
+
+Reviewed-by: stefank, eosterlund, dholmes
+---
+ src/hotspot/share/utilities/bitMap.cpp | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/hotspot/share/utilities/bitMap.cpp b/src/hotspot/share/utilities/bitMap.cpp
+index 21a3229411..687b98e708 100644
+--- a/hotspot/src/share/vm/utilities/bitMap.cpp
++++ b/hotspot/src/share/vm/utilities/bitMap.cpp
+@@ -78,8 +78,10 @@ BitMap::bm_word_t* BitMap::reallocate(const Allocator& allocator, bm_word_t* old
+   if (new_size_in_words > 0) {
+     map = allocator.allocate(new_size_in_words);
+ 
+-    Copy::disjoint_words((HeapWord*)old_map, (HeapWord*) map,
+-                         MIN2(old_size_in_words, new_size_in_words));
++    if (old_map != NULL) {
++      Copy::disjoint_words((HeapWord*)old_map, (HeapWord*) map,
++                           MIN2(old_size_in_words, new_size_in_words));
++    }
+ 
+     if (new_size_in_words > old_size_in_words) {
+       clear_range_of_words(map, old_size_in_words, new_size_in_words);

--- a/openjdk-9/JDK-8241296.patch
+++ b/openjdk-9/JDK-8241296.patch
@@ -1,0 +1,25 @@
+From e566dca620c43d56798770b41cd0d25a63a71b82 Mon Sep 17 00:00:00 2001
+From: Andrew Haley <aph@openjdk.org>
+Date: Thu, 19 Mar 2020 14:53:57 +0000
+Subject: [PATCH] 8241296: Segfault in JNIHandleBlock::oops_do()
+
+Reviewed-by: stefank, shade
+---
+ src/hotspot/share/runtime/thread.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/hotspot/share/runtime/thread.cpp b/src/hotspot/share/runtime/thread.cpp
+index 0aa68f3941..ca7f0b0fa4 100644
+--- a/hotspot/src/share/vm/runtime/thread.cpp
++++ b/hotspot/src/share/vm/runtime/thread.cpp
+@@ -788,7 +788,9 @@ bool Thread::claim_oops_do_par_case(int strong_roots_parity) {
+ }
+ 
+ void Thread::oops_do(OopClosure* f, CodeBlobClosure* cf) {
+-  active_handles()->oops_do(f);
++  if (active_handles() != NULL) {
++    active_handles()->oops_do(f);
++  }
+   // Do oop for ThreadShadow
+   f->do_oop((oop*)&_pending_exception);
+   handle_area()->oops_do(f);

--- a/openjdk-9/JDK-8245051.patch
+++ b/openjdk-9/JDK-8245051.patch
@@ -1,0 +1,76 @@
+From 3df88dc22cf28c4022776bcccaa57bd65e84450c Mon Sep 17 00:00:00 2001
+From: Xin Liu <xliu@openjdk.org>
+Date: Wed, 20 May 2020 11:29:11 -0700
+Subject: [PATCH] 8245051: c1 is broken if it is compiled by gcc without
+ -fno-lifetime-dse
+Origin: https://github.com/openjdk/jdk11u/commit/3df88dc22cf28c4022776bcccaa57bd65e84450c
+Modified: File to patch has another location in JDK9
+
+Initialize BlockBegin block id in constructor rather than operator new
+
+Reviewed-by: kbarrett, thartmann
+---
+ src/hotspot/share/c1/c1_Instruction.hpp | 8 +++-----
+ src/hotspot/share/c1/c1_ValueMap.cpp    | 1 +
+ 2 files changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/src/hotspot/share/c1/c1_Instruction.hpp b/src/hotspot/share/c1/c1_Instruction.hpp
+index 8b8f397995..a94a21e423 100644
+--- a/hotspot/src/share/vm/c1/c1_Instruction.hpp
++++ b/hotspot/src/share/vm/c1/c1_Instruction.hpp
+@@ -303,7 +303,6 @@
+   XHandlers*   _exception_handlers;              // Flat list of exception handlers covering this instruction
+ 
+   friend class UseCountComputer;
+-  friend class BlockBegin;
+ 
+   void update_exception_state(ValueStack* state);
+ 
+@@ -349,7 +348,6 @@
+   void* operator new(size_t size) throw() {
+     Compilation* c = Compilation::current();
+     void* res = c->arena()->Amalloc(size);
+-    ((Instruction*)res)->_id = c->get_next_id();
+     return res;
+   }
+ 
+@@ -410,7 +408,8 @@
+ 
+   // creation
+   Instruction(ValueType* type, ValueStack* state_before = NULL, bool type_is_constant = false)
+-  : _use_count(0)
++  : _id(Compilation::current()->get_next_id())
++  , _use_count(0)
+ #ifndef PRODUCT
+   , _printable_bci(-99)
+ #endif
+@@ -1648,8 +1647,6 @@
+    void* operator new(size_t size) throw() {
+     Compilation* c = Compilation::current();
+     void* res = c->arena()->Amalloc(size);
+-    ((BlockBegin*)res)->_id = c->get_next_id();
+-    ((BlockBegin*)res)->_block_id = c->get_next_block_id();
+     return res;
+   }
+ 
+@@ -1661,6 +1658,7 @@
+   // creation
+   BlockBegin(int bci)
+   : StateSplit(illegalType)
++  , _block_id(Compilation::current()->get_next_block_id())
+   , _bci(bci)
+   , _depth_first_number(-1)
+   , _linear_scan_number(-1)
+diff --git a/src/hotspot/share/c1/c1_ValueMap.cpp b/src/hotspot/share/c1/c1_ValueMap.cpp
+index fd45abda2f..e7cafeb252 100644
+--- a/hotspot/src/share/vm/c1/c1_ValueMap.cpp
++++ b/hotspot/src/share/vm/c1/c1_ValueMap.cpp
+@@ -488,6 +488,7 @@
+   : _current_map(NULL)
+   , _value_maps(ir->linear_scan_order()->length(), ir->linear_scan_order()->length(), NULL)
+   , _compilation(ir->compilation())
++  , _has_substitutions(false)
+ {
+   TRACE_VALUE_NUMBERING(tty->print_cr("****** start of global value numbering"));
+ 
+

--- a/openjdk-9/gcc10-compilation-fix.patch
+++ b/openjdk-9/gcc10-compilation-fix.patch
@@ -1,0 +1,108 @@
+Subject: Fix build error with gcc >= 10.0
+Upstream: Yes
+Upstream-Url: https://bugs.openjdk.java.net/browse/JDK-8235903
+Author: Simon Frankenberger <simon-alpine@fraho.eu>
+
+This is a backport of the fixes to make it compile with gcc10 again.
+
+--- old/jdk/src/java.base/unix/native/libjava/childproc.c
++++ new/jdk/src/java.base/unix/native/libjava/childproc.c
+@@ -33,6 +33,7 @@
+ 
+ #include "childproc.h"
+ 
++const char * const *parentPathv;
+ 
+ ssize_t
+ restartableWrite(int fd, const void *buf, size_t count)
+--- old/jdk/src/java.base/unix/native/libjava/childproc.h
++++ new/jdk/src/java.base/unix/native/libjava/childproc.h
+@@ -118,7 +118,7 @@
+  * The cached and split version of the JDK's effective PATH.
+  * (We don't support putenv("PATH=...") in native code)
+  */
+-const char * const *parentPathv;
++extern const char * const *parentPathv;
+ 
+ ssize_t restartableWrite(int fd, const void *buf, size_t count);
+ int restartableDup2(int fd_from, int fd_to);
+--- old/jdk/src/java.security.jgss/unix/native/libj2gss/NativeFunc.c
++++ new/jdk/src/java.security.jgss/unix/native/libj2gss/NativeFunc.c
+@@ -28,6 +28,9 @@
+ #include <dlfcn.h>
+ #include "NativeFunc.h"
+ 
++/* global GSS function table */
++GSS_FUNCTION_TABLE_PTR ftab;
++
+ /* standard GSS method names (ordering is from mapfile) */
+ static const char RELEASE_NAME[]                = "gss_release_name";
+ static const char IMPORT_NAME[]                 = "gss_import_name";
+--- old/jdk/src/java.security.jgss/unix/native/libj2gss/NativeFunc.h
++++ new/jdk/src/java.security.jgss/unix/native/libj2gss/NativeFunc.h
+@@ -265,6 +265,6 @@
+ typedef GSS_FUNCTION_TABLE *GSS_FUNCTION_TABLE_PTR;
+ 
+ /* global GSS function table */
+-GSS_FUNCTION_TABLE_PTR ftab;
++extern GSS_FUNCTION_TABLE_PTR ftab;
+ 
+ #endif
+--- /dev/null
++++ new/jdk/src/jdk.sctp/unix/native/libsctp/Sctp.c
+@@ -0,0 +1,34 @@
++/*
++ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++#include "Sctp.h"
++
++sctp_getladdrs_func* nio_sctp_getladdrs;
++sctp_freeladdrs_func* nio_sctp_freeladdrs;
++sctp_getpaddrs_func* nio_sctp_getpaddrs;
++sctp_freepaddrs_func* nio_sctp_freepaddrs;
++sctp_bindx_func* nio_sctp_bindx;
++sctp_peeloff_func* nio_sctp_peeloff;
++
+--- old/jdk/src/jdk.sctp/unix/native/libsctp/Sctp.h
++++ new/jdk/src/jdk.sctp/unix/native/libsctp/Sctp.h
+@@ -322,12 +322,12 @@
+ 
+ #endif /* __linux__ */
+ 
+-sctp_getladdrs_func* nio_sctp_getladdrs;
+-sctp_freeladdrs_func* nio_sctp_freeladdrs;
+-sctp_getpaddrs_func* nio_sctp_getpaddrs;
+-sctp_freepaddrs_func* nio_sctp_freepaddrs;
+-sctp_bindx_func* nio_sctp_bindx;
+-sctp_peeloff_func* nio_sctp_peeloff;
++extern sctp_getladdrs_func* nio_sctp_getladdrs;
++extern sctp_freeladdrs_func* nio_sctp_freeladdrs;
++extern sctp_getpaddrs_func* nio_sctp_getpaddrs;
++extern sctp_freepaddrs_func* nio_sctp_freepaddrs;
++extern sctp_bindx_func* nio_sctp_bindx;
++extern sctp_peeloff_func* nio_sctp_peeloff;
+ 
+ jboolean loadSocketExtensionFuncs(JNIEnv* env);
+ 

--- a/openjdk-9/gcc11.patch
+++ b/openjdk-9/gcc11.patch
@@ -1,0 +1,22 @@
+--- a/hotspot/src/share/vm/opto/lcm.cpp
++++ b/hotspot/src/share/vm/opto/lcm.cpp
+@@ -39,7 +39,7 @@
+ // Check whether val is not-null-decoded compressed oop,
+ // i.e. will grab into the base of the heap if it represents NULL.
+ static bool accesses_heap_base_zone(Node *val) {
+-  if (Universe::narrow_oop_base() > 0) { // Implies UseCompressedOops.
++  if (Universe::narrow_oop_base() != 0) { // Implies UseCompressedOops.
+     if (val && val->is_Mach()) {
+       if (val->as_Mach()->ideal_Opcode() == Op_DecodeN) {
+         // This assumes all Decodes with TypePtr::NotNull are matched to nodes that
+--- a/hotspot/src/share/vm/memory/virtualspace.cpp
++++ b/hotspot/src/share/vm/memory/virtualspace.cpp
+@@ -581,7 +581,7 @@
+   assert(markOopDesc::encode_pointer_as_mark(&_base[size])->decode_pointer() == &_base[size],
+          "area must be distinguishable from marks for mark-sweep");
+ 
+-  if (base() > 0) {
++  if (base() != 0) {
+     MemTracker::record_virtual_memory_type((address)base(), mtJavaHeap);
+   }
+ }

--- a/openjdk-9/int-conversion.patch
+++ b/openjdk-9/int-conversion.patch
@@ -1,0 +1,20 @@
+--- a/hotspot/src/jdk.aot/unix/native/libjelfshim/jdk_tools_jaotc_jnilibelf_JNILibELFAPI.c
++++ b/hotspot/src/jdk.aot/unix/native/libjelfshim/jdk_tools_jaotc_jnilibelf_JNILibELFAPI.c
+@@ -262,7 +262,7 @@
+    jlong addr = getNativeAddress(env, ptrObj);
+    if (addr != -1) {
+        // Call libelf function
+-       if ((retPtr = gelf_newehdr((Elf*) addr, elfClass)) == 0) {
++       if ((retPtr = (unsigned long int)gelf_newehdr((Elf*) addr, elfClass)) == 0) {
+            errx(EX_SOFTWARE, "gelf_newehdr() failed: %s.", elf_errmsg(-1));
+        }
+    } else {
+@@ -277,7 +277,7 @@
+    jlong addr = getNativeAddress(env, ptrObj);
+    if (addr != -1) {
+        // Call libelf function
+-       if ((retPtr = gelf_newphdr((Elf*) addr, phnum)) == 0) {
++       if ((retPtr = (unsigned long int)gelf_newphdr((Elf*) addr, phnum)) == 0) {
+            errx(EX_SOFTWARE, "gelf_newphdr() failed: %s.", elf_errmsg(-1));
+        }
+    } else {

--- a/openjdk-9/make-4.3.patch
+++ b/openjdk-9/make-4.3.patch
@@ -1,0 +1,20 @@
+Subject: Fix build error with make >= 4.3
+Upstream: Yes
+Upstream-Url: https://bugs.openjdk.java.net/browse/JDK-8237879
+Author: Simon Frankenberger <simon-alpine@fraho.eu>
+
+diff --git a/make/common/MakeBase.gmk b/make/common/MakeBase.gmk
+index 170c3ed..697f9d2 100644
+--- a/make/common/MakeBase.gmk
++++ b/make/common/MakeBase.gmk
+@@ -904,7 +904,9 @@ DependOnVariableHelper = \
+               $(info NewVariable $1: >$(strip $($1))<) \
+               $(info OldVariable $1: >$(strip $($1_old))<)) \
+           $(call WriteFile, $1_old:=$(call DoubleDollar,$(call EscapeHash,$($1))), \
+-              $(call DependOnVariableFileName, $1, $2))) \
++              $(call DependOnVariableFileName, $1, $2)) \
++              $(eval $(call DependOnVariableFileName, $1, $2): ) \
++        ) \
+         $(call DependOnVariableFileName, $1, $2) \
+     )
+ 

--- a/packages.txt
+++ b/packages.txt
@@ -609,6 +609,7 @@ gtk-2.0
 java-cacerts
 openjdk-7
 openjdk-8
+openjdk-9
 aws-efs-csi-driver
 prometheus-bind-exporter
 clickhouse


### PR DESCRIPTION
new package for java 9 and java 10. although EOL, they will be used for building java 11

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`