### PR TITLE
Adding rabbitmq-c client 

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -876,3 +876,4 @@ soxr
 libasyncns
 libical
 ell
+rabbitmq-c

--- a/rabbitmq-c.yaml
+++ b/rabbitmq-c.yaml
@@ -1,0 +1,46 @@
+package:
+  name: rabbitmq-c
+  version: 0.13.0
+  epoch: 0
+  description: "RabbitMQ C client"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - openssl
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - ca-certificates-bundle
+      - openssl-dev
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/alanxz/rabbitmq-c
+      tag: v${{package.version}}
+      expected-commit: 974d71adceae6d742ae20a4c880d99c131f1460a
+
+  - uses: cmake/configure
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+subpackages:
+  - name: rabbitmq-c-dev
+    description: RabbitMQ C client development headers
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: alanxz/rabbitmq-c
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
This package is a dependency for building the `php-amqp` RabbitMQ PHP extension.


#### For new package PRs only
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`
