### PR TITLE
Setcap for haproxy.

### DIFF
--- a/haproxy.yaml
+++ b/haproxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy
   version: 2.7.6
-  epoch: 0
+  epoch: 1
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: (GPL-2.0-or-later AND GPL-2.1-or-later) WITH OpenSSL-Exception
@@ -27,6 +27,7 @@ environment:
       - openssl-dev
       - pcre2-dev
       - linux-headers
+      - libcap-utils
 
 pipeline:
   - uses: fetch
@@ -54,6 +55,9 @@ pipeline:
       install -d "${{targets.destdir}}"/var/lib/haproxy
 
   - uses: strip
+
+  # This MUST run after strip, which strips capabilities too!
+  - runs: setcap cap_net_bind_service=+eip "${{targets.destdir}}/usr/sbin/haproxy"
 
 subpackages:
   - name: "haproxy-doc"


### PR DESCRIPTION
The default configurations for haproxy can require it to listen on privileged ports.

Fixes:

Related:

### Pre-review Checklist
