### PR TITLE
add k3s

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,0 +1,165 @@
+package:
+  name: k3s
+  version: 1.27.2
+  epoch: 0
+  description:
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - containerd
+      - busybox
+      - ip6tables
+      - libseccomp
+      - conntrack-tools
+      # TODO:
+      # - slirp4netns # rootless support
+      # containerd-shim-runc-v2 # can save some size without packaging containerd-shim and containerd-shim-runc-v1
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - curl
+      - libseccomp-dev
+      - sqlite-dev
+      - zstd
+      - yq
+      - runc # for buildtime version info
+      - containerd # for buildtime version info
+      - crictl # for buildtime version info
+      - crane
+
+var-transforms:
+  # TODO: This transforms the version into the real k3s version. It's needed
+  # because the wolfictl update bot doesn't yet support the k3s version format
+  # (+k3s#). This is a hack, and means if upstream ships a >k3s1 revision, we
+  # won't automatically pick it up. However, this is rare, and this solution
+  # buys us enough time to add support for the k3s version scheme.
+  - from: ${{package.version}}
+    match: ^(.+)$
+    replace: $1+k3s1 # NOTE: Update k3s# if upstream ships a >k3s# revision
+    to: full-package-version
+
+# Upstream uses `dapper` to initialize build environments, but since melange
+# already provides a consistent build environment, we adopt upstreams
+# ./scripts as much as possible. Additionally, we try to replace all k3s
+# built third party components with Wolfi replacements.
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/k3s-io/k3s
+      tag: v${{vars.full-package-version}}
+      expected-commit: 213d7ad499e166290872f51c63d8eaa2f1fe78b3
+  # First build things (almost) identical to upstream, with the k3s components embedded in the "outer" multicall binary.
+  - runs: |
+      # Don't include the k3s-root since it conflicts with wolfi variants (ie: busybox and ip6tables)
+      sed -e '/curl --compressed/d' -i scripts/download
+      mkdir -p build/static bin/aux etc
+      ./scripts/download
+
+      ./scripts/build
+
+      sed -e '/scripts\/build-upload/d' -i scripts/package-cli
+      ./scripts/package-cli
+
+      # Move the "outer" embedded k3s multicall binary into a new name to avoid overwriting
+      mv dist/artifacts/k3s* dist/artifacts/embedded-k3s
+  # Next build things using wolfi components.
+  - uses: patch
+    with:
+      patches: 0001-PATCH-Wolfi-support.patch
+  - runs: |
+      go mod tidy
+
+      ./scripts/build
+
+      # Move the "inner" k3s binary out of the bundle dir and into some place permanent
+      mkdir -p "${{targets.destdir}}"/bin/
+      mv bin/k3s "${{targets.destdir}}"/bin/_k3s
+
+      # This time around, we use a mostly empty bin/ dir with only symlinks to the "inner" k3s binary
+      ./scripts/package-cli
+
+      # Finally, install the "outer" k3s multicall binary
+      install -Dm755 dist/artifacts/k3s* "${{targets.destdir}}"/bin/k3s
+  - uses: strip
+
+subpackages:
+  - name: k3s-embedded
+    description: "k3s with embedded components"
+    dependencies:
+      runtime:
+        - busybox
+        - ip6tables
+        - libseccomp
+        - conntrack-tools
+    pipeline:
+      - runs: |
+          # Install the "outer" k3s multicall binary into the package path
+          install -Dm755 dist/artifacts/embedded-k3s "${{targets.subpkgdir}}"/bin/k3s
+
+  - name: k3s-images
+    description: "k3s images, pre-bundled"
+    pipeline:
+      - runs: |
+          set -e -u -x
+
+          _arch=$(go env GOARCH)
+
+          images=""
+          while read -r line
+          do
+            repo=$(echo $line | cut -d ':' -f 1)
+            tag=$(echo $line | cut -d ':' -f 2)
+
+            # Replace upstream images with cgr.dev equivalents only if they exist
+            case $repo in
+              # docker.io/rancher/klipper-helm)
+              #   image=$(crane digest --full-ref cgr.dev/chainguard/klipper-helm:latest)
+              #   ;;
+              # docker.io/rancher/klipper-lb)
+              #   image=$(crane digest --full-ref cgr.dev/chainguard/klipper-lb:latest)
+              #   ;;
+              # docker.io/rancher/local-path-provisioner)
+              #   image=$(crane digest --full-ref cgr.dev/chainguard/local-path-provisioner:latest)
+              #   ;;
+              docker.io/rancher/mirrored-metrics-server)
+                image=$(crane digest --full-ref cgr.dev/chainguard/metrics-server:latest)
+                ;;
+              docker.io/rancher/mirrored-coredns-coredns)
+                image=$(crane digest --full-ref cgr.dev/chainguard/coredns:latest)
+                ;;
+              docker.io/rancher/mirrored-library-busybox)
+                image=$(crane digest --full-ref cgr.dev/chainguard/busybox:latest)
+                ;;
+              docker.io/rancher/mirrored-library-traefik)
+                image=$(crane digest --full-ref cgr.dev/chainguard/traefik:latest)
+                ;;
+              *)
+                image="$repo:$tag@$(crane digest $repo:$tag)"
+                ;;
+            esac
+
+            images="$images $image"
+          done < ./scripts/airgap/image-list.txt
+
+          echo "Pulling images locally..."
+          echo $images
+          crane pull $images dist/artifacts/k3s-airgap-images-$_arch.tar
+
+          _images_path="${{targets.subpkgdir}}"/var/lib/rancher/k3s/agent/images
+          mkdir -p $_images_path
+
+          # Compression doesn't really do much for overall size since it's mostly already compressed image layers, but follow how upstream does it
+          zstd --no-progress -T0 -16 -f --long=25 dist/artifacts/k3s-airgap-images-$_arch.tar -o $_images_path/k3s-airgap-images-$_arch.tar.zst
+
+update:
+  enabled: true
+  github:
+    identifier: k3s-io/k3s
+    strip-prefix: v
+    strip-suffix: "+k3s1" # NOTE: Update k3s# if upstream ships a >k3s1 revision

