### PR TITLE
bump epoch to ensure it exists on x86

### DIFF
--- a/py3-influxdb-client.yaml
+++ b/py3-influxdb-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-influxdb-client
   version: 1.36.1
-  epoch: 0
+  epoch: 1
   description: "InfluxDB 2.0 python client"
   copyright:
     - license: MIT


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: the package does not exist on x86

kindly ping @Dentrax 

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
