### PR TITLE
Add /opt and /run to wolfi-baselayout

### DIFF
--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 1
+  epoch: 2
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
@@ -40,7 +40,7 @@ pipeline:
 
   - name: Install
     runs: |
-      for i in bin etc etc/profile.d etc/secfixes.d home lib root var/log usr/bin usr/sbin usr/local tmp var/spool/cron; do
+      for i in bin etc etc/profile.d etc/secfixes.d home lib root var/log usr/bin usr/sbin usr/local tmp var/spool/cron opt run; do
         mkdir -p "${{targets.destdir}}"/${i}
       done
 


### PR DESCRIPTION
Fixes:

Fixes missing /opt and /run in all images using the wolfi-baselayout
