### PR TITLE
`gke-cloud-auth-plugin`: new package

### DIFF
--- a/gke-gcloud-auth-plugin.yaml
+++ b/gke-gcloud-auth-plugin.yaml
@@ -1,0 +1,42 @@
+package:
+  name: gke-gcloud-auth-plugin
+  version: 0.0.2
+  epoch: 0
+  description: "kubectl plugin for GKE authentication"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - kubectl
+      - google-cloud-sdk
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/kubernetes/cloud-provider-gcp/archive/refs/tags/auth-provider-gcp/v${{package.version}}.tar.gz
+      expected-sha256: bb74ee2604d454f6a55b374554ac59546c7ed5baa3ea515fcb51185d2d2fd053
+
+  - uses: go/build
+    with:
+      packages: ./cmd/gke-gcloud-auth-plugin
+      output: gke-gcloud-auth-plugin
+      # TODO(mattmoor): Consider adding all of these:
+      # https://github.com/kubernetes/cloud-provider-gcp/blob/e64cf3b0fcb1958cee1fe55d7e30f4573c34bf4e/defs/version.bzl#L38
+      ldflags: -s -w
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes/cloud-provider-gcp
+    strip-prefix: auth-provider-gcp/v
+    tag-filter: auth-provider-gcp/v
+    use-tag: true


### PR DESCRIPTION

#### For new package PRs only
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
