### PR TITLE
Add kubernetes-csi-node-driver-registrar-compat

### DIFF
--- a/kubernetes-csi-node-driver-registrar.yaml
+++ b/kubernetes-csi-node-driver-registrar.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-node-driver-registrar
   version: 2.8.0
-  epoch: 3
+  epoch: 4
   description: Sidecar container that registers a CSI driver with the kubelet using the kubelet plugin registration mechanism.
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,15 @@ pipeline:
       output: csi-node-driver-registrar
 
   - uses: strip
+
+subpackages:
+  - name: kubernetes-csi-node-driver-registrar-compat
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          # The helm chart expects the binaries to be in / instead of /usr/bin
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/csi-node-driver-registrar ${{targets.subpkgdir}}/csi-node-driver-registrar
 
 update:
   enabled: true


### PR DESCRIPTION
This fixes an issue with helm charts that hardcode the path of the binary to be in / instead of in /usr/bin.
