### PR TITLE
Switch fluent-bit to build from git instead of the release URL.

### DIFF
--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -1,18 +1,10 @@
 package:
   name: fluent-bit
   version: 2.1.2
-  epoch: 0
+  epoch: 1
   description: Fast and Lightweight Log processor and forwarder
   copyright:
     - license: Apache-2.0
-
-# creates a new var that contains only the major and minor version to be used in the fetch URL
-# e.g. 2.6.11 will create a new var mangled-package-version=2.6
-var-transforms:
-  - from: ${{package.version}}
-    match: (\d+\.\d+)\.\d+
-    replace: $1
-    to: mangled-package-version
 
 environment:
   contents:
@@ -35,10 +27,11 @@ environment:
       - systemd-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://releases.fluentbit.io/${{vars.mangled-package-version}}/source-${{package.version}}.tar.gz
-      expected-sha256: c866be8c5a31321c1f61fa0cb51cfb5d8daaa979d30351ffc6f3a1507b4d3218
+      repository: https://github.com/fluent/fluent-bit
+      expected-commit: 113c7c00d2addc0dc294f46125ead4fe9e9a094d
+      tag: v${{package.version}}
 
   - runs: |
       cd build
@@ -91,6 +84,9 @@ subpackages:
 
 update:
   enabled: true
-  manual: true # melange bump doesn't work with var-transforms yet
-  release-monitor:
-    identifier: 267335
+  github:
+    identifier: fluent/fluent-bit
+    strip-prefix: v
+    # There are some malformed tags
+    tag-filter: v2
+    use-tag: true


### PR DESCRIPTION
This allows us to turn on auto-updates.


Fixes:

Related:

### Pre-review Checklist

