### PR TITLE
add lighttpd and dependent libdbi package

### DIFF
--- a/libdbi.yaml
+++ b/libdbi.yaml
@@ -1,0 +1,46 @@
+package:
+  name: libdbi
+  version: 0.9.0
+  epoch: 0
+  description: "Database independent abstraction layer for C"
+  copyright:
+    - license: LGPL-2.1-or-later
+  dependencies:
+    runtime:
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://downloads.sourceforge.net/project/libdbi/libdbi/libdbi-${{package.version}}/libdbi-${{package.version}}.tar.gz
+      expected-sha512: ee8777195af43057409d051a6055ec0467cd926d48da076458b09f91d2f0995a1cc4bc071762e401b7bdcd8a4173fd8ea3472db3a1518e34b4c5b5ed24e4e2ce
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: "libdbi-dev"
+    description: "libdbi headers"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - libdbi
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1589

--- a/lighttpd.yaml
+++ b/lighttpd.yaml
@@ -1,0 +1,68 @@
+package:
+  name: lighttpd
+  version: 1.4.71
+  epoch: 0
+  description: Secure, fast, compliant and very flexible web-server
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - readline-dev
+      - automake
+      - autoconf
+      - brotli-dev
+      - e2fsprogs
+      - flex
+      - linux-pam-dev
+      - libtool
+      - m4
+      - pkgconf-dev
+      - libdbi-dev
+      - libxml2-dev
+      - lua5.4-dev
+      - openldap-dev
+      - openssl-dev
+      - pcre-dev
+      - pcre2-dev
+      - sqlite-dev
+      - zlib-dev
+      - zstd-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-${{package.version}}.tar.xz
+      expected-sha512: c1388b563b9cf9dcab0a57bec42b09b2cb5e1932bc137ae5f957d1bf3932ddd8f5f188002a7b9a00f0a92ba3779b21ecbea2ccffa91e686b6660c9cc455d6598
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --with-ldap \
+        --with-pam \
+        --with-attr \
+        --with-openssl \
+        --with-webdav-props \
+        --with-webdav-locks \
+        --with-lua \
+        --with-pcre2 \
+        --with-brotli \
+        --with-zstd \
+        --with-dbi
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1817

--- a/packages.txt
+++ b/packages.txt
@@ -752,3 +752,5 @@ tomcat-native
 cronie
 cilium-cli
 acme.sh
+libdbi
+lighttpd


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

adds `lighttpd` and dependent `libdbi`

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`
