### PR TITLE
fix cves for tigera/operator

### DIFF
--- a/tigera-operator.yaml
+++ b/tigera-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: tigera-operator
   version: 1.30.2
-  epoch: 1
+  epoch: 2
   description: Kubernetes operator for installing Calico and Calico Enterprise
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,18 @@ pipeline:
       expected-commit: 708b1141a692ddb03a46d7726f9c920c195f50d9
 
   - runs: |
+      # GHSA-vvpx-j8f3-3w6h
+      go get golang.org/x/net@v0.7.0
+
+      # Mitigate CVE-2021-38561
+      go get golang.org/x/text@v0.3.8
+
+      # Mitigate GHSA-r48q-9g5r-8q2h
+      go get github.com/emicklei/go-restful@v2.16.0
+
+      go get github.com/tigera/api@eb5ab52 # v3.12.0
+
+      go mod tidy
       PACKAGE_NAME=github.com/tigera/operator
       ARCH=$(go env GOARCH)
       BINDIR=build/_output/bin

--- a/tigera-operator.yaml
+++ b/tigera-operator.yaml
@@ -29,10 +29,7 @@ pipeline:
       # Mitigate CVE-2021-38561
       go get golang.org/x/text@v0.3.8
 
-      # Mitigate GHSA-r48q-9g5r-8q2h
-      go get github.com/emicklei/go-restful@v2.16.0
-
-      go get github.com/tigera/api@eb5ab52 # v3.12.0
+      go get github.com/tigera/api@36fa08b # v3.9.1-calient-0.dev
 
       go mod tidy
       PACKAGE_NAME=github.com/tigera/operator


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
