### PR TITLE
Fix vertical-pod-autoscaler package.

### DIFF
--- a/vertical-pod-autoscaler.yaml
+++ b/vertical-pod-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: vertical-pod-autoscaler
   version: 0.13.0
-  epoch: 0
+  epoch: 1
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -26,23 +26,37 @@ pipeline:
       modroot: vertical-pod-autoscaler
       packages: ./pkg/admission-controller
       output: admission-controller
+      deps: golang.org/x/net@v0.7.0
+      vendor: "true"
+
+  - uses: go/build
+    with:
+      modroot: vertical-pod-autoscaler
+      packages: ./pkg/updater
+      output: updater
+      deps: golang.org/x/net@v0.7.0
+      vendor: "true"
+
+  - uses: go/build
+    with:
+      modroot: vertical-pod-autoscaler
+      packages: ./pkg/recommender
+      output: recommender
+      deps: golang.org/x/net@v0.7.0
+      vendor: "true"
 
 subpackages:
   - name: vertical-pod-autoscaler-updater
     pipeline:
-      - uses: go/build
-        with:
-          modroot: vertical-pod-autoscaler
-          packages: ./pkg/updater
-          output: updater
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/updater ${{targets.subpkgdir}}/usr/bin
 
   - name: vertical-pod-autoscaler-recommender
     pipeline:
-      - uses: go/build
-        with:
-          modroot: vertical-pod-autoscaler
-          packages: ./pkg/recommender
-          output: recommender
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/recommender ${{targets.subpkgdir}}/usr/bin
 
 update:
   enabled: true


### PR DESCRIPTION
The go/build pipeline has a hardcoded "targets.destdir" that isn't replaced in a sub-pipeline. To build multiple go binaries, these should live in the main pipeline then copy steps should be used to move the binaries.

Fixes:

Related:

### Pre-review Checklist
