### PR TITLE
add libslirp and slirp4netns

### DIFF
--- a/libslirp.yaml
+++ b/libslirp.yaml
@@ -1,0 +1,44 @@
+package:
+  name: libslirp
+  version: 4.7.0
+  epoch: 0
+  description: A general purpose TCP-IP emulator
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - meson
+      - glib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v${{package.version}}/libslirp-v${{package.version}}.tar.gz
+      expected-sha512: 387f4a6dad240ce633df2640bb49c6cb0041c8b3afc8d0ef38186d385f00dd9e4ef4443e93e1b71dbf05e22892b6f2771a87a202e815d8ec899ab5c147a1f09f
+
+  - uses: meson/configure
+
+  - uses: meson/compile
+
+  - uses: meson/install
+
+  - uses: strip
+
+subpackages:
+  - name: libslirp-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - libslirp
+    description: libslirp dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 96796

--- a/packages.txt
+++ b/packages.txt
@@ -808,3 +808,5 @@ flannel-cni-plugin
 cri-tools
 btrfs-progs
 sonobuoy
+libslirp
+slirp4netns

--- a/slirp4netns.yaml
+++ b/slirp4netns.yaml
@@ -1,0 +1,45 @@
+package:
+  name: slirp4netns
+  version: 1.2.0
+  epoch: 0
+  description: User-mode networking for unprivileged network namespaces
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - bash
+      - ca-certificates-bundle
+      - build-base
+      - autoconf
+      - automake
+      - glib-dev
+      - libcap-dev
+      - libseccomp-dev
+      - libslirp-dev
+      - pkgconf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rootless-containers/slirp4netns
+      tag: v${{package.version}}
+      expected-commit: 656041d45cfca7a4176f6b7eed9e4fe6c11e8383
+
+  - runs: bash ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: rootless-containers/slirp4netns
+    strip-prefix: v


### PR DESCRIPTION
adds `libslirp` and `slirp4netns`

Related: #873 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`
