### PR TITLE
Add libatomic_ops  libasyncns and soxr packages.

### DIFF
--- a/libatomic_ops.yaml
+++ b/libatomic_ops.yaml
@@ -1,0 +1,55 @@
+package:
+  name: libatomic_ops
+  version: 7.8.0
+  epoch: 0
+  description: Semi-portable access to hardware provided atomic memory operations
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 15676e7674e11bda5a7e50a73f4d9e7d60452271b8acf6fd39a71fefdf89fa31
+      uri: https://github.com/ivmai/libatomic_ops/releases/download/v${{package.version}}/libatomic_ops-${{package.version}}.tar.gz
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --localstatedir=/var \
+        --enable-shared
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: libatomic_ops-static
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/*.a "${{targets.subpkgdir}}"/usr/lib
+
+  - name: libatomic_ops-dev
+    pipeline:
+      - uses: split/dev
+    description: libatomic_ops dev
+
+  - name: libatomic_ops-doc
+    pipeline:
+      - uses: split/manpages
+    description: libatomic_ops manpages
+
+update:
+  release-monitor:
+    identifier: 1561

--- a/packages.txt
+++ b/packages.txt
@@ -869,3 +869,6 @@ libsamplerate
 jack
 sbc
 jwt-tool
+libatomic_ops
+soxr
+libasyncns

--- a/soxr.yaml
+++ b/soxr.yaml
@@ -1,0 +1,49 @@
+# Generated from https://git.alpinelinux.org/aports/plain/community/soxr/APKBUILD
+package:
+  name: soxr
+  version: 0.1.3
+  epoch: 0
+  description: High quality, one-dimensional sample-rate conversion library
+  copyright:
+    - license: LGPL-2.1-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: b111c15fdc8c029989330ff559184198c161100a59312f5dc19ddeb9b5a15889
+      uri: https://sourceforge.net/projects/soxr/files/soxr-${{package.version}}-Source.tar.xz/download
+
+  - uses: cmake/configure
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+subpackages:
+  - name: soxr-doc
+    pipeline:
+      - uses: split/manpages
+    description: soxr manpages
+
+  - name: soxr-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - soxr
+    description: soxr dev
+
+update:
+  release-monitor:
+    identifier: 4859


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
