### PR TITLE
libunwind/1.7.0 package update

### DIFF
--- a/libunwind.yaml
+++ b/libunwind.yaml
@@ -1,7 +1,7 @@
 package:
   name: libunwind
-  version: 1.6.2
-  epoch: 1
+  version: 1.7.0
+  epoch: 0
   description: "Portable and efficient C programming interface (API) to determine the call-chain of a program"
   copyright:
     - license: MIT
@@ -13,12 +13,18 @@ environment:
       - build-base
       - linux-headers
       - xz-dev
+      - autoconf
+      - automake
+      - libtool
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://download.savannah.gnu.org/releases/libunwind/libunwind-${{package.version}}.tar.gz
-      expected-sha512: 1d17dfb14f99a894a6cda256caf9ec481c14068aaf8f3a85fa3befa7c7cca7fca0f544a91a3a7c2f2fc55bab19b06a67ca79f55ac9081151d94478c7f611f8f7
+      repository: https://github.com/libunwind/libunwind
+      tag: v${{package.version}}
+      expected-commit: 688caaf6ef9853cc26ad8bd1706804d48a0df0bc
+
+  - runs: autoreconf -i
 
   - uses: autoconf/configure
 
@@ -42,5 +48,6 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 1748
+  github:
+    identifier: libunwind/libunwind
+    strip-prefix: v


### PR DESCRIPTION
switches from https://download.savannah.gnu.org/releases/libunwind/ to github as 1.7.0 isn't available in the former URL.

fixes #2783