### PR TITLE
add tclx and tcl-tls packages

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -312,6 +312,8 @@ harfbuzz
 fribidi
 gc
 tcl
+tclx
+tcl-tls
 libxmu
 libxaw
 pango

--- a/tcl-tls.yaml
+++ b/tcl-tls.yaml
@@ -1,0 +1,51 @@
+package:
+  name: tcl-tls
+  version: 1.7.22
+  epoch: 0
+  description: OpenSSL extension to Tcl
+  copyright:
+    - license: TCL
+  dependencies:
+    runtime:
+      - tcl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - openssl-dev
+      - tcl-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://core.tcl.tk/tcltls/uv/tcltls-${{package.version}}.tar.gz
+      expected-sha512: 28c76a6e7333b6ed1d83234691d61c9e71a59d0a6a28182fc0f50e97cae7b54da63ac76527e3b16087f3eab0b9cfe19bad02362e485d0cf378724de534805e99
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --host=${{host.triplet.gnu}} \
+        --build=${{host.triplet.gnu}} \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --localstatedir=/var \
+        --enable-shared \
+        --with-ssl-dir=/usr
+
+  - uses: autoconf/make
+
+  - runs: |
+      make DESTDIR="${{targets.destdir}}" install
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 7568

--- a/tclx.yaml
+++ b/tclx.yaml
@@ -1,0 +1,52 @@
+package:
+  name: tclx
+  version: 8.6.1
+  epoch: 0
+  description: TclX extension to Tcl
+  copyright:
+    - license: BSD
+  dependencies:
+    runtime:
+      - tcl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - bash
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - tcl-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/flightaware/tclx/archive/v${{package.version}}.tar.gz
+      expected-sha512: 4a2293aad667b108f19f837686044fc168831781d04a9f8eaa2afe677c587f1e128a536ad9db609720e0046a20ff6f8dd7a0e5dd1232ef775c5a14e24ec0614d
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --host=${{host.triplet.gnu}} \
+        --build=${{host.triplet.gnu}} \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --localstatedir=/var \
+        --enable-threads \
+        --enable-64bit
+
+  - uses: autoconf/make
+
+  - runs: |
+      make DESTDIR="${{targets.destdir}}" install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: flightaware/tclx
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Dependencies for redis tls testing

tclx: new package
tcl-tls: new package

Related: https://github.com/chainguard-dev/image-requests/issues/189


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`
