### PR TITLE
glib: update to v2.76.4

### DIFF
--- a/glib.yaml
+++ b/glib.yaml
@@ -1,6 +1,6 @@
 package:
   name: glib
-  version: 2.76.1
+  version: 2.76.4
   epoch: 0
   description: Common C routines used by Gtk+ and other libs
   copyright:
@@ -40,7 +40,7 @@ var-transforms:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 43dc0f6a126958f5b454136c4398eab420249c16171a769784486e25f2fda19f
+      expected-sha256: 5a5a191c96836e166a7771f7ea6ca2b0069c603c7da3cba1cd38d1694a395dda
       uri: https://download.gnome.org/sources/glib/${{vars.mangled-package-version}}/glib-${{package.version}}.tar.xz
 
   - uses: meson/configure


### PR DESCRIPTION
Tested with zfs, harfbuzz, and openjdk-8

Fixes: #3418

### Pre-review Checklist
#### For version bump PRs
- [x] The `epoch` field is reset to 0
