### PR TITLE
diffoscope: add new package

### DIFF
--- a/diffoscope.yaml
+++ b/diffoscope.yaml
@@ -41,4 +41,4 @@ pipeline:
 update:
   enabled: true
   release-monitor:
-    identifier: 14588
+    identifier: 31806

--- a/diffoscope.yaml
+++ b/diffoscope.yaml
@@ -1,0 +1,43 @@
+package:
+  name: diffoscope
+  version: 245
+  epoch: 0
+  description: "In-depth comparison of files, archives, and directories."
+  copyright:
+    - license: GPL-3.0-or-later
+  dependencies:
+    runtime:
+      - python3
+      - py3-libarchive-c
+      - py3-magic
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - python3
+      - py3-setuptools
+      - py3-docutils
+      - py3-gpep517
+      - py3-wheel
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://files.pythonhosted.org/packages/source/d/diffoscope/diffoscope-${{package.version}}.tar.gz
+      expected-sha256: 922930b14a7189e12a67f08c9e21b09bb621a1005bcaf58fead5df1a42bc4d7b
+
+  - runs: |
+      python3 setup.py build
+
+  - runs: |
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: 14588

--- a/diffoscope.yaml
+++ b/diffoscope.yaml
@@ -10,6 +10,7 @@ package:
       - python3
       - py3-libarchive-c
       - py3-magic
+
 environment:
   contents:
     packages:

--- a/diffoscope.yaml
+++ b/diffoscope.yaml
@@ -40,5 +40,5 @@ pipeline:
 
 update:
   enabled: true
-  github:
+  release-monitor:
     identifier: 14588

--- a/py3-libarchive-c.yaml
+++ b/py3-libarchive-c.yaml
@@ -22,7 +22,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://files.pythonhosted.org/packages/source/l/libarchive-c/libarchive-c-${{package.version}}.tar.gz
-      expected-sha256: d673f56673d87ec740d1a328fa205cafad1d60f5daca4685594deb039d32b159      
+      expected-sha256: d673f56673d87ec740d1a328fa205cafad1d60f5daca4685594deb039d32b159
 
   # Use the correct library soname
   # NOTE: find_library is broken on aarch64, so just hardcode it for now.

--- a/py3-libarchive-c.yaml
+++ b/py3-libarchive-c.yaml
@@ -1,0 +1,40 @@
+package:
+  name: py3-libarchive-c
+  version: 5.0
+  epoch: 0
+  description: "Python interface to libarchive."
+  copyright:
+    - license: CC0-1.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - build-base
+      - wolfi-baselayout
+      - python3
+      - py3-setuptools
+      - libarchive
+      - libarchive-dev
+      - scanelf
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://files.pythonhosted.org/packages/source/l/libarchive-c/libarchive-c-${{package.version}}.tar.gz
+      expected-sha256: d673f56673d87ec740d1a328fa205cafad1d60f5daca4685594deb039d32b159      
+
+  # Use the correct library soname
+  # NOTE: find_library is broken on aarch64, so just hardcode it for now.
+  - runs: |
+      soname=$(scanelf --quiet --soname /usr/lib/libarchive.so | awk '{print $1}')
+      sed -i -e "s:find_library('archive'):'/usr/lib/$soname':" libarchive/ffi.py
+
+  - runs: |
+      python3 setup.py build
+      python3 setup.py install --skip-build --root="${{targets.destdir}}"
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 9954


### PR DESCRIPTION
diffoscope is a tool for in-depth comparison of files, archives, and directories.

~~Depends on #3812 being merged. Do not merge unless that has been merged first.~~ #3812 is merged into this PR now.

Fixes: #3811

Related: #3812

### Pre-review Checklist
#### For new package PRs only
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
