### PR TITLE
Update add-update-prs-to-project.yaml

### DIFF
--- a/.github/workflows/add-update-prs-to-project.yaml
+++ b/.github/workflows/add-update-prs-to-project.yaml
@@ -3,7 +3,6 @@ name: Add all update PRs to Images project
 on:
   pull_request:
     types:
-      - opened
       - labeled
 
 jobs:


### PR DESCRIPTION
looks like it's trying to double add the project based on openeing a pr and the label event.