### PR TITLE
Add pciutils and autoconf archive packages.

### DIFF
--- a/autoconf-archive.yaml
+++ b/autoconf-archive.yaml
@@ -1,0 +1,41 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/autoconf-archive/APKBUILD
+package:
+  name: autoconf-archive
+  version: 2023.02.20
+  epoch: 0
+  description: Collection of re-usable GNU Autoconf macros
+  copyright:
+    - license: GPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 71d4048479ae28f1f5794619c3d72df9c01df49b1c628ef85fde37596dc31a33
+      uri: https://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-${{package.version}}.tar.xz
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: autoconf-archive-doc
+    pipeline:
+      - uses: split/manpages
+    description: autoconf-archive manpages
+
+update:
+  release-monitor:
+    identifier: 142

--- a/pciutils.yaml
+++ b/pciutils.yaml
@@ -1,0 +1,80 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/pciutils/APKBUILD
+package:
+  name: pciutils
+  version: 3.10.0
+  epoch: 0
+  description: PCI bus configuration space access library and tools
+  copyright:
+    - license: GPL-2.0-only
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - linux-headers
+      - hwdata-pci
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: e579d87f1afe2196db7db648857023f80adb500e8194c4488c8b47f9a238c1c6
+      uri: https://github.com/pciutils/pciutils/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - runs: |
+      make OPT="$CFLAGS" ZLIB=no \
+        SHARED=yes \
+        PREFIX=/usr \
+        SHAREDIR=/usr/share/hwdata \
+        MANDIR=/usr/share/man \
+        all
+
+  - runs: |
+      make PREFIX="${{targets.destdir}}"/usr \
+        SHARED=yes \
+        SHAREDIR="${{targets.destdir}}"/usr/share/hwdata \
+        MANDIR="${{targets.destdir}}"/usr/share/man \
+        install
+
+      install -d "${{targets.destdir}}"/usr/lib
+
+      ln -s libpci.so.3 "${{targets.destdir}}"/usr/lib/libpci.so
+      install -D -m 644 lib/libpci.pc "${{targets.destdir}}"/usr/lib/pkgconfig/libpci.pc
+      for i in config.h header.h pci.h types.h; do
+        install -D -m 644 lib/$i "${{targets.destdir}}"/usr/include/pci/$i
+      done
+
+      # this is now supplied by the hwids package
+      rm -rf "${{targets.destdir}}"/usr/sbin/update-pciids
+      rm -rf "${{targets.destdir}}"/usr/share/man/man8/update-pciids.8
+      rm -rf "${{targets.destdir}}"/usr/share/hwdata
+
+  - uses: strip
+
+subpackages:
+  - name: pciutils-doc
+    pipeline:
+      - uses: split/manpages
+    description: pciutils manpages
+
+  - name: pciutils-libs
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/libpci.so* ${{targets.subpkgdir}}/usr/lib/
+          chmod 0755 ${{targets.subpkgdir}}/usr/lib/libpci.so*
+
+  - name: pciutils-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - hwdata-pci
+    description: pciutils dev
+
+update:
+  release-monitor:
+    identifier: 2605


### PR DESCRIPTION
These are required for powertop and fatrace

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
