### PR TITLE
add openjdk-15, 16, and updated 17

### DIFF
--- a/cloudwatch-exporter.yaml
+++ b/cloudwatch-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudwatch-exporter
   version: "0.15.3"
-  epoch: 0
+  epoch: 1
   description: Metrics exporter for Amazon AWS CloudWatch
   copyright:
     - license: Apache-2.0
@@ -17,6 +17,7 @@ environment:
       - curl
       - maven
       - openjdk-17
+      - openjdk-17-default-jvm
 
 pipeline:
   - uses: git-checkout

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins
   version: "2.401"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: MIT
@@ -22,6 +22,7 @@ environment:
       - openssh-client
       - tini
       - openjdk-17
+      - openjdk-17-default-jvm
       - maven
       - tzdata
       - glibc-locale-en
@@ -40,7 +41,7 @@ pipeline:
       patches: ignoreArchiveNotReadableTest.patch
 
   - runs: |
-      export JAVA_HOME=/usr/lib/jvm/openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
       export LANG=en_US.UTF-8
 
       export MAVEN_OPTS="-DforkCount=2"

--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak
   version: 21.1.1
-  epoch: 0
+  epoch: 1
   description:
   target-architecture:
     - all
@@ -13,7 +13,7 @@ package:
   dependencies:
     runtime:
       - bash # some helper scripts use bash
-      - openjdk-17-jre
+      - openjdk-17-default-jvm
 
 environment:
   contents:
@@ -23,6 +23,7 @@ environment:
       - curl
       - maven
       - openjdk-17
+      - openjdk-17-default-jvm
       - bash
       - nodejs-16
       - wolfi-base
@@ -37,7 +38,7 @@ pipeline:
 
   - runs: |
       export LANG=en_US.UTF-8
-      export JAVA_HOME=/usr/lib/jvm/openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
       mvn install -DskipTests=true -Dnode.version=$(node --version) -Pdistribution -q
 

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -1,13 +1,13 @@
 package:
-  name: openjdk-17
-  version: 17.0.8.2
+  name: openjdk-15
+  version: 15.0.10.5
   epoch: 0
   description:
   copyright:
     - license: GPL-2.0-only
   dependencies:
     runtime:
-      - openjdk-17-jre
+      - openjdk-15-jre
       - freetype
       - fontconfig
 
@@ -37,8 +37,8 @@ environment:
       - libjpeg-dev
       - giflib-dev
       - lcms2-dev
-      - openjdk-16-default-jvm
-      - openjdk-16
+      - openjdk-14-default-jvm
+      - openjdk-14
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
 var-transforms:
@@ -50,8 +50,8 @@ var-transforms:
 pipeline:
   - uses: fetch
     with:
-      uri: https://github.com/openjdk/jdk17u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
-      expected-sha512: 9c289c69a451b2b9cd8b32a3028b3226b70e005490b3e7313bc488c393f02909df12d82a8bae416d48fb17269885a141247bd15bec3943503edc9ebc2ebc1c6a
+      uri: https://github.com/openjdk/jdk15u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
+      expected-sha512: 24c8324ebf05d37efaf573d17d5fcbba19b3164fce0a226190a0c9864adda06b5ca8020911ea677a6abfa37bd3000c50eb07cc1f00fa99f4a1d5f588501f1276
 
   - working-directory: /home/build/googletest
     pipeline:
@@ -62,15 +62,15 @@ pipeline:
 
   - uses: patch
     with:
-      patches: FixNullPtrCast.patch
+      patches: aarch64.patch
 
   - runs: chmod +x configure
 
   - uses: autoconf/configure
     with:
       opts: |
-        --with-boot-jdk=/usr/lib/jvm/java-16-openjdk \
-        --prefix=/usr/lib/jvm/java-17-openjdk \
+        --with-boot-jdk=/usr/lib/jvm/java-14-openjdk \
+        --prefix=/usr/lib/jvm/java-15-openjdk \
         --with-vendor-name=wolfi \
         --with-vendor-url=https://wolfi.dev \
         --with-vendor-bug-url=https://github.com/wolfi-dev/os/issues \
