### PR TITLE
fix subpackage names for libjpeg-turbo

### DIFF
--- a/libjpeg-turbo.yaml
+++ b/libjpeg-turbo.yaml
@@ -1,7 +1,7 @@
 package:
   name: libjpeg-turbo
   version: 2.1.91
-  epoch: 3
+  epoch: 4
   description: "Accelerated baseline JPEG compression and decompression library"
   copyright:
     - license: BSD-3-Clause AND IJG AND Zlib
@@ -42,22 +42,22 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "libjpeg-dev"
-    description: "headers for libjpeg"
+  - name: "libjpeg-turbo-dev"
+    description: "headers for libjpeg-turbo"
     pipeline:
       - uses: split/dev
 
-  - name: "libjpeg-doc"
-    description: "libjpeg documentation"
+  - name: "libjpeg-turbo-doc"
+    description: "libjpeg-turbo documentation"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/share/doc/libjpeg
-          mv doc/* "${{targets.subpkgdir}}"/usr/share/doc/libjpeg
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/doc/libjpeg-turbo
+          mv doc/* "${{targets.subpkgdir}}"/usr/share/doc/libjpeg-turbo
     dependencies:
       runtime:
-        - libjpeg-dev
+        - libjpeg-turbo-dev
 
-  - name: "libjpeg-utils"
+  - name: "libjpeg-turbo-utils"
     description: "Utilities for manipulating JPEG images"
     pipeline:
       - runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
