### PR TITLE
packages: remove duplicate luajit entry

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -724,7 +724,6 @@ datadog-cpp
 yaml-cpp
 zipkin-cpp
 jaeger-cpp
-luajit
 lua-resty-core
 lua-resty-upload
 lua-resty-string


### PR DESCRIPTION
Causes the generated makefile to warn about duplicate generated rules in .packagerules
