### PR TITLE
Revert "bazel-6/6.2.0 package update"

### DIFF
--- a/bazel-6.yaml
+++ b/bazel-6.yaml
@@ -1,6 +1,6 @@
 package:
   name: bazel-6
-  version: 6.2.0
+  version: 6.1.2
   epoch: 0
   description: Bazel is an open-source build and test tool
   copyright:
@@ -20,7 +20,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: f1e8f788637ac574d471d619d2096baaca04a19b57a034399e079633db441945
+      expected-sha256: 6fb3ee22fe9fa86d82e173572d504c089f10825d749725592626e090b38c9679
       uri: https://github.com/bazelbuild/bazel/releases/download/${{package.version}}/bazel-${{package.version}}-dist.zip
       extract: false
 


### PR DESCRIPTION
It fails to build.  For whatever reason the CI did not properly detect the change and so it was a false positive.

This reverts commit 9d38b70b24b587dcb9e36a566464ec9d59e171b1.