### PR TITLE
ensures `usr/lib` exists for target of the `usr/lib64` symlink

### DIFF
--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 3
+  epoch: 4
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
@@ -40,7 +40,7 @@ pipeline:
 
   - name: Install
     runs: |
-      for i in bin etc etc/profile.d etc/secfixes.d home lib root var/log usr/bin usr/sbin usr/local tmp var/spool/cron opt run; do
+      for i in bin etc etc/profile.d etc/secfixes.d home lib root var/log usr/bin usr/sbin usr/local tmp var/spool/cron opt run usr/lib; do
         mkdir -p "${{targets.destdir}}"/${i}
       done
 


### PR DESCRIPTION
this materialized as a rather cryptic `file exists` error in `melange` when trying to build the world.

relevant logs:

```bash
/Library/Developer/CommandLineTools/usr/bin/make yamlfile=pkgconf.yaml pkgname=pkgconf packages/aarch64/pkgconf-1.9.5-r0.apk

...

ca-certificates-bundle (20230506-r0) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/ca-certificates-bundle-20230506-r0.apk
wolfi-baselayout (20230201-r3) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/wolfi-baselayout-20230201-r3.apk
ld-linux (2.37-r7) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/ld-linux-2.37-r7.apk
linux-headers (5.16.9-r1) https://packages.wolfi.dev/bootstrap/stage3/aarch64/linux-headers-5.16.9-r1.apk
glibc (2.36-r0) https://packages.wolfi.dev/bootstrap/stage3/aarch64/glibc-2.36-r0.apk
libgcc (13.1.0-r1) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/libgcc-13.1.0-r1.apk
libstdc++ (13.1.0-r1) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/libstdc++-13.1.0-r1.apk
binutils (2.40-r3) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/binutils-2.40-r3.apk
libstdc++-dev (13.1.0-r1) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/libstdc++-dev-13.1.0-r1.apk
libatomic (13.1.0-r1) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/libatomic-13.1.0-r1.apk
gmp (6.2.1-r7) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/gmp-6.2.1-r7.apk
libgomp (13.1.0-r1) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/libgomp-13.1.0-r1.apk
isl (0.26-r0) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/isl-0.26-r0.apk
mpfr (4.2.0-r3) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/mpfr-4.2.0-r3.apk
mpc (1.3.1-r0) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/mpc-1.3.1-r0.apk
zlib (1.2.13-r3) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/zlib-1.2.13-r3.apk
gcc (13.1.0-r1) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/gcc-13.1.0-r1.apk
glibc-dev (2.37-r7) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/glibc-dev-2.37-r7.apk
make (4.3-r3) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/make-4.3-r3.apk
pkgconf (1.9.3-r1) https://packages.wolfi.dev/bootstrap/stage3/aarch64/pkgconf-1.9.3-r1.apk
build-base (1-r5) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/build-base-1-r5.apk
busybox (1.36.1-r2) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/busybox-1.36.1-r2.apk
scanelf (1.3.4-r1) https://packages.wolfi.dev/bootstrap/stage3/aarch64/scanelf-1.3.4-r1.apk
openssl-config (3.1.1-r1) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/openssl-config-3.1.1-r1.apk
libcrypto3 (3.1.1-r1) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/libcrypto3-3.1.1-r1.apk
libssl3 (3.1.1-r1) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/libssl3-3.1.1-r1.apk
wget (1.21.4-r0) /Users/wolf/dev/gh/wolfi/os/packages/aarch64/wget-1.21.4-r0.apk

...

❕ aarch64   | installing libgcc (13.1.0-r1)

...

❕ aarch64   | buildImage failed: installing apk packages: unable to install files for pkg libgcc: error creating directory usr/lib64: mkdir /var/folders/5v/6gvb9x954sbd9tmqq14cwgrh0000gn/T/melange-guest-972405094/usr/lib64: file exists

```

I think this is otherwise benign, as it just adds an empty directory to ensure the already existing symlink `usr/lib64 -> usr/lib` is resolvable so that writes to `usr/lib64/*` don't bomb out

part of #3580 