### PR TITLE
`tmux`: add the tmux package to Wolfi.

### DIFF
--- a/tmux.yaml
+++ b/tmux.yaml
@@ -1,4 +1,3 @@
-# Generated from https://git.alpinelinux.org/aports/plain/main/tmux/APKBUILD
 package:
   name: tmux
   version: 3.3a
@@ -43,7 +42,8 @@ pipeline:
   - uses: autoconf/configure
     with:
       opts: |
-        --sysconfdir=/etc/ --prefix=/usr/
+        --sysconfdir=/etc \
+        --prefix=/usr
 
   - uses: autoconf/make
 

--- a/tmux.yaml
+++ b/tmux.yaml
@@ -1,0 +1,71 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/tmux/APKBUILD
+package:
+  name: tmux
+  version: 3.3a
+  epoch: 0
+  description: Tool to control multiple terminals from a single terminal
+  copyright:
+    - license: ISC
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - bison
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - glibc-dev
+      - icu
+      - libevent
+      - libevent-dev
+      - libtool
+      - m4
+      - pcre-dev
+      - pcre2-dev
+      - pkgconf
+      - pkgconf-dev
+      - posix-libc-utils
+      - wolfi-base
+      - yaml-dev
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/tmux/tmux/archive/refs/tags/${{package.version}}.tar.gz
+      expected-sha256: f9687493203f86d346791a9327cde9148b9b4be959381b1effc575a9364a043f
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --sysconfdir=/etc/ --prefix=/usr/
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      install -D -m644 example_tmux.conf \
+        "${{targets.destdir}}"/usr/share/doc/tmux/examples/tmux.conf
+
+      for file in CHANGES README; do
+        install -m644 "$file" "${{targets.destdir}}"/usr/share/doc/tmux/
+      done
+
+  - uses: strip
+
+subpackages:
+  - name: tmux-doc
+    pipeline:
+      - uses: split/manpages
+    description: tmux manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 4980


### PR DESCRIPTION
This is imported via `melange convert apkbuild` and then heavily modified to add dependencies Jamon and Ariadne thankfully pointed out were missing.

I built an image with a local build of the package and poked around with it inside of a Google Cloud Shell and things seemed to work :party-matt:

I used the ID from [here](https://release-monitoring.org/project/4980/) for release-monitoring 🤞 

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
