### PR TITLE
Upgrade to calico 3.26.0

### DIFF
--- a/calicoctl.yaml
+++ b/calicoctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: calicoctl
-  version: 3.25.1
-  epoch: 2
+  version: 3.26.0
+  epoch: 0
   description: "CLI tool that allows management of Calico API resources"
   copyright:
     - license: Apache-2.0
@@ -21,22 +21,17 @@ pipeline:
     with:
       repository: https://github.com/projectcalico/calico
       tag: v${{package.version}}
-      expected-commit: 9ce0d6eae6f4c132526722d51821e2948aeaca25
+      expected-commit: 8b103f46fbdc989e59d81e08d215ab4a59fa6cec
       destination: calico
 
   - runs: |
       cd calico
       export PACKAGE_NAME=github.com/projectcalico/calico/calicoctl
       export CALICOCTL_GIT_REVISION=$(git rev-parse --short HEAD)
-      export LDFLAGS="-X $PACKAGE_NAME/calicoctl/commands.VERSION=${{package.version}} \
+      export LDFLAGS="-s -w -X $PACKAGE_NAME/calicoctl/commands.VERSION=${{package.version}} \
         -X $PACKAGE_NAME/calicoctl/commands.GIT_REVISION=$CALICOCTL_GIT_REVISION \
         -X $PACKAGE_NAME/calicoctl/commands/common.VERSION=${{package.version}}"
 
-      go get golang.org/x/text@v0.3.8
-      go get golang.org/x/net@v0.7.0
-      go get github.com/prometheus/client_golang@v1.11.1
-      go get github.com/emicklei/go-restful@v2.16.0
-      go mod tidy
       mkdir -p ${{targets.destdir}}/usr/bin
       go build -v -o ${{targets.destdir}}/usr/bin/calicoctl -ldflags "$LDFLAGS" "./calicoctl/calicoctl"
       go build -v -o ${{targets.destdir}}/usr/bin/kube-controllers -ldflags "$LDFLAGS" "./kube-controllers/cmd/kube-controllers"


### PR DESCRIPTION
The automation got wedged due to the `go get` lines.

This also adds `-s -w` to `ldflags`

Fixes: https://github.com/wolfi-dev/os/pull/2372