### PR TITLE
Address vulnerabilities in zot

### DIFF
--- a/zot.yaml
+++ b/zot.yaml
@@ -1,7 +1,7 @@
 package:
   name: zot
-  version: 1.4.3
-  epoch: 5
+  version: 1.4.3 # Check if the Go module patching can be removed in the next release.
+  epoch: 6
   description: A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification)
   copyright:
     - license: Apache-2.0
@@ -16,17 +16,44 @@ environment:
       - busybox
       - go
       - curl
+      - patch
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/project-zot/zot
       tag: v${{package.version}}
-      destination: zot
       expected-commit: 69f0cf6bb4727884af42f38c92858fdb114104de
 
   - runs: |
-      cd zot
+      # Resolve numerous vulnerabilities, and resolve dependency issues caused by these changes.
+
+      go mod edit -replace 'go.opentelemetry.io/otel=go.opentelemetry.io/otel@v1.12.0'
+      go mod edit -replace 'google.golang.org/grpc=google.golang.org/grpc@v1.54.1'
+
+      # Remove replace directives that don't appear to be necessary and introduce vulnerabilities.
+      sed -i '/github\.com\/opencontainers\/runc v1\.1\.2/d' go.mod
+      sed -i '/github\.com\/hashicorp\/go-getter v1\.6\.1/d' go.mod
+
+      go get github.com/docker/distribution@v2.8.2-beta.1
+      go get github.com/docker/docker@v20.10.24
+      go get github.com/hashicorp/go-getter@v1.7.0
+      go get github.com/opencontainers/runc@v1.1.5
+      go get github.com/sigstore/rekor@v1.2.2
+      go get golang.org/x/net@v0.11.0
+
+      go mod tidy
+
+  - runs: |
+      # Zot hasn't been updated to handle the latest version of the image-spec module.
+      # Revert a particular breaking commit in image-spec (63b8bd0) until zot does upgrade.
+
+      moduleDir="$(go env GOPATH)/pkg/mod/github.com/opencontainers/image-spec@v1.1.0-rc3"
+      chmod -R u+w "$moduleDir"
+      patch -p1 -d "$moduleDir" -N < ./revert-removal-of-symbols.patch
+      go clean -cache
+
+  - runs: |
       GOARCH=$(go env GOARCH)
 
       make OS=linux ARCH=${GOARCH} binary

