### PR TITLE
Add consul-1.15 version stream

### DIFF
--- a/consul-1.15.yaml
+++ b/consul-1.15.yaml
@@ -1,0 +1,78 @@
+package:
+  name: consul-1.15
+  version: 1.15.3
+  # When bumping the version check if the CVE/GHSA mitigations below can be removed.
+  epoch: 0
+  description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
+  copyright:
+    - license: MPL-2.0
+  dependencies:
+    provides:
+      - consul=1.15.999 # This is because we had a 1.15.0 consul package, remove in 1.17+
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hashicorp/consul
+      tag: v${{package.version}}
+      expected-commit: 7ce982ce1846ca14e567a91fa7f088084e736155
+      destination: ${{package.name}}
+
+  - working-directory: ${{package.name}}
+    pipeline:
+      - runs: |
+          # Mitigate GHSA-8cfg-vx93-jvxw
+          go get k8s.io/client-go@v0.20.1
+
+          # Mitigate GHSA-ch7v-37xg-75ph
+          go get github.com/coredns/coredns@v1.10.1
+
+          go mod tidy
+          make linux
+      - runs: |
+          mkdir -p ${{targets.destdir}}/bin
+
+          # The docker-entrypoint.sh expects the binary to be in /bin so put it there
+          mv ./pkg/bin/linux_*/consul ${{targets.destdir}}/bin/consul
+      - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-oci-entrypoint
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{package.name}}/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/"
+    dependencies:
+      provides:
+        - consul-oci-entrypoint=1.15
+      runtime:
+        - consul-1.15
+        - busybox
+        - dumb-init
+        - su-exec
+        - libcap-utils
+
+  - name: ${{package.name}}-oci-entrypoint-compat
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
+          ln -s /usr/bin/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/local/bin/"
+    dependencies:
+      provides:
+        - consul-oci-entrypoint-compat=1.15
+      runtime:
+        - consul-1.15-oci-entrypoint
+
+update:
+  enabled: true
+  github:
+    identifier: hashicorp/consul
+    strip-prefix: v
+    tag-filter: v1.15.


### PR DESCRIPTION
I mirrored the exact commit info where we last built things as `consul` prior to picking up `1.16`, so this should be identical.

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
