### PR TITLE
disable openjdk 11 test-hotspot-gtest

### DIFF
--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
   version: 11.0.20.2
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only
@@ -88,7 +88,10 @@ pipeline:
       $_java_bin/java HelloWorld
 
       # run the gtest unittest suites
-      make test-hotspot-gtest
+      # disable for now, as we are seeing builds hang
+      # TestSingleWriterSynchronizer.stress_test_vm
+      # aarch64   | Stressing synchronizer for 3000 ms
+      # make test-hotspot-gtest
 
   - runs: |
       _java_home="usr/lib/jvm/java-11-openjdk"


### PR DESCRIPTION
we are seeing builds hang
```
TestSingleWriterSynchronizer.stress_test_vm
aarch64   | Stressing synchronizer for 3000 ms
```

https://github.com/wolfi-dev/os/actions/runs/4990934730/jobs/8936920447
