### PR TITLE
fix: kustomize was not displaying version info

### DIFF
--- a/kustomize.yaml
+++ b/kustomize.yaml
@@ -1,7 +1,7 @@
 package:
   name: kustomize
   version: 5.0.3
-  epoch: 0
+  epoch: 1
   description: Customization of kubernetes YAML configurations
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,7 @@ pipeline:
     with:
       packages: ./kustomize
       output: kustomize
+      ldflags: -s -X sigs.k8s.io/kustomize/api/provenance.version=kustomize/${{package.version}} -X 'sigs.k8s.io/kustomize/api/provenance.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')'
 
   - uses: strip
 


### PR DESCRIPTION
kustomize was not displaying version info , still commit info is shown as unknown the variable is not exposed to be set https://github.com/kubernetes-sigs/kustomize/blob/master/api/provenance/provenance.go#L61-L63 