--- a/k3s/0001-PATCH-Wolfi-support.patch
+++ b/k3s/0001-PATCH-Wolfi-support.patch
@@ -1,0 +1,119 @@
+From a042f5ea8f73652f9c44c7dd3b7bf3636b942e13 Mon Sep 17 00:00:00 2001
+From: Josh Wolf <josh@wolfs.io>
+Date: Wed, 21 Jun 2023 20:58:41 -0400
+Subject: [PATCH] [PATCH] Wolfi support
+
+---
+ cmd/server/main.go  | 14 --------------
+ scripts/build       | 31 +++----------------------------
+ scripts/package-cli |  4 ++--
+ 3 files changed, 5 insertions(+), 44 deletions(-)
+
+diff --git a/cmd/server/main.go b/cmd/server/main.go
+index 37bf8d2cd3..6329508470 100644
+--- a/cmd/server/main.go
++++ b/cmd/server/main.go
+@@ -11,27 +11,16 @@ import (
+ 	"github.com/k3s-io/k3s/pkg/cli/cert"
+ 	"github.com/k3s-io/k3s/pkg/cli/cmds"
+ 	"github.com/k3s-io/k3s/pkg/cli/completion"
+-	"github.com/k3s-io/k3s/pkg/cli/crictl"
+-	"github.com/k3s-io/k3s/pkg/cli/ctr"
+ 	"github.com/k3s-io/k3s/pkg/cli/etcdsnapshot"
+-	"github.com/k3s-io/k3s/pkg/cli/kubectl"
+ 	"github.com/k3s-io/k3s/pkg/cli/secretsencrypt"
+ 	"github.com/k3s-io/k3s/pkg/cli/server"
+ 	"github.com/k3s-io/k3s/pkg/cli/token"
+ 	"github.com/k3s-io/k3s/pkg/configfilearg"
+-	"github.com/k3s-io/k3s/pkg/containerd"
+-	ctr2 "github.com/k3s-io/k3s/pkg/ctr"
+-	kubectl2 "github.com/k3s-io/k3s/pkg/kubectl"
+-	crictl2 "github.com/kubernetes-sigs/cri-tools/cmd/crictl"
+ 	"github.com/sirupsen/logrus"
+ 	"github.com/urfave/cli"
+ )
+ 
+ func init() {
+-	reexec.Register("containerd", containerd.Main)
+-	reexec.Register("kubectl", kubectl2.Main)
+-	reexec.Register("crictl", crictl2.Main)
+-	reexec.Register("ctr", ctr2.Main)
+ }
+ 
+ func main() {
+@@ -46,9 +35,6 @@ func main() {
+ 	app.Commands = []cli.Command{
+ 		cmds.NewServerCommand(server.Run),
+ 		cmds.NewAgentCommand(agent.Run),
+-		cmds.NewKubectlCommand(kubectl.Run),
+-		cmds.NewCRICTL(crictl.Run),
+-		cmds.NewCtrCommand(ctr.Run),
+ 		cmds.NewTokenCommands(
+ 			token.Create,
+ 			token.Delete,
+diff --git a/scripts/build b/scripts/build
+index 8da0f50d7b..eeacbe2ec1 100755
+--- a/scripts/build
++++ b/scripts/build
+@@ -63,7 +63,7 @@ fi
+ STATIC="
+     -extldflags '-static -lm -ldl -lz -lpthread'
+ "
+-TAGS="ctrd apparmor seccomp netcgo osusergo providerless urfave_cli_no_docs"
++TAGS="apparmor seccomp netcgo osusergo providerless urfave_cli_no_docs"
+ RUNC_TAGS="apparmor seccomp"
+ RUNC_STATIC="static"
+ 
+@@ -133,30 +133,5 @@ fi
+ 
+ echo Building k3s
+ CGO_ENABLED=1 "${GO}" build $BLDFLAGS -tags "$TAGS" -gcflags="all=${GCFLAGS}" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/k3s ./cmd/server/main.go
+-ln -s k3s ./bin/containerd
+-ln -s k3s ./bin/crictl
+-ln -s k3s ./bin/ctr
+-ln -s k3s ./bin/k3s-agent
+-ln -s k3s ./bin/k3s-certificate
+-ln -s k3s ./bin/k3s-completion
+-ln -s k3s ./bin/k3s-etcd-snapshot
+-ln -s k3s ./bin/k3s-secrets-encrypt
+-ln -s k3s ./bin/k3s-server
+-ln -s k3s ./bin/k3s-token
+-ln -s k3s ./bin/kubectl
+-
+-export GOPATH=$(pwd)/build
+-
+-echo Building containerd
+-pushd ./build/src/github.com/containerd/containerd
+-TAGS="${TAGS/netcgo/netgo}"
+-CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -gcflags="all=${GCFLAGS}" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/containerd-shim-runc-v2 ./cmd/containerd-shim-runc-v2
+-popd
+-cp -vf ./build/src/github.com/containerd/containerd/bin/* ./bin/
+-
+-echo Building runc
+-pushd ./build/src/github.com/opencontainers/runc
+-rm -f runc
+-make EXTRA_FLAGS="-gcflags=\"all=${GCFLAGS}\"" EXTRA_LDFLAGS="$LDFLAGS" BUILDTAGS="$RUNC_TAGS" $RUNC_STATIC
+-popd
+-cp -vf ./build/src/github.com/opencontainers/runc/runc ./bin/
++
++export GOPATH=$(pwd)/build
+\ No newline at end of file
+diff --git a/scripts/package-cli b/scripts/package-cli
+index 92fee50e1e..046951682a 100755
+--- a/scripts/package-cli
++++ b/scripts/package-cli
+@@ -7,9 +7,9 @@ cd $(dirname $0)/..
+ 
+ GO=${GO-go}
+ 
+-for i in containerd crictl kubectl k3s-agent k3s-server k3s-token k3s-etcd-snapshot k3s-secrets-encrypt k3s-certificate k3s-completion; do
++for i in k3s-agent k3s-server k3s-token k3s-etcd-snapshot k3s-secrets-encrypt k3s-certificate k3s-completion; do
+     rm -f bin/$i
+-    ln -s k3s bin/$i
++    ln -s /bin/_k3s bin/$i
+ done
+ 
+ for i in bandwidth bridge firewall flannel host-local loopback portmap; do
+-- 
+2.41.0
+

--- a/packages.txt
+++ b/packages.txt
@@ -819,3 +819,4 @@ local-path-provisioner
 fuse-overlayfs
 fuse-overlayfs-snapshotter
 upx
+k3s


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Adds `k3s` package.

The nature of `k3s` and `wolfi` (being container native) means this package has little value in isolation (for now). But an example of how it could be used within a container is [here](https://github.com/chainguard-images/images/pull/877).

Prior art: #2720 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`
