### PR TITLE
build-{aarch64,armv7l,x86_64}.env: split preprocessor flags to CPPFLAGS

### DIFF
--- a/build-aarch64.env
+++ b/build-aarch64.env
@@ -1,6 +1,6 @@
 # Ampere Altra, the CPU used by most cloud providers, is Neoverse N1.
-export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
-export CPPFLAGS="$CFLAGS"
+export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1"
+export CPPFLAGS="-Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
 export GOFLAGS=""

--- a/build-armv7l.env
+++ b/build-armv7l.env
@@ -1,6 +1,6 @@
 # We target the BCM2836 which is Cortex-A7 with the SIMD unit.
-export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv7-a+simd -mtune=cortex-a7 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
-export CPPFLAGS="$CFLAGS"
+export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv7-a+simd -mtune=cortex-a7"
+export CPPFLAGS="-Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
 export GOFLAGS=""

--- a/build-x86_64.env
+++ b/build-x86_64.env
@@ -1,5 +1,5 @@
-export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
-export CPPFLAGS="$CFLAGS"
+export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell"
+export CPPFLAGS="-Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
 export GOFLAGS=""


### PR DESCRIPTION
This was causing glibc 2.38 vector math functions to miscompile on ARM, because the glibc build system -march selection was being overwritten by CPPFLAGS.