### PR TITLE
envoy: add llvm15-tools to get llvm-config at /usr/bin

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -26,6 +26,8 @@ environment:
       - llvm15
       - llvm15-dev
       - llvm-lld-15
+      - llvm15-tools
+      - llvm15-cmake-default
       - coreutils
       - patch
       # We need to stick to gcc 12 for now, envoy doesn't build with gcc >= 13


### PR DESCRIPTION
This may not be necessary in the long run, but lets get envoy green again first.
