### PR TITLE
add caddy package

### DIFF
--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,0 +1,46 @@
+package:
+  name: caddy
+  version: 2.6.4
+  epoch: 0
+  description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/caddyserver/caddy
+      tag: v${{package.version}}
+      expected-commit: 0db29e2ce9799f652f3d16fd5aed6e426d23bd0a
+
+  # TODO: Add support for plugins
+  - uses: go/build
+    with:
+      packages: ./cmd/caddy
+      output: caddy
+      ldflags: -s -w
+
+  - uses: strip
+
+subpackages:
+  - name: caddy-man
+    description: caddy manpages
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share
+          "${{targets.destdir}}"/usr/bin/caddy manpage --directory "${{targets.subpkgdir}}"/usr/share/
+
+update:
+  enabled: true
+  github:
+    identifier: caddyserver/caddy
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v

--- a/packages.txt
+++ b/packages.txt
@@ -752,3 +752,4 @@ tomcat-native
 cronie
 cilium-cli
 acme.sh
+caddy


### PR DESCRIPTION

adds `caddy` package

Related:

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`
