### PR TITLE
bazel-{5,6}: fix build by using GCC 6

### DIFF
--- a/bazel-5.yaml
+++ b/bazel-5.yaml
@@ -1,7 +1,7 @@
 package:
   name: bazel-5
   version: 5.4.1
-  epoch: 0
+  epoch: 1
   description: Bazel is an open-source build and test tool
   copyright:
     - license: Apache-2.0
@@ -15,6 +15,9 @@ environment:
       - python3
       - zip
       - bash
+      - gcc-6
+      - libstdc++-6
+      - libstdc++-6-dev
       - openjdk-11
 
 pipeline:
@@ -32,7 +35,8 @@ pipeline:
 
   - runs: |
       mkdir -p $HOME/.cache/bazel/_bazel_root
-      export JAVA_HOME=/usr/lib/jvm/openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+      export CC=gcc-6.5 CXX=g++-6.5
 
       EMBED_LABEL=${{package.version}}-${{package.epoch}} \
         EXTRA_BAZEL_ARGS=--tool_java_runtime_version=local_jdk \

--- a/bazel-6.yaml
+++ b/bazel-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: bazel-6
   version: 6.1.2
-  epoch: 0
+  epoch: 1
   description: Bazel is an open-source build and test tool
   copyright:
     - license: Apache-2.0
@@ -15,6 +15,9 @@ environment:
       - python3
       - zip
       - bash
+      - gcc-6
+      - libstdc++-6
+      - libstdc++-6-dev
       - openjdk-11
 
 pipeline:
@@ -32,7 +35,9 @@ pipeline:
 
   - runs: |
       mkdir -p $HOME/.cache/bazel/_bazel_root
-      export JAVA_HOME=/usr/lib/jvm/openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+      export CC=gcc-6.5 CXX=g++-6.5
+
       EMBED_LABEL=${{package.version}}-${{package.epoch}} \
         EXTRA_BAZEL_ARGS=--tool_java_runtime_version=local_jdk \
         ./compile.sh


### PR DESCRIPTION
Bazel fails to build with GCC 13.