### PR TITLE
add redis-6.2

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -232,6 +232,7 @@ mold
 dumb-init
 envoy
 redis
+redis-6.2
 mailcap
 php
 composer

--- a/redis-6.2.yaml
+++ b/redis-6.2.yaml
@@ -1,0 +1,47 @@
+package:
+  name: redis-6.2
+  version: 6.2.12
+  epoch: 0
+  description: Advanced key-value store
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    provides:
+      - redis=6.2.12
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - linux-headers
+      - openssl-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://download.redis.io/releases/redis-${{package.version}}.tar.gz
+      expected-sha512: cb955efacfd3ca9c526403f041d3500bfbd757137af46a1b76f2773ff835d9892f6a970cd9893f89f803aa2491f342b603c6208a08aad8f72f37feef4a03e8d1
+
+  - uses: patch
+    with:
+      patches: 0000-Disable-protected-mode.patch
+
+  - runs: |
+      export CFLAGS="$CFLAGS -DUSE_MALLOC_USABLE_SIZE"
+        make USE_JEMALLOC=no \
+        MALLOC=libc \
+        BUILD_TLS=yes \
+        all
+      make install PREFIX=/usr INSTALL_BIN="${{targets.destdir}}/usr/bin"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: redis/redis
+    tag-filter: "6.2"

--- a/redis-6.2/0000-Disable-protected-mode.patch
+++ b/redis-6.2/0000-Disable-protected-mode.patch
@@ -1,0 +1,29 @@
+From b91e39701c7a71f229be34dcf078579d37367436 Mon Sep 17 00:00:00 2001
+From: Dan Lorenc <dlorenc@chainguard.dev>
+Date: Sat, 24 Dec 2022 12:15:14 -0500
+Subject: [PATCH] Disable protected mode.
+
+See https://github.com/docker-library/redis/blob/19f345b2056588c009396bcfc22ba9241a669491/Dockerfile-alpine.template#L43
+for more context - we disable protected mode because it's not needed
+in a docker image and we can't do this via a config option.
+
+---
+ src/config.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/config.c b/src/config.c
+index 78553b758..8547d76c2 100644
+--- a/src/config.c
++++ b/src/config.c
+@@ -3013,7 +3013,7 @@ standardConfig static_configs[] = {
+     createBoolConfig("daemonize", NULL, IMMUTABLE_CONFIG, server.daemonize, 0, NULL, NULL),
+     createBoolConfig("io-threads-do-reads", NULL, DEBUG_CONFIG | IMMUTABLE_CONFIG, server.io_threads_do_reads, 0,NULL, NULL), /* Read + parse from threads? */
+     createBoolConfig("always-show-logo", NULL, IMMUTABLE_CONFIG, server.always_show_logo, 0, NULL, NULL),
+-    createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, server.protected_mode, 1, NULL, NULL),
++    createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, server.protected_mode, 0, NULL, NULL),
+     createBoolConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, server.rdb_compression, 1, NULL, NULL),
+     createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, server.rdb_del_sync_files, 0, NULL, NULL),
+     createBoolConfig("activerehashing", NULL, MODIFIABLE_CONFIG, server.activerehashing, 1, NULL, NULL),
+-- 
+2.37.1 (Apple Git-137.1)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

redis-6.2: new package

this is verbatim from the redis-7 package, supported until 2024 ([ref](https://github.com/redis/redis/security))

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`