### PR TITLE
Switch `buck2` to `fetch` pipeline

### DIFF
--- a/buck2.yaml
+++ b/buck2.yaml
@@ -2,7 +2,7 @@ package:
   name: buck2
   # When bumping, check that the rust version is still correct.
   version: 0.0_git20230706
-  epoch: 1
+  epoch: 2
   description: "Build system, successor to Buck"
   copyright:
     - license: MIT
@@ -21,16 +21,18 @@ vars:
   rust-version: nightly-2023-05-28
 
 pipeline:
-  - uses: git-checkout
+  # This is a workaround as buck2 is not cutting releases.
+  # This approach allows us to rebuild at a particular commit,
+  # which is preferable to the previous approach which started
+  # failing as soon as things floated forward along the tag
+  # we tracked (called "latest").
+  - uses: fetch
     with:
-      repository: https://github.com/facebook/buck2
-      tag: latest
-      # This uses strange versioning, latest is the tag but they'll apparently just bump that tag regularly.
-      expected-commit: bcbdf2f63bf8397754518ca0536125b79fbfc6b0
+      uri: https://github.com/facebook/buck2/archive/bcbdf2f63bf8397754518ca0536125b79fbfc6b0.tar.gz
+      expected-sha512: 607169c0074f58b1f67ad4ce32c2eabd7fbfcf0616f354198bd0b68a405baa7e4c055909df1e1982c75d47a3cace2bceb023238027148e0efd70c36efa6e2eaf
 
   - name: Configure and build
     runs: |
-      git checkout ${{vars.commit}}
       # This build requires a specific version of rust nightly.
       # Be sure to check docs when bumping to more recent commits.
       rustup install ${{vars.rust-version}}


### PR DESCRIPTION
The way we build `buck2` currently breaks every time the FB folks update the `latest` tag, which is creating noise in our world builds.

This changes the way we fetch the commit we build at so that we don't have that problem.

