### PR TITLE
fix nested cni-plugins install location

### DIFF
--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -1,7 +1,7 @@
 package:
   name: cni-plugins
   version: 1.3.0
-  epoch: 1
+  epoch: 2
   description: Some reference and example networking plugins, maintained by the CNI team.
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ pipeline:
       ./build_linux.sh
 
       mkdir -p "${{targets.destdir}}"/usr/bin
-      cp -a bin/ "${{targets.destdir}}"/usr/bin/
+      cp -a bin/* "${{targets.destdir}}"/usr/bin/
 
   - uses: strip
 


### PR DESCRIPTION
the `cni-plugins` were installed into the wrong location:

```
593ae8d79853:/work# apk info -L cni-plugins
cni-plugins-1.3.0-r1 contains:
usr/bin/bin/bandwidth
usr/bin/bin/bridge
usr/bin/bin/dhcp
usr/bin/bin/dummy
usr/bin/bin/firewall
usr/bin/bin/host-device
usr/bin/bin/host-local
usr/bin/bin/ipvlan
usr/bin/bin/loopback
usr/bin/bin/macvlan
usr/bin/bin/portmap
usr/bin/bin/ptp
usr/bin/bin/sbr
usr/bin/bin/static
usr/bin/bin/tap
usr/bin/bin/tuning
usr/bin/bin/vlan
usr/bin/bin/vrf
var/lib/db/sbom/cni-plugins-1.3.0-r1.spdx.json
```
