### PR TITLE
patch cve for acl

### DIFF
--- a/acl.yaml
+++ b/acl.yaml
@@ -1,7 +1,7 @@
 package:
   name: acl
   version: 2.3.1
-  epoch: 2
+  epoch: 3
   description: "access control list utilities"
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -20,6 +20,10 @@ pipeline:
     with:
       uri: https://download.savannah.nongnu.org/releases/acl/acl-${{package.version}}.tar.gz
       expected-sha256: 760c61c68901b37fdd5eefeeaf4c0c7a26bdfdd8ac747a1edff1ce0e243c11af
+
+  - uses: patch
+    with:
+      patches: lfs64.patch
 
   - runs: |
       ./configure \

--- a/acl/lfs64.patch
+++ b/acl/lfs64.patch
@@ -1,0 +1,22 @@
+diff --git a/tools/chacl.c b/tools/chacl.c
+index 525a7ff..8fff875 100644
+--- a/tools/chacl.c
++++ b/tools/chacl.c
+@@ -320,7 +320,7 @@ walk_dir(acl_t acl, acl_t dacl, const char *fname)
+ {
+ 	int failed = 0;
+ 	DIR *dir;
+-	struct dirent64 *d;
++	struct dirent *d;
+ 	char *name;
+ 
+ 	if ((dir = opendir(fname)) == NULL) {
+@@ -332,7 +332,7 @@ walk_dir(acl_t acl, acl_t dacl, const char *fname)
+ 		return(0);	/* got a file, not an error */
+ 	}
+ 
+-	while ((d = readdir64(dir)) != NULL) {
++	while ((d = readdir(dir)) != NULL) {
+ 		/* skip "." and ".." entries */
+ 		if (strcmp(d->d_name, ".") == 0 || strcmp(d->d_name, "..") == 0)
+ 			continue;


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: **_https://git.alpinelinux.org/aports/tree/main/acl/lfs64.patch_**

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
