### PR TITLE
llvm15: modernize, split llvm tools symlinks and cmake defaults into subpackages

### DIFF
--- a/llvm15.yaml
+++ b/llvm15.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm15
   version: 15.0.7
-  epoch: 1
+  epoch: 3
   description: "low-level virtual machine - core frameworks"
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,13 @@ environment:
       - libxml2-dev
       - pkgconf
       - python3
+      - llvm-cmake-15
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
 
 pipeline:
   - uses: fetch
@@ -28,22 +35,13 @@ pipeline:
       uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/llvm-${{package.version}}.src.tar.xz
       expected-sha256: 4ad8b2cc8003c86d0078d15d987d84e3a739f24aae9033865c027abae93ee7a4
 
-  - uses: fetch
-    with:
-      uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/cmake-${{package.version}}.src.tar.xz
-      expected-sha256: 8986f29b634fdaa9862eedda78513969fe9788301c9f2d938f4c10a3e7a3e7ea
-      strip-components: 0
-
-  - runs: |
-      mv cmake-${{package.version}}.src cmake-src
-
   - runs: |
       ffi_include_dir="$(pkg-config --cflags-only-I libffi | sed 's|^-I||g')"
 
       cmake -B build -G Ninja -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm15 \
-        -DCMAKE_MODULE_PATH=/home/build/cmake-src/Modules \
+        -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm${{vars.major-version}} \
+        -DCMAKE_MODULE_PATH=/usr/lib/llvm${{vars.major-version}}/share/cmake/Modules \
         -DFFI_INCLUDE_DIR="${ffi_include_dir}" \
         -DLLVM_BINUTILS_INCDIR=/usr/include \
         -DLLVM_BUILD_DOCS=OFF \
@@ -51,7 +49,7 @@ pipeline:
         -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON \
         -DLLVM_BUILD_LLVM_DYLIB=ON \
         -DLLVM_BUILD_TESTS=OFF \
-        -DLLVM_DEFAULT_TARGET_TRIPLE="$(uname -m)-unknown-linux-gnu" \
+        -DLLVM_DEFAULT_TARGET_TRIPLE="${{host.triplet.gnu}}" \
         -DLLVM_ENABLE_ASSERTIONS=OFF \
         -DLLVM_ENABLE_FFI=ON \
         -DLLVM_ENABLE_LIBCXX=OFF \
@@ -61,7 +59,7 @@ pipeline:
         -DLLVM_ENABLE_TERMINFO=ON \
         -DLLVM_ENABLE_ZLIB=ON \
         -DLLVM_INSTALL_UTILS=ON \
-        -DLLVM_HOST_TRIPLE="$(uname -m)-unknown-linux-gnu" \
+        -DLLVM_HOST_TRIPLE="${{host.triplet.gnu}}" \
         -DLLVM_INCLUDE_EXAMPLES=OFF \
         -DLLVM_LINK_LLVM_DYLIB=ON \
         -DLLVM_APPEND_VC_REV=OFF \
@@ -76,35 +74,21 @@ pipeline:
   - runs: |
       DESTDIR="${{targets.destdir}}" cmake --install build
 
-  - runs: |
-      mkdir -p "${{targets.destdir}}"/usr/bin
+  - working-directory: ${{targets.destdir}}/usr/lib/llvm${{vars.major-version}}
+    pipeline:
+      - runs: |
+          for path in "${{targets.destdir}}"/usr/lib/llvm${{vars.major-version}}/lib/*.a; do
+            name=${path##*/}
+            ln -s ../lib/llvm15/lib/$name "${{targets.destdir}}"/usr/lib/$name
+          done
 
-      for path in "${{targets.destdir}}"/usr/lib/llvm15/bin/*; do
-        name=${path##*/}
-        ln -s ../lib/llvm15/bin/$name "${{targets.destdir}}"/usr/bin/$name
-      done
-
-  - runs: |
-      cd "${{targets.destdir}}"/usr/lib/llvm15
-
-      mkdir -p "${{targets.destdir}}"/usr/lib/
-      for path in "${{targets.destdir}}"/usr/lib/llvm15/lib/*.a; do
-        name=${path##*/}
-        ln -s ../lib/llvm15/lib/$name "${{targets.destdir}}"/usr/lib/$name
-      done
-
-      mkdir -p "${{targets.destdir}}"/usr/lib/
-      for path in "${{targets.destdir}}"/usr/lib/llvm15/lib/*.so*; do
-        name=${path##*/}
-        ln -s ../lib/llvm15/lib/$name "${{targets.destdir}}"/usr/lib/$name
-      done
-
-  - runs: |
-      cd "${{targets.destdir}}"/usr/lib/llvm15
-
-      mkdir -p "${{targets.destdir}}"/usr/lib/cmake
-      mv lib/cmake/llvm "${{targets.destdir}}"/usr/lib/cmake/llvm15
-      ln -s llvm15 "${{targets.destdir}}"/usr/lib/cmake/llvm
+          for path in "${{targets.destdir}}"/usr/lib/llvm${{vars.major-version}}/lib/*.so*; do
+            name=${path##*/}
+            ln -s ../lib/llvm15/lib/$name "${{targets.destdir}}"/usr/lib/$name
+          done
+      - runs: |
+          mkdir -p "${{targets.destdir}}"/usr/lib/cmake
+          mv lib/cmake/llvm "${{targets.destdir}}"/usr/lib/cmake/llvm${{vars.major-version}}
 
   - uses: strip
 
@@ -150,6 +134,29 @@ subpackages:
     dependencies:
       runtime:
         - libLLVM-15
+
+  - name: "llvm15-tools"
+    description: "LLVM 15 tools in /usr/bin"
+    dependencies:
+      provides:
+        - llvm-tools=15
+    pipeline:
+      - working-directory: ${{targets.subpkgdir}}/usr/bin
+        runs: |
+          for path in "${{targets.destdir}}"/usr/lib/llvm${{vars.major-version}}/bin/*; do
+            name=${path##*/}
+            ln -s ../lib/llvm15/bin/$name $name
+          done
+
+  - name: "llvm15-cmake-default"
+    description: "LLVM 15 CMake module definitions in /usr/lib/cmake"
+    dependencies:
+      provides:
+        - llvm-cmake-default=15
+    pipeline:
+      - working-directory: ${{targets.subpkgdir}}/usr/lib/cmake
+        runs: |
+          ln -s llvm${{vars.major-version}} llvm
 
 update:
   enabled: true


### PR DESCRIPTION
This allows LLVM 15 and 16 SDKs to be installed side by side like OpenJDK.