### PR TITLE
kafka: add bitnami compat package

### DIFF
--- a/kafka.yaml
+++ b/kafka.yaml
@@ -2,7 +2,7 @@ package:
   name: kafka
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.5.0
-  epoch: 0
+  epoch: 1
   description:
   target-architecture:
     - all
@@ -48,6 +48,26 @@ pipeline:
 
       # Clean up windows
       rm -rf ${{targets.destdir}}/usr/lib/kafka/bin/*.bat
+
+subpackages:
+  - name: kafka-bitnami-compat
+    description: "compat package with bitnami/kafka image"
+    pipeline:
+      - runs: |
+          set -ex
+
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/scripts/kafka
+          commit=4798c28a6b00e6edd83379bb19032eaa5b9c603d
+
+          for script in kafka/entrypoint.sh kafka/run.sh libkafka.sh kafka-env.sh; do
+            curl -sL -o "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script} \
+                https://raw.githubusercontent.com/bitnami/containers/${commit}/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/${script}
+          done
+
+          for script in libfs.sh libvalidations.sh liblog.sh libbitnami.sh libos.sh; do
+            curl -sL -o "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script} \
+                https://github.com/bitnami/containers/blob/${commit}/bitnami/kafka/3.5/debian-11/prebuildfs/opt/bitnami/scripts/${script}
+          done
 
 update:
   enabled: true


### PR DESCRIPTION
The `bitnami/kafka` image includes an entrypoint that populates `server.properties` based on the contents of env vars, which makes it easier to configure from "outside" the container, rather than having to modify config options which are baked into the image.

https://github.com/bitnami/containers/blob/main/bitnami/kafka/3.5/debian-11/Dockerfile#L60-L61

A number of helper scripts are required to be able to run entrypoint.sh and run.sh, which are also added here.

This installs the scripts from https://github.com/bitnami/containers/commit/4798c28a6b00e6edd83379bb19032eaa5b9c603d since the bitnami repo doesn't do versioned releases.