### PR TITLE
fix cassandra builds

### DIFF
--- a/cassandra.yaml
+++ b/cassandra.yaml
@@ -1,13 +1,14 @@
 package:
   name: cassandra
-  version: 4.1.1
-  epoch: 1
+  version: 4.1.3
+  epoch: 0
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - openjdk-8-jre
+      - openjdk-8-default-jvm
 
 environment:
   contents:
@@ -18,27 +19,29 @@ environment:
       - openjdk-8
       - build-base
       - ant
+      - python3
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/apache/cassandra
-      expected-commit: 8d91b469afd3fcafef7ef85c10c8acc11703ba2d
-      tag: cassandra-4.1.1
+      expected-commit: 2a4cd36475de3eb47207cd88d2d472b876c6816d
+      tag: cassandra-${{package.version}}
 
   - runs: |
       export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
 
-      ant artifacts
+      ant artifacts -Dversion=${{package.version}}
 
       # Install cassandra from the tarball in build/dist into the destdir in /usr/share/java/cassandra
       mkdir -p "${{targets.destdir}}"/usr/share/java/cassandra
-      tar --strip-components 1 -C "${{targets.destdir}}"/usr/share/java/cassandra -xzf build/apache-cassandra-4.1.1-SNAPSHOT-bin.tar.gz
+      tar --strip-components 1 -C "${{targets.destdir}}"/usr/share/java/cassandra -xzf build/apache-cassandra-${{package.version}}-bin.tar.gz
 
       # Symlink everything in the cassandra bin directory into /usr/bin
-      mkdir -p "${{targets.destdir}}"/usr/bin
-      for f in "${{targets.destdir}}"/usr/share/java/cassandra/bin/*; do
-        ln -sf "$f" "${{targets.destdir}}"/usr/bin/"$(basename "$f")"
+      mkdir -p "${{targets.destdir}}"/usr/bin/
+      for f in /home/build/build/dist/bin/*; do
+        filename=$(basename "$f")
+        ln -sf  /usr/share/java/cassandra/bin/"$filename" "${{targets.destdir}}"/usr/bin/"$filename"
       done
 
 update:


### PR DESCRIPTION
1. Uses package versions vars 
2. includes default JVM for path 
3. corrects the symbolic links 