### PR TITLE
only build graph via wolfictl when needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,17 @@ endif
 
 # The list of packages to be built. The order matters.
 # wolfictl determines the list and order
-PKGLIST ?= $(shell $(WOLFICTL) text --dir . --type name)
+# set only to be called when needed, so make can be instant to run
+# when it is not
+PKGLISTCMD ?= $(WOLFICTL) text --dir . --type name
 
 all: ${KEY} .build-packages
+ifeq ($(MAKECMDGOALS),all)
+  PKGLIST := $(addprefix package/,$(shell $(PKGLISTCMD)))
+else
+  PKGLIST :=
+endif
+.build-packages: $(PKGLIST)
 
 ${KEY}:
 	${MELANGE} keygen ${KEY}
@@ -46,14 +54,12 @@ clean:
 
 .PHONY: list list-yaml
 list:
-	$(info $(PKGLIST))
+	$(info $(shell $(PKGLISTCMD)))
 	@printf ''
 
 list-yaml:
-	$(info $(addsuffix .yaml,$(PKGLIST)))
+	$(info $(addsuffix .yaml,$(shell $(PKGLISTCMD))))
 	@printf ''
-
-.build-packages: $(addprefix package/,${PKGLIST})
 
 package/%:
 	$(eval yamlfile := $*.yaml)


### PR DESCRIPTION
We were generating the graph with each call to `make`, and we were calling make recursively with each `package/<something>` target. So `make all` would generate the graph every single time, costing 1.5-2s. That is fine for 3 or 4 packages, but for nearly 1000, it times out.

We have to use recursive make, because we need to pass the original target to the dependency. This below won't work:

```make
package/%: packages/$(ARCH)/$(shell $(MELANGE) package-version $(yamlfile)))
packages/$(ARCH)/%:
    # do stuff
```

the "# do stuff" section needs to know the original package name, so it can `mkdir -p ${sourcedir}`, and call build `melange build ${yamlfile}`, both of which depend on the original package name, not the full version.

Make provides no way to do this. I also looked at target-specific variables, but they are evaluated in the context of the target to be run, e.g. in this case `packages/aarch64/openssl-1.2.3-r1.apk`, and not the original call `package/openssl`, leaving us no way to get the original package name of `openssl`, and hence the source dir and yaml file.

The only way to do that is to call recursive make and pass the information, which determines all vars again.

Therefore, we change it so that it only generates the graph when explicitly needed, i.e. for `.buildpackages`, `list` and `list-yaml`. This makes it very quick.
