### PR TITLE
feat: add corepack

### DIFF
--- a/corepack.yaml
+++ b/corepack.yaml
@@ -1,0 +1,40 @@
+package:
+  name: corepack
+  version: 0.19.0
+  epoch: 0
+  description: Zero-runtime-dependency package acting as bridge between Node projects and their package managers
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 889a93e002451a46710d5a799863c1e788ba6545d196bdc9e978f0bd46d071af
+      uri: https://github.com/nodejs/corepack/releases/download/v${{package.version}}/corepack.tgz
+      strip-components: 0
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/node_modules/corepack
+      cp -R package/* ${{targets.destdir}}/usr/share/node_modules/corepack/
+
+      # Remove windows specific files.
+      rm ${{targets.destdir}}/usr/share/node_modules/corepack/shims/*.cmd
+      rm ${{targets.destdir}}/usr/share/node_modules/corepack/shims/*.ps1
+      rm -rf ${{targets.destdir}}/usr/share/node_modules/corepack/shims/nodewin
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      ln -s /usr/share/node_modules/corepack/shims/* ${{targets.destdir}}/usr/bin/
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: nodejs/corepack
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -849,3 +849,4 @@ ipset
 nuclei
 wasmer
 libzip
+corepack


### PR DESCRIPTION
In NodeJS land, people often use alternative package managers, with yarn and pnpm being the leading two.

Both of these can actually be enabled/configured via corepack, which is an experimental from the NodeJS project: it's a CLI that shims/proxies calls.

I believe this should be added to the nodejs images, so this was step 1 :)

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

