### PR TITLE
Remove CI dependency on apk scan script

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -88,17 +88,6 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      # Note: vulns found in scans do not currently block CI
-      - name: 'Grype scan APKs'
-        if: steps.file_check.outputs.exists == 'true'
-        run: |
-          set -x
-          for line in `cat packages.log`; do
-            # convert the melange output (e.g. "x86_64|grype|grype|0.63.0-r1" ) to an actual apk path
-            apk_path=$(echo "${line}" | awk '{ split($1, pkg, "|"); printf("packages/%s/%s-%s.apk\n", pkg[1], pkg[3], pkg[4]) }')
-            ./scripts/grype-scan-apk.sh "${apk_path}"
-          done
-
       - name: Check sonames
         if: steps.file_check.outputs.exists == 'true'
         run: |


### PR DESCRIPTION
Fixes an issue where CI was depending on the experimental vuln scan script that was removed in #4092 