### PR TITLE
Remove escaping from replacement strings in icu

### DIFF
--- a/icu.yaml
+++ b/icu.yaml
@@ -1,7 +1,7 @@
 package:
   name: icu
   version: 73.1
-  epoch: 0
+  epoch: 1
   description: "International Components for Unicode library"
   copyright:
     - license: MIT
@@ -20,11 +20,11 @@ environment:
 var-transforms:
   - from: ${{package.version}}
     match: \.
-    replace: \-
+    replace: '-'
     to: dash-package-version
   - from: ${{package.version}}
     match: \.
-    replace: \_
+    replace: _
     to: underscore-package-version
 
 pipeline:


### PR DESCRIPTION
I could not build this locally, and I am fairly certain it was due to the escaping in the replacement side, which doesn't look right to me.

I'm building this locally on arm64 now, and it's past the fetch step, but still running.