### PR TITLE
erlang: add dependency on ca-certificates bundle

### DIFF
--- a/erlang.yaml
+++ b/erlang.yaml
@@ -5,6 +5,10 @@ package:
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      # mnesia depends on the ca-certificates bundle
+      - ca-certificates-bundle
 
 environment:
   contents:


### PR DESCRIPTION
Many erlang components require the bundle since OTP 26.  Closes #2336