### PR TITLE
Pass `-ldflags '-s -w'` for all Go builds.

### DIFF
--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -2,7 +2,7 @@ package:
   name: buildkitd
   version: 0.11.6
   description: "concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
 
@@ -37,12 +37,12 @@ pipeline:
 
       mkdir -p ${{targets.destdir}}/usr/bin
       go build \
-        -ldflags "-X ${PKG}/version.Version=${VERSION} -X ${PKG}/version.Revision=${REVISION} -X ${PKG}/version.Package=${PKG} -extldflags '-static'" \
+        -ldflags "-s -w -X ${PKG}/version.Version=${VERSION} -X ${PKG}/version.Revision=${REVISION} -X ${PKG}/version.Package=${PKG} -extldflags '-static'" \
         -tags "osusergo netgo static_build seccomp" \
         -o ${{targets.destdir}}/usr/bin/buildkitd ./cmd/buildkitd
 
       go build \
-        -ldflags "-X ${PKG}/version.Version=${VERSION} -X ${PKG}/version.Revision=${REVISION} -X ${PKG}/version.Package=${PKG} -extldflags '-static'" \
+        -ldflags "-s -w -X ${PKG}/version.Version=${VERSION} -X ${PKG}/version.Revision=${REVISION} -X ${PKG}/version.Package=${PKG} -extldflags '-static'" \
         -o ${{targets.destdir}}/usr/bin/buildctl ./cmd/buildctl
 
   - uses: strip

--- a/chartmuseum.yaml
+++ b/chartmuseum.yaml
@@ -1,7 +1,7 @@
 package:
   name: chartmuseum
   version: 0.15.0
-  epoch: 2
+  epoch: 3
   description: helm chart repository server
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
 
   - runs: |
       cd chartmuseum
-      CGO_ENABLED=0 go build --ldflags="-w -X main.Version=${{package.version}} \
+      CGO_ENABLED=0 go build --ldflags="-s -w -X main.Version=${{package.version}} \
         -X main.Revision=$(git rev-parse --short HEAD)" \
         -o "${{targets.destdir}}/usr/bin/chartmuseum" \
         cmd/chartmuseum/main.go

--- a/cluster-autoscaler.yaml
+++ b/cluster-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler
   version: 1.27.1
-  epoch: 1
+  epoch: 2
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,7 @@ pipeline:
       modroot: cluster-autoscaler
       packages: .
       output: cluster-autoscaler
+      ldflags: -s -w
 
   - uses: strip
 

--- a/cluster-proportional-autoscaler.yaml
+++ b/cluster-proportional-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-proportional-autoscaler
   version: 1.8.8
-  epoch: 0
+  epoch: 1
   description: Kubernetes Cluster Proportional Autoscaler Container
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ pipeline:
       modroot: .
       packages: ./cmd/cluster-proportional-autoscaler
       output: cluster-proportional-autoscaler
-      ldflags: -X github.com/kubernetes-sigs/cluster-proportional-autoscaler/pkg/version.VERSION=v${{package.version}}
+      ldflags: -s -w -X github.com/kubernetes-sigs/cluster-proportional-autoscaler/pkg/version.VERSION=v${{package.version}}
 
   - uses: strip
 

--- a/cortex.yaml
+++ b/cortex.yaml
@@ -1,7 +1,7 @@
 package:
   name: cortex
   version: 1.15.2
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,8 @@ pipeline:
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
       go build -ldflags \
-        "-X main.Branch=$(git rev-parse --abbrev-ref HEAD) \
+        "-s -w \
+        -X main.Branch=$(git rev-parse --abbrev-ref HEAD) \
         -X main.Revision=$(git rev-parse --short HEAD) \
         -X main.Version=$(cat ./VERSION)" \
         -o ${{targets.destdir}}/usr/bin/cortex ./cmd/cortex

--- a/cosign.yaml
+++ b/cosign.yaml
@@ -1,7 +1,7 @@
 package:
   name: cosign
   version: 2.0.2
