### PR TITLE
py3-libarchive-c: new package

### DIFF
--- a/py3-libarchive-c.yaml
+++ b/py3-libarchive-c.yaml
@@ -22,7 +22,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://files.pythonhosted.org/packages/source/l/libarchive-c/libarchive-c-${{package.version}}.tar.gz
-      expected-sha256: d673f56673d87ec740d1a328fa205cafad1d60f5daca4685594deb039d32b159      
+      expected-sha256: d673f56673d87ec740d1a328fa205cafad1d60f5daca4685594deb039d32b159
 
   # Use the correct library soname
   # NOTE: find_library is broken on aarch64, so just hardcode it for now.

--- a/py3-libarchive-c.yaml
+++ b/py3-libarchive-c.yaml
@@ -1,0 +1,40 @@
+package:
+  name: py3-libarchive-c
+  version: 5.0
+  epoch: 0
+  description: "Python interface to libarchive."
+  copyright:
+    - license: CC0-1.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - build-base
+      - wolfi-baselayout
+      - python3
+      - py3-setuptools
+      - libarchive
+      - libarchive-dev
+      - scanelf
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://files.pythonhosted.org/packages/source/l/libarchive-c/libarchive-c-${{package.version}}.tar.gz
+      expected-sha256: d673f56673d87ec740d1a328fa205cafad1d60f5daca4685594deb039d32b159      
+
+  # Use the correct library soname
+  # NOTE: find_library is broken on aarch64, so just hardcode it for now.
+  - runs: |
+      soname=$(scanelf --quiet --soname /usr/lib/libarchive.so | awk '{print $1}')
+      sed -i -e "s:find_library('archive'):'/usr/lib/$soname':" libarchive/ffi.py
+
+  - runs: |
+      python3 setup.py build
+      python3 setup.py install --skip-build --root="${{targets.destdir}}"
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 9954

--- a/py3-libarchive-c.yaml
+++ b/py3-libarchive-c.yaml
@@ -5,7 +5,9 @@ package:
   description: "Python interface to libarchive."
   copyright:
     - license: CC0-1.0
-
+  dependencies:
+    runtime:
+      - libarchive
 environment:
   contents:
     packages:


### PR DESCRIPTION
py3-libarchive-c: new package

This package is a Python interface to libarchive.

This is needed for diffoscope, which I intend to package next.

Prerequisite to #3811.

### Pre-review Checklist

#### For new package PRs only
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates.
