### PR TITLE
move bash completions into separate subpackage

### DIFF
--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.24
   version: 1.24.15
-  epoch: 2
+  epoch: 3
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -71,8 +71,14 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl-1.24
 
+  - name: kubectl-bash-completion-1.24
+    dependencies:
+      runtime:
+        - kubectl-1.24
+    pipeline:
+      - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
-          _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl
+          _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl-1.24
 
   - name: kubeadm-1.24
     description: A tool for quickly installing Kubernetes and setting up a secure cluster

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.25
   version: 1.25.11
-  epoch: 2
+  epoch: 3
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -71,8 +71,14 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl-1.25
 
+  - name: kubectl-bash-completion-1.25
+    dependencies:
+      runtime:
+        - kubectl-1.25
+    pipeline:
+      - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
-          _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl
+          _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl-1.25
 
   - name: kubeadm-1.25
     description: A tool for quickly installing Kubernetes and setting up a secure cluster

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.26
   version: 1.26.6
-  epoch: 2
+  epoch: 3
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -71,8 +71,14 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl-1.26
 
+  - name: kubectl-bash-completion-1.26
+    dependencies:
+      runtime:
+        - kubectl-1.26
+    pipeline:
+      - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
-          _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl
+          _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl-1.26
 
   - name: kubeadm-1.26
     description: A tool for quickly installing Kubernetes and setting up a secure cluster

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.27
   version: 1.27.3
-  epoch: 4
+  epoch: 5
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -67,15 +67,21 @@ subpackages:
   - name: kubectl-1.27
     description: A command line tool for communicating with a Kubernetes API server
     dependencies:
-      provides:
-        - kubectl=1.27
+      runtime:
+        - kubectl-1.27
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl-1.27
 
+  - name: kubectl-bash-completion-1.27
+    dependencies:
+      provides:
+        - kubectl=1.27
+    pipeline:
+      - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
-          _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl
+          _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl-1.27
 
   - name: kubeadm-1.27
     description: A tool for quickly installing Kubernetes and setting up a secure cluster


### PR DESCRIPTION
on the off chance we want the bash completions, keep them around but in a sub package.

this fixes the version conflicts between the bash completions, and brings them in line with the way we deconflict the clis