### PR TITLE
fix CVEs in argocd

### DIFF
--- a/argo-cd.yaml
+++ b/argo-cd.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd
   version: 2.7.7
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -41,7 +41,8 @@ pipeline:
       # CVE-2023-2253
       go get github.com/docker/distribution@v2.8.2-beta.1
 
-      go get k8s.io/kubernetes@v1.24.14
+      # CVE-2023-2728, CVE-2023-2727
+      go get k8s.io/kubernetes@v1.24.15
 
       go mod tidy
 


### PR DESCRIPTION
```
$ grype registry:cgr.dev/chainguard/argocd
NAME               INSTALLED  FIXED-IN  TYPE       VULNERABILITY        SEVERITY
k8s.io/kubernetes  v1.24.14   1.24.15   go-module  GHSA-cgcv-5272-97pr  Medium
k8s.io/kubernetes  v1.24.14   1.24.15   go-module  GHSA-qc2g-gmh6-95p4  Medium
```


advisories PR: https://github.com/wolfi-dev/advisories/pull/78