### PR TITLE
Bump minio-client.

### DIFF
--- a/mc.yaml
+++ b/mc.yaml
@@ -2,8 +2,8 @@ package:
   name: mc
   # minio uses strange versioning, the upstream version is RELEASE.2023-03-23T20-03-04Z
   # when bumping this, also bump the tag in git-checkout below
-  version: 0.20230323.200304
-  epoch: 3
+  version: 0.20230628.215417
+  epoch: 0
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0
@@ -21,8 +21,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/minio/mc
-      tag: RELEASE.2023-03-23T20-03-04Z
-      expected-commit: 81453d7c8fcc7621f976cfd8e8a72e78f4d243c7
+      tag: RELEASE.2023-06-28T21-54-17Z
+      expected-commit: eebdcdf36501cec35c893d7e8ab7a7473ff6860a
 
   - runs: |
       make build


### PR DESCRIPTION
This is a manual update, this addresses a CVE in a go dep.


Fixes:

Related:

### Pre-review Checklist