-  epoch: 2
+  epoch: 3
   description: Container Signing
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
     with:
       packages: ./cmd/cosign
       output: cosign
-      ldflags: -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}}
+      ldflags: -s -w -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}}
 
 update:
   enabled: true

--- a/crane.yaml
+++ b/crane.yaml
@@ -1,7 +1,7 @@
 package:
   name: crane
   version: 0.15.2
-  epoch: 0
+  epoch: 1
   description: Tool for interacting with remote images and registries.
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,7 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cmd/crane
-      ldflags: -buildid= -X github.com/google/go-containerregistry/cmd/crane/cmd.Version=${{package.version}} -X github.com/google/go-containerregistry/pkg/v1/remote/transport.Version=${{package.version}}
+      ldflags: -s -w -buildid= -X github.com/google/go-containerregistry/cmd/crane/cmd.Version=${{package.version}} -X github.com/google/go-containerregistry/pkg/v1/remote/transport.Version=${{package.version}}
       output: crane
 
   - uses: strip

--- a/docker-credential-ecr-login.yaml
+++ b/docker-credential-ecr-login.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-credential-ecr-login
   version: 0.7.1
-  epoch: 0
+  epoch: 1
   description: Credential helper for Docker to use the AWS Elastic Container Registry
   copyright:
     - license: Apache-2.0
@@ -22,7 +22,7 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cli/docker-credential-ecr-login
-      ldflags: -X github.com/awslabs/amazon-ecr-credential-helper/ecr-login/version.Version=${{package.version}}
+      ldflags: -s -w -X github.com/awslabs/amazon-ecr-credential-helper/ecr-login/version.Version=${{package.version}}
       output: docker-credential-ecr-login
 
   - uses: strip

--- a/ferretdb.yaml
+++ b/ferretdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: ferretdb
   version: 1.2.1
-  epoch: 0
+  epoch: 1
   description: "A truly Open Source MongoDB alternative"
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,7 @@ pipeline:
       packages: ./cmd/ferretdb
       output: ferretdb
       tags: ferretdb_tigris
+      ldflags: -s -w
 
   - uses: strip
 

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-helm-controller
   version: 0.33.0
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit Helm reconciler, for declarative Helming
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,7 @@ pipeline:
     with:
       packages: .
       output: helm-controller
+      ldflags: -s -w
 
   - uses: strip
 

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-kustomize-controller
   version: 0.35.1
-  epoch: 3
+  epoch: 4
   description: The GitOps Toolkit Kustomize reconciler
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,7 @@ pipeline:
     with:
       packages: .
       output: kustomize-controller
+      ldflags: -s -w
 
   - uses: strip
 

--- a/gatekeeper.yaml
+++ b/gatekeeper.yaml
@@ -1,7 +1,7 @@
 package:
   name: gatekeeper
   version: 3.12.0
-  epoch: 0
+  epoch: 1
   description: Gatekeeper - Policy Controller for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
       cd gatekeeper
       FRAMEWORKS_VERSION=$(go list -f '{{ .Version }}' -m github.com/open-policy-agent/frameworks/constraint)
       OPA_VERSION=$(go list -f '{{ .Version }}' -m github.com/open-policy-agent/opa)
-      CGO_ENABLED=0 GO111MODULE=on go build -mod vendor -a -ldflags "-X github.com/open-policy-agent/gatekeeper/pkg/version.Version=v${{package.version}} -X main.frameworksVersion=${FRAMEWORKS_VERSION} -X main.opaVersion=${OPA_VERSION}" -o manager
+      CGO_ENABLED=0 GO111MODULE=on go build -mod vendor -a -ldflags "-s -w -X github.com/open-policy-agent/gatekeeper/pkg/version.Version=v${{package.version}} -X main.frameworksVersion=${FRAMEWORKS_VERSION} -X main.opaVersion=${OPA_VERSION}" -o manager
       mkdir -p ${{targets.destdir}}/usr/bin
       install -Dm755 ./manager ${{targets.destdir}}/usr/bin/manager
 

