### PR TITLE
don't upload apks if they already exist

### DIFF
--- a/.github/workflows/push-production.yaml
+++ b/.github/workflows/push-production.yaml
@@ -82,7 +82,9 @@ jobs:
               "${{ github.workspace }}/packages/x86_64/APKINDEX.json" gs://wolfi-production-registry-destination/os/x86_64/
 
           # apks will be cached in CDN for an hour by default.
+          # Don't upload the object if it already exists.
           gcloud --quiet storage cp \
+              --no-clobber \
               "${{ github.workspace }}/packages/x86_64/*.apk" gs://wolfi-production-registry-destination/os/x86_64/
 
   postrun:


### PR DESCRIPTION
Each build downloads all apks, builds anything missing, and uploads all apks. Since the GCS bucket has [Object Versioning](https://cloud.google.com/storage/docs/object-versioning) enabled, we store multiple copies of the same apk ([example](https://console.cloud.google.com/storage/browser/_details/wolfi-production-registry-destination/os/x86_64/7zip-22.01-r0.apk;tab=version_history?project=prod-images-c6e5)), for every apk. We have a lifecycle rule to reap old versions when there are 10+ non-current versions, but that only gives us a ~day of history with our current build volume.

By uploading with [`--no-clobber`](https://cloud.google.com/sdk/gcloud/reference/storage/cp#--clobber), we won't upload a new file if one already exists, saving storage costs and presumably some upload time.

With this change, if an object gets deleted, the old non-live version will still exist in the history until 10+ copies of it are created and deleted, and some time has passed (lifecycle rules apply daily, I think).

It might be possible to go through and reap old non-live duplicate versions, but I don't think it would necessarily be worth it.

If this change looks good I'll make the same one in wolfictl so we can get this for arm builds.