### PR TITLE
fix: ensure corepack cli available on path

### DIFF
--- a/corepack.yaml
+++ b/corepack.yaml
@@ -1,7 +1,7 @@
 package:
   name: corepack
   version: 0.19.0
-  epoch: 0
+  epoch: 1
   description: Zero-runtime-dependency package acting as bridge between Node projects and their package managers
   copyright:
     - license: MIT
@@ -29,8 +29,7 @@ pipeline:
       rm -rf ${{targets.destdir}}/usr/share/node_modules/corepack/shims/nodewin
 
       mkdir -p ${{targets.destdir}}/usr/bin
-      ln -s /usr/share/node_modules/corepack/shims/* ${{targets.destdir}}/usr/bin/
-
+      ln -s ${{targets.destdir}}/usr/share/node_modules/corepack/dist/corepack.js /usr/bin/corepack
   - uses: strip
 
 update:

--- a/corepack.yaml
+++ b/corepack.yaml
@@ -30,6 +30,7 @@ pipeline:
 
       mkdir -p ${{targets.destdir}}/usr/bin
       ln -s ${{targets.destdir}}/usr/share/node_modules/corepack/dist/corepack.js /usr/bin/corepack
+
   - uses: strip
 
 update:


### PR DESCRIPTION
First, the wildcard expansion didn't work on the original link command (pipelines not executed in a shell?), but we actually only need the corepack file anyway.

Secondly, we now link directly to corepack.js instead of the shim; due to the shim trying to require (relative path) the dist file. The shims seem to be more of an inconvenience than convenience, so bypassing altogether. 

I've tested this by `apk add --update corepack` in `wolfi-base` and I run the `ln` command myself. Everything works great now.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
