### PR TITLE
Apply a patch to fix libwebsocket build

### DIFF
--- a/libwebsockets.yaml
+++ b/libwebsockets.yaml
@@ -29,7 +29,7 @@ pipeline:
 
   # This is from:
   # https://patch-diff.githubusercontent.com/raw/warmcat/libwebsockets/pull/2824.patch
-  # To fix a type mismatch error with openssl types.
+  # To fix an issue where an integer was being used instead of an enumerable type.
   - uses: patch
     with:
       patches: 2824.patch

--- a/libwebsockets.yaml
+++ b/libwebsockets.yaml
@@ -1,7 +1,7 @@
 package:
   name: libwebsockets
   version: 4.3.2
-  epoch: 0
+  epoch: 1
   description: C library for lightweight websocket clients and servers
   copyright:
     - license: MIT
@@ -26,6 +26,13 @@ pipeline:
     with:
       expected-sha256: 6a85a1bccf25acc7e8e5383e4934c9b32a102880d1e4c37c70b27ae2a42406e1
       uri: https://github.com/warmcat/libwebsockets/archive/v${{package.version}}.tar.gz
+
+  # This is from:
+  # https://patch-diff.githubusercontent.com/raw/warmcat/libwebsockets/pull/2824.patch
+  # To fix a type mismatch error with openssl types.
+  - uses: patch
+    with:
+      patches: 2824.patch
 
   - uses: cmake/configure
     with:

--- a/libwebsockets/2824.patch
+++ b/libwebsockets/2824.patch
@@ -1,0 +1,28 @@
+From 722e44cb5b74cae206f47a6dc0d985eba8ed1b2e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 26 Jan 2023 17:17:49 -0800
+Subject: [PATCH] Fix -Werror=enum-int-mismatch in
+ lws_tls_server_abort_connection()
+
+GCC 13 is findinf this function signature mismatch.
+
+../git/lib/tls/openssl/openssl-server.c:713:1: error: conflicting types for 'lws_tls_server_abort_connection' due to enum/integer mismatch; have 'int(struct lws *)' [-Werror=enum-int-mismatch]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ lib/tls/openssl/openssl-server.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/tls/openssl/openssl-server.c b/lib/tls/openssl/openssl-server.c
+index f2e77324f..43d65e030 100644
+--- a/lib/tls/openssl/openssl-server.c
++++ b/lib/tls/openssl/openssl-server.c
+@@ -699,7 +699,7 @@ lws_tls_server_new_nonblocking(struct lws *wsi, lws_sockfd_type accept_fd)
+ 	return 0;
+ }
+ 
+-int
++enum lws_ssl_capable_status
+ lws_tls_server_abort_connection(struct lws *wsi)
+ {
+ 	if (wsi->tls.use_ssl)


### PR DESCRIPTION
Currently this is broken at HEAD because of a type mismatch with openssl headers.

This picks up the upstream patch linked in the comment to correct things.
