### PR TITLE
add required dependent packages to aws-efs-csi-driver

### DIFF
--- a/aws-efs-csi-driver.yaml
+++ b/aws-efs-csi-driver.yaml
@@ -1,10 +1,19 @@
 package:
   name: aws-efs-csi-driver
   version: 1.5.9
-  epoch: 0
+  epoch: 1
   description: CSI driver for Amazon EFS.
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - py3-botocore # required for cross account mount: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/Dockerfile#L52
+      # Ref: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/Dockerfile#L61-L78
+      - efs-utils # pull in nfs-utils & busybox
+      - mount
+      - umount
+      - openssl
+      - tcpdump
 
 environment:
   contents:
@@ -27,9 +36,12 @@ pipeline:
       # Our global LDFLAGS conflict with a Makefile parameter
       unset LDFLAGS
       make ARCH=$(go env GOARCH)
-      mkdir -p ${{targets.destdir}}/usr/bin
+      install -Dm755 bin/aws-efs-csi-driver ${{targets.destdir}}/usr/bin/aws-efs-csi-driver
+
       mkdir -p ${{targets.destdir}}/etc/amazon/efs
-      cp bin/aws-efs-csi-driver ${{targets.destdir}}/usr/bin/
+      cp THIRD-PARTY ${{targets.destdir}}/
+      # Ref: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/Dockerfile#L86
+      mkdir -p ${{targets.destdir}}/etc/amazon/efs-static-files
 
 update:
   enabled: true

--- a/efs-utils.yaml
+++ b/efs-utils.yaml
@@ -1,0 +1,63 @@
+package:
+  name: efs-utils
+  version: 1.35.0
+  epoch: 0
+  description: Utilities for Amazon Elastic File System (EFS)
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      # Ref: https://github.com/aws/efs-utils/blob/master/amazon-efs-utils.spec#L49-L58
+      - nfs-utils
+      - openssl
+      - util-linux
+      - busybox
+      - stunnel
+      - systemd
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-baselayout
+      - busybox
+      - make
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/aws/efs-utils
+      tag: v${{package.version}}
+      expected-commit: 550df10cfbcb8c89ef65a7021a5a2168e4dbf787
+
+  # This looks a little funny, but it aims to be easier to maintain, so we just
+  # copy from the upstream `build-deb.sh` script the bits we need.
+  # Ref: https://github.com/aws/efs-utils/blob/master/build-deb.sh
+  - runs: |
+      export BUILD_ROOT="${{targets.destdir}}"
+      mkdir -p ${BUILD_ROOT}
+
+      echo 'Creating application directories'
+      mkdir -p ${BUILD_ROOT}/etc/amazon/efs
+      mkdir -p ${BUILD_ROOT}/etc/init/
+      mkdir -p ${BUILD_ROOT}/etc/systemd/system
+      mkdir -p ${BUILD_ROOT}/sbin
+      mkdir -p ${BUILD_ROOT}/usr/bin
+      mkdir -p ${BUILD_ROOT}/var/log/amazon/efs
+      mkdir -p ${BUILD_ROOT}/usr/share/man/man8
+
+      echo 'Copying application files'
+      install -p -m 644 dist/amazon-efs-mount-watchdog.conf ${BUILD_ROOT}/etc/init
+      install -p -m 644 dist/amazon-efs-mount-watchdog.service ${BUILD_ROOT}/etc/systemd/system
+      install -p -m 444 dist/efs-utils.crt ${BUILD_ROOT}/etc/amazon/efs
+      install -p -m 644 dist/efs-utils.conf ${BUILD_ROOT}/etc/amazon/efs
+      install -p -m 755 src/mount_efs/__init__.py ${BUILD_ROOT}/sbin/mount.efs
+      install -p -m 755 src/watchdog/__init__.py ${BUILD_ROOT}/usr/bin/amazon-efs-mount-watchdog
+
+update:
+  enabled: true
+  github:
+    identifier: aws/efs-utils
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v

--- a/nfs-utils.yaml
+++ b/nfs-utils.yaml
@@ -1,0 +1,83 @@
+package:
+  name: nfs-utils
+  version: 2.6.3
+  epoch: 0
+  description: kernel-mode NFS
+  copyright:
+    - license: GPL-2.0-only
+  dependencies:
+    runtime:
+      - python3
+      - busybox
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - util-linux-dev
+      - libcap-dev
+      - libevent-dev
+      - libtirpc-dev
+      - libtool
+      - libseccomp-dev
+      - lvm2-dev
+      - openldap-dev
+      - sqlite-dev
+      - keyutils-dev
+      - pkgconf-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://www.kernel.org/pub/linux/utils/nfs-utils/${{package.version}}/nfs-utils-${{package.version}}.tar.xz
+      expected-sha512: 6f22f3a0564501ce4dc747ca278aae0e76801093f6857996281f300438a92659c3f380943d2515fca54769389bf1ee964aa0ff0af10b3dc4ee512dc8554e457d
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --without-tcp-wrappers \
+        --with-rpcgen=internal \
+        --enable-ipv6 \
+        --enable-nfsv4 \
+        --enable-uuid \
+        --enable-gss \
+        --enable-svcgss \
+        --enable-libmount-mount
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-dev
+    description: "headers for ${{package.name}}"
+    pipeline:
+      - uses: split/dev
+
+  - name: ${{package.name}}-static
+    description: "${{package.name}} static library"
+    pipeline:
+      - uses: split/static
+
+  - name: ${{package.name}}-doc
+    description: "${{package.name}} manpages"
+    pipeline:
+      - uses: split/manpages
+
+  - name: ${{package.name}}-db
+    description: "${{package.name}} debug symbols"
+    pipeline:
+      - uses: split/debug
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2081

--- a/stunnel.yaml
+++ b/stunnel.yaml
@@ -1,0 +1,54 @@
+package:
+  name: stunnel
+  version: 5.70
+  epoch: 0
+  description: SSL encryption wrapper between network client and server
+  copyright:
+    - license: GPL-2.0-or-later with OpenSSL exception
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - openssl-dev
+      - linux-headers
+      - python3
+
+# transform melange version x.y => x
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d+)\.\d+
+    replace: $1
+    to: mangled-package-version
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://www.stunnel.org/archive/${{vars.mangled-package-version}}.x/stunnel-${{package.version}}.tar.gz
+      expected-sha512: f3fd1c248561d300932ebf64988f4de6596be898bbfe8f370566d9fd9eafef294704f85ed9699410377d7f1c4c27f8ba0edbaabccca87fac7d5a40ac90a3b837
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --enable-ipv6
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-doc
+    description: "${{package.name}} manpages"
+    pipeline:
+      - uses: split/manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 4901


### PR DESCRIPTION
we were missing `efs-utils` and all the dependent packages/runtimes that requires.

this setup gets us to successfully boot and provision/claim volumes