### PR TITLE
new packages: tekton pipelines and chains

### DIFF
--- a/tekton-chains.yaml
+++ b/tekton-chains.yaml
@@ -1,0 +1,41 @@
+package:
+  name: tekton-chains
+  version: 0.16.0
+  epoch: 0
+  description: Supply Chain Security in Tekton Pipelines
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tektoncd/chains
+      tag: v${{package.version}}
+      expected-commit: 5ca4264d34969ba37cb5ad0799da2ffd077f3735
+      destination: chains
+
+  - uses: go/build
+    with:
+      packages: ./cmd/controller
+      output: tekton-chains
+      modroot: chains
+      vendor: true
+      deps: '
+        github.com/cloudflare/circl@v1.3.3
+        github.com/docker/distribution@v2.8.2-beta.1'
+
+      # https://github.com/tektoncd/pipeline/issues/6909
+      # github.com/tektoncd/pipeline@v0.47.0'
+
+      # TODO: This would fix a medium CVE, but breaks client-go without changes to chains
+      # github.com/sigstore/rekor@v1.1.1'
+
+update:
+  enabled: true
+  github:
+    identifier: tektoncd/chains
+    strip-prefix: v

--- a/tekton-chains.yaml
+++ b/tekton-chains.yaml
@@ -24,15 +24,7 @@ pipeline:
       output: tekton-chains
       modroot: chains
       vendor: true
-      deps: '
-        github.com/cloudflare/circl@v1.3.3
-        github.com/docker/distribution@v2.8.2-beta.1'
-
-      # https://github.com/tektoncd/pipeline/issues/6909
-      # github.com/tektoncd/pipeline@v0.47.0'
-
-      # TODO: This would fix a medium CVE, but breaks client-go without changes to chains
-      # github.com/sigstore/rekor@v1.1.1'
+      deps: github.com/cloudflare/circl@v1.3.3 github.com/docker/distribution@v2.8.2-beta.1
 
 update:
   enabled: true

--- a/tekton-pipelines.yaml
+++ b/tekton-pipelines.yaml
@@ -24,7 +24,6 @@ pipeline:
       output: tekton-pipelines-controller
       modroot: tekton
       vendor: true
-      deps: github.com/docker/distribution@v2.8.2-beta.1
 
 data:
   - name: cmds

--- a/tekton-pipelines.yaml
+++ b/tekton-pipelines.yaml
@@ -24,9 +24,7 @@ pipeline:
       output: tekton-pipelines-controller
       modroot: tekton
       vendor: true
-      deps: '
-        github.com/docker/distribution@v2.8.2-beta.1
-        github.com/docker/docker@v23.0.3'
+      deps: github.com/docker/distribution@v2.8.2-beta.1 github.com/docker/docker@v23.0.3
 
 data:
   - name: cmds

--- a/tekton-pipelines.yaml
+++ b/tekton-pipelines.yaml
@@ -1,0 +1,59 @@
+package:
+  name: tekton-pipelines-controller
+  version: 0.47.3
+  epoch: 0
+  description: A cloud-native Pipeline resource.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tektoncd/pipeline
+      tag: v${{package.version}}
+      expected-commit: 7277870d2023b11fc36c93d41f1e48e4bb64535d
+      destination: tekton
+
+  - uses: go/build
+    with:
+      packages: ./cmd/controller
+      output: tekton-pipelines-controller
+      modroot: tekton
+      vendor: true
+      deps: '
+        github.com/docker/distribution@v2.8.2-beta.1
+        github.com/docker/docker@v23.0.3'
+
+data:
+  - name: cmds
+    items:
+      entrypoint: entrypoint
+      events: events
+      nop: nop
+      resolvers: resolvers
+      sidecarlogresults: sidecarlogresults
+      webhook: webhook
+      workingdirinit: workingdirinit
+
+subpackages:
+  - range: cmds
+    name: tekton-pipelines-${{range.key}}
+    description: tekton pipelines ${{range.key}}
+    pipeline:
+      - name: tekton-pipelines-${{range.key}}
+        pipeline:
+          - uses: go/build
+            with:
+              packages: ./cmd/${{range.key}}
+              output: tekton-pipelines-${{range.key}}
+              modroot: tekton
+
+update:
+  enabled: true
+  github:
+    identifier: tektoncd/pipeline
+    strip-prefix: v

