### PR TITLE
glibc enhancements

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.37
-  epoch: 8
+  epoch: 9
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later
@@ -70,6 +70,9 @@ pipeline:
     runs: |
       cd build
       echo "user-defined-trusted-dirs=/usr/local/lib:/usr/local/lib64:/usr/lib:/usr/lib64:/lib:/lib64" >> configparms.base
+      echo "rtlddir=/lib" >> configparms.base
+      echo "slibdir=/lib" >> configparms.base
+      echo "libdir=/usr/lib" >> configparms.base
 
       echo "build-programs=no" > configparms
       cat configparms.base >> configparms
@@ -332,10 +335,11 @@ subpackages:
             runs: |
               mkdir -p "${{targets.subpkgdir}}"/lib
               mv "${{targets.destdir}}"/lib/ld-linux-aarch64.so.1 "${{targets.subpkgdir}}"/lib/
+          # Regrettably, the LSB *requires* the GLIBC ELF loader to be installed in `/lib64`.
           - if: ${{build.arch}} == 'x86_64'
             runs: |
               mkdir -p "${{targets.subpkgdir}}"/lib64
-              mv "${{targets.destdir}}"/lib64/ld-linux-x86-64.so.2 "${{targets.subpkgdir}}"/lib64/
+              mv "${{targets.destdir}}"/lib/ld-linux-x86-64.so.2 "${{targets.subpkgdir}}"/lib64/
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/etc
           mv "${{targets.destdir}}"/etc/ld.so.* "${{targets.subpkgdir}}"/etc/
@@ -430,26 +434,26 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mkdir -p "${{targets.subpkgdir}}"/lib64
+          mkdir -p "${{targets.subpkgdir}}"/lib
           mkdir -p "${{targets.subpkgdir}}"/var
 
           mv "${{targets.destdir}}"/usr/bin/makedb "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/lib64/libnss_db.so.2 "${{targets.subpkgdir}}"/lib64
+          mv "${{targets.destdir}}"/lib/libnss_db.so.2 "${{targets.subpkgdir}}"/lib
           mv "${{targets.destdir}}"/var/db "${{targets.subpkgdir}}"/var
 
   - name: "nss-hesiod"
     description: "NSS module for hesiod lookups"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/lib64
-          mv "${{targets.destdir}}"/lib64/libnss_hesiod.so.2 "${{targets.subpkgdir}}"/lib64
+          mkdir -p "${{targets.subpkgdir}}"/lib
+          mv "${{targets.destdir}}"/lib/libnss_hesiod.so.2 "${{targets.subpkgdir}}"/lib
 
   - name: "pcprofiledump"
     description: "PC profiling tool"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/lib64
-          mv "${{targets.destdir}}"/lib64/libpcprofile.so "${{targets.subpkgdir}}"/lib64
+          mkdir -p "${{targets.subpkgdir}}"/lib
+          mv "${{targets.destdir}}"/lib/libpcprofile.so "${{targets.subpkgdir}}"/lib
 
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/pcprofiledump "${{targets.subpkgdir}}"/usr/bin

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.37
-  epoch: 7
+  epoch: 8
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later
@@ -69,15 +69,22 @@ pipeline:
   - name: 'Configure glibc'
     runs: |
       cd build
+      echo "user-defined-trusted-dirs=/usr/local/lib:/usr/local/lib64:/usr/lib:/usr/lib64:/lib:/lib64" >> configparms.base
+
+      echo "build-programs=no" > configparms
+      cat configparms.base >> configparms
+
+      # We remove fortify when building the libraries
       export CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
       export CPPFLAGS=${CPPFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
+
       ../configure \
         --prefix=/usr \
         --libdir=/usr/lib \
         --datadir=/usr/share \
         --includedir=/usr/include \
         --host=${{host.triplet.gnu}} \
-        --build=$(../config.guess) \
+        --build=${{host.triplet.gnu}} \
         --disable-werror \
         --enable-kernel=4.9
 
@@ -87,8 +94,13 @@ pipeline:
       make -C build -j$(nproc)
 
   - runs: |
-      export CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
-      export CPPFLAGS=${CPPFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
+      # Build the programs with fortify
+      echo "build-programs=yes" > build/configparms
+      echo "CFLAGS += -Wp,-D_FORTIFY_SOURCE=3" >> build/configparms
+      cat build/configparms.base >> build/configparms
+      make -C build -j$(nproc)
+
+  - runs: |
       make -C build -j$(nproc) install DESTDIR="${{targets.destdir}}"
 
   - name: "Set up ldconfig"
@@ -324,6 +336,9 @@ subpackages:
             runs: |
               mkdir -p "${{targets.subpkgdir}}"/lib64
               mv "${{targets.destdir}}"/lib64/ld-linux-x86-64.so.2 "${{targets.subpkgdir}}"/lib64/
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/etc
+          mv "${{targets.destdir}}"/etc/ld.so.* "${{targets.subpkgdir}}"/etc/
     dependencies:
       runtime:
         - wolfi-baselayout


### PR DESCRIPTION
- Adds `/usr/local/lib` and `/usr/local/lib64` to the system search path.
- Builds glibc tooling with FORTIFY instead of turning it off for everything.