### PR TITLE
kafka 3.4.1 version bump remove cve updates

### DIFF
--- a/kafka.yaml
+++ b/kafka.yaml
@@ -1,8 +1,8 @@
 package:
   name: kafka
   # When bumping check to see if the CVE mitigation can be removed.
-  version: "3.4.0"
-  epoch: 3
+  version: 3.4.1
+  epoch: 0
   description:
   target-architecture:
     - all
@@ -31,16 +31,11 @@ pipeline:
     with:
       repository: https://github.com/apache/kafka
       tag: ${{package.version}}
-      expected-commit: 2e1947d240607d53f071f61c875cfffc3fec47fe
+      expected-commit: 8a516edc2755df89982a9afe9e771ea7cf4a17ac
 
   - runs: |
       export LANG=en_US.UTF-8
 
-      # Mitigate CVE-2023-26048 and CVE-2023-26049 by bumping jetty
-      sed -i 's/\(jetty:\s*"\)[^"]\+"/\19.4.51.v20230217"/' gradle/dependencies.gradle
-
-      # Bump jose4j to 0.9.3 to mitigate GHSA-jgvc-jfgh-rjvv
-      sed -i 's/jose4j: "0\.7\.9"/jose4j: "0.9.3"/' gradle/dependencies.gradle
       ./gradlew clean releaseTarGz
 
       tar -xf core/build/distributions/kafka_2.13-${{package.version}}.tgz


### PR DESCRIPTION
removed cve fixes  as it is addressed in upstream 
https://github.com/apache/kafka/compare/3.4.0...3.4.1

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
