### PR TITLE
Fix build for Ruby 3.0 and 3.1

### DIFF
--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.0
   version: 3.0.6
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -40,6 +40,9 @@ pipeline:
 
   - name: Configure
     runs: |
+      # Our default LDFLAGS cause an issue with ruby. We need to remove '-z, noexecheap' from LDFLAGS
+      LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"
+
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.4
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -40,6 +40,9 @@ pipeline:
 
   - name: Configure
     runs: |
+      # Our default LDFLAGS cause an issue with ruby. We need to remove '-z, noexecheap' from LDFLAGS
+      LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"
+
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -45,6 +45,7 @@ pipeline:
     runs: |
       # Our default LDFLAGS cause an issue with ruby. We need to remove '-z, noexecheap' from LDFLAGS
       LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"
+
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \


### PR DESCRIPTION
This fixes our inability to build `ruby-3.0` and `ruby-3.1`.
