### PR TITLE
DNM test bumping linenoise

### DIFF
--- a/linenoise.yaml
+++ b/linenoise.yaml
@@ -1,7 +1,7 @@
 package:
   name: linenoise
   version: 1.0
-  epoch: 2
+  epoch: 3
   description: "minimal alternative to GNU readline"
   copyright:
     - license: MIT


### PR DESCRIPTION
With the k8s runner I am seeing:
```
⚠️  aarch64   | make: *** No rule to make target 'install'.  Stop.
⚠️  aarch64   | non-recoverable error (exec.CodeExitError) executing remote command: command terminated with exit code 2
```
