### PR TITLE
Vault: Add entrypoint subpackage 

### DIFF
--- a/vault.yaml
+++ b/vault.yaml
@@ -58,7 +58,7 @@ pipeline:
       # We can later delete the sbin one.
       mkdir "${{targets.destdir}}/usr/bin"
       chmod 755 "${{targets.destdir}}/usr/bin"
-      ln -s "${{targets.destdir}}/usr/sbin/vault" "${{targets.destdir}}/usr/bin/vault"
+      ln -s /usr/sbin/vault "${{targets.destdir}}/usr/bin/vault"
 
       install -m644 -D "./vault.hcl" "${{targets.destdir}}/etc/vault/vault.hcl"
 

--- a/vault.yaml
+++ b/vault.yaml
@@ -54,11 +54,30 @@ pipeline:
       install -m644 -D "./vault.confd" "${{targets.destdir}}/etc/conf.d/vault"
 
       install -m755 -D ./vault/bin/vault "${{targets.destdir}}/usr/sbin/vault"
+      # Really want to move the binary out of sbin. Let's have it in two locations temporarily
+      # We can later delete the sbin one.
+      mkdir "${{targets.destdir}}/usr/bin"
+      chmod 755 "${{targets.destdir}}/usr/bin"
+      ln -s "${{targets.destdir}}/usr/sbin/vault" "${{targets.destdir}}/usr/bin/vault"
+
       install -m644 -D "./vault.hcl" "${{targets.destdir}}/etc/vault/vault.hcl"
 
       install -m750 -d "${{targets.destdir}}/var/lib/vault"
 
   - uses: strip
+
+subpackages:
+  - name: "vault-entrypoint"
+    description: "Container entrypoint script for vault and required dependencies"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/bin"
+          cp ./vault/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/docker-entrypoint.sh"
+
+    dependencies:
+      runtime:
+        - dumb-init
+        - busybox
 
 update:
   enabled: true

--- a/vault.yaml
+++ b/vault.yaml
@@ -66,7 +66,6 @@ pipeline:
 
   - uses: strip
 
-    # Apparently caps have to be set after strip!
   - runs: setcap cap_ipc_lock=+ep "${{targets.destdir}}/usr/bin/vault"
 
 subpackages:

--- a/vault.yaml
+++ b/vault.yaml
@@ -15,6 +15,7 @@ environment:
       - python3
       - nodejs-16
       - yarn
+      - libcap-utils
 
 pipeline:
   - uses: git-checkout
@@ -54,8 +55,9 @@ pipeline:
       install -m644 -D "./vault.confd" "${{targets.destdir}}/etc/conf.d/vault"
 
       install -m755 -D ./vault/bin/vault "${{targets.destdir}}/usr/sbin/vault"
-      # Really want to move the binary out of sbin. Let's have it in two locations temporarily
-      # We can later delete the sbin one.
+      setcap cap_ipc_lock=+ep  "${{targets.destdir}}/usr/sbin/vault"
+      # Binary doesn't require root, so let's move it out of sbin - for a temporary period have it
+      # in both locations. We can later delete the sbin one.
       mkdir "${{targets.destdir}}/usr/bin"
       chmod 755 "${{targets.destdir}}/usr/bin"
       ln -s /usr/sbin/vault "${{targets.destdir}}/usr/bin/vault"

--- a/vault.yaml
+++ b/vault.yaml
@@ -73,7 +73,6 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"
           cp ./vault/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/docker-entrypoint.sh"
-
     dependencies:
       runtime:
         - dumb-init

--- a/vault.yaml
+++ b/vault.yaml
@@ -62,9 +62,11 @@ pipeline:
       chmod 755 "${{targets.destdir}}/usr/bin"
       ln -s /usr/sbin/vault "${{targets.destdir}}/usr/bin/vault"
 
-      install -m644 -D "./vault.hcl" "${{targets.destdir}}/etc/vault/vault.hcl"
+      mkdir "${{targets.destdir}}/etc/vault"
+      chmod 755 "${{targets.destdir}}/etc/vault"
 
-      install -m750 -d "${{targets.destdir}}/var/lib/vault"
+      install -m755 -d "${{targets.destdir}}/var/lib/vault"
+      install -m755 -d "${{targets.destdir}}/var/log/vault"
 
   - uses: strip
 
@@ -74,11 +76,13 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"
-          cp ./vault/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/docker-entrypoint.sh"
+          install -m755 ./docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/docker-entrypoint.sh"
     dependencies:
       runtime:
         - dumb-init
         - busybox
+        - su-exec
+        - libcap-utils
 
 update:
   enabled: true

--- a/vault.yaml
+++ b/vault.yaml
@@ -58,11 +58,12 @@ pipeline:
 
       # Directory for config
       mkdir "${{targets.destdir}}/etc/vault"
