### PR TITLE
openjdk-9: fix build on aarch64

### DIFF
--- a/openjdk-9.yaml
+++ b/openjdk-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-9
   version: 9.0.4
-  epoch: 0
+  epoch: 1
   description: "Oracle OpenJDK 9"
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -55,7 +55,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: JDK-8187578.patch JDK-8241296.patch JDK-8245051.patch gcc10-compilation-fix.patch gcc11.patch int-conversion.patch make-4.3.patch
+      patches: JDK-8187578.patch JDK-8241296.patch JDK-8224851.patch JDK-8245051.patch gcc10-compilation-fix.patch gcc11.patch int-conversion.patch make-4.3.patch
 
   - runs: |
       CFLAGS='' CXXFLAGS='' LDFLAGS='' \

--- a/openjdk-9/JDK-8224851.patch
+++ b/openjdk-9/JDK-8224851.patch
@@ -1,0 +1,30 @@
+Subject: Remove fpu_control.h include and partly apply patch for JDK-8224851
+Upstream: No
+Author: Simon Frankenberger <simon-alpine@fraho.eu>
+
+The header is not present with musl and including it results in build error.
+It's not needed anyways.
+
+The second patch fixes "error: redeclaration of 'using MacroAssembler::call_VM_leaf_base'"
+
+--- old/hotspot/src/os_cpu/linux_aarch64/vm/os_linux_aarch64.cpp
++++ new/hotspot/src/os_cpu/linux_aarch64/vm/os_linux_aarch64.cpp
+@@ -77,7 +77,6 @@
+ # include <pwd.h>
+ # include <poll.h>
+ # include <ucontext.h>
+-# include <fpu_control.h>
+ 
+ #ifdef BUILTIN_SIM
+ #define REG_SP REG_RSP
+--- old/hotspot/src/cpu/aarch64/vm/interp_masm_aarch64.hpp
++++ new/hotspot/src/cpu/aarch64/vm/interp_masm_aarch64.hpp
+@@ -39,8 +39,6 @@
+  protected:
+ 
+  protected:
+-  using MacroAssembler::call_VM_leaf_base;
+-
+   // Interpreter specific version of call_VM_base
+   using MacroAssembler::call_VM_leaf_base;
+ 


### PR DESCRIPTION
Part of the JDK-8224851 fixes needed to be backported to allow building on aarch64.