### PR TITLE
htop: new package

### DIFF
--- a/htop.yaml
+++ b/htop.yaml
@@ -1,0 +1,52 @@
+package:
+  name: htop
+  version: 3.2.2
+  epoch: 0
+  description: "A cross-platform interactive process viewer."
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - build-base
+      - pkgconf-dev
+      - ncurses-dev
+      - libcap-dev
+      - libnl3-dev
+      - linux-headers
+      - autoconf
+      - automake
+      - python3
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/htop-dev/htop/releases/download/${{package.version}}/htop-${{package.version}}.tar.xz
+      expected-sha256: bac9e9ab7198256b8802d2e3b327a54804dc2a19b77a5f103645b11c12473dc8
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --prefix="/usr" \
+        --sysconfdir="/etc" \
+        --mandir="/usr/share/man" \
+        --localstatedir="/var" \
+        --enable-cgroup \
+        --enable-capabilities \
+        --enable-delayacct \
+        --enable-taskstats
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1332


### PR DESCRIPTION
htop is a rich command-line process monitor.

Fixes: #3826

### Pre-review Checklist

#### For new package PRs only
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates