### PR TITLE
Pin elixir inside rabbitmq.

### DIFF
--- a/rabbitmq-server.yaml
+++ b/rabbitmq-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-server
   version: 3.12.0
-  epoch: 0
+  epoch: 1
   description: Open source RabbitMQ. core server and tier 1 (built-in) plugins
   copyright:
     - license: MPL-2.0
@@ -16,7 +16,8 @@ environment:
     packages:
       - erlang
       - erlang-dev
-      - elixir
+      # New builds of elixir break the rabbitmq cli build
+      - elixir<1.15
       - ca-certificates-bundle
       - build-base
       - automake


### PR DESCRIPTION
New builds of elixir break the rabbitmq build.

Fixes:

Related:

### Pre-review Checklist
