### PR TITLE
kubernetes-csi-external-provisioner: new package

### DIFF
--- a/kubernetes-csi-external-provisioner.yaml
+++ b/kubernetes-csi-external-provisioner.yaml
@@ -1,0 +1,37 @@
+package:
+  epoch: 0
+  name: kubernetes-csi-external-provisioner
+  version: 3.5.0
+  description: A dynamic provisioner for Kubernetes CSI plugins.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-csi/external-provisioner
+      expected-commit: ab68435fa2386edf8577a02b5bf2dc4baeadbf57
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      packages: ./cmd/csi-provisioner
+      output: csi-provisioner
+      ldflags: -X main.version=${{package.version}}
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-csi/external-provisioner
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -645,6 +645,7 @@ nri-prometheus
 kube-bench
 hugo
 secrets-store-csi-driver-provider-aws
+kubernetes-csi-external-provisioner
 paranoia
 trust-manager
 stakater-reloader


### PR DESCRIPTION
#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

