### PR TITLE
dogfood our CSI secrets-store images in this repo

### DIFF
--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -82,6 +82,31 @@ jobs:
       - working-directory: ${{github.workspace}}/wolfictl
         run: ./scripts/setup-cluster.sh ${SERVICE_ACCOUNT}
 
+      # Dogfood our own CSI secrets-store images.
+      # These can introduce a bootstrapping issue: if the images are broken,
+      # we won't be able to use them to build a fixed replacement.
+      # In that case, comment this out to use the upstream directly.
+      - run: |
+          kubectl set image daemonset/csi-secrets-store \
+            -n kube-system \
+            secrets-store=cgr.dev/chainguard/secrets-store-csi-driver:latest@sha256:fc2a4b8f69848e60adfef76e679a7f02bb9152ce657f86a9ef43e646894df07c
+
+          kubectl set image daemonset/csi-secrets-store \
+            -n kube-system \
+            liveness-probe=cgr.dev/chainguard/kubernetes-csi-livenessprobe:latest@sha256:6036cc3cc715fcf969d6cc4e0aaf8c6de97f52036bc482f1f41ca4863d66e830
+
+          kubectl set image daemonset/csi-secrets-store \
+            -n kube-system
+            node-driver-registrar=cgr.dev/chainguard/kubernetes-csi-node-driver-registrar:latest@sha256:93e7a091395e6f2d5d14979ae8591876916ef8e003198f642c0768471a02e7fc
+
+          kubectl set image daemonset/csi-secrets-store-provider-gcp \
+            -n kube-system \
+            provider=cgr.dev/chainguard/secrets-store-csi-driver-provider-gcp:latest@sha256:5f7d984f210024efc3f671cb54d914dafb19b9d32feb756143787e17f612a502
+
+          # Wait for DaemonSets to become ready.
+          kubectl rollout status daemonset -n kube-system csi-secrets-store
+          kubectl rollout status daemonset -n kube-system csi-secrets-store-provider-gcp
+
   # TODO: Update source cache here, instead of in a separate workflow.
   #       This likely depends on making the source cache bucket configurable by
   #       wolfictl, or if we have staging builds reuse the prod source cache, then


### PR DESCRIPTION
We're already dogfooding two of these images, the two most likely to break:

https://github.com/wolfi-dev/wolfictl/blob/0e133a790f792c2877c1d8c674d5473f516afffc/scripts/setup-cluster.sh#L27-L29
https://github.com/wolfi-dev/wolfictl/blob/0e133a790f792c2877c1d8c674d5473f516afffc/scripts/setup-cluster.sh#L37-L39

But, since we define them in wolfictl's setup-cluster.sh, we don't get the benefit of digestabot to pin and bump updates. Moving these dogfood configs into this repo will give us that benefit, and we can remove the change from setup-cluster.sh

As before, if these images break, we should comment them out and use the upstream to unbreak them, then reuse them once they work.

Once this merges we can drop the `kubectl set image`s from setup-cluster.sh (https://github.com/wolfi-dev/wolfictl/pull/242)

Supercedes https://github.com/wolfi-dev/wolfictl/pull/227/