### PR TITLE
cadvisor: eliminate all CVEs

### DIFF
--- a/cadvisor.yaml
+++ b/cadvisor.yaml
@@ -1,7 +1,7 @@
 package:
   name: cadvisor
   version: 0.47.1
-  epoch: 2
+  epoch: 3
   description: Analyzes resource usage and performance characteristics of running containers.
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,10 @@ pipeline:
       go get golang.org/x/net@v0.7.0
       # Handle CVE-2023-27561
       go get github.com/opencontainers/runc@v1.1.5
+      # Handle GHSA-232p-vwff-86mp GHSA-33pg-m6jh-5237 and GHSA-6wrf-mxfj-pf5p
+      go get github.com/docker/docker@v20.10.24
+      # Handle GHSA-hqxw-f8mx-cpmw
+      go get github.com/docker/distribution@v2.8.2-beta.1
       go mod tidy
       cd cmd
       go mod tidy


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

```
 ✔ Vulnerability DB        [no update available]
 ✔ Indexed test
 ✔ Cataloged packages      [83 packages]
 ✔ Scanning image...       [2 vulnerabilities]
   ├── 0 critical, 1 high, 1 medium, 0 low, 0 negligible
   └── 0 fixed

No vulnerabilities found
```

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
