### PR TITLE
Bump the ko epoch to `r7`

### DIFF
--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.13.0 # When bumping the version check if the GHSA mitigations below can be removed.
-  epoch: 6
+  epoch: 7
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
This bumps the ko epoch to `r7` to confirm that `t:` shows up in our `APKINDEX.tar.gz` and triggers our "build date epoch" semantics.
