### PR TITLE
add argp-standalone

### DIFF
--- a/argp-standalone.yaml
+++ b/argp-standalone.yaml
@@ -1,0 +1,56 @@
+package:
+  name: argp-standalone
+  version: 1.5.0
+  epoch: 0
+  description: "Hierarchial argument parsing library broken out from glibc"
+  copyright:
+    - license: LGPL-2.1-or-later
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - autoconf
+      - automake
+      - libtool
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/argp-standalone/argp-standalone/archive/refs/tags/${{package.version}}.tar.gz
+      expected-sha512: fa2eb61ea00f7a13385e5c1e579dd88471d6ba3a13b6353e924fe71914b90b40688b42a9f1789bc246e03417fee1788b1990753cda8c8d4a544e85f26b63f9e2
+
+  - uses: patch
+    with:
+      patches: gnu89-inline.patch
+
+  - runs: |
+      autoreconf -vif
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        CFLAGS="$CFLAGS -fPIC" \
+        --host=${{host.triplet.gnu}} \
+        --build=${{host.triplet.gnu}} \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man
+
+  - uses: autoconf/make
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/lib
+      mkdir -p "${{targets.destdir}}"/usr/include
+      install -D -m644 argp.h "${{targets.destdir}}"/usr/include/argp.h
+      install -D -m755 libargp.a "${{targets.destdir}}"/usr/lib/libargp.a
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 21336

--- a/argp-standalone/gnu89-inline.patch
+++ b/argp-standalone/gnu89-inline.patch
@@ -1,0 +1,21 @@
+diff --git a/configure.ac b/configure.ac
+index 932b9da..b4f85bb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -80,15 +80,10 @@ AC_CHECK_DECLS([program_invocation_name, program_invocation_short_name],
+ # Set these flags *last*, or else the test programs won't compile
+ if test x$GCC = xyes ; then
+   # Using -ggdb3 makes (some versions of) Redhat's gcc-2.96 dump core
+-  if "$CC" --version | grep '^2\.96$' 1>/dev/null 2>&1; then
+-    true
+-  else
+-    CFLAGS="$CFLAGS -ggdb3"
+-  fi
+   CFLAGS="$CFLAGS -Wall -W \
+  -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes \
+  -Waggregate-return \
+- -Wpointer-arith -Wbad-function-cast -Wnested-externs"
++ -Wpointer-arith -Wbad-function-cast -Wnested-externs -fgnu89-inline"
+ fi
+ 
+ CPPFLAGS="$CPPFLAGS -I$srcdir"

--- a/packages.txt
+++ b/packages.txt
@@ -741,6 +741,7 @@ lua-resty-balancer
 lua-cjson
 lmdb
 libsrt
+argp-standalone
 yajl
 crun
 modsecurity


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

~But I couldn't achieve to copy files to target, as described in the package function [here](https://git.alpinelinux.org/aports/tree/main/argp-standalone/APKBUILD#n35). Any ideas @tuananh @kaniini ? CI is failing with the following error:~

```shell
 install: can't stat 'libargp.a': No such file or directory
```

Thanks to @amouat for fixing my issue ❤️ 

- _Upstream: https://git.alpinelinux.org/aports/tree/main/argp-standalone/APKBUILD_

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