-      chmod 755 "${{targets.destdir}}/etc/vault"
+      # Vault user must be able to write to this
+      chmod 777 "${{targets.destdir}}/etc/vault"
 
       # Directory for logs
-      install -m755 -d "${{targets.destdir}}/var/lib/vault"
-      install -m755 -d "${{targets.destdir}}/var/log/vault"
+      install -m777 -d "${{targets.destdir}}/var/lib/vault"
+      install -m777 -d "${{targets.destdir}}/var/log/vault"
 
   - uses: strip
 

--- a/vault.yaml
+++ b/vault.yaml
@@ -55,7 +55,6 @@ pipeline:
       install -m644 -D "./vault.confd" "${{targets.destdir}}/etc/conf.d/vault"
 
       install -m755 -D ./vault/bin/vault "${{targets.destdir}}/usr/bin/vault"
-      setcap cap_ipc_lock=+ep  "${{targets.destdir}}/usr/bin/vault"
 
       # Directory for config
       mkdir "${{targets.destdir}}/etc/vault"
@@ -66,6 +65,9 @@ pipeline:
       install -m755 -d "${{targets.destdir}}/var/log/vault"
 
   - uses: strip
+
+    # Apparently caps have to be set after strip!
+  - runs: setcap cap_ipc_lock=+ep "${{targets.destdir}}/usr/bin/vault"
 
 subpackages:
   - name: "vault-entrypoint"

--- a/vault.yaml
+++ b/vault.yaml
@@ -54,17 +54,14 @@ pipeline:
   - runs: |
       install -m644 -D "./vault.confd" "${{targets.destdir}}/etc/conf.d/vault"
 
-      install -m755 -D ./vault/bin/vault "${{targets.destdir}}/usr/sbin/vault"
-      setcap cap_ipc_lock=+ep  "${{targets.destdir}}/usr/sbin/vault"
-      # Binary doesn't require root, so let's move it out of sbin - for a temporary period have it
-      # in both locations. We can later delete the sbin one.
-      mkdir "${{targets.destdir}}/usr/bin"
-      chmod 755 "${{targets.destdir}}/usr/bin"
-      ln -s /usr/sbin/vault "${{targets.destdir}}/usr/bin/vault"
+      install -m755 -D ./vault/bin/vault "${{targets.destdir}}/usr/bin/vault"
+      setcap cap_ipc_lock=+ep  "${{targets.destdir}}/usr/bin/vault"
 
+      # Directory for config
       mkdir "${{targets.destdir}}/etc/vault"
       chmod 755 "${{targets.destdir}}/etc/vault"
 
+      # Directory for logs
       install -m755 -d "${{targets.destdir}}/var/lib/vault"
       install -m755 -d "${{targets.destdir}}/var/log/vault"
 
@@ -77,6 +74,10 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"
           install -m755 ./docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/docker-entrypoint.sh"
+
+          # The upstream helm chart expects the entrypoint in /usr/local/bin
+          mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
+          ln -s /usr/bin/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/local/bin/docker-entrypoint.sh"
     dependencies:
       runtime:
         - dumb-init

