### PR TITLE
tekton: fix subpackage install location

### DIFF
--- a/tekton-pipelines.yaml
+++ b/tekton-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: tekton-pipelines
   version: 0.49.0
-  epoch: 0
+  epoch: 1
   description: A cloud-native Pipeline resource.
   copyright:
     - license: Apache-2.0
@@ -48,6 +48,7 @@ subpackages:
               packages: ./cmd/${{range.key}}
               output: tekton-pipelines-${{range.key}}
               modroot: tekton
+              subpackage: "true"
 
 update:
   enabled: true


### PR DESCRIPTION
The subpackages were empty since they didn't set `subpackages: "true"` (previously, #3655)