### PR TITLE
openjdk-{11,17}: swap fontconfig dependency with libfontconfig1

### DIFF
--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,15 +1,13 @@
 package:
   name: openjdk-11
   version: 11.0.20.8
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only
   dependencies:
     runtime:
       - openjdk-11-jre
-      - freetype
-      - fontconfig
 
 environment:
   contents:
@@ -113,7 +111,7 @@ subpackages:
     dependencies:
       runtime:
         - freetype
-        - fontconfig
+        - libfontconfig1
         - openjdk-11-jre-base
     pipeline:
       - runs: |

--- a/openjdk-12.yaml
+++ b/openjdk-12.yaml
@@ -8,8 +8,6 @@ package:
   dependencies:
     runtime:
       - openjdk-12-jre
-      - freetype
-      - fontconfig
 
 environment:
   contents:
@@ -117,7 +115,7 @@ subpackages:
     dependencies:
       runtime:
         - freetype
-        - fontconfig
+        - libfontconfig1
         - openjdk-12-jre-base
     pipeline:
       - runs: |

--- a/openjdk-13.yaml
+++ b/openjdk-13.yaml
@@ -8,8 +8,6 @@ package:
   dependencies:
     runtime:
       - openjdk-13-jre
-      - freetype
-      - fontconfig
 
 environment:
   contents:
@@ -114,7 +112,7 @@ subpackages:
     dependencies:
       runtime:
         - freetype
-        - fontconfig
+        - libfontconfig1
         - openjdk-13-jre-base
     pipeline:
       - runs: |

--- a/openjdk-14.yaml
+++ b/openjdk-14.yaml
@@ -8,8 +8,6 @@ package:
   dependencies:
     runtime:
       - openjdk-14-jre
-      - freetype
-      - fontconfig
 
 environment:
   contents:
@@ -111,7 +109,7 @@ subpackages:
     dependencies:
       runtime:
         - freetype
-        - fontconfig
+        - libfontconfig1
         - openjdk-14-jre-base
     pipeline:
       - runs: |

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -8,8 +8,6 @@ package:
   dependencies:
     runtime:
       - openjdk-15-jre
-      - freetype
-      - fontconfig
 
 environment:
   contents:
@@ -119,7 +117,7 @@ subpackages:
     dependencies:
       runtime:
         - freetype
-        - fontconfig
+        - libfontconfig1
         - openjdk-15-jre-base
     pipeline:
       - runs: |

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -8,8 +8,6 @@ package:
   dependencies:
     runtime:
       - openjdk-16-jre
-      - freetype
-      - fontconfig
 
 environment:
   contents:
@@ -119,7 +117,7 @@ subpackages:
     dependencies:
       runtime:
         - freetype
-        - fontconfig
+        - libfontconfig1
         - openjdk-16-jre-base
     pipeline:
       - runs: |

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,15 +1,13 @@
 package:
   name: openjdk-17
   version: 17.0.8.7
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only
   dependencies:
     runtime:
       - openjdk-17-jre
-      - freetype
-      - fontconfig
 
 environment:
   contents:
@@ -125,7 +123,7 @@ subpackages:
     dependencies:
       runtime:
         - freetype
-        - fontconfig
+        - libfontconfig1
         - openjdk-17-jre-base
     pipeline:
       - runs: |

--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -8,8 +8,6 @@ package:
   dependencies:
     runtime:
       - openjdk-18-jre
-      - freetype
-      - fontconfig
 
 environment:
   contents:
@@ -119,7 +117,7 @@ subpackages:
     dependencies:
       runtime:
         - freetype
-        - fontconfig
+        - libfontconfig1
         - openjdk-18-jre-base
     pipeline:
       - runs: |

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -8,8 +8,6 @@ package:
   dependencies:
     runtime:
       - openjdk-19-jre
-      - freetype
-      - fontconfig
 
 environment:
   contents:
@@ -119,7 +117,7 @@ subpackages:
     dependencies:
       runtime:
         - freetype
-        - fontconfig
+        - libfontconfig1
         - openjdk-19-jre-base
     pipeline:
       - runs: |

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -8,8 +8,6 @@ package:
   dependencies:
     runtime:
       - openjdk-20-jre
-      - freetype
-      - fontconfig
 
 environment:
   contents:
@@ -125,7 +123,7 @@ subpackages:
     dependencies:
       runtime:
         - freetype
-        - fontconfig
+        - libfontconfig1
         - openjdk-20-jre-base
     pipeline:
       - runs: |


### PR DESCRIPTION
OpenJDK lazy loads the fontconfig library at runtime with `dlopen`.  Change the dependency to `libfontconfig1` to avoid pulling in the fontconfig utilities.

Related: chainguard-images/images#297