### PR TITLE
fix kube-fluentd-operator config symlink + kube-fluentd-operator/1.17.4 package update

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
-  version: 1.17.3
-  epoch: 1
+  version: 1.17.4
+  epoch: 0
   description: foo
   copyright:
     - license: MIT
@@ -41,7 +41,7 @@ pipeline:
     with:
       repository: https://github.com/vmware/kube-fluentd-operator
       tag: v${{package.version}}
-      expected-commit: 701df715b09f9fbd3b6210b386a33f4fe78598b8
+      expected-commit: 0310b4eb0ed747c0eb192db998d67dead5faa1b7
 
   - runs: |
       cd base-image

--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.17.3
-  epoch: 0
+  epoch: 1
   description: foo
   copyright:
     - license: MIT
@@ -91,9 +91,9 @@ subpackages:
   - name: kube-fluentd-operator-compat
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/fluentd
+          mkdir -p ${{targets.subpkgdir}}/fluentd/etc
           ln -sf /var/lib/kube-fluentd-operator/initdb/entrypoint.sh ${{targets.subpkgdir}}/fluentd/entrypoint.sh
-          ln -sf /etc/fluent/fluent.conf ${{targets.subpkgdir}}/fluentd/failsafe.conf
+          ln -sf /etc/fluent/fluent.conf ${{targets.subpkgdir}}/fluentd/etc/failsafe.conf
           ln -sf /etc/fluent/plugin ${{targets.subpkgdir}}/fluentd/plugins
 
 update:


### PR DESCRIPTION
the helm chart is expecting the config in `/fluentd/etc`