### PR TITLE
Pull in the latest `ncurses`

### DIFF
--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
   version: 6.4
-  epoch: 2
+  epoch: 3
   description: "console display library"
   copyright:
     - license: MIT
@@ -25,8 +25,8 @@ pipeline:
   - uses: fetch
     with:
       #      uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{package.version}}-20220820.tgz
-      uri: https://distfiles.alpinelinux.org/distfiles/edge/ncurses-${{package.version}}-20230114.tgz
-      expected-sha512: b2e89c70b0181ccb7422e1789c6e495682391a0621f3327f6961a49f9f590898d979b84544954f02b9e18b2da4ddf989858797b7ab1d6703ecfb879886a200fe
+      uri: https://distfiles.alpinelinux.org/distfiles/edge/ncurses-${{package.version}}-20230715.tgz
+      expected-sha512: d7e7bda2a3af1c24043074f7951351a3f07eabd5be734fa7809d7b90290b65576abcdc82e06fda397413a5093101a021b381d204630c0f355e01d115ed897b72
 
   - name: Configure
     runs: |


### PR DESCRIPTION
The previous archive was no longer available, so builds failed.