--- a/git-lfs.yaml
+++ b/git-lfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-lfs
   version: 3.3.0
-  epoch: 8
+  epoch: 9
   description: "large file support for git"
   copyright:
     - license: MIT
@@ -39,7 +39,7 @@ pipeline:
 
   - runs: |
       cd git-lfs
-      make EXTRA_GO_FLAGS="-v -tags netcgo" EXTRA_LD_FLAGS="-extldflags '${LDFLAGS}'" VERSION="v${{package.version}}"
+      make EXTRA_GO_FLAGS="-v -tags netcgo" EXTRA_LD_FLAGS="-s -w -extldflags '${LDFLAGS}'" VERSION="v${{package.version}}"
       install -Dm755 bin/git-lfs "${{targets.destdir}}"/usr/bin/git-lfs
 
   - uses: strip

--- a/go-bindata.yaml
+++ b/go-bindata.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-bindata
   version: 3.1.3
-  epoch: 6
+  epoch: 7
   description: A small utility which generates Go code from any file
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,7 @@ pipeline:
     with:
       packages: ./go-bindata
       output: go-bindata
+      ldflags: -s -w
 
 update:
   enabled: true

--- a/go-md2man.yaml
+++ b/go-md2man.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-md2man
   version: 2.0.2
-  epoch: 2
+  epoch: 3
   description: Utility to convert markdown to man pages
   copyright:
     - license: MIT
@@ -24,6 +24,7 @@ pipeline:
     with:
       packages: .
       output: go-md2man
+      ldflags: -s -w
 
   - runs: |
       ${{targets.destdir}}/usr/bin/go-md2man -in go-md2man.1.md -out go-md2man.1

--- a/grpc-health-probe.yaml
+++ b/grpc-health-probe.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-health-probe
   version: 0.4.18
-  epoch: 1
+  epoch: 2
   description: A command-line tool to perform health-checks for gRPC applications in Kubernetes and elsewhere
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,7 @@ pipeline:
       packages: .
       output: grpc_health_probe
       tags: netgo
+      ldflags: -s -w
 
   - uses: strip
 

--- a/grpcurl.yaml
+++ b/grpcurl.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpcurl
   version: 1.8.7
-  epoch: 3
+  epoch: 4
   description: CLI tool to interact with gRPC servers
   target-architecture:
     - all
@@ -31,7 +31,7 @@ pipeline:
     with:
       packages: ./cmd/grpcurl
       output: grpcurl
-      ldflags: -X main.version=v${{package.version}}
+      ldflags: -s -w -X main.version=v${{package.version}}
 
   - uses: strip
 

--- a/grype.yaml
+++ b/grype.yaml
@@ -1,7 +1,7 @@
 package:
   name: grype
   version: 0.62.2
-  epoch: 0
+  epoch: 1
   description: Vulnerability scanner for container images, filesystems, and SBOMs
   copyright:
     - license: Apache-2.0
@@ -21,7 +21,7 @@ pipeline:
 
   - runs: |
       CGO_ENABLED=0 go build \
-        -ldflags "-X github.com/anchore/grype/internal/version.version=${{package.version}}" \
+        -ldflags "-s -w -X github.com/anchore/grype/internal/version.version=${{package.version}}" \
         -o "${{targets.destdir}}/usr/bin/grype"
 
 update:

--- a/k8sgpt-operator.yaml
+++ b/k8sgpt-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8sgpt-operator
   version: 0.0.16
-  epoch: 0
+  epoch: 1
   description: Automatic SRE Superpowers within your Kubernetes cluster
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,6 @@ environment:
       - ca-certificates-bundle
 
 pipeline:
-  # We can't use go/install because this requires specific ldflags to set the version
   - uses: git-checkout
     with:
       repository: https://github.com/k8sgpt-ai/k8sgpt-operator
@@ -27,6 +26,7 @@ pipeline:
     with:
       packages: .
       output: manager
+      ldflags: -s -w
 
 update:
   enabled: true

--- a/kube-bench.yaml
+++ b/kube-bench.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-bench
   version: 0.6.14
