### PR TITLE
Wolfictl 40facec0 db27 4a7d a65b 02b779a91e84 fix

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,7 +1,7 @@
 package:
   name: goreleaser
-  version: 1.18.2
-  epoch: 1
+  version: 1.19.0
+  epoch: 0
   description: Deliver Go binaries as fast and easily as possible
   copyright:
     - license: Apache-2.0

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -12,9 +12,16 @@ environment:
       - git
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/goreleaser/goreleaser@v${{package.version}}
+      expected-commit: a6e6e7098de5716f209e42ca1fa487227fd4ed7d
+      repository: https://github.com/goreleaser/goreleaser
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      packages: main.go
+      output: goreleaser
 
 update:
   enabled: true


### PR DESCRIPTION
#### For version bump PRs
- [x] The `epoch` field is reset to 0
