### PR TITLE
bump epochs on packages dependent on Go

### DIFF
--- a/apko.yaml
+++ b/apko.yaml
@@ -2,7 +2,7 @@ package:
   name: apko
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
   version: 0.9.0
-  epoch: 0
+  epoch: 1
   description: Build OCI images using APK directly without Dockerfile
   copyright:
     - license: Apache-2.0

--- a/argo-cd.yaml
+++ b/argo-cd.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd
   version: 2.7.7
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0

--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-workflows
   version: 3.4.8
-  epoch: 3
+  epoch: 4
   description: Workflow engine for Kubernetes.
   copyright:
     - license: Apache-2.0

--- a/aws-ebs-csi-driver.yaml
+++ b/aws-ebs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-ebs-csi-driver
   version: 1.20.0
-  epoch: 0
+  epoch: 1
   description: CSI driver for Amazon EBS.
   copyright:
     - license: Apache-2.0

--- a/aws-efs-csi-driver.yaml
+++ b/aws-efs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-efs-csi-driver
   version: 1.5.8
-  epoch: 0
+  epoch: 1
   description: CSI driver for Amazon EFS.
   copyright:
     - license: Apache-2.0

--- a/aws-flb-cloudwatch.yaml
+++ b/aws-flb-cloudwatch.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-cloudwatch
   version: 1.9.4
-  epoch: 0
+  epoch: 1
   description: A Fluent Bit output plugin for CloudWatch Logs
   copyright:
     - license: Apache-2.0

--- a/aws-flb-firehose.yaml
+++ b/aws-flb-firehose.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-firehose
   version: 1.7.2
-  epoch: 0
+  epoch: 1
   description: A Fluent Bit output plugin for Amazon Kinesis Data Firehose
   copyright:
     - license: Apache-2.0

--- a/aws-flb-kinesis.yaml
+++ b/aws-flb-kinesis.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-kinesis
   version: 1.10.2
-  epoch: 0
+  epoch: 1
   description: A Fluent Bit output plugin for Kinesis Streams.
   copyright:
     - license: Apache-2.0

--- a/aws-load-balancer-controller.yaml
+++ b/aws-load-balancer-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-load-balancer-controller
   version: 2.5.3
-  epoch: 0
+  epoch: 1
   description: A Kubernetes controller for Elastic Load Balancers
   copyright:
     - license: Apache-2.0

--- a/bom.yaml
+++ b/bom.yaml
@@ -1,7 +1,7 @@
 package:
   name: bom
   version: 0.5.1
-  epoch: 2
+  epoch: 3
   description: A utility to generate SPDX-compliant Bill of Materials manifests
   copyright:
     - license: Apache-2.0

--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -2,7 +2,7 @@ package:
   name: buildkitd
   version: 0.11.6
   description: "concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
-  epoch: 2
+  epoch: 3
   copyright:
     - license: Apache-2.0
 

--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: caddy
   version: 2.6.4
-  epoch: 0
+  epoch: 1
   description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
   copyright:
     - license: Apache-2.0

--- a/cadvisor.yaml
+++ b/cadvisor.yaml
@@ -1,7 +1,7 @@
 package:
   name: cadvisor
   version: 0.47.3
-  epoch: 0
+  epoch: 1
   description: Analyzes resource usage and performance characteristics of running containers.
   copyright:
     - license: Apache-2.0

--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.26.1
-  epoch: 5
+  epoch: 6
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64

--- a/cert-manager.yaml
+++ b/cert-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: cert-manager
   version: 1.12.2
-  epoch: 0
+  epoch: 1
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0

--- a/chartmuseum.yaml
+++ b/chartmuseum.yaml
@@ -1,7 +1,7 @@
 package:
   name: chartmuseum
   version: 0.16.0
-  epoch: 0
+  epoch: 1
   description: helm chart repository server
   copyright:
     - license: Apache-2.0

--- a/cilium-cli.yaml
+++ b/cilium-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-cli
   version: 0.15.0
-  epoch: 0
+  epoch: 1
   description: CLI to install, manage & troubleshoot Kubernetes clusters running Cilium
   copyright:
     - license: Apache-2.0

--- a/cloudflared.yaml
+++ b/cloudflared.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudflared
   version: 2023.5.1
-  epoch: 0
+  epoch: 1
   description: Cloudflare Tunnel client
   copyright:
     - license: Apache-2.0

--- a/cluster-autoscaler.yaml
+++ b/cluster-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler
   version: 1.27.2
-  epoch: 2
+  epoch: 3
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/cluster-proportional-autoscaler.yaml
+++ b/cluster-proportional-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-proportional-autoscaler
   version: 1.8.8
-  epoch: 2
+  epoch: 3
   description: Kubernetes Cluster Proportional Autoscaler Container
   copyright:
     - license: Apache-2.0

--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -1,7 +1,7 @@
 package:
   name: cni-plugins
   version: 1.3.0
-  epoch: 2
+  epoch: 3
   description: Some reference and example networking plugins, maintained by the CNI team.
   copyright:
     - license: Apache-2.0

--- a/configmap-reload.yaml
+++ b/configmap-reload.yaml
@@ -1,7 +1,7 @@
 package:
   name: configmap-reload
   version: 0.11.1
-  epoch: 0
+  epoch: 1
   description: Simple binary to trigger a reload when a Kubernetes ConfigMap is updated
   copyright:
     - license: Apache-2.0

--- a/consul.yaml
+++ b/consul.yaml
@@ -2,7 +2,7 @@ package:
   name: consul
   version: 1.16.0
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
-  epoch: 0
+  epoch: 1
   description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
   copyright:
     - license: MPL-2.0

--- a/containerd.yaml
+++ b/containerd.yaml
@@ -1,7 +1,7 @@
 package:
   name: containerd
   version: 1.7.2
-  epoch: 1
+  epoch: 2
   description: An open and reliable container runtime
   copyright:
     - license: Apache-2.0

--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: 1.10.1
-  epoch: 1
+  epoch: 2
   description: CoreDNS is a DNS server that chains plugins
   target-architecture:
     - all

--- a/cortex.yaml
+++ b/cortex.yaml
@@ -1,7 +1,7 @@
 package:
   name: cortex
   version: 1.15.3
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0

--- a/cosign.yaml
+++ b/cosign.yaml
@@ -1,7 +1,7 @@
 package:
   name: cosign
   version: 2.1.1
-  epoch: 0
+  epoch: 1
   description: Container Signing
   copyright:
     - license: Apache-2.0

--- a/crane.yaml
+++ b/crane.yaml
@@ -1,7 +1,7 @@
 package:
   name: crane
   version: 0.15.2
