### PR TITLE
Remove setcap on vault binary

### DIFF
--- a/vault.yaml
+++ b/vault.yaml
@@ -59,7 +59,7 @@ pipeline:
       # Directory for config. Vault user needs write privileges
       install -m777 -d "${{targets.destdir}}/etc/vault"
 
-      # Directory for logs. Vault user needs write privilveges.
+      # Directory for logs. Vault user needs write privileges.
       install -m777 -d "${{targets.destdir}}/var/lib/vault"
       install -m777 -d "${{targets.destdir}}/var/log/vault"
 

--- a/vault.yaml
+++ b/vault.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault
   version: 1.13.2
-  epoch: 3
+  epoch: 4
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0
@@ -56,18 +56,14 @@ pipeline:
 
       install -m755 -D ./vault/bin/vault "${{targets.destdir}}/usr/bin/vault"
 
-      # Directory for config
-      mkdir "${{targets.destdir}}/etc/vault"
-      # Vault user must be able to write to this
-      chmod 777 "${{targets.destdir}}/etc/vault"
+      # Directory for config. Vault user needs write privileges
+      install -m777 -d "${{targets.destdir}}/etc/vault"
 
-      # Directory for logs
+      # Directory for logs. Vault user needs write privilveges.
       install -m777 -d "${{targets.destdir}}/var/lib/vault"
       install -m777 -d "${{targets.destdir}}/var/log/vault"
 
   - uses: strip
-
-  - runs: setcap cap_ipc_lock=+ep "${{targets.destdir}}/usr/bin/vault"
 
 subpackages:
   - name: "vault-entrypoint"


### PR DESCRIPTION
Having setcap set on the binary broke upstream Helm chart compatibility due to https://github.com/hashicorp/vault-helm/pull/198.

This also required some changes to the entrypoint.