### PR TITLE
gdb move info pages into docs subpackage

### DIFF
--- a/gdb.yaml
+++ b/gdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdb
   version: "13.2"
-  epoch: 0
+  epoch: 1
   description: The GNU Debugger
   target-architecture:
     - all
@@ -58,6 +58,7 @@ subpackages:
   - name: gdb-doc
     pipeline:
       - uses: split/manpages
+      - uses: split/infodir
     description: gdb manpages
 
 update:


### PR DESCRIPTION
Fixes an error when installing gdb:
```
ERROR: gdb-13.2-r0: trying to overwrite usr/share/info/dir owned by libffi-3.4.4-r2.
```