### PR TITLE
add http-parser dev subpackage and root libs in /usr/lib

### DIFF
--- a/http-parser.yaml
+++ b/http-parser.yaml
@@ -1,7 +1,7 @@
 package:
   name: http-parser
   version: 2.9.4
-  epoch: 2
+  epoch: 3
   description: "Parser for HTTP Request/Response written in C"
   copyright:
     - license: MIT
@@ -27,9 +27,18 @@ pipeline:
   - name: Build
     runs: CC=gcc make library
 
-  - runs: CC=gcc DESTDIR=${{targets.destdir}} make install
+  - runs: CC=gcc DESTDIR=${{targets.destdir}} make install PREFIX="/usr"
 
   - uses: strip
+
+subpackages:
+  - name: "http-parser-dev"
+    description: "headers for http-parser"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - http-parser
 
 update:
   enabled: true

--- a/libgit2.yaml
+++ b/libgit2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgit2
   version: 1.7.0
-  epoch: 0
+  epoch: 1
   description: "A cross-platform, linkable library implementation of Git that you can use in your application."
   copyright:
     - license: GPL-2.0-only WITH GCC-exception-2.0
@@ -21,7 +21,7 @@ environment:
       - pkgconf
       - pcre2-dev
       - libssh2-dev
-      - http-parser
+      - http-parser-dev
 
 pipeline:
   - uses: fetch


### PR DESCRIPTION
split dev libs and ensure they're rooted in `/usr/lib` instead of the more annoying `/usr/local/lib`

also bump `libgit2` to use the new `-dev` package, which afaik is the only dependent pacakge.