### PR TITLE
Add kubernetes dashboard metrics scraper package.

### DIFF
--- a/kubernetes-dashboard-metrics-scraper.yaml
+++ b/kubernetes-dashboard-metrics-scraper.yaml
@@ -1,0 +1,40 @@
+package:
+  name: kubernetes-dashboard-metrics-scraper
+  version: 1.0.9
+  epoch: 0
+  description: Container to scrape, store, and retrieve a window of time from the Metrics Server.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - build-base
+      - ncurses-dev
+      - glibc-dev
+      - sqlite
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/dashboard-metrics-scraper
+      tag: v${{package.version}}
+      expected-commit: b3f5d8f275bf12d8581769851a985fbc41fd371b
+
+  - runs: |
+      hack/build.sh
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv /metrics-sidecar ${{targets.destdir}}/usr/bin/metrics-sidecar
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/dashboard-metrics-scraper
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v

--- a/packages.txt
+++ b/packages.txt
@@ -629,6 +629,7 @@ spicedb
 configmap-reload
 k8sgpt
 kubernetes-dashboard
+kubernetes-dashboard-metrics-scraper
 buildkitd
 nri-kubernetes
 newrelic-infra-operator


### PR DESCRIPTION


Fixes:

Related:

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`
