### PR TITLE
use ${{build.arch}} in favor of unset envs

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.26.1
-  epoch: 8
+  epoch: 9
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64
@@ -70,7 +70,7 @@ pipeline:
           # NOTE: This disables Wolfi's default host level CFLAGS since this is BPF bytecode, instead, we pick up the defaults specified in the Makefiles
           export CFLAGS="-Wno-error=unused-but-set-variable -D__x86_64__"
 
-          if [[ ${ARCH} == "x86_64" ]]; then
+          if [ "${{build.arch}}" = "x86_64" ]; then
             export CFLAGS="-Wno-error=unused-but-set-variable -m64 -D__x86_64__"
           fi
           make -C bpf-gpl CC=clang LD=llc
@@ -83,7 +83,7 @@ pipeline:
           # NOTE: This disables Wolfi's default host level CFLAGS since this is BPF bytecode, instead, we pick up the defaults specified in the Makefiles
 
           export CFLAGS="-Wno-error=sign-compare"
-          if [[ ${ARCH} == "x86_64" ]]; then
+          if [ "${{build.arch}}" = "x86_64" ]; then
             export CFLAGS="-Wno-error=sign-compare -m64"
           fi
 


### PR DESCRIPTION
use the builtin `${{build.arch}}` instead of relying on setting `$ARCH` (which was unset 😬)