### PR TITLE
remove glibc runtime dependency on wolfi-baselayout, eliminate runtime loop

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -8,6 +8,7 @@ package:
   dependencies:
     runtime:
       - wolfi-baselayout
+      - glibc-locale-posix
       - '!musl'
   scriptlets:
     trigger:

--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -7,7 +7,6 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - glibc-locale-posix
       - ca-certificates-bundle
 
 environment:


### PR DESCRIPTION
`glibc.yaml` has a runtime dependency on `wolfi-baselayout`. This created a loop:

1. wolfi-baselayout [depends runtime on](https://github.com/wolfi-dev/os/blob/main/wolfi-baselayout.yaml#L10) glibc-local-posix
1. which is a [subpackage of glibc](https://github.com/wolfi-dev/os/blob/main/glibc.yaml#L457-L462)
1. glibc, in turn, [depends runtime on wolfi-baselayout](https://github.com/wolfi-dev/os/blob/main/glibc.yaml#L10).

At @kaniini 's suggestion, removing the `glibc` runtime (_not_ buildtime) dependency on `wolfi-basealayout`.

To be honest, I am not sure the right way to test this. If it were buildtime, it would be easy: either the package builds correctly or it does not. Do we have anything in tests that catches this?
