### PR TITLE
fuse3: bump to 3.15.1

### DIFF
--- a/fuse3.yaml
+++ b/fuse3.yaml
@@ -1,6 +1,6 @@
 package:
   name: fuse3
-  version: 3.15.0
+  version: 3.15.1
   epoch: 0
   description: The reference implementation of the Linux FUSE (Filesystem in Userspace) interface
   copyright:
@@ -21,8 +21,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 70589cfd5e1cff7ccd6ac91c86c01be340b227285c5e200baa284e401eea2ca0
-      uri: https://github.com/libfuse/libfuse/releases/download/fuse-${{package.version}}/fuse-${{package.version}}.tar.xz
+      expected-sha256: 13ef77cda531a21c2131f9576042970e98035c0a5f019abf661506efd2d38a4e
+      uri: https://github.com/libfuse/libfuse/releases/download/fuse-${{package.version}}/fuse-${{package.version}}.tar.gz
 
   - uses: meson/configure
 


### PR DESCRIPTION
Closes #3367

Fixes: #3367

### Pre-review Checklist

#### For version bump PRs
- [x] The `epoch` field is reset to 0
