### PR TITLE
rust: use proper llvm-config path

### DIFF
--- a/rust.yaml
+++ b/rust.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust
   version: 1.71.1
-  epoch: 0
+  epoch: 1
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
@@ -59,7 +59,7 @@ pipeline:
         --enable-local-rust \
         --local-rust-root="/usr" \
         --llvm-root="/usr/lib/llvm15" \
-        --llvm-config="/usr/bin/llvm-config" \
+        --llvm-config="/usr/lib/llvm15/bin/llvm-config" \
         --disable-docs \
         --enable-extended \
         --tools="cargo,src" \


### PR DESCRIPTION
Update llvm-config path to use the one in the LLVM root, so that system-wide LLVM symlinks do not need to be installed.