### PR TITLE
change ratelimit package name, add compat package for upstream helm chart

### DIFF
--- a/envoy-ratelimit.yaml
+++ b/envoy-ratelimit.yaml
@@ -1,5 +1,5 @@
 package:
-  name: ratelimit
+  name: envoy-ratelimit
   # This project doesn't do releases and everything is commit based.
   # This corresponds to commit e2a87f41d3a78d54eda197b3d49fcdcbca9a4f48
   version: "0.0_git20230508"
@@ -15,6 +15,15 @@ pipeline:
 
   - runs: |
       mv ${{targets.destdir}}/usr/bin/service_cmd ${{targets.destdir}}/usr/bin/ratelimit
+
+subpackages:
+  - name: "envoy-ratelimit-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          # The helm chart expects the ratelimit binary to be in /bin instead of /usr/bin
+          mkdir -p "${{targets.subpkgdir}}"/bin
+          ln -sf /usr/bin/ratelimit ${{targets.subpkgdir}}/bin/ratelimit
 
 update:
   enabled: false

--- a/packages.txt
+++ b/packages.txt
@@ -499,7 +499,7 @@ metrics-server
 k8s-sidecar
 prometheus-config-reloader
 prometheus-operator
-ratelimit
+envoy-ratelimit
 logstash
 ntpd-rs
 trust-dns

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -3,3 +3,4 @@ py3.10-installer-0.7.0-r0.apk
 py3.10-installer-0.7.0-r1.apk
 erlang-26.0-r0.apk
 erlang-dev-26.0-r0.apk
+ratelimit-0.0_git20230508-r0.apk


### PR DESCRIPTION


<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