-  epoch: 1
+  epoch: 2
   description: Checks whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,7 @@ pipeline:
       packages: .
       output: kube-bench
       ldflags: |
+        -s -w
         -X github.com/aquasecurity/kube-bench/cmd.cfgDir=/etc/kube-bench/cfg
         -X github.com/aquasecurity/kube-bench/cmd.KubeBenchVersion=v${{package.version}}
 

--- a/kubernetes-csi-external-provisioner.yaml
+++ b/kubernetes-csi-external-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
-  epoch: 0
   name: kubernetes-csi-external-provisioner
   version: 3.5.0
+  epoch: 1
   description: A dynamic provisioner for Kubernetes CSI plugins.
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
     with:
       packages: ./cmd/csi-provisioner
       output: csi-provisioner
-      ldflags: -X main.version=${{package.version}}
+      ldflags: -s -w -X main.version=${{package.version}}
 
 update:
   enabled: true

--- a/kubernetes-csi-livenessprobe.yaml
+++ b/kubernetes-csi-livenessprobe.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-livenessprobe
   version: 2.10.0
-  epoch: 0
+  epoch: 1
   description: A sidecar container that can be included in a CSI plugin pod to enable integration with Kubernetes Liveness Probe.
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cmd/livenessprobe
-      ldflags: "-X main.version=v${{package.version}} -extldflags '-static'"
+      ldflags: "-s -w -X main.version=v${{package.version}} -extldflags '-static'"
       vendor: "true"
       output: livenessprobe
 

--- a/kubernetes-csi-node-driver-registrar.yaml
+++ b/kubernetes-csi-node-driver-registrar.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-node-driver-registrar
   version: 2.8.0
-  epoch: 0
+  epoch: 1
   description: Sidecar container that registers a CSI driver with the kubelet using the kubelet plugin registration mechanism.
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cmd/csi-node-driver-registrar
-      ldflags: "-X main.version=v${{package.version}} -extldflags '-static'"
+      ldflags: "-s -w -X main.version=v${{package.version}} -extldflags '-static'"
       vendor: "true"
       output: csi-node-driver-registrar
 

--- a/kubernetes-ingress-defaultbackend.yaml
+++ b/kubernetes-ingress-defaultbackend.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-ingress-defaultbackend
   version: 1.23.1
-  epoch: 0
+  epoch: 1
   description: 'A simple web server that respond 404 common used in kubernetes ingress, serve pages 404 at root and 200 at /healthz'
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,7 @@ pipeline:
     with:
       packages: ./cmd/404-server
       output: defaultbackend
+      ldflags: -s -w
 
   - uses: strip
 

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubevela
   version: 1.8.2
-  epoch: 0
+  epoch: 1
   description: KubeVela is a modern application delivery platform that makes deploying and operating applications across today's hybrid, multi-cloud environments easier, faster and more reliable
   copyright:
     - license: Apache-2.0
@@ -30,13 +30,13 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cmd/core/main.go
-      ldflags: -X github.com/oam-dev/kubevela/version.VelaVersion=${{package.version}}
+      ldflags: -s -w -X github.com/oam-dev/kubevela/version.VelaVersion=${{package.version}}
       output: manager
 
   - uses: go/build
     with:
       packages: ./references/cmd/cli/main.go
-      ldflags: -X github.com/oam-dev/kubevela/version.VelaVersion=${{package.version}}
+      ldflags: -s -w -X github.com/oam-dev/kubevela/version.VelaVersion=${{package.version}}
       output: vela
 
   - uses: strip

--- a/kustomize.yaml
+++ b/kustomize.yaml
@@ -1,7 +1,7 @@
 package:
   name: kustomize
   version: 5.0.3
-  epoch: 1
+  epoch: 2
   description: Customization of kubernetes YAML configurations
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ pipeline:
     with:
       packages: ./kustomize
       output: kustomize
