### PR TITLE
WIP: update protobuf build

### DIFF
--- a/protobuf.yaml
+++ b/protobuf.yaml
@@ -1,6 +1,6 @@
 package:
   name: protobuf
-  version: 3.21.12
+  version: 3.23.1
   epoch: 0
   description: Library for extensible, efficient structure packing
   copyright:
@@ -12,28 +12,23 @@ environment:
       - busybox
       - ca-certificates-bundle
       - build-base
-      - automake
-      - autoconf
-      - zlib-dev
-      - libtool
+      - bazel-6
+      - openjdk-17
+      - bash
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 930c2c3b5ecc6c9c12615cf5ad93f1cd6e12d0aba862b572e076259970ac3a53
-      uri: https://github.com/protocolbuffers/protobuf/archive/v${{package.version}}.tar.gz
+      repository: https://github.com/protocolbuffers/protobuf
+      tag: v${{package.version}}
+      expected-commit: 2dca62f7296e5b49d729f7384f975cecb38382a0
 
+  # https://github.com/protocolbuffers/protobuf/blob/main/src/README.md#c-protobuf---unix
   - runs: |
-      ./autogen.sh
-      # rm -rf third_party/googletest
-
-  - uses: autoconf/configure
-
-  - uses: autoconf/make
-
-  - uses: autoconf/make-install
-
-  - uses: strip
+      git submodule update --init --recursive
+      bazel build :protoc :protobuf
+      mkdir -p ${{targets.destdir}}/usr/bin
+      cp bazel-bin/protoc ${{targets.destdir}}/usr/bin
 
 subpackages:
   - name: protobuf-dev


### PR DESCRIPTION
protobuf updates don't pass ([example](https://github.com/wolfi-dev/os/pull/2116)) because the upstream project changed how they build, from using autogen.sh and autoconf to using Bazel.

This is a WIP draft attempt to get the build working with Bazel.