### PR TITLE
Fix static build for libtheora.

### DIFF
--- a/libtheora.yaml
+++ b/libtheora.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtheora
   version: 1.1.1
-  epoch: 0
+  epoch: 1
   description: An open video codec developed by the Xiph.org
   copyright:
     - license: BSD-3-Clause
@@ -62,18 +62,16 @@ pipeline:
   - uses: strip
 
 subpackages:
+  # This has to come before -dev
+  - name: ${{package.name}}-static
+    description: ${{package.name}} static libraries
+    pipeline:
+      - uses: split/static
+
   - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
     description: ${{package.name}} dev
-
-  - name: ${{package.name}}-static
-    description: ${{package.name}} static libraries
-    pipeline:
-      - runs: |
-          ls -latr "${{targets.destdir}}"/usr/lib
-          mkdir -p "${{targets.subpkdir}}"/usr/lib
-          mv "${{targets.destdir}}"/usr/lib "${{targets.subpkdir}}"/usr/lib
 
   - name: ${{package.name}}-doc
     description: ${{package.name}} documentation


### PR DESCRIPTION


Fixes:

Related:

### Pre-review Checklist



#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
