### PR TITLE
Bump to python 3.12 beta 1.

### DIFF
--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   # When bumping to a real non-prerelease you'll have to change the URL pattern on line 45
-  version: 3.12.0_alpha7
+  version: 3.12.0_beta1
   epoch: 0
   description: "the Python programming language"
   copyright:
@@ -33,8 +33,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://www.python.org/ftp/python/3.12.0/Python-3.12.0a7.tar.xz
-      expected-sha256: a19ae4dc5afebdff5e1312346f160062a11e0dbd5f9e68a6a981ea37b21608e1
+      uri: https://www.python.org/ftp/python/3.12.0/Python-3.12.0b1.tar.xz
+      expected-sha256: 8ba76ca64acd745babdfb8467820964df98858ee6a9577bf1d93447257be581e
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
Fixes:

Related:

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
