### PR TITLE
build-env: add additional CFLAGS/LDFLAGS from the OpenSSF hardening guide

### DIFF
--- a/build-aarch64.env
+++ b/build-aarch64.env
@@ -1,6 +1,6 @@
 # Ampere Altra, the CPU used by most cloud providers, is Neoverse N1.
-export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1 -Wp,-D_FORTIFY_SOURCE=3"
+export CFLAGS="-O2 -Wall -Wextra -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wtrampolines"
 export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now"
+export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
 export GOFLAGS=""

--- a/build-armv7l.env
+++ b/build-armv7l.env
@@ -1,6 +1,6 @@
 # We target the BCM2836 which is Cortex-A7 with the SIMD unit.
-export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv7-a+simd -mtune=cortex-a7 -Wp,-D_FORTIFY_SOURCE=3"
+export CFLAGS="-O2 -Wall -Wextra -fomit-frame-pointer -march=armv7-a+simd -mtune=cortex-a7 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wtrampolines"
 export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now"
+export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
 export GOFLAGS=""

--- a/build-x86_64.env
+++ b/build-x86_64.env
@@ -1,5 +1,5 @@
-export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -Wp,-D_FORTIFY_SOURCE=3"
+export CFLAGS="-O2 -Wall -Wextra -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wtrampolines"
 export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now"
+export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
 export GOFLAGS=""


### PR DESCRIPTION
Not all of the suggestions in the hardening guide are appropriate for distributions, either because they are case-specific, or the performance hit is too great, but we can enable some of them for Wolfi.

The flags enabled are:

- `-Wextra`: make the compiler warn about more things like integer conversion issues
- `-Wp,-D_GLIBCXX_ASSERTIONS`: like FORTIFY, but for C++ containers
- `-Wtrampolines`: warn when trampolines are generated, which cause text relocations
- `-z noexecstack`: require the stack be non-executable
- `-z noexecheap`: require the heap be non-executable