### PR TITLE
gitlab: add `gitlab-runner`, `gitlab-runner-helper` and `glab` packages

### DIFF
--- a/gitlab-runner.yaml
+++ b/gitlab-runner.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitlab-runner
   version: 16.2.0
-  epoch: 1
+  epoch: 0
   description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
   copyright:
     - license: MIT

--- a/gitlab-runner.yaml
+++ b/gitlab-runner.yaml
@@ -1,0 +1,86 @@
+package:
+  name: gitlab-runner
+  version: 16.2.0
+  epoch: 1
+  description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+  environment:
+    CGO_ENABLED: "1"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-runner
+      tag: v${{package.version}}
+      expected-commit: 782e15dae28e70213e21b29f2fed257d2cf2998c
+
+  # - uses: go/build
+  #   with:
+  #     packages: .
+  #     output: gitlab-runner
+  #     # TODO marshall: there are a few more: https://gitlab.com/gitlab-org/gitlab-runner/-/blob/v16.2.0/Makefile?ref_type=tags#L33-36
+  #     ldflags: -s -w -X gitlab.com/gitlab-org/gitlab-runner/common.NAME=${{package.name}} -X gitlab.com/gitlab-org/gitlab-runner/common.VERSION=v${{package.version}}
+
+subpackages:
+  - name: gitlab-runner-fips
+    description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
+    dependencies:
+      provides:
+        - gitlab-runner
+      runtime:
+        - libcrypto3
+    pipeline:
+      - uses: go-fips/build
+        with:
+          packages: .
+          output: gitlab-runner-fips
+          strict: true
+          ldflags: -s -w -X gitlab.com/gitlab-org/gitlab-runner/common.NAME=${{package.name}} -X gitlab.com/gitlab-org/gitlab-runner/common.VERSION=v${{package.version}}
+      
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/gitlab-runner-fips "${{targets.subpkgdir}}"/usr/bin/gitlab-runner
+
+  # - name: gitlab-runner-helper
+  #   description: GitLab Runner Helper
+  #   pipeline:
+  #     - uses: go/build
+  #       with:
+  #         packages: ./apps/gitlab-runner-helper
+  #         output: gitlab-runner-helper
+  #         ldflags: -s -w -X gitlab.com/gitlab-org/gitlab-runner/common.NAME=${{package.name}} -X gitlab.com/gitlab-org/gitlab-runner/common.VERSION=v${{package.version}}
+
+  #     - runs: |
+  #         mkdir -p "${{targets.subpkgdir}}"/usr/bin
+  #         mv "${{targets.destdir}}"/usr/bin/gitlab-runner-helper "${{targets.subpkgdir}}"/usr/bin
+  
+  - name: gitlab-runner-helper-fips
+    description: GitLab Runner Helper
+    dependencies:
+      provides:
+        - gitlab-runner-helper
+      runtime:
+        - libcrypto3
+    pipeline:
+      - uses: go-fips/build
+        with:
+          packages: ./apps/gitlab-runner-helper
+          output: gitlab-runner-helper-fips
+          strict: true
+          ldflags: -s -w -X gitlab.com/gitlab-org/gitlab-runner/common.NAME=${{package.name}} -X gitlab.com/gitlab-org/gitlab-runner/common.VERSION=v${{package.version}}
+
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/gitlab-runner-helper-fips "${{targets.subpkgdir}}"/usr/bin/gitlab-runner-helper
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11337

--- a/gitlab-runner.yaml
+++ b/gitlab-runner.yaml
@@ -11,8 +11,6 @@ environment:
     packages:
       - ca-certificates-bundle
       - busybox
-  environment:
-    CGO_ENABLED: "1"
 
 pipeline:
   - uses: git-checkout
@@ -21,64 +19,24 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 782e15dae28e70213e21b29f2fed257d2cf2998c
 
-  # - uses: go/build
-  #   with:
-  #     packages: .
-  #     output: gitlab-runner
-  #     # TODO marshall: there are a few more: https://gitlab.com/gitlab-org/gitlab-runner/-/blob/v16.2.0/Makefile?ref_type=tags#L33-36
-  #     ldflags: -s -w -X gitlab.com/gitlab-org/gitlab-runner/common.NAME=${{package.name}} -X gitlab.com/gitlab-org/gitlab-runner/common.VERSION=v${{package.version}}
+  - uses: go/build
+    with:
+      packages: .
+      output: gitlab-runner
+      ldflags: -s -w -X gitlab.com/gitlab-org/gitlab-runner/common.NAME=${{package.name}} -X gitlab.com/gitlab-org/gitlab-runner/common.VERSION=v${{package.version}}
 
 subpackages:
