### PR TITLE
add upx-v4.0.2: new package

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -818,3 +818,4 @@ slirp4netns
 local-path-provisioner
 fuse-overlayfs
 fuse-overlayfs-snapshotter
+upx

--- a/upx.yaml
+++ b/upx.yaml
@@ -42,8 +42,8 @@ pipeline:
       output-dir: build
 
   - runs: |
-    name: Run tests
       ctest --test-dir build --output-on-failure
+    name: Run tests
 
   - uses: cmake/install
     name: Install UPX

--- a/upx.yaml
+++ b/upx.yaml
@@ -43,7 +43,6 @@ pipeline:
 
   - runs: |
       ctest --test-dir build --output-on-failure
-    name: Run tests
 
   - uses: cmake/install
     name: Install UPX

--- a/upx.yaml
+++ b/upx.yaml
@@ -1,0 +1,68 @@
+package:
+  name: upx
+  version: 4.0.2
+  epoch: 0
+  description: "The Ultimate Packer for eXecutables"
+  copyright:
+    - license: GPL-2.0
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - build-base
+      - cmake
+      - samurai
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/upx/upx
+      expected-commit: 33cdcb0e8277576cc64894bb332c469942864bcd
+      tag: v${{package.version}}
+
+  - runs: |
+      git submodule update --init
+
+  - uses: cmake/configure
+    name: Cmake Configure
+    with:
+      opts: |
+        -B build \
+        -G Ninja \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DUPX_CONFIG_DISABLE_WERROR=ON \
+        -DUPX_CONFIG_DISABLE_SANITIZE=ON \
+        -DUPX_CONFIG_DISABLE_GITREV=ON
+
+  - uses: cmake/build
+    name: Building UPX
+    with:
+      output-dir: build
+
+  - runs: |
+    name: Run tests
+      ctest --test-dir build --output-on-failure
+
+  - uses: cmake/install
+    name: Install UPX
+    with:
+      output-dir: build
+
+  - uses: strip
+
+subpackages:
+  - name: "upx-doc"
+    description: "upx documentation"
+    pipeline:
+      - uses: split/manpages
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share
+          mv "${{targets.destdir}}"/usr/share/doc/upx "${{targets.subpkgdir}}"/usr/share
+
+update:
+  enabled: true
+  github:
+    identifier: upx/upx
+    strip-prefix: v


### PR DESCRIPTION
Related: https://github.com/wolfi-dev/os/issues/2921

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

I am opening this PR to add upx. Everything seems to build and package cleanly but I did notice that the program crashed when I tried to run it. Would appreciate some eyes on that to debug and push it over the line.
