### PR TITLE
Add semgrep, py3-semgrep and dependencies

### DIFF
--- a/py3-boltons.yaml
+++ b/py3-boltons.yaml
@@ -1,0 +1,45 @@
+package:
+  name: py3-boltons
+  version: 23.0.0
+  epoch: 0
+  description: "When they're not builtins, they're boltons."
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-setuptools
+      - py3-gpep517
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/mahmoud/boltons
+      tag: ${{package.version}}
+      expected-commit: 2adf15c735396b10e5050072babba0c319766726
+
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/boltons-${{package.version}}-*.whl
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: mahmoud/boltons

--- a/py3-bracex.yaml
+++ b/py3-bracex.yaml
@@ -1,0 +1,50 @@
+package:
+  name: py3-bracex
+  version: 2.3
+  epoch: 0
+  description: "Bash style brace expander."
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-gpep517
+      - py3-pip
+      - py3-setuptools
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/facelessuser/bracex
+      tag: ${{package.version}}
+      expected-commit: 8edd0c52847188fb116a6fb507d8d359c3cabd93
+
+  - runs: |
+      # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
+      export SOURCE_DATE_EPOCH=315532800
+      python3 -m pip install -U hatchling
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/bracex-${{package.version}}-*.whl
+      install -Dm644 LICENSE.md \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: facelessuser/bracex
+    strip-suffix: .post1

--- a/py3-click-option-group.yaml
+++ b/py3-click-option-group.yaml
@@ -1,0 +1,47 @@
+package:
+  name: py3-click-option-group
+  version: 0.5.6
+  epoch: 0
+  description: "Option groups missing in Click."
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - python3
+      - py3-click
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - python3
+      - py3-gpep517
+      - py3-setuptools
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/click-contrib/click-option-group
+      tag: v${{package.version}}
+      expected-commit: 515950e26672c347922dbe3c7b2cc8ac0bd33856
+
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/click_option_group-${{package.version}}-*.whl
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: click-contrib/click-option-group
+    strip-prefix: v

--- a/py3-defusedxml.yaml
+++ b/py3-defusedxml.yaml
@@ -1,0 +1,46 @@
+package:
+  name: py3-defusedxml
+  version: 0.7.1
+  epoch: 0
+  description: "XML bomb protection for Python stdlib modules"
+  copyright:
+    - license: PSF-2.0
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-setuptools
+      - py3-gpep517
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tiran/defusedxml
+      tag: v${{package.version}}
+      expected-commit: ebff1b493751e2f0775314bdd4188d64f07ea184
+
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/defusedxml-${{package.version}}-*.whl
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: tiran/defusedxml
+    strip-prefix: v

--- a/py3-face.yaml
+++ b/py3-face.yaml
@@ -1,0 +1,45 @@
+package:
+  name: py3-face
+  version: 22.0.0
+  epoch: 0
+  description: "A command-line application framework (and CLI parser). Friendly for users, full-featured for developers."
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - python3
+      - py3-boltons
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-gpep517
+      - py3-setuptools
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/mahmoud/face
+      tag: v${{package.version}}
+      expected-commit: 6c8b1070312683cca0ed723f1cb99a7307f5ee91
+
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/face-${{package.version}}-*.whl
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: mahmoud/face
+    strip-prefix: v

--- a/py3-glom.yaml
+++ b/py3-glom.yaml
@@ -1,0 +1,45 @@
+package:
+  name: py3-glom
+  version: 23.3.0
+  epoch: 0
+  description: "Python's nested data operator (and CLI), for all your declarative restructuring needs. Got data? Glom it!"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - python3
+      - py3-attrs
+      - py3-boltons
+      - py3-face
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-gpep517
+      - py3-setuptools
+      - py3-wheel
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://files.pythonhosted.org/packages/source/g/glom/glom-${{package.version}}.tar.gz
+      expected-sha256: 031699280fa4666048e43d2eab68be1044ffcd487ab74acb792de2eeb0bc2515
+
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/glom-${{package.version}}-*.whl
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 120576

