### PR TITLE
add glibc as a runtime dep to calico packages

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -143,6 +143,7 @@ subpackages:
         - libnetfilter_cthelper
         - libnetfilter_cttimeout
         - libnetfilter_queue
+        - glibc
     pipeline:
       - assertions:
           required-steps: 1
@@ -225,6 +226,7 @@ subpackages:
         - libelf
         - zlib
         - libbpf
+        - glibc
     pipeline:
       - working-directory: felix
       - runs: |
@@ -291,6 +293,9 @@ subpackages:
             ./felix/fv/test-workload
 
   - name: "calico-cni"
+    dependencies:
+      runtime:
+        - glibc
     pipeline:
       # NOTE: cni is a multicall binary: https://github.com/projectcalico/calico/blob/master/cni-plugin/cmd/calico/calico.go
       - uses: go/build
@@ -323,6 +328,9 @@ subpackages:
           ln -sf /usr/bin/calico-cni "${{targets.subpkgdir}}"/opt/cni/bin/install
 
   - name: "calico-apiserver"
+    dependencies:
+      runtime:
+        - glibc
     pipeline:
       - uses: go/build
         with:
@@ -340,6 +348,9 @@ subpackages:
           ldflags: "-s -w -X github.com/projectcalico/calico/cmd/apiserver/server.VERSION=${{package.version}}) -X github.com/projectcalico/calico/cmd/apiserver/server.BUILD_DATE=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_DESCRIPTION=$(git describe --tags) -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_REVISION=$(git rev-parse --short HEAD)"
 
   - name: "calico-app-policy"
+    dependencies:
+      runtime:
+        - glibc
     pipeline:
       - uses: go/build
         with:
@@ -377,6 +388,9 @@ subpackages:
 
   - name: "calico-pod2daemon"
     description: "The calico pod2daemon components"
+    dependencies:
+      runtime:
+        - glibc
     pipeline:
       - uses: go/build
         with:


### PR DESCRIPTION
it's really hard to tell which packages depend on `glibc` just based on the upstream dockerfiles ([example](https://github.com/projectcalico/calico/blob/master/cni-plugin/Dockerfile.amd64#L35))

this covers our basis by adding it as a runtime dep to all packages, and saves us from significant work in the future if we ever decide to ship a `calico-fips` variant