### PR TITLE
unset SOURCE_DATE_EPOCH for jdk18,19,20

### DIFF
--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -64,7 +64,10 @@ pipeline:
     with:
       patches: FixNullPtrCast.patch detect-busybox-date-as-gnu-date.patch
 
-  - runs: chmod +x configure
+  - runs: |
+      # does not support timestamps before 1980
+      unset SOURCE_DATE_EPOCH
+      chmod +x configure
 
   - uses: autoconf/configure
     with:

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -64,7 +64,10 @@ pipeline:
     with:
       patches: FixNullPtrCast.patch JDK-8282306_disable-test.patch
 
-  - runs: chmod +x configure
+  - runs: |
+      # does not support timestamps before 1980
+      unset SOURCE_DATE_EPOCH
+      chmod +x configure
 
   - uses: autoconf/configure
     with:

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -64,7 +64,10 @@ pipeline:
     with:
       patches: FixNullPtrCast.patch JDK-8282306_disable-test.patch JDK-8299245_disable-tests.patch
 
-  - runs: chmod +x configure
+  - runs: |
+      #does not support timestamps before 1980
+      unset SOURCE_DATE_EPOCH
+      chmod +x configure
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
Fixes JDK 18,19,20 builds 
