### PR TITLE
libpthread-stubs: use xz instead of bz2

### DIFF
--- a/libpthread-stubs.yaml
+++ b/libpthread-stubs.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpthread-stubs
-  version: 0.4
-  epoch: 2
+  version: 0.5
+  epoch: 0
   description: Pthread functions stubs for platforms missing them
   copyright:
     - license: X11
@@ -18,8 +18,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: e4d05911a3165d3b18321cc067fdd2f023f06436e391c6a28dff618a78d2e733
-      uri: https://xcb.freedesktop.org/dist/libpthread-stubs-${{package.version}}.tar.bz2
+      expected-sha256: 59da566decceba7c2a7970a4a03b48d9905f1262ff94410a649224e33d2442bc
+      uri: https://xcb.freedesktop.org/dist/libpthread-stubs-${{package.version}}.tar.xz
 
   - uses: autoconf/configure
 


### PR DESCRIPTION
the latest release of libpthread-stubs doesn't have bz2 sources anymore switch to xz , the bot should be able to upgrade the future releases 
fixes https://github.com/wolfi-dev/os/issues/3716