### PR TITLE
calico: remove nsswitch.conf from typhad package

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.26.1
-  epoch: 2
+  epoch: 3
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64
@@ -424,7 +424,6 @@ subpackages:
             ./typha/cmd/calico-typha
 
           mkdir -p "${{targets.subpkgdir}}"/etc/calico
-          cp ./typha/docker-image/nsswitch.conf "${{targets.subpkgdir}}"/etc/nsswitch.conf
           cp ./typha/docker-image/typha.cfg "${{targets.subpkgdir}}"/etc/calico/typha.cfg
 
           mkdir -p "${{targets.subpkgdir}}"/licenses


### PR DESCRIPTION
This conflicts with wolfi-baselayout meaning the package can't effectively be installed alongside it.

The contents of the configs seem to be mostly the same anyway.