### PR TITLE
Add a CVE patch for CVE-2021-3468 for avahi.

### DIFF
--- a/avahi.yaml
+++ b/avahi.yaml
@@ -1,7 +1,7 @@
 package:
   name: avahi
   version: 0.8
-  epoch: 0
+  epoch: 1
   description: A multicast/unicast DNS-SD framework
   target-architecture:
     - all
@@ -34,6 +34,12 @@ pipeline:
     with:
       uri: https://github.com/lathiat/avahi/releases/download/v${{package.version}}/avahi-${{package.version}}.tar.gz
       expected-sha256: 060309d7a333d38d951bc27598c677af1796934dbd98e1024e7ad8de798fedda
+
+  - uses: patch
+    with:
+      # The patch source is https://patch-diff.githubusercontent.com/raw/lathiat/avahi/pull/330.patch
+      # It was merged upstream but a release hasn't been made yet.
+      patches: CVE-2021-3468.patch
 
   - uses: autoconf/configure
     with:

--- a/avahi/CVE-2021-3468.patch
+++ b/avahi/CVE-2021-3468.patch
@@ -1,0 +1,37 @@
+From 447affe29991ee99c6b9732fc5f2c1048a611d3b Mon Sep 17 00:00:00 2001
+From: Riccardo Schirone <sirmy15@gmail.com>
+Date: Fri, 26 Mar 2021 11:50:24 +0100
+Subject: [PATCH] Avoid infinite-loop in avahi-daemon by handling HUP event in
+ client_work
+
+If a client fills the input buffer, client_work() disables the
+AVAHI_WATCH_IN event, thus preventing the function from executing the
+`read` syscall the next times it is called. However, if the client then
+terminates the connection, the socket file descriptor receives a HUP
+event, which is not handled, thus the kernel keeps marking the HUP event
+as occurring. While iterating over the file descriptors that triggered
+an event, the client file descriptor will keep having the HUP event and
+the client_work() function is always called with AVAHI_WATCH_HUP but
+without nothing being done, thus entering an infinite loop.
+
+See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=984938
+---
+ avahi-daemon/simple-protocol.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/avahi-daemon/simple-protocol.c b/avahi-daemon/simple-protocol.c
+index 3e0ebb114..6c0274d65 100644
+--- a/avahi-daemon/simple-protocol.c
++++ b/avahi-daemon/simple-protocol.c
+@@ -424,6 +424,11 @@ static void client_work(AvahiWatch *watch, AVAHI_GCC_UNUSED int fd, AvahiWatchEv
+         }
+     }
+ 
++    if (events & AVAHI_WATCH_HUP) {
++        client_free(c);
++        return;
++    }
++
+     c->server->poll_api->watch_update(
+         watch,
+         (c->outbuf_length > 0 ? AVAHI_WATCH_OUT : 0) |


### PR DESCRIPTION


Fixes:

Related:

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [X] Patch source: _patch source here_
