### PR TITLE
gettext: add glibc-iconv dependency

### DIFF
--- a/gettext.yaml
+++ b/gettext.yaml
@@ -1,10 +1,13 @@
 package:
   name: gettext
   version: "0.22"
-  epoch: 0
+  epoch: 1
   description: GNU locale utilities
   copyright:
     - license: GPL-3.0-or-later AND LGPL-2.1-or-later AND MIT
+  dependencies:
+    runtime:
+      - glibc-iconv
 
 environment:
   contents:


### PR DESCRIPTION
The glibc iconv plugins are needed to convert non-unicode translation data to unicode.
Fixes: xkeyboard-config failure to rebuild

cc @mattmoor