### PR TITLE
bump openjdk-8 to jdk8u382-b05

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
-  version: 8.372.07
-  epoch: 3
+  version: 8.382.05
+  epoch: 0
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later
@@ -69,15 +69,15 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://icedtea.classpath.org/download/source/icedtea-3.27.0.tar.xz
-      expected-sha512: ee16aeb4f1564a1fb6132ed5165f925ca8edc8cef13b46291589ceaff42e8f9922f0834e4aba899da061e78ea48805e4ac5bba73a73d5389c05ba4efd1663812
+      uri: https://icedtea.classpath.org/download/source/icedtea-3.28.0.tar.xz
+      expected-sha512: 39c626b6e6ee0a73bc69f6a6e649c44cceb265f23f215631ef84dc232df840d5b2e5d8796c912c68c7fdfb4a885cce4a651cf314e0399f39059e551e54a34093
 
   - working-directory: /home/build/icedtea-drops
     pipeline:
       - uses: fetch
         with:
-          uri: https://icedtea.classpath.org/download/drops/icedtea8/3.27.0/openjdk-git.tar.xz
-          expected-sha512: 227fa26be948f4405e3d8c363a7d196b66aa0c00139c2c4cbfda28ba8d554b6f983765eb0499a63bcae3c6166d5fa51499a3558fc5efee35d1d9b14bc1075aa1
+          uri: https://icedtea.classpath.org/download/drops/icedtea8/3.28.0/openjdk-git.tar.xz
+          expected-sha512: 3613cbc7f21408cda599fd9fe2e01d3deee4b08d2bc446bb0ddabfec345ce1894b69031d51cb3fb7d60bdae13ad01fd6af63925c13718e0ea364fb49b1df7e2b
           extract: false
       - uses: fetch
         with:


### PR DESCRIPTION
Basic package tests 
```
[sdk] ❯ java -version
openjdk version "1.8.0_382"
OpenJDK Runtime Environment (IcedTea 3.28.0) (Wolfi 8.382.05-r0)
OpenJDK 64-Bit Server VM (build 25.382-b05, mixed mode)

```
```
[sdk] ❯ java HelloWorld 
Hello World!
```