-      ldflags: -s -X sigs.k8s.io/kustomize/api/provenance.version=kustomize/${{package.version}} -X 'sigs.k8s.io/kustomize/api/provenance.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')'
+      ldflags: -s -w -X sigs.k8s.io/kustomize/api/provenance.version=kustomize/${{package.version}} -X 'sigs.k8s.io/kustomize/api/provenance.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')'
 
   - uses: strip
 

--- a/kyverno-cli.yaml
+++ b/kyverno-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-cli
   version: 1.9.4
-  epoch: 0
+  epoch: 1
   description: Kubernetes Native Policy Management CLI
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cmd/cli/kubectl-kyverno
-      ldflags: -X github.com/kyverno/kyverno/pkg/version.BuildVersion=${{package.version}}
+      ldflags: -s -w -X github.com/kyverno/kyverno/pkg/version.BuildVersion=${{package.version}}
       output: kyverno-cli
 
   - uses: strip

--- a/memcached-exporter.yaml
+++ b/memcached-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached-exporter
   version: 0.11.3
-  epoch: 1
+  epoch: 2
   description: Exports metrics from memcached servers for consumption by Prometheus.
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,7 @@ pipeline:
     with:
       packages: ./cmd/memcached_exporter
       output: memcached_exporter
+      ldflags: -s -w
 
   - uses: strip
 

--- a/nats-server.yaml
+++ b/nats-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: nats-server
   version: 2.9.17
-  epoch: 0
+  epoch: 1
   description: High-Performance server for NATS.io, the cloud and edge native messaging system.
   copyright:
     - license: Apache-2.0
@@ -22,16 +22,11 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 4f2c9a51849dfe5b1679f20a499fff5bc5ccb942
 
-  - uses: go/build
-    with:
-      packages: .
-      output: nats-server
-
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
       mkdir -p ${{targets.destdir}}/etc/nats
       go build \
-        -ldflags "-w -X github.com/nats-io/nats-server/v2/server.gitCommit=$(git rev-parse HEAD)" \
+        -ldflags "-s -w -X github.com/nats-io/nats-server/v2/server.gitCommit=$(git rev-parse HEAD)" \
         -o ${{targets.destdir}}/usr/bin/nats-server \
         .
       mv docker/nats-server.conf ${{targets.destdir}}/etc/nats/nats-server.conf

--- a/nats.yaml
+++ b/nats.yaml
@@ -1,7 +1,7 @@
 package:
   name: nats
   version: 0.0.35
-  epoch: 3
+  epoch: 4
   description: The NATS Command Line Interface.
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,7 @@ pipeline:
       packages: .
       output: nats
       modroot: nats
+      ldflags: -s -w
 
 update:
   enabled: true

--- a/newrelic-nri-kube-events.yaml
+++ b/newrelic-nri-kube-events.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-nri-kube-events
   version: 2.1.0
-  epoch: 0
+  epoch: 1
   description: New Relic integration that forwards Kubernetes events to New Relic
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cmd/nri-kube-events
-      ldflags: -X main.integrationVersion=v${{ package.version }}
+      ldflags: -s -w -X main.integrationVersion=v${{ package.version }}
       output: nri-kube-events
 
 update:

--- a/nri-prometheus.yaml
+++ b/nri-prometheus.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-prometheus
   version: 2.18.1
-  epoch: 0
+  epoch: 1
   description: Fetch metrics in the Prometheus metrics inside or outside Kubernetes and send them to the New Relic Metrics platform.
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,7 @@ pipeline:
       packages: ./cmd/nri-prometheus
       output: nri-prometheus
       deps: google.golang.org/protobuf@v1.29.1
+      ldflags: -s -w
 
   - uses: strip
 

--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: oauth2-proxy
   version: 7.4.0
-  epoch: 2
+  epoch: 3
   description: Reverse proxy and static file server that provides authentication using various providers to validate accounts by email, domain or group.
   copyright:
     - license: MIT
@@ -26,7 +26,7 @@ pipeline:
     with:
       packages: .
       output: oauth2-proxy
-      ldflags: -X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.Version=${{package.version}}
+      ldflags: -s -w -X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.Version=${{package.version}}
       # GHSA-vvpx-j8f3-3w6h
       deps: golang.org/x/net@v0.7.0
 

