### PR TITLE
fix git-p4

### DIFF
--- a/git.yaml
+++ b/git.yaml
@@ -1,7 +1,7 @@
 package:
   name: git
   version: 2.40.1
-  epoch: 0
+  epoch: 1
   description: "distributed version control system"
   copyright:
     - license: GPL-2.0-or-later
@@ -35,7 +35,6 @@ pipeline:
       INSTALL_SYMLINKS=1
       USE_LIBPCRE2=YesPlease
       NO_PERL=YesPlease
-      NO_PYTHON=YesPlease
       NO_TCLTK=YesPlease
       EOF
 


### PR DESCRIPTION
without this fix...

```
$ cat /usr/libexec/git-core/git-p4

echo >&2 "fatal: git was built without support for $(basename $0) (NO_PYTHON=YesPlease)."
exit 128
```

