### PR TITLE
iptables: Enable IP forwarding rules

### DIFF
--- a/iptables.yaml
+++ b/iptables.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables
   version: "1.8.9"
-  epoch: 0
+  epoch: 1 
   description: Linux kernel firewall, NAT and packet mangling tools
   copyright:
     - license: GPL-2.0-or-later

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables
   version: "1.8.9"
-  epoch: 1 
+  epoch: 1
   description: Linux kernel firewall, NAT and packet mangling tools
   copyright:
     - license: GPL-2.0-or-later

--- a/iptables/ip6tables.confd
+++ b/iptables/ip6tables.confd
@@ -11,4 +11,4 @@ SAVE_RESTORE_OPTIONS="-c"
 SAVE_ON_STOP="yes"
 
 # Enable/disable IPv6 forwarding with the rules
-IPFORWARD="no"
+IPFORWARD="yes"

--- a/iptables/iptables.confd
+++ b/iptables/iptables.confd
@@ -11,4 +11,4 @@ SAVE_RESTORE_OPTIONS="-c"
 SAVE_ON_STOP="yes"
 
 # Enable/disable IPv4 forwarding with the rules
-IPFORWARD="no"
+IPFORWARD="yes"


### PR DESCRIPTION
* iptables: Enable IP forwarding rules

This will enable Istio sidecar proxy image to be built based on Wolfi iptables APK.