### PR TITLE
add ca-certs-bundle as runtime dep of wolfi-baselayout

### DIFF
--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,13 +1,14 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 2
+  epoch: 3
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - glibc-locale-posix
+      - ca-certificates-bundle
 
 environment:
   contents:


### PR DESCRIPTION
We've found quite a lot of cases where images forget to include a dependency on `ca-certificates-bundle`, leading to surprising breakages when the container in question tries to talk to the internet.

One solution would be to more uniformly add ca-certs-bundle to every image, and automate a check to require it.

Another would be to add it as a runtime dep of wolfi-baselayout, which everything depends on already. This is that.

There might theoretically be a case where an image doesn't need ca-certs and now gets it. This isn't a huge cost though, since certs are small and unlikely to introduce any vulnerabilities. It's much more likely that an image silently can't reach resources on the internet, and our testing just hasn't discovered that yet.

Marking draft while we discuss.