--- a/osv-scanner.yaml
+++ b/osv-scanner.yaml
@@ -1,7 +1,7 @@
 package:
   name: osv-scanner
   version: 1.3.3
-  epoch: 0
+  epoch: 1
   description: Vulnerability scanner written in Go which uses the data provided by https://osv.dev
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,7 @@ pipeline:
     with:
       packages: ./cmd/...
       output: osv-scanner
+      ldflags: -s -w
 
   - uses: strip
 

--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus
   version: 2.44.0
-  epoch: 0
+  epoch: 1
   description: The Prometheus monitoring system and time series database.
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,7 @@ pipeline:
       go get google.golang.org/protobuf@v1.29.1
 
   - runs: |
-      GOLDFLAGS="-X github.com/prometheus/common/version.Version=${{package.version}}
+      GOLDFLAGS="-s -w -X github.com/prometheus/common/version.Version=${{package.version}}
         -X github.com/prometheus/common/version.Revision=WolfiLinux
         -X github.com/prometheus/common/version.Branch=master
         -X github.com/prometheus/common/version.BuildUser=$USER@$HOSTNAME

--- a/pulumi-kubernetes-operator.yaml
+++ b/pulumi-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-kubernetes-operator
   version: 1.12.1
-  epoch: 0
+  epoch: 1
   description: A Kubernetes Operator that automates the deployment of Pulumi Stacks
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,7 @@ pipeline:
 
           # Original Go build args found in ./scripts/build.sh
           CGO_ENABLED=0 go build -o "${{targets.destdir}}/usr/bin/${{package.name}}" \
-            -ldflags "-X github.com/pulumi/pulumi-kubernetes-operator/version.Version=v${{package.version}} -w -extldflags \"-static\"" \
+            -ldflags "-s -w -X github.com/pulumi/pulumi-kubernetes-operator/version.Version=v${{package.version}} -extldflags \"-static\"" \
             -tags netgo ./cmd/manager/main.go
       - uses: strip
 

--- a/pulumi-language-dotnet.yaml
+++ b/pulumi-language-dotnet.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-dotnet
   version: 3.55.1
-  epoch: 0
+  epoch: 1
   description: Pulumi Language SDK for Dotnet
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ pipeline:
     with:
       packages: .
       output: pulumi-language-dotnet
-      ldflags: -X github.com/pulumi/pulumi-language-dotnet/pkg/version.Version=v${{package.version}}
+      ldflags: -s -w -X github.com/pulumi/pulumi-language-dotnet/pkg/version.Version=v${{package.version}}
       modroot: pulumi-language-dotnet
 
   - uses: strip

--- a/pulumi-language-java.yaml
+++ b/pulumi-language-java.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-java
   version: 0.9.3
-  epoch: 0
+  epoch: 1
   description: Pulumi Language SDK for Java
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ pipeline:
     with:
       packages: ./cmd/pulumi-language-java
       output: pulumi-language-java
-      ldflags: -X github.com/pulumi/pulumi-java/pkg/version.Version=v${{package.version}}
+      ldflags: -s -w -X github.com/pulumi/pulumi-java/pkg/version.Version=v${{package.version}}
       # Mitigate GHSA-hw7c-3rfg-p46j
       deps: google.golang.org/protobuf@v1.29.1
       modroot: pkg

--- a/restic.yaml
+++ b/restic.yaml
@@ -2,7 +2,7 @@ package:
   name: restic
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
   version: 0.15.2
-  epoch: 1
+  epoch: 2
   description: restic is a backup program which allows saving multiple revisions of files and directories in an encrypted repository stored on different backends
   copyright:
     - license: BSD-2-Clause
@@ -27,7 +27,7 @@ pipeline:
 
       CGO_ENABLED=0 go build \
         -trimpath -ldflags \
-        "-buildid= -X main.version=${{package.version}}" \
+        "-s -w -buildid= -X main.version=${{package.version}}" \
         -o "${{targets.destdir}}/usr/bin/restic" ./cmd/restic
 
   - uses: strip

