### PR TITLE
Add libsodium extension since PHP 7.2 this extension is bundled with PHP

### DIFF
--- a/php.yaml
+++ b/php.yaml
@@ -21,6 +21,7 @@ environment:
       - openssl-dev
       - readline-dev
       - sqlite-dev
+      - libsodium-dev
 
 pipeline:
   - uses: fetch
@@ -38,6 +39,7 @@ pipeline:
         --with-readline \
         --with-zlib \
         --with-pdo-mysql \
+        --with-sodium \
         --enable-fpm
 
   - uses: autoconf/make


### PR DESCRIPTION
As PHP move towards PHP 7.0.0, they must look at the current state of cryptography in PHP. Libmcrypt hasn't been touched in eight years (last release was in 2007), leaving openssl as the only viable option for PHP 5.x and 7.0 users.

Meanwhile, libsodium bindings have been available in PECL for a while now, and has reached stability.

Libsodium is a modern cryptography library that offers authenticated encryption, high-speed elliptic curve cryptography, and much more. Unlike other cryptography standards (which are a potluck of cryptography primitives; i.e. WebCrypto), libsodium is comprised of carefully selected algorithms implemented by security experts to avoid side-channel vulnerabilities.

https://wiki.php.net/rfc/libsodium
https://paragonie.com/book/pecl-libsodium/read/00-intro.md
https://www.php.net/manual/en/sodium.installation.php

Issue:
For instance, you cannot adhere to best practices such as using JWT tokens in PHP Symfony.
