### PR TITLE
posix-cc-wrappers: new package

### DIFF
--- a/posix-cc-wrappers.yaml
+++ b/posix-cc-wrappers.yaml
@@ -1,0 +1,50 @@
+package:
+  name: posix-cc-wrappers
+  version: 1
+  epoch: 0
+  description: "Wrappers around GCC and Clang for POSIX conformance"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - working-directory: '${{targets.destdir}}/usr/bin'
+    pipeline:
+      - runs: |
+          ln -s gcc cc
+      - runs: |
+          cat >c89 <<'EOF'
+          #!/bin/sh
+          _flavor="-std=c89"
+          for opt; do
+            case "$opt" in
+            -ansi|-std=c89|-std=iso9899:1990) _flavor="";;
+            -std=*) echo "$(basename $0) called with non ANSI/ISO C option $opt" >&2
+                    exit 1;;
+            esac
+          done
+          exec cc $_flavor ${1+"$@"}
+          EOF
+      - runs: |
+          cat >c99 <<'EOF'
+          #!/bin/sh
+          _flavor="-std=c99"
+          for opt; do
+            case "$opt" in
+            -std=c99|-std=iso9899:1999) _flavor="";;
+            -std=*) echo "$(basename $0) called with non ISO C99 option $opt" >&2
+                    exit 1;;
+            esac
+          done
+          exec cc $_flavor ${1+"$@"}
+          EOF
+      - runs: |
+          chmod 755 c?9
+
+update:
+  enabled: false
+  manual: true


### PR DESCRIPTION
These are simple wrapper scripts which provide the c89 and c99 commands, which are required by POSIX.