### PR TITLE
gcc{-12}: use posix-cc-wrappers to manage the cc/c89/c99 aliases

### DIFF
--- a/build-aarch64.env
+++ b/build-aarch64.env
@@ -1,6 +1,6 @@
 # Ampere Altra, the CPU used by most cloud providers, is Neoverse N1.
 export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv8-a -mtune=neoverse-n1"
-export CPPFLAGS="-Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
+export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
 export GOFLAGS=""

--- a/build-armv7l.env
+++ b/build-armv7l.env
@@ -1,6 +1,6 @@
 # We target the BCM2836 which is Cortex-A7 with the SIMD unit.
 export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv7-a+simd -mtune=cortex-a7"
-export CPPFLAGS="-Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
+export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
 export GOFLAGS=""

--- a/build-x86_64.env
+++ b/build-x86_64.env
@@ -1,5 +1,5 @@
 export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell"
-export CPPFLAGS="-Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
+export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
 export GOFLAGS=""

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.3.0
-  epoch: 2
+  epoch: 3
   description: "the GNU compiler collection - version 12"
   copyright:
     - license: GPL-3.0-or-later
@@ -11,6 +11,7 @@ package:
     runtime:
       - binutils
       - libstdc++-12-dev
+      - posix-cc-wrappers
 
 environment:
   contents:

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 13.2.0
-  epoch: 0
+  epoch: 1
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later
@@ -9,6 +9,7 @@ package:
     runtime:
       - binutils
       - libstdc++-dev
+      - posix-cc-wrappers
 
 environment:
   contents:
@@ -79,9 +80,6 @@ pipeline:
 
   - runs: |
       chmod 755 ${{targets.destdir}}/usr/lib64/libgcc_s.*
-
-  - runs: |
-      ln -s gcc ${{targets.destdir}}/usr/bin/cc
 
   - name: 'Clean up documentation'
     runs: |


### PR DESCRIPTION
This allows for cc/c89/c99 to work regardless of whether GCC 12 or 13 are the default.