### PR TITLE
add xfsprogs and dependent inih

### DIFF
--- a/inih.yaml
+++ b/inih.yaml
@@ -1,0 +1,61 @@
+package:
+  name: inih
+  version: 57
+  epoch: 0
+  description: Simple .INI file parser for embedded systems
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - meson
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/benhoyt/inih
+      tag: r${{package.version}}
+      expected-commit: 9cecf0643da0846e77f64d10a126d9f48b9e05e8
+
+  - uses: meson/configure
+    with:
+      opts: |
+        -Ddefault_library=both \
+        -Ddistro_install=true \
+        -Dwith_INIReader=true \
+        -Dmulti-line_entries=true \
+        -Dutf-8_bom=true \
+        -Dinline_comments=true \
+        -Duse_heap=false
+
+  - uses: meson/compile
+
+  - uses: meson/install
+
+  - uses: strip
+
+subpackages:
+  - name: inih-dev
+    description: inih dev
+    dependencies:
+      runtime:
+        - inih
+    pipeline:
+      - uses: split/dev
+
+  - name: inih-static
+    description: inih static
+    pipeline:
+      - uses: split/static
+
+update:
+  enabled: true
+  github:
+    identifier: benhoyt/inih
+    strip-prefix: r
+    use-tag: true
+    tag-filter: r

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -1,0 +1,60 @@
+package:
+  name: xfsprogs
+  version: 6.4.0
+  epoch: 0
+  description: XFS filesystem utilities
+  copyright:
+    - license: LGPL-2.1-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - util-linux-dev
+      - attr-dev
+      - inih-dev
+      - linux-headers
+      - userspace-rcu-dev
+      - userspace-rcu-static
+      - gettext-dev
+      - file
+      - readline-dev
+      - libtool
+      - bash
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://mirrors.edge.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-${{package.version}}.tar.xz
+      expected-sha512: 831e7747640bc2964b182226d8bb6f637610b123aeec9b3cb97a5de5d5b65bde30c6b40ad2e78de6a5214e823dd75de3a2bdfddd8ab1638f5c7340a760c91b3f
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --sbindir=/usr/sbin \
+        --enable-gettext=no
+
+  - uses: autoconf/make
+
+  - runs: |
+      make DIST_ROOT="${{targets.destdir}}" PKG_ROOT_SBIN_DIR="/usr/sbin" PKG_ROOT_LIB_DIR="/usr/lib64" install install-dev
+
+      find ${{targets.destdir}} -name '*.la' -print -exec rm \{} \;
+
+      chown -R root:root "${{targets.destdir}}"/*
+
+  - uses: strip
+
+subpackages:
+  - name: xfsprogs-dev
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5188


### PR DESCRIPTION
adds `xfsprogs` and `inih`

both of which are likely required by `aws-ebs-csi-driver` for resizing capabilities