### PR TITLE
gnutls: fix underlinking

### DIFF
--- a/gnutls.yaml
+++ b/gnutls.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnutls
   version: 3.7.8
-  epoch: 1
+  epoch: 2
   description: TLS protocol implementation
   copyright:
     - license: LGPL-2.1-or-later
@@ -61,6 +61,10 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  # Fix underlinking problem with GNUTLS depending on P11-KIT.
+  - runs: |
+      echo 'Requires: p11-kit-1' >> "${{targets.destdir}}"/usr/lib/pkgconfig/gnutls.pc
 
   - uses: strip
 


### PR DESCRIPTION
When building with `-Wl,-z,now`, all symbols must be resolved at link time, as lazy binding is disabled.  This provides better performance and also provides protections when combined with `-z relro` against segments being overwritten at runtime.

However, there is a bug in the GNUTLS build, where the p11-kit symbols are not linked by the pkg-config file normally, allowing the dependency to be resolved through lazy binding instead.  Fix this by adding a Requires relationship on the p11-kit package in the pkg-config file.

Fixes: proxysql failure to rebuild from source

cc @mattmoor