### PR TITLE
update ncurses-20230701 source

### DIFF
--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
-  version: 6.4
-  epoch: 2
+  version: 6.4_p20230701
+  epoch: 0
   description: "console display library"
   copyright:
     - license: MIT
@@ -21,12 +21,18 @@ environment:
       - build-base
       - ncurses
 
+# transform melange version to contain "-" rather than "_" so we can use a var in the fetch URL
+var-transforms:
+  - from: ${{package.version}}
+    match: \.(\d+)$
+    replace: +$1
+    to: mangled-package-version
+
 pipeline:
   - uses: fetch
     with:
-      #      uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{package.version}}-20220820.tgz
-      uri: https://distfiles.alpinelinux.org/distfiles/edge/ncurses-${{package.version}}-20230114.tgz
-      expected-sha512: b2e89c70b0181ccb7422e1789c6e495682391a0621f3327f6961a49f9f590898d979b84544954f02b9e18b2da4ddf989858797b7ab1d6703ecfb879886a200fe
+      uri: https://distfiles.alpinelinux.org/distfiles/edge/ncurses-${{vars.mangled-package-version}}.tgz
+      expected-sha512: 116a6c4d4535842563326112c7aee7aeb9ebf3f0b4e0c778e0e31e6212f6f1d560fa3a1915847a45897fc71f06d094e518616c55e156b038b30bbebaf48d6d27
 
   - name: Configure
     runs: |


### PR DESCRIPTION
update to the new `20230701` source for `ncurses`

if there's a more accepted way of pinning to a source for `ncurses`, please let me know :|

part of #3580 