### PR TITLE
[kubectl] bump github.com/docker/distribution to v2.8.2

### DIFF
--- a/kubectl.yaml
+++ b/kubectl.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubectl
   version: 1.27.3
-  epoch: 0
+  epoch: 1
   description: Command-line interface for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,7 @@ pipeline:
       expected-sha256: 8ef07217229e1c0dab21cc014ee05f79dffd31d3bf13a8ff3c730e031973f3e8
 
   - runs: |
-      go get github.com/docker/distribution@v2.8.2-beta.1
+      go get github.com/docker/distribution@v2.8.2
       go mod vendor
       make kubectl
       mkdir -p ${{targets.destdir}}/usr/bin/


### PR DESCRIPTION
- [kubectl] bump github.com/docker/distribution to v2.8.2

Fixes: n/a

Related: n/a

