### PR TITLE
add prometheus-nats-exporter

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -697,3 +697,4 @@ coredns
 gatekeeper
 cni-plugins
 kubeflow-jupyter-web-app
+prometheus-nats-exporter

--- a/prometheus-nats-exporter.yaml
+++ b/prometheus-nats-exporter.yaml
@@ -1,0 +1,39 @@
+package:
+  name: prometheus-nats-exporter
+  version: 0.11.0
+  epoch: 0
+  description: A Prometheus exporter for NATS metrics
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+      - curl
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/nats-io/prometheus-nats-exporter
+      tag: v${{package.version}}
+      expected-commit: 18e9b7e0014b8d66fce9ed11d048cee73b74c417
+
+  - runs: |
+      make build
+      mkdir -p ${{targets.destdir}}/usr/bin
+      install -Dm755 prometheus-nats-exporter ${{targets.destdir}}/usr/bin/
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: nats-io/prometheus-nats-exporter
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v


### PR DESCRIPTION
prometheus-nats-exporter: new package

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

