### PR TITLE
pkgconf: update distfiles URI

### DIFF
--- a/pkgconf.yaml
+++ b/pkgconf.yaml
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://distfiles.dereferenced.org/pkgconf/pkgconf-${{package.version}}.tar.gz
+      uri: https://distfiles.ariadne.space/pkgconf/pkgconf-${{package.version}}.tar.gz
       expected-sha256: 6466efd2e38c4c0ac5de4e345f0dc6dad57e689efb08c31f2a71547683d20dc7
 
   - name: 'Configure pkgconf'


### PR DESCRIPTION
The domain registrar which managed the domain registration for dereferenced.org allowed the domain to be compromised.