### PR TITLE
Bump jose4j in kafka to mitigate a GHSA.

### DIFF
--- a/kafka.yaml
+++ b/kafka.yaml
@@ -2,7 +2,7 @@ package:
   name: kafka
   # When bumping check to see if the CVE mitigation can be removed.
   version: "3.4.0"
-  epoch: 2
+  epoch: 3
   description:
   target-architecture:
     - all
@@ -39,6 +39,8 @@ pipeline:
       # Mitigate CVE-2023-26048 and CVE-2023-26049 by bumping jetty
       sed -i 's/\(jetty:\s*"\)[^"]\+"/\19.4.51.v20230217"/' gradle/dependencies.gradle
 
+      # Bump jose4j to 0.9.3 to mitigate GHSA-jgvc-jfgh-rjvv
+      sed -i 's/jose4j: "0\.7\.9"/jose4j: "0.9.3"/' gradle/dependencies.gradle
       ./gradlew clean releaseTarGz
 
       tar -xf core/build/distributions/kafka_2.13-${{package.version}}.tgz


### PR DESCRIPTION
This has been applied upstream but a release hasn't been cut yet.

### Pre-review Checklist
