### PR TITLE
krb5/1.21 package update

### DIFF
--- a/krb5.yaml
+++ b/krb5.yaml
@@ -1,7 +1,7 @@
 package:
   name: krb5
-  version: 1.20.1
-  epoch: 2
+  version: 1.21
+  epoch: 0
   description: The Kerberos network authentication system
   copyright:
     - license: MIT
@@ -27,8 +27,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851
-      uri: https://web.mit.edu/kerberos/dist/krb5/1.20/krb5-${{package.version}}.tar.gz
+      expected-sha256: 69f8aaff85484832df67a4bbacd99b9259bd95aab8c651fbbe65cdc9620ea93b
+      uri: https://web.mit.edu/kerberos/dist/krb5/1.21/krb5-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
fixes #2649

#### For version bump PRs
- [x] The `epoch` field is reset to 0
