### PR TITLE
add oci-entry-compat packge to go with the upstream helm

### DIFF
--- a/prometheus-config-reloader.yaml
+++ b/prometheus-config-reloader.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-config-reloader
   version: 0.65.1
-  epoch: 0
+  epoch: 1
   description: Prometheus Operator creates/configures/manages Prometheus clusters atop Kubernetes
   copyright:
     - license: Apache-2.0
@@ -36,6 +36,16 @@ pipeline:
           # test uses the -race flag which is incompatible with -buildmode=pie
           unset GOFLAGS
           make test-unit
+
+subpackages:
+  - name: ${{package.name}}-oci-entrypoint-compat
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/bin"
+          ln -s /usr/bin/prometheus-config-reloader "${{targets.subpkgdir}}/bin/prometheus-config-reloader"
+    dependencies:
+      runtime:
+        - prometheus-config-reloader
 
 update:
   enabled: true


### PR DESCRIPTION
Upstream helm requires the path to be in  /bin/prometheus-config-reloader

**Ignore the test-image-name

```
default             12m         Normal    Pulled              pod/prometheus-cg-test-kube-prometheus-st-prometheus-0             Successfully pulled image "ttl.sh/ajay-argocd601:latest" in 369.655209ms (615.585042ms including waiting)
default             12m         Normal    Created             pod/prometheus-cg-test-kube-prometheus-st-prometheus-0             Created container init-config-reloader
default             12m         Warning   Failed              pod/prometheus-cg-test-kube-prometheus-st-prometheus-0             Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/bin/prometheus-config-reloader": stat /bin/prometheus-config-reloader: no such file or directory: unknown
``` 

Probably this package should be moved as an sub-package under prometheus-operator  , for the current change its out of scope 