### PR TITLE
update JAVA_HOME to newly standardized path

### DIFF
--- a/ant.yaml
+++ b/ant.yaml
@@ -1,7 +1,7 @@
 package:
   name: ant
   version: 1.10.13
-  epoch: 0
+  epoch: 1
   description: A Java build tool
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,7 @@ pipeline:
       expected-sha256: 06a8f6f11529aeadcd10f96335dcd8b166188e2b970d27a648006a1be79b29f7
 
   - runs: |
-      export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk/
+      export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
       sh build.sh -Ddist.dir=${{targets.destdir}}/usr/share/java/ant dist
 
       rm ${{targets.destdir}}/usr/share/java/ant/bin/*.bat

--- a/bazel-5.yaml
+++ b/bazel-5.yaml
@@ -1,7 +1,7 @@
 package:
   name: bazel-5
   version: 5.4.1
-  epoch: 0
+  epoch: 1
   description: Bazel is an open-source build and test tool
   copyright:
     - license: Apache-2.0
@@ -32,7 +32,7 @@ pipeline:
 
   - runs: |
       mkdir -p $HOME/.cache/bazel/_bazel_root
-      export JAVA_HOME=/usr/lib/jvm/openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 
       EMBED_LABEL=${{package.version}}-${{package.epoch}} \
         EXTRA_BAZEL_ARGS=--tool_java_runtime_version=local_jdk \

--- a/bazel-6.yaml
+++ b/bazel-6.yaml
@@ -1,6 +1,6 @@
 package:
   name: bazel-6
-  version: 6.1.2
+  version: 6.2.0
   epoch: 0
   description: Bazel is an open-source build and test tool
   copyright:
@@ -32,7 +32,7 @@ pipeline:
 
   - runs: |
       mkdir -p $HOME/.cache/bazel/_bazel_root
-      export JAVA_HOME=/usr/lib/jvm/openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
       EMBED_LABEL=${{package.version}}-${{package.epoch}} \
         EXTRA_BAZEL_ARGS=--tool_java_runtime_version=local_jdk \
         ./compile.sh

--- a/cassandra.yaml
+++ b/cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra
   version: 4.1.1
-  epoch: 0
+  epoch: 1
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,7 @@ pipeline:
       tag: cassandra-4.1.1
 
   - runs: |
-      export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk/
+      export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
 
       ant artifacts
 

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
   version: 11.0.20.2
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: GPL-2.0-only


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: updates `JAVA_HOME` for packages depending on jdk8/11 to the newly standardized locations. We will do this for the remaining packages that depend on >jdk17 once that's updated as well

The exception to this bump is `envoy`. In my initial testing I'm getting failures to build that I believe are unrelated to `JAVA_HOME` or our new build of openjdk-11, so I'm excluding it from this PR and will land it separately.

Related: #2075 

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