-  epoch: 3
+  epoch: 4
   description: Tool for interacting with remote images and registries.
   copyright:
     - license: Apache-2.0

--- a/cri-tools.yaml
+++ b/cri-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: cri-tools
   version: 1.27.1
-  epoch: 0
+  epoch: 1
   description: CLI and validation tools for Kubelet Container Runtime Interface (CRI) .
   copyright:
     - license: Apache-2.0

--- a/ctop.yaml
+++ b/ctop.yaml
@@ -1,7 +1,7 @@
 package:
   name: ctop
   version: 0.7.7
-  epoch: 4
+  epoch: 5
   description: Top-like interface for container metrics
   target-architecture:
     - all

--- a/cue.yaml
+++ b/cue.yaml
@@ -1,7 +1,7 @@
 package:
   name: cue
   version: 0.5.0
-  epoch: 2
+  epoch: 3
   description: The home of the CUE language! Validate and define text-based and dynamic configuration
   copyright:
     - license: Apache-2.0

--- a/dataplaneapi.yaml
+++ b/dataplaneapi.yaml
@@ -1,7 +1,7 @@
 package:
   name: dataplaneapi
   version: 2.8.0
-  epoch: 0
+  epoch: 1
   description: HAProxy Data Plane API
   copyright:
     - license: Apache-2.0

--- a/delve.yaml
+++ b/delve.yaml
@@ -1,7 +1,7 @@
 package:
   name: delve
   version: 1.21.0
-  epoch: 1
+  epoch: 2
   description: Delve is a debugger for the Go programming language.
   copyright:
     - license: MIT

--- a/dex.yaml
+++ b/dex.yaml
@@ -2,7 +2,7 @@ package:
   name: dex
   # When bumping the version check if the GHSA mitigations below can be removed.
   version: 2.37.0
-  epoch: 0
+  epoch: 1
   description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors
   copyright:
     - license: Apache-2.0

--- a/dgraph.yaml
+++ b/dgraph.yaml
@@ -1,7 +1,7 @@
 package:
   name: dgraph
   version: 23.0.1
-  epoch: 0
+  epoch: 1
   description: A distributed graph database
   copyright:
     - license: Apache-2.0

--- a/dive.yaml
+++ b/dive.yaml
@@ -1,7 +1,7 @@
 package:
   name: dive
   version: 0.11.0
-  epoch: 0
+  epoch: 1
   description: A tool for exploring each layer in a docker image
   copyright:
     - license: MIT

--- a/docker-credential-acr-env.yaml
+++ b/docker-credential-acr-env.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-credential-acr-env
   version: 0.7.0
-  epoch: 1
+  epoch: 2
   description: ACR Docker Credential Helper
   copyright:
     - license: Apache-2.0

--- a/docker-credential-ecr-login.yaml
+++ b/docker-credential-ecr-login.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-credential-ecr-login
   version: 0.7.1
-  epoch: 2
+  epoch: 3
   description: Credential helper for Docker to use the AWS Elastic Container Registry
   copyright:
     - license: Apache-2.0

--- a/docker-credential-gcr.yaml
+++ b/docker-credential-gcr.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-credential-gcr
   version: 2.1.10
-  epoch: 0
+  epoch: 1
   description: A Docker credential helper for GCR users
   copyright:
     - license: Apache-2.0

--- a/eksctl.yaml
+++ b/eksctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: eksctl
   version: 0.148.0
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0

--- a/esbuild.yaml
+++ b/esbuild.yaml
@@ -1,7 +1,7 @@
 package:
   name: esbuild
   version: 0.18.11
-  epoch: 0
+  epoch: 1
   description: An extremely fast bundler for the web
   copyright:
     - license: MIT

--- a/etcd.yaml
+++ b/etcd.yaml
@@ -2,7 +2,7 @@ package:
   name: etcd
   version: 3.5.9
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
-  epoch: 1
+  epoch: 2
   description: A highly-available key value store for shared configuration and service discovery.
   copyright:
     - license: Apache-2.0

--- a/external-dns.yaml
+++ b/external-dns.yaml
@@ -1,7 +1,7 @@
 package:
   name: external-dns
   version: 0.13.5
-  epoch: 1
+  epoch: 2
   description: Configure external DNS servers (AWS Route53, Google CloudDNS and others) for Kubernetes Ingresses and Services.
   target-architecture:
     - all

--- a/external-secrets-operator.yaml
+++ b/external-secrets-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: external-secrets-operator
   version: 0.9.1
-  epoch: 0
+  epoch: 1
   description: Integrate external secret management systems with Kubernetes
   copyright:
     - license: Apache-2.0

--- a/ferretdb.yaml
+++ b/ferretdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: ferretdb
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: "A truly Open Source MongoDB alternative"
   copyright:
     - license: Apache-2.0

--- a/flannel-cni-plugin.yaml
+++ b/flannel-cni-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: flannel-cni-plugin
   version: 1.1.2
-  epoch: 0
+  epoch: 1
   description: flannel cni plugin
   copyright:
     - license: Apache-2.0

--- a/flannel.yaml
+++ b/flannel.yaml
@@ -1,7 +1,7 @@
 package:
   name: flannel
   version: 0.22.0
-  epoch: 0
+  epoch: 1
   description: flannel is a network fabric for containers, designed for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-helm-controller
   version: 0.35.0
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit Helm reconciler, for declarative Helming
   copyright:
     - license: Apache-2.0

--- a/flux-image-automation-controller.yaml
+++ b/flux-image-automation-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-image-automation-controller
   version: 0.35.0
-  epoch: 0
+  epoch: 1
   description: GitOps Toolkit controller that patches container image tags in Git
   copyright:
     - license: Apache-2.0

--- a/flux-image-reflector-controller.yaml
+++ b/flux-image-reflector-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-image-reflector-controller
   version: 0.29.1
-  epoch: 0
+  epoch: 1
   description: GitOps Toolkit controller that scans container registries
   copyright:
     - license: Apache-2.0

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-kustomize-controller
   version: 1.0.1
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit Kustomize reconciler
   copyright:
     - license: Apache-2.0

--- a/flux-notification-controller.yaml
+++ b/flux-notification-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-notification-controller
   version: 1.0.0
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit event forwarded and notification dispatcher
   copyright:
     - license: Apache-2.0

--- a/flux-source-controller.yaml
+++ b/flux-source-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-source-controller
   version: 1.0.1
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit source management component
   copyright:
     - license: Apache-2.0

--- a/flux.yaml
+++ b/flux.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux
   version: 2.0.1
