### PR TITLE
calico: add symlink to calico-cni-compat

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.26.1
-  epoch: 1
+  epoch: 2
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64

--- a/calico.yaml
+++ b/calico.yaml
@@ -312,6 +312,7 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/opt/cni/bin/
           ln -sf /usr/bin/calico-cni "${{targets.subpkgdir}}"/opt/cni/bin/calico-ipam
+          ln -sf /usr/bin/calico-cni "${{targets.subpkgdir}}"/opt/cni/bin/calico
           ln -sf /usr/bin/calico-cni "${{targets.subpkgdir}}"/opt/cni/bin/install
 
   - name: "calico-apiserver"


### PR DESCRIPTION
The upstream `calico/cni` image has another copy of `calico-cni` available at `/opt/cni/bin/calico`, which gets called by the calico-node daemonset.

https://oci.dag.dev/layers/calico/cni@sha256:eb518dae10e9969596f9fda4f68af32f9bd6a66f95aad810054540ebd955a09c/opt/cni/bin/