### PR TITLE
don't cache security.json

### DIFF
--- a/.github/workflows/secdb-production.yaml
+++ b/.github/workflows/secdb-production.yaml
@@ -50,4 +50,8 @@ jobs:
 
       - name: 'Upload the security database to a bucket'
         run: |
-          gcloud --quiet alpha storage cp --recursive ${{ github.workspace }}/security.json gs://wolfi-production-registry-destination/os/
+          # Don't cache the security.json.
+          gcloud --quiet alpha storage cp \
+              --cache-control=no-store \
+              ${{ github.workspace }}/security.json \
+              gs://wolfi-production-registry-destination/os/


### PR DESCRIPTION
The security.json feed doesn't need to be cached -- it's not requested often, it's small, and caching can obscure important updates.