### PR TITLE
Fix envoy build by pinning to gcc 12.

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -1,7 +1,7 @@
 package:
   name: envoy
   version: 1.26.1
-  epoch: 0
+  epoch: 1
   description: Cloud-native high-performance edge/middle/service proxy
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,16 @@ environment:
     packages:
       - busybox
       - ca-certificates-bundle
-      - build-base
+      - wolfi-baselayout
+      - binutils
+      # We need to stick to gcc 12 for now, envoy doesn't build with gcc 13
+      - gcc=12.2.0-r11
+      - libstdc++=12.2.0-r11
+      - libstdc++-dev=12.2.0-r11
+      - libgcc=12.2.0-r11
+      - pkgconf
+      - make
+      - glibc-dev
       - git
       - bazel-6
       - openjdk-11
@@ -21,7 +30,6 @@ environment:
       - samurai
       - python3-dev
       - clang-15
-      - libstdc++
       - llvm15
       - llvm15-dev
       - llvm-lld
@@ -37,7 +45,7 @@ pipeline:
       destination: envoy
 
   - runs: |
-      export JAVA_HOME=/usr/lib/jvm/openjdk
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
       mkdir -p .cache/bazel/_bazel_root
 
       cd envoy


### PR DESCRIPTION
The new gcc-12 package itself doesn't install, but this works and unblocks envoy updates.


Fixes:

Related:

### Pre-review Checklist