-  epoch: 0
+  epoch: 1
   description: Open and extensible continuous delivery solution for Kubernetes. Powered by GitOps Toolkit.
   copyright:
     - license: Apache-2.0

--- a/fuse-overlayfs-snapshotter.yaml
+++ b/fuse-overlayfs-snapshotter.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs-snapshotter
   version: 1.0.6
-  epoch: 0
+  epoch: 1
   description: fuse-overlayfs plugin for rootless containerd
   copyright:
     - license: Apache-2.0

--- a/gatekeeper.yaml
+++ b/gatekeeper.yaml
@@ -1,7 +1,7 @@
 package:
   name: gatekeeper
   version: 3.12.0
-  epoch: 3
+  epoch: 4
   description: Gatekeeper - Policy Controller for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/git-lfs.yaml
+++ b/git-lfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-lfs
   version: 3.3.0
-  epoch: 10
+  epoch: 11
   description: "large file support for git"
   copyright:
     - license: MIT

--- a/go-bindata.yaml
+++ b/go-bindata.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-bindata
   version: 3.1.3
-  epoch: 8
+  epoch: 9
   description: A small utility which generates Go code from any file
   copyright:
     - license: Apache-2.0

--- a/go-md2man.yaml
+++ b/go-md2man.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-md2man
   version: 2.0.2
-  epoch: 4
+  epoch: 5
   description: Utility to convert markdown to man pages
   copyright:
     - license: MIT

--- a/gobuster.yaml
+++ b/gobuster.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobuster
   version: 3.5.0
-  epoch: 0
+  epoch: 1
   description: "a tool used to brute force attack for URIs, DNS, etc."
   copyright:
     - license: Apache-2.0

--- a/golangci-lint.yaml
+++ b/golangci-lint.yaml
@@ -1,7 +1,7 @@
 package:
   name: golangci-lint
   version: 1.53.3
-  epoch: 0
+  epoch: 1
   description: Fast linters Runner for Go
   copyright:
     - license: Apache-2.0

--- a/gomplate.yaml
+++ b/gomplate.yaml
@@ -1,7 +1,7 @@
 package:
   name: gomplate
   version: 3.11.5
-  epoch: 3
+  epoch: 4
   description: A go templating utility.
   copyright:
     - license: MIT

--- a/grpc-health-probe.yaml
+++ b/grpc-health-probe.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-health-probe
   version: 0.4.19
-  epoch: 0
+  epoch: 1
   description: A command-line tool to perform health-checks for gRPC applications in Kubernetes and elsewhere
   copyright:
     - license: Apache-2.0

--- a/grpcurl.yaml
+++ b/grpcurl.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpcurl
   version: 1.8.7
-  epoch: 5
+  epoch: 6
   description: CLI tool to interact with gRPC servers
   target-architecture:
     - all

--- a/grype.yaml
+++ b/grype.yaml
@@ -1,7 +1,7 @@
 package:
   name: grype
   version: 0.63.1
-  epoch: 0
+  epoch: 1
   description: Vulnerability scanner for container images, filesystems, and SBOMs
   copyright:
     - license: Apache-2.0

--- a/guac.yaml
+++ b/guac.yaml
@@ -1,7 +1,7 @@
 package:
   name: guac
   version: 0.1.0
-  epoch: 1
+  epoch: 2
   description: GUAC aggregates software security metadata into a high fidelity graph database.
   copyright:
     - license: Apache-2.0

--- a/haproxy-ingress.yaml
+++ b/haproxy-ingress.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-ingress
   version: 0.14.4
-  epoch: 0
+  epoch: 1
   description: HAProxy Ingress
   copyright:
     - license: Apache-2.0

--- a/helm.yaml
+++ b/helm.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm
   version: 3.12.1
-  epoch: 0
+  epoch: 1
   description: The Kubernetes Package Manager
   copyright:
     - license: Apache-2.0

--- a/hey.yaml
+++ b/hey.yaml
@@ -1,7 +1,7 @@
 package:
   name: hey
   version: 0.1.4
-  epoch: 1
+  epoch: 2
   description: HTTP load generator, ApacheBench (ab) replacement
   copyright:
     - license: Apache-2.0

--- a/http-echo.yaml
+++ b/http-echo.yaml
@@ -1,7 +1,7 @@
 package:
   name: http-echo
   version: 0.2.3
-  epoch: 1
+  epoch: 2
   description: A tiny go web server that echos what you start it with!
   copyright:
     - license: MPL-2.0

--- a/influx.yaml
+++ b/influx.yaml
@@ -1,7 +1,7 @@
 package:
   name: influx
   version: 2.7.3
-  epoch: 2
+  epoch: 3
   description: CLI for managing resources in InfluxDB v2
   copyright:
     - license: MIT

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -1,7 +1,7 @@
 package:
   name: influxd
   version: 2.7.1
-  epoch: 2
+  epoch: 3
   description: Scalable datastore for metrics, events, and real-time analytics
   copyright:
     - license: MIT

--- a/ingress-nginx-controller.yaml
+++ b/ingress-nginx-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: ingress-nginx-controller
   version: 1.8.0
-  epoch: 1
+  epoch: 2
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0

--- a/ipfs.yaml
+++ b/ipfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: ipfs
   version: 0.21.0
-  epoch: 0
+  epoch: 1
   description: An IPFS implementation in Go
   copyright:
     - license: Apache-2.0

--- a/jaeger-agent.yaml
+++ b/jaeger-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: jaeger-agent
   version: 1.47.0
-  epoch: 0
+  epoch: 1
   description: CNCF Jaeger, a Distributed Tracing Platform
   copyright:
     - license: Apache-2.0

--- a/k3d.yaml
+++ b/k3d.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3d
   version: 5.5.1
-  epoch: 1
+  epoch: 2
   description: Little helper to run CNCF's k3s in Docker
   copyright:
     - license: Apache-2.0

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.27.3
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0

--- a/k8sgpt-operator.yaml
+++ b/k8sgpt-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8sgpt-operator
   version: 0.0.19
-  epoch: 0
+  epoch: 1
   description: Automatic SRE Superpowers within your Kubernetes cluster
   copyright:
     - license: Apache-2.0

--- a/k8sgpt.yaml
+++ b/k8sgpt.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8sgpt
   version: 0.3.9
-  epoch: 0
+  epoch: 1
   description: Giving Kubernetes Superpowers to everyone
   copyright:
     - license: Apache-2.0

--- a/kaf.yaml
+++ b/kaf.yaml
@@ -1,7 +1,7 @@
 package:
   name: kaf
   version: 0.2.6
-  epoch: 0
+  epoch: 1
   description: Modern CLI for Apache Kafka, written in Go
   copyright:
     - license: Apache-2.0

