### PR TITLE
fix registrar ref again

### DIFF
--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -97,7 +97,7 @@ jobs:
 
           kubectl set image daemonset/csi-secrets-store \
             -n kube-system \
-            node-driver-registrar=cgr.dev/chainguard/kubernetes-csi-node-driver-registrar:latest@sha256:f0c117b46aaba7a129ca30fdefa34536493f41da1353f1034949d7afa8f7fbbfa
+            node-driver-registrar=cgr.dev/chainguard/kubernetes-csi-node-driver-registrar:latest@sha256:f0c117b46aaba7a129ca30fdefa34536493f41da1353f1034949d7afa8f7fbbf
 
           kubectl set image daemonset/csi-secrets-store-provider-gcp \
             -n kube-system \


### PR DESCRIPTION
drop trailing `a` that makes this digest invalid

I don't even know how I managed this.