### PR TITLE
fix kmod symlinks paths

### DIFF
--- a/kmod.yaml
+++ b/kmod.yaml
@@ -1,7 +1,7 @@
 package:
   name: kmod
   version: "30"
-  epoch: 0
+  epoch: 1
   description: Linux kernel module management utilities
   copyright:
     - license: GPL-2.0-or-later
@@ -48,7 +48,7 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/bin
       mkdir -p ${{targets.destdir}}/usr/sbin
       for i in lsmod rmmod insmod modinfo modprobe depmod; do
-        ln -sf ../usr/bin/kmod ${{targets.destdir}}/usr/sbin/$i
+        ln -sf ../bin/kmod ${{targets.destdir}}/usr/sbin/$i
       done
       for i in lsmod modinfo; do
         ln -s kmod ${{targets.destdir}}/usr/bin/$i


### PR DESCRIPTION
the symlinks to `kmod` are using the wrong relative path, the fixed links are below:

```shell
$ pwd
/usr/sbin
$ ls -lah modprobe
lrwxrwxrwx 1 root root 11 Jan  1  1970 modprobe -> ../bin/kmod
$ ls -lah ../bin/kmod
-rwxr-xr-x 1 root root 195K Jan  1  1970 ../bin/kmod
```

related #873 
