### PR TITLE
add spire- prefix to oidc-discovery-provider subpkg

### DIFF
--- a/spire-server.yaml
+++ b/spire-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: spire-server
   version: 1.6.4
-  epoch: 1
+  epoch: 2
   description: The SPIFFE Runtime Environment (SPIRE) server
   copyright:
     - license: Apache-2.0
@@ -54,7 +54,7 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           install -Dm755 ./bin/spire-agent "${{targets.subpkgdir}}/usr/bin/spire-agent"
 
-  - name: oidc-discovery-provider
+  - name: spire-oidc-discovery-provider
     description: The SPIFFE Runtime Environment (SPIRE) agent
     pipeline:
       - runs: |

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -6,3 +6,4 @@ erlang-dev-26.0-r0.apk
 ratelimit-0.0_git20230508-r0.apk
 mongo-tools-100.7.1-r0.apk
 ingress-default-backend-1.23.1-r0.apk
+oidc-discovery-provider-1.6.4-r1.apk


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
