### PR TITLE
Revert "mongo-tools/100.7.1 package update"

### DIFF
--- a/mongo-tools.yaml
+++ b/mongo-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: mongo-tools
-  version: 100.7.1
-  epoch: 0
+  version: 100.7.0 # TODO: enable auto updates when mongo-tools is updated to > 100.7.1
+  epoch: 2
   description: Tools for MongoDB
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: https://github.com/mongodb/mongo-tools
       tag: ${{package.version}}
-      expected-commit: 37b612251ce19ea92aa07b5b19fde10557e81a27
+      expected-commit: 17946f45f5fabfcdd99f8960b9109f976d370631
 
   - runs: |
       ./make build
@@ -29,6 +29,7 @@ pipeline:
 
 update:
   enabled: true
+  manual: true # TODO: remove when mongo-tools is updated to > 100.7.1
   github:
     identifier: mongodb/mongo-tools
     strip-prefix: v

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -4,3 +4,4 @@ py3.10-installer-0.7.0-r1.apk
 erlang-26.0-r0.apk
 erlang-dev-26.0-r0.apk
 ratelimit-0.0_git20230508-r0.apk
+mongo-tools-100.7.1-r0.apk


### PR DESCRIPTION
ARM releases are broken with this update

And withdraw package version as x86 did pass.

```
exit 0
ℹ️  aarch64   | START  | build
⚠️  aarch64   | panic: ubuntu1804 platform name changed
⚠️  aarch64   |
⚠️  aarch64   | goroutine 1 [running]:
⚠️  aarch64   | github.com/mongodb/mongo-tools/release/platform.DetectLocal()
```

https://github.com/wolfi-dev/os/actions/runs/5078444818/jobs/9124388927

This reverts commit 60f6ee8e831cbf966aa0843c4db4b3dd88eb4165.

