### PR TITLE
dogfood our own gcloud image

### DIFF
--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -136,6 +136,7 @@ jobs:
             --bucket=${BUCKET} \
             --src-bucket=${SRC_BUCKET} \
             --sdk-image ghcr.io/wolfi-dev/sdk:latest@sha256:ec70f835c3885d831ae1e5ba08425e0ec08ad2e55ed9b46f5dd5faff459e713c \
+            --gcloud-image cgr.dev/chainguard/google-cloud-sdk:latest \
             --pending-timeout=10m \
             --secret-key \
             --arch=arm64

--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -136,7 +136,7 @@ jobs:
             --bucket=${BUCKET} \
             --src-bucket=${SRC_BUCKET} \
             --sdk-image ghcr.io/wolfi-dev/sdk:latest@sha256:ec70f835c3885d831ae1e5ba08425e0ec08ad2e55ed9b46f5dd5faff459e713c \
-            --gcloud-image cgr.dev/chainguard/google-cloud-sdk:latest \
+            --gcloud-image cgr.dev/chainguard/google-cloud-sdk:latest@sha256:4c957383ff6ee6877a104fc99fec8576038a777cc55e4b29a0fcddf2c3d07c14 \
             --pending-timeout=10m \
             --secret-key \
             --arch=arm64


### PR DESCRIPTION
This has the usual potential bootstrapping issues, which we already have by dogfooding our CSI secrets-store images, and which has the same solution if it ever becomes a problem -- remove the tag and we'll use the official upstream gcloud image instead.