### PR TITLE
go-licenses init at 1.6.0

### DIFF
--- a/go-licenses.yaml
+++ b/go-licenses.yaml
@@ -1,0 +1,23 @@
+package:
+  name: go-licenses
+  version: 1.6.0
+  epoch: 0
+  description: A lightweight tool to report on the licenses used by a Go package and its dependencies. Highlight! Versioned external URL to licenses can be found at the same time.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - go
+
+pipeline:
+  - uses: go/install
+    with:
+      package: github.com/google/go-licenses@v${{package.version}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: google/go-licenses
+    strip-prefix: v

--- a/packages.txt
+++ b/packages.txt
@@ -914,6 +914,7 @@ pgcat
 sysstat
 mycli
 valgrind
+go-licenses
 aws-flb-kinesis
 py3-importlib-resources
 py3-tzdata


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
