### PR TITLE
Add kubeflow-jupyter-web-app package.

### DIFF
--- a/kubeflow-jupyter-web-app.yaml
+++ b/kubeflow-jupyter-web-app.yaml
@@ -1,0 +1,78 @@
+package:
+  name: kubeflow-jupyter-web-app
+  version: 1.7.0
+  epoch: 0
+  description: Kubeflow jupyter web app component
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - python3
+      - py3-setuptools
+      - bash
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - python3
+      - nodejs-16
+      - py3-setuptools
+      - py3-wheel
+      - py3-pip
+      - openssl
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubeflow/kubeflow
+      tag: v${{package.version}}
+      expected-commit: cce5c88047815c45df8a52c8592e5890ae1b1949
+
+  - runs: |
+      # Build the backend common libs into a wheel
+      cd components/crud-web-apps/common/backend
+      python3 setup.py bdist_wheel
+      pip3 install . --prefix=/usr --root="${{targets.destdir}}"
+
+      # Build the frontend common packages
+      cd ../frontend/kubeflow-common-lib
+      npm ci
+      npm run build
+
+      # Build the frontend and copy the common package into it
+      cd ../../../jupyter/frontend
+      npm ci
+      mv ../../common/frontend/kubeflow-common-lib/dist/kubeflow node_modules/
+
+      # This usually uses node 12, but it works with this.
+      export NODE_OPTIONS=--openssl-legacy-provider
+      npm run build -- --output-path=./dist/default --configuration=production
+
+      # Build the jupyter backend
+      cd ../backend
+      pip3 install -r requirements.txt --prefix=/usr --root="${{targets.destdir}}"
+
+      # Now move it all into place
+      mkdir -p "${{targets.destdir}}/usr/share/kubeflow-jupyter-web-app/"
+
+      # Move the backend
+      mv ../backend/apps "${{targets.destdir}}/usr/share/kubeflow-jupyter-web-app/"
+      mv ../backend/entrypoint.py "${{targets.destdir}}/usr/share/kubeflow-jupyter-web-app/"
+
+      # Move the frontend
+      mv ../frontend/dist/default "${{targets.destdir}}/usr/share/kubeflow-jupyter-web-app/apps/default/static"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubeflow/kubeflow
+    use-tag: true
+    # There were some malformed early tags
+    tag-filter: v1
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -696,3 +696,4 @@ kubernetes-ingress-defaultbackend
 coredns
 gatekeeper
 cni-plugins
+kubeflow-jupyter-web-app


### PR DESCRIPTION
I tested this in a local image and it fails the same way as the upstream one.

The only CVEs are false positives.

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`