### PR TITLE
fix bazel 6 build

### DIFF
--- a/bazel-6.yaml
+++ b/bazel-6.yaml
@@ -26,6 +26,7 @@ pipeline:
       expected-sha256: 4cf4d264bff388ee0012735728630d23832d3c9d021383b2fadceadb0775dd6b
       uri: https://github.com/bazelbuild/bazel/releases/download/${{package.version}}/bazel-${{package.version}}-dist.zip
       extract: false
+      delete: false
 
   - runs: unzip bazel-${{package.version}}-dist.zip
 


### PR DESCRIPTION
Regression introduced as apart of  https://github.com/chainguard-dev/melange/pull/486 , 
when extract is false deleted should be overridden or set to false 