### PR TITLE
New package: libzip 1.10.0

### DIFF
--- a/libzip.yaml
+++ b/libzip.yaml
@@ -1,0 +1,40 @@
+package:
+  name: libzip
+  version: 1.10.0
+  epoch: 0
+  description: "A C library for reading, creating, and modifying zip archives."
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - zlib
+      - bzip2
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - ca-certificates-bundle
+      - openssl
+      - busybox
+      - zlib-dev
+      - bzip2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://libzip.org/download/libzip-${{package.version}}.tar.gz
+      expected-sha256: 52a60b46182587e083b71e2b82fcaaba64dd5eb01c5b1f1bc71069a3858e40fe
+
+  - uses: cmake/configure
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10649

--- a/packages.txt
+++ b/packages.txt
@@ -846,3 +846,4 @@ runit
 libtheora
 ipset
 nuclei
+libzip


### PR DESCRIPTION
Adding package `libzip` as it is a dependency for the `php-zip` extension.

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`

