### PR TITLE
Revert bumps in aws-efs-csi driver.

### DIFF
--- a/aws-efs-csi-driver.yaml
+++ b/aws-efs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-efs-csi-driver
   version: 1.5.6
-  epoch: 2
+  epoch: 3
   description: CSI driver for Amazon EFS.
   copyright:
     - license: Apache-2.0
@@ -26,15 +26,6 @@ pipeline:
   - runs: |
       # Our global LDFLAGS conflict with a Makefile parameter
       unset LDFLAGS
-      go mod edit -require k8s.io/kubernetes@v1.24.14
-      go mod edit -replace k8s.io/apiserver=k8s.io/apiserver@v0.27.3
-      go mod edit -replace k8s.io/component-helpers=k8s.io/component-helpers@v0.27.3
-      go mod edit -replace k8s.io/component-base=k8s.io/component-base@v0.27.3
-      go mod edit -replace k8s.io/client-go=k8s.io/client-go@v0.27.3
-      go mod edit -replace k8s.io/api=k8s.io/api@v0.27.3
-      go mod edit -replace k8s.io/apimachinery=k8s.io/apimachinery@v0.27.3
-      go mod tidy -compat=1.17
-      go mod vendor
       make ARCH=$(go env GOARCH)
       mkdir -p ${{targets.destdir}}/usr/bin
       mkdir -p ${{targets.destdir}}/etc/amazon/efs


### PR DESCRIPTION
These don't work. I thought I tested it but mistyped something and had an older version.

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only