### PR TITLE
Refactor node packaging

### DIFF
--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -1,8 +1,13 @@
 package:
   name: nodejs-16
   version: 16.20.1
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
+  dependencies:
+    runtime:
+      - npm
+    provides:
+      - nodejs=16.20.999
   copyright:
     - license: MIT
 
@@ -54,7 +59,7 @@ pipeline:
         --with-intl=system-icu \
         --without-corepack
 
-        make BUILDTYPE=Release
+        make BUILDTYPE=Release -j$(nproc)
 
   - uses: autoconf/make
 
@@ -64,6 +69,12 @@ pipeline:
       make DESTDIR="$${{targets.destdir}}" install
 
   - uses: strip
+
+  # Get rid of the bundled npm, we don't need it.
+  - runs: |
+      rm -rf "${{targets.destdir}}"/usr/lib/node_modules
+      rm "${{targets.destdir}}"/usr/bin/npm
+      rm "${{targets.destdir}}"/usr/bin/npx
 
 update:
   enabled: true

--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -8,6 +8,7 @@ package:
       - npm
     provides:
       - nodejs=16.20.999
+      - nodejs-lts=16
   copyright:
     - license: MIT
 

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,11 +1,13 @@
 package:
   name: nodejs-18
   version: 18.17.0 # When bumping this, also bump the provides below!
-  epoch: 0
+  epoch: 2
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT
   dependencies:
+    runtime:
+      - npm
     provides:
       - nodejs=18.17.999
 
@@ -57,7 +59,7 @@ pipeline:
         --with-intl=system-icu \
         --without-corepack
 
-        make BUILDTYPE=Release
+        make BUILDTYPE=Release -j$(nproc)
 
   - uses: autoconf/make
 
@@ -67,6 +69,12 @@ pipeline:
       make DESTDIR="$${{targets.destdir}}" install
 
   - uses: strip
+
+  # Get rid of the bundled npm, we don't need it.
+  - runs: |
+      rm -rf "${{targets.destdir}}"/usr/lib/node_modules
+      rm "${{targets.destdir}}"/usr/bin/npm
+      rm "${{targets.destdir}}"/usr/bin/npx
 
 update:
   enabled: true

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-18
   version: 18.17.0 # When bumping this, also bump the provides below!
-  epoch: 2
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT
@@ -10,6 +10,7 @@ package:
       - npm
     provides:
       - nodejs=18.17.999
+      - nodejs-lts=18
 
 environment:
   contents:

--- a/nodejs-19.yaml
+++ b/nodejs-19.yaml
@@ -1,8 +1,13 @@
 package:
   name: nodejs-19
   version: 19.9.0
-  epoch: 1
+  epoch: 2
   description: "JavaScript runtime built on V8 engine"
+  dependencies:
+    runtime:
+      - npm
+    provides:
+      - nodejs=19
   copyright:
     - license: MIT
 
@@ -54,7 +59,7 @@ pipeline:
         --with-intl=system-icu \
         --without-corepack
 
-        make BUILDTYPE=Release
+        make BUILDTYPE=Release -j$(nproc)
 
   - uses: autoconf/make
 
@@ -64,6 +69,12 @@ pipeline:
       make DESTDIR="$${{targets.destdir}}" install
 
   - uses: strip
+
+  # Get rid of the bundled npm, we don't need it.
+  - runs: |
+      rm -rf "${{targets.destdir}}"/usr/lib/node_modules
+      rm "${{targets.destdir}}"/usr/bin/npm
+      rm "${{targets.destdir}}"/usr/bin/npx
 
 update:
   enabled: true

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,8 +1,13 @@
 package:
   name: nodejs-20
   version: 20.5.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
+  dependencies:
+    runtime:
+      - npm
+    provides:
+      - nodejs=20
   copyright:
     - license: MIT
 
@@ -54,7 +59,7 @@ pipeline:
         --with-intl=system-icu \
         --without-corepack
 
-        make BUILDTYPE=Release
+        make BUILDTYPE=Release -j$(nproc)
 
   - uses: autoconf/make
 
@@ -64,6 +69,12 @@ pipeline:
       make DESTDIR="$${{targets.destdir}}" install
 
   - uses: strip
+
+  # Get rid of the bundled npm, we don't need it.
+  - runs: |
+      rm -rf "${{targets.destdir}}"/usr/lib/node_modules
+      rm "${{targets.destdir}}"/usr/bin/npm
+      rm "${{targets.destdir}}"/usr/bin/npx
 
 update:
   enabled: true

