### PR TITLE
fix opensearch2 build

### DIFF
--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -1,6 +1,6 @@
 package:
   name: opensearch-2
-  version: "2.7.0"
+  version: "2.8.0"
   epoch: 0
   description:
   target-architecture:
@@ -29,12 +29,13 @@ pipeline:
     with:
       repository: https://github.com/opensearch-project/OpenSearch
       tag: ${{package.version}}
-      expected-commit: b7a6e09e492b1e965d827525f7863b366ef0e304
+      expected-commit: db90a415ff2fd428b4f7b3f800a51dc229287cb4
 
   - runs: |
       export LANG=en_US.UTF-8
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+      gradle localDistro
 
-      ./gradlew localDistro
 
       mkdir -p ${{targets.destdir}}/usr/share/opensearch/logs
 


### PR DESCRIPTION
Fixes open search-2 build failing  [here](https://github.com/wolfi-dev/os/actions/runs/5192877661/jobs/9362659913?pr=2630)
 - moves to local gradle as gradlew was redownloading the gradle again