### PR TITLE
fontconfig: split library and config components

### DIFF
--- a/fontconfig.yaml
+++ b/fontconfig.yaml
@@ -1,7 +1,7 @@
 package:
   name: fontconfig
   version: 2.14.2
-  epoch: 1
+  epoch: 2
   description: Library for configuring and customizing font access
   copyright:
     - license: MIT
@@ -62,12 +62,27 @@ subpackages:
     pipeline:
       - uses: split/static
 
+  - name: fontconfig-config
+    description: fontconfig configuration data
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr
+          mv "${{targets.destdir}}"/usr/share "${{targets.subpkgdir}}"/usr/
+          mv "${{targets.destdir}}"/etc "${{targets.subpkgdir}}"/etc
+
+  - name: libfontconfig1
+    description: fontconfig shared library
+    dependencies:
+      runtime:
+        - fontconfig-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libfontconfig.so.* "${{targets.subpkgdir}}"/usr/lib
+
   - name: fontconfig-dev
     pipeline:
       - uses: split/dev
-    dependencies:
-      runtime:
-        - fontconfig
     description: fontconfig dev
 
 update:


### PR DESCRIPTION
Split fontconfig library and config components to allow fontconfig programs to be optionally installed.

Related: chainguard-images/images#297