### PR TITLE
7zip: fix package download URI

### DIFF
--- a/7zip.yaml
+++ b/7zip.yaml
@@ -16,7 +16,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://7-zip.org/a/7z${{vars.mangled-package-version}}-src.tar.xz
+      uri: https://7-zip.org/a/7z${{package.version}}-src.tar.xz
       expected-sha512: 3f391b1bd65a0654eb5b31b50f1d400f0ec38ab191d88e15849a6e4d164b7bf2ce4a6d70ec8b6e27bde1b83bb2d45b65c03129499334669e05ee025784be455a
       strip-components: 0
 


### PR DESCRIPTION
In the previous PR I merged, I missed that `${{vars.package-mangled-version}}` was not appropriately replaced with `${{package.version}}` for 7zip.  That fixes this.