### PR TITLE
kafka: fix bitnami compat scripts

### DIFF
--- a/kafka.yaml
+++ b/kafka.yaml
@@ -2,7 +2,7 @@ package:
   name: kafka
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.5.0
-  epoch: 1
+  epoch: 2
   description:
   target-architecture:
     - all
@@ -62,11 +62,13 @@ subpackages:
           for script in kafka/entrypoint.sh kafka/run.sh libkafka.sh kafka-env.sh; do
             curl -sL -o "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script} \
                 https://raw.githubusercontent.com/bitnami/containers/${commit}/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/${script}
+            chmod +x "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script}
           done
 
           for script in libfs.sh libvalidations.sh liblog.sh libbitnami.sh libos.sh; do
             curl -sL -o "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script} \
                 https://github.com/bitnami/containers/blob/${commit}/bitnami/kafka/3.5/debian-11/prebuildfs/opt/bitnami/scripts/${script}
+            chmod +x "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script}
           done
 
 update:


### PR DESCRIPTION
Before:

```
$ tar -tvf packages/aarch64/kafka-bitnami-compat-3.5.0-r1.apk
-rw-r--r--  0 root   root      649 Dec 31  1969 opt/bitnami/scripts/kafka/entrypoint.sh
-rw-r--r--  0 root   root     1139 Dec 31  1969 opt/bitnami/scripts/kafka/run.sh
-rw-r--r--  0 root   root     5697 Dec 31  1969 opt/bitnami/scripts/kafka-env.sh
-rw-r--r--  0 root   root    33479 Dec 31  1969 opt/bitnami/scripts/libbitnami.sh
-rw-r--r--  0 root   root    59496 Dec 31  1969 opt/bitnami/scripts/libfs.sh
-rw-r--r--  0 root   root    41708 Dec 31  1969 opt/bitnami/scripts/libkafka.sh
-rw-r--r--  0 root   root    44886 Dec 31  1969 opt/bitnami/scripts/liblog.sh
-rw-r--r--  0 root   root   119245 Dec 31  1969 opt/bitnami/scripts/libos.sh
-rw-r--r--  0 root   root    61651 Dec 31  1969 opt/bitnami/scripts/libvalidations.sh
```

After:

```
$ tar -tvf packages/aarch64/kafka-bitnami-compat-3.5.0-r2.apk
-rwxr-xr-x  0 root   root      649 Dec 31  1969 opt/bitnami/scripts/kafka/entrypoint.sh
-rwxr-xr-x  0 root   root     1139 Dec 31  1969 opt/bitnami/scripts/kafka/run.sh
-rwxr-xr-x  0 root   root     5697 Dec 31  1969 opt/bitnami/scripts/kafka-env.sh
-rwxr-xr-x  0 root   root    33488 Dec 31  1969 opt/bitnami/scripts/libbitnami.sh
-rwxr-xr-x  0 root   root    59496 Dec 31  1969 opt/bitnami/scripts/libfs.sh
-rwxr-xr-x  0 root   root    41708 Dec 31  1969 opt/bitnami/scripts/libkafka.sh
-rwxr-xr-x  0 root   root    44886 Dec 31  1969 opt/bitnami/scripts/liblog.sh
-rwxr-xr-x  0 root   root   119254 Dec 31  1969 opt/bitnami/scripts/libos.sh
-rwxr-xr-x  0 root   root    61651 Dec 31  1969 opt/bitnami/scripts/libvalidations.sh
```