--- a/zot/revert-removal-of-symbols.patch
+++ b/zot/revert-removal-of-symbols.patch
@@ -1,0 +1,270 @@
+commit cb308cd1d7c438c28746547e0c283f31cb61716a
+Author: Dan Luhring <dluhring@chainguard.dev>
+Date:   Mon Jul 3 17:52:19 2023 -0400
+
+    Revert "Remove artifact manifest"
+
+    This reverts commit 63b8bd02f5b5a2ce464a9a8ea6df049c326ce20f.
+
+diff --git a/Makefile b/Makefile
+index dd2074d..9e529c9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -30,6 +30,7 @@ DOC_FILES := \
+ 	descriptor.md \
+ 	image-layout.md \
+ 	manifest.md \
++	artifact.md \
+ 	image-index.md \
+ 	layer.md \
+ 	config.md \
+diff --git a/annotations.md b/annotations.md
+index 49f5f82..f3752e5 100644
+--- a/annotations.md
++++ b/annotations.md
+@@ -16,8 +16,10 @@ This property contains arbitrary metadata.
+
+ ## Pre-Defined Annotation Keys
+
+-This specification defines the following annotation keys, intended for but not limited to [image index](image-index.md), image [manifest](manifest.md), and [descriptor](descriptor.md) authors.
++This specification defines the following annotation keys, intended for but not limited to [image index](image-index.md), image [manifest](manifest.md), [artifact](artifact.md), and [descriptor](descriptor.md) authors.
+
++* **org.opencontainers.artifact.created** date and time on which the artifact was built, conforming to [RFC 3339][rfc3339].
++* **org.opencontainers.artifact.description**: human readable description for the artifact (string)
+ * **org.opencontainers.image.created** date and time on which the image was built, conforming to [RFC 3339][rfc3339].
+ * **org.opencontainers.image.authors** contact details of the people or organization responsible for the image (freeform string)
+ * **org.opencontainers.image.url** URL to find more information on the image (string)
+diff --git a/artifact.md b/artifact.md
+new file mode 100644
+index 0000000..3d2b44c
+--- /dev/null
++++ b/artifact.md
+@@ -0,0 +1,74 @@
++# OCI Artifact Manifest Specification
++
++The goal of the Artifact Manifest Specification is to define content addressable artifacts in order to store them along side container images in a registry.
++Like [OCI Images](manifest.md), OCI Artifacts may be referenced by the hash of their manifest.
++Unlike OCI Images, OCI Artifacts are not meant to be used by any container runtime.
++
++Examples of artifacts that may be stored along with container images are Software Bill of Materials (SBOM), Digital Signatures, Provenance data, Supply Chain Attestations, scan results, and Helm charts.
++
++This section defines the `application/vnd.oci.artifact.manifest.v1+json` [media type](media-types.md).
++For the media type(s) that this is compatible with see the [matrix](media-types.md#compatibility-matrix).
++
++# Artifact Manifest
++
++## *Artifact Manifest* Property Descriptions
++
++- **`mediaType`** *string*
++
++  This property MUST be used and contain the media type `application/vnd.oci.artifact.manifest.v1+json`.
++
++- **`artifactType`** *string*
++
++  This property SHOULD be used and contain the mediaType of the referenced artifact.
++  If defined, the value MUST comply with [RFC 6838][rfc6838], including the [naming requirements in its section 4.2][rfc6838-s4.2], and MAY be registered with [IANA][iana].
++
++- **`blobs`** *array of objects*
++
++  This OPTIONAL property is an array of objects and each item in the array MUST be a [descriptor](descriptor.md).
++  Each descriptor represents an artifact of any IANA mediaType.
++  The list MAY be ordered for certain artifact types like scan results.
++
++- **`subject`** *[descriptor](descriptor.md)*
++
++  This OPTIONAL property specifies a [descriptor](descriptor.md) of another manifest.
++  This value, used by the [`referrers` API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers), indicates a relationship to the specified manifest.
++
++- **`annotations`** *string-string map*
++
++  This OPTIONAL property contains additional metadata for the artifact manifest.
++  This OPTIONAL property MUST use the [annotation rules](annotations.md#rules).
++
++  See [Pre-Defined Annotation Keys](annotations.md#pre-defined-annotation-keys).
++
++  Annotations MAY be used to filter the response from the [`referrers` API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers).
++
++## Examples
++
++*Example showing an artifact manifest for an example SBOM referencing an image:*
++
++```jsonc,title=Manifest&mediatype=application/vnd.oci.artifact.manifest.v1%2Bjson
++{
++  "mediaType": "application/vnd.oci.artifact.manifest.v1+json",
++  "artifactType": "application/vnd.example.sbom.v1",
++  "blobs": [
++    {
++      "mediaType": "application/gzip",
++      "size": 123,
++      "digest": "sha256:87923725d74f4bfb94c9e86d64170f7521aad8221a5de834851470ca142da630"
++    }
++  ],
++  "subject": {
++    "mediaType": "application/vnd.oci.image.manifest.v1+json",
++    "size": 1234,
++    "digest": "sha256:cc06a2839488b8bd2a2b99dcdc03d5cfd818eed72ad08ef3cc197aac64c0d0a0"
++  },
++  "annotations": {
++    "org.opencontainers.artifact.created": "2022-01-01T14:42:55Z",
++    "org.example.sbom.format": "json"
++  }
++}
++```
++
++[iana]:         https://www.iana.org/assignments/media-types/media-types.xhtml
++[rfc6838]:      https://tools.ietf.org/html/rfc6838
++[rfc6838-s4.2]: https://tools.ietf.org/html/rfc6838#section-4.2
+diff --git a/descriptor.md b/descriptor.md
+index f936b91..82d303f 100644
+--- a/descriptor.md
++++ b/descriptor.md
+@@ -55,11 +55,14 @@ The following fields contain the primary properties that constitute a Descriptor
+ - **`artifactType`** *string*
+
+   This OPTIONAL property contains the type of an artifact when the descriptor points to an artifact.
++  This is the value of `artifactType` when the descriptor references an [artifact manifest](artifact.md).
+   This is the value of the config descriptor `mediaType` when the descriptor references an [image manifest](manifest.md).
+   If defined, the value MUST comply with [RFC 6838][rfc6838], including the [naming requirements in its section 4.2][rfc6838-s4.2], and MAY be registered with [IANA][iana].
+
+ Descriptors pointing to [`application/vnd.oci.image.manifest.v1+json`](manifest.md) SHOULD include the extended field `platform`, see [Image Index Property Descriptions](image-index.md#image-index-property-descriptions) for details.
+
++Descriptors pointing to [`application/vnd.oci.artifact.manifest.v1+json`](artifact.md) SHOULD include the extended field `artifactType`.
++
+ ### Reserved
+
+ Extended _Descriptor_ field additions proposed in other OCI specifications SHOULD first be considered for addition into this specification.
+@@ -203,7 +206,7 @@ In the following example, the descriptor indicates the type of artifact it is re
+
+ ```json,title=Content%20Descriptor&mediatype=application/vnd.oci.descriptor.v1%2Bjson
+ {
+-  "mediaType": "application/vnd.oci.image.manifest.v1+json",
++  "mediaType": "application/vnd.oci.artifact.manifest.v1+json",
+   "size": 123,
+   "digest": "sha256:87923725d74f4bfb94c9e86d64170f7521aad8221a5de834851470ca142da630",
+   "artifactType": "application/vnd.example.sbom.v1"
+diff --git a/image-index.md b/image-index.md
+index 5d32c6b..7695bb6 100644
+--- a/image-index.md
++++ b/image-index.md
+@@ -35,6 +35,7 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
+     Implementations MUST support at least the following media types:
+
+     - [`application/vnd.oci.image.manifest.v1+json`](manifest.md)
++    - [`application/vnd.oci.artifact.manifest.v1+json`](artifact.md)
+
+     Also, implementations SHOULD support the following media types:
+
+@@ -156,9 +157,14 @@ When the variant of the CPU is not listed in the table, values are implementatio
+       }
+     },
+     {
+-      "mediaType": "application/vnd.oci.image.index.v1+json",
++      "mediaType": "application/vnd.oci.artifact.manifest.v1+json",
+       "size": 7682,
+-      "digest": "sha256:601570aaff1b68a61eb9c85b8beca1644e698003e0cdb5bce960f193d265a8b7"
++      "digest": "sha256:601570aaff1b68a61eb9c85b8beca1644e698003e0cdb5bce960f193d265a8b7",
++      "artifactType": "application/example",
++      "annotations": {
++          "com.example.artifactKey1": "value1",
++          "com.example.artifactKey2": "value2"
++        }
+     }
+   ],
+   "annotations": {
+diff --git a/img/media-types.dot b/img/media-types.dot
+index 8583d5f..b6b331a 100644
+--- a/img/media-types.dot
++++ b/img/media-types.dot
+@@ -4,6 +4,7 @@ digraph G {
+     {
+       rank=same
+       manifest [shape=note, label="Image manifest\napplication/vnd.oci.image.manifest.v1+json"]
++      artifact [shape=note, label="Artifact Manifest\napplication/vnd.oci.artifact.manifest.v1+json"]
+     }
+     config [shape=note, label="Image config JSON\napplication/vnd.oci.image.config.v1+json"]
+     layer [shape=note, label="Layer tar archive\napplication/vnd.oci.image.layer.v1.tar\napplication/vnd.oci.image.layer.v1.tar+gzip\napplication/vnd.oci.image.layer.nondistributable.v1.tar\napplication/vnd.oci.image.layer.nondistributable.v1.tar+gzip"]
+@@ -13,5 +14,9 @@ digraph G {
+   imageIndex -> manifest [label="1..*"]
+   manifest -> config [label="1..1"]
+   manifest -> layer [label="1..*"]
++  artifact -> manifest [label="0..1"] [constraint = false];
++  artifact -> artifact [label="0..1"];
+   manifest -> manifest [label="0..1"];
++  artifact -> imageIndex [label="0..1"]
++  artifact -> layer[label="0..*"]
+ }
+diff --git a/img/media-types.png b/img/media-types.png
+index 70d2fe6..cfb9f5b 100644
+Binary files a/img/media-types.png and b/img/media-types.png differ
+diff --git a/spec.md b/spec.md
+index 4a37788..a3e7684 100644
+--- a/spec.md
++++ b/spec.md
+@@ -17,6 +17,7 @@ The goal of this specification is to enable the creation of interoperable tools
+ - [Image Index](image-index.md)
+ - [Filesystem Layers](layer.md)
+ - [Image Configuration](config.md)
++- [Artifact Manifest](artifact.md)
+ - [Annotations](annotations.md)
+ - [Conversion](conversion.md)
+ - [Considerations](considerations.md)
+@@ -53,6 +54,7 @@ The high-level components of the spec include:
+
+ * [Image Manifest](manifest.md) - a document describing the components that make up a container image
+ * [Image Index](image-index.md) - an annotated list of manifests
++* [Artifact Manifest](artifact.md) - a document describing the components that make up an artifact
+ * [Image Layout](image-layout.md) - a filesystem layout representing the contents of an image
+ * [Filesystem Layer](layer.md) - a changeset that describes a container's filesystem
+ * [Image Configuration](config.md) - a document determining layer ordering and configuration of the image suitable for translation into a [runtime bundle][runtime-spec]
+diff --git a/specs-go/v1/artifact.go b/specs-go/v1/artifact.go
+new file mode 100644
+index 0000000..b755ec2
+--- /dev/null
++++ b/specs-go/v1/artifact.go
+@@ -0,0 +1,34 @@
++// Copyright 2022 The Linux Foundation
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++package v1
++
++// Artifact describes an artifact manifest.
++// This structure provides `application/vnd.oci.artifact.manifest.v1+json` mediatype when marshalled to JSON.
++type Artifact struct {
++	// MediaType is the media type of the object this schema refers to.
++	MediaType string `json:"mediaType"`
++
++	// ArtifactType is the IANA media type of the artifact this schema refers to.
++	ArtifactType string `json:"artifactType,omitempty"`
++
++	// Blobs is a collection of blobs referenced by this manifest.
++	Blobs []Descriptor `json:"blobs,omitempty"`
++
++	// Subject (reference) is an optional link from the artifact to another manifest forming an association between the artifact and the other manifest.
++	Subject *Descriptor `json:"subject,omitempty"`
++
++	// Annotations contains arbitrary metadata for the artifact manifest.
++	Annotations map[string]string `json:"annotations,omitempty"`
++}
+diff --git a/specs-go/v1/mediatype.go b/specs-go/v1/mediatype.go
+index 5dd3125..3126d81 100644
+--- a/specs-go/v1/mediatype.go
++++ b/specs-go/v1/mediatype.go
+@@ -72,4 +72,7 @@ const (
+
+ 	// MediaTypeScratch specifies the media type for an unused blob containing the value `{}`
+ 	MediaTypeScratch = "application/vnd.oci.scratch.v1+json"
++
++	// MediaTypeArtifactManifest specifies the media type for a content descriptor.
++	MediaTypeArtifactManifest = "application/vnd.oci.artifact.manifest.v1+json"
+ )


### PR DESCRIPTION
Before:

```console
$ ./scripts/grype-scan-apk.sh ./packages/aarch64/zot-1.4.3-r5.apk json | jq '.matches | length'
28
```

After:

```console
$ ./scripts/grype-scan-apk.sh ./packages/aarch64/zot-1.4.3-r6.apk json | jq '.matches | length'
4
```

What's remaining is 2 GHSAs (multiplied by two binaries: `zot` and `zli`) in `github.com/notaryproject/notation-go`, where zot's code base depends directly on symbols in its current version of notation-go that are removed in the very next version — so it's not possible to resolve these vulnerabilities without breaking zot or reimplementing the affected piece of zot's code.