### PR TITLE
fix underlinking of librdkafka

### DIFF
--- a/librdkafka.yaml
+++ b/librdkafka.yaml
@@ -1,7 +1,7 @@
 package:
   name: librdkafka
   version: 2.2.0
-  epoch: 1
+  epoch: 2
   description: "The Apache Kafka C/C++ library"
   copyright:
     - license: BSD-2-Clause
@@ -36,7 +36,7 @@ pipeline:
       -DCMAKE_INSTALL_LIBDIR=/usr/lib \
       -DCMAKE_BUILD_TYPE=RelWithDebinfo \
       -DRDKAFKA_BUILD_EXAMPLES=OFF \
-      -DRDKAFKA_BUILD_TESTS="$(want_check && echo ON || echo OFF)"
+      -DRDKAFKA_BUILD_TESTS="OFF"
       cmake --build build
 
   - runs: |
@@ -48,12 +48,6 @@ subpackages:
   - name: librdkafka-dev
     pipeline:
       - uses: split/dev
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib
-          mv "${{targets.destdir}}"/usr/lib/*.so* "${{targets.subpkgdir}}"/usr/lib/
-    dependencies:
-      runtime:
-        - librdkafka
     description: librdkafka dev
 
 update:

--- a/librdkafka.yaml
+++ b/librdkafka.yaml
@@ -1,7 +1,7 @@
 package:
   name: librdkafka
   version: 2.2.0
-  epoch: 0
+  epoch: 1
   description: "The Apache Kafka C/C++ library"
   copyright:
     - license: BSD-2-Clause

--- a/lz4.yaml
+++ b/lz4.yaml
@@ -1,7 +1,7 @@
 package:
   name: lz4
   version: 1.9.4
-  epoch: 2
+  epoch: 3
   description: "lossless high performance compression algorithm"
   copyright:
     - license: BSD-2-Clause AND GPL-2.0-only
@@ -34,6 +34,11 @@ subpackages:
     pipeline:
       - uses: split/manpages
       - uses: split/infodir
+
+  - name: "lz4-static"
+    description: "lz4 static library"
+    pipeline:
+      - uses: split/static
 
   - name: "lz4-dev"
     description: "lz4 development headers"


### PR DESCRIPTION
On x86_64, CMake was preferring the liblz4.a static library rather than liblz4.so.  Solve this by moving the static library to its own dedicated subpackage.