### PR TITLE
update minio to RELEASE.2023-05-27T05-56-19Z

### DIFF
--- a/minio.yaml
+++ b/minio.yaml
@@ -2,8 +2,8 @@ package:
   name: minio
   # minio uses strange versioning, the upstream version is RELEASE.2023-04-13T03-08-07Z
   # when bumping this, also bump the tag in git-checkout below
-  version: 0.20230413.030807
-  epoch: 1
+  version: 0.20230527.055619
+  epoch: 0
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0
@@ -13,7 +13,8 @@ environment:
     packages:
       - busybox
       - ca-certificates-bundle
-      - go
+      # Pinned to 1.19 due to upstream issues
+      - go-1.19
       - build-base
       - perl
 
@@ -21,8 +22,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/minio/minio
-      tag: RELEASE.2023-04-13T03-08-07Z
-      expected-commit: a42650c065fe22c6a6d3ce526d80c5354d4bceac
+      tag: RELEASE.2023-05-27T05-56-19Z
+      expected-commit: 394690dcfb1b80532d5785bbf5313a0e57b58a00
 
   - runs: |
       make build


### PR DESCRIPTION

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
