### PR TITLE
replace ruby3.2-webrick unstaisfied dep with actual

### DIFF
--- a/ruby3.2-fluentd14.yaml
+++ b/ruby3.2-fluentd14.yaml
@@ -22,7 +22,7 @@ package:
       - ruby3.2-strptime
       - ruby3.2-tzinfo
       - ruby3.2-tzinfo-data
-      - 'ruby3.2-webrick<1.8'
+      - ruby3.2-webrick
       - ruby3.2-yajl-ruby
 
 environment:

--- a/ruby3.2-fluentd15.yaml
+++ b/ruby3.2-fluentd15.yaml
@@ -17,7 +17,7 @@ package:
       - ruby3.2-strptime
       - ruby3.2-tzinfo
       - ruby3.2-tzinfo-data
-      - 'ruby3.2-webrick<1.8'
+      - ruby3.2-webrick
       - ruby3.2-yajl-ruby
 
 environment:


### PR DESCRIPTION
The files `ruby3.2-fluentd14.yaml` and `ruby3.2-fluentd15.yaml` have the following dependency:

```yaml
  dependencies:
    runtime:
      # ...
      - 'ruby3.2-webrick<1.8'
```

This doesn't make sense, as nothing in here provides that, and there is no external dependency. The one provider of `ruby3.2-webrick` is [ruby3.2-webrick.yaml](https://github.com/wolfi-dev/os/blob/main/ruby3.2-webrick.yaml), which provides version `1.8.1-r1`, which, obviously, will not satisfy `<1.8`

Per @kaniini the right fix here is to just have it accept `ruby3.2-webrick`

```yaml
  dependencies:
    runtime:
      # ...
      - ruby3.2-webrick
```