--- a/tekton-pipelines.yaml
+++ b/tekton-pipelines.yaml
@@ -1,5 +1,5 @@
 package:
-  name: tekton-pipelines-controller
+  name: tekton-pipelines
   version: 0.47.3
   epoch: 0
   description: A cloud-native Pipeline resource.

--- a/tekton-pipelines.yaml
+++ b/tekton-pipelines.yaml
@@ -24,7 +24,7 @@ pipeline:
       output: tekton-pipelines-controller
       modroot: tekton
       vendor: true
-      deps: github.com/docker/distribution@v2.8.2-beta.1 github.com/docker/docker@v23.0.3
+      deps: github.com/docker/distribution@v2.8.2-beta.1
 
 data:
   - name: cmds

--- a/tekton-pipelines.yaml
+++ b/tekton-pipelines.yaml
@@ -1,6 +1,6 @@
 package:
   name: tekton-pipelines
-  version: 0.47.3
+  version: 0.49.0
   epoch: 0
   description: A cloud-native Pipeline resource.
   copyright:
@@ -15,7 +15,7 @@ pipeline:
     with:
       repository: https://github.com/tektoncd/pipeline
       tag: v${{package.version}}
-      expected-commit: 7277870d2023b11fc36c93d41f1e48e4bb64535d
+      expected-commit: c802069e0884af70b32a083f4c3a47e4db14f334
       destination: tekton
 
   - uses: go/build


### PR DESCRIPTION
```
$ wolfictl scan packages/aarch64/tekton-*                               
tekton-chains-0.16.0-r0.apk
└── 📄 /usr/bin/tekton-chains
        📦 github.com/sigstore/rekor v1.0.1 (go-module)
            High CVE-2023-30551 GHSA-2h5h-59f5-c5x9 fixed in 1.1.1
            Medium CVE-2023-33199 GHSA-frqx-jfcm-6jjr fixed in 1.2.0
        📦 github.com/tektoncd/pipeline v0.47.0 (go-module)
            Low CVE-2023-37264 GHSA-w2h3-vvvq-3m53
 
tekton-pipelines-0.49.0-r0.apk
└── 📄 /usr/bin/tekton-pipelines-controller
        📦 github.com/docker/distribution v2.8.1+incompatible (go-module)
            High CVE-2023-2253 GHSA-hqxw-f8mx-cpmw fixed in 2.8.2-beta.1
 
tekton-pipelines-entrypoint-0.49.0-r0.apk
✅ No vulnerabilities found
tekton-pipelines-events-0.49.0-r0.apk
✅ No vulnerabilities found
tekton-pipelines-nop-0.49.0-r0.apk
✅ No vulnerabilities found
tekton-pipelines-resolvers-0.49.0-r0.apk
✅ No vulnerabilities found
tekton-pipelines-sidecarlogresults-0.49.0-r0.apk
✅ No vulnerabilities found
tekton-pipelines-webhook-0.49.0-r0.apk
✅ No vulnerabilities found
tekton-pipelines-workingdirinit-0.49.0-r0.apk
✅ No vulnerabilities found
```

The rekor and distribution deps seemingly can't be bumped without causing a build breakage due to added methods in k8s client-go

https://github.com/tektoncd/pipeline/security/advisories/GHSA-w2h3-vvvq-3m53 is not yet fixed upstream (https://github.com/tektoncd/pipeline/issues/6909)

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in `advisories` and `secfixes`
