### PR TITLE
fix: thanos operator bad signature

### DIFF
--- a/thanos-operator.yaml
+++ b/thanos-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-operator
   version: 0.3.7
-  epoch: 0
+  epoch: 1
   description: Kubernetes operator for deploying Thanos
   copyright:
     - license: Apache-2.0

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -12,3 +12,4 @@ acl-2.3.1-r3.apk
 acl-dev-2.3.1-r3.apk
 libacl1-2.3.1-r3.apk
 xtrans-1.5.0-r0.apk
+thanos-operator-0.3.7-r0


### PR DESCRIPTION

```
(1/1) Installing thanos-operator (0.3.7-r0)
ERROR: thanos-operator-0.3.7-r0: BAD signature
1 error; 976 MiB in 52 packages
```