--- a/kaniko.yaml
+++ b/kaniko.yaml
@@ -1,7 +1,7 @@
 package:
   name: kaniko
   version: 1.12.1
-  epoch: 1
+  epoch: 2
   description: Build Container Images In Kubernetes
   copyright:
     - license: Apache-2.0

--- a/keda.yaml
+++ b/keda.yaml
@@ -1,7 +1,7 @@
 package:
   name: keda
   version: 2.11.1
-  epoch: 1
+  epoch: 2
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0

--- a/kind.yaml
+++ b/kind.yaml
@@ -1,7 +1,7 @@
 package:
   name: kind
   version: 0.20.0
-  epoch: 0
+  epoch: 1
   description: Kubernetes IN Docker - local clusters for testing Kubernetes
   copyright:
     - license: Apache-2.0

--- a/kine.yaml
+++ b/kine.yaml
@@ -1,7 +1,7 @@
 package:
   name: kine
   version: 0.10.1
-  epoch: 1
+  epoch: 2
   description: Run Kubernetes on MySQL, Postgres, sqlite, dqlite, not etcd.
   copyright:
     - license: Apache-2.0

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.14.1 # When bumping the version check if the GHSA mitigations below can be removed.
-  epoch: 1
+  epoch: 2
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0

--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
   version: 1.100.3
-  epoch: 0
+  epoch: 1
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0

--- a/kpt.yaml
+++ b/kpt.yaml
@@ -1,7 +1,7 @@
 package:
   name: kpt
   version: 1.0.0_beta31
-  epoch: 3
+  epoch: 4
   description: Automate Kubernetes Configuration Editing
   copyright:
     - license: Apache-2.0

--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.17.5
-  epoch: 0
+  epoch: 1
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT

--- a/kube-state-metrics.yaml
+++ b/kube-state-metrics.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-state-metrics
   version: 2.9.2
-  epoch: 1
+  epoch: 2
   description: Add-on agent to generate and expose cluster-level metrics.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.24
   version: 1.24.15
-  epoch: 3
+  epoch: 4
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.25
   version: 1.25.11
-  epoch: 3
+  epoch: 4
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.26
   version: 1.26.6
-  epoch: 3
+  epoch: 4
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.27
   version: 1.27.3
-  epoch: 5
+  epoch: 6
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-external-attacher.yaml
+++ b/kubernetes-csi-external-attacher.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-attacher
   version: 4.3.0
-  epoch: 1
+  epoch: 2
   description: Sidecar container that watches Kubernetes VolumeAttachment objects and triggers ControllerPublish/Unpublish against a CSI endpoint
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-external-provisioner.yaml
+++ b/kubernetes-csi-external-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-provisioner
   version: 3.5.0
-  epoch: 2
+  epoch: 3
   description: A dynamic provisioner for Kubernetes CSI plugins.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-external-resizer.yaml
+++ b/kubernetes-csi-external-resizer.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-resizer
   version: 1.8.0
-  epoch: 1
+  epoch: 2
   description: Sidecar container that watches Kubernetes PersistentVolumeClaims objects and triggers controller side expansion operation against a CSI endpoint
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-external-snapshotter.yaml
+++ b/kubernetes-csi-external-snapshotter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-snapshotter
   version: 6.2.2
-  epoch: 1
+  epoch: 2
   description: Sidecar container that watches Kubernetes Snapshot CRD objects and triggers CreateSnapshot/DeleteSnapshot against a CSI endpoint
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-livenessprobe.yaml
+++ b/kubernetes-csi-livenessprobe.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-livenessprobe
   version: 2.10.0
-  epoch: 2
+  epoch: 3
   description: A sidecar container that can be included in a CSI plugin pod to enable integration with Kubernetes Liveness Probe.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-node-driver-registrar.yaml
+++ b/kubernetes-csi-node-driver-registrar.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-node-driver-registrar
   version: 2.8.0
-  epoch: 2
+  epoch: 3
   description: Sidecar container that registers a CSI driver with the kubelet using the kubelet plugin registration mechanism.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-dashboard-metrics-scraper.yaml
+++ b/kubernetes-dashboard-metrics-scraper.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-metrics-scraper
   version: 1.0.9
-  epoch: 2
+  epoch: 3
   description: Container to scrape, store, and retrieve a window of time from the Metrics Server.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-dashboard.yaml
+++ b/kubernetes-dashboard.yaml
@@ -2,7 +2,7 @@ package:
   name: kubernetes-dashboard
   # When bumping, check to see if the GHSA mitigations below can be removed.
   version: 2.7.0
-  epoch: 3
+  epoch: 4
   description: General-purpose web UI for Kubernetes clusters
   copyright:
     - license: Apache-2.0

--- a/kubernetes-ingress-defaultbackend.yaml
+++ b/kubernetes-ingress-defaultbackend.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-ingress-defaultbackend
   version: 1.24.0
-  epoch: 0
+  epoch: 1
   description: 'A simple web server that respond 404 common used in kubernetes ingress, serve pages 404 at root and 200 at /healthz'
   copyright:
     - license: Apache-2.0

--- a/kubescape.yaml
+++ b/kubescape.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubescape
   version: 2.3.7
-  epoch: 0
+  epoch: 1
   description: "Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubevela
   version: 1.9.4
-  epoch: 0
+  epoch: 1
   description: KubeVela is a modern application delivery platform that makes deploying and operating applications across today's hybrid, multi-cloud environments easier, faster and more reliable
   copyright:
     - license: Apache-2.0

--- a/kubewatch.yaml
+++ b/kubewatch.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubewatch
   version: 2.5.0
-  epoch: 1
+  epoch: 2
   description: Watch k8s events and trigger Handlers
   copyright:
     - license: Apache-2.0

--- a/kustomize.yaml
+++ b/kustomize.yaml
@@ -1,7 +1,7 @@
 package:
   name: kustomize
   version: 5.1.0
-  epoch: 0
+  epoch: 1
   description: Customization of kubernetes YAML configurations
   copyright:
     - license: Apache-2.0

--- a/kyverno.yaml
+++ b/kyverno.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno
   version: 1.10.1
-  epoch: 0
+  epoch: 1
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0

--- a/local-path-provisioner.yaml
+++ b/local-path-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: local-path-provisioner
   version: 0.0.24
-  epoch: 0
+  epoch: 1
   description: Dynamically provisioning persistent local storage with Kubernetes
   copyright:
     - license: Apache-2.0

--- a/loki.yaml
+++ b/loki.yaml
@@ -1,7 +1,7 @@
 package:
   name: loki
   version: 2.8.2
