### PR TITLE
force remove cleanup to prevent erroneous errors

### DIFF
--- a/rust.yaml
+++ b/rust.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust
   version: 1.70.0
-  epoch: 0
+  epoch: 1
   description: "rust a type safe memory safe language"
   copyright:
     - license: Apache-2.0 AND MIT
@@ -97,11 +97,11 @@ pipeline:
 
   # delete uneeded files eg uninstalltion
   - runs: |
-      rm ${{targets.destdir}}/usr/lib/rustlib/components
-      rm ${{targets.destdir}}/usr/lib/rustlib/install.log
-      rm ${{targets.destdir}}/usr/lib/rustlib/rust-installer-version
-      rm ${{targets.destdir}}/usr/lib/rustlib/uninstall.sh
-      rm ${{targets.destdir}}/usr/lib/rustlib/manifest-*
+      rm -f ${{targets.destdir}}/usr/lib/rustlib/components
+      rm -f ${{targets.destdir}}/usr/lib/rustlib/install.log
+      rm -f ${{targets.destdir}}/usr/lib/rustlib/rust-installer-version
+      rm -f ${{targets.destdir}}/usr/lib/rustlib/uninstall.sh
+      rm -f ${{targets.destdir}}/usr/lib/rustlib/manifest-*
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions

--- a/rust.yaml
+++ b/rust.yaml
@@ -52,16 +52,17 @@ pipeline:
       cd rustc-${{package.version}}-src
       ./configure \
         --host="${ARCH}" \
-        --target="${ARCH}" \
+        --target="${ARCH},wasm32-wasi,wasm32-unknown-unknown" \
         --prefix="/usr" \
         --release-channel="stable" \
+        --release-description="Wolfi OS ${{pacakge.name}} ${{package.version}}-r${{package.epoch}}" \
         --enable-local-rust \
         --local-rust-root="/usr" \
         --llvm-root="/usr/lib/llvm15" \
         --llvm-config="/usr/bin/llvm-config" \
         --disable-docs \
         --enable-extended \
-        --tools="cargo,src" \
+        --tools="cargo,clippy,src,rustfmt,rust-demangler" \
         --enable-llvm-link-shared \
         --enable-option-checking \
         --enable-locked-deps \
@@ -76,7 +77,13 @@ pipeline:
         --set="target.${ARCH}.musl-root=/usr" \
         --set="target.${ARCH}.crt-static=false" \
         --set="target.${ARCH}.musl-root=/usr" \
-        --set="target.${ARCH}.crt-static=false"
+        --set="target.${ARCH}.crt-static=false" \
+        --set="target.wasm32-unknown-unknown.sanitizers=false" \
+        --set="target.wasm32-unknown-unknown.profiler=false" \
+        --set="target.wasm32-unknown-unknown.linker=lld" \
+        --set="target.wasm32-wasi.sanitizers=false" \
+        --set="target.wasm32-wasi.profiler=false" \
+        --set="target.wasm32-wasi.wasi-root=/usr/share/wasi-sysroot"
 
   - runs: |
       cd rustc-${{package.version}}-src
@@ -91,7 +98,7 @@ pipeline:
       export CXXFLAGS="$CXXFLAGS -O2 -I/usr/include/llvm15"
       export OPENSSL_NO_VENDOR=1
       export RUST_BACKTRACE=1
-      DESTDIR=${{targets.destdir}} python3 ./x.py install --jobs ${JOBS:-2}
+      DESTDIR=${{targets.destdir}} python3 ./x.py install --jobs "$(nproc)"
 
   - uses: strip
 
@@ -107,9 +114,9 @@ pipeline:
   # overwrite them with symlinks to the per-architecture versions
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/lib32
-      cd ${{targets.destdir}}
-      ln -srft usr/lib   usr/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.so
-      ln -srft usr/lib32 usr/lib/rustlib/i686-unknown-linux-gnu/lib/*.so
+      cd "${{targets.destdir}}"
+      ln -srft usr/lib   ${{targets.destdir}}/usr/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.so
+      ln -srft usr/lib32 ${{targets.destdir}}/usr/lib/rustlib/i686-unknown-linux-gnu/lib/*.so
 
 update:
   enabled: true


### PR DESCRIPTION
some/newer versions of `rust` don't have files relevant for cleaning up. this just adds an `-f` so we don't surface errors due to empty cleanups

relevant dump:

```
ℹ  aarch64   | executing command [/bin/sh -c set -e
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
rm /home/build/melange-out/rust/usr/lib/rustlib/components
rm /home/build/melange-out/rust/usr/lib/rustlib/install.log
rm /home/build/melange-out/rust/usr/lib/rustlib/rust-installer-version
rm /home/build/melange-out/rust/usr/lib/rustlib/uninstall.sh
rm /home/build/melange-out/rust/usr/lib/rustlib/manifest-*

exit 0]
⚠  aarch64   | rm: cannot remove '/home/build/melange-out/rust/usr/lib/rustlib/components': No such file or directory
2023/06/13 14:58:55 ERROR: failed to build package. the build environment has been preserved:

```

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
