### PR TITLE
calico: bump epoch to pick up new runtime deps

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.26.1
-  epoch: 6
+  epoch: 7
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64


### PR DESCRIPTION
see #3581 