### PR TITLE
Setcap for the spire oidc provider.

### DIFF
--- a/spire-server.yaml
+++ b/spire-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: spire-server
   version: 1.6.4
-  epoch: 2
+  epoch: 3
   description: The SPIFFE Runtime Environment (SPIRE) server
   copyright:
     - license: Apache-2.0
@@ -17,6 +17,7 @@ environment:
       - go
       - build-base
       - git
+      - libcap-utils
 
 pipeline:
   - uses: git-checkout
@@ -61,6 +62,7 @@ subpackages:
           cd spire
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           install -Dm755 ./bin/oidc-discovery-provider "${{targets.subpkgdir}}/usr/bin/oidc-discovery-provider"
+          setcap cap_net_bind_service=+ep "${{targets.subpkgdir}}/usr/bin/oidc-discovery-provider"
 
 update:
   enabled: true


### PR DESCRIPTION
The image typically runs as root, but this allows it to run as non-root.

Fixes:

Related:

### Pre-review Checklist
