### PR TITLE
Remove pie from GOFLAGS

### DIFF
--- a/build-aarch64.env
+++ b/build-aarch64.env
@@ -3,4 +3,4 @@ export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1 
 export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now"
-export GOFLAGS="-buildmode=pie"
+export GOFLAGS=""

--- a/build-armv7l.env
+++ b/build-armv7l.env
@@ -3,4 +3,4 @@ export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv7-a+simd -mtune=cortex-
 export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now"
-export GOFLAGS="-buildmode=pie"
+export GOFLAGS=""

--- a/build-x86_64.env
+++ b/build-x86_64.env
@@ -2,4 +2,4 @@ export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell 
 export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now"
-export GOFLAGS="-buildmode=pie"
+export GOFLAGS=""


### PR DESCRIPTION
We don't think this setting has a worthwhile benefit to the Go binaries we're building. cc: @joshrwolf @kaniini 