### PR TITLE
ruby-3.2: fix sha256 of 3.2.2 release

### DIFF
--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: 3.2.2
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -43,6 +43,8 @@ pipeline:
 
   - name: Configure
     runs: |
+      # Our default LDFLAGS cause an issue with ruby. We need to remove '-z, noexecheap' from LDFLAGS
+      LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -39,7 +39,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://cache.ruby-lang.org/pub/ruby/3.2/ruby-${{package.version}}.tar.gz
-      expected-sha256: 13d67901660ee3217dbd9dd56059346bd4212ce64a69c306ef52df64935f8dbd
+      expected-sha256: 96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc
 
   - name: Configure
     runs: |


### PR DESCRIPTION
This fixes the `ruby-3.2` build for the version 3.2.2. The current sha256 of this version doesn't match the release version:

```
$ melange update-cache ruby-3.2.yaml
2023/06/11 10:19:41 fetching artifacts relating to ruby-3.2-3.2.2
2023/06/11 10:19:41 processing fetch node:
2023/06/11 10:19:41   uri: https://cache.ruby-lang.org/pub/ruby/3.2/ruby-${{package.version}}.tar.gz
2023/06/11 10:19:41   evaluated: https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz
2023/06/11 10:19:43   fetched-as: /tmp/melange-update-3223485716
2023/06/11 10:19:43   actual-sha256: 96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc
2023/06/11 10:19:43   actual-sha512: bcc68f3f24c1c8987d9c80b57332e5791f25b935ba38daf5addf60dbfe3a05f9dcaf21909681b88e862c67c6ed103150f73259c6e35c564f13a00f432e3c1e46
Error: sha256 mismatch: 96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc != 13d67901660ee3217dbd9dd56059346bd4212ce64a69c306ef52df64935f8dbd
2023/06/11 10:19:43 error during command execution: sha256 mismatch: 96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc != 13d67901660ee3217dbd9dd56059346bd4212ce64a69c306ef52df64935f8dbd
```

This update makes the sha256 checksum match what's on the ruby-lang.org release page and what I get back when downloading the artifact:

![image](https://github.com/wolfi-dev/os/assets/579876/f11c6e4b-e894-448c-af60-813e327573a1)

With this change applied:

```
melange update-cache ruby-3.2.yaml
2023/06/11 10:22:03 fetching artifacts relating to ruby-3.2-3.2.2
2023/06/11 10:22:03 processing fetch node:
2023/06/11 10:22:03   uri: https://cache.ruby-lang.org/pub/ruby/3.2/ruby-${{package.version}}.tar.gz
2023/06/11 10:22:03   evaluated: https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz
2023/06/11 10:22:06   fetched-as: /tmp/melange-update-91168631
2023/06/11 10:22:06   actual-sha256: 96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc
2023/06/11 10:22:06   actual-sha512: bcc68f3f24c1c8987d9c80b57332e5791f25b935ba38daf5addf60dbfe3a05f9dcaf21909681b88e862c67c6ed103150f73259c6e35c564f13a00f432e3c1e46
2023/06/11 10:22:06   wrote: /var/cache/melange/sha256:96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc
```