### PR TITLE
fix argocd to include ui

### DIFF
--- a/argo-cd.yaml
+++ b/argo-cd.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd
   version: 2.7.2
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -24,10 +24,12 @@ pipeline:
       expected-commit: cbee7e6011407ed2d1066c482db74e97e0cc6bdb
 
   - runs: |
-      cp ui/package.json .
-      cp ui/yarn.lock .
+      cd ui
       yarn install
       yarn cache clean
+      NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTIONS=--max_old_space_size=8192 yarn build
+
+      cd ..
 
       # Our global LDFLAGS conflict with a Makefile parameter
       unset LDFLAGS


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Argo cd server was not including the ui would fail in rendering the ui 
https://github.com/argoproj/argo-cd/blob/master/Dockerfile#L91-L99
https://github.com/argoproj/argo-cd/blob/master/Dockerfile#L113
