### PR TITLE
add wireguard-tools and wireguard-go

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -752,3 +752,5 @@ tomcat-native
 cronie
 cilium-cli
 acme.sh
+wireguard-tools
+wireguard-go

--- a/wireguard-go.yaml
+++ b/wireguard-go.yaml
@@ -1,0 +1,36 @@
+package:
+  name: wireguard-go
+  version: 0.0.20230223
+  epoch: 0
+  description: "Go Implementation of WireGuard"
+  copyright:
+    - license: GPL-2.0-only
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://git.zx2c4.com/wireguard-go
+      tag: ${{package.version}}
+      expected-commit: 21636207a6756120f56f836b06c086b627f7b911
+
+  - uses: go/build
+    with:
+      packages: .
+      output: wireguard-go
+      ldflags: -s -w
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: WireGuard/wireguard-go
+    use-tag: true

--- a/wireguard-tools.yaml
+++ b/wireguard-tools.yaml
@@ -1,0 +1,44 @@
+package:
+  name: wireguard-tools
+  version: 1.0.20210914
+  epoch: 0
+  description: "Next generation secure network tunnel: userspace tools"
+  copyright:
+    - license: GPL-2.0-only
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - bash
+      - ca-certificates-bundle
+      - build-base
+      - libmnl-dev
+      - iproute2
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://git.zx2c4.com/wireguard-tools
+      tag: v${{package.version}}
+      expected-commit: 3ba6527130c502144e7388b900138bca6260f4e8
+
+  - uses: autoconf/make-install
+    with:
+      dir: src
+      opts: |
+        WITH_BASHCOMPLETION=no \
+        WITH_WGQUICK=no \
+        WITH_SYSTEMDUNITS=no
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/share/doc/${{package.name}}
+      cp -rf contrib "${{targets.destdir}}"/usr/share/doc/${{package.name}}/
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 62381


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

adds `wireguard-tools` and `wireguard-go`.

`wireguard-go` isn't really used, especially in the context of wolfi where it's in the kernel, but include it for completeness

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`
