### PR TITLE
deconflict kubernetes, and use a kubernetes-$v-default package choose

### DIFF
--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.24
   version: 1.24.15
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -69,7 +69,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl
+          install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl-1.24
 
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
           _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl
@@ -88,7 +88,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubeadm ${{targets.subpkgdir}}/usr/bin/kubeadm
+          install -m755 _output/bin/kubeadm ${{targets.subpkgdir}}/usr/bin/kubeadm-1.24
 
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
           _output/bin/kubeadm completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubeadm
@@ -103,7 +103,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubelet ${{targets.subpkgdir}}/usr/bin/kubelet
+          install -m755 _output/bin/kubelet ${{targets.subpkgdir}}/usr/bin/kubelet-1.24
 
           install -d ${{targets.subpkgdir}}/var/lib/kubelet
           install -d ${{targets.subpkgdir}}/var/log/kubelet
@@ -116,7 +116,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-scheduler ${{targets.subpkgdir}}/usr/bin/kube-scheduler
+          install -m755 _output/bin/kube-scheduler ${{targets.subpkgdir}}/usr/bin/kube-scheduler-1.24
 
           install -d ${{targets.subpkgdir}}/var/log/kube-scheduler
 
@@ -128,7 +128,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-proxy ${{targets.subpkgdir}}/usr/bin/kube-proxy
+          install -m755 _output/bin/kube-proxy ${{targets.subpkgdir}}/usr/bin/kube-proxy-1.24
 
           install -d ${{targets.subpkgdir}}/var/lib/kube-proxy
           install -d ${{targets.subpkgdir}}/var/log/kube-proxy
@@ -141,7 +141,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-controller-manager ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
+          install -m755 _output/bin/kube-controller-manager ${{targets.subpkgdir}}/usr/bin/kube-controller-manager-1.24
 
           install -d ${{targets.subpkgdir}}/var/log/kube-controller-manager
 
@@ -153,7 +153,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-apiserver ${{targets.subpkgdir}}/usr/bin/kube-apiserver
+          install -m755 _output/bin/kube-apiserver ${{targets.subpkgdir}}/usr/bin/kube-apiserver-1.24
 
           install -d ${{targets.subpkgdir}}/var/log/kube-apiserver
 
@@ -167,7 +167,19 @@ subpackages:
         runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
           CFLAGS="$CFLAGS -static -DVERSION=${{vars.pause-version}}-${{package.version}}"
-          gcc -o "${{targets.subpkgdir}}"/usr/bin/pause linux/pause.c
+          gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.7 linux/pause.c
+
+  - name: kubernetes-1.24-default
+    description: "Compatibility package to set 1.24 as the default kubernetes, and add packages to their shortened path"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          ln -s kubectl-1.24 ${{targets.subpkgdir}}/usr/bin/kubectl
+          ln -s kubelet-1.24 ${{targets.subpkgdir}}/usr/bin/kubelet
+          ln -s kube-scheduler-1.24 ${{targets.subpkgdir}}/usr/bin/kube-scheduler
+          ln -s kube-proxy-1.24 ${{targets.subpkgdir}}/usr/bin/kube-proxy
+          ln -s kube-controller-manager-1.24 ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
+          ln -s kube-apiserver-1.24 ${{targets.subpkgdir}}/usr/bin/kube-apiserver
 
 update:
   enabled: true

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.25
   version: 1.25.11
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -69,7 +69,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl
+          install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl-1.25
 
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
           _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl
@@ -88,7 +88,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubeadm ${{targets.subpkgdir}}/usr/bin/kubeadm
+          install -m755 _output/bin/kubeadm ${{targets.subpkgdir}}/usr/bin/kubeadm-1.25
 
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
           _output/bin/kubeadm completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubeadm
@@ -103,7 +103,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubelet ${{targets.subpkgdir}}/usr/bin/kubelet
+          install -m755 _output/bin/kubelet ${{targets.subpkgdir}}/usr/bin/kubelet-1.25
 
           install -d ${{targets.subpkgdir}}/var/lib/kubelet
           install -d ${{targets.subpkgdir}}/var/log/kubelet
@@ -116,7 +116,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-scheduler ${{targets.subpkgdir}}/usr/bin/kube-scheduler
+          install -m755 _output/bin/kube-scheduler ${{targets.subpkgdir}}/usr/bin/kube-scheduler-1.25
 
           install -d ${{targets.subpkgdir}}/var/log/kube-scheduler
 
