### PR TITLE
Set CGO_ENABLED=0 for cluster-autoscaler, coredns, kubernetes-ingress…

### DIFF
--- a/cluster-autoscaler.yaml
+++ b/cluster-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler
   version: 1.27.2
-  epoch: 4
+  epoch: 5
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -13,6 +13,8 @@ environment:
       - ca-certificates-bundle
       - build-base
       - go
+  environment:
+    CGO_ENABLED: 0
 
 pipeline:
   - uses: git-checkout

--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: 1.10.1
-  epoch: 2
+  epoch: 3
   description: CoreDNS is a DNS server that chains plugins
   target-architecture:
     - all
@@ -22,6 +22,8 @@ environment:
       - make
       - go
       - libcap-utils
+  environment:
+    CGO_ENABLED: 0
 
 pipeline:
   - uses: git-checkout

--- a/kubernetes-ingress-defaultbackend.yaml
+++ b/kubernetes-ingress-defaultbackend.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-ingress-defaultbackend
   version: 1.24.0
-  epoch: 1
+  epoch: 2
   description: 'A simple web server that respond 404 common used in kubernetes ingress, serve pages 404 at root and 200 at /healthz'
   copyright:
     - license: Apache-2.0
@@ -14,6 +14,8 @@ environment:
       - build-base
       - go
       - ca-certificates-bundle
+  environment:
+    CGO_ENABLED: 0
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
…-defaultbackend

these packages contain shared c library files like `lib/libc.so.6` when they might not need to

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
