### PR TITLE
Adding php-amqp

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -881,3 +881,4 @@ php-igbinary
 bluez
 pulseaudio
 php-redis
+php-amqp

--- a/php-amqp.yaml
+++ b/php-amqp.yaml
@@ -1,0 +1,50 @@
+package:
+  name: php-amqp
+  version: 1.11.0
+  epoch: 0
+  description: "PHP extension to communicate with any AMQP compliant server"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - php
+      - rabbitmq-c
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - autoconf
+      - busybox
+      - php
+      - php-dev
+      - rabbitmq-c-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-amqp/php-amqp
+      tag: "v${{package.version}}"
+      expected-commit: a757b6657eedbbe3802756720f78f33e058d8d66
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      set -x
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+update:
+  enabled: true
+  github:
+    identifier: php-amqp/php-amqp
+    strip-prefix: v
+    tag-filter: v

--- a/php-amqp.yaml
+++ b/php-amqp.yaml
@@ -48,3 +48,4 @@ update:
     identifier: php-amqp/php-amqp
     strip-prefix: v
     tag-filter: v
+    use-tag: true


### PR DESCRIPTION
Adding the `php-amqp` extension.

#### For new package PRs only
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates