### PR TITLE
Rebuild the perl-xml-parser with the new build of perl.

### DIFF
--- a/perl-xml-parser.yaml
+++ b/perl-xml-parser.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-xml-parser
   version: "2.46"
-  epoch: 0
+  epoch: 1
   description: A perl module for parsing XML documents
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl


### PR DESCRIPTION
This is incompatible and triggers "loadable library and perl binaries are mismatched".

Fixes:

Related:

### Pre-review Checklist
