### PR TITLE
replace virtual dep cmd:diff with explicit package diffutils

### DIFF
--- a/golangci-lint.yaml
+++ b/golangci-lint.yaml
@@ -8,7 +8,7 @@ package:
   dependencies:
     runtime:
       - go
-      - cmd:diff
+      - diffutils
 
 environment:
   contents:


### PR DESCRIPTION
package `golangci-lint` had the following in its runtime dependencies:

```yaml
  dependencies:
    runtime:
      - go
      - cmd:diff
```

This is depending on a virtual, which we should not do. The PR replaces it with dependency on the explicit package `diffutils`

As discussed with @kaniini 