### PR TITLE
Add proxysql package.

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -759,3 +759,4 @@ libdbi
 lighttpd
 mdbook
 ffmpeg
+proxysql

--- a/proxysql.yaml
+++ b/proxysql.yaml
@@ -1,0 +1,56 @@
+package:
+  name: proxysql
+  version: 2.5.2
+  epoch: 0
+  description: High-performance MySQL proxy with a GPL license
+  copyright:
+    - license: GPL-3.0
+
+environment:
+  contents:
+    packages:
+      - automake
+      - bzip2
+      - build-base
+      - busybox
+      - git
+      - openssl
+      - patch
+      - openssl-dev
+      - posix-libc-utils
+      - jemalloc-dev
+      - perl
+      - cmake
+      - gnutls-dev
+      - autoconf
+      - libtool
+      - python3
+      - zlib-dev
+      - util-linux-dev
+      - gawk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/sysown/proxysql
+      tag: v${{package.version}}
+      expected-commit: 7f727b3acadcac3042cd4bdd7cc821858df58d1d
+    pipeline:
+      - runs: |
+          # Our default LDFLAGS cause an issue with proxysql. We need to add -fPIC.
+          export CFLAGS="${CFLAGS} -fPIC"
+          export CPPFLAGS="$CFLAGS"
+          export CXXFLAGS="$CFLAGS"
+          make -j$(nproc)
+      - runs: |
+          mkdir -p ${{targets.destdir}}/usr/bin
+          mkdir -p ${{targets.destdir}}/etc
+          install -m 0755 src/proxysql ${{targets.destdir}}/usr/bin
+          install -m 0600 etc/proxysql.cnf ${{targets.destdir}}/etc
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: sysown/proxysql
+    strip-prefix: v


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`
