### PR TITLE
Cni static

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.26.1
-  epoch: 7
+  epoch: 8
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64
@@ -295,37 +295,48 @@ subpackages:
   - name: "calico-cni"
     dependencies:
       runtime:
-        - glibc
+        - flannel-cni-plugin
+        - cni-plugins-loopback
+        - cni-plugins-host-local
+        - cni-plugins-portmap
+        - cni-plugins-tuning
+        - cni-plugins-bandwidth
     pipeline:
       # NOTE: cni is a multicall binary: https://github.com/projectcalico/calico/blob/master/cni-plugin/cmd/calico/calico.go
-      - uses: go/build
-        with:
-          modroot: .
-          packages: ./cni-plugin/cmd/calico
-          output: calico-cni # this is a dead target, but "calico" isn't a useful leg in this subpackage, so append -cni to prevent naming conflicts
-          subpackage: "true"
-          ldflags: "-s -w -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
       - runs: |
-          ln -sf /usr/bin/calico-cni "${{targets.subpkgdir}}"/usr/bin/calico-ipam
-          ln -sf /usr/bin/calico-cni "${{targets.subpkgdir}}"/usr/bin/install
-      # TODO: Build these from source
-      - working-directory: cni-plugin
-        runs: |
-          make fetch-cni-bins
-
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          cp bin/**/* "${{targets.subpkgdir}}"/usr/bin/
+          # On boot (of calico-node) the CNI is installed/copied onto the host
+          # node and run when pod network sandboxes are created. Since it runs on
+          # the host, we explicitly statically compile this to ensure it doesn't
+          # conflict with the hosts GLIBC, which is often a much more outdated
+          # version than what we build with.
+          LDFLAGS="-s -w -extldflags '-static'"
+          LDFLAGS="$LDFLAGS -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>')"
+          CGO_ENABLED=0 \
+            go build -v -buildvcs=false \
+            -ldflags "$LDFLAGS" \
+            -o cni-plugin/out/calico \
+            ./cni-plugin/cmd/calico
+      - runs: |
+          install -Dm755 cni-plugin/out/calico "${{targets.subpkgdir}}"/usr/bin/calico
+          ln -sf /usr/bin/calico "${{targets.subpkgdir}}"/usr/bin/calico-ipam
+          ln -sf /usr/bin/calico "${{targets.subpkgdir}}"/usr/bin/install
 
   - name: "calico-cni-compat"
     dependencies:
       runtime:
         - calico-cni
+        - flannel-cni-plugin-compat
+        - cni-plugins-loopback-compat
+        - cni-plugins-host-local-compat
+        - cni-plugins-portmap-compat
+        - cni-plugins-tuning-compat
+        - cni-plugins-bandwidth-compat
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/opt/cni/bin/
-          ln -sf /usr/bin/calico-cni "${{targets.subpkgdir}}"/opt/cni/bin/calico-ipam
-          ln -sf /usr/bin/calico-cni "${{targets.subpkgdir}}"/opt/cni/bin/calico
-          ln -sf /usr/bin/calico-cni "${{targets.subpkgdir}}"/opt/cni/bin/install
+          mkdir -p "${{targets.subpkgdir}}"/opt/cni/bin
+          ln -s /usr/bin/calico "${{targets.subpkgdir}}"/opt/cni/bin/calico
+          ln -s /usr/bin/calico "${{targets.subpkgdir}}"/opt/cni/bin/calico-ipam
+          ln -s /usr/bin/calico "${{targets.subpkgdir}}"/opt/cni/bin/install
 
   - name: "calico-apiserver"
     dependencies:

--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -22,7 +22,11 @@ pipeline:
       expected-commit: 38f18d26ecfef550b8bac02656cc11103fd7cff1
 
   - runs: |
-      ./build_linux.sh
+      # Ensure we build statically since CNI plugins often get moved onto the
+      # host machine where we can't guarantee GLIBC verion compatibility
+      LDFLAGS="-s -w -extldflags '-static'"
+      LDFLAGS="$LDFLAGS -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=$(git describe --tags --dirty)"
+      CGO_ENABLED=0 ./build_linux.sh -ldflags "$LDFLAGS"
 
       mkdir -p "${{targets.destdir}}"/usr/bin
       cp -a bin/* "${{targets.destdir}}"/usr/bin/
@@ -92,6 +96,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           cp bin/${{range.key}} "${{targets.subpkgdir}}"/usr/bin
+  - range: plugins
+    name: cni-plugins-${{range.key}}-compat
+    dependencies:
+      runtime:
+        - ${{range.key}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/opt/cni/bin
+          ln -s /usr/bin/${{range.key}} "${{targets.subpkgdir}}"/opt/cni/bin/${{range.key}}
 
 update:
   enabled: true

--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -1,7 +1,7 @@
 package:
   name: cni-plugins
   version: 1.3.0
-  epoch: 3
+  epoch: 4
   description: Some reference and example networking plugins, maintained by the CNI team.
   copyright:
     - license: Apache-2.0

--- a/flannel-cni-plugin.yaml
+++ b/flannel-cni-plugin.yaml
@@ -5,9 +5,6 @@ package:
   description: flannel cni plugin
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - flannel
 
 environment:
   contents:
@@ -25,12 +22,27 @@ pipeline:
       expected-commit: 18a3027e7d03feeb6ecdfdbc3bf254a8c8b38b04
 
   - runs: |
-      make ARCH=$(go env GOARCH) build_linux
+      # Ensure we build statically since CNI plugins often get moved onto the
+      # host machine where we can't guarantee GLIBC verion compatibility
+      # `-extldflags "-static"` is included by default
+      CGO_ENABLED=0 \
+      EXTRA_LDFLAGS="-s -w" \
+      scripts/build_flannel.sh
 
       # "$BUILD_DIR" is hardcoded to ~/go/...
       install -Dm755 $GOPATH/src/github.com/flannel-io/cni-plugin/dist/flannel-$(go env GOARCH) "${{targets.destdir}}"/usr/bin/flannel
 
   - uses: strip
+
+subpackages:
+  - name: flannel-cni-plugin-compat
+    dependencies:
+      runtime:
+        - flannel-cni-plugin
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/opt/cni/bin
+          ln -s /usr/bin/flannel "${{targets.subpkgdir}}"/opt/cni/bin/flannel
 
 update:
   enabled: true

--- a/flannel-cni-plugin.yaml
+++ b/flannel-cni-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: flannel-cni-plugin
   version: 1.1.2
-  epoch: 1
+  epoch: 2
   description: flannel cni plugin
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
`calico-cni` on boot installs the cni plugins onto the host via a host mount, since we can't dictate the host's GLIBC, this PR ensures we always build the cni plugin statically.

this also updates calico to use the wolfi built cni-plugins, which is also updated to be built statically.

comments are left in the package config for the next poor soul who goes down this 🐰 🕳️ 