### PR TITLE
cjson: refactor build recipe

### DIFF
--- a/cjson.yaml
+++ b/cjson.yaml
@@ -1,7 +1,7 @@
 package:
   name: cjson
   version: 1.7.16
-  epoch: 0
+  epoch: 1
   description: Lighweight JSON parser in C
   copyright:
     - license: MIT
@@ -18,10 +18,11 @@ environment:
       - samurai
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: b0ca16e9f4c22b54482a3bfc14b64b50d8f2e305ee6014b0b3d3d9e700934f8d
-      uri: https://github.com/DaveGamble/cJSON/archive/v${{package.version}}.tar.gz
+      repository: https://github.com/DaveGamble/cJSON
+      tag: v${{package.version}}
+      expected-commit: cb8693b058ba302f4829ec6d03f609ac6f848546
 
   - uses: cmake/configure
 
@@ -35,9 +36,6 @@ subpackages:
   - name: cjson-dev
     pipeline:
       - uses: split/dev
-    dependencies:
-      runtime:
-        - cjson
     description: cjson dev
 
 update:


### PR DESCRIPTION
- switch to git-checkout action
- remove explicit dependency (cjson-dev -> cjson), now solved with SCA in Melange

Fixes: failure to rebuild cjson from source due to retagging