### PR TITLE
aws-ebs-csi-driver remove cve fix

### DIFF
--- a/aws-ebs-csi-driver.yaml
+++ b/aws-ebs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-ebs-csi-driver
   version: 1.21.0
-  epoch: 0
+  epoch: 1
   description: CSI driver for Amazon EBS.
   copyright:
     - license: Apache-2.0
@@ -26,8 +26,6 @@ pipeline:
   - runs: |
       # Our global LDFLAGS conflict with a Makefile parameter
       unset LDFLAGS
-      go mod edit -require k8s.io/kubernetes@v1.27.2
-      go mod tidy
       make ARCH=$(go env GOARCH)
       mkdir -p ${{targets.destdir}}/usr/bin
       cp bin/aws-ebs-csi-driver ${{targets.destdir}}/usr/bin/


### PR DESCRIPTION
remove cve patch as upstream addresses it here https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/v1.21.0/go.mod#L24