### PR TITLE
add argocd compat subpackage and disable -pie buildmode

### DIFF
--- a/argo-cd.yaml
+++ b/argo-cd.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd
   version: 2.7.1
-  epoch: 1
+  epoch: 2
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -31,21 +31,62 @@ pipeline:
 
       # Our global LDFLAGS conflict with a Makefile parameter
       unset LDFLAGS
+      # Our global `-pie` flag results in a binary that cannot be copied to a non chainguard image
+      # Disable the `-pie` flag here since ArgoCD's helm charts like to copy around the multicall binary to different images (ie: dex)
+      unset GOFLAGS
       make argocd-all
 
       mkdir -p ${{targets.destdir}}/usr/bin
       mv dist/argocd* ${{targets.destdir}}/usr/bin/
 
+      # ArgoCD manifests and helm charts all hardcode the executables path to /usr/local/bin/*
+      mkdir -p ${{targets.destdir}}/usr/local/bin/
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-server
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-repo-server
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-cmp-server
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-application-controller
-      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-dex
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-notifications
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-applicationset-controller
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-k8s-auth
 
   - uses: strip
+
+subpackages:
+  - name: argo-cd-repo-server
+    description: "ArgoCD repo server"
+    dependencies:
+      runtime:
+        - argo-cd-compat
+        - git
+        - git-lfs
+        - gnupg
+        - gpg
+        - gpg-agent
+        - tzdata
+        - helm
+        - kustomize
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          cp hack/gpg-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/gpg-wrapper.sh
+          cp hack/git-verify-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/git-verify-wrapper.sh
+
+  - name: argo-cd-compat
+    description: "Compatibility package for locating binaries according to upstream helm charts"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
+          # This must be copied and not symlinked due to how `argocd` copies executables between (init)containers
+          # example: https://github.com/argoproj/argo-helm/blob/argo-cd-5.33.1/charts/argo-cd/templates/dex/deployment.yaml#L136-L143
+          cp ${{targets.destdir}}/usr/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd
+
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-server
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-repo-server
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-cmp-server
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-application-controller
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-notifications
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-applicationset-controller
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-k8s-auth
 
 update:
   enabled: true


### PR DESCRIPTION
image reference this was tested against: https://github.com/chainguard-images/images/pull/568