### PR TITLE
Fix cdparanoia lib permissions.

### DIFF
--- a/cdparanoia.yaml
+++ b/cdparanoia.yaml
@@ -1,7 +1,7 @@
 package:
   name: cdparanoia
   version: 10.2
-  epoch: 3
+  epoch: 4
   description: An audio CD extraction application
   copyright:
     - license: GPL-2.0-or-later
@@ -63,8 +63,14 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
-          find ${{targets.destdir}}/usr/lib
-          mv ${{targets.destdir}}/usr/lib/libcdda*.so* ${{targets.subpkgdir}}/usr/lib/
+
+          # Delete unused static libraries
+          rm -f ${{targets.destdir}}/usr/lib/*.a
+
+          mv ${{targets.destdir}}/usr/lib/* ${{targets.subpkgdir}}/usr/lib/
+
+          # Fix permissions so melnage detects the libraries
+          chmod 755 "${{targets.subpkgdir}}"/usr/lib/*.so*
     description: Libraries for libcdda_paranoia (Paranoia III)
 
   - name: ${{package.name}}-dev


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
