### PR TITLE
add wolfi-local pipelines, starting with go-fips 

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           printf "packages=" >> $GITHUB_OUTPUT
 
-          wolfictl text -t name > packages-list
+          wolfictl text -t name --pipeline-dir=./pipelines/ > packages-list
           while read pkg; do
             for file in ${{ steps.changes.outputs.all_changed_files }}; do
               [ "${file%.yaml}" = "$pkg" ] && printf "%s " ${file%.yaml} >> $GITHUB_OUTPUT

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ MELANGE_OPTS += --arch ${ARCH}
 MELANGE_OPTS += --env-file build-${ARCH}.env
 MELANGE_OPTS += --namespace wolfi
 MELANGE_OPTS += --generate-index false
+MELANGE_OPTS += --pipeline-dir ./pipelines/
 MELANGE_OPTS += ${MELANGE_EXTRA_OPTS}
 
 ifeq (${USE_CACHE}, yes)
@@ -36,7 +37,7 @@ endif
 # wolfictl determines the list and order
 # set only to be called when needed, so make can be instant to run
 # when it is not
-PKGLISTCMD ?= $(WOLFICTL) text --dir . --type name
+PKGLISTCMD ?= $(WOLFICTL) text --dir . --type name --pipeline-dir=./pipelines/
 
 all: ${KEY} .build-packages
 ifeq ($(MAKECMDGOALS),all)

--- a/ko-fips.yaml
+++ b/ko-fips.yaml
@@ -11,7 +11,6 @@ environment:
     packages:
       - ca-certificates-bundle
       - busybox
-      - go-fips
   environment:
     CGO_ENABLED: "0"
 
@@ -23,11 +22,12 @@ pipeline:
       expected-commit: 200db7243f02b5c0303e21d8ab8e3b4ad3a229d0
       destination: ko
 
-  - runs: |
-      cd ko
-      go build -o "${{targets.destdir}}"/usr/bin/ko \
-          -ldflags "-s -w -X github.com/google/ko/pkg/commands.Version=${{package.version}}" \
-          -trimpath
+  - uses: go-fips/build
+    with:
+      packages: .
+      output: ko
+      modroot: ko
+      ldflags: -s -w -X github.com/google/ko/pkg/commands.Version=${{package.version}}
 
 update:
   enabled: true

--- a/pipelines/go-fips/build.yaml
+++ b/pipelines/go-fips/build.yaml
@@ -1,0 +1,93 @@
+name: Run a build using the go compiler
+
+needs:
+  packages:
+    - go-fips
+    - busybox
+    - ca-certificates-bundle
+
+inputs:
+  packages:
+    description: |
+      List of space-separated packages to compile. Files con also be specified.
+      This value is passed as an argument to go build. All paths are relative
+      to inputs.modroot.
+    required: true
+
+  tags:
+    description: |
+      A comma-separated list of build tags to pass to the go compiler
+  
+  output:
+    description: |
+      Filename to use when writing the binary. The final install location inside 
+      the apk will be in prefix / install-dir / output
+    required: true
+
+  vendor:
+    description: |
+      If true, the go mod command will also update the vendor directory
+    default: "false"
+
+  subpackage:
+    description: |
+      Indicates that the build will write to a subpackage target folder
+    default: "false"
+
+  modroot:
+    default: "."
+    required: false
+    description: |
+      Top directory of the go module, this is where go.mod lives. Before buiding
+      the go pipeline wil cd into this directory.
+
+  prefix:
+    description: |
+      Prefix to relocate binaries
+    default: usr
+
+  ldflags:
+    description:
+      List of [pattern=]arg to pass to the go compiler with -ldflags
+
+  install-dir:
+    description: |
+      Directory where binaries will be installed
+    default: bin
+
+  deps:
+    description: |
+      space separated list of go modules to update before building. example: github.com/foo/bar@v1.2.3
+
+pipeline:
+  - runs: |
+      TAGS=""
+      LDFLAGS=""
+
+      if [ ! "${{inputs.tags}}" == "" ]; then
+        TAGS="${{inputs.tags}}"
+      fi
+
+      if [ ! "${{inputs.ldflags}}" == "" ]; then
+        LDFLAGS="${{inputs.ldflags}}"
+      fi
+
+      BASE_PATH="${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"
+      if [ "${{inputs.subpackage}}" == "true" ]; then
+        DEST_PATH="-o ${{targets.subpkgdir}}/${BASE_PATH}"
+      else
+        DEST_PATH="-o ${{targets.destdir}}/${BASE_PATH}"
+      fi
+
+      cd "${{inputs.modroot}}"
+
+      # Install any specified dependencies
+      if [ ! "${{inputs.deps}}" == "" ]; then
+        for dep in ${{inputs.deps}}; do
+          go get $dep
+        done
+        go mod tidy
+        # If vendor is specified, update the vendor directory
+        "${{inputs.vendor}}" && go mod vendor
+      fi
+      go build ${DEST_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" -trimpath ${{inputs.packages}}

--- a/pipelines/go-fips/install.yaml
+++ b/pipelines/go-fips/install.yaml
@@ -1,0 +1,69 @@
+name: Run a build using the go compiler
+
+needs:
+  packages:
+    - go-fips
+    - busybox
+    - ca-certificates-bundle
+    - git
+
+inputs:
+  package:
+    description: |
+      Import path to the package 
+    required: true
+
+  version: 
+    description: |
+      Package version to install. This can be a version tag (v1.0.0), a 
+      commit hash or another ref (eg latest or HEAD).
+
+  prefix:
+    description: |
+      Prefix to relocate binaries
+    default: usr
+
+  install-dir:
+    description: |
+      Directory where binaries will be installed
+    default: bin
+
+  ldflags:
+    description:
+      List of [pattern=]arg to pass to the go compiler with -ldflags
+
+  tags:
+    description: |
+      A comma-separated list of build tags to pass to the go compiler
+
+pipeline:
+  - runs: |
+      TAGS=""
+      LDFLAGS=""
+      VERSION=""
+
+      # Installed binaries will be stored in a tmp dir
+      export GOBIN=$(mktemp -d)
+
+      if [ ! "${{inputs.tags}}" == "" ]; then
+        TAGS="${{inputs.tags}}"
+      fi
+
+      if [ ! "${{inputs.ldflags}}" == "" ]; then
+        LDFLAGS="${{inputs.ldflags}}"
+      fi
+
+      if [ ! "${{inputs.version}}" == "" ]; then
+        VERSION="@${{inputs.version}}"
+      fi
+
+      # Run go install
+      go install ${DEST_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" ${{inputs.package}}${VERSION}
+      mkdir -p ${{targets.destdir}}/${{inputs.prefix}}/${{inputs.install-dir}}
+
+      # Move all resulting files to the target dir
+      echo "go/install: Installing built binaries"
+      for f in $(ls ${GOBIN})
+      do
+        mv -v ${GOBIN}/${f} ${{targets.destdir}}/${{inputs.prefix}}/${{inputs.install-dir}}/${f}
+      done


### PR DESCRIPTION
This adds a `./pipelines/` directory with custom pipelines defined by Wolfi (outside of Melange's built-in pipelines).

The first such pipelines are `go-fips/build` and `go-fips/install`, which are copies of `go/{build,install}`, just using `go-fips` instead of `go`.

To do this, we need https://github.com/wolfi-dev/wolfictl/pull/295, which lets `wolfictl text` etc learn to look for extra pipelines when determining dependencies.