### PR TITLE
kafka: install more compat scripts

### DIFF
--- a/kafka.yaml
+++ b/kafka.yaml
@@ -2,7 +2,7 @@ package:
   name: kafka
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.5.1
-  epoch: 0
+  epoch: 1
   description:
   target-architecture:
     - all
@@ -57,20 +57,23 @@ subpackages:
           set -ex
 
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/scripts/kafka
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/scripts/java
 
           commit=4798c28a6b00e6edd83379bb19032eaa5b9c603d
           git clone https://github.com/bitnami/containers /tmp/bitnami && cd /tmp/bitnami
           git checkout ${commit}
 
-          for script in kafka/entrypoint.sh kafka/run.sh libkafka.sh kafka-env.sh; do
-            install -Dm755 ./bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/${script} \
-                "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script}
-          done
+          install -Dm755 ./bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/java/*.sh \
+              "${{targets.subpkgdir}}"/opt/bitnami/scripts/java/
 
-          for script in libfs.sh libvalidations.sh liblog.sh libbitnami.sh libos.sh; do
-            install -Dm755 ./bitnami/kafka/3.5/debian-11/prebuildfs/opt/bitnami/scripts/${script} \
-                "${{targets.subpkgdir}}"/opt/bitnami/scripts/${script}
-          done
+          install -Dm755 ./bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/kafka/*.sh \
+              "${{targets.subpkgdir}}"/opt/bitnami/scripts/kafka/
+
+          install -Dm755 ./bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/*.sh \
+              "${{targets.subpkgdir}}"/opt/bitnami/scripts/
+
+          install -Dm755 ./bitnami/kafka/3.5/debian-11/prebuildfs/opt/bitnami/scripts/*.sh \
+              "${{targets.subpkgdir}}"/opt/bitnami/scripts/
 
 update:
   enabled: true


### PR DESCRIPTION
Without this change, the entrypoint script calls `libfile.sh` which we didn't copy over.

Instead of trying to be smart and decide exactly which files to bring in, just bring them all in.