### PR TITLE
Feature: set `SOURCE_DATE_EPOCH` based on the config file.

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -59,16 +59,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: 'Trust the github workspace'
+        run: |
+          # This is to avoid fatal errors about "dubious ownership" because we are
+          # running inside of a container action with the workspace mounted in.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: 'Generate local signing key'
         run: |
           make MELANGE="melange" local-melange.rsa
 
       - name: 'Build Wolfi'
         run: |
-          # This is to avoid fatal errors about "dubious ownership" because we are
-          # running inside of a container action with the workspace mounted in.
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
           for package in ${{needs.changes.outputs.packages}}; do
             make MELANGE="melange" MELANGE_EXTRA_OPTS="--create-build-log" REPO="$GITHUB_WORKSPACE/packages" BUILDWORLD=no packages/$package -j1
           done

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -65,6 +65,10 @@ jobs:
 
       - name: 'Build Wolfi'
         run: |
+          # This is to avoid fatal errors about "dubious ownership" because we are
+          # running inside of a container action with the workspace mounted in.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
           for package in ${{needs.changes.outputs.packages}}; do
             make MELANGE="melange" MELANGE_EXTRA_OPTS="--create-build-log" REPO="$GITHUB_WORKSPACE/packages" BUILDWORLD=no packages/$package -j1
           done

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ $(pkgtarget): ${KEY}
 	mkdir -p ./$(sourcedir)/
 ifdef SOURCE_DATE_EPOCH
 	$(eval CONFIG_DATE_EPOCH := $(SOURCE_DATE_EPOCH))
-oelse
+else
 	$(eval CONFIG_DATE_EPOCH := $(shell git log -1 --pretty=%ct --follow $(pkgname).yaml))
 endif
 	SOURCE_DATE_EPOCH=${CONFIG_DATE_EPOCH} ${MELANGE} build $(pkgname).yaml ${MELANGE_OPTS} --source-dir ./$(sourcedir)/ --log-policy builtin:stderr,${TARGETDIR}/buildlogs/$(pkgfullname).log

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,12 @@ $(eval pkgtarget = $(TARGETDIR)/$(pkgfullname).apk)
 packages/$(pkgname): $(pkgtarget)
 $(pkgtarget): ${KEY}
 	mkdir -p ./$(sourcedir)/
-	$(eval SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct --follow $(pkgname).yaml))
-	SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} ${MELANGE} build $(pkgname).yaml ${MELANGE_OPTS} --source-dir ./$(sourcedir)/ --log-policy builtin:stderr,${TARGETDIR}/buildlogs/$(pkgfullname).log
+ifdef SOURCE_DATE_EPOCH
+	$(eval CONFIG_DATE_EPOCH := $(SOURCE_DATE_EPOCH))
+oelse
+	$(eval CONFIG_DATE_EPOCH := $(shell git log -1 --pretty=%ct --follow $(pkgname).yaml))
+endif
+	SOURCE_DATE_EPOCH=${CONFIG_DATE_EPOCH} ${MELANGE} build $(pkgname).yaml ${MELANGE_OPTS} --source-dir ./$(sourcedir)/ --log-policy builtin:stderr,${TARGETDIR}/buildlogs/$(pkgfullname).log
 
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ $(eval pkgtarget = $(TARGETDIR)/$(pkgfullname).apk)
 packages/$(pkgname): $(pkgtarget)
 $(pkgtarget): ${KEY}
 	mkdir -p ./$(sourcedir)/
-	$(eval SOURCE_DATE_EPOCH := $(shell git log -1 --pretty=%ct --follow $(pkgname).yaml))
+	$(eval SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct --follow $(pkgname).yaml))
 	SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} ${MELANGE} build $(pkgname).yaml ${MELANGE_OPTS} --source-dir ./$(sourcedir)/ --log-policy builtin:stderr,${TARGETDIR}/buildlogs/$(pkgfullname).log
 
 endef

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ TARGETDIR = packages/${ARCH}
 MELANGE ?= ../melange/melange
 KEY ?= local-melange.rsa
 REPO ?= $(shell pwd)/packages
-SOURCE_DATE_EPOCH ?= 0
 CACHE_DIR ?= gs://wolfi-sources/
 
 WOLFI_SIGNING_PUBKEY ?= https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
@@ -41,6 +40,7 @@ $(eval pkgtarget = $(TARGETDIR)/$(pkgfullname).apk)
 packages/$(pkgname): $(pkgtarget)
 $(pkgtarget): ${KEY}
 	mkdir -p ./$(sourcedir)/
+	$(eval SOURCE_DATE_EPOCH := $(shell git log -1 --pretty=%ct --follow $(pkgname).yaml))
 	SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} ${MELANGE} build $(pkgname).yaml ${MELANGE_OPTS} --source-dir ./$(sourcedir)/ --log-policy builtin:stderr,${TARGETDIR}/buildlogs/$(pkgfullname).log
 
 endef

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.13.0 # When bumping the version check if the GHSA mitigations below can be removed.
-  epoch: 4
+  epoch: 5
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
:gift: This sets the `SOURCE_DATE_EPOCH` for a particular APK to be [the standard `git` command](https://reproducible-builds.org/docs/source-date-epoch/) with the qualification: `--follow {pkg}.yaml`.

The logic here is simple yet subtle: Our SDE should reflect the last change that influenced the APK, and the melange config fixes the version used to build, so it is in essence the last node in a sort of virtual merkle DAG.

If the above weren't true, then it would somewhat fundamentally indicate that our builds are not reproducible and that is something we should then fix.

Fixes: https://github.com/chainguard-images/images/issues/535

/kind feature

This also "touches" the `ko` package in an effort to observe this behavior in action when this change lands. 🤞 
