### PR TITLE
Revert erlang-26

### DIFF
--- a/erlang.yaml
+++ b/erlang.yaml
@@ -1,6 +1,6 @@
 package:
   name: erlang
-  version: "26.0"
+  version: 25.3.2
   epoch: 0
   description: General-purpose programming language and runtime environment
   copyright:
@@ -22,7 +22,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 3ff3c53d7ef9a45b5720e95b8756269c1a1b58eb51accc992ca97522fdb234d4
+      expected-sha256: aed4e4726cdc587ab820c8379d63e511e46a1b1cc0c59d6a720b51ae625b2510
       uri: https://github.com/erlang/otp/releases/download/OTP-${{package.version}}/otp_src_${{package.version}}.tar.gz
 
   - runs: |

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -120,3 +120,5 @@ ko-0.13.0-r5.apk
 py3.10-installer-0.5.1-r0.apk
 py3.10-installer-0.7.0-r0.apk
 py3.10-installer-0.7.0-r1.apk
+erlang-26.0-r0.apk
+erlang-dev-26.0-r0.apk


### PR DESCRIPTION
TLS certificate validation is partially broken in this version, we will try again with 26.1.