### PR TITLE
Cleanup: Withdraw rolled back package.

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -116,3 +116,4 @@ metrics-server-0.6.3-r1.apk
 metrics-server-0.6.3-r2.apk
 aws-ebs-csi-driver-1.18.0-r0.apk
 aws-ebs-csi-driver-1.18.0-r1.apk
+ko-0.13.0-r5.apk


### PR DESCRIPTION
:broom: This package only built for amd64 and we rolled the change back because it broke arm64.

This is now causing the `ko` image to fail because the package used to determine the tagging cannot be definitively resolved.

/kind cleanup

ref: https://github.com/chainguard-images/images/pull/585