### PR TITLE
npm: fix permissions error when run in a nonroot environment

### DIFF
--- a/npm.yaml
+++ b/npm.yaml
@@ -1,7 +1,7 @@
 package:
   name: npm
   version: 9.8.1
-  epoch: 0
+  epoch: 1
   description: "the npm package manager for javascript, mainline"
   copyright:
     - license: Artistic-2.0
@@ -66,8 +66,9 @@ pipeline:
   - runs: |
       destdir="${{targets.destdir}}"/usr/lib/node_modules/npm
 
-      mkdir -p $destdir
+      install -dDm755 "$destdir"
       rsync -av --exclude melange-out /home/build/ "$destdir"
+      chmod 755 "$destdir"
 
   - working-directory: ${{targets.destdir}}/usr/bin
     runs: |


### PR DESCRIPTION
When the npm package is copied into place, `/usr/lib/node_modules/npm` was being chmod 700 by `rsync`.