### PR TITLE
Drop noexecheap from wayland-protocols

### DIFF
--- a/wayland-protocols.yaml
+++ b/wayland-protocols.yaml
@@ -1,6 +1,6 @@
 package:
   name: wayland-protocols
-  version: "1.31"
+  version: "1.32"
   epoch: 0
   description: Protocols and protocol extensions complementing the Wayland core protocol
   copyright:
@@ -18,12 +18,15 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: a07fa722ed87676ec020d867714bc9a2f24c464da73912f39706eeef5219e238
+      expected-sha256: 7459799d340c8296b695ef857c07ddef24c5a09b09ab6a74f7b92640d2b1ba11
       uri: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/${{package.version}}/downloads/wayland-protocols-${{package.version}}.tar.xz
 
-  - uses: meson/configure
-
-  - uses: meson/compile
+  - runs: |
+      # This flag doesn't work on the new version
+      export LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"
+      env
+      meson . output --prefix=/usr
+      meson compile -j $(nproc) -C output
 
   - uses: meson/install
 


### PR DESCRIPTION
And bump to 1.32

Fixes: https://github.com/wolfi-dev/os/pull/3351

Related:

### Pre-review Checklist

