### PR TITLE
Bump traefik to 2.10.3 and resolve CVEs again.

### DIFF
--- a/traefik.yaml
+++ b/traefik.yaml
@@ -1,7 +1,7 @@
 package:
   name: traefik
-  version: 2.10.1
-  epoch: 6
+  version: 2.10.3
+  epoch: 0
   description: The Cloud Native Application Proxy
   copyright:
     - license: MIT
@@ -16,19 +16,16 @@ environment:
       - git
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/traefik/traefik/releases/download/v${{package.version}}/traefik-v${{package.version}}.src.tar.gz
-      expected-sha256: 34c19da8a28e10e5634afd7336a9b7944dbf21bfbacf4248d0140c329ef0049f
+      repository: https://github.com/traefik/traefik
+      expected-commit: 7741c68eaa719d114c6d7444c965b7ae373e46a6
+      tag: v${{package.version}}
 
   - runs: |
-      go get go.mongodb.org/mongo-driver@v1.11.2
-      go get github.com/Azure/go-autorest/autorest/adal@v0.9.22
-      go get github.com/hashicorp/go-discover@v0.0.0-20230125175744-70b45b3eb8b7
-      go get github.com/hashicorp/consul@v1.15.0
+      go mod edit -replace github.com/hashicorp/consul=github.com/hashicorp/consul@v1.14.7
+      go get github.com/docker/distribution@v2.8.2
       go get github.com/docker/docker@v20.10.24
-      go get github.com/docker/distribution@v2.8.2-beta.1
-      go get github.com/hashicorp/consul@v1.15.3
       go mod tidy
       VERSION=v${{package.version}} ./script/make.sh generate binary
       mkdir -p "${{targets.destdir}}/usr/bin"


### PR DESCRIPTION
This one was a bit tricky and needed a replace.

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->
