### PR TITLE
workflows: push-production: explicitly call "make all" due to GNU make bug

### DIFF
--- a/.github/workflows/push-production.yaml
+++ b/.github/workflows/push-production.yaml
@@ -73,7 +73,7 @@ jobs:
 
       - name: 'Build Wolfi'
         run: |
-          make MELANGE="sudo -E melange" MELANGE_DIR=/usr/share/melange KEY=wolfi-signing.rsa REPO="${{ github.workspace }}/packages" -j1
+          make MELANGE="sudo -E melange" MELANGE_DIR=/usr/share/melange KEY=wolfi-signing.rsa REPO="${{ github.workspace }}/packages" -j1 all
 
       - name: 'Normalize repository permissions'
         run: |


### PR DESCRIPTION
Without this, `$MAKECMDGOALS` evals as an empty string, rather than `all`.