### PR TITLE
build lua-lzlib with -fPIC

### DIFF
--- a/lua5.3-lzlib.yaml
+++ b/lua5.3-lzlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua5.3-lzlib
   version: 0.4.3
-  epoch: 2
+  epoch: 3
   description: "zlib binding for lua"
   copyright:
     - license: MIT
@@ -30,8 +30,8 @@ pipeline:
 
   - runs: |
       set -x
-      make CFLAGS="$CFLAGS \\$(pkg-config --debug --cflags lua5.3)" \
-           LDFLAGS="$LDFLAGS \\$(pkg-config --debug --libs lua5.3)"
+      make CFLAGS="$CFLAGS \\$(pkg-config --debug --cflags lua5.3) -fPIC" \
+           LDFLAGS="$LDFLAGS \\$(pkg-config --debug --libs lua5.3) -fPIC"
 
   - runs: |
       install -Dm755 zlib.so "${{targets.destdir}}"/usr/lib/lua/5.3/zlib.so


### PR DESCRIPTION
another error materializing when building the world:

```bash
⚠  aarch64   | + make 'CFLAGS=-O2 -Wall -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS \-I/usr/include/lua5.3' 'LDFLAGS=-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap \-L/usr/lib/lua5.3 -llua -lm'
ℹ  aarch64   | cc -O2 -Wall -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS \-I/usr/include/lua5.3 -O2 -Wall -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS  -c -o lzlib.o lzlib.c
ℹ  aarch64   | cc -o zlib.so -shared lzlib.o -L../zlib-1.2.3 -lz -L/home/build/local/lua-5.2/lib -L/home/build/local/lua-5.2/bin
⚠  aarch64   | /usr/lib/gcc/aarch64-unknown-linux-gnu/12.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: read-only segment has dynamic relocations
⚠  aarch64   | collect2: error: ld returned 1 exit status
⚠  aarch64   | make: *** [Makefile:48: zlib.so] Error 1
```

adding `-fPIC` to build pic seems like a suitable solution