### PR TITLE
consul helm chart compat subpackage

### DIFF
--- a/consul.yaml
+++ b/consul.yaml
@@ -36,11 +36,9 @@ pipeline:
 
           go mod tidy
           make linux
-
       - runs: |
           mkdir -p ${{targets.destdir}}/usr/bin
           mv ./pkg/bin/linux_*/consul ${{targets.destdir}}/usr/bin/consul
-
       - uses: strip
 
 subpackages:

--- a/consul.yaml
+++ b/consul.yaml
@@ -38,6 +38,8 @@ pipeline:
           make linux
       - runs: |
           mkdir -p ${{targets.destdir}}/bin
+
+          # The docker-entrypoint.sh expects the binary to be in /bin so put it there
           mv ./pkg/bin/linux_*/consul ${{targets.destdir}}/bin/consul
       - uses: strip
 

--- a/consul.yaml
+++ b/consul.yaml
@@ -37,8 +37,8 @@ pipeline:
           go mod tidy
           make linux
       - runs: |
-          mkdir -p ${{targets.destdir}}/usr/bin
-          mv ./pkg/bin/linux_*/consul ${{targets.destdir}}/usr/bin/consul
+          mkdir -p ${{targets.destdir}}/bin
+          mv ./pkg/bin/linux_*/consul ${{targets.destdir}}/bin/consul
       - uses: strip
 
 subpackages:
@@ -46,30 +46,23 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          cp consul/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/"
+          mv consul/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/"
     dependencies:
       runtime:
+        - consul
         - busybox
         - dumb-init
         - su-exec
-
-  - name: ${{package.name}}-compat
-    description: "Compatiblity package for locating binaries according to upstream helm charts"
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
-          cp "${{targets.destdir}}/usr/bin/consul" "${{targets.subpkgdir}}/usr/local/bin"
+        - libcap-utils
 
   - name: ${{package.name}}-oci-entrypoint-compat
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
-          cp consul/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/local/bin/"
+          ln -s /usr/bin/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/local/bin/"
     dependencies:
       runtime:
-        - busybox
-        - dumb-init
-        - su-exec
+        - consul-oci-entrypoint
 
 update:
   enabled: true

--- a/consul.yaml
+++ b/consul.yaml
@@ -2,7 +2,7 @@ package:
   name: consul
   version: 1.15.2
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
-  epoch: 2
+  epoch: 3
   description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
   copyright:
     - license: MPL-2.0
@@ -20,32 +20,53 @@ pipeline:
       repository: https://github.com/hashicorp/consul
       tag: v${{package.version}}
       expected-commit: 5e08e229dbdaed5adf3ca99afe9df247c51507da
-      destination: consul
+      destination: ${{package.name}}
 
-  - runs: |
-      cd consul
-      # Mitigate GHSA-vvpx-j8f3-3w6h
-      go get golang.org/x/net@v0.7.0
-      # Mitigate GHSA-8cfg-vx93-jvxw
-      go get k8s.io/client-go@v0.20.1
+  - working-directory: ${{package.name}}
+    pipeline:
+      - runs: |
+          # Mitigate GHSA-vvpx-j8f3-3w6h
+          go get golang.org/x/net@v0.7.0
 
-      # Mitigate GHSA-ch7v-37xg-75ph
-      go get github.com/coredns/coredns@v1.10.1
-      go mod tidy
-      make linux
+          # Mitigate GHSA-8cfg-vx93-jvxw
+          go get k8s.io/client-go@v0.20.1
 
-  - runs: |
-      mkdir -p ${{targets.destdir}}/usr/bin
-      mv consul/pkg/bin/linux_*/consul ${{targets.destdir}}/usr/bin/consul
+          # Mitigate GHSA-ch7v-37xg-75ph
+          go get github.com/coredns/coredns@v1.10.1
 
-  - uses: strip
+          go mod tidy
+          make linux
+
+      - runs: |
+          mkdir -p ${{targets.destdir}}/usr/bin
+          mv ./pkg/bin/linux_*/consul ${{targets.destdir}}/usr/bin/consul
+
+      - uses: strip
 
 subpackages:
-  - name: consul-oci-entrypoint
+  - name: ${{package.name}}-oci-entrypoint
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv consul/.release/docker/docker-entrypoint.sh ${{targets.subpkgdir}}/usr/bin/
+          cp consul/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/"
+    dependencies:
+      runtime:
+        - busybox
+        - dumb-init
+        - su-exec
+
+  - name: ${{package.name}}-compat
+    description: "Compatiblity package for locating binaries according to upstream helm charts"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
+          cp "${{targets.destdir}}/usr/bin/consul" "${{targets.subpkgdir}}/usr/local/bin"
+
+  - name: ${{package.name}}-oci-entrypoint-compat
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
+          cp consul/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/local/bin/"
     dependencies:
       runtime:
         - busybox


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Some [upstream helm charts ](https://github.com/hashicorp/consul-k8s/blob/bd16ab83383dbec5f8db680f39d85edd66b25b62/charts/consul/templates/client-daemonset.yaml#L283)require the binary to sit in `/usr/local/bin`. This PR adds a compat subpackage to install consul and the entrypoint in `/usr/local/bin`

Built locally and tested with

```sh
docker run -it --rm --entrypoint '/bin/sh' consul:local-amd64 -ec 'exec /usr/local/bin/docker-entrypoint.sh'
```



