### PR TITLE
Add suricata-update 1.2.7 for use with Suricata

### DIFF
--- a/suricata-update.yaml
+++ b/suricata-update.yaml
@@ -1,0 +1,37 @@
+package:
+  name: suricata-update
+  version: 1.2.7
+  epoch: 0
+  description: "The tool for updating your Suricata rules"
+  copyright:
+    - license: GPL-2.0-only
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - py3-pip
+
+pipeline:
+  - uses: fetch
+    with:
+      repository: https://github.com/OISF/suricata-update/archive/refs/tags/${{package.version}}.tar.gz
+      expected-sha256: 0b024b564f1fc5e20db3bf824ae8aabc47fff630cf2632a5e820c18000ebbf5e
+
+  - runs: |
+      python3 setup.py build
+
+  - runs: |
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 17309

--- a/suricata-update.yaml
+++ b/suricata-update.yaml
@@ -20,7 +20,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      repository: https://github.com/OISF/suricata-update/archive/refs/tags/${{package.version}}.tar.gz
+      uri: https://github.com/OISF/suricata-update/archive/refs/tags/${{package.version}}.tar.gz
       expected-sha256: 0b024b564f1fc5e20db3bf824ae8aabc47fff630cf2632a5e820c18000ebbf5e
 
   - runs: |


### PR DESCRIPTION
Adds: [suricata-update](https://github.com/OISF/suricata-update) 1.2.7 for use with [Suricata IDS/IPS](https://github.com/wolfi-dev/os/pull/4064)

### Pre-review Checklist

#### For new package PRs only
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates