### PR TITLE
Resolve vulnerabilities in paranoia

### DIFF
--- a/paranoia.yaml
+++ b/paranoia.yaml
@@ -1,7 +1,7 @@
 package:
   name: paranoia
   version: 0.2.1
-  epoch: 1
+  epoch: 2
   description: Inspect certificate authorities in container images
   copyright:
     - license: Apache-2.0
@@ -13,21 +13,24 @@ environment:
       - busybox
       - build-base
       - go
-      - ca-certificates-bundle
 
 pipeline:
-  # We can't use go/install because this requires specific ldflags to set the version
   - uses: git-checkout
     with:
       repository: https://github.com/jetstack/paranoia
       tag: v${{package.version}}
       expected-commit: 1f670639114b5b1c3696b93319f3c9175085084a
-      destination: paranoia
 
   - runs: |
-      cd paranoia
-      mkdir -p ${{targets.destdir}}/usr/bin
+      # GHSA-hqxw-f8mx-cpmw
+      go get github.com/docker/distribution@v2.8.2-beta.1
+
+      # GHSA-232p-vwff-86mp, GHSA-33pg-m6jh-5237, GHSA-6wrf-mxfj-pf5p
+      go get github.com/docker/docker@v20.10.24
+
       CGO_ENABLED=0 GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) go build -a -installsuffix cgo -o paranoia .
+
+      mkdir -p ${{targets.destdir}}/usr/bin
       install -Dm755 ./paranoia ${{targets.destdir}}/usr/bin/paranoia
 
 update:


### PR DESCRIPTION
Before:

```console
$ ./scripts/grype-scan-apk.sh ./packages/aarch64/paranoia-0.2.1-r1.apk       
NAME                            INSTALLED               FIXED-IN      TYPE       VULNERABILITY        SEVERITY 
github.com/docker/distribution  v2.8.1+incompatible     2.8.2-beta.1  go-module  GHSA-hqxw-f8mx-cpmw  High      
github.com/docker/docker        v20.10.20+incompatible  20.10.24      go-module  GHSA-232p-vwff-86mp  High      
github.com/docker/docker        v20.10.20+incompatible  20.10.24      go-module  GHSA-33pg-m6jh-5237  Medium    
github.com/docker/docker        v20.10.20+incompatible  20.10.24      go-module  GHSA-6wrf-mxfj-pf5p  Medium
```

After:

```console
$ ./scripts/grype-scan-apk.sh ./packages/aarch64/paranoia-0.2.1-r2.apk
No vulnerabilities found
```