### PR TITLE
Switch consul to leverage version streams

### DIFF
--- a/consul-1.16.yaml
+++ b/consul-1.16.yaml
@@ -1,11 +1,14 @@
 package:
-  name: consul
+  name: consul-1.16
   version: 1.16.0
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
-  epoch: 1
+  epoch: 2
   description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
   copyright:
     - license: MPL-2.0
+  dependencies:
+    provides:
+      - consul=1.16
 
 environment:
   contents:
@@ -45,10 +48,12 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv consul/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/"
+          mv ${{package.name}}/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/"
     dependencies:
+      provides:
+        - consul-oci-entrypoint=1.16
       runtime:
-        - consul
+        - consul-1.16
         - busybox
         - dumb-init
         - su-exec
@@ -60,11 +65,14 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
           ln -s /usr/bin/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/local/bin/"
     dependencies:
+      provides:
+        - consul-oci-entrypoint-compat=1.16
       runtime:
-        - consul-oci-entrypoint
+        - consul-1.16-oci-entrypoint
 
 update:
   enabled: true
   github:
     identifier: hashicorp/consul
     strip-prefix: v
+    tag-filter: v1.16.

--- a/consul-1.16.yaml
+++ b/consul-1.16.yaml
@@ -2,13 +2,13 @@ package:
   name: consul-1.16
   version: 1.16.0
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
-  epoch: 2
+  epoch: 0
   description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
   copyright:
     - license: MPL-2.0
   dependencies:
     provides:
-      - consul=1.16
+      - consul=1.16.999 # This is because we had a 1.16.0 consul package, remove in 1.17+
 
 environment:
   contents:


### PR DESCRIPTION
This change is largely `s/consul/consul-1.16/` which enables us to track `1.16` directly, but also more easily other versions (1.14 and 1.15 are also both currently supported upstream).