### PR TITLE
clang-15: chase LLVM 15 changes

### DIFF
--- a/clang-15.yaml
+++ b/clang-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-15
   version: 15.0.7
-  epoch: 0
+  epoch: 1
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,16 @@ environment:
       - help2man
       - llvm15
       - llvm15-dev
+      - llvm-cmake-15
       - libLLVM-15
+      - llvm15-cmake-default
+      - llvm15-tools
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
 
 pipeline:
   - uses: fetch
@@ -41,15 +50,6 @@ pipeline:
       expected-sha256: 809a2ef46d46be3b83ca389356404ac041fa6d8f5496cb02ec35d252afb64fd1
       strip-components: 0
 
-  - uses: fetch
-    with:
-      uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/cmake-${{package.version}}.src.tar.xz
-      expected-sha256: 8986f29b634fdaa9862eedda78513969fe9788301c9f2d938f4c10a3e7a3e7ea
-      strip-components: 0
-
-  - runs: |
-      mv cmake-${{package.version}}.src ../cmake
-
   - runs: |
       mv clang-tools-extra-${{package.version}}.src tools/extra
 
@@ -59,8 +59,9 @@ pipeline:
       cmake -B build -G Ninja -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_MODULE_PATH=/usr/lib/llvm${{vars.major-version}}/share/cmake/Modules \
         -DCLANG_BUILT_STANDALONE=TRUE \
-        -DLLVM_CONFIG=/usr/lib/llvm15/bin/llvm-config \
+        -DLLVM_CONFIG=/usr/lib/llvm${{vars.major-version}}/bin/llvm-config \
         -DCLANG_ENABLE_ARCMT=ON \
         -DCLANG_ENABLE_STATIC_ANALYZER=ON \
         -DCLANG_INCLUDE_TESTS=OFF \
@@ -83,7 +84,7 @@ pipeline:
         --name "Wolfi Clang ${{package.version}}-r${{package.epoch}}" \
         --version-string "${{package.version}}-r${{package.epoch}}" \
         --help-option "--help-hidden" \
-        ./build/bin/clang > clang.1
+        ./build/bin/clang > clang-${{vars.major-version}}.1
 
   - runs: |
       DESTDIR="${{targets.destdir}}" cmake --install build
@@ -95,7 +96,7 @@ pipeline:
          "${{targets.destdir}}"/usr/share/clang/clang-doc-default-stylesheet.css \
          "${{targets.destdir}}"/usr/share/clang/index.js
 
-      install -Dm644 clang.1 -t "${{targets.destdir}}"/usr/share/man/man1/
+      install -Dm644 clang-${{vars.major-version}}.1 -t "${{targets.destdir}}"/usr/share/man/man1/
 
       mkdir -p "${{targets.destdir}}"/usr/share/bash-completion/completions
       mv "${{targets.destdir}}"/usr//share/clang/bash-autocomplete.sh \
@@ -170,8 +171,12 @@ subpackages:
           mv "${{targets.destdir}}"/usr/bin/clang-format* "${{targets.subpkgdir}}"/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/clang-include-fixer* "${{targets.subpkgdir}}"/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/clang-move* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-linker-wrapper* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-nvlink-wrapper* "${{targets.subpkgdir}}"/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/clang-offload-bundler* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-offload-packager* "${{targets.subpkgdir}}"/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/clang-offload-wrapper* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-pseudo* "${{targets.subpkgdir}}"/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/clang-query* "${{targets.subpkgdir}}"/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/clang-refactor* "${{targets.subpkgdir}}"/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/clang-rename* "${{targets.subpkgdir}}"/usr/bin/
@@ -196,6 +201,20 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/clang/run-find-all-symbols.py "${{targets.subpkgdir}}"/usr/share/clang/
 
           mv "${{targets.destdir}}"/usr/share/emacs "${{targets.subpkgdir}}"/usr/share/
+
+  - name: "clang-15-default"
+    description: "Clang 15 default symlinks"
+    dependencies:
+      runtime:
+        - clang-15
+      provides:
+        - clang=15
+    pipeline:
+      - working-directory: ${{targets.subpkgdir}}"/usr/bin
+        runs: |
+          for i in clang clang++ clang-cl clang-cpp; do
+            mv "${{targets.destdir}}"/usr/bin/$i $i
+          done
 
   - name: "py3-clang"
     description: "Clang 15 Python bindings"


### PR DESCRIPTION
- Set up `clang` version stream, providing `clang~15`.
- Depend on `llvm15-tools` because `llvm-config` is needed on `/usr/bin`.