### PR TITLE
Update the vulkan-headers commit SHA

### DIFF
--- a/vulkan-headers.yaml
+++ b/vulkan-headers.yaml
@@ -1,7 +1,7 @@
 package:
   name: vulkan-headers
   version: 1.3.257
-  epoch: 0
+  epoch: 1
   description: Vulkan header files and API registry
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: https://github.com/KhronosGroup/Vulkan-Headers
       tag: v${{package.version}}
-      expected-commit: 195c58410f9c6ee9f1c6a9e56bbaaa614947d5bf
+      expected-commit: 485c0395ad85bcefe7aed17d23362d93f61f942d
 
   - runs: |
       cmake -B build \


### PR DESCRIPTION
When I build this locally I see:
```
⚠️  aarch64   | Cloning into '/tmp/tmp.3RiQTf'...
⚠️  aarch64   | Note: switching to '485c0395ad85bcefe7aed17d23362d93f61f942d'.
⚠️  aarch64   | 
⚠️  aarch64   | You are in 'detached HEAD' state. You can look around, make experimental
⚠️  aarch64   | changes and commit them, and you can discard any commits you make in this
⚠️  aarch64   | state without impacting any branches by switching back to a branch.
⚠️  aarch64   | 
⚠️  aarch64   | If you want to create a new branch to retain commits you create, you may
⚠️  aarch64   | do so (now or later) by using -c with the switch command. Example:
⚠️  aarch64   | 
⚠️  aarch64   |   git switch -c <new-branch-name>
⚠️  aarch64   | 
⚠️  aarch64   | Or undo this operation with:
⚠️  aarch64   | 
⚠️  aarch64   |   git switch -
⚠️  aarch64   | 
⚠️  aarch64   | Turn off this advice by setting config variable advice.detachedHead to false
⚠️  aarch64   | 
ℹ️  aarch64   | Error (git-checkout): expect commit 195c58410f9c6ee9f1c6a9e56bbaaa614947d5bf, got 485c0395ad85bcefe7aed17d23362d93f61f942d
```

Looking at the upstream repo, the commit we are getting appears to be what's published:
<img width="350" alt="image" src="https://github.com/wolfi-dev/os/assets/2442466/4278498e-fbac-473b-9dd3-dad2fad45afe">
