### PR TITLE
bump openjdk-10 epoch to regenerate the APKINDEX as it is missing, th…

### DIFF
--- a/openjdk-10.yaml
+++ b/openjdk-10.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-10
   version: 10.0.2
-  epoch: 0
+  epoch: 1
   description: "Oracle OpenJDK 10"
   copyright:
     - license: GPL-2.0-with-classpath-exception


### PR DESCRIPTION
…e arm build failed on push to main

the build failure:
```
Copying file://./packages/aarch64/APKINDEX.tar.gz to gs://wolfi-production-registry-destination/os/aarch64/APKINDEX.tar.gz

ERROR: HTTPError 400: Cannot insert legacy ACL for an object when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access
```

https://github.com/chainguard-images/images/actions/runs/4986356643/jobs/8933939069

