### PR TITLE
Add Sourcegraph CLI package.

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -684,3 +684,4 @@ newrelic-fluent-bit-output
 kaf
 dask-gateway
 http-echo
+src

--- a/src.yaml
+++ b/src.yaml
@@ -1,0 +1,38 @@
+package:
+  name: src
+  version: 5.0.3
+  epoch: 0
+  description: Sourcegraph CLI
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+      - git
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/sourcegraph/src-cli
+      expected-commit: f0e8fc23d8de8a3e3cb306da7f8444734ccf9f3b
+      tag: ${{package.version}}
+
+  - uses: go/build
+    with:
+      packages: ./cmd/src
+      output: src
+      ldflags: "-X github.com/sourcegraph/src-cli/internal/version.BuildTag=${{package.version}}"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: sourcegraph/src-cli


### PR DESCRIPTION
There's still an issue with the ldflags variable for the version not working.

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`