@@ -128,7 +128,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-proxy ${{targets.subpkgdir}}/usr/bin/kube-proxy
+          install -m755 _output/bin/kube-proxy ${{targets.subpkgdir}}/usr/bin/kube-proxy-1.25
 
           install -d ${{targets.subpkgdir}}/var/lib/kube-proxy
           install -d ${{targets.subpkgdir}}/var/log/kube-proxy
@@ -141,7 +141,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-controller-manager ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
+          install -m755 _output/bin/kube-controller-manager ${{targets.subpkgdir}}/usr/bin/kube-controller-manager-1.25
 
           install -d ${{targets.subpkgdir}}/var/log/kube-controller-manager
 
@@ -153,7 +153,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-apiserver ${{targets.subpkgdir}}/usr/bin/kube-apiserver
+          install -m755 _output/bin/kube-apiserver ${{targets.subpkgdir}}/usr/bin/kube-apiserver-1.25
 
           install -d ${{targets.subpkgdir}}/var/log/kube-apiserver
 
@@ -167,7 +167,19 @@ subpackages:
         runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
           CFLAGS="$CFLAGS -static -DVERSION=${{vars.pause-version}}-${{package.version}}"
-          gcc -o "${{targets.subpkgdir}}"/usr/bin/pause linux/pause.c
+          gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.8 linux/pause.c
+
+  - name: kubernetes-1.25-default
+    description: "Compatibility package to set 1.25 as the default kubernetes, and add packages to their shortened path"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          ln -s kubectl-1.25 ${{targets.subpkgdir}}/usr/bin/kubectl
+          ln -s kubelet-1.25 ${{targets.subpkgdir}}/usr/bin/kubelet
+          ln -s kube-scheduler-1.25 ${{targets.subpkgdir}}/usr/bin/kube-scheduler
+          ln -s kube-proxy-1.25 ${{targets.subpkgdir}}/usr/bin/kube-proxy
+          ln -s kube-controller-manager-1.25 ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
+          ln -s kube-apiserver-1.25 ${{targets.subpkgdir}}/usr/bin/kube-apiserver
 
 update:
   enabled: true

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.26
   version: 1.26.6
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -69,7 +69,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl
+          install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl-1.26
 
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
           _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl
@@ -88,7 +88,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubeadm ${{targets.subpkgdir}}/usr/bin/kubeadm
+          install -m755 _output/bin/kubeadm ${{targets.subpkgdir}}/usr/bin/kubeadm-1.26
 
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
           _output/bin/kubeadm completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubeadm
@@ -103,7 +103,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubelet ${{targets.subpkgdir}}/usr/bin/kubelet
+          install -m755 _output/bin/kubelet ${{targets.subpkgdir}}/usr/bin/kubelet-1.26
 
           install -d ${{targets.subpkgdir}}/var/lib/kubelet
           install -d ${{targets.subpkgdir}}/var/log/kubelet
@@ -116,7 +116,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-scheduler ${{targets.subpkgdir}}/usr/bin/kube-scheduler
+          install -m755 _output/bin/kube-scheduler ${{targets.subpkgdir}}/usr/bin/kube-scheduler-1.26
 
           install -d ${{targets.subpkgdir}}/var/log/kube-scheduler
 
@@ -128,7 +128,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-proxy ${{targets.subpkgdir}}/usr/bin/kube-proxy
+          install -m755 _output/bin/kube-proxy ${{targets.subpkgdir}}/usr/bin/kube-proxy-1.26
 
           install -d ${{targets.subpkgdir}}/var/lib/kube-proxy
           install -d ${{targets.subpkgdir}}/var/log/kube-proxy
@@ -141,7 +141,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-controller-manager ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
+          install -m755 _output/bin/kube-controller-manager ${{targets.subpkgdir}}/usr/bin/kube-controller-manager-1.26
 
           install -d ${{targets.subpkgdir}}/var/log/kube-controller-manager
 
@@ -153,7 +153,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-apiserver ${{targets.subpkgdir}}/usr/bin/kube-apiserver
+          install -m755 _output/bin/kube-apiserver ${{targets.subpkgdir}}/usr/bin/kube-apiserver-1.26
 
           install -d ${{targets.subpkgdir}}/var/log/kube-apiserver
 
