### PR TITLE
7zip: switch to manual update as bot doesnt work with mangled vars

### DIFF
--- a/7zip.yaml
+++ b/7zip.yaml
@@ -53,5 +53,6 @@ subpackages:
 
 update:
   enabled: true
+  manual: true
   release-monitor:
     identifier: 265148


### PR DESCRIPTION
fixes #2913

No epoch bump needed as just configuring auto updates.