### PR TITLE
kubernetes-csi-external-provisioner: ca-certificates is not needed at…

### DIFF
--- a/kubernetes-csi-external-provisioner.yaml
+++ b/kubernetes-csi-external-provisioner.yaml
@@ -1,13 +1,10 @@
 package:
   name: kubernetes-csi-external-provisioner
   version: 3.5.0
-  epoch: 4
+  epoch: 5
   description: A dynamic provisioner for Kubernetes CSI plugins.
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - ca-certificates
 
 environment:
   contents:


### PR DESCRIPTION
… runtime
