### PR TITLE
boost: fix subpackage names

### DIFF
--- a/boost.yaml
+++ b/boost.yaml
@@ -115,7 +115,7 @@ subpackages:
       - uses: split/manpages
 
   - range: libs
-    name: boost-"${{range.key}}"
+    name: boost-${{range.key}}
     description: "${{range.key}} boost library"
     pipeline:
       - runs: |


### PR DESCRIPTION
```
curl -s https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz | tar -xO APKINDEX | grep P:boost-\" | uniq
P:boost-"atomic"
P:boost-"chrono"
P:boost-"container"
P:boost-"context"
P:boost-"contract"
P:boost-"coroutine"
P:boost-"date_time"
P:boost-"fiber"
P:boost-"filesystem"
P:boost-"graph"
P:boost-"iostreams"
P:boost-"math"
P:boost-"prg_exec_monitor"
P:boost-"program_options"
P:boost-"python3"
P:boost-"random"
P:boost-"regex"
P:boost-"serialization"
P:boost-"system"
P:boost-"thread"
P:boost-"unit_test_framework"
P:boost-"wave"
P:boost-"wserialization"
```

Maybe worth a lint check, or having melange check for valid package names while building.