### PR TITLE
fix: openjdk java version string

### DIFF
--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
   version: 11.0.20.3
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only
@@ -77,7 +77,8 @@ pipeline:
         --with-debug-level=release \
         --with-libjpeg=system \
         --with-giflib=system \
-        --with-lcms=system
+        --with-lcms=system \
+        --with-version-string="${{vars.mangled-package-version}}"
 
   - runs: make jdk-image
 


### PR DESCRIPTION
```
== Java Version === 
openjdk 11.0.18 2023-01-17
OpenJDK Runtime Environment (build 11.0.18+10-post-Debian-1deb11u1)
OpenJDK 64-Bit Server VM (build 11.0.18+10-post-Debian-1deb11u1, mixed mode)



[sdk] ❯ java --version
openjdk 11.0.20-internal 2023-07-18
OpenJDK Runtime Environment (build 11.0.20-internal+0-wolfi-r0)
OpenJDK 64-Bit Server VM (build 11.0.20-internal+0-wolfi-r0, mixed mode)

```

After fix 

```
[sdk] ❯ java --version
openjdk 11.0.20 2023-07-18
OpenJDK Runtime Environment (build 11.0.20+4-wolfi-r0)
OpenJDK 64-Bit Server VM (build 11.0.20+4-wolfi-r0, mixed mode
```