### PR TITLE
PR template: Remove secfixes, add advisories link

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -35,7 +35,7 @@ addressed, and remove any items that are not relevant to this PR.
 
 #### For security-related PRs
 <!-- remove if unrelated -->
-- [ ] The security fix is recorded in `advisories` and `secfixes`
+- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
 
 #### For version bump PRs
 <!-- remove if unrelated -->


### PR DESCRIPTION
Make contributing friendlier for n00bs:

- secfixes is dead
- new contributors won't know what `advisories` is referencing.