### PR TITLE
kubectl: strip debug info from binary

### DIFF
--- a/kubectl.yaml
+++ b/kubectl.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubectl
   version: 1.27.2
-  epoch: 0
+  epoch: 1
   description: Command-line interface for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,8 @@ pipeline:
       make kubectl
       mkdir -p ${{targets.destdir}}/usr/bin/
       cp _output/bin/kubectl ${{targets.destdir}}/usr/bin/kubectl
+
+  - uses: strip
 
 update:
   enabled: true


### PR DESCRIPTION
Make our binary ~9MB smaller on ARM.  As a side effect, we also lose the `ld-linux` dependency, as we are now building go binaries staticly without PIE (which needs an ELF interpreter).