### PR TITLE
don't BUILDWORLD unless asked

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: 'Build Wolfi'
         run: |
           for package in ${{needs.changes.outputs.packages}}; do
-            make MELANGE="melange" MELANGE_EXTRA_OPTS="--create-build-log" REPO="$GITHUB_WORKSPACE/packages" BUILDWORLD=no packages/$package -j1
+            make MELANGE="melange" MELANGE_EXTRA_OPTS="--create-build-log" REPO="$GITHUB_WORKSPACE/packages" packages/$package -j1
           done
 
       - name: Check for file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,11 +32,9 @@ Add a new entry for your package near the bottom of [`packages.txt`](packages.tx
 your-package-name
 ```
 
-Once you're done writing the new package configuration file, you can test it by triggering a build with `make packages/<your-package-name> BUILDWORLD=no USE_CACHE=no`.
+Once you're done writing the new package configuration file, you can test it by triggering a build with `make packages/<your-package-name>`.
 
-note: `USE_CACHE=no` disables using a GCP cloud bucket for caching pipeline sources.  This is mainly used for production setups and not needed for local development.
-
-If you do use a cache for your sources and see GCS auth related errors, your gcloud auth credentials might be the issue. Try running `gcloud auth login && gcloud auth application-default login`.
+If you do use a cache for your sources and see GCS auth related errors, your gcloud auth credentials might be the issue. Try running `gcloud auth login && gcloud auth application-default login`, then add `USE_CACHE=yes` to your `make` invocation.
 
 Your build packages should be found in the generated `./packages` directory.
 

--- a/HOW_TO_PATCH_CVES.md
+++ b/HOW_TO_PATCH_CVES.md
@@ -52,16 +52,10 @@ For the ease of explanation, we'll assume we're addressing a single reported vul
 
     For example, if we're patching CVE-2018-25032 in the "zlib" package, where the version is 1.2.3 and the epoch is 4, we'd enter `zlib` as the package, `CVE-2018-25032` as the vulnerability and `1.2.3-r4` as the fixed version.
 
-1. Verify that our update package will build successfully by running Melange. To do this, run (in a container if you're not already on Linux):
+1. Verify that our update package will build successfully by running Melange. To do this, run:
 
     ```shell
-    make
-    ```
-
-    Note that currently, this will build the **entire world**. If you want to build just a single package, you can run the following to build the package:
-
-    ```shell
-    BUILDWORLD=no make packages/${ARCH}/${PACKAGE_NAME}-${PACKAGE_VERSION}.apk
+    make packages/${PACKAGE_NAME}
     ```
 
 1. Open a PR.

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ifeq (${USE_CACHE}, yes)
 	MELANGE_OPTS += --cache-source ${CACHE_DIR}
 endif
 
-ifeq (${BUILDWORLD}, no)
+ifneq (${BUILDWORLD}, yes)
 MELANGE_OPTS += -k ${WOLFI_SIGNING_PUBKEY}
 MELANGE_OPTS += -r ${WOLFI_PROD}
 endif

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -30,8 +30,11 @@ There are presently some caveats, however:
 # Reproducing the entire OS
 
 The easiest way to verify reproducibility in the build system is to
-simply build the OS twice with the same key.  Or you can download the
-entire Wolfi package collection using `gsutil -m rsync`:
+simply build the OS twice with the same key. To build all packages, run `make
+BUILDWORLD=yes`.
+
+Or you can download the entire Wolfi package collection using `gsutil -m
+rsync`:
 
     gsutil -m rsync gs://wolfi-production-registry-destination/os/ wolfi-packages/os/
 
@@ -48,12 +51,12 @@ comparing the package directories.
 If you just want to test an individual Wolfi package for reproducibility,
 the same caveats above still apply.  But you can ask the build system to
 build just a single package, without building dependencies, by using the
-`BUILDWORLD=no` knob.  For example, with `execline`:
+`=no` knob.  For example, with `execline`:
 
-    # doas make packages/execline BUILDWORLD=no
+    # doas make packages/execline
     ...
     # doas mv packages packages-1
-    # doas make packages/execline BUILDWORLD=no
+    # doas make packages/execline
     ...
     # doas mv packages packages-2
     # sha256sum packages-1/$(uname -m)/*.apk | sed -e s:packages-1:packages-2:g | sha256sum -c


### PR DESCRIPTION
This switches the default for `BUILDWORLD` from `yes` to `no`. This means to build a package you just need to:

```
make package/<package-name>
```