### PR TITLE
bzip2: split out libbz2 from the bzip2 utilities

### DIFF
--- a/bzip2.yaml
+++ b/bzip2.yaml
@@ -1,7 +1,7 @@
 package:
   name: bzip2
   version: 1.0.8
-  epoch: 4
+  epoch: 5
   description: "a library implementing the bzip2 compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT
@@ -64,20 +64,22 @@ pipeline:
   - runs: |
       make PREFIX="${{targets.destdir}}/usr" install
 
-      install -D libbz2.so.${{package.version}} "${{targets.destdir}}"/usr/lib/libbz2.so.${{package.version}}
-      ln -s libbz2.so.${{package.version}} "${{targets.destdir}}"/usr/lib/libbz2.so
-      ln -s libbz2.so.${{package.version}} "${{targets.destdir}}"/usr/lib/libbz2.so.1
-
   - uses: strip
 
 subpackages:
+  - name: "libbz2-1"
+    description: bzip2 shared library
+    pipeline:
+      - runs: |
+          install -D libbz2.so.${{package.version}} "${{targets.subpkgdir}}"/usr/lib/libbz2.so.${{package.version}}
+          ln -s libbz2.so.${{package.version}} "${{targets.subpkgdir}}"/usr/lib/libbz2.so.1
+
   - name: "bzip2-dev"
     description: "bzip2 headers"
     pipeline:
       - uses: split/dev
-    dependencies:
-      runtime:
-        - bzip2
+      - runs: |
+          ln -s libbz2.so.1 "${{targets.subpkgdir}}"/usr/lib/libbz2.so
 
 update:
   enabled: true


### PR DESCRIPTION
Freetype only requires libbz2, not the actual bzip2 utilities.  Split it out so that we can drop the utilities where we don't need them.

Related: chainguard-images/images#297