### PR TITLE
Add couchdb package, with erlang-25/26 split.

### DIFF
--- a/couchdb.yaml
+++ b/couchdb.yaml
@@ -1,0 +1,76 @@
+package:
+  name: couchdb
+  version: 3.3.2
+  epoch: 0
+  description: Seamless multi-master syncing database with an intuitive HTTP/JSON API, designed for reliability
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+
+environment:
+  contents:
+    packages:
+      - erlang-25
+      - erlang-25-dev
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - busybox
+      - openssl-dev
+      - nodejs-16
+      - icu-dev
+      - libtool
+      - mozjs91-dev
+      - mozjs91
+      - python3
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 11a2340709af2e3ebcb052337c9acb88f7fac3cb
+      repository: https://github.com/apache/couchdb
+      tag: ${{package.version}}
+
+  - uses: autoconf/configure
+    with:
+      opts: --spidermonkey-version=91
+
+  - runs: |
+      export CFLAGS="$CFLAGS -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare"
+      make release
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/usr/share/
+      mv rel/couchdb ${{targets.destdir}}/usr/share/couchdb
+
+      rm ${{targets.destdir}}/usr/share/couchdb/bin/couchdb.cmd
+
+      # symlink every file in /usr/share/couchdb/bin to /usr/bin
+      for file in ${{targets.destdir}}/usr/share/couchdb/bin/*; do
+        ln -s /usr/share/couchdb/bin/$(basename $file) ${{targets.destdir}}/usr/bin/$(basename $file)
+      done
+
+  - uses: strip
+
+subpackages:
+  - name: couchdb-compat
+    pipeline:
+      - runs: |
+          # link /usr/share/couchdb to /opt/couchdb
+          mkdir -p ${{targets.subpkgdir}}/opt
+          ln -sf /usr/share/couchdb ${{targets.subpkgdir}}/opt/couchdb
+
+  - name: couchdb-doc
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share/couchdb/
+          mv ${{targets.destdir}}/usr/share/couchdb/share ${{targets.subpkgdir}}/usr/share/couchdb/
+
+update:
+  # This doesn't work with mangled package versions
+  enabled: false
+  github:
+    identifier: apache/couchdb
+    use-tag: true

--- a/erlang-25.yaml
+++ b/erlang-25.yaml
@@ -1,0 +1,73 @@
+package:
+  name: erlang-25
+  version: 25.3.2.2
+  epoch: 0
+  description: General-purpose programming language and runtime environment
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      # mnesia depends on the ca-certificates bundle
+      - ca-certificates-bundle
+    provides:
+      - erlang=25.3.2.2
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - openssl-dev
+      - ncurses-dev
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 83a36f3d90deef36adb615bbfb46cd327f0b76b7668e1f7f253fd66b4ae24518
+      uri: https://github.com/erlang/otp/releases/download/OTP-${{package.version}}/otp_src_${{package.version}}.tar.gz
+
+  - runs: |
+      export CPPFLAGS="-D_BSD_SOURCE $CPPFLAGS"
+
+      ./otp_build autoconf
+      ./configure \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --infodir=/usr/share/info \
+        --host="$CHOST" \
+        --build="$CBUILD" \
+        --enable-threads \
+        --enable-shared-zlib \
+        --enable-ssl=dynamic-ssl-lib \
+        --enable-jit
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: "erlang-25-dev"
+    description: "headers for erlang"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - erlang
+      provides:
+        - erlang-dev=25.3.2.2
+
+update:
+  enabled: true
+  github:
+    identifier: erlang/otp
+    strip-prefix: OTP-
+    use-tag: true
+    tag-filter: OTP-25

--- a/erlang-26.yaml
+++ b/erlang-26.yaml
@@ -1,5 +1,5 @@
 package:
-  name: erlang
+  name: erlang-26
   version: 26.0.1
   epoch: 0
   description: General-purpose programming language and runtime environment
@@ -9,6 +9,8 @@ package:
     runtime:
       # mnesia depends on the ca-certificates bundle
       - ca-certificates-bundle
+    provides:
+      - erlang=26.999.0
 
 environment:
   contents:
@@ -52,13 +54,15 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "erlang-dev"
+  - name: "erlang-26-dev"
     description: "headers for erlang"
     pipeline:
       - uses: split/dev
     dependencies:
       runtime:
         - erlang
+      provides:
+        - erlang-dev=26.999.0
 
 update:
   enabled: true

--- a/packages.txt
+++ b/packages.txt
@@ -260,7 +260,8 @@ libxpm
 dav1d
 aom
 libavif
-erlang
+erlang-25
+erlang-26
 elixir
 rabbitmq-server
 gd
@@ -767,4 +768,5 @@ ffmpeg
 guacamole-server
 proxysql
 mozjs91
+couchdb
 gdb


### PR DESCRIPTION
Couchdb needs erlang25 to build still, so I split the erlang package into 25 and 26.

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`
