### PR TITLE
don't use our gcloud image, which needs to be root

### DIFF
--- a/.github/workflows/dag-push-production.yaml
+++ b/.github/workflows/dag-push-production.yaml
@@ -153,7 +153,6 @@ jobs:
             --bucket=${BUCKET} \
             --src-bucket=${SRC_BUCKET} \
             --sdk-image ghcr.io/wolfi-dev/sdk:latest@sha256:ec70f835c3885d831ae1e5ba08425e0ec08ad2e55ed9b46f5dd5faff459e713c \
-            --gcloud-image cgr.dev/chainguard/google-cloud-sdk:latest@sha256:99e0727f6aae3266c10d6d86ed513bcc606578514186e51e7f2e00b087c529a1 \
             --pending-timeout=10m \
             --secret-key \
             --arch=arm64


### PR DESCRIPTION
With our image we get

```
mkdir: can't create directory './packages/': Permission denied
```

The upstream image runs as `root` so this isn't an issue, perhaps we need a `-root` variant ourselves.