### PR TITLE
clean up xfsprogs into relevant subpackages

### DIFF
--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -1,7 +1,7 @@
 package:
   name: xfsprogs
   version: 6.4.0
-  epoch: 0
+  epoch: 1
   description: XFS filesystem utilities
   copyright:
     - license: LGPL-2.1-or-later
@@ -51,8 +51,35 @@ pipeline:
 
 subpackages:
   - name: xfsprogs-dev
+    description: "headers for xfsprogs"
     pipeline:
       - uses: split/dev
+
+  - name: xfsprogs-libs
+    description: "libraries for xfsprogs"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
+          mv "${{targets.destdir}}"/usr/lib64/lib*.so.* "${{targets.subpkgdir}}"/usr/lib64
+
+  - name: xfsprogs-doc
+    description: "xfsprogs manpages"
+    pipeline:
+      - uses: split/manpages
+
+  - name: xfs-scrub
+    description: "xfs-scrub attempts to check and repair all metadata in a mounted XFS filesystem"
+    dependencies:
+      runtime:
+        - xfsprogs
+        - python3
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/xfsprogs
+          mv "${{targets.destdir}}"/usr/lib/xfsprogs/xfs_scrub* "${{targets.subpkgdir}}"/usr/lib/xfsprogs/
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/sbin
+          mv "${{targets.destdir}}"/usr/sbin/xfs_scrub* "${{targets.subpkgdir}}"/usr/sbin/
 
 update:
   enabled: true


### PR DESCRIPTION
most things just need the `xfsprogs` bins, this just cleans things up and reduces the overall package size a bit