### PR TITLE
fix python installer, remove provides as causes a conflict with py3.1…

### DIFF
--- a/py3.10-installer.yaml
+++ b/py3.10-installer.yaml
@@ -1,14 +1,12 @@
 # Generated from https://pypi.org/project/installer/
 package:
   name: py3.10-installer
-  version: 0.7.0 # When bumping this, also bump the provides below!
-  epoch: 1
+  version: 0.7.0
+  epoch: 2
   description: A library for installing Python wheels.
   copyright:
     - license: "MIT"
   dependencies:
-    provides:
-      - py3-installer=0.7.999
     runtime:
       - python-3.10
 

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -117,3 +117,4 @@ metrics-server-0.6.3-r2.apk
 aws-ebs-csi-driver-1.18.0-r0.apk
 aws-ebs-csi-driver-1.18.0-r1.apk
 ko-0.13.0-r5.apk
+py3.10-installer-0.7.0-r1.apk


### PR DESCRIPTION
…1-installer

also withdraw the bad version from the index

