### PR TITLE
llvm15: move tools subpackage before dev subpackage

### DIFF
--- a/llvm15.yaml
+++ b/llvm15.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm15
   version: 15.0.7
-  epoch: 3
+  epoch: 4
   description: "low-level virtual machine - core frameworks"
   copyright:
     - license: Apache-2.0
@@ -114,6 +114,19 @@ subpackages:
           rm -f "${{targets.destdir}}"/usr/lib/$soname
           rm -f "${{targets.destdir}}"/usr/lib/$sonamefull
 
+  - name: "llvm15-tools"
+    description: "LLVM 15 tools in /usr/bin"
+    dependencies:
+      provides:
+        - llvm-tools=15
+    pipeline:
+      - working-directory: ${{targets.subpkgdir}}/usr/bin
+        runs: |
+          for path in "${{targets.destdir}}"/usr/lib/llvm${{vars.major-version}}/bin/*; do
+            name=${path##*/}
+            ln -s ../lib/llvm15/bin/$name $name
+          done
+
   - name: "llvm15-dev"
     description: "headers for llvm15"
     pipeline:
@@ -134,19 +147,6 @@ subpackages:
     dependencies:
       runtime:
         - libLLVM-15
-
-  - name: "llvm15-tools"
-    description: "LLVM 15 tools in /usr/bin"
-    dependencies:
-      provides:
-        - llvm-tools=15
-    pipeline:
-      - working-directory: ${{targets.subpkgdir}}/usr/bin
-        runs: |
-          for path in "${{targets.destdir}}"/usr/lib/llvm${{vars.major-version}}/bin/*; do
-            name=${path##*/}
-            ln -s ../lib/llvm15/bin/$name $name
-          done
 
   - name: "llvm15-cmake-default"
     description: "LLVM 15 CMake module definitions in /usr/lib/cmake"


### PR DESCRIPTION
Otherwise a /usr/bin/llvm-config symlink wont be created, which is needed by the LLVM build system for whatever reason (despite being given a direct path to llvm-config).