### PR TITLE
Re-add gtk-3 package.

### DIFF
--- a/gtk-3.yaml
+++ b/gtk-3.yaml
@@ -1,0 +1,129 @@
+package:
+  name: gtk-3
+  version: 3.24.38
+  epoch: 0
+  description: The GTK+ Toolkit (v3)
+  copyright:
+    - license: LGPL-2.1-or-later
+
+# creates a new var that contains only the major and minor version to be used in the fetch URL
+# e.g. 2.46.0 will create a new var mangled-package-version=2.46
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d+\.\d+)\.\d+
+    replace: $1
+    to: mangled-package-version
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - autoconf
+      - automake
+      - git
+      - cmake
+      - ninja
+      - harfbuzz-dev
+      - mesa-dev
+      - gtk-doc
+      - libtool
+      - shared-mime-info
+      - at-spi2-core-dev
+      - gdk-pixbuf-dev
+      - glib-dev
+      - libepoxy-dev
+      - libxext-dev
+      - libxi-dev
+      - libxinerama-dev
+      - libxkbcommon
+      - libxkbcommon-dev
+      - libatk-bridge-2.0
+      - libxtst-dev
+      - dbus-dev
+      - cairo-dev
+      - cups-dev
+      - expat-dev
+      - fontconfig-dev
+      - gettext-dev
+      - gobject-introspection-dev
+      - hicolor-icon-theme
+      - iso-codes-dev
+      - libice-dev
+      - libx11-dev
+      - libxcomposite-dev
+      - libxcursor-dev
+      - libxdamage-dev
+      - libxfixes-dev
+      - libxrandr-dev
+      - meson
+      - pango-dev
+      - tiff-dev
+      - wayland-dev
+      - wayland-protocols
+      - zlib-dev
+      - fribidi-dev
+      - libxft-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://download.gnome.org/sources/gtk+/${{vars.mangled-package-version}}/gtk+-${{package.version}}.tar.xz
+      expected-sha512: e99ec10959191b55013fce37e83f0e85bf36597db101e324081479792a2047d032cf0d213d69c02eeb4b7cd6d56d6489b7b2a60904b2bd7af23ea1b9c5a79528
+
+  - uses: meson/configure
+    with:
+      opts: |
+        -Db_lto=true \
+        -Dman=true \
+        -Dgtk_doc=false \
+        -Dbroadway_backend=true \
+        -Dexamples=false
+
+  - uses: meson/compile
+
+  - uses: meson/install
+
+  - runs: |
+      # We've had trouble with this build accidentally including pango. This should be fixed,
+      # but throw in a test here in case.
+      if [ -f ${{targets.destdir}}/usr/lib/libpango-1.0.so ]; then
+        echo "ERROR: libpango-1.0.so found in /usr/lib. This is a bug in the build system."
+        exit 1
+      fi
+
+  - uses: strip
+
+subpackages:
+  - name: gtk-3-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - shared-mime-info
+        - at-spi2-core-dev
+        - gdk-pixbuf-dev
+        - glib-dev
+        - libepoxy-dev
+        - libxext-dev
+        - libxi-dev
+        - libxinerama-dev
+        - libxkbcommon-dev
+        - wayland-dev
+    description: gtk+3 dev
+
+  - name: gtk-3-doc
+    pipeline:
+      - uses: split/manpages
+    description: gtk+3 manpages
+
+  - name: gtk-3-lang
+    pipeline:
+      - uses: split/locales
+    description: gtk+3 locales
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 311549

--- a/packages.txt
+++ b/packages.txt
@@ -610,6 +610,7 @@ intltool
 hicolor-icon-theme
 gtk-doc
 gtk-2.0
+gtk-3
 java-cacerts
 openjdk-7
 openjdk-8


### PR DESCRIPTION
This was missing a few deps which caused it to ignore pango, and then use it's own version of pango. This led to a conflict with pango, which broke builds that depended on both.

Fixes:

Related:

### Pre-review Checklist