@@ -105,7 +105,7 @@ pipeline:
       # make test-hotspot-gtest
 
   - runs: |
-      _java_home="usr/lib/jvm/java-17-openjdk"
+      _java_home="usr/lib/jvm/java-15-openjdk"
 
       mkdir -p "${{targets.destdir}}"/$_java_home
       cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
@@ -114,16 +114,16 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "openjdk-17-jre"
-    description: "OpenJDK 17 Java Runtime Environment"
+  - name: "openjdk-15-jre"
+    description: "OpenJDK 15 Java Runtime Environment"
     dependencies:
       runtime:
         - freetype
         - fontconfig
-        - openjdk-17-jre-base
+        - openjdk-15-jre-base
     pipeline:
       - runs: |
-          _java_home="usr/lib/jvm/java-17-openjdk"
+          _java_home="usr/lib/jvm/java-15-openjdk"
 
           mkdir -p "${{targets.subpkgdir}}"/$_java_home/lib
           mv "${{targets.destdir}}"/$_java_home/lib/libawt_xawt.so \
@@ -135,15 +135,15 @@ subpackages:
               "${{targets.destdir}}"/$_java_home/lib/libsplashscreen.so \
               "${{targets.subpkgdir}}"/$_java_home/lib
 
-  - name: "openjdk-17-jre-base"
-    description: "OpenJDK 17 Java Runtime Environment (headless)"
+  - name: "openjdk-15-jre-base"
+    description: "OpenJDK 15 Java Runtime Environment (headless)"
     dependencies:
       runtime:
         - java-common
         - java-cacerts
     pipeline:
       - runs: |
-          _java_home="usr/lib/jvm/java-17-openjdk"
+          _java_home="usr/lib/jvm/java-15-openjdk"
 
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
           mv "${{targets.destdir}}"/$_java_home/lib \
@@ -151,19 +151,22 @@ subpackages:
 
           mkdir -p "${{targets.subpkgdir}}"/$_java_home/bin
           for i in java \
-                    jfr \
                     jrunscript \
                     keytool \
+                    rmid \
                     rmiregistry; do
             mv "${{targets.destdir}}"/$_java_home/bin/$i "${{targets.subpkgdir}}"/$_java_home/bin/$i
           done
+
+          [ "${{build.arch}}" = "x86_64" ] && \
+            mv "${{targets.destdir}}"/$_java_home/bin/jaotc "${{targets.subpkgdir}}"/$_java_home/bin/jaotc
 
           mv "${{targets.destdir}}"/$_java_home/legal "${{targets.subpkgdir}}"/$_java_home
           mv "${{targets.destdir}}"/$_java_home/conf "${{targets.subpkgdir}}"/$_java_home
           mv "${{targets.destdir}}"/$_java_home/release "${{targets.subpkgdir}}"/$_java_home
           cp ASSEMBLY_EXCEPTION \
               LICENSE \
-              README.md \
+              README \
              "${{targets.subpkgdir}}"/$_java_home
 
           # symlink to shared java cacerts store
@@ -174,48 +177,42 @@ subpackages:
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
 
-  - name: "openjdk-17-jmods"
-    description: "OpenJDK 17 jmods"
+  - name: "openjdk-15-jmods"
+    description: "OpenJDK 15 jmods"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
-          mv "${{targets.destdir}}"/usr/lib/jvm/java-17-openjdk/jmods \
-             "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-15-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-15-openjdk/jmods \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-15-openjdk
 
-  - name: "openjdk-17-doc"
-    description: "OpenJDK 17 Documentation"
+  - name: "openjdk-15-doc"
+    description: "OpenJDK 15 Documentation"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
-          mv "${{targets.destdir}}"/usr/lib/jvm/java-17-openjdk/man \
-             "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-15-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-15-openjdk/man \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-15-openjdk
 