-  epoch: 1
+  epoch: 2
   description: Like Prometheus, but for logs.
   copyright:
     - license: AGPL-3.0

--- a/mc.yaml
+++ b/mc.yaml
@@ -3,7 +3,7 @@ package:
   # minio uses strange versioning, the upstream version is RELEASE.2023-03-23T20-03-04Z
   # when bumping this, also bump the tag in git-checkout below
   version: 0.20230628.215417
-  epoch: 0
+  epoch: 1
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0

--- a/melange.yaml
+++ b/melange.yaml
@@ -2,7 +2,7 @@ package:
   name: melange
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
   version: 0.4.0
-  epoch: 0
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0

--- a/memcached-exporter.yaml
+++ b/memcached-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached-exporter
   version: 0.13.0
-  epoch: 1
+  epoch: 2
   description: Exports metrics from memcached servers for consumption by Prometheus.
   copyright:
     - license: Apache-2.0

--- a/metacontroller.yaml
+++ b/metacontroller.yaml
@@ -1,7 +1,7 @@
 package:
   name: metacontroller
   version: 4.10.4
-  epoch: 0
+  epoch: 1
   description: Writing kubernetes controllers can be simple
   target-architecture:
     - all

--- a/metacontroller.yaml
+++ b/metacontroller.yaml
@@ -1,7 +1,7 @@
 package:
   name: metacontroller
   version: 4.10.4
-  epoch: 1
+  epoch: 0
   description: Writing kubernetes controllers can be simple
   target-architecture:
     - all

--- a/metallb.yaml
+++ b/metallb.yaml
@@ -1,7 +1,7 @@
 package:
   name: metallb
   version: 0.13.10
-  epoch: 0
+  epoch: 1
   description: "A network load-balancer implementation for Kubernetes using standard routing protocols"
   copyright:
     - license: Apache-2.0

--- a/metrics-server.yaml
+++ b/metrics-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: metrics-server
   version: 0.6.3
-  epoch: 5
+  epoch: 6
   description: Scalable and efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.
   target-architecture:
     - all

--- a/mongo-tools.yaml
+++ b/mongo-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: mongo-tools
   version: 100.7.0 # TODO: enable auto updates when mongo-tools is updated to > 100.7.1
-  epoch: 2
+  epoch: 3
   description: Tools for MongoDB
   copyright:
     - license: Apache-2.0

--- a/nats-server.yaml
+++ b/nats-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: nats-server
   version: 2.9.19
-  epoch: 0
+  epoch: 1
   description: High-Performance server for NATS.io, the cloud and edge native messaging system.
   copyright:
     - license: Apache-2.0

--- a/nats.yaml
+++ b/nats.yaml
@@ -1,7 +1,7 @@
 package:
   name: nats
   version: 0.0.35
-  epoch: 5
+  epoch: 6
   description: The NATS Command Line Interface.
   copyright:
     - license: Apache-2.0

--- a/nerdctl.yaml
+++ b/nerdctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: nerdctl
   version: 1.4.0
-  epoch: 1
+  epoch: 2
   description: Docker-compatible CLI for containerd, with support for Compose, Rootless, eStargz, OCIcrypt, IPFS, ...
   copyright:
     - license: Apache-2.0

--- a/newrelic-fluent-bit-output.yaml
+++ b/newrelic-fluent-bit-output.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-fluent-bit-output
   version: 1.17.3
-  epoch: 1
+  epoch: 2
   description: A Fluent Bit output plugin that sends logs to New Relic
   copyright:
     - license: Apache-2.0

--- a/newrelic-infra-operator.yaml
+++ b/newrelic-infra-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-infra-operator
   version: 0.10.2
-  epoch: 0
+  epoch: 1
   description: Newrelic kubernetes operator of infrastructure
   copyright:
     - license: Apache-2.0

--- a/newrelic-infrastructure-agent.yaml
+++ b/newrelic-infrastructure-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-infrastructure-agent
   version: 1.43.2
-  epoch: 1
+  epoch: 2
   description: New Relic Infrastructure Agent
   copyright:
     - license: Apache-2.0

--- a/newrelic-infrastructure-agent.yaml
+++ b/newrelic-infrastructure-agent.yaml
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: https://github.com/newrelic/infrastructure-agent
       tag: ${{package.version}}
-      expected-commit: 29f18ead67f8279c57dbfc5ad5fde94d0bc991c5
+      expected-commit: 4778a9187654402c775b677dcf4af28e3e3d7dad
 
   - runs: |
       # Our global LDFLAGS conflict with a Makefile parameter: https://github.com/newrelic/infrastructure-agent/blob/07ab68f181e25a1552588a3953167e0b15f52372/build/build.mk#L20-L22

--- a/newrelic-infrastructure-agent.yaml
+++ b/newrelic-infrastructure-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-infrastructure-agent
   version: 1.43.2
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Agent
   copyright:
     - license: Apache-2.0

--- a/newrelic-infrastructure-bundle.yaml
+++ b/newrelic-infrastructure-bundle.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-infrastructure-bundle
   version: 3.2.9
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure containerised agent bundle
   copyright:
     - license: Apache-2.0

--- a/newrelic-nri-kube-events.yaml
+++ b/newrelic-nri-kube-events.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-nri-kube-events
   version: 2.1.2
-  epoch: 0
+  epoch: 1
   description: New Relic integration that forwards Kubernetes events to New Relic
   copyright:
     - license: Apache-2.0

--- a/newrelic-prometheus-configurator.yaml
+++ b/newrelic-prometheus-configurator.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-prometheus-configurator
   version: 1.4.2
-  epoch: 0
+  epoch: 1
   description: New Relic Prometheus Configurator
   target-architecture:
     - all

--- a/newrelic-prometheus-configurator.yaml
+++ b/newrelic-prometheus-configurator.yaml
@@ -22,7 +22,7 @@ pipeline:
     with:
       repository: https://github.com/newrelic/newrelic-prometheus-configurator
       tag: v${{package.version}}
-      expected-commit: c5391aaa333d6f4003916b7bf4fef757ffa35618
+      expected-commit: 15fdd3d7dcfa8b1454ee70d962935425c9f3e5f0
 
   - runs: |
       GOOS=$(go env GOOS)

--- a/node-problem-detector.yaml
+++ b/node-problem-detector.yaml
@@ -1,7 +1,7 @@
 package:
   name: node-problem-detector
   version: 0.8.13
-  epoch: 4
+  epoch: 5
   description: node-problem-detector aims to make various node problems visible to the upstream layers in the cluster management stack.
   copyright:
     - license: Apache-2.0

