### PR TITLE
add a *temporary* large timeout for build world's CI

### DIFF
--- a/.github/workflows/build-world.yaml
+++ b/.github/workflows/build-world.yaml
@@ -24,6 +24,8 @@ jobs:
       options: |
         --cap-add NET_ADMIN --cap-add SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor:unconfined
 
+    timeout-minutes: 2880 # 2 days
+
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
it appears this needs to be manually set, even for self hosted runners 💆 