-  - name: "openjdk-17-demos"
-    description: "OpenJDK 17 Demos"
+  - name: "openjdk-15-demos"
+    description: "OpenJDK 15 Demos"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
-          mv "${{targets.destdir}}"/usr/lib/jvm/java-17-openjdk/demo \
-             "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-15-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-15-openjdk/demo \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-15-openjdk
 
-  - name: "openjdk-17-default-jvm"
-    description: "Use the openjdk-17 JVM as the default JVM"
+  - name: "openjdk-15-default-jvm"
+    description: "Use the openjdk-15 JVM as the default JVM"
     dependencies:
       runtime:
-        - openjdk-17-jre
+        - openjdk-15-jre
       provides:
-        - default-jvm=1.17
+        - default-jvm=1.15
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
-          ln -sf java-17-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+          ln -sf java-15-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
 
 update:
-  enabled: true
-  manual: true # jdk version scheme unsupported for now.
-  shared: true
-  github:
-    identifier: openjdk/jdk17u
-    strip-prefix: jdk-
-    tag-filter: jdk-17
-    use-tag: true
+  # OpenJDK 15 is EOL
+  enabled: false

--- a/openjdk-15/HelloWorld.java
+++ b/openjdk-15/HelloWorld.java
@@ -1,0 +1,3 @@
+public class HelloWorld {
+  public static void main(String[] args) { System.out.println("Hello World!"); }
+}

--- a/openjdk-15/aarch64.patch
+++ b/openjdk-15/aarch64.patch
@@ -1,0 +1,17 @@
+Subject: Remove fpu_control.h include
+Upstream: No
+Author: Simon Frankenberger <simon-alpine@fraho.eu>
+
+The header is not present with musl and including it results in build error.
+It's not needed anyways.
+
+--- old/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
++++ new/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+@@ -75,7 +75,6 @@
+ # include <pwd.h>
+ # include <poll.h>
+ # include <ucontext.h>
+-# include <fpu_control.h>
+ 
+ #define REG_FP 29
+ #define REG_LR 30

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -1,13 +1,13 @@
 package:
-  name: openjdk-17
-  version: 17.0.8.2
+  name: openjdk-16
+  version: 16.0.2.7
   epoch: 0
   description:
   copyright:
     - license: GPL-2.0-only
   dependencies:
     runtime:
-      - openjdk-17-jre
+      - openjdk-16-jre
       - freetype
       - fontconfig
 
@@ -37,8 +37,8 @@ environment:
       - libjpeg-dev
       - giflib-dev
       - lcms2-dev
-      - openjdk-16-default-jvm
-      - openjdk-16
+      - openjdk-15-default-jvm
+      - openjdk-15
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
 var-transforms:
@@ -50,8 +50,8 @@ var-transforms:
 pipeline:
   - uses: fetch
     with:
-      uri: https://github.com/openjdk/jdk17u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
-      expected-sha512: 9c289c69a451b2b9cd8b32a3028b3226b70e005490b3e7313bc488c393f02909df12d82a8bae416d48fb17269885a141247bd15bec3943503edc9ebc2ebc1c6a
+      uri: https://github.com/openjdk/jdk16u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
+      expected-sha512: 78af6dfddda1d6de1a82c8f792eb634dd2c3646395cc875524abf0804402120d2baedbac19b79cd80c16a3e89469857e5c7aa000a0bf67f6eae5f4099c8be180
 
   - working-directory: /home/build/googletest
     pipeline:
@@ -69,8 +69,8 @@ pipeline:
   - uses: autoconf/configure
     with:
       opts: |
-        --with-boot-jdk=/usr/lib/jvm/java-16-openjdk \
-        --prefix=/usr/lib/jvm/java-17-openjdk \
+        --with-boot-jdk=/usr/lib/jvm/java-15-openjdk \
+        --prefix=/usr/lib/jvm/java-16-openjdk \
         --with-vendor-name=wolfi \
         --with-vendor-url=https://wolfi.dev \
         --with-vendor-bug-url=https://github.com/wolfi-dev/os/issues \
