### PR TITLE
Bump poetry to 1.5.0.

### DIFF
--- a/poetry.yaml
+++ b/poetry.yaml
@@ -1,6 +1,6 @@
 package:
   name: poetry
-  version: 1.4.2
+  version: 1.5.0
   epoch: 0
   description: "Python packaging and dependency management made easy"
   copyright:
@@ -23,7 +23,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/python-poetry/poetry/archive/${{package.version}}.tar.gz
-      expected-sha256: 8cdbad22dfd11ca9c7e37bcafe18ae931b80e0776adbe6df8d24091bd2b23eff
+      expected-sha256: 51dc32599edba7eafeb5038282aa9c5629d1e1ac72061075b0a302b3546bd839
 
   - runs: |
       POETRY_HOME=/usr/share/pypoetry python3 install-poetry.py -y --path .


### PR DESCRIPTION
The automated PR failed and is too far behind now.


Fixes: https://github.com/wolfi-dev/os/pull/2164

Related:

### Pre-review Checklist