### PR TITLE
add missing runtime deps to ebs-csi-driver

### DIFF
--- a/aws-ebs-csi-driver.yaml
+++ b/aws-ebs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-ebs-csi-driver
   version: 1.21.0
-  epoch: 2
+  epoch: 3
   description: CSI driver for Amazon EBS.
   copyright:
     - license: Apache-2.0
@@ -10,6 +10,8 @@ package:
       - mount
       - lsblk
       - blkid
+      - blockdev
+      - xfsprogs
       - e2fsprogs
       - e2fsprogs-extra
 


### PR DESCRIPTION
Tested with https://github.com/chainguard-images/images/pull/1175