### PR TITLE
remove unneeded and cycle-causing busybox strip dep

### DIFF
--- a/busybox.yaml
+++ b/busybox.yaml
@@ -67,8 +67,6 @@ pipeline:
       mkdir -p "${{targets.destdir}}"/etc/busybox-paths.d
       ./busybox --list-path > "${{targets.destdir}}"/etc/busybox-paths.d/busybox
 
-  - uses: strip
-
 subpackages:
   - name: busybox-full
     dependencies:


### PR DESCRIPTION
Per @kaniini busybox itself strips its binaries, so it does not need to depend upon `strip`. Removing it removes a cycle, see [this comment](https://github.com/wolfi-dev/os/pull/2318#issuecomment-1601592954)