### PR TITLE
Revert "add a fallback to the current timestamp for SOURCE_DATE_EPOCH"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,7 @@ $(pkgtarget): ${KEY}
 ifdef SOURCE_DATE_EPOCH
 	$(eval CONFIG_DATE_EPOCH := $(SOURCE_DATE_EPOCH))
 else
-	# Grab the files last commit timestamp, if it's not in git, use the current timestamp
-	$(eval CONFIG_DATE_EPOCH := $(shell git ls-files --error-unmatch $(pkgname).yaml &>/dev/null && git log -1 --pretty=%ct --follow $(pkgname).yaml || date +%s))
+	$(eval CONFIG_DATE_EPOCH := $(shell git log -1 --pretty=%ct --follow $(pkgname).yaml))
 endif
 	SOURCE_DATE_EPOCH=${CONFIG_DATE_EPOCH} ${MELANGE} build $(pkgname).yaml ${MELANGE_OPTS} --source-dir ./$(sourcedir)/ --log-policy builtin:stderr,${TARGETDIR}/buildlogs/$(pkgfullname).log
 


### PR DESCRIPTION
Reverts wolfi-dev/os#2216

Breaks the CI build:

https://github.com/wolfi-dev/os/actions/runs/5049441840/jobs/9058899488#step:12:17

```
SOURCE_DATE_EPOCH=py3-flit-core.yaml 1684781800 melange build py3-flit-core.yaml --repository-append /home/runner/work/os/os/packages --keyring-append wolfi-signing.rsa.pub --signing-key wolfi-signing.rsa --arch x86_64 --env-file build-x86_64.env --namespace wolfi --generate-index false  --cache-source gs://wolfi-sources/ --source-dir ./py3-flit-core/ --log-policy builtin:stderr,packages/x86_64/buildlogs/py3-flit-core-3.9.0-r0.log
```