### PR TITLE
expat: split libraries from main package

### DIFF
--- a/expat.yaml
+++ b/expat.yaml
@@ -1,7 +1,7 @@
 package:
   name: expat
   version: 2.5.0
-  epoch: 3
+  epoch: 4
   description: "XML SAX Parser library written in C"
   copyright:
     - license: MIT
@@ -44,9 +44,13 @@ subpackages:
     description: "expat headers"
     pipeline:
       - uses: split/dev
-    dependencies:
-      runtime:
-        - expat
+
+  - name: "libexpat1"
+    description: "libexpat shared library"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr
+          mv "${{targets.destdir}}"/usr/lib "${{targets.subpkgdir}}"/usr/
 
 update:
   enabled: true


### PR DESCRIPTION
Most programs using expat do not require the xmlwf utility, as they just use libexpat directly.

Related: chainguard-images/images#297