### PR TITLE
fix tcptraceroute build

### DIFF
--- a/tcptraceroute.yaml
+++ b/tcptraceroute.yaml
@@ -1,7 +1,7 @@
 package:
   name: tcptraceroute
   version: 1.5_beta7
-  epoch: 0
+  epoch: 1
   description: Display route path using TCP probes
   copyright:
     - license: LGPL-2.0-or-later
@@ -34,8 +34,8 @@ pipeline:
   - uses: autoconf/configure
     with:
       opts: |
-        --build=$CBUILD \
-        --host=$CHOST \
+        --host=${{host.triplet.gnu}} \
+        --build=${{host.triplet.gnu}} \
         --prefix=/usr \
         --sysconfdir=/etc \
         --mandir=/usr/share/man \


### PR DESCRIPTION
```
⚠️  aarch64   | UNAME_MACHINE = aarch64
⚠️  aarch64   | UNAME_RELEASE = 5.15.89+
⚠️  aarch64   | UNAME_SYSTEM  = Linux
⚠️  aarch64   | UNAME_VERSION = #1 SMP Sat Mar 18 09:28:00 UTC 2023
⚠️  aarch64   | configure: error: cannot guess build type; you must specify one
ℹ️  aarch64   | checking build system type...
2023/06/20 12:57:05 ERROR: failed to build package. the build environment has been preserved:
```

https://github.com/wolfi-dev/os/actions/runs/5322650469/jobs/9639610550

