### PR TITLE
Patch CVE-2023-2804 in libjpeg-turbo.

### DIFF
--- a/libjpeg-turbo.yaml
+++ b/libjpeg-turbo.yaml
@@ -1,7 +1,7 @@
 package:
   name: libjpeg-turbo
   version: 2.1.91
-  epoch: 2
+  epoch: 3
   description: "Accelerated baseline JPEG compression and decompression library"
   copyright:
     - license: BSD-3-Clause AND IJG AND Zlib
@@ -21,6 +21,11 @@ pipeline:
       repository: https://github.com/libjpeg-turbo/libjpeg-turbo
       tag: ${{package.version}}
       expected-commit: 6c610333497302c52ff36046f9ff72f0c3a6dc2e
+
+  # Patch source: https://github.com/libjpeg-turbo/libjpeg-turbo/commit/9f756bc67a84d4566bf74a0c2432aa55da404021.patch
+  - uses: patch
+    with:
+      patches: CVE-2023-2804.patch
 
   - runs: |
       cmake -B build -G Ninja \

--- a/libjpeg-turbo/CVE-2023-2804.patch
+++ b/libjpeg-turbo/CVE-2023-2804.patch
@@ -1,0 +1,91 @@
+From 9f756bc67a84d4566bf74a0c2432aa55da404021 Mon Sep 17 00:00:00 2001
+From: DRC <information@libjpeg-turbo.org>
+Date: Tue, 4 Apr 2023 13:53:21 -0500
+Subject: [PATCH] Lossless decomp: Range-limit 12-bit samples
+
+12-bit is the only data precision for which the range of the sample data
+type exceeds the valid sample range, so it is possible to craft a 12-bit
+lossless JPEG image that contains out-of-range 12-bit samples.
+Attempting to decompress such an image using color quantization or merged
+upsampling (NOTE: libjpeg-turbo cannot generate YCbCr or subsampled
+lossless JPEG images, but it can decompress them) caused segfaults or
+buffer overruns when those algorithms attempted to use the out-of-range
+sample values as array indices.  This commit modifies the lossless
+decompressor so that it range-limits the output of the scaler when using
+12-bit samples.
+
+Fixes #670
+Fixes #672
+Fixes #673
+Fixes #674
+Fixes #675
+Fixes #676
+Fixes #677
+Fixes #678
+Fixes #679
+Fixes #681
+Fixes #683
+---
+ ChangeLog.md |  7 +++++++
+ jdlossls.c   | 14 +++++++++++++-
+ 2 files changed, 20 insertions(+), 1 deletion(-)
+
+diff --git a/ChangeLog.md b/ChangeLog.md
+index 93b08061e..de8e45dfb 100644
+--- a/ChangeLog.md
++++ b/ChangeLog.md
+@@ -8,6 +8,13 @@ subsampling, which allows losslessly transposed or rotated 4:1:1 JPEG images to
+ be losslessly cropped, partially decompressed, or decompressed to planar YUV
+ images.
+ 
++2. Fixed various segfaults and buffer overruns that occurred when attempting to
++decompress various specially-crafted malformed 12-bit-per-component lossless
++JPEG images.  These issues were caused by out-of-range sample values that were
++not range-limited before being used as array indices.  The issues were specific
++to 12-bit data precision, since that is the only data precision for which the
++range of the sample data type exceeds the valid sample range.
++
+ 
+ 2.1.91 (3.0 beta2)
+ ==================
+diff --git a/jdlossls.c b/jdlossls.c
+index 4d15e6bba..cfdca7e3a 100644
+--- a/jdlossls.c
++++ b/jdlossls.c
+@@ -6,7 +6,7 @@
+  * Lossless JPEG Modifications:
+  * Copyright (C) 1999, Ken Murchison.
+  * libjpeg-turbo Modifications:
+- * Copyright (C) 2022, D. R. Commander.
++ * Copyright (C) 2022-2023, D. R. Commander.
+  * For conditions of distribution and use, see the accompanying README.ijg
+  * file.
+  *
+@@ -217,7 +217,15 @@ simple_upscale(j_decompress_ptr cinfo,
+                JDIFFROW diff_buf, _JSAMPROW output_buf, JDIMENSION width)
+ {
+   do {
++#if BITS_IN_JSAMPLE == 12
++    /* 12-bit is the only data precision for which the range of the sample data
++     * type exceeds the valid sample range.  Thus, we need to range-limit the
++     * samples, because other algorithms may try to use them as array indices.
++     */
++    *output_buf++ = (_JSAMPLE)((*diff_buf++ << cinfo->Al) & 0xFFF);
++#else
+     *output_buf++ = (_JSAMPLE)(*diff_buf++ << cinfo->Al);
++#endif
+   } while (--width);
+ }
+ 
+@@ -226,7 +234,11 @@ noscale(j_decompress_ptr cinfo,
+         JDIFFROW diff_buf, _JSAMPROW output_buf, JDIMENSION width)
+ {
+   do {
++#if BITS_IN_JSAMPLE == 12
++    *output_buf++ = (_JSAMPLE)((*diff_buf++) & 0xFFF);
++#else
+     *output_buf++ = (_JSAMPLE)(*diff_buf++);
++#endif
+   } while (--width);
+ }
+ 


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist


#### For new package PRs only

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
