### PR TITLE
py3.10-installer: remove errant provides entry for py3-installer

### DIFF
--- a/py3.10-installer.yaml
+++ b/py3.10-installer.yaml
@@ -2,13 +2,11 @@
 package:
   name: py3.10-installer
   version: 0.7.0 # When bumping this, also bump the provides below!
-  epoch: 1
+  epoch: 2
   description: A library for installing Python wheels.
   copyright:
     - license: "MIT"
   dependencies:
-    provides:
-      - py3-installer=0.7.999
     runtime:
       - python-3.10
 

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -117,3 +117,6 @@ metrics-server-0.6.3-r2.apk
 aws-ebs-csi-driver-1.18.0-r0.apk
 aws-ebs-csi-driver-1.18.0-r1.apk
 ko-0.13.0-r5.apk
+py3.10-installer-0.5.1-r0.apk
+py3.10-installer-0.7.0-r0.apk
+py3.10-installer-0.7.0-r1.apk


### PR DESCRIPTION
Also withdraw the defective versions.