### PR TITLE
add kubernetes-csi/external-attacher

### DIFF
--- a/external-attacher.yaml
+++ b/external-attacher.yaml
@@ -1,0 +1,37 @@
+package:
+  name: external-attacher
+  version: 4.3.0
+  epoch: 0
+  description: Sidecar container that watches Kubernetes VolumeAttachment objects and triggers ControllerPublish/Unpublish against a CSI endpoint
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+
+pipeline:
+  # We can't use go/install because this requires specific ldflags to set the version
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-csi/external-attacher
+      tag: v${{package.version}}
+      expected-commit: 910cd35d72e6a99cc7b8451a5065aecc11bd7fff
+
+  - runs: |
+      make build
+      mkdir -p ${{targets.destdir}}/usr/bin
+      install -Dm755 ./bin/csi-attacher ${{targets.destdir}}/usr/bin/csi-attacher
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-csi/external-attacher
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v

--- a/packages.txt
+++ b/packages.txt
@@ -662,5 +662,6 @@ kubernetes-csi-livenessprobe
 kubernetes-csi-node-driver-registrar
 cluster-proportional-autoscaler
 hey
+external-attacher
 kaf
 http-echo


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