--- a/py3-jsonschema-specifications.yaml
+++ b/py3-jsonschema-specifications.yaml
@@ -1,0 +1,49 @@
+package:
+  name: py3-jsonschema-specifications
+  version: 2023.07.1
+  epoch: 0
+  description: "Cross-specification JSON referencing (JSON Schema, OpenAPI, and the one you just made up!)."
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+      - py3-referencing
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-gpep517
+      - py3-pip
+      - py3-setuptools
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/python-jsonschema/jsonschema-specifications
+      tag: v${{package.version}}
+      expected-commit: c22c205e6bc2f93bebf42eefebafc49f96766bce
+
+  - runs: |
+      # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
+      export SOURCE_DATE_EPOCH=315532800
+      python3 -m pip install -U hatchling hatch-vcs
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/jsonschema_specifications-*.whl
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: python-jsonschema/jsonschema-specifications
+    strip-prefix: v

--- a/py3-jsonschema.yaml
+++ b/py3-jsonschema.yaml
@@ -1,0 +1,51 @@
+package:
+  name: py3-jsonschema
+  version: 4.19.0
+  epoch: 0
+  description: "Python Classes Without Boilerplate."
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+      - py3-attrs
+      - py3-jsonschema-specifications
+      - py3-referencing
+      - py3-rpds-py
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-gpep517
+      - py3-pip
+      - py3-setuptools
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/python-jsonschema/jsonschema
+      tag: v${{package.version}}
+      expected-commit: 2f5ff0b14c9ec317a64aef02898f7c44e81ec607
+
+  - runs: |
+      # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
+      export SOURCE_DATE_EPOCH=315532800
+      python3 -m pip install -U hatchling hatch-vcs hatch-fancy-pypi-readme
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/jsonschema-${{package.version}}-py3-none-any.whl
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3898

--- a/py3-markdown-it-py.yaml
+++ b/py3-markdown-it-py.yaml
@@ -1,0 +1,50 @@
+package:
+  name: py3-markdown-it-py
+  version: 3.0.0
+  epoch: 0
+  description: "Python port of markdown-it. Markdown parsing, done right!"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+      - py3-mdurl
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-flit-core
+      - py3-gpep517
+      - py3-setuptools
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/executablebooks/markdown-it-py
+      tag: v${{package.version}}
+      expected-commit: bee6d1953be75717a3f2f6a917da6f464bed421d
+
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/markdown_it_py-${{package.version}}-*.whl
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+      install -Dm644 LICENSE.markdown-it \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE.markdown-it
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: executablebooks/markdown-it-py
+    strip-prefix: v

--- a/py3-mdurl.yaml
+++ b/py3-mdurl.yaml
@@ -1,0 +1,46 @@
+package:
+  name: py3-mdurl
+  version: 0.1.2
+  epoch: 0
+  description: "Markdown URL utilities"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-flit-core
+      - py3-gpep517
+      - py3-setuptools
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/executablebooks/mdurl
+      tag: ${{package.version}}
+      expected-commit: 596bf1c8752de45fa576a52c315d6d8cc5bb1a4e
+
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/mdurl-${{package.version}}-*.whl
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: executablebooks/mdurl

--- a/py3-peewee.yaml
+++ b/py3-peewee.yaml
@@ -1,0 +1,45 @@
+package:
+  name: py3-peewee
+  version: 3.16.3
+  epoch: 0
+  description: "a little orm"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-setuptools
+      - py3-gpep517
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/coleifer/peewee
+      tag: ${{package.version}}
+      expected-commit: 0d82aa9cf11327584d15a3892a7a435b50a00f9d
+
+  - runs: |
+      NO_SQLITE=1 python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/peewee-${{package.version}}-*.whl
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: coleifer/peewee

--- a/py3-python-lsp-jsonrpc.yaml
+++ b/py3-python-lsp-jsonrpc.yaml
@@ -1,0 +1,48 @@
+package:
+  name: py3-python-lsp-jsonrpc
+  version: 1.0.0
+  epoch: 0
+  description: "JSON RPC 2.0 server library"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+      - py3-ujson
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - python3
+      - py3-gpep517
+      - py3-setuptools
+      - py3-setuptools-scm
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/python-lsp/python-lsp-jsonrpc
+      tag: v${{package.version}}
+      expected-commit: af196bbbd46a87a5de74c7da40a9e59367727ba4
+
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/python_lsp_jsonrpc-${{package.version}}-*.whl
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: python-lsp/python-lsp-jsonrpc
+    strip-prefix: v

