### PR TITLE
Adding php-redis

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -879,3 +879,4 @@ ell
 php-igbinary
 bluez
 pulseaudio
+php-redis

--- a/php-redis.yaml
+++ b/php-redis.yaml
@@ -36,7 +36,6 @@ pipeline:
 
   - name: Make install
     runs: |
-      set -x
       INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
 
 update:

--- a/php-redis.yaml
+++ b/php-redis.yaml
@@ -1,0 +1,45 @@
+package:
+  name: php-redis
+  version: 5.3.7
+  epoch: 0
+  description: "A PHP extension for Redis"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - php
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - autoconf
+      - busybox
+      - php
+      - php-dev
+      - php-igbinary
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/phpredis/phpredis
+      tag: ${{package.version}}
+      expected-commit: 98d64ba86f37d2d3048500461f50b05f302f36ea
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure --enable-redis-igbinary
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      set -x
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+update:
+  enabled: true
+  github:
+    identifier: phpredis/phpredis


### PR DESCRIPTION
Adding the `php-redis` extension.

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] REQUIRED - The package is added to `packages.txt`