### PR TITLE
dotnet-6 and dotnet-7 updates, enable LLVMgold plugin

### DIFF
--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -21,6 +21,7 @@ environment:
       - ncurses-dev
       - clang-15
       - llvm15
+      - llvm15-dev
       - krb5-dev
       - zlib-dev
       - icu-dev

--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -1,6 +1,6 @@
 package:
   name: dotnet-6
-  version: 6.0.116
+  version: 6.0.118
   epoch: 0
   description: ".NET SDK, version 6"
   target-architecture:
@@ -39,7 +39,7 @@ pipeline:
     with:
       repository: https://github.com/dotnet/installer
       tag: v${{package.version}}
-      expected-commit: b605cc131fcdef9956ddefe092069c57938a98db
+      expected-commit: b8b476fbe60becae6d0c3d36b7ba964aeee3523d
       destination: /home/build/installer
 
   - working-directory: /home/build/installer

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-7
-  version: 7.0.105
-  epoch: 1
+  version: 7.0.107
+  epoch: 0
   description: ".NET SDK"
   target-architecture:
     - all
@@ -42,7 +42,7 @@ pipeline:
     with:
       repository: https://github.com/dotnet/installer
       tag: v${{package.version}}
-      expected-commit: e1bc5e001c9b8e87d9f99e06eb7dbf04c508f450
+      expected-commit: bf72c06963e2bb23c1abfd97a9ed50e47e155027
       destination: /home/build/installer
 
   - working-directory: /home/build/installer

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -24,6 +24,7 @@ environment:
       - ncurses-dev
       - clang-15
       - llvm15
+      - llvm15-dev
       - krb5-dev
       - zlib-dev
       - icu-dev


### PR DESCRIPTION
LLVMgold plugin is now required by the .NET build system.