### PR TITLE
fix tekton pipelines subpackages again

### DIFF
--- a/tekton-pipelines.yaml
+++ b/tekton-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: tekton-pipelines
   version: 0.49.0
-  epoch: 1
+  epoch: 2
   description: A cloud-native Pipeline resource.
   copyright:
     - license: Apache-2.0
@@ -41,14 +41,12 @@ subpackages:
     name: tekton-pipelines-${{range.key}}
     description: tekton pipelines ${{range.key}}
     pipeline:
-      - name: tekton-pipelines-${{range.key}}
-        pipeline:
-          - uses: go/build
-            with:
-              packages: ./cmd/${{range.key}}
-              output: tekton-pipelines-${{range.key}}
-              modroot: tekton
-              subpackage: "true"
+      - uses: go/build
+        with:
+          packages: ./cmd/${{range.key}}
+          output: tekton-pipelines-${{range.key}}
+          modroot: tekton
+          subpackage: "true"
 
 update:
   enabled: true


### PR DESCRIPTION
There was a bug in `subpackages` and they didn't do anything, but also did that nothing silently.

Before:
```
$ ls packages/aarch64/tekton-pipelines-*.apk | xargs -n 1 tar -tvf  | grep usr/bin/
-rwxr-xr-x  0 root   root 82795518 Dec 31  1969 usr/bin/tekton-pipelines-controller
```

(subpackages didn't include any built binaries)

After:

```
$ ls packages/aarch64/tekton-pipelines-*.apk | xargs -n 1 tar -tvf  | grep usr/bin/
-rwxr-xr-x  0 root   root 82795518 Dec 31  1969 usr/bin/tekton-pipelines-controller
-rwxr-xr-x  0 root   root 53973669 Dec 31  1969 usr/bin/tekton-pipelines-entrypoint
-rwxr-xr-x  0 root   root 62503687 Dec 31  1969 usr/bin/tekton-pipelines-events
-rwxr-xr-x  0 root   root  2012262 Dec 31  1969 usr/bin/tekton-pipelines-nop
-rwxr-xr-x  0 root   root 76150322 Dec 31  1969 usr/bin/tekton-pipelines-resolvers
-rwxr-xr-x  0 root   root 53770755 Dec 31  1969 usr/bin/tekton-pipelines-sidecarlogresults
-rwxr-xr-x  0 root   root 62416843 Dec 31  1969 usr/bin/tekton-pipelines-webhook
-rwxr-xr-x  0 root   root  2026307 Dec 31  1969 usr/bin/tekton-pipelines-workingdirinit
```