### PR TITLE
workflows: upload x86_64 APKINDEX.json file to storage

### DIFF
--- a/.github/workflows/push-production.yaml
+++ b/.github/workflows/push-production.yaml
@@ -77,6 +77,10 @@ jobs:
               --cache-control=no-store \
               "${{ github.workspace }}/packages/x86_64/APKINDEX.tar.gz" gs://wolfi-production-registry-destination/os/x86_64/
 
+          gcloud --quiet storage cp \
+              --cache-control=no-store \
+              "${{ github.workspace }}/packages/x86_64/APKINDEX.json" gs://wolfi-production-registry-destination/os/x86_64/
+
           # apks will be cached in CDN for an hour by default.
           gcloud --quiet storage cp \
               "${{ github.workspace }}/packages/x86_64/*.apk" gs://wolfi-production-registry-destination/os/x86_64/

--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -56,5 +56,6 @@ jobs:
               melange index -o APKINDEX.tar.gz -a $arch *.apk
               melange sign-index --signing-key="${{ github.workspace }}/wolfi-signing.rsa" APKINDEX.tar.gz
               gsutil -h "Cache-Control:no-store" cp "${{ github.workspace }}/packages/${arch}/APKINDEX.tar.gz" gs://wolfi-production-registry-destination/os/${arch}/APKINDEX.tar.gz
+              gsutil -h "Cache-Control:no-store" cp "${{ github.workspace }}/packages/${arch}/APKINDEX.json" gs://wolfi-production-registry-destination/os/${arch}/APKINDEX.json
             popd
           done


### PR DESCRIPTION
This is needed for the package viewer