### PR TITLE
glibc: split libcrypt into its own subpackage

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.38
-  epoch: 0
+  epoch: 1
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later
@@ -464,6 +464,13 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/sbin
           mv "${{targets.destdir}}"/sbin/sln "${{targets.subpkgdir}}"/sbin
+
+  - name: "libcrypt1"
+    description: "Password hashing library included with glibc"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/lib
+          mv "${{targets.destdir}}"/lib/libcrypt.so* "${{targets.subpkgdir}}"/lib/
 
   - name: "glibc-locale-posix"
     description: "POSIX locale data for glibc"


### PR DESCRIPTION
This allows us to replace libcrypt with libxcrypt as part of validation testing of libxcrypt before we drop libcrypt entirely.

Related: #4104, #4112