### PR TITLE
don't use our own csi helper images, they need tests

### DIFF
--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -91,14 +91,6 @@ jobs:
             -n kube-system \
             secrets-store=cgr.dev/chainguard/secrets-store-csi-driver:latest@sha256:fc2a4b8f69848e60adfef76e679a7f02bb9152ce657f86a9ef43e646894df07c
 
-          kubectl set image daemonset/csi-secrets-store \
-            -n kube-system \
-            liveness-probe=cgr.dev/chainguard/kubernetes-csi-livenessprobe:latest@sha256:6036cc3cc715fcf969d6cc4e0aaf8c6de97f52036bc482f1f41ca4863d66e830
-
-          kubectl set image daemonset/csi-secrets-store \
-            -n kube-system \
-            node-driver-registrar=cgr.dev/chainguard/kubernetes-csi-node-driver-registrar:latest@sha256:f0c117b46aaba7a129ca30fdefa34536493f41da1353f1034949d7afa8f7fbbf
-
           kubectl set image daemonset/csi-secrets-store-provider-gcp \
             -n kube-system \
             provider=cgr.dev/chainguard/secrets-store-csi-driver-provider-gcp:latest@sha256:5f7d984f210024efc3f671cb54d914dafb19b9d32feb756143787e17f612a502


### PR DESCRIPTION
I'll make the same change in enterprise-packages too.