--- a/nodetaint.yaml
+++ b/nodetaint.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodetaint
   version: 0.0.4
-  epoch: 0
+  epoch: 1
   description: Controller to manage taints for nodes in a k8s cluster.
   copyright:
     - license: Apache-2.0

--- a/nri-kubernetes.yaml
+++ b/nri-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-kubernetes
   version: 3.15.1
-  epoch: 0
+  epoch: 1
   description: New Relic integration for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/nri-prometheus.yaml
+++ b/nri-prometheus.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-prometheus
   version: 2.18.5
-  epoch: 0
+  epoch: 1
   description: Fetch metrics in the Prometheus metrics inside or outside Kubernetes and send them to the New Relic Metrics platform.
   copyright:
     - license: Apache-2.0

--- a/nuclei.yaml
+++ b/nuclei.yaml
@@ -1,7 +1,7 @@
 package:
   name: nuclei
   version: 2.9.8
-  epoch: 0
+  epoch: 1
   description: "yaml based vulnerability scanner"
   copyright:
     - license: MIT

--- a/nvidia-device-plugin.yaml
+++ b/nvidia-device-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: nvidia-device-plugin
   version: 0.14.0
-  epoch: 3
+  epoch: 4
   description: NVIDIA device plugin for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: oauth2-proxy
   version: 7.4.0
-  epoch: 4
+  epoch: 5
   description: Reverse proxy and static file server that provides authentication using various providers to validate accounts by email, domain or group.
   copyright:
     - license: MIT

--- a/oras.yaml
+++ b/oras.yaml
@@ -1,7 +1,7 @@
 package:
   name: oras
   version: 1.0.0
-  epoch: 2
+  epoch: 3
   description: OCI registry client - managing content like artifacts, images, packages.
   copyright:
     - license: Apache-2.0

--- a/osv-scanner.yaml
+++ b/osv-scanner.yaml
@@ -1,7 +1,7 @@
 package:
   name: osv-scanner
   version: 1.3.5
-  epoch: 0
+  epoch: 1
   description: Vulnerability scanner written in Go which uses the data provided by https://osv.dev
   copyright:
     - license: Apache-2.0

--- a/paranoia.yaml
+++ b/paranoia.yaml
@@ -1,7 +1,7 @@
 package:
   name: paranoia
   version: 0.2.1
-  epoch: 2
+  epoch: 3
   description: Inspect certificate authorities in container images
   copyright:
     - license: Apache-2.0

--- a/policy-controller.yaml
+++ b/policy-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: policy-controller
   version: 0.8.0
-  epoch: 0
+  epoch: 1
   description: "The policy admission controller used to enforce policy on a cluster on verifiable supply-chain metadata from cosign."
   copyright:
     - license: Apache-2.0

--- a/prometheus-alertmanager.yaml
+++ b/prometheus-alertmanager.yaml
@@ -2,7 +2,7 @@ package:
   name: prometheus-alertmanager
   # When bumping this version you can remove the `go get` line in the build script
   version: 0.25.0
-  epoch: 4
+  epoch: 5
   description: Prometheus Alertmanager
   copyright:
     - license: Apache-2.0

--- a/prometheus-bind-exporter.yaml
+++ b/prometheus-bind-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-bind-exporter
   version: 0.6.1
-  epoch: 2
+  epoch: 3
   description: Prometheus exporter for BIND
   copyright:
     - license: Apache-2.0

--- a/prometheus-config-reloader.yaml
+++ b/prometheus-config-reloader.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-config-reloader
   version: 0.66.0
-  epoch: 0
+  epoch: 1
   description: Prometheus Operator creates/configures/manages Prometheus clusters atop Kubernetes
   copyright:
     - license: Apache-2.0

--- a/prometheus-elasticsearch-exporter.yaml
+++ b/prometheus-elasticsearch-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-elasticsearch-exporter
   version: 1.6.0
-  epoch: 0
+  epoch: 1
   description: Elasticsearch stats exporter for Prometheus
   copyright:
     - license: Apache-2.0

--- a/prometheus-mysqld-exporter.yaml
+++ b/prometheus-mysqld-exporter.yaml
@@ -2,7 +2,7 @@ package:
   name: prometheus-mysqld-exporter
   # When bumping this version you can remove the `go get` line in the build script
   version: 0.15.0
-  epoch: 0
+  epoch: 1
   description: Prometheus Exporter for MySQL server metrics
   copyright:
     - license: Apache-2.0

--- a/prometheus-nats-exporter.yaml
+++ b/prometheus-nats-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-nats-exporter
   version: 0.12.0
-  epoch: 0
+  epoch: 1
   description: A Prometheus exporter for NATS metrics
   copyright:
     - license: Apache-2.0

--- a/prometheus-node-exporter.yaml
+++ b/prometheus-node-exporter.yaml
@@ -2,7 +2,7 @@ package:
   name: prometheus-node-exporter
   # When bumping this version you can remove the `go get` line in the build script
   version: 1.6.0
-  epoch: 1
+  epoch: 2
   description: Prometheus Exporter for machine metrics
   copyright:
     - license: Apache-2.0

--- a/prometheus-operator.yaml
+++ b/prometheus-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-operator
   version: 0.66.0
-  epoch: 0
+  epoch: 1
   description: Prometheus Operator creates/configures/manages Prometheus clusters atop Kubernetes
   copyright:
     - license: Apache-2.0

--- a/prometheus-postgres-exporter.yaml
+++ b/prometheus-postgres-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-postgres-exporter
   version: 0.13.1
-  epoch: 0
+  epoch: 1
   description: Prometheus Exporter for Postgres server metrics
   copyright:
     - license: Apache-2.0

--- a/prometheus-redis-exporter.yaml
+++ b/prometheus-redis-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-redis-exporter
   version: 1.51.0
-  epoch: 0
+  epoch: 1
   description: Prometheus Exporter for Redis Metrics.
   copyright:
     - license: MIT

--- a/prometheus-stackdriver-exporter.yaml
+++ b/prometheus-stackdriver-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-stackdriver-exporter
   version: 0.14.1
-  epoch: 1
+  epoch: 2
   description: Google Stackdriver Prometheus exporter
   copyright:
     - license: Apache-2.0

--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus
   version: 2.45.0
-  epoch: 0
+  epoch: 1
   description: The Prometheus monitoring system and time series database.
   copyright:
     - license: Apache-2.0

--- a/pulumi-kubernetes-operator.yaml
+++ b/pulumi-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-kubernetes-operator
   version: 1.12.1
-  epoch: 2
+  epoch: 3
   description: A Kubernetes Operator that automates the deployment of Pulumi Stacks
   copyright:
     - license: Apache-2.0

