### PR TITLE
add cri-tools (crictl)

### DIFF
--- a/cri-tools.yaml
+++ b/cri-tools.yaml
@@ -1,0 +1,58 @@
+package:
+  name: cri-tools
+  version: 1.27.0
+  epoch: 0
+  description: CLI and validation tools for Kubelet Container Runtime Interface (CRI) .
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/cri-tools
+      tag: v${{package.version}}
+      expected-commit: b60f39bc21df6988e2e0c7a9cd041802b1473ec2
+
+  - runs: |
+      # Fix for CVE-2023-2253
+      go get github.com/docker/distribution@v2.8.2-beta.1
+      make vendor
+
+  - uses: go/build
+    with:
+      packages: ./cmd/crictl
+      output: crictl
+      ldflags: -s -w -X github.com/kubernetes-sigs/cri-tools/pkg/version.VERSION=${{package.version}}
+
+  - runs: |
+      make critest
+      install -Dm755 build/bin/linux/**/critest "${{targets.destdir}}"/usr/bin/critest
+
+  - uses: strip
+
+subpackages:
+  - name: "crictl"
+    description: "CLI for kubelet CRI"
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/crictl ${{targets.subpkgdir}}/usr/bin/crictl
+
+  - name: "critest"
+    description: "validation test suites for kubelet CRI"
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/critest ${{targets.subpkgdir}}/usr/bin/critest
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/cri-tools
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -803,3 +803,4 @@ gdb
 gcc-12
 flannel
 flannel-cni-plugin
+cri-tools


### PR DESCRIPTION
adds `cri-tools` package (and `crictl` executable)

Related: #873 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`