### PR TITLE
graphviz switch libjpeg-dev to libjpeg-turbo-dev

### DIFF
--- a/graphviz.yaml
+++ b/graphviz.yaml
@@ -20,7 +20,7 @@ environment:
       - freetype-dev
       - gd-dev
       - gmp-dev
-      - libjpeg-dev
+      - libjpeg-turbo-dev
       - libpng-dev
       - libsm-dev
       - libxext-dev
@@ -100,7 +100,7 @@ subpackages:
         - freetype-dev
         - gd-dev
         - gmp-dev
-        - libjpeg-dev
+        - libjpeg-turbo-dev
         - libpng-dev
         - libsm-dev
         - libxext-dev


### PR DESCRIPTION
Fixes the graphviz dependency on `libjpeg-dev` to be our `libjpeg-turbo-dev`. Follow-up to #3302 and #3131