### PR TITLE
add klipper-{lb,helm} packages

### DIFF
--- a/klipper-helm.yaml
+++ b/klipper-helm.yaml
@@ -1,0 +1,36 @@
+package:
+  name: klipper-helm
+  version: 0.8.0-build20230510
+  epoch: 0
+  description: Klipper helm integration job image
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - busybox
+      - helm
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - curl
+
+# NOTE: We intentionally don't package helmv2. This results in errors when using `HelmChart`'s in k3s that require helmv2.
+# TODO: Package the necessary helm plugins: [helm-mapkubeapis, helm-set-status]
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/k3s-io/klipper-helm
+      tag: v${{package.version}}
+      expected-commit: 964381ebeaca4e666e9d2836b55bb60a99e2b201
+  - runs: |
+      install -Dm755 entry "${{targets.destdir}}"/usr/bin/entry
+
+update:
+  enabled: true
+  github:
+    identifier: k3s-io/klipper-helm
+    strip-prefix: v

--- a/klipper-lb.yaml
+++ b/klipper-lb.yaml
@@ -1,0 +1,35 @@
+package:
+  name: klipper-lb
+  version: 0.4.4
+  epoch: 0
+  description: Embedded service load balancer in Klipper
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - busybox
+      - ip6tables
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - curl
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/k3s-io/klipper-lb
+      tag: v${{package.version}}
+      expected-commit: 63942dfab1d4f2a6deed94eeada077ef2462b8c1
+
+  - runs: |
+      install -Dm755 entry "${{targets.destdir}}"/usr/bin/entry
+
+update:
+  enabled: true
+  github:
+    identifier: k3s-io/klipper-lb
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -811,3 +811,5 @@ btrfs-progs
 sonobuoy
 libslirp
 slirp4netns
+klipper-lb
+klipper-helm


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

adds `klipper-{lb,helm}` packages.

This does not add the optionally dependent `helm-mapkubeapis` or `helm-set-status` plugins. These can/will be added in future packages, and pulled in via the `apko` config.

Related: #873 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`