### PR TITLE
try to improve contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 
 ## Setup development environment
 
-To ease the development of Wolfi OS, you can use the [`sdk` Chainguard Image](https://github.com/chainguard-images/images/tree/main/images/sdk) that already includes both [apko](https://github.com/chainguard-dev/apko) and [melange](https://github.com/chainguard-dev/melange).
+To ease the development of Wolfi OS, you can use the [Wolfi `sdk` image](https://github.com/wolfi-dev/tools/pkgs/container/sdk) that already includes both [apko](https://github.com/chainguard-dev/apko) and [melange](https://github.com/chainguard-dev/melange).
 On Linux and Mac it is also possible to install both the above tools directly into your system.
 
 If you choose not to install the tooling onto your local machine, you can start a container based development environment using
@@ -18,14 +18,7 @@ If you choose not to install the tooling onto your local machine, you can start 
 make dev-container
 ```
 
-What it does is start the `chainguard-images/sdk` image and mount the current working directory into it.
-
-Now, the `Makefile` script assume that there're melange folder & melange binary the upper level dir (`../melange`). I change it locally to the following because it's where they are in `chainguard-image/sdk`.
-
-```
-MELANGE_DIR ?= /usr/share/melange
-MELANGE ?= $(shell which melange)
-```
+What it does is start the `ghcr.io/wolfi-dev/sdk` image and mount the current working directory into it.
 
 ## Write your first Wolfi package
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifeq (${ARCH}, arm64)
 endif
 TARGETDIR = packages/${ARCH}
 
-MELANGE ?= ../melange/melange
+MELANGE ?= $(shell which melange)
 KEY ?= local-melange.rsa
 REPO ?= $(shell pwd)/packages
 SOURCE_DATE_EPOCH ?= 0
@@ -83,4 +83,4 @@ $(foreach pkg,$(PKGLIST),$(eval $(call build-package,$(pkg))))
 .build-packages: ${PACKAGES}
 
 dev-container:
-	docker run --privileged --rm -it -v "${PWD}:${PWD}" -w "${PWD}" ghcr.io/wolfi-dev/sdk:latest@sha256:515a2c5072753f81ce2cbb81bda54b035aefcdb41d7249070009fc018fecd4c9
+	docker run --privileged --rm -it -v "${PWD}:${PWD}" -w "${PWD}" ghcr.io/wolfi-dev/sdk:latest@sha256:3ef78225a85ab45f46faac66603c9da2877489deb643174ba1e42d8cbf0e0644


### PR DESCRIPTION
- set `MELANGE=$(shell which melange)` by default in the Makefile, remove guidance to set this yourself
- remove mention of `MELANGE_DIR`
- update old docs that mentioned a Chainguard `sdk` image
- use latest `ghcr.io/wolfi-dev/sdk` image, which supports `--log-policy` flag -- I don't know why the digestabot isn't updating this