### PR TITLE
add: Reconcile Wolfi index github action

### DIFF
--- a/.github/workflows/reconcile-wolfi-index.yaml
+++ b/.github/workflows/reconcile-wolfi-index.yaml
@@ -1,0 +1,52 @@
+name: Reconcile Wolfi Index
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Withdraw packages
+    runs-on: ubuntu-16-core
+
+    permissions:
+      id-token: write
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: chainguard-dev/actions/setup-melange@main
+
+      - id: auth
+        name: 'Authenticate to Google Cloud'
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
+          service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
+
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: prod-images-c6e5
+
+      - run: echo "${{ secrets.MELANGE_RSA }}" > ./wolfi-signing.rsa
+      - run: |
+          sudo mkdir -p /etc/apk/keys
+          sudo cp ./wolfi-signing.rsa.pub /etc/apk/keys/wolfi-signing.rsa.pub
+
+      - name: 'Sync public package repository'
+        run: |
+          mkdir "${{ github.workspace }}/packages"
+          gsutil -m rsync -r gs://wolfi-production-registry-destination/os/ "${{ github.workspace }}/packages/"
+          find "${{ github.workspace }}/packages" -print -exec touch \{} \;
+
+      - name: 'Reconcile Wolfi index'
+        run: |
+          for arch in x86_64 aarch64; do
+            pushd "${{ github.workspace }}/packages/"$arch
+              melange index -o APKINDEX.tar.gz -a $arch *.apk
+              melange sign-index --signing-key="${{ github.workspace }}/wolfi-signing.rsa" APKINDEX.tar.gz
+              gsutil -h "Cache-Control:no-store" cp "${{ github.workspace }}/packages/${arch}/APKINDEX.tar.gz" gs://wolfi-production-registry-destination/os/${arch}/APKINDEX.tar.gz
+              gsutil -h "Cache-Control:no-store" cp "${{ github.workspace }}/packages/${arch}/APKINDEX.json" gs://wolfi-production-registry-destination/os/${arch}/APKINDEX.json
+            popd
+          done


### PR DESCRIPTION
this is a copy of  https://github.com/wolfi-dev/os/blob/main/.github/workflows/withdraw-packages.yaml with an exception of removing anything from the gs://bucket , just reindexes the APK indexes 

- once this runs successfully I will merge the  withdraw-packages and reindex workflows with an conditional expression 
```
on:
  workflow_dispatch:
    inputs:
      reconcile-index:
        description: 'Reconciles Index'
        required: false
        default: true
        type: boolean
```