### PR TITLE
add gdb package

### DIFF
--- a/gdb.yaml
+++ b/gdb.yaml
@@ -1,0 +1,66 @@
+package:
+  name: gdb
+  version: "13.2"
+  epoch: 0
+  description: The GNU Debugger
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+        - '*'
+      attestation: TODO
+      license: GPL-3.0-or-later AND LGPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - expat-dev
+      - gmp-dev
+      - libtool
+      - linux-headers
+      - ncurses-dev
+      - perl
+      - python3-dev
+      - readline-dev
+      - texinfo
+      - zlib-dev
+      - zstd-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: fd5bebb7be1833abdb6e023c2f498a354498281df9d05523d8915babeb893f0a
+      uri: https://ftp.gnu.org/gnu/gdb/gdb-${{package.version}}.tar.xz
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --with-python=/usr/bin/python3 \
+        --disable-nls \
+        --disable-werror \
+        --mandir=/usr/share/man \
+        --infodir=/usr/share/info \
+        --with-system-readline \
+        --with-system-zlib
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: gdb-doc
+    pipeline:
+      - uses: split/manpages
+    description: gdb manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11798

--- a/packages.txt
+++ b/packages.txt
@@ -762,3 +762,4 @@ lighttpd
 mdbook
 ffmpeg
 proxysql
+gdb


### PR DESCRIPTION
The GNU Debugger

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`
