### PR TITLE
add local-path-provisioner

### DIFF
--- a/local-path-provisioner.yaml
+++ b/local-path-provisioner.yaml
@@ -1,0 +1,38 @@
+package:
+  name: local-path-provisioner
+  version: 0.0.24
+  epoch: 0
+  description: Dynamically provisioning persistent local storage with Kubernetes
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - busybox
+      - zlib
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rancher/local-path-provisioner
+      tag: v${{package.version}}
+      expected-commit: 97e0501428f0a5bcac49ecd0bfdb051797c4a6c5
+
+  - uses: go/build
+    with:
+      packages: .
+      output: local-path-provisioner
+      ldflags: -s -w -X main.VERSION=${{package.version}}
+
+update:
+  enabled: true
+  github:
+    identifier: rancher/local-path-provisioner
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -811,3 +811,4 @@ btrfs-progs
 sonobuoy
 libslirp
 slirp4netns
+local-path-provisioner


### PR DESCRIPTION
adds `local-path-provisioner`

Related: #873 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`