### PR TITLE
Add kube-fluentd-operator

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,0 +1,103 @@
+package:
+  name: kube-fluentd-operator
+  version: 1.17.3
+  epoch: 0
+  description: foo
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - jemalloc
+      - ruby-3.2
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - ruby3.2-bundler
+      - build-base
+      - busybox
+      - git
+      - libffi-dev
+      - gmp-dev
+      - bzip2
+      - zlib-dev
+      - libedit
+      - libedit-dev
+      - gdbm
+      - gdbm-dev
+      - openssl-dev
+      - gpg
+      - wget
+      # - shadow
+
+vars:
+  FLUENT_PLUGIN_GOOGLE_CLOUD_COMMIT: "619c813c265d51f4dd0b1cada3a07e615b47cdde"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/vmware/kube-fluentd-operator
+      tag: v${{package.version}}
+      expected-commit: 701df715b09f9fbd3b6210b386a33f4fe78598b8
+
+  - runs: |
+      cd base-image
+      GEM_DIR=${{targets.destdir}}$(ruby -e 'puts Gem.default_dir')
+      mkdir -p ${GEM_DIR}
+      bundle config set --local path ${GEM_DIR}
+      bundle install
+
+      mkdir -p ${{targets.destdir}}/etc/fluent/plugin
+      mv ./plugins/* ${{targets.destdir}}/etc/fluent/plugin
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+
+      # a forked version of fluent-plugin-google-cloud is used to align the fluentd version
+      # cloning here as CI checks fail when using the git-checkout pipeline
+      cd ..
+      git clone https://github.com/javiercri/fluent-plugin-google-cloud.git
+      cd fluent-plugin-google-cloud
+      git checkout ${{vars.FLUENT_PLUGIN_GOOGLE_CLOUD_COMMIT}}
+
+      bundle config set --local path ${GEM_DIR}
+      bundle install
+
+  - uses: strip
+
+subpackages:
+  - name: kube-fluentd-operator-oci-entrypoint
+    description: Entrypoint for using kube-fluentd-operator
+    dependencies:
+      runtime:
+        - bash
+    pipeline:
+      - runs: |
+          cd base-image
+          mkdir -p ${{targets.subpkgdir}}/var/lib/kube-fluentd-operator/initdb
+          cp entrypoint.sh ${{targets.subpkgdir}}/var/lib/kube-fluentd-operator/initdb/
+          chmod +x ${{targets.subpkgdir}}/var/lib/kube-fluentd-operator/initdb/entrypoint.sh
+
+  - name: kube-fluentd-operator-default-config
+    description: Default configuration for kube-fluentd-operator
+    pipeline:
+      - runs: |
+          cd base-image
+          mkdir -p ${{targets.subpkgdir}}/etc/fluent
+          cp failsafe.conf ${{targets.subpkgdir}}/etc/fluent/fluent.conf
+
+  - name: kube-fluentd-operator-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/fluentd
+          ln -sf /var/lib/kube-fluentd-operator/initdb/entrypoint.sh ${{targets.subpkgdir}}/fluentd/entrypoint.sh
+          ln -sf /etc/fluent/fluent.conf ${{targets.subpkgdir}}/fluentd/failsafe.conf
+          ln -sf /etc/fluent/plugin ${{targets.subpkgdir}}/fluentd/plugins
+
+update:
+  enabled: true
+  github:
+    identifier: vmware/kube-fluentd-operator
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -857,6 +857,7 @@ wasm-tools
 corepack
 esbuild
 ruff
+kube-fluentd-operator
 oranda
 sudo-rs
 ocaml


### PR DESCRIPTION

#### For new package PRs only
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] REQUIRED - The package is added to `packages.txt`
