### PR TITLE
Fix build order - cdparanoia comes before gst-plugin-base

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -782,6 +782,7 @@ x264
 ffmpeg
 libdaemon
 avahi
+cdparanoia
 gst-plugins-base
 guacamole-server
 proxysql
@@ -845,4 +846,3 @@ runit
 libtheora
 ipset
 nuclei
-cdparanoia


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist

