### PR TITLE
fix policy violations in YAML files

### DIFF
--- a/argon2.yaml
+++ b/argon2.yaml
@@ -7,10 +7,10 @@ package:
     - license: Apache-2.0
 
 environment:
+  environment:
+    PREFIX: ${{targets.destdir}}
+    DESTDIR: ${{targets.destdir}}
   contents:
-    environment:
-      PREFIX: ${{targets.destdir}}
-      DESTDIR: ${{targets.destdir}}
     packages:
       - wolfi-base
       - build-base

--- a/argon2.yaml
+++ b/argon2.yaml
@@ -7,9 +7,6 @@ package:
     - license: Apache-2.0
 
 environment:
-  environment:
-    PREFIX: ${{targets.destdir}}
-    DESTDIR: ${{targets.destdir}}
   contents:
     packages:
       - wolfi-base

--- a/exim.yaml
+++ b/exim.yaml
@@ -27,7 +27,6 @@ environment:
       - build-base
       - ca-certificates-bundle
   accounts:
-    runs: exim
     users:
       - username: exim
         uid: 1001

--- a/fastjar.yaml
+++ b/fastjar.yaml
@@ -42,6 +42,6 @@ subpackages:
       - uses: split/manpages
 
 update:
-  enable: true
+  enabled: true
   release-monitor:
     identifier: 14692

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -12,7 +12,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
-  env:
+  environment:
     CGO_ENABLED: "0"
 
 pipeline:

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -12,7 +12,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
-  env:
+  environment:
     CGO_ENABLED: 0
 
 pipeline:

--- a/grpc-health-probe.yaml
+++ b/grpc-health-probe.yaml
@@ -13,7 +13,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
-  env:
+  environment:
     CGO_ENABLED: "0"
 
 pipeline:

--- a/iproute2.yaml
+++ b/iproute2.yaml
@@ -1,7 +1,7 @@
 package:
   name: iproute2
   version: 6.3.0
-  epoch: 0
+  epoch: 1
   description: IP Routing Utilities
   copyright:
     - license: GPL-2.0-or-later
@@ -44,7 +44,8 @@ pipeline:
 subpackages:
   - name: iproute2-doc
     description: iproute2 documentation
-    uses: autoconf/split-manpages
+    pipeline:
+      - uses: split/manpages
 
 update:
   enabled: true

--- a/java-common.yaml
+++ b/java-common.yaml
@@ -19,4 +19,4 @@ pipeline:
       done
 
 update:
-  enable: false
+  enabled: false

--- a/kubernetes-csi-external-snapshotter.yaml
+++ b/kubernetes-csi-external-snapshotter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-snapshotter
   version: 6.2.1
-  epoch: 0
+  epoch: 1
   description: Sidecar container that watches Kubernetes Snapshot CRD objects and triggers CreateSnapshot/DeleteSnapshot against a CSI endpoint
   copyright:
     - license: Apache-2.0
@@ -29,14 +29,16 @@ pipeline:
 
 subpackages:
   - name: kubernetes-csi-external-snapshot-controller
-    runs: |
-      mkdir -p ${{targets.destdir}}/usr/bin
-      install -Dm755 ./bin/snapshot-controller ${{targets.subpkgdir}}/usr/bin/snapshot-controller
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.destdir}}/usr/bin
+          install -Dm755 ./bin/snapshot-controller ${{targets.subpkgdir}}/usr/bin/snapshot-controller
 
   - name: kubernetes-csi-external-snapshot-validation-webhook
-    runs: |
-      mkdir -p ${{targets.destdir}}/usr/bin
-      install -Dm755 ./bin/snapshot-validation-webhook ${{targets.subpkgdir}}/usr/bin/snapshot-validation-webhook
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.destdir}}/usr/bin
+          install -Dm755 ./bin/snapshot-validation-webhook ${{targets.subpkgdir}}/usr/bin/snapshot-validation-webhook
 
 update:
   enabled: true

--- a/ratelimit.yaml
+++ b/ratelimit.yaml
@@ -17,4 +17,4 @@ pipeline:
       mv ${{targets.destdir}}/usr/bin/service_cmd ${{targets.destdir}}/usr/bin/ratelimit
 
 update:
-  enables: false
+  enabled: false

--- a/unbound.yaml
+++ b/unbound.yaml
@@ -1,7 +1,7 @@
 package:
   name: unbound
   version: 1.17.1
-  epoch: 0
+  epoch: 1
   description: "Unbound is a validating, recursive, and caching DNS resolver."
   copyright:
     - license: BSD-3-Clause
@@ -27,10 +27,10 @@ pipeline:
 
   - uses: autoconf/configure
     with:
-    opts: |
-      --with-libevent \
-      --with-expat \
-      --enable-dnscrypt
+      opts: |
+        --with-libevent \
+        --with-expat \
+        --enable-dnscrypt
 
   - uses: autoconf/make
 


### PR DESCRIPTION
These policy violations were found as a result of chainguard-dev/melange#465, which made it an explicit policy violation to use undefined keywords in the melange package definitions.