@@ -105,7 +105,7 @@ pipeline:
       # make test-hotspot-gtest
 
   - runs: |
-      _java_home="usr/lib/jvm/java-17-openjdk"
+      _java_home="usr/lib/jvm/java-16-openjdk"
 
       mkdir -p "${{targets.destdir}}"/$_java_home
       cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
@@ -114,16 +114,16 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "openjdk-17-jre"
-    description: "OpenJDK 17 Java Runtime Environment"
+  - name: "openjdk-16-jre"
+    description: "OpenJDK 16 Java Runtime Environment"
     dependencies:
       runtime:
         - freetype
         - fontconfig
-        - openjdk-17-jre-base
+        - openjdk-16-jre-base
     pipeline:
       - runs: |
-          _java_home="usr/lib/jvm/java-17-openjdk"
+          _java_home="usr/lib/jvm/java-16-openjdk"
 
           mkdir -p "${{targets.subpkgdir}}"/$_java_home/lib
           mv "${{targets.destdir}}"/$_java_home/lib/libawt_xawt.so \
@@ -135,15 +135,15 @@ subpackages:
               "${{targets.destdir}}"/$_java_home/lib/libsplashscreen.so \
               "${{targets.subpkgdir}}"/$_java_home/lib
 
-  - name: "openjdk-17-jre-base"
-    description: "OpenJDK 17 Java Runtime Environment (headless)"
+  - name: "openjdk-16-jre-base"
+    description: "OpenJDK 16 Java Runtime Environment (headless)"
     dependencies:
       runtime:
         - java-common
         - java-cacerts
     pipeline:
       - runs: |
-          _java_home="usr/lib/jvm/java-17-openjdk"
+          _java_home="usr/lib/jvm/java-16-openjdk"
 
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
           mv "${{targets.destdir}}"/$_java_home/lib \
@@ -151,12 +151,15 @@ subpackages:
 
           mkdir -p "${{targets.subpkgdir}}"/$_java_home/bin
           for i in java \
-                    jfr \
                     jrunscript \
                     keytool \
+                    rmid \
                     rmiregistry; do
             mv "${{targets.destdir}}"/$_java_home/bin/$i "${{targets.subpkgdir}}"/$_java_home/bin/$i
           done
+
+          [ "${{build.arch}}" = "x86_64" ] && \
+            mv "${{targets.destdir}}"/$_java_home/bin/jaotc "${{targets.subpkgdir}}"/$_java_home/bin/jaotc
 
           mv "${{targets.destdir}}"/$_java_home/legal "${{targets.subpkgdir}}"/$_java_home
           mv "${{targets.destdir}}"/$_java_home/conf "${{targets.subpkgdir}}"/$_java_home
@@ -174,48 +177,42 @@ subpackages:
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
 
-  - name: "openjdk-17-jmods"
-    description: "OpenJDK 17 jmods"
+  - name: "openjdk-16-jmods"
+    description: "OpenJDK 16 jmods"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
-          mv "${{targets.destdir}}"/usr/lib/jvm/java-17-openjdk/jmods \
-             "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-16-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-16-openjdk/jmods \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-16-openjdk
 
-  - name: "openjdk-17-doc"
-    description: "OpenJDK 17 Documentation"
+  - name: "openjdk-16-doc"
+    description: "OpenJDK 16 Documentation"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
-          mv "${{targets.destdir}}"/usr/lib/jvm/java-17-openjdk/man \
-             "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-16-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-16-openjdk/man \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-16-openjdk
 
-  - name: "openjdk-17-demos"
-    description: "OpenJDK 17 Demos"
+  - name: "openjdk-16-demos"
+    description: "OpenJDK 16 Demos"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
-          mv "${{targets.destdir}}"/usr/lib/jvm/java-17-openjdk/demo \
-             "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-16-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-16-openjdk/demo \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-16-openjdk
 
