### PR TITLE
add libgit2 static subpackage

### DIFF
--- a/libgit2.yaml
+++ b/libgit2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgit2
   version: 1.7.0
-  epoch: 1
+  epoch: 2
   description: "A cross-platform, linkable library implementation of Git that you can use in your application."
   copyright:
     - license: GPL-2.0-only WITH GCC-exception-2.0
@@ -31,7 +31,7 @@ pipeline:
 
   - name: Configure
     runs: |
-      CC=gcc CXX=g++ cmake -B build -G Ninja \
+      CC=gcc CXX=g++ cmake -B build-shared -G Ninja \
         -DCMAKE_BUILD_TYPE=None \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INSTALL_LIBDIR=lib \
@@ -41,11 +41,21 @@ pipeline:
         -DUSE_BUNDLED_ZLIB=OFF \
         -DUSE_SSH=ON \
         -DBUILD_TESTS=OFF
+      cmake --build build-shared
+      DESTDIR=${{targets.destdir}} cmake --install build-shared
 
-  - name: Build
-    runs: |
-      cmake --build build
-      DESTDIR=${{targets.destdir}} cmake --install build
+      CC=gcc CXX=g++ cmake -B build-static -G Ninja \
+        -DCMAKE_BUILD_TYPE=None \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DUSE_HTTPS=OpenSSL \
+        -DREGEX_BACKEND=pcre2 \
+        -DUSE_BUNDLED_ZLIB=OFF \
+        -DUSE_SSH=ON \
+        -DBUILD_TESTS=OFF \
+        -DBUILD_SHARED_LIBS=OFF
+      cmake --build build-static
+      DESTDIR=${{targets.destdir}} cmake --install build-static
 
 subpackages:
   - name: "libgit2-dev"
@@ -55,6 +65,11 @@ subpackages:
     dependencies:
       runtime:
         - libgit2
+
+  - name: "libgit2-static"
+    description: "libgit2 static library"
+    pipeline:
+      - uses: split/static
 
 update:
   enabled: true


### PR DESCRIPTION
adds a static build of `libgit2`, which is semi ripped from alpine: https://git.alpinelinux.org/aports/tree/community/libgit2/APKBUILD

this also removes the `system` dependency on `http_parser`, which does not have a static alternative. this seems to be commonplace amongst distros
