### PR TITLE
fix libvorbis-dev subpkg

### DIFF
--- a/libvorbis.yaml
+++ b/libvorbis.yaml
@@ -1,7 +1,7 @@
 package:
   name: libvorbis
   version: 1.3.7
-  epoch: 0
+  epoch: 1
   description: Vorbis codec library
   copyright:
     - license: BSD-3-Clause
@@ -47,9 +47,6 @@ subpackages:
   - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
-    dependencies:
-      runtime:
-        - ${{package.name}}
     description: ${{package.name}} dev
 
 update:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: 

I got the following error when I tried to add `libvorbis-dev`, cc @Dentrax 


To reproduce the issue run the following:

```shell
$ docker container run --rm -it --entrypoint="" cgr.dev/chainguard/wolfi-base:latest sh
/# apk update
/# apk add libvorbis-dev
ERROR: unable to select packages:
  ${{package.name}} (no such package):
    required by: libvorbis-dev-1.3.7-r0[${{package.name}}]
/ #
```

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
