### PR TITLE
add librdkafka

### DIFF
--- a/librdkafka.yaml
+++ b/librdkafka.yaml
@@ -1,0 +1,65 @@
+package:
+  name: librdkafka
+  version: 2.1.1
+  epoch: 0
+  description: "The Apache Kafka C/C++ library"
+  copyright:
+    - license: BSD-2-Clause
+
+environment:
+  contents:
+    packages:
+      # - bsd-compat-headers
+      - linux-headers
+      - build-base
+      - busybox
+      - cmake
+      - ca-certificates-bundle
+      - openssl-dev
+      - samurai
+      - lz4-dev
+      - zstd-dev
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 6bf1761e7ed1820b587fda24277f6606ec046da281064df13c4380f49a92f3e2b165614b9c622d46b27078ec024a4dc211610e500e597265e8219f8869c4d203
+      uri: https://github.com/edenhill/librdkafka/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - runs: |
+      CFLAGS="$CFLAGS -flto=auto" \
+      CXXFLAGS="$CXXFLAGS -flto=auto" \
+      cmake -B build -G Ninja \
+      -DCMAKE_INSTALL_PREFIX=/usr \
+      -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+      -DCMAKE_BUILD_TYPE=RelWithDebinfo \
+      -DRDKAFKA_BUILD_EXAMPLES=OFF \
+      -DRDKAFKA_BUILD_TESTS="$(want_check && echo ON || echo OFF)"
+      cmake --build build
+
+  - runs: |
+      DESTDIR="${{targets.destdir}}" cmake --install build
+
+  - uses: strip
+
+subpackages:
+  - name: librdkafka-dev
+    pipeline:
+      - uses: split/dev
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/*.so* "${{targets.subpkgdir}}"/usr/lib/
+    dependencies:
+      runtime:
+        - librdkafka
+    description: librdkafka dev
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - full-integration-tests
+  github:
+    identifier: edenhill/librdkafka
+    strip-prefix: v
+    use-tag: true

--- a/packages.txt
+++ b/packages.txt
@@ -756,6 +756,7 @@ cilium-cli
 wireguard-tools
 wireguard-go
 acme.sh
+librdkafka
 caddy
 cloudflared
 libdbi


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_

_**IMPORTANT NOTES for the reviewer**_ :

I'm actually trying to build [kafkacat](https://git.alpinelinux.org/aports/tree/community/kafkacat/APKBUILD), [librdkafka](https://git.alpinelinux.org/aports/tree/community/librdkafka/APKBUILD) is one of the dependencies of that package, but when I try to librdkafka, I noticed that it [depends](https://git.alpinelinux.org/aports/tree/community/librdkafka/APKBUILD#n17) on another package we don't have yet named [rapidjson](https://git.alpinelinux.org/aports/tree/community/rapidjson/APKBUILD), but without adding that dependency, it worked somehow, so the question is should I still build rapidjson package and add it to its dependencies?
