### PR TITLE
gcc-12: add gcc-12-default package which can provide the gcc slot

### DIFF
--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.3.0
-  epoch: 1
+  epoch: 2
   description: "the GNU compiler collection - version 12"
   copyright:
     - license: GPL-3.0-or-later
@@ -119,6 +119,28 @@ subpackages:
           mv "${{targets.destdir}}"/$gcclibdir/include/*++* "${{targets.subpkgdir}}"/$gcclibdir/include/
           mv "${{targets.destdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/* \
             "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/
+
+  - name: 'gcc-12-default'
+    description: 'Use GCC 12 as system gcc'
+    dependencies:
+      provides:
+        - gcc=12.3.1
+      runtime:
+        - gcc-12
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+
+          for i in c++ g++ gcc gcc-ar gcc-nm gcc-ranlib; do
+            ln -sf "${{host.triplet.gnu}}-"$i"-12" "${{targets.subpkgdir}}"/usr/bin/"${{host.triplet.gnu}}-"$i
+          done
+
+          for i in c++ g++ cpp gcc gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do
+            ln -sf $i"-12" "${{targets.subpkgdir}}"/usr/bin/$i
+          done
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          ln -sf libgcc_s.so.1 "${{targets.subpkgdir}}"/usr/lib/libgcc_s.so
 
 update:
   enabled: false


### PR DESCRIPTION
Allow GCC 12 to act as system toolchain, instead of GCC 13, by providing the `gcc` name on a `gcc-12-default` package.  This allows for GCC to be slotted like Java, Kubernetes, etc.