### PR TITLE
Bump buck2 and the rust version used to build it.

### DIFF
--- a/buck2.yaml
+++ b/buck2.yaml
@@ -1,7 +1,7 @@
 package:
   name: buck2
   # When bumping, check that the rust version is still correct.
-  version: 0.0_git20230603
+  version: 0.0_git20230706
   epoch: 0
   description: "Build system, successor to Buck"
   copyright:
@@ -18,7 +18,7 @@ environment:
       - rustup
 
 vars:
-  rust-version: nightly-2023-03-07
+  rust-version: nightly-2023-05-28
 
 pipeline:
   - uses: git-checkout
@@ -26,7 +26,7 @@ pipeline:
       repository: https://github.com/facebook/buck2
       tag: latest
       # This uses strange versioning, latest is the tag but they'll apparently just bump that tag regularly.
-      expected-commit: ac9e9745fa0badecefa814853d59a2ba6bbbe174
+      expected-commit: 134ba2150318193ff7d2c2f26d65adee91aa8a3d
 
   - name: Configure and build
     runs: |


### PR DESCRIPTION


Fixes:

Related:

### Pre-review Checklist


#### For new package PRs only


#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
