### PR TITLE
curl: split out rustls-ffi backend to its own dedicated package

### DIFF
--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -1,10 +1,13 @@
 package:
-  name: curl
+  name: curl-rustls
   version: 8.1.2
   epoch: 1
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      - libcurl-rustls4
 
 environment:
   contents:
@@ -17,6 +20,7 @@ environment:
       - openssl-dev
       - zlib-dev
       - brotli-dev
+      - rustls-ffi
 
 pipeline:
   - uses: fetch
@@ -29,8 +33,8 @@ pipeline:
       opts: |
         --enable-ipv6 \
         --enable-unix-sockets \
-        --with-openssl \
-        --without-rustls \
+        --without-openssl \
+        --with-rustls \
         --with-nghttp2 \
         --with-pic \
         --disable-ldap \
@@ -38,29 +42,20 @@ pipeline:
 
   - uses: autoconf/make
 
-  - uses: autoconf/make-install
+  - runs: |
+      make install DESTDIR="/home/build/curl-rustls"
 
   - uses: strip
 
 subpackages:
-  - name: "curl-dev"
-    description: "headers for libcurl"
-    pipeline:
-      - uses: split/dev
-
-  - name: "curl-doc"
-    description: "documentation for curl"
-    pipeline:
-      - uses: split/manpages
-
-  - name: "libcurl-openssl4"
-    description: "curl library (openssl backend)"
+  - name: "libcurl-rustls4"
+    description: "curl library (rustls backend)"
     dependencies:
-      provider-priority: 5
+      provider-priority: 10
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
-          mv "${{targets.destdir}}"/usr/lib/libcurl.so.* "${{targets.subpkgdir}}"/usr/lib/
+          mv "/home/build/curl-rustls"/usr/lib/libcurl.so.* "${{targets.subpkgdir}}"/usr/lib/
 
 update:
   enabled: true

--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -45,8 +45,6 @@ pipeline:
   - runs: |
       make install DESTDIR="/home/build/curl-rustls"
 
-  - uses: strip
-
 subpackages:
   - name: "libcurl-rustls4"
     description: "curl library (rustls backend)"
@@ -56,6 +54,7 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "/home/build/curl-rustls"/usr/lib/libcurl.so.* "${{targets.subpkgdir}}"/usr/lib/
+          strip "${{targets.subpkgdir}}"/usr/lib/libcurl.so.*
 
 update:
   enabled: true

--- a/packages.txt
+++ b/packages.txt
@@ -298,6 +298,7 @@ krb5-conf
 krb5
 libtirpc
 rustls-ffi
+curl-rustls
 spire-server
 kustomize
 alpine-keys


### PR DESCRIPTION
this allows the rustls backend to be built at a point in time after the openssl backend is built, thus resolving a dependency cycle: curl -> rust -> rustls -> curl

(there is a similar cycle with cmake which is also solved by this)