### PR TITLE
cdparanoia add this back, tested locally after removing configure opt…

### DIFF
--- a/cdparanoia.yaml
+++ b/cdparanoia.yaml
@@ -1,0 +1,85 @@
+package:
+  name: cdparanoia
+  version: 10.2
+  epoch: 1
+  description: An audio CD extraction application
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - libtool
+      - linux-headers
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 4ab0a0f5ef44d56c1af72d1fc1035566a1a89c4eeddb9e8baea675fe51c06138d913342afc8bed167d9fa55672fa25a2763ce21f7e24c1232e4739aff20733a7
+      uri: https://downloads.xiph.org/releases/cdparanoia/cdparanoia-III-${{package.version}}.src.tgz
+
+  - uses: patch
+    with:
+      patches: fix-includes.patch
+
+  - uses: patch
+    with:
+      patches: format-security.patch
+
+  - uses: patch
+    with:
+      patches: gcc.patch
+
+  - runs: |
+      mv configure.guess config.guess
+      mv configure.sub config.sub
+      # update_config_sub
+      sed -i -e '/configure.\(guess\|sub\)/d' configure.in
+      aclocal && autoconf
+      libtoolize
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        CFLAGS="$CFLAGS -fPIC" \
+        CPPFLAGS="$CFLAGS" \
+        CXXFLAGS="$CFLAGS"
+
+  - uses: autoconf/make
+
+  - runs: |
+      make -j1 prefix="${{targets.destdir}}"/usr LIBDIR=${{targets.destdir}}/usr/lib MANDIR="${{targets.destdir}}"/usr/share/man install
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    description: ${{package.name}} dev
+
+  - name: ${{package.name}}-doc
+    pipeline:
+      - uses: split/manpages
+    description: ${{package.name}} manpages
+
+  - name: ${{package.name}}-libs
+    pipeline:
+      - runs: |
+          ls -latr  ${{targets.destdir}}/usr/lib
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/ ${{targets.subpkgdir}}/usr/lib/
+    description: Libraries for libcdda_paranoia (Paranoia III)
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 15309

--- a/cdparanoia/fix-includes.patch
+++ b/cdparanoia/fix-includes.patch
@@ -1,0 +1,7 @@
+--- cdparanoia-III-10.2.orig/utils.h
++++ cdparanoia-III-10.2/utils.h
+@@ -1,3 +1,4 @@
++#include <sys/types.h>
+ #include <stdlib.h>
+ #include <endian.h>
+ #include <stdio.h>

--- a/cdparanoia/format-security.patch
+++ b/cdparanoia/format-security.patch
@@ -1,0 +1,17 @@
+diff --git a/main.c b/main.c
+index 664acac..d568fb1 100644
+--- a/main.c
++++ b/main.c
+@@ -588,10 +588,10 @@ static void callback(long inpos, int function){
+ 	    buffer[aheadposition+19]='>';
+ 	}
+    
+-	fprintf(stderr,buffer);
++	fprintf(stderr, "%s", buffer);
+        
+ 	if (logfile != NULL && function==-1) {
+-	  fprintf(logfile,buffer+1);
++	  fprintf(logfile, "%s", buffer+1);
+ 	  fprintf(logfile,"\n\n");
+ 	  fflush(logfile);
+ 	}

