### PR TITLE
http-echo: new package

### DIFF
--- a/http-echo.yaml
+++ b/http-echo.yaml
@@ -1,0 +1,51 @@
+package:
+  name: http-echo
+  version: 0.2.3
+  epoch: 0
+  description: A tiny go web server that echos what you start it with!
+  copyright:
+    - license: MPL-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "off"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hashicorp/http-echo
+      tag: v${{package.version}}
+      expected-commit: f375b4ddff406ff94e661212fea488785ea7f809
+
+  - runs: |
+      # https://github.com/hashicorp/http-echo/blob/f375b4ddff406ff94e661212fea488785ea7f809/Makefile#L50
+      # https://github.com/hashicorp/http-echo/blob/f375b4ddff406ff94e661212fea488785ea7f809/scripts/compile.sh
+      GIT_COMMIT="$(git rev-parse --short HEAD)"
+      GIT_DIRTY="$(test -n $(git status --porcelain) && echo +CHANGES || true)"
+
+      LDFLAGS="-s -w"
+      LDFLAGS="$LDFLAGS -X main.Name=${{package.name}}"
+      LDFLAGS="$LDFLAGS -X main.Version=${{package.version}}"
+      LDFLAGS="$LDFLAGS -X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY}"
+
+      go build \
+        -ldflags="$LDFLAGS" \
+        -o ${{targets.destdir}}/http-echo \
+        .
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: hashicorp/http-echo
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -660,3 +660,4 @@ sysfsutils
 kubernetes-csi-livenessprobe
 kubernetes-csi-node-driver-registrar
 cluster-proportional-autoscaler
+http-echo


### PR DESCRIPTION
https://github.com/hashicorp/http-echo

The http-echo binary is placed at / instead of /usr/bin because that is where upstream sticks it in their docker images.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
