### PR TITLE
Bring back "build date epoch"

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -59,6 +59,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: 'Trust the github workspace'
+        run: |
+          # This is to avoid fatal errors about "dubious ownership" because we are
+          # running inside of a container action with the workspace mounted in.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: 'Generate local signing key'
         run: |
           make MELANGE="melange" local-melange.rsa

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ TARGETDIR = packages/${ARCH}
 MELANGE ?= $(shell which melange)
 KEY ?= local-melange.rsa
 REPO ?= $(shell pwd)/packages
-SOURCE_DATE_EPOCH ?= 0
 CACHE_DIR ?= gs://wolfi-sources/
 
 WOLFI_SIGNING_PUBKEY ?= https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
@@ -41,7 +40,12 @@ $(eval pkgtarget = $(TARGETDIR)/$(pkgfullname).apk)
 packages/$(pkgname): $(pkgtarget)
 $(pkgtarget): ${KEY}
 	mkdir -p ./$(sourcedir)/
-	SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} ${MELANGE} build $(pkgname).yaml ${MELANGE_OPTS} --source-dir ./$(sourcedir)/ --log-policy builtin:stderr,${TARGETDIR}/buildlogs/$(pkgfullname).log
+ifdef SOURCE_DATE_EPOCH
+	$(eval CONFIG_DATE_EPOCH := $(SOURCE_DATE_EPOCH))
+else
+	$(eval CONFIG_DATE_EPOCH := $(shell git log -1 --pretty=%ct --follow $(pkgname).yaml))
+endif
+	SOURCE_DATE_EPOCH=${CONFIG_DATE_EPOCH} ${MELANGE} build $(pkgname).yaml ${MELANGE_OPTS} --source-dir ./$(sourcedir)/ --log-policy builtin:stderr,${TARGETDIR}/buildlogs/$(pkgfullname).log
 
 endef
 

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.13.0 # When bumping the version check if the GHSA mitigations below can be removed.
-  epoch: 5
+  epoch: 4
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.13.0 # When bumping the version check if the GHSA mitigations below can be removed.
-  epoch: 4
+  epoch: 5
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
The first commit here is a pure revert of the revert commit.

The second commit here drops the `ko` epoch bump which we withdrew.  I will bump this to `6` in a subsequent change once this lands.

The main difference is that we have swapped `kontext` implementations to one that now supports [what we need](https://github.com/chainguard-dev/kontext/blob/347f191bd8d465631acc627f8a8309e01016fce0/.github/workflows/e2e-test.yaml#L64C21-L65).

Fixes: https://github.com/chainguard-images/images/issues/535
