### PR TITLE
Update the checksum of the rarian archive

### DIFF
--- a/rarian.yaml
+++ b/rarian.yaml
@@ -1,7 +1,7 @@
 package:
   name: rarian
   version: 0.8.4
-  epoch: 0
+  epoch: 1
   description: Documentation meta-data library, designed as a replacement for Scrollkeeper.
   copyright:
     - license: GPL-2.0+, LGPL-2.1+, Zlib
@@ -20,7 +20,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577
+      expected-sha256: 55624f9001fce8f6c8032d7d57bf2acfe7c150bafb3b1bb715319a1b2eb9b2c5
       uri: https://gitlab.freedesktop.org/rarian/rarian/-/releases/${{package.version}}/downloads/assets/rarian-${{package.version}}.tar.bz2
 
   - uses: autoconf/configure


### PR DESCRIPTION
Trying to rebuild this:
```
ℹ️  x86_64    | remote executing command [/bin/sh -c [ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
if [ "aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577" == "" ] && [ "" == "" ]; then
  printf "One of expected-sha256 or expected-sha512 is required"
  exit 1
fi

bn=$(basename https://gitlab.freedesktop.org/rarian/rarian/-/releases/0.8.4/downloads/assets/rarian-0.8.4.tar.bz2)

if [ ! "aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577" == "" ]; then
  fn="/var/cache/melange/sha256:aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577"
  if [ -f $fn ]; then
    printf "fetch: found $fn in cache\n"
    cp $fn $bn
  fi
else
  fn="/var/cache/melange/sha512:"
  if [ -f $fn ]; then
    printf "fetch: found $fn in cache\n"
    cp $fn $bn
  fi
fi

if [ ! -f $bn ]; then
  wget -q '-T5' '--dns-timeout=20' '--tries=5' --random-wait --retry-connrefused --continue 'https://gitlab.freedesktop.org/rarian/rarian/-/releases/0.8.4/downloads/assets/rarian-0.8.4.tar.bz2'
fi

if [ "aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577" != "" ]; then
  printf "%s  %s\n" 'aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577' $bn | sha256sum -c
else
  printf "%s  %s\n" '' $bn | sha512sum -c
fi

if [ "true" = "true" ]; then
  tar -x '--strip-components=1' -f $bn
fi

if [ "false" = "true" ]; then
  rm $bn
fi

exit 0]
⚠️  x86_64    | sha256sum: WARNING: 1 of 1 computed checksums did NOT match
```

I downloaded the latest and computed this checksum.