### PR TITLE
upgrade gem grpc pacakge to apply cve fixes

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.17.5
-  epoch: 1
+  epoch: 2
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -67,6 +67,9 @@ pipeline:
       git clone https://github.com/javiercri/fluent-plugin-google-cloud.git
       cd fluent-plugin-google-cloud
       git checkout ${{vars.FLUENT_PLUGIN_GOOGLE_CLOUD_COMMIT}}
+
+      # to fix some CVEs in the grpc
+      sed -e "s/'grpc', '1.52.0'/'grpc', '1.53.0'/g" -i fluent-plugin-google-cloud.gemspec
 
       bundle config set --local path ${GEM_DIR}
       bundle config set --local without 'development test'


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
* kube-fluentd-operator: fix a few CVEs

```
grpc     1.52.0     1.53.0    gem   GHSA-6628-q6j9-w8vg  High
grpc     1.52.0     1.53.0    gem   GHSA-9hxf-ppjv-w6rq  Medium
grpc     1.52.0     1.53.0    gem   GHSA-cfgp-2977-2fmm  High
```


Related: https://github.com/wolfi-dev/advisories/issues/102

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo


