### PR TITLE
`fping`: reorder the `strip` and `setcap`

### DIFF
--- a/fping.yaml
+++ b/fping.yaml
@@ -1,7 +1,7 @@
 package:
   name: fping
   version: 5.1
-  epoch: 0
+  epoch: 1
   description: A utility to ping multiple hosts at once
   copyright:
     - license: GPL-2.0-only
@@ -35,10 +35,10 @@ pipeline:
 
   - uses: autoconf/make-install
 
-  - runs: |
-      setcap cap_net_raw=+ep "${{targets.destdir}}"/usr/sbin/fping
-
   - uses: strip
+
+  # This MUST run after strip, which strips capabilities too!
+  - runs: setcap cap_net_raw=+ep "${{targets.destdir}}"/usr/sbin/fping
 
 subpackages:
   - name: "fping-doc"


### PR DESCRIPTION
It turns out `strip` strips the capabilities from a file's `xattrs`, so running `setcap` prior to `strip` is pointless.

This reorders the strip/setcap and bumps the epoch of fping.
