### PR TITLE
pin wolfictl digest to previous version to see if that helps publishi…

### DIFF
--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -134,7 +134,7 @@ jobs:
             --cpu=30 --ram=100Gi \
             --bucket=${BUCKET} \
             --src-bucket=${SRC_BUCKET} \
-            --sdk-image ghcr.io/wolfi-dev/sdk:latest@sha256:48d1c07f3f2a7d681303e05a18c8c3e747afd2ae27414807240727b989fa2d1b \
+            --sdk-image ghcr.io/wolfi-dev/sdk:latest@sha256:5101604b8fc621767bd5b9024dd39d4bde1fb737cd216b8971950201977cd2d8 \
             --secret-key \
             --arch=arm64
 


### PR DESCRIPTION
…ng public APKINDEX

this is the error we're seeing...
```
Copying file://./packages/aarch64/APKINDEX.tar.gz to gs://wolfi-production-registry-destination/os/aarch64/APKINDEX.tar.gz

ERROR: HTTPError 400: Cannot insert legacy ACL for an object when uniform bucket-level access is enabled.
```
