### PR TITLE
Adding php-igbinary PHP extension

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -876,3 +876,4 @@ soxr
 libasyncns
 libical
 ell
+php-igbinary

--- a/php-igbinary.yaml
+++ b/php-igbinary.yaml
@@ -11,12 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - build-base
       - autoconf

--- a/php-igbinary.yaml
+++ b/php-igbinary.yaml
@@ -1,0 +1,52 @@
+package:
+  name: php-igbinary
+  version: 3.2.14
+  epoch: 0
+  description: "Igbinary is a drop in replacement for the standard php serializer."
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - php
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/bootstrap/stage3
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - build-base
+      - autoconf
+      - busybox
+      - php
+      - php-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/igbinary/igbinary
+      tag: ${{package.version}}
+      expected-commit: 102ad68159791e76667f8455cbc171e6ec78253c
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      ./configure CFLAGS="-O2 -g" --enable-igbinary
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      set -x
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+update:
+  enabled: true
+  github:
+    identifier: igbinary/igbinary


### PR DESCRIPTION
Adds the php-igbinary extension, which is a dependency for php-redis built with igbinary support.

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`