--- a/npm.yaml
+++ b/npm.yaml
@@ -1,0 +1,92 @@
+package:
+  name: npm
+  version: 9.8.1
+  epoch: 0
+  description: "the npm package manager for javascript, mainline"
+  copyright:
+    - license: Artistic-2.0
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - build-base
+      - rsync
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://registry.npmjs.org/npm/-/npm-${{package.version}}.tgz
+      expected-sha512: 01f0ef4e1433b085e162093dce16e4e51fa587cd7594a90b01e40c3214b2a5fd4133bcd469f788201ccccdeb297ae544274f8bbd8dfaa114187fb20a2f3537af
+
+  - uses: patch
+    with:
+      patches: dont-check-for-last-version.patch
+
+  - runs: |
+      # Wrapper scripts written in Bash and CMD.
+      rm bin/npm bin/npx bin/*.cmd
+      rm README.md
+
+      # HTML docs
+      rm -rf docs
+
+  - working-directory: /home/build/node_modules
+    runs: |
+      find . -type f \( \
+             -name '.*' -o \
+             -name '*.cmd' -o \
+             -name '*.bat' -o \
+             -name '*.map' -o \
+             -name '*.md' -o \
+             \( -name '*.ts' -a ! -name '*.d.ts' \) -o \
+             -name 'AUTHORS*' -o \
+             -name 'LICENSE*' -o \
+             -name 'license' -o \
+             -name 'Makefile' -o \
+             -name 'README*' -o \
+             -name 'readme.markdown' \) -delete
+
+      rm -rf ./*/.git* ./*/doc ./*/docs ./*/examples ./*/scripts ./*/test
+      rm -rf ./node-gyp/gyp/.git*
+
+      find . -type f -executable ! -name 'node-gyp*' -exec chmod -x {} \;
+
+  - working-directory: /home/build/man
+    runs: |
+      for f in man5/folders.5 man5/install.5 man7/*.7; do
+        sec=${f##*.}
+        name=$(basename $f .$sec)
+        title=$(echo "$name" | tr '[:lower:]' '[:upper:]')
+
+        sed -Ei "s/^\.TH \"$title\"/.TH \"NPM-$title\"/" "$f"
+        mv "$f" "${f%/*}/npm-$name.$sec"
+      done
+
+  - runs: |
+      destdir="${{targets.destdir}}"/usr/lib/node_modules/npm
+
+      mkdir -p $destdir
+      rsync -av --exclude melange-out /home/build/ "$destdir"
+
+  - working-directory: ${{targets.destdir}}/usr/bin
+    runs: |
+      ln -s ../lib/node_modules/npm/bin/npm-cli.js npm
+      ln -s ../lib/node_modules/npm/bin/npx-cli.js npx
+      ln -s ../lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js node-gyp
+
+  - working-directory: ${{targets.destdir}}/usr/share
+    runs: |
+      mv "${{targets.destdir}}"/usr/lib/node_modules/npm/man man
+      ln -s ../../../share/man "${{targets.destdir}}"/usr/lib/node_modules/npm/man
+
+subpackages:
+  - name: "npm-doc"
+    description: "npm documentation"
+    pipeline:
+      - uses: split/manpages
+
+update:
+  enabled: true
+  github:
+    identifier: npm/cli

--- a/npm/dont-check-for-last-version.patch
+++ b/npm/dont-check-for-last-version.patch
@@ -1,0 +1,17 @@
+Don't check for last version
+
+Patch based on https://sources.debian.org/src/npm/7.5.2+ds-2/debian/patches/dont-check-for-last-version.patch
+
+diff --git a/lib/utils/update-notifier.js b/lib/utils/update-notifier.js
+index 2c839bf..5616195 100644
+--- a/lib/utils/update-notifier.js
++++ b/lib/utils/update-notifier.js
+@@ -75,6 +75,8 @@ const updateCheck = async (npm, spec, version, current) => {
+ }
+ 
+ const updateNotifier = async (npm, spec = 'latest') => {
++  // XXX-Patched: Maintained by external package manager
++  return null;
+   // if we're on a prerelease train, then updates are coming fast
+   // check for a new one daily.  otherwise, weekly.
+   const { version } = npm

--- a/npm/npmrc
+++ b/npm/npmrc
@@ -1,0 +1,6 @@
+# Do not modify this file - use /etc/npmrc instead!
+
+globalconfig=/etc/npmrc
+globalignorefile=/etc/npmignore
+prefix=/usr/local
+python=/usr/bin/python3


### PR DESCRIPTION
* Convert `nodejs` into a proper version stream, e.g. `apk add nodejs~19`, will pick nodejs 19, and so on.
* Drop bundled `npm`, replace it with a common npm across all versions that reflects the latest release.
* Add `nodejs-lts` version stream which contains node 16 and 18 at the moment.