--- a/vault/docker-entrypoint.sh
+++ b/vault/docker-entrypoint.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/dumb-init /bin/sh
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+# Modified by Chainguard 
+
+set -e
+
+# Note above that we run dumb-init as PID 1 in order to reap zombie processes
+# as well as forward signals to all processes in its session. Normally, sh
+# wouldn't do either of these functions so we'd leak zombies as well as do
+# unclean termination of all our sub-processes.
+
+# Prevent core dumps
+ulimit -c 0
+
+# Allow setting VAULT_REDIRECT_ADDR and VAULT_CLUSTER_ADDR using an interface
+# name instead of an IP address. The interface name is specified using
+# VAULT_REDIRECT_INTERFACE and VAULT_CLUSTER_INTERFACE environment variables. If
+# VAULT_*_ADDR is also set, the resulting URI will combine the protocol and port
+# number with the IP of the named interface.
+get_addr () {
+    local if_name=$1
+    local uri_template=$2
+    ip addr show dev $if_name | awk -v uri=$uri_template '/\s*inet\s/ { \
+      ip=gensub(/(.+)\/.+/, "\\1", "g", $2); \
+      print gensub(/^(.+:\/\/).+(:.+)$/, "\\1" ip "\\2", "g", uri); \
+      exit}'
+}
+
+if [ -n "$VAULT_REDIRECT_INTERFACE" ]; then
+    export VAULT_REDIRECT_ADDR=$(get_addr $VAULT_REDIRECT_INTERFACE ${VAULT_REDIRECT_ADDR:-"http://0.0.0.0:8200"})
+    echo "Using $VAULT_REDIRECT_INTERFACE for VAULT_REDIRECT_ADDR: $VAULT_REDIRECT_ADDR"
+fi
+if [ -n "$VAULT_CLUSTER_INTERFACE" ]; then
+    export VAULT_CLUSTER_ADDR=$(get_addr $VAULT_CLUSTER_INTERFACE ${VAULT_CLUSTER_ADDR:-"https://0.0.0.0:8201"})
+    echo "Using $VAULT_CLUSTER_INTERFACE for VAULT_CLUSTER_ADDR: $VAULT_CLUSTER_ADDR"
+fi
+
+
+#
+# File storage points to `/var/lib/vault` (which is created)
+# MUST ADD DOCUMENTATION ON THIS, SO USER CAN MOUNT A VOLUME
+#
+# Upstream does set various env vars
+# https://developer.hashicorp.com/vault/docs/commands#environment-variables 
+#
+# Note vault loads all files ending in .hcl or .json in the config dir
+
+
+# Users can add additional config files to this directory as json or hcl. 
+# Also note VAULT_LOCAL_CONFIG below
+VAULT_CONFIG_DIR=/etc/vault
+
+# Used to store encrypted secrets with filesystem driver. 
+VAULT_FILE_DIR=/var/lib/vault 
+# logs dir
+VAULT_LOGS_DIR=/var/log/vault
+
+# You can also set the VAULT_LOCAL_CONFIG environment variable to pass some
+# Vault configuration JSON without having to bind any volumes.
+if [ -n "$VAULT_LOCAL_CONFIG" ]; then
+    echo "$VAULT_LOCAL_CONFIG" > "$VAULT_CONFIG_DIR/local.json"
+fi
+
+# If the user is trying to run Vault directly with some arguments, then
+# pass them to Vault.
+if [ "${1:0:1}" = '-' ]; then
+    set -- vault "$@"
+fi
+
+# Look for Vault subcommands.
+if [ "$1" = 'server' ]; then
+    shift
+    set -- vault server \
+        -config="$VAULT_CONFIG_DIR" \
+        -dev-root-token-id="$VAULT_DEV_ROOT_TOKEN_ID" \
+        -dev-listen-address="${VAULT_DEV_LISTEN_ADDRESS:-"0.0.0.0:8200"}" \
+        "$@"
+elif [ "$1" = 'version' ]; then
+    # This needs a special case because there's no help output.
+    set -- vault "$@"
+elif vault --help "$1" 2>&1 | grep -q "vault $1"; then
+    # We can't use the return code to check for the existence of a subcommand, so
+    # we have to use grep to look for a pattern in the help output.
+    set -- vault "$@"
+fi
+
+# If we are running Vault and root, make sure it executes as the proper user.
+if [ "$1" = 'vault' ] && [ "$(id -u)" = '0' ]; then
+    if [ -z "$SKIP_CHOWN" ]; then
+        # If the config dir is bind mounted then chown it
+        if [ "$(stat -c %u $VAULT_CONFIG_DIR)" != "$(id -u vault)" ]; then
+            chown -R vault:vault $VAULT_CONFIG_DIR || echo "Could not chown $VAULT_CONFIG_DIR (may not have appropriate permissions)"
+        fi
+
+        # If the logs dir is bind mounted then chown it
+        if [ "$(stat -c %u $VAULT_LOGS_DIR)" != "$(id -u vault)" ]; then
+            chown -R vault:vault $VAULT_LOGS_DIR
+        fi
+
+        # If the file dir is bind mounted then chown it
+        if [ "$(stat -c %u $VAULT_FILE_DIR)" != "$(id -u vault)" ]; then
+            chown -R vault:vault $VAULT_FILE_DIR
+        fi
+    fi
+
+    # In the case vault has been started in a container without IPC_LOCK privileges
+    # Note this will probably require running as root and setcap
+    if ! vault -version 1>/dev/null 2>/dev/null; then
+	>&2 echo "Couldn't start vault with IPC_LOCK. Disabling IPC_LOCK, please use --cap-add IPC_LOCK"
+	setcap cap_ipc_lock=-ep $(readlink -f $(which vault))
+    fi
+
+    set -- su-exec vault "$@"
+fi
+
+exec "$@"

--- a/vault/vault.confd
+++ b/vault/vault.confd
@@ -1,1 +1,1 @@
-vault_opts="server -config=/etc/vault.hcl"
+vault_opts="server -config=/etc/vault"


### PR DESCRIPTION
Should allow us to create an image that is close to upstream and usable as Helm replacement.

Also made symlink of vault binary to /usr/bin/, so we can later remove it from /usr/sbin
