### PR TITLE
go-fips-{1.19,1.20}: pin to appropriate mainline go version to build

### DIFF
--- a/go-fips-1.19.yaml
+++ b/go-fips-1.19.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-fips-1.19
   version: 1.19.12
-  epoch: 0
+  epoch: 1
   description: "the Go programming language with OpenSSL cryptography"
   copyright:
     - license: BSD-3-Clause
@@ -23,10 +23,8 @@ environment:
       - build-base
       - bash
       - openssl-dev
-      # The first time this is built, it depends on go-stage0.yaml being built first,
-      # using pre-built go binaries, which `provides` a go package at an earlier version.
-      # Afterwards it depends on previous versions of this package built from source.
-      - go
+      # We always use the equivalent non-FIPS branch of Go to build this.
+      - go~1.19
 
 pipeline:
   - uses: fetch

--- a/go-fips-1.20.yaml
+++ b/go-fips-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-fips-1.20
   version: 1.20.7
-  epoch: 0
+  epoch: 1
   description: "the Go programming language with OpenSSL cryptography"
   copyright:
     - license: BSD-3-Clause
@@ -13,9 +13,6 @@ package:
       - bash
       - binutils-gold # Needed for cgo linking due to upstream issue #15696 which forces use of the gold linker.
       - openssl-dev # Needed for building against cryptographic packages.
-      # The first time this is built, it depends on go-stage0.yaml being built first,
-      # using pre-built go binaries, which `provides` a go package at an earlier version.
-      # Afterwards it depends on previous versions of this package built from source.
       - '!go-1.20'
 
 environment:
@@ -25,8 +22,9 @@ environment:
       - ca-certificates-bundle
       - build-base
       - bash
-      - go
       - openssl-dev
+      # We always use the equivalent non-FIPS branch of Go to build this.
+      - go~1.20
 
 pipeline:
   - uses: fetch


### PR DESCRIPTION
This locks the Go versions such that `go-fips-1.19` is built using the `go~1.19` version stream, and `go-fips-1.20` is built using the `go~1.20` version stream.