### PR TITLE
libguac-client-vnc and libguac-client-telnet added as subpkg

### DIFF
--- a/guacamole-server.yaml
+++ b/guacamole-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: guacamole-server
   version: 1.5.2
-  epoch: 0
+  epoch: 1
   description: clientless remote desktop gateway server
   copyright:
     - license: Apache-2.0
@@ -16,14 +16,20 @@ environment:
       - cairo-dev
       - automake
       - libpng-dev
+      - libtelnet
+      - libvncserver-dev
       - util-linux-dev
       - pango-dev
       - perl
+      - openssl-dev
       - libwebp-dev
       - ffmpeg-dev
       - curl
       - libswresample4
-      - ffmpeg
+      - harfbuzz-dev
+      - expat-dev
+      - libxft-dev
+      - fribidi-dev
 
 pipeline:
   - uses: fetch
@@ -37,9 +43,12 @@ pipeline:
         --host=$CHOST \
         --prefix=/usr \
         --sysconfdir=/etc \
+        --libdir=/usr/lib \
         --mandir=/usr/share/man \
         --localstatedir=/var \
-        --disable-static \
+        --with-pango \
+        --with-vnc \
+        --with-telnet
 
   - uses: autoconf/make
 
@@ -57,6 +66,20 @@ subpackages:
     description: guacamole-server development files
     pipeline:
       - uses: split/dev
+
+  - name: libguac-client-vnc
+    description: guacamole-server VNC client plugin
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/libguac-client-vnc.so.* ${{targets.subpkgdir}}/usr/lib/
+
+  - name: libguac-client-telnet
+    description: guacamole-server Telnet client plugin
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/libguac-client-telnet.so.* ${{targets.subpkgdir}}/usr/lib/
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