--- a/rqlite.yaml
+++ b/rqlite.yaml
@@ -2,7 +2,7 @@ package:
   name: rqlite
   # When bumping the version, you can remove the `go get` line in the build.
   version: 7.19.0
-  epoch: 0
+  epoch: 1
   description: The lightweight, distributed relational database built on SQLite
   copyright:
     - license: MIT
@@ -32,10 +32,10 @@ pipeline:
       go mod tidy
       go build -tags osusergo,netgo,sqlite_omit_load_extension \
           -o ${{targets.destdir}}/usr/bin/rqlite \
-          -ldflags="-extldflags=-static" \
+          -ldflags="-s -w -extldflags=-static" \
           ./cmd/rqlite
       go build -tags osusergo,netgo,sqlite_omit_load_extension \
-          -ldflags="-extldflags=-static" \
+          -ldflags="-s -w -extldflags=-static" \
           -o ${{targets.destdir}}/usr/bin/rqlited \
           ./cmd/rqlited
 

--- a/spicedb.yaml
+++ b/spicedb.yaml
@@ -1,7 +1,7 @@
 package:
   name: spicedb
   version: 1.21.0
-  epoch: 0
+  epoch: 1
   description: Open Source, Google Zanzibar-inspired fine-grained permissions database
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,7 @@ pipeline:
     with:
       packages: ./cmd/spicedb
       output: spicedb
+      ldflags: -s -w
 
   - uses: strip
 

--- a/src.yaml
+++ b/src.yaml
@@ -1,7 +1,7 @@
 package:
   name: src
   version: 5.0.3
-  epoch: 0
+  epoch: 1
   description: Sourcegraph CLI
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
     with:
       packages: ./cmd/src
       output: src
-      ldflags: "-X github.com/sourcegraph/src-cli/internal/version.BuildTag=${{package.version}}"
+      ldflags: "-s -w -X github.com/sourcegraph/src-cli/internal/version.BuildTag=${{package.version}}"
 
   - uses: strip
 

--- a/stakater-reloader.yaml
+++ b/stakater-reloader.yaml
@@ -1,7 +1,7 @@
 package:
   name: stakater-reloader
   version: 1.0.25
-  epoch: 0
+  epoch: 1
   description: A Kubernetes controller to watch changes in ConfigMap and Secrets and do rolling upgrades on Pods
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,7 @@ pipeline:
     with:
       packages: .
       output: manager
+      ldflags: -s -w
 
   - uses: strip
 

--- a/step-ca.yaml
+++ b/step-ca.yaml
@@ -1,7 +1,7 @@
 package:
   name: step-ca
   version: 0.24.2
-  epoch: 0
+  epoch: 1
   description: A private certificate authority (X.509 & SSH) & ACME server for secure automated certificate management, so you can use TLS everywhere & SSO for SSH.
   copyright:
     - license: Apache-2.0
@@ -22,7 +22,7 @@ pipeline:
 
   - runs: |
       CGO_ENABLED=0 go build -v \
-        -ldflags='-w -X "main.Version=${{package.version}}"' \
+        -ldflags='-s -w -X "main.Version=${{package.version}}"' \
         -o "${{targets.destdir}}/usr/bin/step-ca" ./cmd/step-ca
 
 update:

--- a/step.yaml
+++ b/step.yaml
@@ -1,7 +1,7 @@
 package:
   name: step
   version: 0.24.4
-  epoch: 0
+  epoch: 1
   description: A zero trust swiss army knife for working with X509, OAuth, JWT, OATH OTP, etc.
   copyright:
     - license: Apache-2.0
@@ -17,6 +17,7 @@ pipeline:
     with:
       packages: ./cmd/step
       output: step
+      ldflags: -s -w
 
 update:
   enabled: true

--- a/terraform.yaml
+++ b/terraform.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform
   version: 1.4.6
-  epoch: 2
+  epoch: 3
   copyright:
     - license: MPL-2.0
 