--- a/py3-referencing.yaml
+++ b/py3-referencing.yaml
@@ -1,0 +1,50 @@
+package:
+  name: py3-referencing
+  version: 0.30.2
+  epoch: 0
+  description: "Cross-specification JSON referencing (JSON Schema, OpenAPI, and the one you just made up!)."
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+      - py3-attrs
+      - py3-rpds-py
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-gpep517
+      - py3-pip
+      - py3-setuptools
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/python-jsonschema/referencing
+      tag: v${{package.version}}
+      expected-commit: d37bef22e48b7b91a10dce14904755a539bf15e1
+
+  - runs: |
+      # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
+      export SOURCE_DATE_EPOCH=315532800
+      python3 -m pip install -U hatchling hatch-vcs
+      git submodule update --init
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/referencing-${{package.version}}-*.whl
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 304263

--- a/py3-rich.yaml
+++ b/py3-rich.yaml
@@ -1,0 +1,49 @@
+package:
+  name: py3-rich
+  version: 13.5.2
+  epoch: 0
+  description: "Rich is a Python library for rich text and beautiful formatting in the terminal."
+  copyright:
+    - license: LGPL-2.1
+  dependencies:
+    runtime:
+      - python3
+      - py3-pygments
+      - py3-markdown-it-py
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-gpep517
+      - py3-setuptools
+      - py3-pip
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Textualize/rich
+      tag: v${{package.version}}
+      expected-commit: 720800e6930d85ad027b1e9bd0cbb96b5e994ce3
+
+  - runs: |
+      export SETUPTOOLS_SCM_PRETEND_VERSION=${{package.version}}
+      python3 -m pip install -U poetry
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer -d "${{targets.destdir}}" \
+        dist/*.whl
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: Textualize/rich
+    strip-prefix: v

--- a/py3-rpds-py.yaml
+++ b/py3-rpds-py.yaml
@@ -1,0 +1,49 @@
+package:
+  name: py3-rpds-py
+  version: 0.9.2
+  epoch: 0
+  description: "Python bindings to Rust's persistent data structures (rpds)."
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - python3
+      - py3-gpep517
+      - py3-pip
+      - py3-setuptools
+      - py3-wheel
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/crate-py/rpds
+      tag: v${{package.version}}
+      expected-commit: d7b5670ec9f53f3a9a93e99668450c2b489df772
+
+  - runs: |
+      python3 -m pip install -U maturin
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/rpds_py-${{package.version}}-*.whl
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 330423

--- a/py3-ruamel-yaml-clib.yaml
+++ b/py3-ruamel-yaml-clib.yaml
@@ -1,0 +1,46 @@
+package:
+  name: py3-ruamel-yaml-clib
+  version: 0.2.7
+  epoch: 0
+  description: "C version of reader, parser and emitter for ruamel.yaml derived from libyaml."
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - ca-certificates-bundle
+      - busybox
+      - build-base
+      - python3
+      - python3-dev
+      - py3-setuptools
+      - py3-gpep517
+      - py3-wheel
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://files.pythonhosted.org/packages/source/r/ruamel.yaml.clib/ruamel.yaml.clib-${{package.version}}.tar.gz
+      expected-sha256: 1f08fd5a2bea9c4180db71678e850b995d2a5f4537be0e94557668cf0f5f9497
+
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/ruamel.yaml.clib-${{package.version}}-*.whl
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 131030

--- a/py3-semgrep.yaml
+++ b/py3-semgrep.yaml
@@ -1,0 +1,62 @@
+package:
+  name: py3-semgrep
+  version: 1.36.0
+  epoch: 0
+  description: "Lightweight static analysis for many languages. Find bug variants with patterns that look like source code."
+  copyright:
+    - license: LGPL-2.1
+  dependencies:
+    runtime:
+      - python3
+      - py3-boltons
+      - py3-click
+      - py3-click-option-group
+      - py3-colorama
+      - py3-glom
+      - py3-defusedxml
+      - py3-attrs
+      - py3-jsonschema
+      - py3-packaging
+      - py3-peewee
+      - py3-python-lsp-jsonrpc
+      - py3-requests
+      - py3-rich
+      - py3-ruamel-yaml
+      - py3-tomli
+      - py3-typing-extensions
+      - py3-wcmatch
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-gpep517
+      - py3-wheel
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/returntocorp/semgrep
+      tag: v${{package.version}}
+      expected-commit: 52543b77abc9cb2ca5122aa2e71593318a368e19
+
+  - runs: |
+      cd cli
+      git submodule update --init -- src/semgrep/semgrep_interfaces
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer -d "${{targets.destdir}}" \
+        dist/*.whl
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: returntocorp/semgrep
+    strip-prefix: v

--- a/py3-ujson.yaml
+++ b/py3-ujson.yaml
@@ -1,0 +1,48 @@
+package:
+  name: py3-ujson
+  version: 5.8.0
+  epoch: 0
+  description: "Ultra fast JSON decoder and encoder written in C with Python bindings."
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python3
+      - python3-dev
+      - py3-gpep517
+      - py3-setuptools
+      - py3-setuptools-scm
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ultrajson/ultrajson
+      tag: ${{package.version}}
+      expected-commit: 7ce19144fdcff1068e253f3cb9b6343a464a65c7
+
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/ujson-${{package.version}}-*.whl
+      install -Dm644 LICENSE.txt \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: ultrajson/ultrajson

--- a/py3-wcmatch.yaml
+++ b/py3-wcmatch.yaml
@@ -1,0 +1,50 @@
+package:
+  name: py3-wcmatch
+  version: 8.4.1
+  epoch: 0
+  description: "Wilcard File Name matching library."
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+      - py3-bracex
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - python3
+      - py3-gpep517
+      - py3-pip
+      - py3-setuptools
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/facelessuser/wcmatch
+      tag: ${{package.version}}
+      expected-commit: d8f283502e0e00a8592cd087d3c1c0d87d1f028a
+
+  - runs: |
+      # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
+      export SOURCE_DATE_EPOCH=315532800
+      python3 -m pip install -U hatchling
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/wcmatch-${{package.version}}-*.whl
+      install -Dm644 LICENSE.md \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: facelessuser/wcmatch

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1,0 +1,60 @@
+package:
+  name: semgrep
+  version: 1.36.0
+  epoch: 0
+  description: "Lightweight static analysis for many languages. Find bug variants with patterns that look like source code."
+  copyright:
+    - license: LGPL-2.1
+  dependencies:
+    runtime:
+      - python3
+      - py3-semgrep
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - ocaml
+      - opam
+      - autoconf
+      - posix-libc-utils # ldd
+      - patch # needed for 'opam init'
+      - curl # needed for opam, it tries to use wget with missing flags instead.
+      - bubblewrap # build errors without it but bubblewrap throws a warning that it's not working anyway
+      - python3 # used in make install
+      - py3-pip # used in make install
+      - pcre-dev # linked against
+      - gmp-dev # linked against
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/returntocorp/semgrep
+      tag: v${{package.version}}
+      expected-commit: 52543b77abc9cb2ca5122aa2e71593318a368e19
+
+  - runs: |
+      opam init --compiler=ocaml-base-compiler.4.14.0 -y
+      opam switch create 4.14.0+static ocaml-base-compiler.4.14.0
+      eval $(opam env --switch=4.14.0+static)
+      make dev-setup
+      make core
+      make core-install
+
+  - runs: |
+      install -Dm755 _build/default/src/main/Main.exe \
+        "${{targets.destdir}}"/usr/bin/osemgrep
+      ln -sf /usr/bin/osemgrep "${{targets.destdir}}"/usr/bin/semgrep-core
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: semgrep/semgrep
+    strip-prefix: v


### PR DESCRIPTION
First pass at building semgrep, pysemgrep and all the dependencies.

`wolfictl scan`:
![2023-08-07_18-32](https://github.com/wolfi-dev/os/assets/68455785/b550fe5e-8929-4226-a783-8d35d3b90c8e)

semgrep-cli dependency graph:
 ![semgrep-deps](https://github.com/wolfi-dev/os/assets/68455785/2579352c-e36f-4e68-9214-2b8990c72fde)

Dependencies:

* py3-attrs
* py3-boltons
* py3-bracex
* py3-click-option-group
* py3-defusedxml
* py3-face
* py3-glom
* py3-idna
* py3-jsonschema
* py3-jsonschema-specifications
* py3-markdown-it-py
* py3-mdurl
* py3-peewee
* py3-python-lsp-jsonrpc
* py3-referencing
* py3-requests
* py3-rich
* py3-rpds
* py3-ruamel.yaml
* py3-ruamel.yaml.clib
* py3-ujson
* py3-wcmatch

Fixes:
Fixes #797 
https://github.com/wolfi-dev/os/issues/797

Related:

### Pre-review Checklist

#### For new package PRs only
- [x] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
