### PR TITLE
remove unnecessary strip that causes loop

### DIFF
--- a/py3.11-setuptools.yaml
+++ b/py3.11-setuptools.yaml
@@ -32,8 +32,6 @@ pipeline:
   - name: Python Install
     runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
 
-  - uses: strip
-
 update:
   enabled: true
   shared: true

--- a/samurai.yaml
+++ b/samurai.yaml
@@ -37,7 +37,8 @@ pipeline:
   - runs: |
       make install PREFIX="/usr" DESTDIR="${{targets.destdir}}"
 
-  - uses: strip
+  - runs: |
+      strip "${{targets.destdir}}"/usr/bin/samu
 
   - runs: |
       ln -s samu "${{targets.destdir}}"/usr/bin/ninja


### PR DESCRIPTION
Per @kaniini we can remove `uses: strip` from several packages that are causing loops. One case does not need it, the other we can execute it directly.

Reference suggestions by @kaniini [here](https://github.com/wolfi-dev/os/pull/2318#issuecomment-1608757685) and [here](https://github.com/wolfi-dev/os/pull/2318#issuecomment-1608794791)