### PR TITLE
ensure openjdk-11 jdk depends on jre

### DIFF
--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,12 +1,13 @@
 package:
   name: openjdk-11
   version: 11.0.20.2
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-only
   dependencies:
     runtime:
+      - openjdk-11-jre
       - freetype
       - fontconfig
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: ensures jdk depends on jre for openjdk 11 to make `apk add openjdk-11` work as one would expect