### PR TITLE
`metacontroller` requires `goreleaser<1.19`

### DIFF
--- a/goreleaser-1.18.yaml
+++ b/goreleaser-1.18.yaml
@@ -1,0 +1,27 @@
+package:
+  name: goreleaser-1.18
+  version: 1.18.2
+  epoch: 0
+  description: Deliver Go binaries as fast and easily as possible
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - goreleaser=1.18.999 # This should be goreleaser=${{package.version}}-${{package.epoch}}
+
+environment:
+  contents:
+    packages:
+      - git
+
+pipeline:
+  - uses: go/install
+    with:
+      package: github.com/goreleaser/goreleaser@v${{package.version}}
+
+update:
+  enabled: true
+  github:
+    identifier: goreleaser/goreleaser
+    strip-prefix: v
+    tag-filter: v1.18

--- a/metacontroller.yaml
+++ b/metacontroller.yaml
@@ -1,7 +1,7 @@
 package:
   name: metacontroller
   version: 4.10.4
-  epoch: 0
+  epoch: 1
   description: Writing kubernetes controllers can be simple
   target-architecture:
     - all
@@ -19,7 +19,7 @@ environment:
       - build-base
       - git
       - go
-      - goreleaser
+      - goreleaser-1.18 # This relies on a deprecated field removed in 1.19
       - make
 
 pipeline:


### PR DESCRIPTION
This is because of this feature deprecation at the latest version tag: https://goreleaser.com/deprecations/#archivesreplacements
