### PR TITLE
php: include php-zip extension

### DIFF
--- a/php.yaml
+++ b/php.yaml
@@ -1,7 +1,7 @@
 package:
   name: php
   version: 8.2.7
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -38,7 +38,7 @@ environment:
       - oniguruma-dev
       - libxslt-dev
       - postgresql-15-dev
-      - zip
+      - libzip
 
 pipeline:
   - uses: fetch
@@ -112,7 +112,8 @@ pipeline:
         --enable-xmlreader=shared \
         --enable-xmlwriter=shared \
         --enable-posix=shared \
-        --with-pgsql=shared
+        --with-pgsql=shared \
+        --with-zip=shared
 
   - uses: autoconf/make
     with:
@@ -168,6 +169,7 @@ data:
       xmlreader: XMLReader
       xmlwriter: XMLWriter
       fileinfo: fileinfo
+      zip: Zip
 
 subpackages:
   - range: extensions


### PR DESCRIPTION
This PR adds the `php-zib` extension as an optional subpackage.

