### PR TITLE
add nproc to rust builds

### DIFF
--- a/rust.yaml
+++ b/rust.yaml
@@ -1,8 +1,8 @@
 package:
   name: rust
   version: 1.71.0
-  epoch: 0
-  description: "rust a type safe memory safe language"
+  epoch: 1
+  description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
   dependencies:
@@ -91,7 +91,7 @@ pipeline:
       export CXXFLAGS="$CXXFLAGS -O2 -I/usr/include/llvm15"
       export OPENSSL_NO_VENDOR=1
       export RUST_BACKTRACE=1
-      DESTDIR=${{targets.destdir}} python3 ./x.py install --jobs ${JOBS:-2}
+      DESTDIR=${{targets.destdir}} python3 ./x.py install --jobs $(nproc)
 
   - uses: strip
 
@@ -115,5 +115,4 @@ update:
   enabled: true
   github:
     identifier: rust-lang/rust
-    strip-prefix: v
     use-tag: true


### PR DESCRIPTION
obligatory `make rust go brrrrr`.

it looks like `JOBS` isn't set, so we were defaulting to `2`. the build isn't insanely multithreaded, but it's still a significant boost. on my test machine (43x172), this resulted in:

```bash
os on  rust-jobs [$!?] took 50m51s

vs

os on  rust-jobs [$!?] took 20m22s
```