### PR TITLE
proxysql: add libgcrypt-dev dependency, needed for vendored libmicrohttpd

### DIFF
--- a/proxysql.yaml
+++ b/proxysql.yaml
@@ -1,7 +1,7 @@
 package:
   name: proxysql
   version: 2.5.3
-  epoch: 0
+  epoch: 1
   description: High-performance MySQL proxy with a GPL license
   copyright:
     - license: GPL-3.0
@@ -28,6 +28,7 @@ environment:
       - zlib-dev
       - util-linux-dev
       - gawk
+      - libgcrypt-dev
 
 pipeline:
   - uses: git-checkout

--- a/proxysql.yaml
+++ b/proxysql.yaml
@@ -42,7 +42,7 @@ pipeline:
           export CFLAGS="${CFLAGS} -fPIC"
           export CPPFLAGS="$CFLAGS"
           export CXXFLAGS="$CFLAGS"
-          make -j$(nproc)
+          make -j$(nproc) GIT_VERSION=${{package.version}}-r${{package.epoch}}
       - runs: |
           mkdir -p ${{targets.destdir}}/usr/bin
           mkdir -p ${{targets.destdir}}/etc


### PR DESCRIPTION
Fixes: failure to rebuild proxysql from source