### PR TITLE
build flags: remove -Wextra and -Wtrampolines

### DIFF
--- a/build-aarch64.env
+++ b/build-aarch64.env
@@ -1,5 +1,5 @@
 # Ampere Altra, the CPU used by most cloud providers, is Neoverse N1.
-export CFLAGS="-O2 -Wall -Wextra -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wtrampolines"
+export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"

--- a/build-armv7l.env
+++ b/build-armv7l.env
@@ -1,5 +1,5 @@
 # We target the BCM2836 which is Cortex-A7 with the SIMD unit.
-export CFLAGS="-O2 -Wall -Wextra -fomit-frame-pointer -march=armv7-a+simd -mtune=cortex-a7 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wtrampolines"
+export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv7-a+simd -mtune=cortex-a7 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"

--- a/build-x86_64.env
+++ b/build-x86_64.env
@@ -1,4 +1,4 @@
-export CFLAGS="-O2 -Wall -Wextra -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wtrampolines"
+export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"


### PR DESCRIPTION
the -Wtrampolines flag is GCC-specific and is intended to issue warnings about the use of a very rarely used GCC feature that allows dynamically-generated trampolines at runtime to be created.

the only time this happens is when the GCC nested functions extension is used, which is basically never.  this conflicts with programs built using Clang with -Werror, such as those built by Bazel and MSBuild.

the -Wextra flag enables a lot of extra warnings that are not enabled by -Wall.  this is useful for developers, who are reading their build logs, but not useful for packagers who are just building software, and most likely are only reading build logs on failures.  the -Wextra flag also causes problems with Bazel and MSBuild for the same reason as -Wtrampolines, the extra warnings conflict with -Werror.