### PR TITLE
Add libhtp 0.5.45 package for use with Suricata

### DIFF
--- a/libhtp.yaml
+++ b/libhtp.yaml
@@ -1,0 +1,61 @@
+package:
+  name: libhtp
+  version: 0.5.45
+  epoch: 0
+  description: LibHTP is a security-aware parser for the HTTP protocol and the related bits and pieces
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - build-base
+      - automake
+      - autoconf
+      - glibc-iconv
+      - libtool
+      - m4
+      - xz-dev
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: d4214f94522fa5a1ec1909dbb52831c534788d93bc6b2ca8252de9332b11b606
+      uri: https://github.com/OISF/libhtp/archive/refs/tags/${{package.version}}.tar.gz
+
+  - runs: |
+      ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: libhtp-static
+    pipeline:
+      - uses: split/static
+    description: libhtp static
+
+  - name: libhtp-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - libhtp
+    description: libhtp dev
+
+  - name: libhtp-doc
+    pipeline:
+      - uses: split/manpages
+    description: libhtp manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1632


### PR DESCRIPTION
Adds: [libhtp-0.5.45](https://github.com/OISF/libhtp/) for use with [Suricata IDS/IPS](https://github.com/wolfi-dev/os/pull/4064)

### Pre-review Checklist

#### For new package PRs only
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates

