### PR TITLE
Add test config files to kube-bench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 packages/*
 melange-cache/*
 local-melange.rsa*
+melange.rsa*
 dag.svg
 .idea

--- a/kube-bench.yaml
+++ b/kube-bench.yaml
@@ -1,34 +1,43 @@
 package:
   name: kube-bench
   version: 0.6.14
-  epoch: 0
+  epoch: 1
   description: Checks whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - kubectl
 
 environment:
   contents:
     packages:
       - wolfi-baselayout
       - busybox
-      - build-base
-      - go
-      - ca-certificates-bundle
 
 pipeline:
-  # We can't use go/install because this requires specific ldflags to set the version
   - uses: git-checkout
     with:
       repository: https://github.com/aquasecurity/kube-bench
       tag: v${{package.version}}
       expected-commit: c2880848f05aaf87c1768c226840356a9a4688fd
-      destination: kube-bench
 
-  - runs: |
-      cd kube-bench
-      make build
-      mkdir -p ${{targets.destdir}}/usr/bin
-      install -Dm755 ./kube-bench  ${{targets.destdir}}/usr/bin/kube-bench
+  - uses: go/build
+    with:
+      modroot: .
+      packages: .
+      output: kube-bench
+      ldflags: |
+        -X github.com/aquasecurity/kube-bench/cmd.cfgDir=/etc/kube-bench/cfg
+        -X github.com/aquasecurity/kube-bench/cmd.KubeBenchVersion=v${{package.version}}
+
+subpackages:
+  - name: "kube-bench-configs"
+    description: "Configuration files for kube-bench"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc/kube-bench/cfg
+          cp -rv ./cfg/* ${{targets.subpkgdir}}/etc/kube-bench/cfg
 
 update:
   enabled: true


### PR DESCRIPTION
The kube-bench package needed config data (YAML files) to drive the tests it executes at runtime.