### PR TITLE
update ha-proxy to 2.8

### DIFF
--- a/haproxy.yaml
+++ b/haproxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy
-  version: 2.7.6
-  epoch: 1
+  version: 2.8.0
+  epoch: 0
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: (GPL-2.0-or-later AND GPL-2.1-or-later) WITH OpenSSL-Exception
@@ -33,7 +33,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://www.haproxy.org/download/${{vars.mangled-package-version}}/src/haproxy-${{package.version}}.tar.gz
-      expected-sha256: 133f357ddb3fcfc5ad8149ef3d74cbb5db6bb4a5ab67289ce0b0ab686cdeb74f
+      expected-sha256: 61cdafb5db7e9174d0757b8e4bcde938352306fb7cc8ff2b5f55c26dd48a6cf7
 
   - uses: autoconf/make
     with:


### PR DESCRIPTION
Fixes https://github.com/wolfi-dev/os/issues/2453

```
package test 
[sdk] ❯ apk add --allow-untrusted haproxy-2.8.0-r0.apk 
WARNING: opening /github/workspace/packages: No such file or directory
(1/2) Installing libpcre2-posix-3 (10.42-r2)
(2/2) Installing haproxy (2.8.0-r0)
OK: 803 MiB in 51 packages
[sdk] ❯ /usr/sbin/haproxy 
HAProxy version 2.8.0-fdd8154 2023/05/31 - https://haproxy.org/
Status: long-term supported branch - will stop receiving fixes around Q2 2028.
Known bugs: http://www.haproxy.org/bugs/bugs-2.8.0.html
Running on: Linux 5.19.0-43-generic

```


#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
