### PR TITLE
rarian: Update  to 0.8.4 and pull source artifact from gitlab

### DIFF
--- a/rarian.yaml
+++ b/rarian.yaml
@@ -1,7 +1,7 @@
 package:
   name: rarian
-  version: 0.8.1
-  epoch: 2
+  version: 0.8.4
+  epoch: 0
   description: Documentation meta-data library, designed as a replacement for Scrollkeeper.
   copyright:
     - license: GPL-2.0+, LGPL-2.1+, Zlib
@@ -21,7 +21,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577
-      uri: https://download.gnome.org/sources/rarian/0.8/rarian-${{package.version}}.tar.bz2
+      uri: https://gitlab.freedesktop.org/rarian/rarian/-/releases/${{package.version}}/downloads/assets/rarian-.tar.bz2
 
   - uses: autoconf/configure
     with:

--- a/rarian.yaml
+++ b/rarian.yaml
@@ -21,7 +21,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577
-      uri: https://gitlab.freedesktop.org/rarian/rarian/-/releases/${{package.version}}/downloads/assets/rarian-.tar.bz2
+      uri: https://gitlab.freedesktop.org/rarian/rarian/-/releases/${{package.version}}/downloads/assets/rarian-${{package.version}}.tar.bz2
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
The project is now hosted on gitlab and so the 0.8.4 update is 404ing.