--- a/pulumi-language-dotnet.yaml
+++ b/pulumi-language-dotnet.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-dotnet
   version: 3.55.1
-  epoch: 3
+  epoch: 4
   description: Pulumi Language SDK for Dotnet
   copyright:
     - license: Apache-2.0

--- a/pulumi-language-java.yaml
+++ b/pulumi-language-java.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-java
   version: 0.9.4
-  epoch: 1
+  epoch: 2
   description: Pulumi Language SDK for Java
   copyright:
     - license: Apache-2.0

--- a/pulumi-language-yaml.yaml
+++ b/pulumi-language-yaml.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-yaml
   version: 1.1.1
-  epoch: 3
+  epoch: 4
   description: Pulumi Language SDK for YAML
   copyright:
     - license: Apache-2.0

--- a/pulumi.yaml
+++ b/pulumi.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi
   version: 3.74.0
-  epoch: 1
+  epoch: 2
   description: Infrastructure as Code in any programming language
   copyright:
     - license: Apache-2.0

--- a/regclient.yaml
+++ b/regclient.yaml
@@ -1,7 +1,7 @@
 package:
   name: regclient
   version: 0.5.0
-  epoch: 0
+  epoch: 1
   description: Docker and OCI Registry Client in Go and tooling using those libraries
   copyright:
     - license: Apache-2.0

--- a/rekor-cli.yaml
+++ b/rekor-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: rekor-cli
   version: 1.2.2
-  epoch: 0
+  epoch: 1
   description: Rekor command line interface tool
   target-architecture:
     - all

--- a/rekor-server.yaml
+++ b/rekor-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: rekor-server
   version: 1.2.2
-  epoch: 0
+  epoch: 1
   description: Rekor signature transparency log server
   target-architecture:
     - all

--- a/restic.yaml
+++ b/restic.yaml
@@ -2,7 +2,7 @@ package:
   name: restic
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
   version: 0.15.2
-  epoch: 3
+  epoch: 4
   description: restic is a backup program which allows saving multiple revisions of files and directories in an encrypted repository stored on different backends
   copyright:
     - license: BSD-2-Clause

--- a/rqlite.yaml
+++ b/rqlite.yaml
@@ -2,7 +2,7 @@ package:
   name: rqlite
   # When bumping the version, you can remove the `go get` line in the build.
   version: 7.21.4
-  epoch: 0
+  epoch: 1
   description: The lightweight, distributed relational database built on SQLite
   copyright:
     - license: MIT

--- a/runc.yaml
+++ b/runc.yaml
@@ -1,7 +1,7 @@
 package:
   name: runc
   version: 1.1.7
-  epoch: 2
+  epoch: 3
   description: CLI tool for spawning and running containers according to the OCI specification
   copyright:
     - license: Apache-2.0

--- a/scorecard.yaml
+++ b/scorecard.yaml
@@ -1,7 +1,7 @@
 package:
   name: scorecard
   version: 4.11.0
-  epoch: 0
+  epoch: 1
   description: OpenSSF Scorecard - Security health metrics for Open Source
   copyright:
     - license: Apache-2.0

--- a/secrets-store-csi-driver-provider-aws.yaml
+++ b/secrets-store-csi-driver-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: secrets-store-csi-driver-provider-aws
   version: 0.3.3
-  epoch: 0
+  epoch: 1
   description: AWS Secrets Manager and AWS Systems Manager Parameter Store provider for the Secret Store CSI Driver.
   copyright:
     - license: Apache-2.0

--- a/secrets-store-csi-driver-provider-azure.yaml
+++ b/secrets-store-csi-driver-provider-azure.yaml
@@ -1,7 +1,7 @@
 package:
   name: secrets-store-csi-driver-provider-azure
   version: 1.4.1
-  epoch: 3
+  epoch: 4
   description: Azure Key Vault provider for Secret Store CSI driver
   copyright:
     - license: MIT

--- a/secrets-store-csi-driver-provider-gcp.yaml
+++ b/secrets-store-csi-driver-provider-gcp.yaml
@@ -2,7 +2,7 @@ package:
   name: secrets-store-csi-driver-provider-gcp
   # When bumping the version check if the GHSA mitigations below can be removed.
   version: 1.2.0
-  epoch: 4
+  epoch: 5
   description: Google Secret Manager provider for the Secret Store CSI Driver.
   copyright:
     - license: Apache-2.0

--- a/secrets-store-csi-driver.yaml
+++ b/secrets-store-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: secrets-store-csi-driver
   version: 1.3.4
-  epoch: 0
+  epoch: 1
   description: Secrets Store CSI driver for Kubernetes secrets
   copyright:
     - license: Apache-2.0

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,7 +1,7 @@
 package:
   name: skaffold
   version: 2.6.1
-  epoch: 0
+  epoch: 1
   description: Easy and Repeatable Kubernetes Development
   copyright:
     - license: Apache-2.0

--- a/skopeo.yaml
+++ b/skopeo.yaml
@@ -1,7 +1,7 @@
 package:
   name: skopeo
   version: 1.13.0
-  epoch: 0
+  epoch: 1
   description: Work with remote images registries - retrieving information, images, signing content
   copyright:
     - license: Apache-2.0

--- a/sonobuoy.yaml
+++ b/sonobuoy.yaml
@@ -1,7 +1,7 @@
 package:
   name: sonobuoy
   version: 0.56.17
-  epoch: 0
+  epoch: 1
   description: Sonobuoy is a diagnostic tool that makes it easier to understand the state of a Kubernetes cluster by running a set of Kubernetes conformance tests and other plugins in an accessible and non-destructive manner.
   copyright:
     - license: Apache-2.0

--- a/spark-operator.yaml
+++ b/spark-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-operator
   version: 1.1.27
-  epoch: 5
+  epoch: 6
   description: Kubernetes operator for managing the lifecycle of Apache Spark applications on Kubernetes.
   target-architecture:
     - all

--- a/spicedb.yaml
+++ b/spicedb.yaml
@@ -1,7 +1,7 @@
 package:
   name: spicedb
   version: 1.22.2
-  epoch: 0
+  epoch: 1
   description: Open Source, Google Zanzibar-inspired fine-grained permissions database
   copyright:
     - license: Apache-2.0

--- a/spire-server.yaml
+++ b/spire-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: spire-server
   version: 1.7.0
-  epoch: 0
+  epoch: 1
   description: The SPIFFE Runtime Environment (SPIRE) server
   copyright:
     - license: Apache-2.0

--- a/src.yaml
+++ b/src.yaml
@@ -1,7 +1,7 @@
 package:
   name: src
   version: 5.1.0
