### PR TITLE
adds valgrind-3.21.0

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -884,3 +884,4 @@ pulseaudio
 php-redis
 php-amqp
 pgcat
+valgrind

--- a/valgrind.yaml
+++ b/valgrind.yaml
@@ -1,0 +1,82 @@
+package:
+  name: valgrind
+  version: "3.21.0"
+  epoch: 0
+  description: "Tool to help find memory-management problems in programs"
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - sed
+      - perl
+      - linux-headers
+      - python3
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 3e86cda2f2d6cd30807fac7933ba2c46a97a2b4a868db989e6b0cceeadf029af7ee34ba900466a346948289aacb30f4399799bb83b97cc49a4d2d810441e5cfd
+      uri: https://sourceware.org/pub/valgrind/valgrind-${{package.version}}.tar.bz2
+
+  - runs: |
+      export CFLAGS="${CFLAGS/-fno-plt} -fno-stack-protector -no-pie -U_FORTIFY_SOURCE"
+      ./configure \
+        --build=$CBUILD \
+        --host=$CHOST \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --infodir=/usr/share/info \
+        --localstatedir=/var \
+        --without-mpicc
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      make DESTDIR="$${{targets.destdir}}" install
+
+subpackages:
+  - name: valgrind-doc
+    pipeline:
+      - uses: split/manpages
+    description: valgrind manpages
+
+  - name: valgrind-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - valgrind
+    description: valgrind dev
+
+  - name: valgrind-scripts
+    dependencies:
+      runtime:
+        - valgrind
+        - python3
+        - perl
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/ms_print \
+              ${{targets.destdir}}/usr/bin/cg_merge \
+              ${{targets.destdir}}/usr/bin/cg_annotate \
+              ${{targets.destdir}}/usr/bin/cg_diff \
+              ${{targets.destdir}}/usr/bin/callgrind_control \
+              ${{targets.destdir}}/usr/bin/callgrind_annotate \
+              ${{targets.subpkgdir}}/usr/bin
+    description: valgrind perl+python cachegrind/callgrind script tools
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 13639


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
