### PR TITLE
gcc-12: disable libcc1

### DIFF
--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.3.0
-  epoch: 0
+  epoch: 1
   description: "the GNU compiler collection - version 12"
   copyright:
     - license: GPL-3.0-or-later
@@ -70,7 +70,8 @@ pipeline:
             --enable-gnu-indirect-function \
             --enable-gnu-unique-object \
             --enable-version-specific-runtime-libs \
-            --with-linker-hash-style=gnu
+            --with-linker-hash-style=gnu \
+            --disable-libcc1
 
           make -j$(nproc)
           make -j$(nproc) install DESTDIR="${{targets.destdir}}"


### PR DESCRIPTION
libcc1 is a plugin for GDB, we do not need it for GCC 12.