### PR TITLE
Add check-status to calico-kube-controllers

### DIFF
--- a/calicoctl.yaml
+++ b/calicoctl.yaml
@@ -40,6 +40,7 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/bin
       go build -v -o ${{targets.destdir}}/usr/bin/calicoctl -ldflags "$LDFLAGS" "./calicoctl/calicoctl"
       go build -v -o ${{targets.destdir}}/usr/bin/kube-controllers -ldflags "$LDFLAGS" "./kube-controllers/cmd/kube-controllers"
+      go build -v -o ${{targets.destdir}}/usr/bin/check-status -ldflags "$LDFLAGS" "./kube-controllers/cmd/check-status"
       go build -v -o ${{targets.destdir}}/usr/bin/cni-plugin -ldflags "$LDFLAGS" "./cni-plugin/cmd/calico"
 
   - uses: strip
@@ -51,6 +52,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/kube-controllers ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/check-status ${{targets.subpkgdir}}/usr/bin
 
   - name: "calico-cni-plugin"
     description: "calico cni plugin"


### PR DESCRIPTION
This is used for the liveness/readiness probes.