### PR TITLE
openjdk-11: upgrade to 11.0.20.2, align with other JDK packaging

### DIFF
--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
-  version: 11.0.19.5
-  epoch: 2
+  version: 11.0.20.2
+  epoch: 0
   description:
   copyright:
     - license: GPL-2.0-only
@@ -36,10 +36,8 @@ environment:
       - libjpeg-dev
       - giflib-dev
       - lcms2-dev
-      # TODO: This should depend on an openjdk-11-stage0.yaml, which is built using
-      # pre-built openjdk-10 binaries and `provides` openjdk-11 at an earlier version.
-      # Afterwards it can depend on previous versions of this package built from source.
-      - openjdk-11
+      - openjdk-10-default-jvm
+      - openjdk-10
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
 var-transforms:
@@ -52,14 +50,15 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/openjdk/jdk11u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
-      expected-sha256: 83cdfc35fe9de04534e147c83bf983dc5dba8e15e009891df466a743ce119075
+      expected-sha256: 608a9c1719fe6634c717cc6f94041433b859406280b4324e74ce629ff282532f
 
   - runs: chmod +x configure
 
   - uses: autoconf/configure
     with:
       opts: |
-        --with-boot-jdk=/usr/lib/jvm/openjdk \
+        --with-boot-jdk=/usr/lib/jvm/java-10-openjdk \
+        --prefix=/usr/lib/jvm/java-11-openjdk \
         --with-vendor-name=wolfi \
         --with-vendor-url=https://wolfi.dev \
         --with-vendor-bug-url=https://github.com/wolfi-dev/os/issues \
@@ -79,54 +78,130 @@ pipeline:
         --with-giflib=system \
         --with-lcms=system
 
-  - runs: make images
+  - runs: make jdk-image
+
+  # Check we built something valid
+  - runs: |
+      _java_bin="./build/*-normal-server-release/images/jdk/bin"
+
+      $_java_bin/javac -d . HelloWorld.java
+      $_java_bin/java HelloWorld
+
+      # run the gtest unittest suites
+      make test-hotspot-gtest
 
   - runs: |
