### PR TITLE
fix kots build

### DIFF
--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
-  version: 1.100.3
-  epoch: 1
+  version: 1.101.0
+  epoch: 0
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0
@@ -21,7 +21,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/replicatedhq/kots/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: 400e7777e646238484c75ce738b366312205ed561e33efd699600b7ff1689472
+      expected-sha256: d90835dc3db8a70a8d52327c3188634b2afb4cc0c246f107ce697ae665428eeb
 
   - runs: |
       set -x
@@ -29,8 +29,10 @@ pipeline:
       mkdir -p "${DESTDIR}"
 
       # Mitigate GHSA-hqxw-f8mx-cpmw / CVE-2023-2253
-      go get github.com/docker/distribution@v2.8.2-beta.1+incompatible
-
+      go get github.com/docker/distribution@v2.8.2+incompatible
+      # the following dependency was upgraded to github.com/replicatedhq/troubleshoot@v0.70.0
+      # causing build issues , remove this when the upstream upgrades https://github.com/replicatedhq/kots/blob/main/go.mod#L53
+      go get github.com/replicatedhq/troubleshoot@v0.69.1
       go mod tidy
 
       # Scripts etc.


### PR DESCRIPTION
fixes build issue for kots https://github.com/wolfi-dev/os/pull/3709 

and bumps the dependency from beta to github.com/docker/distribution@v2.8.2+incompatible