### PR TITLE
add a CI action to build the stateful world

### DIFF
--- a/.github/workflows/build-world.yaml
+++ b/.github/workflows/build-world.yaml
@@ -1,0 +1,69 @@
+name: Build the world
+
+on:
+  workflow_dispatch:
+    
+jobs:
+  build:
+    name: Build OS packages
+    runs-on:
+      - self-hosted
+      - ${{ matrix.arch }}
+
+    # Only run one build per arch at a time
+    concurrency:
+      group: build-world-${{ matrix.arch }}
+
+    strategy:
+      matrix:
+        arch: [ "x86_64", "aarch64" ]
+      fail-fast: false
+
+    container:
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:78751faebed64630b64351fff0431e38cf08c70997c19a72146698ced651aad0
+      options: |
+        --cap-add NET_ADMIN --cap-add SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor:unconfined
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: 'Trust the github workspace'
+        run: |
+          # This is to avoid fatal errors about "dubious ownership" because we are
+          # running inside of a container action with the workspace mounted in.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: 'Generate local signing key'
+        run: |
+          make MELANGE="melange" local-melange.rsa
+
+      - name: 'Build Wolfi World'
+        run: |
+          # Run all and allow failures, all we really care about is the buildlogs for failures
+          make MELANGE="melange" MELANGE_EXTRA_OPTS="--create-build-log" REPO="$GITHUB_WORKSPACE/packages" BUILDWORLD=no ARCH="${{ matrix.arch }}" all -j1 -k
+
+          # Move the failures into another directory (for ease of uploading)
+          mkdir -p buildlogs-failures
+          grep -L -r "generating apk index from packages in packages/" packages/**/buildlogs | xargs -I '{}' cp '{}' buildlogs-failures
+
+      - name: Upload failed build logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: buildlogs-failures
+          path: ${{ github.workspace }}/buildlogs-failures/*
+          retention-days: 7
+
+  # TODO: Enable the notification
+  # postrun:
+  #   name: Notify failures
+  #   runs-on: ubuntu-latest
+  #   if: failure()
+  #   steps:
+  #     - uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
+  #       id: slack
+  #       with:
+  #         payload: '{"text": "[build world] failure: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
+  #       env:
+  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Adds an action to use our fancy new self hosted runners to build the world.

This current iteration ironically keeps `BUILDWORLD=no` for now until we're confident the dag is correct.