### PR TITLE
add blockdev util-linux bin

### DIFF
--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -67,6 +67,7 @@ data:
     items:
       agetty: agetty program from util-linux
       blkid: Block device identification tool from util-linux
+      blockdev: Call block device ioctls from the command line
       cfdisk: Curses based partition table manipulator from util-linux
       findmnt: Find mount from util-linux
       flock: File locker from util-linux


### PR DESCRIPTION
adds `blockdev`, most likely required by `aws-ebs-csi-driver`