### PR TITLE
Fix speex and speexdsp packages.

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -861,6 +861,7 @@ oranda
 sudo-rs
 ocaml
 opam
+speex
 speexdsp
 flac
 libsndfile

--- a/speex.yaml
+++ b/speex.yaml
@@ -1,0 +1,60 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/speex/APKBUILD
+package:
+  name: speex
+  version: 1.2.1
+  epoch: 0
+  description: an audio compression format designed for speech
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - autoconf
+      - automake
+      - libtool
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 4b44d4f2b38a370a2d98a78329fefc56a0cf93d1c1be70029217baae6628feea
+      uri: http://downloads.us.xiph.org/releases/speex/speex-${{package.version}}.tar.gz
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --build=$CBUILD \
+        --host=$CHOST \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --infodir=/usr/share/info \
+        --disable-static
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: speex-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - speex
+    description: speex dev
+
+  - name: speex-doc
+    pipeline:
+      - uses: split/manpages
+    description: speex manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 14498

--- a/speexdsp.yaml
+++ b/speexdsp.yaml
@@ -2,7 +2,7 @@
 package:
   name: speexdsp
   version: 1.2.1
-  epoch: 0
+  epoch: 1
   description: A voice compression format (DSP)
   copyright:
     - license: BSD-3-Clause
@@ -16,23 +16,24 @@ environment:
       - autoconf
       - automake
       - libtool
+      - pkgconf
 
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 4b44d4f2b38a370a2d98a78329fefc56a0cf93d1c1be70029217baae6628feea
-      uri: http://downloads.us.xiph.org/releases/speex/speex-${{package.version}}.tar.gz
+      expected-sha256: b36d4f16e42b7103b7fc3e4a8f98b6bf889dd1f70f65c2365af07be82844db29
+      uri: https://gitlab.xiph.org/xiph/speexdsp/-/archive/SpeexDSP-${{package.version}}/speexdsp-SpeexDSP-${{package.version}}.tar.bz2
+
+  - runs: |
+      autoreconf -fiv
+      # Theres a bug in the generated configure script here related to fft and pkg-config
+      sed -i 's|PKG_CHECK_MODULES(FFT, fftw3f)||g' configure
+      sed -i 's|@FFT_CFLAGS@||g' libspeexdsp/Makefile.am
 
   - uses: autoconf/configure
     with:
       opts: |
-        --build=$CBUILD \
-        --host=$CHOST \
-        --prefix=/usr \
-        --sysconfdir=/etc \
-        --mandir=/usr/share/man \
-        --infodir=/usr/share/info \
-        --disable-static
+        --disable-static \
 
   - uses: autoconf/make
 


### PR DESCRIPTION
I misadded speex as speexdsp - they're separate packages.

Fixes:

Related:

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
