### PR TITLE
move bazel and envoy below openjdk

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -204,8 +204,6 @@ libfontenc
 mkfontscale
 encodings
 ttf-dejavu
-bazel-5,bazel
-bazel-6,bazel
 libmaxminddb
 clang-15
 jenkins
@@ -228,7 +226,6 @@ mimalloc2
 libtbb
 mold
 dumb-init
-envoy
 redis
 redis-6.2
 mailcap
@@ -617,6 +614,9 @@ openjdk-12
 openjdk-13
 openjdk-14
 openjdk-17
+bazel-5,bazel
+bazel-6,bazel
+envoy
 aws-efs-csi-driver
 prometheus-bind-exporter
 clickhouse


### PR DESCRIPTION
openjdk 11 now depends on 10 which has moved down the packages list order
