### PR TITLE
fix path when copying the python libs

### DIFF
--- a/kube-downscaler.yaml
+++ b/kube-downscaler.yaml
@@ -22,10 +22,10 @@ pipeline:
       expected-commit: c005fc8840500da7c4e2c024ff4ad77eaf470075
 
   - runs: |
-      mkdir -p ${{targets.destdir}}/usr/lib/python3.11/site-packages
+      mkdir -p ${{targets.destdir}}/usr/lib/python3.11
       poetry config virtualenvs.create false
       poetry install --no-interaction --only main --no-ansi -vvv
-      mv /usr/lib/python3.11/site-packages ${{targets.destdir}}/usr/lib/python3.11/site-packages
+      mv /usr/lib/python3.11/site-packages ${{targets.destdir}}/usr/lib/python3.11
       mv kube_downscaler/ ${{targets.destdir}}/
       sed -i "s/__version__ = .*/__version__ = '${{package.version}}'/" ${{targets.destdir}}/kube_downscaler/__init__.py
 


### PR DESCRIPTION
- fix path when copying the python libs

it put the files under `/usr/lib/python3.11/site-packages/site-packages` and the correct should be `/usr/lib/python3.11/site-packages`