### PR TITLE
fix subpackage names for libjpeg-turbo

### DIFF
--- a/gdk-pixbuf.yaml
+++ b/gdk-pixbuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdk-pixbuf
   version: 2.42.10
-  epoch: 3
+  epoch: 4
   description: GTK+ image loading library
   copyright:
     - license: LGPL-2.1-or-later
@@ -19,7 +19,7 @@ environment:
       - autoconf
       - glib-dev
       - gobject-introspection-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - libpng-dev
       - meson
       - py3-docutils
@@ -64,7 +64,7 @@ subpackages:
       runtime:
         - gdk-pixbuf
         - shared-mime-info
-        - libjpeg-dev
+        - libjpeg-turbo-dev
         - libpng-dev
         - tiff-dev
     description: gdk-pixbuf dev

--- a/gtk-2.0.yaml
+++ b/gtk-2.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: gtk-2.0
   version: 2.24.33
-  epoch: 0
+  epoch: 1
   description: The GTK+ Toolkit (v2)
   copyright:
     - license: LGPL-2.0-or-later
@@ -32,7 +32,7 @@ environment:
       - gobject-introspection-dev
       - gtk-doc
       - harfbuzz-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - tiff-dev
       - hicolor-icon-theme
       - libice-dev

--- a/guacamole-server.yaml
+++ b/guacamole-server.yaml
@@ -12,7 +12,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - build-base
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - cairo-dev
       - automake
       - libpng-dev

--- a/lcms2.yaml
+++ b/lcms2.yaml
@@ -1,7 +1,7 @@
 package:
   name: lcms2
   version: "2.15"
-  epoch: 0
+  epoch: 1
   description: "Color Management Engine"
   copyright:
     - license: MIT AND GPL-3.0-only
@@ -13,7 +13,7 @@ environment:
       - ca-certificates-bundle
       - build-base
       - zlib-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       # - tiff-dev
 
 pipeline:

--- a/libavif.yaml
+++ b/libavif.yaml
@@ -1,7 +1,7 @@
 package:
   name: libavif
   version: 0.11.1
-  epoch: 0
+  epoch: 1
   description: Library for encoding and decoding .avif files
   copyright:
     - license: BSD-2-Clause
@@ -17,7 +17,7 @@ environment:
       - aom-dev
       - cmake
       - dav1d-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - libpng-dev
       - samurai
       - zlib-dev

--- a/libvncserver.yaml
+++ b/libvncserver.yaml
@@ -1,7 +1,7 @@
 package:
   name: libvncserver
   version: 0.9.14
-  epoch: 0
+  epoch: 1
   description: Library to make writing a vnc server easy
   copyright:
     - license: GPL-2.0-or-later
@@ -15,7 +15,7 @@ environment:
       - ninja
       - build-base
       - libgcrypt-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - libpng-dev
       - libice-dev
       - libx11-dev

--- a/libwebp.yaml
+++ b/libwebp.yaml
@@ -1,7 +1,7 @@
 package:
   name: libwebp
   version: 1.3.1
-  epoch: 0
+  epoch: 1
   description: Libraries for working with WebP images
   copyright:
     - license: BSD-3-Clause
@@ -14,7 +14,7 @@ environment:
       - build-base
       - automake
       - giflib-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - libpng-dev
       - libtool
 

--- a/openjdk-10.yaml
+++ b/openjdk-10.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-10
   version: 10.0.2
-  epoch: 2
+  epoch: 3
   description: "Oracle OpenJDK 10"
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -33,7 +33,7 @@ environment:
       - alsa-lib-dev
       - libffi-dev
       - fontconfig-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - libpng-dev

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
   version: 11.0.20.4
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: GPL-2.0-only
@@ -34,7 +34,7 @@ environment:
       - zip
       - fontconfig-dev
       - libxi-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - openjdk-10-default-jvm

--- a/openjdk-12.yaml
+++ b/openjdk-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-12
   version: 12.0.2.10
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only
@@ -35,7 +35,7 @@ environment:
       - zip
       - fontconfig-dev
       - libxi-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - zlib-dev

--- a/openjdk-13.yaml
+++ b/openjdk-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-13
   version: 13.0.14.5
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only
@@ -34,7 +34,7 @@ environment:
       - zip
       - fontconfig-dev
       - libxi-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - openjdk-12-default-jvm

--- a/openjdk-14.yaml
+++ b/openjdk-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-14
   version: 14.0.2.12
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only
@@ -34,7 +34,7 @@ environment:
       - zip
       - fontconfig-dev
       - libxi-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - openjdk-13-default-jvm

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-15
   version: 15.0.10.5
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only
@@ -34,7 +34,7 @@ environment:
       - zip
       - fontconfig-dev
       - libxi-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - openjdk-14-default-jvm

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-16
   version: 16.0.2.7
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only
@@ -34,7 +34,7 @@ environment:
       - zip
       - fontconfig-dev
       - libxi-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - openjdk-15-default-jvm

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
   version: 17.0.8.2
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-only
@@ -34,7 +34,7 @@ environment:
       - zip
       - fontconfig-dev
       - libxi-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - openjdk-16-default-jvm

--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-18
   version: 18.0.2.1.0
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -34,7 +34,7 @@ environment:
       - zip
       - fontconfig-dev
       - libxi-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - openjdk-17-default-jvm

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-19
   version: 19.0.2.7
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -34,7 +34,7 @@ environment:
       - zip
       - fontconfig-dev
       - libxi-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - openjdk-18-default-jvm

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-20
   version: 20.0.1.9
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -34,7 +34,7 @@ environment:
       - zip
       - fontconfig-dev
       - libxi-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - openjdk-19-default-jvm

--- a/openjdk-7.yaml
+++ b/openjdk-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-7
   version: 7.321.2.6.28
-  epoch: 1
+  epoch: 2
   description: "IcedTea distribution of OpenJDK 7 (UNSUPPORTED)"
   copyright:
     - license: GPL-2.0-or-later
@@ -47,7 +47,7 @@ environment:
       - expat-dev
       - fontconfig-dev
       - libxi-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - java-gcj-compat-default-jvm

--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.372.07
-  epoch: 2
+  epoch: 3
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later
@@ -45,7 +45,7 @@ environment:
       - expat-dev
       - fontconfig-dev
       - libxi-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - openjdk-7-default-jvm

--- a/openjdk-9.yaml
+++ b/openjdk-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-9
   version: 9.0.4
-  epoch: 2
+  epoch: 3
   description: "Oracle OpenJDK 9"
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -33,7 +33,7 @@ environment:
       - alsa-lib-dev
       - libffi-dev
       - fontconfig-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - giflib-dev
       - lcms2-dev
       - libpng-dev

--- a/tiff.yaml
+++ b/tiff.yaml
@@ -1,7 +1,7 @@
 package:
   name: tiff
   version: 4.5.1
-  epoch: 0
+  epoch: 1
   description: Provides support for the Tag Image File Format or TIFF
   copyright:
     - license: libtiff
@@ -15,7 +15,7 @@ environment:
       - automake
       - autoconf
       - zlib-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - libwebp-dev
       - zstd-dev
       - python3
@@ -49,7 +49,7 @@ subpackages:
       runtime:
         - tiff
         - zlib-dev
-        - libjpeg-dev
+        - libjpeg-turbo-dev
         - libwebp-dev
         - zstd-dev
     description: tiff dev


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