-      mkdir -p ${{targets.destdir}}/usr/lib/jvm/openjdk
-      cp -r ./build/linux-*-server-release/images/jdk/* ${{targets.destdir}}/usr/lib/jvm/openjdk
+      _java_home="usr/lib/jvm/java-11-openjdk"
 
-      mkdir -p ${{targets.destdir}}/usr/bin
-      ln -sf /usr/lib/jvm/openjdk/bin/java ${{targets.destdir}}/usr/bin/java
-      ln -sf /usr/lib/jvm/openjdk/bin/javac ${{targets.destdir}}/usr/bin/javac
+      mkdir -p "${{targets.destdir}}"/$_java_home
+      cp -r build/*-normal-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
+      rm "${{targets.destdir}}"/$_java_home/lib/src.zip
+
+  - uses: strip
 
 subpackages:
-  - name: openjdk-11-jre
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm/openjdk
-          for dir in conf \
-                   include \
-                   jmods \
-                   legal \
-                   lib \
-                   release; do
-                      cp -r ./build/linux-*-server-release/images/jdk/${dir} ${{targets.subpkgdir}}/usr/lib/jvm/openjdk/${dir}
-          done
-          mkdir -p ${{targets.subpkgdir}}/usr/lib/jvm/openjdk/bin
-          for c in java \
-                  jjs \
-                  keytool \
-                  pack200 \
-                  rmid \
-                  rmiregistry \
-                  unpack200; do
-                      cp ./build/linux-*-server-release/images/jdk/bin/${c} ${{targets.subpkgdir}}/usr/lib/jvm/openjdk/bin/${c}
-          done
-
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -sf /usr/lib/jvm/openjdk/bin/java ${{targets.subpkgdir}}/usr/bin/java
-    description: OpenJDK 11 (JRE)
+  - name: "openjdk-11-jre"
+    description: "OpenJDK 11 Java Runtime Environment"
     dependencies:
       runtime:
         - freetype
         - fontconfig
-
-  - name: openjdk-11-jre-doc
+        - openjdk-11-jre-base
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/share
-          mv  ${{targets.destdir}}/usr/lib/jvm/openjdk/man ${{targets.subpkgdir}}/usr/share
-    description: OpenJDK 11 manpages
+          _java_home="usr/lib/jvm/java-11-openjdk"
+
+          mkdir -p "${{targets.subpkgdir}}"/$_java_home/lib
+          mv "${{targets.destdir}}"/$_java_home/lib/libawt_xawt.so \
+              "${{targets.destdir}}"/$_java_home/lib/libfontmanager.so \
+              "${{targets.destdir}}"/$_java_home/lib/libjavajpeg.so \
+              "${{targets.destdir}}"/$_java_home/lib/libjawt.so \
+              "${{targets.destdir}}"/$_java_home/lib/libjsound.so \
+              "${{targets.destdir}}"/$_java_home/lib/liblcms.so \
+              "${{targets.destdir}}"/$_java_home/lib/libsplashscreen.so \
+              "${{targets.subpkgdir}}"/$_java_home/lib
+
+  - name: "openjdk-11-jre-base"
+    description: "OpenJDK 11 Java Runtime Environment (headless)"
+    dependencies:
+      runtime:
+        - java-common
+        - java-cacerts
+    pipeline:
+      - runs: |
+          _java_home="usr/lib/jvm/java-11-openjdk"
+
+          mkdir -p "${{targets.subpkgdir}}"/$_java_home
+          mv "${{targets.destdir}}"/$_java_home/lib \
+             "${{targets.subpkgdir}}"/$_java_home
+
+          mkdir -p "${{targets.subpkgdir}}"/$_java_home/bin
+          for i in java \
+                    jfr \
+                    jjs \
+                    jrunscript \
+                    keytool \
+                    pack200 \
+                    rmid \
+                    rmiregistry \
+                    unpack200; do
+            mv "${{targets.destdir}}"/$_java_home/bin/$i "${{targets.subpkgdir}}"/$_java_home/bin/$i
+          done
+
+          [ "${{build.arch}}" = "x86_64" ] && \
+            mv "${{targets.destdir}}"/$_java_home/bin/jaotc "${{targets.subpkgdir}}"/$_java_home/bin/jaotc
+
+          mv "${{targets.destdir}}"/$_java_home/legal "${{targets.subpkgdir}}"/$_java_home
+          mv "${{targets.destdir}}"/$_java_home/conf "${{targets.subpkgdir}}"/$_java_home
+          mv "${{targets.destdir}}"/$_java_home/release "${{targets.subpkgdir}}"/$_java_home
+          cp ASSEMBLY_EXCEPTION \
+              LICENSE \
+              README.md \
+             "${{targets.subpkgdir}}"/$_java_home
+
+          # symlink to shared java cacerts store
+          rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
+          ln -sf /etc/ssl/certs/java/cacerts \
+            "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
+
+          # symlink for `java-common` to work (which expects jre in $_java_home/jre)
+          ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+
+  - name: "openjdk-11-jmods"
+    description: "OpenJDK 11 jmods"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-11-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-11-openjdk/jmods \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-11-openjdk
+
+  - name: "openjdk-11-doc"
+    description: "OpenJDK 11 Documentation"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-11-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-11-openjdk/man \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-11-openjdk
+
+  - name: "openjdk-11-demos"
+    description: "OpenJDK 11 Demos"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-11-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-11-openjdk/demo \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-11-openjdk
+
+  - name: "openjdk-11-default-jvm"
+    description: "Use the openjdk-11 JVM as the default JVM"
+    dependencies:
+      runtime:
+        - openjdk-11-jre
+      provides:
+        - default-jvm=1.11
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-11-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
 
 update:
   enabled: true

--- a/openjdk-11/HelloWorld.java
+++ b/openjdk-11/HelloWorld.java
@@ -1,0 +1,3 @@
+public class HelloWorld {
+  public static void main(String[] args) { System.out.println("Hello World!"); }
+}


### PR DESCRIPTION
- Upgrade to 11.0.20.2
- Use OpenJDK 10 as bootstrap JDK
- Align with the new `default-jvm` contract.