### PR TITLE
fix: add missing \

### DIFF
--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -96,7 +96,7 @@ jobs:
             liveness-probe=cgr.dev/chainguard/kubernetes-csi-livenessprobe:latest@sha256:6036cc3cc715fcf969d6cc4e0aaf8c6de97f52036bc482f1f41ca4863d66e830
 
           kubectl set image daemonset/csi-secrets-store \
-            -n kube-system
+            -n kube-system \
             node-driver-registrar=cgr.dev/chainguard/kubernetes-csi-node-driver-registrar:latest@sha256:93e7a091395e6f2d5d14979ae8591876916ef8e003198f642c0768471a02e7fc
 
           kubectl set image daemonset/csi-secrets-store-provider-gcp \


### PR DESCRIPTION
This causes setup to fail because `kubectl set image` has no edit being requested.