@@ -167,7 +167,19 @@ subpackages:
         runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
           CFLAGS="$CFLAGS -static -DVERSION=${{vars.pause-version}}-${{package.version}}"
-          gcc -o "${{targets.subpkgdir}}"/usr/bin/pause linux/pause.c
+          gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.9 linux/pause.c
+
+  - name: kubernetes-1.26-default
+    description: "Compatibility package to set 1.26 as the default kubernetes, and add packages to their shortened path"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          ln -s kubectl-1.26 ${{targets.subpkgdir}}/usr/bin/kubectl
+          ln -s kubelet-1.26 ${{targets.subpkgdir}}/usr/bin/kubelet
+          ln -s kube-scheduler-1.26 ${{targets.subpkgdir}}/usr/bin/kube-scheduler
+          ln -s kube-proxy-1.26 ${{targets.subpkgdir}}/usr/bin/kube-proxy
+          ln -s kube-controller-manager-1.26 ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
+          ln -s kube-apiserver-1.26 ${{targets.subpkgdir}}/usr/bin/kube-apiserver
 
 update:
   enabled: true

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.27
   version: 1.27.3
-  epoch: 3
+  epoch: 4
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -72,7 +72,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl
+          install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl-1.27
 
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
           _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl
@@ -91,7 +91,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubeadm ${{targets.subpkgdir}}/usr/bin/kubeadm
+          install -m755 _output/bin/kubeadm ${{targets.subpkgdir}}/usr/bin/kubeadm-1.27
 
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
           _output/bin/kubeadm completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubeadm
@@ -106,7 +106,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubelet ${{targets.subpkgdir}}/usr/bin/kubelet
+          install -m755 _output/bin/kubelet ${{targets.subpkgdir}}/usr/bin/kubelet-1.27
 
           install -d ${{targets.subpkgdir}}/var/lib/kubelet
           install -d ${{targets.subpkgdir}}/var/log/kubelet
@@ -119,7 +119,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-scheduler ${{targets.subpkgdir}}/usr/bin/kube-scheduler
+          install -m755 _output/bin/kube-scheduler ${{targets.subpkgdir}}/usr/bin/kube-scheduler-1.27
 
           install -d ${{targets.subpkgdir}}/var/log/kube-scheduler
 
@@ -131,7 +131,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-proxy ${{targets.subpkgdir}}/usr/bin/kube-proxy
+          install -m755 _output/bin/kube-proxy ${{targets.subpkgdir}}/usr/bin/kube-proxy-1.27
 
           install -d ${{targets.subpkgdir}}/var/lib/kube-proxy
           install -d ${{targets.subpkgdir}}/var/log/kube-proxy
@@ -144,7 +144,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-controller-manager ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
+          install -m755 _output/bin/kube-controller-manager ${{targets.subpkgdir}}/usr/bin/kube-controller-manager-1.27
 
           install -d ${{targets.subpkgdir}}/var/log/kube-controller-manager
 
@@ -156,7 +156,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-apiserver ${{targets.subpkgdir}}/usr/bin/kube-apiserver
+          install -m755 _output/bin/kube-apiserver ${{targets.subpkgdir}}/usr/bin/kube-apiserver-1.27
 
           install -d ${{targets.subpkgdir}}/var/log/kube-apiserver
 
@@ -170,7 +170,19 @@ subpackages:
         runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
           CFLAGS="$CFLAGS -static -DVERSION=${{vars.pause-version}}-${{package.version}}"
-          gcc -o "${{targets.subpkgdir}}"/usr/bin/pause linux/pause.c
+          gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.9 linux/pause.c
+
+  - name: kubernetes-1.27-default
+    description: "Compatibility package to set 1.27 as the default kubernetes, and add packages to their shortened path"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          ln -s kubectl-1.27 ${{targets.subpkgdir}}/usr/bin/kubectl
+          ln -s kubelet-1.27 ${{targets.subpkgdir}}/usr/bin/kubelet
+          ln -s kube-scheduler-1.27 ${{targets.subpkgdir}}/usr/bin/kube-scheduler
+          ln -s kube-proxy-1.27 ${{targets.subpkgdir}}/usr/bin/kube-proxy
+          ln -s kube-controller-manager-1.27 ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
+          ln -s kube-apiserver-1.27 ${{targets.subpkgdir}}/usr/bin/kube-apiserver
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: allows multiple kubernetes versions to be installed on the same system without conflicting