--- a/cdparanoia/gcc.patch
+++ b/cdparanoia/gcc.patch
@@ -1,0 +1,582 @@
+Index: interface/test_interface.c
+===================================================================
+--- a/interface/test_interface.c	(Revision 15337)
++++ b/interface/test_interface.c	(Revision 15340)
+@@ -66,9 +66,9 @@
+   if(!fd)fd=fdopen(d->cdda_fd,"r");
+ 
+   if(begin<lastread)
+-    d->private->last_milliseconds=20;
++    d->private_data->last_milliseconds=20;
+   else
+-    d->private->last_milliseconds=sectors;
++    d->private_data->last_milliseconds=sectors;
+ 
+ #ifdef CDDA_TEST_UNDERRUN
+   sectors-=1;
+Index: interface/cdda_interface.h
+===================================================================
+--- a/interface/cdda_interface.h	(Revision 15337)
++++ b/interface/cdda_interface.h	(Revision 15340)
+@@ -84,7 +84,7 @@
+   int is_atapi;
+   int is_mmc;
+ 
+-  cdda_private_data_t *private;
++  cdda_private_data_t *private_data;
+   void         *reserved;
+   unsigned char inqbytes[4];
+ 
+Index: interface/interface.c
+===================================================================
+--- a/interface/interface.c	(Revision 15337)
++++ b/interface/interface.c	(Revision 15340)
+@@ -39,9 +39,9 @@
+     if(d->drive_model)free(d->drive_model);
+     if(d->cdda_fd!=-1)close(d->cdda_fd);
+     if(d->ioctl_fd!=-1 && d->ioctl_fd!=d->cdda_fd)close(d->ioctl_fd);
+-    if(d->private){
+-      if(d->private->sg_hd)free(d->private->sg_hd);
+-      free(d->private);
++    if(d->private_data){
++      if(d->private_data->sg_hd)free(d->private_data->sg_hd);
++      free(d->private_data);
+     }
+ 
+     free(d);
+@@ -127,7 +127,7 @@
+ 	}
+       }	
+     }
+-    if(ms)*ms=d->private->last_milliseconds;
++    if(ms)*ms=d->private_data->last_milliseconds;
+     return(sectors);
+   }
+   
+Index: interface/scsi_interface.c
+===================================================================
+--- a/interface/scsi_interface.c	(Revision 15337)
++++ b/interface/scsi_interface.c	(Revision 15340)
+@@ -15,13 +15,13 @@
+ static int timed_ioctl(cdrom_drive *d, int fd, int command, void *arg){
+   struct timespec tv1;
+   struct timespec tv2;
+-  int ret1=clock_gettime(d->private->clock,&tv1);
++  int ret1=clock_gettime(d->private_data->clock,&tv1);
+   int ret2=ioctl(fd, command,arg);
+-  int ret3=clock_gettime(d->private->clock,&tv2);
++  int ret3=clock_gettime(d->private_data->clock,&tv2);
+   if(ret1<0 || ret3<0){
+-    d->private->last_milliseconds=-1;
++    d->private_data->last_milliseconds=-1;
+   }else{
+-    d->private->last_milliseconds = (tv2.tv_sec-tv1.tv_sec)*1000. + (tv2.tv_nsec-tv1.tv_nsec)/1000000.;
++    d->private_data->last_milliseconds = (tv2.tv_sec-tv1.tv_sec)*1000. + (tv2.tv_nsec-tv1.tv_nsec)/1000000.;
+   }
+   return ret2;
+ }
+@@ -96,7 +96,7 @@
+ static void clear_garbage(cdrom_drive *d){
+   fd_set fdset;
+   struct timeval tv;
+-  struct sg_header *sg_hd=d->private->sg_hd;
++  struct sg_header *sg_hd=d->private_data->sg_hd;
+   int flag=0;
+ 
+   /* clear out any possibly preexisting garbage */
+@@ -185,7 +185,7 @@
+   struct timespec tv2;
+   int tret1,tret2;
+   int status = 0;
+-  struct sg_header *sg_hd=d->private->sg_hd;
++  struct sg_header *sg_hd=d->private_data->sg_hd;
+   long writebytes=SG_OFF+cmd_len+in_size;
+ 
+   /* generic scsi device services */
+@@ -195,7 +195,7 @@
+ 
+   memset(sg_hd,0,sizeof(sg_hd)); 
+   memset(sense_buffer,0,SG_MAX_SENSE); 
+-  memcpy(d->private->sg_buffer,cmd,cmd_len+in_size);
++  memcpy(d->private_data->sg_buffer,cmd,cmd_len+in_size);
+   sg_hd->twelve_byte = cmd_len == 12;
+   sg_hd->result = 0;
+   sg_hd->reply_len = SG_OFF + out_size;
+@@ -209,7 +209,7 @@
+      tell if the command failed.  Scared yet? */
+ 
+   if(bytecheck && out_size>in_size){
+-    memset(d->private->sg_buffer+cmd_len+in_size,bytefill,out_size-in_size); 
++    memset(d->private_data->sg_buffer+cmd_len+in_size,bytefill,out_size-in_size); 
+     /* the size does not remove cmd_len due to the way the kernel
+        driver copies buffers */
+     writebytes+=(out_size-in_size);
+@@ -243,7 +243,7 @@
+   }
+ 
+   sigprocmask (SIG_BLOCK, &(d->sigset), NULL );
+-  tret1=clock_gettime(d->private->clock,&tv1);  
++  tret1=clock_gettime(d->private_data->clock,&tv1);  
+   errno=0;
+   status = write(d->cdda_fd, sg_hd, writebytes );
+ 
+@@ -289,7 +289,7 @@
+     }
+   }
+ 
+-  tret2=clock_gettime(d->private->clock,&tv2);  
++  tret2=clock_gettime(d->private_data->clock,&tv2);  
+   errno=0;
+   status = read(d->cdda_fd, sg_hd, SG_OFF + out_size);
+   sigprocmask ( SIG_UNBLOCK, &(d->sigset), NULL );
+@@ -313,7 +313,7 @@
+   if(bytecheck && in_size+cmd_len<out_size){
+     long i,flag=0;
+     for(i=in_size;i<out_size;i++)
+-      if(d->private->sg_buffer[i]!=bytefill){
++      if(d->private_data->sg_buffer[i]!=bytefill){
+ 	flag=1;
+ 	break;
+       }
+@@ -326,9 +326,9 @@
+ 
+   errno=0;
+   if(tret1<0 || tret2<0){
+-    d->private->last_milliseconds=-1;
++    d->private_data->last_milliseconds=-1;
+   }else{
+-    d->private->last_milliseconds = (tv2.tv_sec-tv1.tv_sec)*1000 + (tv2.tv_nsec-tv1.tv_nsec)/1000000;
++    d->private_data->last_milliseconds = (tv2.tv_sec-tv1.tv_sec)*1000 + (tv2.tv_nsec-tv1.tv_nsec)/1000000;
+   }
+   return(0);
+ }
+@@ -347,7 +347,7 @@
+ 
+   memset(&hdr,0,sizeof(hdr));
+   memset(sense,0,sizeof(sense));
+-  memcpy(d->private->sg_buffer,cmd+cmd_len,in_size);
++  memcpy(d->private_data->sg_buffer,cmd+cmd_len,in_size);
+ 
+   hdr.cmdp = cmd;
+   hdr.cmd_len = cmd_len;
+@@ -355,7 +355,7 @@
+   hdr.mx_sb_len = SG_MAX_SENSE;
+   hdr.timeout = 50000;
+   hdr.interface_id = 'S';
+-  hdr.dxferp =  d->private->sg_buffer;
++  hdr.dxferp =  d->private_data->sg_buffer;
+   hdr.flags = SG_FLAG_DIRECT_IO;  /* direct IO if we can get it */
+ 
+   /* scary buffer fill hack */
+@@ -400,7 +400,7 @@
+   if(bytecheck && in_size<out_size){
+     long i,flag=0;
+     for(i=in_size;i<out_size;i++)
+-      if(d->private->sg_buffer[i]!=bytefill){
++      if(d->private_data->sg_buffer[i]!=bytefill){
+ 	flag=1;
+ 	break;
+       }
+@@ -412,7 +412,7 @@
+   }
+ 
+   /* Can't rely on .duration because we can't be certain kernel has HZ set to something useful */
+-  /* d->private->last_milliseconds = hdr.duration; */
++  /* d->private_data->last_milliseconds = hdr.duration; */
+ 
+   errno = 0;
+   return 0;
+@@ -445,9 +445,9 @@
+ 
+   handle_scsi_cmd(d, cmd, 6, 0, 56, 0,0, sense);
+ 
+-  key = d->private->sg_buffer[2] & 0xf;
+-  ASC = d->private->sg_buffer[12];
+-  ASCQ = d->private->sg_buffer[13];
++  key = d->private_data->sg_buffer[2] & 0xf;
++  ASC = d->private_data->sg_buffer[12];
++  ASCQ = d->private_data->sg_buffer[13];
+   
+   if(key == 2 && ASC == 4 && ASCQ == 1) return 0;
+   return 1;
+@@ -492,7 +492,7 @@
+   if (handle_scsi_cmd (d, cmd, 10, 0, size+4,'\377',1,sense)) return(1);
+ 
+   {
+-    unsigned char *b=d->private->sg_buffer;
++    unsigned char *b=d->private_data->sg_buffer;
+     if(b[0])return(1); /* Handles only up to 256 bytes */
+     if(b[6])return(1); /* Handles only up to 256 bytes */
+ 
+@@ -604,8 +604,8 @@
+ static unsigned int get_orig_sectorsize(cdrom_drive *d){
+   if(mode_sense(d,12,0x01))return(-1);
+ 
+-  d->orgdens = d->private->sg_buffer[4];
+-  return(d->orgsize = ((int)(d->private->sg_buffer[10])<<8)+d->private->sg_buffer[11]);
++  d->orgdens = d->private_data->sg_buffer[4];
++  return(d->orgsize = ((int)(d->private_data->sg_buffer[10])<<8)+d->private_data->sg_buffer[11]);
+ }
+ 
+ /* switch CDROM scsi drives to given sector size  */
+@@ -664,8 +664,8 @@
+     return(-4);
+   }
+ 
+-  first=d->private->sg_buffer[2];
+-  last=d->private->sg_buffer[3];
++  first=d->private_data->sg_buffer[2];
++  last=d->private_data->sg_buffer[3];
+   tracks=last-first+1;
+ 
+   if (last > MAXTRK || first > MAXTRK || last<0 || first<0) {
+@@ -683,7 +683,7 @@
+       return(-5);
+     }
+     {
+-      scsi_TOC *toc=(scsi_TOC *)(d->private->sg_buffer+4);
++      scsi_TOC *toc=(scsi_TOC *)(d->private_data->sg_buffer+4);
+ 
+       d->disc_toc[i-first].bFlags=toc->bFlags;
+       d->disc_toc[i-first].bTrack=i;
+@@ -704,7 +704,7 @@
+     return(-2);
+   }
+   {
+-    scsi_TOC *toc=(scsi_TOC *)(d->private->sg_buffer+4);
++    scsi_TOC *toc=(scsi_TOC *)(d->private_data->sg_buffer+4);
+     
+     d->disc_toc[i-first].bFlags=toc->bFlags;
+     d->disc_toc[i-first].bTrack=0xAA;
+@@ -738,7 +738,7 @@
+   }
+ 
+   /* copy to our structure and convert start sector */
+-  tracks = d->private->sg_buffer[1];
++  tracks = d->private_data->sg_buffer[1];
+   if (tracks > MAXTRK) {
+     cderror(d,"003: CDROM reporting illegal number of tracks\n");
+     return(-3);
+@@ -754,33 +754,33 @@
+       return(-5);
+     }
+     
+-    d->disc_toc[i].bFlags = d->private->sg_buffer[10];
++    d->disc_toc[i].bFlags = d->private_data->sg_buffer[10];
+     d->disc_toc[i].bTrack = i + 1;
+ 
+     d->disc_toc[i].dwStartSector= d->adjust_ssize * 
+-	(((signed char)(d->private->sg_buffer[2])<<24) | 
+-	 (d->private->sg_buffer[3]<<16)|
+-	 (d->private->sg_buffer[4]<<8)|
+-	 (d->private->sg_buffer[5]));
++	(((signed char)(d->private_data->sg_buffer[2])<<24) | 
++	 (d->private_data->sg_buffer[3]<<16)|
++	 (d->private_data->sg_buffer[4]<<8)|
++	 (d->private_data->sg_buffer[5]));
+   }
+ 
+   d->disc_toc[i].bFlags = 0;
+   d->disc_toc[i].bTrack = i + 1;
+-  memcpy (&foo, d->private->sg_buffer+2, 4);
+-  memcpy (&bar, d->private->sg_buffer+6, 4);
++  memcpy (&foo, d->private_data->sg_buffer+2, 4);
++  memcpy (&bar, d->private_data->sg_buffer+6, 4);
+   d->disc_toc[i].dwStartSector = d->adjust_ssize * (be32_to_cpu(foo) +
+ 						    be32_to_cpu(bar));
+ 
+   d->disc_toc[i].dwStartSector= d->adjust_ssize * 
+-    ((((signed char)(d->private->sg_buffer[2])<<24) | 
+-      (d->private->sg_buffer[3]<<16)|
+-      (d->private->sg_buffer[4]<<8)|
+-      (d->private->sg_buffer[5]))+
++    ((((signed char)(d->private_data->sg_buffer[2])<<24) | 
++      (d->private_data->sg_buffer[3]<<16)|
++      (d->private_data->sg_buffer[4]<<8)|
++      (d->private_data->sg_buffer[5]))+
+      
+-     ((((signed char)(d->private->sg_buffer[6])<<24) | 
+-       (d->private->sg_buffer[7]<<16)|
+-       (d->private->sg_buffer[8]<<8)|
+-       (d->private->sg_buffer[9]))));
++     ((((signed char)(d->private_data->sg_buffer[6])<<24) | 
++       (d->private_data->sg_buffer[7]<<16)|
++       (d->private_data->sg_buffer[8]<<8)|
++       (d->private_data->sg_buffer[9]))));
+ 
+ 
+   d->cd_extra = FixupTOC(d,tracks+1);
+@@ -817,7 +817,7 @@
+   cmd[8] = sectors;
+   if((ret=handle_scsi_cmd(d,cmd,10,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -836,7 +836,7 @@
+   cmd[9] = sectors;
+   if((ret=handle_scsi_cmd(d,cmd,12,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -854,7 +854,7 @@
+   cmd[8] = sectors;
+   if((ret=handle_scsi_cmd(d,cmd,10,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -872,7 +872,7 @@
+   cmd[9] = sectors;
+   if((ret=handle_scsi_cmd(d,cmd,12,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -890,7 +890,7 @@
+   cmd[8] = sectors;
+   if((ret=handle_scsi_cmd(d,cmd,10,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -908,7 +908,7 @@
+   cmd[9] = sectors;
+   if((ret=handle_scsi_cmd(d,cmd,12,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -922,7 +922,7 @@
+   cmd[8] = sectors;
+   if((ret=handle_scsi_cmd(d,cmd,12,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -936,7 +936,7 @@
+   cmd[8] = sectors;
+   if((ret=handle_scsi_cmd(d,cmd,12,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -950,7 +950,7 @@
+   cmd[8] = sectors;
+   if((ret=handle_scsi_cmd(d,cmd,12,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -964,7 +964,7 @@
+   cmd[8] = sectors;
+   if((ret=handle_scsi_cmd(d,cmd,12,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -978,7 +978,7 @@
+   cmd[8] = sectors;
+   if((ret=handle_scsi_cmd(d,cmd,12,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -992,7 +992,7 @@
+   cmd[8] = sectors;
+   if((ret=handle_scsi_cmd(d,cmd,12,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -1026,7 +1026,7 @@
+ 
+   if((ret=handle_scsi_cmd(d,cmd,12,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -1039,7 +1039,7 @@
+ 
+   if((ret=handle_scsi_cmd(d,cmd,12,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -1052,7 +1052,7 @@
+   
+   if((ret=handle_scsi_cmd(d,cmd,12,0,sectors * CD_FRAMESIZE_RAW,'\177',1,sense)))
+     return(ret);
+-  if(p)memcpy(p,d->private->sg_buffer,sectors*CD_FRAMESIZE_RAW);
++  if(p)memcpy(p,d->private_data->sg_buffer,sectors*CD_FRAMESIZE_RAW);
+   return(0);
+ }
+ 
+@@ -1275,7 +1275,7 @@
+ static int count_2352_bytes(cdrom_drive *d){
+   long i;
+   for(i=2351;i>=0;i--)
+-    if(d->private->sg_buffer[i]!=(unsigned char)'\177')
++    if(d->private_data->sg_buffer[i]!=(unsigned char)'\177')
+       return(((i+3)>>2)<<2);
+ 
+   return(0);
+@@ -1284,7 +1284,7 @@
+ static int verify_nonzero(cdrom_drive *d){
+   long i,flag=0;
+   for(i=0;i<2352;i++)
+-    if(d->private->sg_buffer[i]!=0){
++    if(d->private_data->sg_buffer[i]!=0){
+       flag=1;
+       break;
+     }
+@@ -1621,7 +1621,7 @@
+   d->is_mmc=0;
+   if(mode_sense(d,22,0x2A)==0){
+   
+-    b=d->private->sg_buffer;
++    b=d->private_data->sg_buffer;
+     b+=b[3]+4;
+     
+     if((b[0]&0x3F)==0x2A){
+@@ -1669,7 +1669,7 @@
+     cderror(d,"008: Unable to identify CDROM model\n");
+     return(NULL);
+   }
+-  return (d->private->sg_buffer);
++  return (d->private_data->sg_buffer);
+ }
+ 
+ int scsi_init_drive(cdrom_drive *d){
+@@ -1725,8 +1725,8 @@
+   check_cache(d);
+ 
+   d->error_retry=1;
+-  d->private->sg_hd=realloc(d->private->sg_hd,d->nsectors*CD_FRAMESIZE_RAW + SG_OFF + 128);
+-  d->private->sg_buffer=((unsigned char *)d->private->sg_hd)+SG_OFF;
++  d->private_data->sg_hd=realloc(d->private_data->sg_hd,d->nsectors*CD_FRAMESIZE_RAW + SG_OFF + 128);
++  d->private_data->sg_buffer=((unsigned char *)d->private_data->sg_hd)+SG_OFF;
+   d->report_all=1;
+   return(0);
+ }
+Index: interface/cooked_interface.c
+===================================================================
+--- a/interface/cooked_interface.c	(Revision 15337)
++++ b/interface/cooked_interface.c	(Revision 15340)
+@@ -13,13 +13,13 @@
+ static int timed_ioctl(cdrom_drive *d, int fd, int command, void *arg){
+   struct timespec tv1;
+   struct timespec tv2;
+-  int ret1=clock_gettime(d->private->clock,&tv1);
++  int ret1=clock_gettime(d->private_data->clock,&tv1);
+   int ret2=ioctl(fd, command,arg);
+-  int ret3=clock_gettime(d->private->clock,&tv2);
++  int ret3=clock_gettime(d->private_data->clock,&tv2);
+   if(ret1<0 || ret3<0){
+-    d->private->last_milliseconds=-1;
++    d->private_data->last_milliseconds=-1;
+   }else{
+-    d->private->last_milliseconds = (tv2.tv_sec-tv1.tv_sec)*1000. + (tv2.tv_nsec-tv1.tv_nsec)/1000000.;
++    d->private_data->last_milliseconds = (tv2.tv_sec-tv1.tv_sec)*1000. + (tv2.tv_nsec-tv1.tv_nsec)/1000000.;
+   }
+   return ret2;
+ }
+Index: interface/scan_devices.c
+===================================================================
+--- a/interface/scan_devices.c	(Revision 15337)
++++ b/interface/scan_devices.c	(Revision 15340)
+@@ -264,11 +264,11 @@
+   d->interface=COOKED_IOCTL;
+   d->bigendianp=-1; /* We don't know yet... */
+   d->nsectors=-1;
+-  d->private=calloc(1,sizeof(*d->private));
++  d->private_data=calloc(1,sizeof(*d->private_data));
+   {
+     /* goddamnit */
+     struct timespec tv;
+-    d->private->clock=(clock_gettime(CLOCK_MONOTONIC,&tv)<0?CLOCK_REALTIME:CLOCK_MONOTONIC);
++    d->private_data->clock=(clock_gettime(CLOCK_MONOTONIC,&tv)<0?CLOCK_REALTIME:CLOCK_MONOTONIC);
+   }
+   idmessage(messagedest,messages,"\t\tCDROM sensed: %s\n",description);
+   return(d);
+@@ -674,15 +674,15 @@
+   d->bigendianp=-1; /* We don't know yet... */
+   d->nsectors=-1;
+   d->messagedest = messagedest;
+-  d->private=calloc(1,sizeof(*d->private));
++  d->private_data=calloc(1,sizeof(*d->private_data));
+   {
+     /* goddamnit */
+     struct timespec tv;
+-    d->private->clock=(clock_gettime(CLOCK_MONOTONIC,&tv)<0?CLOCK_REALTIME:CLOCK_MONOTONIC);
++    d->private_data->clock=(clock_gettime(CLOCK_MONOTONIC,&tv)<0?CLOCK_REALTIME:CLOCK_MONOTONIC);
+   }
+   if(use_sgio){
+     d->interface=SGIO_SCSI;
+-    d->private->sg_buffer=(unsigned char *)(d->private->sg_hd=malloc(MAX_BIG_BUFF_SIZE));
++    d->private_data->sg_buffer=(unsigned char *)(d->private_data->sg_hd=malloc(MAX_BIG_BUFF_SIZE));
+     g_fd=d->cdda_fd=dup(d->ioctl_fd);
+   }else{
+     version=verify_SG_version(d,messagedest,messages);
+@@ -696,8 +696,8 @@
+     }
+ 
+     /* malloc our big buffer for scsi commands */
+-    d->private->sg_hd=malloc(MAX_BIG_BUFF_SIZE);
+-    d->private->sg_buffer=((unsigned char *)d->private->sg_hd)+SG_OFF;
++    d->private_data->sg_hd=malloc(MAX_BIG_BUFF_SIZE);
++    d->private_data->sg_buffer=((unsigned char *)d->private_data->sg_hd)+SG_OFF;
+   }
+ 
+   {
+@@ -772,9 +772,9 @@
+   if(i_fd!=-1)close(i_fd);
+   if(g_fd!=-1)close(g_fd);
+   if(d){
+-    if(d->private){
+-      if(d->private->sg_hd)free(d->private->sg_hd);
+-      free(d->private);
++    if(d->private_data){
++      if(d->private_data->sg_hd)free(d->private_data->sg_hd);
++      free(d->private_data);
+     }
+     free(d);
+   }
+@@ -821,7 +821,7 @@
+   d->interface=TEST_INTERFACE;
+   d->bigendianp=-1; /* We don't know yet... */
+   d->nsectors=-1;
+-  d->private=calloc(1,sizeof(*d->private));
++  d->private_data=calloc(1,sizeof(*d->private_data));
+   d->drive_model=copystring("File based test interface");
+   idmessage(messagedest,messages,"\t\tCDROM sensed: %s\n",d->drive_model);
+   

--- a/packages.txt
+++ b/packages.txt
@@ -843,3 +843,4 @@ runit
 libtheora
 ipset
 nuclei
+cdparanoia


### PR DESCRIPTION
…ions already set by the melange pipeline

The melange configure pipeline already sets https://github.com/chainguard-dev/melange/blob/58d5b8b3a565bb012ff37fde1c38e4b359e79c96/pkg/build/pipelines/autoconf/configure.yaml#L23-L30

This PR is the same that was added earlier today with these options removed, specifically I think [these](https://github.com/wolfi-dev/os/pull/3179/files#diff-22cd19076d863d742394656b9a0a6abc918014176bb077cf9047704c55116d3cR52-R53) args caused the issue on arm

using epoch 1 as we have withdrawn epoch 0.


#### For new package PRs only
<!-- remove if unrelated -->
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`
