### PR TITLE
xtrans/1.5.0 package update

### DIFF
--- a/xtrans.yaml
+++ b/xtrans.yaml
@@ -1,7 +1,7 @@
 package:
   name: xtrans
-  version: 1.4.0
-  epoch: 2
+  version: 1.5.0
+  epoch: 0
   description: X transport library
   copyright:
     - license: MIT
@@ -20,8 +20,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 377c4491593c417946efcd2c7600d1e62639f7a8bbca391887e2c4679807d773
-      uri: https://www.x.org/releases/individual/lib/xtrans-${{package.version}}.tar.bz2
+      expected-sha256: 1ba4b703696bfddbf40bacf25bce4e3efb2a0088878f017a50e9884b0c8fb1bd
+      uri: https://www.x.org/releases/individual/lib/xtrans-${{package.version}}.tar.xz
 
   - uses: autoconf/configure
 


### PR DESCRIPTION
fixes #2784

#### For version bump PRs
- [x] The `epoch` field is reset to 0

