### PR TITLE
envoy: use gcc 12 slot to build, instead of pinning

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -1,7 +1,7 @@
 package:
   name: envoy
   version: 1.26.2
-  epoch: 0
+  epoch: 1
   description: Cloud-native high-performance edge/middle/service proxy
   copyright:
     - license: Apache-2.0
@@ -13,14 +13,7 @@ environment:
       - ca-certificates-bundle
       - wolfi-baselayout
       - binutils
-      # We need to stick to gcc 12 for now, envoy doesn't build with gcc 13
-      - gcc=12.2.0-r11
-      - libstdc++=12.2.0-r11
-      - libstdc++-dev=12.2.0-r11
-      - libgcc=12.2.0-r11
-      - pkgconf
-      - make
-      - glibc-dev
+      - build-base
       - git
       - bazel-6
       - openjdk-11
@@ -35,6 +28,8 @@ environment:
       - llvm-lld
       - coreutils
       - patch
+      # We need to stick to gcc 12 for now, envoy doesn't build with gcc >= 13
+      - gcc-12-default
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Use the `gcc-12-default` package to use GCC 12 explicitly, rather than pinning to a specific GCC 12 version.