### PR TITLE
Bump minio to a recent release.

### DIFF
--- a/minio.yaml
+++ b/minio.yaml
@@ -1,9 +1,9 @@
 package:
   name: minio
-  # minio uses strange versioning, the upstream version is RELEASE.2023-04-13T03-08-07Z
+  # minio uses strange versioning, the upstream version is RELEASE.2023-06-19T19-52-50Z
   # when bumping this, also bump the tag in git-checkout below
-  version: 0.20230609.073212
-  epoch: 1
+  version: 0.20230619.195250
+  epoch: 0
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0
@@ -22,8 +22,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/minio/minio
-      tag: RELEASE.2023-06-09T07-32-12Z
-      expected-commit: 6b7c98bd0fde630c6aee78d702b9d37b0200f52c
+      tag: RELEASE.2023-06-19T19-52-50Z
+      expected-commit: f9b8d1c6999e65ab31899cbbe0314f5a4e5257c3
 
   - runs: |
       make build


### PR DESCRIPTION
These aren't automated because of their strange versioning scheme, but this picks up two CVE fixes.

Fixes:

Related:

### Pre-review Checklist
