### PR TITLE
adds ruby deps for ruby-splunk-hec

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -888,3 +888,9 @@ php-amqp
 pgcat
 valgrind
 aws-flb-kinesis
+ruby3.2-openid_connect
+ruby3.2-prometheus-client
+ruby3.2-public_suffix
+ruby3.2-rack-oauth2
+ruby3.2-rack
+ruby3.2-ruby2_keywords

--- a/ruby3.2-openid_connect.yaml
+++ b/ruby3.2-openid_connect.yaml
@@ -1,0 +1,59 @@
+package:
+  name: ruby3.2-openid_connect
+  version: 2.2.0
+  epoch: 0
+  description: OpenID Connect Server & Client Library
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby3.2-activemodel
+      - ruby3.2-attr_required
+      - ruby3.2-faraday
+      - ruby3.2-faraday-follow_redirects
+      - ruby3.2-json-jwt
+      - ruby3.2-net-smtp
+      - ruby3.2-rack-oauth2
+      - ruby3.2-swd
+      - ruby3.2-tzinfo
+      - ruby3.2-validate_email
+      - ruby3.2-validate_url
+      - ruby3.2-webfinger
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      README: 'CONFIRM WITH: curl -L https://github.com/nov/openid_connect/archive/refs/tags/v2.2.0.tar.gz | sha256sum'
+      expected-sha256: 1dc67cf3cc7a66749c981209fbe89240204856e89fff0b6a8ffd1ae75679b4bf
+      uri: https://github.com/nov/openid_connect/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: openid_connect
+
+update:
+  enabled: true
+  github:
+    identifier: nov/openid_connect
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-prometheus-client.yaml
+++ b/ruby3.2-prometheus-client.yaml
@@ -1,0 +1,45 @@
+package:
+  name: ruby3.2-prometheus-client
+  version: 4.1.0
+  epoch: 0
+  description: A suite of instrumentation metric primitivesthat can be exposed through a web services interface.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - build-base
+      - ruby-3.2
+      - ruby-3.2-dev
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      README: 'CONFIRM WITH: curl -L https://github.com/prometheus/client_ruby/archive/refs/tags/v4.1.0.tar.gz | sha256sum'
+      expected-sha256: 8680f074f19b2d18844187826f62254802fd46ca1e1e880609c318ceeaad4912
+      uri: https://github.com/prometheus/client_ruby/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: prometheus-client
+
+update:
+  enabled: true
+  github:
+    identifier: prometheus/client_ruby
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-public_suffix.yaml
+++ b/ruby3.2-public_suffix.yaml
@@ -1,0 +1,45 @@
+package:
+  name: ruby3.2-public_suffix
+  version: 5.0.3
+  epoch: 0
+  description: PublicSuffix can parse and decompose a domain name into top level domain, domain and subdomains.
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      README: 'CONFIRM WITH: curl -L https://github.com/weppos/publicsuffix-ruby/tree/v5.0.3/archive/refs/tags/v5.0.3.tar.gz | sha256sum'
+      uri: http://github.com/weppos/publicsuffix-ruby/tree/v${{package.version}}/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-sha256: c720e1654569d37cc0646b61cef87483d6ff7c2f1d6959e6f4bbe8b4b0122b19
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: public_suffix
+
+update:
+  enabled: true
+  github:
+    identifier: weppos/publicsuffix-ruby
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-rack-oauth2.yaml
+++ b/ruby3.2-rack-oauth2.yaml
@@ -1,0 +1,53 @@
+package:
+  name: ruby3.2-rack-oauth2
+  version: 2.2.0
+  epoch: 0
+  description: OAuth 2.0 Server & Client Library. Both Bearer token type are supported.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby3.2-activesupport
+      - ruby3.2-attr_required
+      - ruby3.2-faraday
+      - ruby3.2-faraday-follow_redirects
+      - ruby3.2-json-jwt
+      - ruby3.2-rack
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      README: 'CONFIRM WITH: curl -L http://github.com/nov/rack-oauth2/archive/refs/tags/v2.2.0.tar.gz | sha256sum'
+      expected-sha256: 0f8a93658ae3772745f29bc346fc8f91f8209a2813fbae898e1350310424b010
+      uri: http://github.com/nov/rack-oauth2/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: rack-oauth2
+
+update:
+  enabled: true
+  github:
+    identifier: nov/rack-oauth2
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-rack.yaml
+++ b/ruby3.2-rack.yaml
@@ -1,0 +1,55 @@
+package:
+  name: ruby3.2-rack
+  version: 3.0.8
+  epoch: 0
+  description: |
+    Rack provides a minimal, modular and adaptable interface for developing
+    web applications in Ruby. By wrapping HTTP requests and responses in
+    the simplest way possible, it unifies and distills the API for web
+    servers, web frameworks, and software in between (the so-called
+    middleware) into a single method call.
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      README: 'CONFIRM WITH: curl -L https://github.com/rack/rack/archive/refs/tags/v3.0.8.tar.gz | sha256sum'
+      expected-sha256: f4cf32bece433d81682590e953a50ecc97282d83b2c1acaea96a30f53feba8ea
+      uri: https://github.com/rack/rack/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: patch
+    with:
+      README: This is only required if the gemspec is using a signing key
+      patches: patches/${{package.name}}.patch
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: rack
+
+update:
+  enabled: true
+  github:
+    identifier: rack/rack
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-ruby2_keywords.yaml
+++ b/ruby3.2-ruby2_keywords.yaml
@@ -1,0 +1,51 @@
+package:
+  name: ruby3.2-ruby2_keywords
+  version: 0.0.5
+  epoch: 0
+  description: Shim library for Module#ruby2_keywords
+  copyright:
+    - license: Ruby
+    - license: BSD-2-Clause
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      README: 'CONFIRM WITH: curl -L https://github.com/ruby/ruby2_keywords/archive/refs/tags/v0.0.5.tar.gz | sha256sum'
+      expected-sha256: e4e9cbcb02ae68903d8fe50391c0a912296511043340c3f5da47e9bbc282938f
+      uri: https://github.com/ruby/ruby2_keywords/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: patch
+    with:
+      README: This is only required if the gemspec is using a signing key
+      patches: patches/${{package.name}}.patch
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: ruby2_keywords
+
+update:
+  enabled: true
+  github:
+    identifier: ruby/ruby2_keywords
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
