### PR TITLE
Update subpackage names for gst-plugins-base

### DIFF
--- a/gst-plugins-base.yaml
+++ b/gst-plugins-base.yaml
@@ -1,7 +1,7 @@
 package:
   name: gst-plugins-base
   version: 1.22.4
-  epoch: 0
+  epoch: 1
   description: GStreamer streaming media framework base plug-ins
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.0-or-later

--- a/gst-plugins-base.yaml
+++ b/gst-plugins-base.yaml
@@ -13,7 +13,7 @@ environment:
       - ca-certificates-bundle
       - build-base
       - alsa-lib-dev
-      # - cdparanoia-dev
+      - cdparanoia-dev
       - expat-dev
       - glib-dev
       - gobject-introspection-dev

--- a/gst-plugins-base.yaml
+++ b/gst-plugins-base.yaml
@@ -60,22 +60,22 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: gst-plugins-dev
+  - name: gst-plugins-base-dev
     pipeline:
       - uses: split/dev
-    description: gst-plugins dev
+    description: gst-plugins-base dev
 
-  - name: gst-plugins-doc
+  - name: gst-plugins-base-doc
     pipeline:
       - uses: split/manpages
-    description: gst-plugins manpages
+    description: gst-plugins-base manpages
 
-  - name: gst-plugins-lang
+  - name: gst-plugins-base-lang
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/share/locale
           mv ${{targets.destdir}}/usr/share/locale ${{targets.subpkgdir}}/usr/share/locale
-    description: gst-plugins lang
+    description: gst-plugins-base lang
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Uses the same naming scheme for the dev/doc/lang subpackages 

Related:

https://github.com/wolfi-dev/os/pull/3232

