### PR TITLE
looks like urllib may have deleted a release and force pushed + tagge…

### DIFF
--- a/py3-urllib3.yaml
+++ b/py3-urllib3.yaml
@@ -22,7 +22,7 @@ pipeline:
     with:
       repository: https://github.com/urllib3/urllib3.git
       tag: ${{package.version}}
-      expected-commit: 09ac3751ffa64fa9291558a045ad338373afe60f
+      expected-commit: c9fa144545eedb5dc4a2cc3f255e95602a1d7db0
 
   - runs: |
       # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"


### PR DESCRIPTION
…d  a different commit

https://github.com/urllib3/urllib3/releases/tag/2.0.4 <- released 21 mins ago, original update PR for that version was received [1 hour ago](https://github.com/wolfi-dev/os/pull/3707).  The [commit](https://github.com/urllib3/urllib3/commit/09ac3751ffa64fa9291558a045ad338373afe60f) from that automated is now not associated with a branch.

No epoch bump needed as apk was never published for either arch