### PR TITLE
Bump zig and switch it to llvm 16.

### DIFF
--- a/zig.yaml
+++ b/zig.yaml
@@ -1,6 +1,6 @@
 package:
   name: zig
-  version: 0.10.1
+  version: 0.11.0
   epoch: 0
   description: "General-purpose programming language designed for robustness, optimality, and maintainability"
   copyright:
@@ -12,12 +12,12 @@ environment:
       - wolfi-base
       - busybox
       - cmake
-      - clang-15
-      - clang-15-dev
+      - clang-16
+      - clang-16-dev
       - build-base
       - libstdc++
-      - llvm15
-      - llvm15-dev
+      - llvm16
+      - llvm16-dev
       - llvm-lld
       - libxml2-dev
       - llvm-lld-dev
@@ -28,17 +28,20 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/ziglang/zig/archive/${{package.version}}.tar.gz
-      expected-sha256: b511709d5276eca9bd706924d7928c7477fe799ad62d5d37f5f90d7dceadfa2a
+      expected-sha256: 71de3e958293dffaa17f7ad1438c775389f5406991c96b533bb1501178092b02
 
   - runs: |
-      cmake -B build -G Ninja \
+      export LDFLAGS="$LDFLAGS,--copy-dt-needed-entries"
+      CC=clang CXX=clang LD=llvm-lld cmake -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_PREFIX_PATH=/usr \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DZIG_VERSION="${{package.version}}" \
         -DZIG_SHARED_LLVM=ON
-      cmake --build build
+
+      # Limit builds to one core because it uses a lot of memory
+      cmake --build build -j$(nproc)
 
       # Workaround for missing zig binary in the build dir.
       DESTDIR="build/.dest" cmake --install build
@@ -48,10 +51,6 @@ pipeline:
 
       cd ..
       DESTDIR="${{targets.destdir}}" cmake --install build
-
-      mkdir -p ${{targets.destdir}}/usr/share/doc/${{package.name}}
-      install -Dm644 zig-cache/langref.html \
-        ${{targets.destdir}}/usr/share/doc/${{package.name}}/langref.html
 
   - uses: strip
 


### PR DESCRIPTION


Fixes: https://github.com/wolfi-dev/os/pull/4182

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
