### PR TITLE
adds cilium cli package

### DIFF
--- a/cilium-cli.yaml
+++ b/cilium-cli.yaml
@@ -1,0 +1,36 @@
+package:
+  name: cilium-cli
+  version: 0.14.6
+  epoch: 0
+  description: CLI to install, manage & troubleshoot Kubernetes clusters running Cilium
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cilium/cilium-cli
+      tag: v${{package.version}}
+      expected-commit: a21731054b5412dc2e91249178483d2d773d7f13
+      destination: cilium-cli
+
+  - runs: |
+      cd cilium-cli
+      make install
+      install -Dm755  /usr/local/bin/cilium ${{targets.destdir}}/usr/bin/cilium
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: cilium/cilium-cli
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -746,3 +746,4 @@ crun
 modsecurity
 ingress-nginx
 ingress-nginx-controller
+cilium-cli


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Adds [cilium-cli](https://github.com/cilium/cilium-cli) package


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
