### PR TITLE
add node-problem-detector-compat

### DIFF
--- a/node-problem-detector.yaml
+++ b/node-problem-detector.yaml
@@ -1,7 +1,7 @@
 package:
   name: node-problem-detector
   version: 0.8.13
-  epoch: 2
+  epoch: 3
   description: node-problem-detector aims to make various node problems visible to the upstream layers in the cluster management stack.
   copyright:
     - license: Apache-2.0
@@ -88,6 +88,12 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin/
           install -m755 -D ./output/$(go env GOOS)_$(go env GOARCH)/bin/log-counter "${{targets.subpkgdir}}"/usr/bin/log-counter
+
+  - name: node-problem-detector
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}
+          ln -sf /usr/bin/node-problem-detector ${{targets.subpkgdir}}/node-problem-detector
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: 

Since we put the `node-problem-detector` binary under /usr/bin/ by default, official image puts it under root / path. So we have to adjust the command to make it work.


Related: github.com/chainguard-images/images/pull/870

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
