### PR TITLE
remove py3-asn1 runtime depending on itself

### DIFF
--- a/py3-asn1.yaml
+++ b/py3-asn1.yaml
@@ -8,7 +8,6 @@ package:
   dependencies:
     runtime:
       - python3
-      - py3-asn1
 
 environment:
   contents:


### PR DESCRIPTION
package `py3-asn1` has the following:

```yaml
  name: py3-asn1
  dependencies:
    runtime:
      - python3
      - py3-asn1
```

It is nonsensical for `py3-asn1` package to depend in runtime on `py3-asn1`; it _is_ `py3-asn1`; by definition, it already is installed. This removes it.

As discussed with @kaniini 