### PR TITLE
Update the `spirv-headers` checksum, bump `spirv-tools`.

### DIFF
--- a/spirv-headers.yaml
+++ b/spirv-headers.yaml
@@ -2,7 +2,7 @@
 package:
   name: spirv-headers
   version: 1.3.250.1
-  epoch: 1
+  epoch: 2
   description: Machine-readable files for the SPIR-V Registry
   copyright:
     - license: GPL-3.0-or-later
@@ -21,7 +21,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 442c3b329c0c1ef82a778c55b794410474c69bc08f8fb6cffaacf92c73af6f14
+      expected-sha256: d5f8c4b7906baf9c51aedbbb2dd942009e8658e3340c6e64699518666a03e043
       uri: https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/sdk-${{package.version}}.tar.gz
 
   - runs: |

--- a/spirv-tools.yaml
+++ b/spirv-tools.yaml
@@ -1,7 +1,7 @@
 # Generated from https://git.alpinelinux.org/aports/plain/main/spirv-tools/APKBUILD
 package:
   name: spirv-tools
-  version: 1.3.250.0
+  version: 1.3.250.1
   epoch: 0
   description: API and commands for processing SPIR-V modules
   copyright:
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 1c1d428537031ff0a753a6ebcc473e9c2b39bda351b556f5378cab1c0cf9c278
+      expected-sha256: 6cfa228695e4a0300ff30eafd88056128c67342a0f0838400cb3a566caadc7d4
       uri: https://github.com/KhronosGroup/SPIRV-tools/archive/refs/tags/sdk-${{package.version}}.tar.gz
 
   - runs: |


### PR DESCRIPTION
I believe that according to https://github.com/KhronosGroup/SPIRV-Tools/issues/5298 the `spirv-headers` tag was on the wrong commit and this was updated, which caused the `spirv-tools` build to fail.

I was able to build both of these packages successfully locally, let's see what CI says.

Fixes: https://github.com/wolfi-dev/os/pull/3293

#### For version bump PRs
- [x] The `epoch` field is reset to 0
