### PR TITLE
remove unneeded `apk-tools` from kubernetes build environment

### DIFF
--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.24
   version: 1.24.15
-  epoch: 4
+  epoch: 5
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -21,7 +21,6 @@ environment:
       - coreutils # needed for non busybox version of `mktemp`
       - findutils # needed for non busybox version of `xargs`
       - rsync
-      - apk-tools
 
 # "transform" the kubernetes version into the corresponding pause version, these don't always line up
 var-transforms:

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.25
   version: 1.25.11
-  epoch: 4
+  epoch: 5
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -21,7 +21,6 @@ environment:
       - coreutils # needed for non busybox version of `mktemp`
       - findutils # needed for non busybox version of `xargs`
       - rsync
-      - apk-tools
 
 # "transform" the kubernetes version into the corresponding pause version, these don't always line up
 var-transforms:

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.26
   version: 1.26.6
-  epoch: 4
+  epoch: 5
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -21,7 +21,6 @@ environment:
       - coreutils # needed for non busybox version of `mktemp`
       - findutils # needed for non busybox version of `xargs`
       - rsync
-      - apk-tools
 
 # "transform" the kubernetes version into the corresponding pause version, these don't always line up
 var-transforms:

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.27
   version: 1.27.3
-  epoch: 6
+  epoch: 7
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,6 @@ environment:
       - coreutils # needed for non busybox version of `mktemp`
       - findutils # needed for non busybox version of `xargs`
       - rsync
-      - apk-tools
 
 # "transform" the kubernetes version into the corresponding pause version, these don't always line up
 var-transforms:


### PR DESCRIPTION
this is a nit, but lets be perfectionists?