### PR TITLE
add fuse-overlayfs and fuse-overlayfs-snapshotter packages

### DIFF
--- a/fuse-overlayfs-snapshotter.yaml
+++ b/fuse-overlayfs-snapshotter.yaml
@@ -1,0 +1,40 @@
+package:
+  name: fuse-overlayfs-snapshotter
+  version: 1.0.6
+  epoch: 0
+  description: fuse-overlayfs plugin for rootless containerd
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - fuse-overlayfs
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - go
+      - fuse3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/containerd/fuse-overlayfs-snapshotter
+      expected-commit: a705ae6f22850358821ec1e7d968bc79003934ef
+      tag: v${{package.version}}
+
+  - runs: |
+      make bin/containerd-fuse-overlayfs-grpc
+
+      make install BINDIR="${{targets.destdir}}"/usr/bin
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: containerd/fuse-overlayfs-snapshotter
+    strip-prefix: v

--- a/fuse-overlayfs.yaml
+++ b/fuse-overlayfs.yaml
@@ -1,0 +1,50 @@
+package:
+  name: fuse-overlayfs
+  version: 1.12
+  epoch: 0
+  description: FUSE implementation for overlayfs
+  copyright:
+    - license: GPL-2.0-or-later
+  dependencies:
+    runtime:
+      # TODO: Provide a static build option as well
+      - fuse3
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - linux-headers
+      - fuse3-dev
+      - automake
+      - autoconf
+      - libtool
+      - pkgconf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/containers/fuse-overlayfs
+      expected-commit: 560ab7d9de5c1de115dda75fcd9420c59beeee37
+      tag: v${{package.version}}
+
+  - name: Run autoreconf
+    runs: |
+      ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: containers/fuse-overlayfs
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -812,3 +812,5 @@ sonobuoy
 libslirp
 slirp4netns
 local-path-provisioner
+fuse-overlayfs
+fuse-overlayfs-snapshotter


### PR DESCRIPTION
adds `fuse-overlayfs-snapshotter`, required for using `overlayfs` within k3s in docker (rootless anyways)

Related: #873 #2970 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`