-  - name: "openjdk-17-default-jvm"
-    description: "Use the openjdk-17 JVM as the default JVM"
+  - name: "openjdk-16-default-jvm"
+    description: "Use the openjdk-16 JVM as the default JVM"
     dependencies:
       runtime:
-        - openjdk-17-jre
+        - openjdk-16-jre
       provides:
-        - default-jvm=1.17
+        - default-jvm=1.16
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
-          ln -sf java-17-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+          ln -sf java-16-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
 
 update:
-  enabled: true
-  manual: true # jdk version scheme unsupported for now.
-  shared: true
-  github:
-    identifier: openjdk/jdk17u
-    strip-prefix: jdk-
-    tag-filter: jdk-17
-    use-tag: true
+  # OpenJDK 16 is EOL
+  enabled: false

--- a/openjdk-16/FixNullPtrCast.patch
+++ b/openjdk-16/FixNullPtrCast.patch
@@ -1,0 +1,88 @@
+Subject: Fix cast errors with latest GCC (11.2)
+Upstream: No
+Author: Simon Frankenberger <simon-alpine@fraho.eu>
+
+This patch fixes multiple casting errors reported by GCC 11.2
+
+--- old/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
++++ new/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
+@@ -317,10 +317,10 @@
+     _from -= Interpreter::stackElementSize;
+ 
+     if (_num_int_args < Argument::n_int_register_parameters_c-1) {
+-      *_int_args++ = (*from_addr == 0) ? NULL : (intptr_t)from_addr;
++      *_int_args++ = (*from_addr == 0) ? (intptr_t) 0 : (intptr_t)from_addr;
+       _num_int_args++;
+     } else {
+-      *_to++ = (*from_addr == 0) ? NULL : (intptr_t) from_addr;
++      *_to++ = (*from_addr == 0) ? (intptr_t) 0 : (intptr_t) from_addr;
+       _num_int_args++;
+     }
+   }
+--- old/src/hotspot/cpu/x86/interp_masm_x86.cpp
++++ new/src/hotspot/cpu/x86/interp_masm_x86.cpp
+@@ -1122,7 +1122,7 @@
+ 
+     bind(loop);
+     // check if current entry is used
+-    cmpptr(Address(rmon, BasicObjectLock::obj_offset_in_bytes()), (int32_t) NULL);
++    cmpptr(Address(rmon, BasicObjectLock::obj_offset_in_bytes()), 0);
+     jcc(Assembler::notEqual, exception);
+ 
+     addptr(rmon, entry_size); // otherwise advance to next entry
+--- old/src/hotspot/cpu/x86/interpreterRT_x86_64.cpp
++++ new/src/hotspot/cpu/x86/interpreterRT_x86_64.cpp
+@@ -443,10 +443,10 @@
+     _from -= Interpreter::stackElementSize;
+ 
+     if (_num_int_args < Argument::n_int_register_parameters_c-1) {
+-      *_int_args++ = (*from_addr == 0) ? NULL : (intptr_t)from_addr;
++      *_int_args++ = (*from_addr == 0) ? (intptr_t) 0 : (intptr_t) from_addr;
+       _num_int_args++;
+     } else {
+-      *_to++ = (*from_addr == 0) ? NULL : (intptr_t) from_addr;
++      *_to++ = (*from_addr == 0) ? (intptr_t) 0 : (intptr_t) from_addr;
+     }
+   }
+ 
+--- old/src/hotspot/share/oops/access.hpp
++++ new/src/hotspot/share/oops/access.hpp
+@@ -295,8 +295,8 @@
+   static inline void arraycopy(arrayOop src_obj, size_t src_offset_in_bytes,
+                                arrayOop dst_obj, size_t dst_offset_in_bytes,
+                                size_t length) {
+-    AccessT::arraycopy(src_obj, src_offset_in_bytes, reinterpret_cast<const T*>(NULL),
+-                       dst_obj, dst_offset_in_bytes, reinterpret_cast<T*>(NULL),
++    AccessT::arraycopy(src_obj, src_offset_in_bytes, static_cast<const T*>(NULL),
++                       dst_obj, dst_offset_in_bytes, static_cast<T*>(NULL),
+                        length);
+   }
+ 
+@@ -304,7 +304,7 @@
+   static inline void arraycopy_to_native(arrayOop src_obj, size_t src_offset_in_bytes,
+                                          T* dst,
+                                          size_t length) {
+-    AccessT::arraycopy(src_obj, src_offset_in_bytes, reinterpret_cast<const T*>(NULL),
++    AccessT::arraycopy(src_obj, src_offset_in_bytes, static_cast<const T*>(NULL),
+                        NULL, 0, dst,
+                        length);
+   }
+@@ -314,15 +314,15 @@
+                                            arrayOop dst_obj, size_t dst_offset_in_bytes,
+                                            size_t length) {
+     AccessT::arraycopy(NULL, 0, src,
+-                       dst_obj, dst_offset_in_bytes, reinterpret_cast<T*>(NULL),
++                       dst_obj, dst_offset_in_bytes, static_cast<T*>(NULL),
+                        length);
+   }
+ 
+   static inline bool oop_arraycopy(arrayOop src_obj, size_t src_offset_in_bytes,
+                                    arrayOop dst_obj, size_t dst_offset_in_bytes,
+                                    size_t length) {
+-    return AccessT::oop_arraycopy(src_obj, src_offset_in_bytes, reinterpret_cast<const HeapWord*>(NULL),
+-                                  dst_obj, dst_offset_in_bytes, reinterpret_cast<HeapWord*>(NULL),
++    return AccessT::oop_arraycopy(src_obj, src_offset_in_bytes, static_cast<const HeapWord*>(NULL),
++                                  dst_obj, dst_offset_in_bytes, static_cast<HeapWord*>(NULL),
+                                   length);
+   }
+ 

--- a/openjdk-16/HelloWorld.java
+++ b/openjdk-16/HelloWorld.java
@@ -1,0 +1,3 @@
+public class HelloWorld {
+  public static void main(String[] args) { System.out.println("Hello World!"); }
+}

--- a/openjdk-16/aarch64.patch
+++ b/openjdk-16/aarch64.patch
@@ -1,0 +1,17 @@
+Subject: Remove fpu_control.h include
+Upstream: No
+Author: Simon Frankenberger <simon-alpine@fraho.eu>
+
+The header is not present with musl and including it results in build error.
+It's not needed anyways.
+
+--- old/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
++++ new/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+@@ -75,7 +75,6 @@
+ # include <pwd.h>
+ # include <poll.h>
+ # include <ucontext.h>
+-# include <fpu_control.h>
+ 
+ #define REG_FP 29
+ #define REG_LR 30

--- a/openjdk-17/FixNullPtrCast.patch
+++ b/openjdk-17/FixNullPtrCast.patch
@@ -1,0 +1,17 @@
+Subject: Fix cast errors with latest GCC
+Upstream: No
+Author: Simon Frankenberger <simon-alpine@fraho.eu>
+
+This patch fixes one remaining casting error reported by GCC 12 for aarch64
+
+--- old/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
++++ new/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
+@@ -267,7 +267,7 @@
+ 
+   virtual void pass_object() {
+     intptr_t* addr = single_slot_addr();
+-    intptr_t value = *addr == 0 ? NULL : (intptr_t)addr;
++    intptr_t value = *addr == 0 ? (intptr_t) 0 : (intptr_t)addr;
+     if (pass_gpr(value) < 0) {
+       pass_stack<>(value);
+     }

--- a/openjdk-17/HelloWorld.java
+++ b/openjdk-17/HelloWorld.java
@@ -1,0 +1,3 @@
+public class HelloWorld {
+  public static void main(String[] args) { System.out.println("Hello World!"); }
+}

--- a/openjdk-17/JDK-8282306_disable-test.patch
+++ b/openjdk-17/JDK-8282306_disable-test.patch
@@ -1,0 +1,16 @@
+Author: Simon Frankenberger <simon-alpine@fraho.eu>
+Subject: Disable failing test
+Upstream: Yes (https://bugs.openjdk.org/browse/JDK-8282306)
+
+Disable failing test as workaround
+
+--- old/test/hotspot/gtest/runtime/test_os.cpp
++++ new/test/hotspot/gtest/runtime/test_os.cpp
+@@ -844,7 +844,7 @@
+ }
+ 
+ TEST_VM(os, is_first_C_frame) {
+-#if !defined(_WIN32) && !defined(ZERO)
++#if !defined(_WIN32) && !defined(ZERO) && false
+   frame invalid_frame;
+   EXPECT_TRUE(os::is_first_C_frame(&invalid_frame)); // the frame has zeroes for all values

--- a/openjdk-17/aarch64.patch
+++ b/openjdk-17/aarch64.patch
@@ -1,0 +1,17 @@
+Subject: Remove fpu_control.h include
+Upstream: No
+Author: Simon Frankenberger <simon-alpine@fraho.eu>
+
+The header is not present with musl and including it results in build error.
+It's not needed anyways.
+
+--- old/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
++++ new/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+@@ -75,7 +75,6 @@
+ # include <pwd.h>
+ # include <poll.h>
+ # include <ucontext.h>
+-# include <fpu_control.h>
+ 
+ #define REG_FP 29
+ #define REG_LR 30

--- a/packages.txt
+++ b/packages.txt
@@ -203,7 +203,6 @@ encodings
 ttf-dejavu
 libmaxminddb
 clang-15
-jenkins
 cosign
 yasm
 crane
@@ -453,7 +452,6 @@ fping
 ethtool
 iftop
 tcpdump
-zookeeper
 nats-server
 nats
 nsc
@@ -510,7 +508,6 @@ lzo
 runc
 metacontroller
 gcsfuse
-keycloak
 argo-cd
 conda
 spark-operator
@@ -610,10 +607,15 @@ openjdk-11
 openjdk-12
 openjdk-13
 openjdk-14
+openjdk-15
+openjdk-16
 openjdk-17
 bazel-5
 bazel-6
 envoy
+jenkins
+keycloak
+zookeeper
 aws-efs-csi-driver
 prometheus-bind-exporter
 clickhouse

--- a/zookeeper.yaml
+++ b/zookeeper.yaml
@@ -2,7 +2,7 @@ package:
   name: zookeeper
   # When bumping, check to see if the CVE mitigations below can be removed.
   version: "3.8.1"
-  epoch: 1
+  epoch: 2
   description:
   target-architecture:
     - all
@@ -14,7 +14,7 @@ package:
   dependencies:
     runtime:
       - bash # some helper scripts use bash
-      - openjdk-17-jre
+      - openjdk-17-default-jvm
 
 environment:
   contents:
@@ -24,6 +24,7 @@ environment:
       - curl
       - maven
       - openjdk-17
+      - openjdk-17-default-jvm
 
 pipeline:
   - uses: git-checkout
@@ -34,7 +35,7 @@ pipeline:
 
   - runs: |
       export LANG=en_US.UTF-8
-      export JAVA_HOME=/usr/lib/jvm/openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
       # Mitigate CVE-2023-26048 and CVE-2023-26049 by bumping jetty
       sed -i 's/\(<jetty.version>\)[^<]\+/\19.4.51.v20230217/' pom.xml


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

new packages: openjdk-15 and 16

updated packages: openjdk-17, zookeeper, keycloak, jenkins, cloudwatch-exporter

this brings openjdk17 up to par with the updated way we're packaging openjdk

Related:

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`