### PR TITLE
`ruby3.2-validate_url`: unbreak at HEAD.

### DIFF
--- a/ruby3.2-validate_url.yaml
+++ b/ruby3.2-validate_url.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-validate_url
   version: 1.0.15
-  epoch: 0
+  epoch: 1
   description: Library for validating urls in Rails.
   dependencies:
     runtime:
@@ -21,12 +21,14 @@ environment:
       - git
 
 pipeline:
-  - runs: |
-      # This is a workaround as validate_url is not tagged
-      git clone http://github.com/perfectline/validates_url .
-      git checkout 3036c474d4ca48a2636bc71241165c2645a80c98
-
-      sed -i 's/s.version = "1.0.14"/s.version = "1.0.15"/g' validate_url.gemspec
+  # This is a workaround as validate_url stopped tagging releases
+  # after their 1.0.5 release. It is adapted from our git-checkout
+  # pipeline as of 2023-07-24.
+  - uses: fetch
+    with:
+      # This commit is the 1.0.15 release
+      uri: https://github.com/perfectline/validates_url/archive/9c8a33558bba162fcc8c23732ba5b6e47fceaf86.tar.gz
+      expected-sha512: 3e5af128a911c5eb7c7c8b128f8834000aa540105c4ba5d4b6ff30ae7c11038c1e7ad73afc3c03e28260b4167954967a3db4f73fb8a4dc083b95b5cce6767572
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
This fixes an issue with `ruby3.2-validate_url` where the `git clone {url} .` was failing at HEAD because the directory isn't empty (it has `lost+found`).

To address this, I played around with a few options, but ended up adapting a forked version of our current `git-checkout` pipeline.

This also moves 1.0.15 one commit ahead to let us drop the `sed` command, since they updated the upstream repo with a superset of this change.
