### PR TITLE
kafka: fix kafka-bitnami-compat

### DIFF
--- a/kafka.yaml
+++ b/kafka.yaml
@@ -2,7 +2,7 @@ package:
   name: kafka
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.5.0
-  epoch: 2
+  epoch: 3
   description:
   target-architecture:
     - all
@@ -57,18 +57,19 @@ subpackages:
           set -ex
 
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/scripts/kafka
+
           commit=4798c28a6b00e6edd83379bb19032eaa5b9c603d
+          git clone https://github.com/bitnami/containers /tmp/bitnami && cd /tmp/bitnami
+          git checkout ${commit}
 
           for script in kafka/entrypoint.sh kafka/run.sh libkafka.sh kafka-env.sh; do
-            curl -sL -o "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script} \
-                https://raw.githubusercontent.com/bitnami/containers/${commit}/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/${script}
-            chmod +x "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script}
+            install -Dm755 ./bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/${script} \
+                "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script}
           done
 
           for script in libfs.sh libvalidations.sh liblog.sh libbitnami.sh libos.sh; do
-            curl -sL -o "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script} \
-                https://github.com/bitnami/containers/blob/${commit}/bitnami/kafka/3.5/debian-11/prebuildfs/opt/bitnami/scripts/${script}
-            chmod +x "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script}
+            install -Dm755 ./bitnami/kafka/3.5/debian-11/prebuildfs/opt/bitnami/scripts/${script} \
+                "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script}
           done
 
 update:


### PR DESCRIPTION
Fetching via curl from raw.githubusercontent.com seems to result in malformed output. Instead of trying to be clever, just clone the repo and copy the necessary files.

Before:

```
$ tar -Oxf packages/aarch64/kafka-bitnami-compat-3.5.0-r2.apk opt/bitnami/scripts/libos.sh | head -c 200
{"payload":{"allShortcutsEnabled":false,"fileTree":{"bitnami/kafka/3.5/debian-11/prebuildfs/opt/bitnami/scripts":{"items":[{"name":"libbitnami.sh","path":"bitnami/kafka/3.5/debian-11/prebuildfs/opt/biopt/bitnami/scripts/libos.sh: Write error
```

After:

```
$ tar -Oxf packages/aarch64/kafka-bitnami-compat-3.5.0-r3.apk opt/bitnami/scripts/libos.sh | head -c 200
#!/bin/bash
# Copyright VMware, Inc.
# SPDX-License-Identifier: APACHE-2.0
#
# Library for operating system actions

# shellcheck disable=SC1091

# Load Generic Libraries
. /opt/bitnami/scripts/liblog%   
```