### PR TITLE
remove meson dependency on strip

### DIFF
--- a/meson.yaml
+++ b/meson.yaml
@@ -29,8 +29,6 @@ pipeline:
 
   - runs: python3 setup.py install --prefix=/usr --root=${{targets.destdir}}
 
-  - uses: strip
-
 subpackages:
   - name: meson-doc
     pipeline:


### PR DESCRIPTION
Similar to #2937 .

We had an infinite loop:

1. [pax-utils depends in its pipelines on meson](https://github.com/wolfi-dev/os/blob/main/pax-utils.yaml#L31)
1. which in its pipelines [uses strip](https://github.com/wolfi-dev/os/blob/main/meson.yaml#L32)
1. whose [needs include scanelf](https://github.com/chainguard-dev/melange/blob/12a1c4076cc005f04798f710c2fce3ed6cb47904/pkg/build/pipelines/strip.yaml#L6)
1. which in turn is a [subpackage of pax-utils](https://github.com/wolfi-dev/os/blob/main/pax-utils.yaml#L41)

As suggested by @kaniini , this removes `meson` from depending on `strip`, as meson is python and shouldn't need it.

Unlike #2937, this is a buildtime change, so CI either will succeed in building it or not, so enabling auto-merge.