@@ -28,6 +28,7 @@ pipeline:
     with:
       packages: .
       output: terraform
+      ldflags: -s -w
 
   - uses: strip
 

--- a/terragrunt.yaml
+++ b/terragrunt.yaml
@@ -1,7 +1,7 @@
 package:
   name: terragrunt
   version: 0.45.16
-  epoch: 0
+  epoch: 1
   description: Thin wrapper for Terraform providing extra tools
   copyright:
     - license: MIT
@@ -24,7 +24,7 @@ pipeline:
       uri: https://github.com/gruntwork-io/terragrunt/archive/refs/tags/v${{package.version}}.tar.gz
 
   - runs: |
-      go build -v -o bin/terragrunt -ldflags "-X main.VERSION=v${{package.version}}"
+      go build -v -o bin/terragrunt -ldflags "-s -w -X main.VERSION=v${{package.version}}"
       install -Dm755 bin/terragrunt "${{targets.destdir}}"/usr/bin/terragrunt
 
   - uses: strip

--- a/vault.yaml
+++ b/vault.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault
   version: 1.13.2
-  epoch: 1
+  epoch: 2
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0
@@ -42,6 +42,7 @@ pipeline:
       _gotags="vault ui"
 
       _go_ldflags="
+      -s -w
       -X github.com/hashicorp/vault/sdk/version.Version=${{package.version}}
       -X github.com/hashicorp/vault/sdk/version.GitCommit=$(git rev-parse HEAD)
       -X github.com/hashicorp/vault/sdk/version.BuildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")

--- a/vertical-pod-autoscaler.yaml
+++ b/vertical-pod-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: vertical-pod-autoscaler
   version: 0.13.0
-  epoch: 1
+  epoch: 2
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,7 @@ pipeline:
     with:
       modroot: vertical-pod-autoscaler
       packages: ./pkg/admission-controller
+      ldflags: -s -w
       output: admission-controller
       deps: golang.org/x/net@v0.7.0
       vendor: "true"
@@ -33,6 +34,7 @@ pipeline:
     with:
       modroot: vertical-pod-autoscaler
       packages: ./pkg/updater
+      ldflags: -s -w
       output: updater
       deps: golang.org/x/net@v0.7.0
       vendor: "true"
@@ -41,6 +43,7 @@ pipeline:
     with:
       modroot: vertical-pod-autoscaler
       packages: ./pkg/recommender
+      ldflags: -s -w
       output: recommender
       deps: golang.org/x/net@v0.7.0
       vendor: "true"

--- a/vt-cli.yaml
+++ b/vt-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: vt-cli
   version: 0.13.0
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ pipeline:
     with:
       packages: ./vt/
       output: vt
-      ldflags: -X github.com/VirusTotal/vt-cli/cmd.Version=${{package.version}}
+      ldflags: -s -w -X github.com/VirusTotal/vt-cli/cmd.Version=${{package.version}}
       deps: golang.org/x/text@v0.3.8
 
   - uses: strip

--- a/weaviate.yaml
+++ b/weaviate.yaml
@@ -1,7 +1,7 @@
 package:
   name: weaviate
   version: 1.19.6
-  epoch: 0
+  epoch: 1
   description: Weaviate is an open source vector database that stores both objects and vectors, allowing for combining vector search with structured filtering with the fault-tolerance and scalability of a cloud-native database, all accessible through GraphQL, REST, and various language clients.
   copyright:
     - license: BSD-3-Clause
@@ -24,7 +24,7 @@ pipeline:
       mkdir -p ${{targets.destdir}}/bin
       GITHASH=$(git rev-parse --short HEAD)
       go build \
-        -ldflags '-w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'' \
+        -ldflags '-s -w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'' \
         -o ${{targets.destdir}}/bin/weaviate ./cmd/weaviate-server
 
 update:


### PR DESCRIPTION
These options strip debug and symbol information to get the smallest possible Go binaries.  Many of our binaries were already passing one or both of these, but this pass tries to add them basically everywhere else.
