### PR TITLE
update jenkins/2.409 + renable auto updates as jenkins on arm

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins
-  version: "2.401"
-  epoch: 1
+  version: "2.409"
+  epoch: 0
   description:
   copyright:
     - license: MIT
@@ -34,7 +34,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/jenkinsci/jenkins/archive/refs/tags/jenkins-${{package.version}}.tar.gz
-      expected-sha256: 2eb98967d5348473d61fb69a1a91396c99711ebe27e377a9b9afa0773ae2980a
+      expected-sha256: e8bfaf7343da4fcd6ec06b97e68210d01bdac52a2fc7cbfbae167238bae3b44f
 
   - uses: patch
     with:
@@ -54,7 +54,6 @@ pipeline:
 
 update:
   enabled: true
-  manual: true # as of 2.402 arm builds are broken, issue tracking this https://issues.jenkins.io/browse/JENKINS-71147
   github:
     identifier: jenkinsci/jenkins
     strip-prefix: jenkins-


### PR DESCRIPTION
successfully tested the arm build locally with the latest version

fixes #2642

#### For version bump PRs
- [x] The `epoch` field is reset to 0
