### PR TITLE
go-1.21: Add missing go.env file

### DIFF
--- a/go-1.21.yaml
+++ b/go-1.21.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.21
   version: 1.21_rc2
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -55,6 +55,7 @@ pipeline:
       cp -a pkg lib "${{targets.destdir}}"/usr/lib/go/
       cp -r doc misc "${{targets.destdir}}"/usr/share/doc/go
       cp -a src "${{targets.destdir}}"/usr/lib/go/
+      cp -p go.env "${{targets.destdir}}"/usr/lib/go/go.env
 
       rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/obj
       rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/bootstrap


### PR DESCRIPTION
See https://github.com/golang/go/issues/57179 for context.

Related: https://github.com/chainguard-images/images/issues/982
