### PR TITLE
gcc-12: new package

### DIFF
--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,0 +1,126 @@
+package:
+  name: gcc-12
+  version: 12.3.0
+  epoch: 0
+  description: "the GNU compiler collection - version 12"
+  copyright:
+    - license: GPL-3.0-or-later
+  options:
+    no-provides: true
+  dependencies:
+    runtime:
+      - binutils
+      - libstdc++-12-dev
+
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - build-base
+      - ca-certificates-bundle
+      - texinfo
+      - gawk
+      - bison
+      - flex-dev
+      - gmp-dev
+      - mpfr-dev
+      - mpc-dev
+      - isl-dev
+      - zlib-dev
+      - make
+      - zip
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://ftp.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
+      expected-sha256: 949a5d4f99e786421a93b532b22ffab5578de7321369975b91aec97adfda8c3b
+
+  - working-directory: /home/build/build
+    pipeline:
+      - name: 'Configure GCC'
+        runs: |
+          # We use generic CFLAGS, because GCC 6 is older than the CFLAGS we normally use.
+          CFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
+          CXXFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
+          CPPFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
+          export CFLAGS CXXFLAGS CPPFLAGS
+
+          ../configure \
+            --prefix=/usr \
+            --program-suffix="-12" \
+            --disable-nls \
+            --disable-werror \
+            --with-glibc-version=2.35 \
+            --enable-initfini-array \
+            --disable-nls \
+            --disable-multilib \
+            --disable-libatomic \
+            --disable-libsanitizer \
+            --enable-host-shared \
+            --enable-shared \
+            --enable-threads \
+            --enable-tls \
+            --enable-default-pie \
+            --enable-default-ssp \
+            --with-system-zlib \
+            --enable-languages=c,c++ \
+            --enable-bootstrap \
+            --enable-gnu-indirect-function \
+            --enable-gnu-unique-object \
+            --enable-version-specific-runtime-libs \
+            --with-linker-hash-style=gnu
+
+          make -j$(nproc)
+          make -j$(nproc) install DESTDIR="${{targets.destdir}}"
+
+  # We don't want to keep the .la files.
+  - runs: |
+      find ${{targets.destdir}} -name '*.la' -print -exec rm \{} \;
+
+  # Remove libffi
+  - runs: |
+      rm -f "${{targets.destdir}}"/usr/lib/libffi* "${{targets.destdir}}"/usr/share/man/man3/ffi*
+      find "${{targets.destdir}}" -name 'ffi*.h' | xargs rm -f
+
+  - name: 'Clean up documentation'
+    runs: |
+      rm -rf ${{targets.destdir}}/usr/share/info
+
+  - uses: strip
+
+subpackages:
+  - name: 'gcc-12-doc'
+    pipeline:
+      - uses: split/manpages
+
+  - name: 'libstdc++-12'
+    pipeline:
+      - runs: |
+          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+
+          mkdir -p "${{targets.subpkgdir}}"/$gcclibdir
+          mv "${{targets.destdir}}"/$gcclibdir/*++.so.* "${{targets.subpkgdir}}"/$gcclibdir
+    options:
+      no-provides: true
+
+  - name: 'libstdc++-12-dev'
+    pipeline:
+      - runs: |
+          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+
+          mkdir -p "${{targets.subpkgdir}}"/$gcclibdir
+          mkdir -p "${{targets.subpkgdir}}"/$gcclibdir/include
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx
+          mv "${{targets.destdir}}"/$gcclibdir/*++.a "${{targets.subpkgdir}}"/$gcclibdir/
+          mv "${{targets.destdir}}"/$gcclibdir/libstdc++.so "${{targets.subpkgdir}}"/$gcclibdir/
+          mv "${{targets.destdir}}"/$gcclibdir/include/*++* "${{targets.subpkgdir}}"/$gcclibdir/include/
+          mv "${{targets.destdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/* \
+            "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/
+
+update:
+  enabled: false
+  manual: true
+  release-monitor:
+    identifier: 6502

--- a/packages.txt
+++ b/packages.txt
@@ -793,3 +793,4 @@ spirv-tools
 libva
 glslang
 gdb
+gcc-12


### PR DESCRIPTION
`gcc-12` provides GCC 12 configured in such a way that it can sit alongside GCC 13 without conflicts.  It can be used to build software which is presently incompatible with GCC 13, though GCC 13 should be used whenever possible.