### PR TITLE
libapr: fix build file path

### DIFF
--- a/libapr.yaml
+++ b/libapr.yaml
@@ -1,7 +1,7 @@
 package:
   name: libapr
   version: 1.7.4
-  epoch: 0
+  epoch: 1
   description: "Apache Portable Runtime Library (APR)"
   copyright:
     - license: Apache-2.0
@@ -40,15 +40,19 @@ pipeline:
     with:
       opts: |
         --prefix=/usr \
-        --libdir=/usr/lib
+        --libdir=/usr/lib \
+        --with-installbuilddir=/usr/share/apr-1/build
 
   - uses: autoconf/make
 
   - uses: autoconf/make-install
 
+  # These files are needed for building other packages like tomcat-native.
+  # Those packages expect a `/build` to exist under the apr root.
   - runs: |
-      mkdir -p "${{targets.destdir}}"/usr/share/
-      mv "${{targets.destdir}}"/usr/build-1 "${{targets.destdir}}"/usr/share/
+      for file in find_apr.m4 apr_common.m4 install.sh gen-build.py get-version.sh config.guess config.sub; do
+        install build/$file -t ${{targets.destdir}}/usr/share/apr-1/build
+      done
 
   - uses: strip
 


### PR DESCRIPTION
This PR changes the build file path for libapr to be `/usr/share/apr-1/build` instead of the previous `/usr/share/build-1`. Packages like tomcat-native expect these files to exist in a `aprsrc/build` dir.

ref: https://gitlab.archlinux.org/archlinux/packaging/packages/apr/-/blob/main/PKGBUILD#L45 and https://gitlab.archlinux.org/archlinux/packaging/packages/apr/-/blob/main/ship_find_apr.m4.patch#L18

/cc @ajayk 