-  epoch: 0
+  epoch: 1
   description: Sourcegraph CLI
   copyright:
     - license: Apache-2.0

--- a/stakater-reloader.yaml
+++ b/stakater-reloader.yaml
@@ -1,7 +1,7 @@
 package:
   name: stakater-reloader
   version: 1.0.29
-  epoch: 0
+  epoch: 1
   description: A Kubernetes controller to watch changes in ConfigMap and Secrets and do rolling upgrades on Pods
   copyright:
     - license: Apache-2.0

--- a/step-ca.yaml
+++ b/step-ca.yaml
@@ -1,7 +1,7 @@
 package:
   name: step-ca
   version: 0.24.2
-  epoch: 2
+  epoch: 3
   description: A private certificate authority (X.509 & SSH) & ACME server for secure automated certificate management, so you can use TLS everywhere & SSO for SSH.
   copyright:
     - license: Apache-2.0

--- a/tailscale.yaml
+++ b/tailscale.yaml
@@ -1,7 +1,7 @@
 package:
   name: tailscale
   version: 1.44.0
-  epoch: 0
+  epoch: 1
   description: The easiest, most secure way to use WireGuard and 2FA.
   copyright:
     - license: BSD-3-Clause

--- a/telegraf.yaml
+++ b/telegraf.yaml
@@ -1,7 +1,7 @@
 package:
   name: telegraf
   version: 1.27.2
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: MIT

--- a/terraform.yaml
+++ b/terraform.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform
   version: 1.5.2
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MPL-2.0
 

--- a/terragrunt.yaml
+++ b/terragrunt.yaml
@@ -1,7 +1,7 @@
 package:
   name: terragrunt
   version: 0.48.1
-  epoch: 0
+  epoch: 1
   description: Thin wrapper for Terraform providing extra tools
   copyright:
     - license: MIT

--- a/thanos-operator.yaml
+++ b/thanos-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-operator
   version: 0.3.7
-  epoch: 1
+  epoch: 2
   description: Kubernetes operator for deploying Thanos
   copyright:
     - license: Apache-2.0

--- a/tigera-operator.yaml
+++ b/tigera-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: tigera-operator
   version: 1.30.4
-  epoch: 0
+  epoch: 1
   description: Kubernetes operator for installing Calico and Calico Enterprise
   copyright:
     - license: Apache-2.0

--- a/tkn.yaml
+++ b/tkn.yaml
@@ -1,7 +1,7 @@
 package:
   name: tkn
   version: 0.31.1
-  epoch: 0
+  epoch: 1
   description: A CLI for interacting with Tekton!
   copyright:
     - license: Apache-2.0

--- a/traefik.yaml
+++ b/traefik.yaml
@@ -1,7 +1,7 @@
 package:
   name: traefik
   version: 2.10.1
-  epoch: 5
+  epoch: 6
   description: The Cloud Native Application Proxy
   copyright:
     - license: MIT

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,7 +1,7 @@
 package:
   name: trivy
   version: 0.43.1
-  epoch: 0
+  epoch: 1
   description: Simple and comprehensive vulnerability scanner for containers
   copyright:
     - license: Apache-2.0

--- a/trust-manager.yaml
+++ b/trust-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: trust-manager
   version: 0.5.0
-  epoch: 2
+  epoch: 3
   description: trust-manager is an operator for distributing trust bundles across a Kubernetes cluster.
   copyright:
     - license: Apache-2.0

--- a/vault-csi-provider.yaml
+++ b/vault-csi-provider.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-csi-provider
   version: 1.4.0
-  epoch: 2
+  epoch: 3
   description: CSI (Container Storage Interface) plugin for HashiCorp Vault
   copyright:
     - license: MPL-2.0

--- a/vault-k8s.yaml
+++ b/vault-k8s.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-k8s
   version: 1.2.1
-  epoch: 2
+  epoch: 3
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0

--- a/vault.yaml
+++ b/vault.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault
   version: 1.14.0
-  epoch: 0
+  epoch: 1
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0

--- a/vertical-pod-autoscaler.yaml
+++ b/vertical-pod-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: vertical-pod-autoscaler
   version: 0.14.0
-  epoch: 0
+  epoch: 1
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/vt-cli.yaml
+++ b/vt-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: vt-cli
   version: 0.13.0
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: Apache-2.0

--- a/wazero.yaml
+++ b/wazero.yaml
@@ -1,7 +1,7 @@
 package:
   name: wazero
   version: 1.3.0
-  epoch: 0
+  epoch: 1
   description: The zero dependency WebAssembly runtime for Go developers
   copyright:
     - license: Apache-2.0

--- a/weaviate.yaml
+++ b/weaviate.yaml
@@ -1,7 +1,7 @@
 package:
   name: weaviate
   version: 1.20.0
-  epoch: 0
+  epoch: 1
   description: Weaviate is an open source vector database that stores both objects and vectors, allowing for combining vector search with structured filtering with the fault-tolerance and scalability of a cloud-native database, all accessible through GraphQL, REST, and various language clients.
   copyright:
     - license: BSD-3-Clause

--- a/wire-go.yaml
+++ b/wire-go.yaml
@@ -1,7 +1,7 @@
 package:
   name: wire-go
   version: 0.5.0
-  epoch: 0
+  epoch: 1
   description: Compile-time Dependency Injection for Go
   copyright:
     - license: Apache-2.0

--- a/wireguard-go.yaml
+++ b/wireguard-go.yaml
@@ -1,7 +1,7 @@
 package:
   name: wireguard-go
   version: 0.0.20230223
-  epoch: 0
+  epoch: 1
   description: "Go Implementation of WireGuard"
   copyright:
     - license: GPL-2.0-only

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -1,7 +1,7 @@
 package:
   name: zarf
   version: 0.28.1
-  epoch: 0
+  epoch: 1
   description: DevSecOps for Air Gap & Limited-Connection Systems.
   copyright:
     - license: Apache-2.0

--- a/zot.yaml
+++ b/zot.yaml
@@ -1,7 +1,7 @@
 package:
   name: zot
   version: 1.4.3 # Check if the Go module patching can be removed in the next release.
-  epoch: 6
+  epoch: 7
   description: A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification)
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Go had a patch release for a security fix in net/http (https://github.com/wolfi-dev/os/pull/3531) so we should rebuild anything built with Go using that version of stdlib to ensure the fix is available in all the packages.

Previously, https://github.com/wolfi-dev/os/pull/1797

This was done with:

```
git grep -l -- "- go$" *.yaml | xargs wolfictl bump
```

...then reverting changes to `go-[fips]-1.[19,20].yaml` manually.