-  - name: gitlab-runner-fips
-    description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
-    dependencies:
-      provides:
-        - gitlab-runner
-      runtime:
-        - libcrypto3
-    pipeline:
-      - uses: go-fips/build
-        with:
-          packages: .
-          output: gitlab-runner-fips
-          strict: true
-          ldflags: -s -w -X gitlab.com/gitlab-org/gitlab-runner/common.NAME=${{package.name}} -X gitlab.com/gitlab-org/gitlab-runner/common.VERSION=v${{package.version}}
-      
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/gitlab-runner-fips "${{targets.subpkgdir}}"/usr/bin/gitlab-runner
-
-  # - name: gitlab-runner-helper
-  #   description: GitLab Runner Helper
-  #   pipeline:
-  #     - uses: go/build
-  #       with:
-  #         packages: ./apps/gitlab-runner-helper
-  #         output: gitlab-runner-helper
-  #         ldflags: -s -w -X gitlab.com/gitlab-org/gitlab-runner/common.NAME=${{package.name}} -X gitlab.com/gitlab-org/gitlab-runner/common.VERSION=v${{package.version}}
-
-  #     - runs: |
-  #         mkdir -p "${{targets.subpkgdir}}"/usr/bin
-  #         mv "${{targets.destdir}}"/usr/bin/gitlab-runner-helper "${{targets.subpkgdir}}"/usr/bin
-  
-  - name: gitlab-runner-helper-fips
+  - name: gitlab-runner-helper
     description: GitLab Runner Helper
-    dependencies:
-      provides:
-        - gitlab-runner-helper
-      runtime:
-        - libcrypto3
     pipeline:
-      - uses: go-fips/build
+      - uses: go/build
         with:
           packages: ./apps/gitlab-runner-helper
-          output: gitlab-runner-helper-fips
-          strict: true
+          output: gitlab-runner-helper
           ldflags: -s -w -X gitlab.com/gitlab-org/gitlab-runner/common.NAME=${{package.name}} -X gitlab.com/gitlab-org/gitlab-runner/common.VERSION=v${{package.version}}
-
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/gitlab-runner-helper-fips "${{targets.subpkgdir}}"/usr/bin/gitlab-runner-helper
+          mv "${{targets.destdir}}"/usr/bin/gitlab-runner-helper "${{targets.subpkgdir}}"/usr/bin
 
 update:
   enabled: true

--- a/glab.yaml
+++ b/glab.yaml
@@ -1,7 +1,7 @@
 package:
   name: glab
   version: 1.31.0
-  epoch: 1
+  epoch: 0
   description: A GitLab CLI tool bringing GitLab to your command line
   copyright:
     - license: MIT

--- a/glab.yaml
+++ b/glab.yaml
@@ -11,9 +11,6 @@ environment:
     packages:
       - ca-certificates-bundle
       - busybox
-      - go
-  environment:
-    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout

--- a/glab.yaml
+++ b/glab.yaml
@@ -1,0 +1,34 @@
+package:
+  name: glab
+  version: 1.31.0
+  epoch: 1
+  description: A GitLab CLI tool bringing GitLab to your command line
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/cli
+      tag: v${{package.version}}
+      expected-commit: 1f8464b403a4611ef689a89893cb700718abdb20
+
+  - uses: go/build
+    with:
+      packages: ./cmd/glab
+      output: glab
+      ldflags: -s -w -X main.version=v${{package.version}}
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 127208

--- a/pipelines/go-fips/build.yaml
+++ b/pipelines/go-fips/build.yaml
@@ -59,12 +59,6 @@ inputs:
     description: |
       space separated list of go modules to update before building. example: github.com/foo/bar@v1.2.3
 
-  strict:
-    description: |
-      If true, compiles with `GOEXPERIMENT=strictfipsruntime` which adds runtime checks
-      ensuring FIPS mode is enabled and the OpenSSL backend is available.
-    default: "false"
-
 pipeline:
   - runs: |
       TAGS=""
@@ -72,14 +66,6 @@ pipeline:
 
       if [ ! "${{inputs.tags}}" == "" ]; then
         TAGS="${{inputs.tags}}"
-      fi
-
-      if [ "${{inputs.strict}}" == "true" ]; then
-        if [ ! "${TAGS}" == "" ]; then
-          TAGS="${TAGS},goexperiment.strictfipsruntime"
-        else
-          TAGS="goexperiment.strictfipsruntime"
-        fi
       fi
 
       if [ ! "${{inputs.ldflags}}" == "" ]; then

--- a/pipelines/go-fips/build.yaml
+++ b/pipelines/go-fips/build.yaml
@@ -59,6 +59,12 @@ inputs:
     description: |
       space separated list of go modules to update before building. example: github.com/foo/bar@v1.2.3
 
+  strict:
+    description: |
+      If true, compiles with `GOEXPERIMENT=strictfipsruntime` which adds runtime checks
+      ensuring FIPS mode is enabled and the OpenSSL backend is available.
+    default: "false"
+
 pipeline:
   - runs: |
       TAGS=""
@@ -66,6 +72,14 @@ pipeline:
 
       if [ ! "${{inputs.tags}}" == "" ]; then
         TAGS="${{inputs.tags}}"
+      fi
+
+      if [ "${{inputs.strict}}" == "true" ]; then
+        if [ ! "${TAGS}" == "" ]; then
+          TAGS="${TAGS},goexperiment.strictfipsruntime"
+        else
+          TAGS="goexperiment.strictfipsruntime"
+        fi
       fi
 
       if [ ! "${{inputs.ldflags}}" == "" ]; then


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

For reference these packages are currently available in Alpine as a community package: https://pkgs.alpinelinux.org/packages?name=gitlab-runner

It is also available officially from these repos: https://docs.gitlab.com/runner/install/linux-repository.html

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
