### PR TITLE
Updating php epoch

### DIFF
--- a/php.yaml
+++ b/php.yaml
@@ -1,7 +1,7 @@
 package:
   name: php
   version: 8.2.6
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01


### PR DESCRIPTION
This PR bumps the `epoch` in the php package, since the last change incorporated at #2441 is not yet being picked up by the build.