### PR TITLE
adds additional util-linux subpackages

### DIFF
--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -1,7 +1,7 @@
 package:
   name: util-linux
   version: 2.39
-  epoch: 0
+  epoch: 1
   description: Random collection of Linux utilities
   copyright:
     - license: |-
@@ -77,9 +77,12 @@ data:
       lsblk: Block device list tool from util-linux
       runuser: Run a program with substitute user and group ID
       mcookie: Generate random numbers for xauth from util-linux
+      mount: Makes a file system available for use
       partx: Tell the kernel about disk partition changes from util-linux
+      setarch: Change reported architecture in new program environment and/or set personality flags
       setpriv: Run a program with different Linux privilege settings
       sfdisk: Partition table manipulator from util-linux
+      umount: Unmount filesystems
       uuidgen: UUID generator from util-linux
       wipefs: Utility to wipe filesystems from device from util-linux
 


### PR DESCRIPTION
It looks like these were missed because they didn't show up in the `case/esac` statement in the alpine build ([here](https://git.alpinelinux.org/aports/tree/main/util-linux/APKBUILD)), but they are included as part of the subpackages definition.

this adds extra subpackage targets for these utils, so we don't have to pull the entire `util-linux-misc` subpackage to get them.

related: #873 