### PR TITLE
Add new packages for kubeflow-katib

### DIFF
--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -1,0 +1,80 @@
+package:
+  epoch: 0
+  name: kubeflow-katib
+  version: 0.15.0
+  description: Kubeflow Katib services
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - wget
+      - ca-certificates
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - build-base
+      - python-3.10-dev
+      - py3.10-pip
+      - gfortran
+      - pcre-dev
+      # libopenblas-dev liblapack-dev not sure if these are needed, builds fine without.  From https://github.com/kubeflow/katib/blob/b9dc63efb55bec19bdd80ca6f2930a65795f7c41/cmd/earlystopping/medianstop/v1beta1/Dockerfile#L10
+
+data:
+  - name: go-builds
+    items:
+      cert-generator: cert-generator/v1beta1
+      controller: katib-controller/v1beta1
+      db-manager: db-manager/v1beta1
+      file-metricscollector: metricscollector/v1beta1/file-metricscollector
+      suggestion-goptuna: suggestion/goptuna/v1beta1
+
+  - name: python-builds
+    items:
+      earlystopping: earlystopping/medianstop/v1beta1
+      tfevent-metricscollector: metricscollector/v1beta1/tfevent-metricscollector
+      suggestion-hyperband: suggestion/hyperband/v1beta1
+      suggestion-hyperopt: suggestion/hyperopt/v1beta1
+      suggestion-nas-darts: suggestion/nas/darts/v1beta1
+      suggestion-nas-enas: suggestion/nas/enas/v1beta1
+      suggestion-optuna-enas: suggestion/optuna/v1beta1
+      suggestion-pbt-enas: suggestion/pbt/v1beta1
+      suggestion-skopt-enas: suggestion/skopt/v1beta1
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubeflow/katib
+      expected-commit: 05ab6f012ab6723609700a47a6cfa1845080e9b6
+      tag: v${{package.version}}
+
+subpackages:
+  - range: go-builds
+    name: "katib-${{range.key}}"
+    description: Kubeflow Katib ${{range.key}}
+    pipeline:
+      - uses: go/build
+        with:
+          packages: "./cmd/${{range.value}}"
+          output: katib-${{range.key}}
+          ldflags: -X main.version=${{package.version}}
+          subpackage: true
+
+  - range: python-builds
+    name: katib-${{range.key}}
+    description: Kubeflow Katib ${{range.key}}
+    pipeline:
+      - runs: |
+          cd ./cmd/${{range.value}}
+          pip install --prefer-binary -r requirements.txt --prefix=/usr --root=${{targets.subpkgdir}}
+
+          install -Dm755 ./main.py ${{targets.subpkgdir}}/usr/bin/
+
+update:
+  enabled: true
+  github:
+    identifier: kubeflow/katib
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -674,6 +674,7 @@ kubernetes-csi-node-driver-registrar
 wavefront-proxy
 cluster-proportional-autoscaler
 kubewatch
+kubeflow-katib
 hey
 external-resizer
 external-attacher


### PR DESCRIPTION
This includes:

katib-cert-generator
katib-db-manager
katib-earlystopping
katib-katib-controller
katib-metricscollector
katib-suggestion-skopt-enas
katib-suggestion-goptuna
katib-suggestion-hyperband
katib-suggestion-hyperopt
katib-suggestion-nas-darts
katib-suggestion-nas-enas
katib-suggestion-optuna-enas
katib-suggestion-pbt-enas

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`
