### PR TITLE
add kubernetes livenessprobe and node-driver-registrar

### DIFF
--- a/kubernetes-csi-livenessprobe.yaml
+++ b/kubernetes-csi-livenessprobe.yaml
@@ -1,0 +1,36 @@
+package:
+  name: kubernetes-csi-livenessprobe
+  version: 2.10.0
+  epoch: 0
+  description: A sidecar container that can be included in a CSI plugin pod to enable integration with Kubernetes Liveness Probe.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-csi/livenessprobe
+      tag: v${{package.version}}
+      expected-commit: 6700c0d90283fa4ef11fd6f80b1e73c55f34c6f7
+
+  - uses: go/build
+    with:
+      packages: ./cmd/livenessprobe
+      ldflags: "-X main.version=v${{package.version}} -extldflags '-static'"
+      vendor: "true"
+      output: livenessprobe
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-csi/livenessprobe
+    strip-prefix: v

--- a/kubernetes-csi-node-driver-registrar.yaml
+++ b/kubernetes-csi-node-driver-registrar.yaml
@@ -1,0 +1,36 @@
+package:
+  name: kubernetes-csi-node-driver-registrar
+  version: 2.8.0
+  epoch: 0
+  description: Sidecar container that registers a CSI driver with the kubelet using the kubelet plugin registration mechanism.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-csi/node-driver-registrar
+      tag: v${{package.version}}
+      expected-commit: e3aefd1766a2e006a39a7433000b8244542b2a5d
+
+  - uses: go/build
+    with:
+      packages: ./cmd/csi-node-driver-registrar
+      ldflags: "-X main.version=v${{package.version}} -extldflags '-static'"
+      vendor: "true"
+      output: csi-node-driver-registrar
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-csi/node-driver-registrar
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -650,3 +650,5 @@ trust-manager
 stakater-reloader
 vt-cli
 sysfsutils
+kubernetes-csi-livenessprobe
+kubernetes-csi-node-driver-registrar


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

livenessprobe: new package
node-driver-registrar: new package

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`
