### PR TITLE
wait longer for build pods to become ready

### DIFF
--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -136,6 +136,7 @@ jobs:
             --bucket=${BUCKET} \
             --src-bucket=${SRC_BUCKET} \
             --sdk-image ghcr.io/wolfi-dev/sdk:latest@sha256:ec70f835c3885d831ae1e5ba08425e0ec08ad2e55ed9b46f5dd5faff459e713c \
+            --pending-timeout=10m \
             --secret-key \
             --arch=arm64
 


### PR DESCRIPTION
We're experiencing build failures on arm builds because the pod starts, runs `fetch-packages` to sync all our apks, and times out after 5 minutes. Logs indicate it's doing work during this time, but the `fetch-packages` init container takes longer than 5 minutes so we give up.

The correct actual solution would be to _not_ fetch all our apks every time we build, which hopefully we'll do at some point.

For now, just bump the `--pending-timeout` flag from the default 5m up to 10m.