### PR TITLE
nuclei was added

### DIFF
--- a/nuclei.yaml
+++ b/nuclei.yaml
@@ -1,0 +1,26 @@
+package:
+  name: nuclei
+  version: 2.9.7
+  epoch: 0
+  description: "yaml based vulnerability scanner"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - go
+
+pipeline:
+  - uses: go/install
+    with:
+      package: github.com/projectdiscovery/nuclei/v2/cmd/nuclei
+      version: v${{package.version}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    strip-prefix: v
+    identifier: projectdiscovery/nuclei

--- a/packages.txt
+++ b/packages.txt
@@ -831,3 +831,4 @@ k3s
 gobuster
 runit
 ipset
+nuclei


### PR DESCRIPTION
- "nuclei-2.9.7: new package"
- #3184 

- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`
