### PR TITLE
coreutils: fix chroot symlink target

### DIFF
--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: coreutils
   version: "9.3"
-  epoch: 0
+  epoch: 1
   description: "GNU core utilities"
   copyright:
     - license: GPL-3.0-or-later
@@ -60,7 +60,7 @@ pipeline:
       done
 
       rm usr/bin/chroot
-      ln -s ../bin/chroot usr/sbin/chroot
+      ln -s ../bin/coreutils usr/sbin/chroot
 
       # shouldn't be here, but you never know...
       rm -f usr/bin/groups


### PR DESCRIPTION
Fixes: `chroot` failing to work when `coreutils` is installed