### PR TITLE
cmake: bump to v3.27.0

### DIFF
--- a/cmake.yaml
+++ b/cmake.yaml
@@ -30,6 +30,8 @@ pipeline:
       uri: https://www.cmake.org/files/v3.27/cmake-${{package.version}}.tar.gz
       expected-sha256: aaeddb6b28b993d0a6e32c88123d728a17561336ab90e0bf45032383564d3cb8
 
+  # Depending on system cppdap and jsoncpp would create a circular
+  # dependency; thus, we use bundled ones.
   - runs: |
       ./bootstrap \
         --prefix=/usr \

--- a/cmake.yaml
+++ b/cmake.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake
-  version: 3.24.2
-  epoch: 2
+  version: 3.27.0
+  epoch: 0
   description: "cross-platform asynchronous I/O library"
   copyright:
     - license: BSD-3-Clause
@@ -27,8 +27,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://www.cmake.org/files/v3.24/cmake-${{package.version}}.tar.gz
-      expected-sha256: 0d9020f06f3ddf17fb537dc228e1a56c927ee506b486f55fe2dc19f69bf0c8db
+      uri: https://www.cmake.org/files/v3.27/cmake-${{package.version}}.tar.gz
+      expected-sha256: aaeddb6b28b993d0a6e32c88123d728a17561336ab90e0bf45032383564d3cb8
 
   - runs: |
       ./bootstrap \
@@ -37,6 +37,7 @@ pipeline:
         --datadir=/share/cmake \
         --docdir=/share/doc/cmake \
         --system-libs \
+        --no-system-cppdap \
         --no-system-jsoncpp \
         --generator=Ninja \
         --parallel=$(nproc)


### PR DESCRIPTION
Tested with multiple packages:
- systemd
- jsonc
- libogg
- tcpdump

Fixes: #3713 
