### PR TITLE
fix and update logstash/8.8.1

### DIFF
--- a/logstash.yaml
+++ b/logstash.yaml
@@ -1,6 +1,6 @@
 package:
   name: logstash
-  version: "8.7.0" # 8.7.1-r0 and 8.7.0-r1 have been withdrawn, when bumping, avoid these to avoid withdrawing the same package again
+  version: 8.8.1
   epoch: 0
   description: Logstash - transport and process your logs, events, or other data
   target-architecture:
@@ -25,21 +25,24 @@ environment:
       - openjdk-11
       - ruby-3.1
       - bash
+      - ruby3.1-bundler
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/elastic/logstash
       tag: v${{package.version}}
-      expected-commit: 82d8400440fea09f84c6e8e549a7a613cb9a5260
+      expected-commit: f1a41e558cd915ac9d2f91dc3fdd2865cec3343d
 
   - runs: |
       export OSS=true
       export LOGSTASH_SOURCE=1
       export LANG=en_US.UTF-8
+      export GEM_HOME=$PWD/vendor/bundle/jruby/3.1
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+      export LS_JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 
       gem install rake
-      gem install bundler
 
       ./gradlew installDevelopmentGems
       rake bootstrap
@@ -50,7 +53,7 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/share/java/logstash
       tar --strip-components 1 -C ${{targets.destdir}}/usr/share/java/logstash -xf build/logstash-oss-*-SNAPSHOT-no-jdk.tar.gz
 
-      mkdir -p ${{targets.destdir}}/usr/bin/$name
+      mkdir -p ${{targets.destdir}}/usr/bin
       for i in ${{targets.destdir}}/usr/share/java/logstash/bin/*; do
         name=$(basename $i)
         ln -sf /usr/share/java/logstash/bin/$name ${{targets.destdir}}/usr/bin/$name
@@ -58,7 +61,6 @@ pipeline:
 
 update:
   enabled: true
-  manual: true # avoid creating PRs while build fails on arm
   github:
     identifier: elastic/logstash
     strip-prefix: v


### PR DESCRIPTION
previous version failed on arm, I've tested locally with arm and it worked so enabling auto updates again

fixes #2667

#### For version bump PRs
- [x] The `epoch` field is reset to 0
