### PR TITLE
Use the wolfictl in the SDK container we run inside

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -90,7 +90,6 @@ jobs:
 
       # Note: vulns found in scans do not currently block CI
       - name: 'Grype scan APKs'
-        id: grype-scan
         if: steps.file_check.outputs.exists == 'true'
         run: |
           set -x
@@ -101,22 +100,16 @@ jobs:
           done
 
       - name: Check sonames
-        id: soname
         if: steps.file_check.outputs.exists == 'true'
-        uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:7e693b6957ee6e3d66a9446dc2cd604dbf86f31fa4d8b9200fd8c7a742c5928c
-        with:
-          entrypoint: wolfictl
-          args: check so-name
+        runs: |
+          wolfictl check so-name
 
       - name: Check diff
-        id: diff
         if: steps.file_check.outputs.exists == 'true'
         # Let's not fail the whole job if this step fails as it is for improved UX rather than an enforced check
         continue-on-error: true
-        uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:7e693b6957ee6e3d66a9446dc2cd604dbf86f31fa4d8b9200fd8c7a742c5928c
-        with:
-          entrypoint: wolfictl
-          args: check diff
+        runs: |
+          wolfictl check diff
 
       - name: Check for diff file
         id: diff_file_check

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -101,14 +101,14 @@ jobs:
 
       - name: Check sonames
         if: steps.file_check.outputs.exists == 'true'
-        runs: |
+        run: |
           wolfictl check so-name
 
       - name: Check diff
         if: steps.file_check.outputs.exists == 'true'
         # Let's not fail the whole job if this step fails as it is for improved UX rather than an enforced check
         continue-on-error: true
-        runs: |
+        run: |
           wolfictl check diff
 
       - name: Check for diff file


### PR DESCRIPTION
We run this entire action inside of the SDK container, so just use that to provide `wolfictl` instead of using the dedicated `wolfictl` container.