### PR TITLE
makefile: fix typo for build log location in generated rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ list-yaml:
 		echo "$$pkgtarget: $${pkgname}.yaml \$${KEY}";		\
 		printf "\t%s\n" "@mkdir -p ./$${pkgdir}/";		\
 		printf "\t%s" "SDE=\$${SOURCE_DATE_EPOCH}; [ -z \"\$$\$$SDE\" ] && SDE=\`git log -1 --pretty=%ct --follow $${pkgname}.yaml\`;"; \
-		printf "\t%s\n\n" "SOURCE_DATE_EPOCH=\$$\$$SDE \$${MELANGE} build $${pkgname}.yaml \$${MELANGE_OPTS} --source-dir ./$${pkgdir}/ --log-policy builtin:stderr,\$${TARGETDIR}/buildlogs/$${pkgfullname}.log"; \
+		printf "\t%s\n\n" "SOURCE_DATE_EPOCH=\$$\$$SDE \$${MELANGE} build $${pkgname}.yaml \$${MELANGE_OPTS} --source-dir ./$${pkgdir}/ --log-policy builtin:stderr,\$${TARGETDIR}/buildlogs/$${pkgver}.log"; \
 	done > .packagerules
 
 -include .packagerules


### PR DESCRIPTION
I forgot to update the `$${pkgfullname}` to `$${pkgver}` when updating the generated rules template.