### PR TITLE
add single workflow for multiarch HEAD build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,176 @@
+name: Build Wolfi OS
+
+on:
+  # TODO: Enable this when we're ready to go live
+  # push:
+  #   branches: ['main']
+  #   paths-ignore:
+  #     - README.md
+
+  workflow_dispatch:
+
+# Only run one build at a time to prevent out of sync signatures
+concurrency:
+  group: build-${{ github.ref }}
+
+jobs:
+  build:
+    name: Build packages
+    if: github.repository == 'wolfi-dev/os'
+
+    strategy:
+      matrix:
+        arch: [ "x86_64", "aarch64" ]
+      fail-fast: false
+
+    runs-on: 
+      - self-hosted
+      - ${{ matrix.arch }}
+
+    # Ensure this is deprivileged, isolated job
+    # permissions:
+
+    container:
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:a360a3c166c64398edfaa08916950ccf80e1ee4b774b5a26a53145fccb8fb7a6
+      # TODO: Deprivilege
+      options: |
+        --cap-add NET_ADMIN --cap-add SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor:unconfined
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: 'Trust the github workspace'
+        run: |
+          # This is to avoid fatal errors about "dubious ownership" because we are
+          # running inside of a container action with the workspace mounted in.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      # Build with a local key, we'll resign this with the real key later
+      - name: 'Generate local signing key'
+        run: |
+          make MELANGE="melange" local-melange.rsa
+
+      - name: 'Prepare package repository'
+        run: |
+          mkdir -p "${{ github.workspace }}/packages"
+          cp /etc/apk/keys/wolfi-signing.rsa.pub ${{ github.workspace }}/packages/wolfi-signing.rsa.pub
+
+      # Use a gcsfuse RO mount set up by the self-hosted runner. This prevents
+      # needing to exchange tokens and avoids storing keys (even ephemeral
+      # ones) on the self hosted runner. The gcsfuse mount is set up with RO
+      # via workload identity federation.
+      # TODO: Replace this with wolfictl build
+      - name: 'Build Wolfi'
+        run: |
+          make MELANGE="melange" \
+            KEY=wolfi-signing.rsa \
+            ARCH=${{ matrix.arch }} \
+            MELANGE_EXTRA_OPTS="--repository-append=/gcsfuse/wolfi-registry" \
+            package/$package -j1
+
+      - name: 'Normalize repository permissions'
+        run: |
+          sudo chown -R $(id -u):$(id -g) "${{ github.workspace }}/packages"
+
+      - name: 'Archive built packages to Github Artifacts'
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages-${{ matrix.arch }}
+          path: ./packages/
+          retention-days: 1 # Low ttl since this is just an intermediary used once
+
+  upload:
+    runs-on: ubuntu-latest
+    needs: build
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: auth
+        name: 'Authenticate to Google Cloud'
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
+          service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
+
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: prod-images-c6e5
+
+      - uses: chainguard-dev/actions/setup-melange@main
+
+      - name: 'Sync public package repository'
+        run: |
+          mkdir -p "${{ github.workspace }}/packages/"
+          gsutil -m rsync -r gs://wolfi-production-registry-destination/os/ "${{ github.workspace }}/packages/"
+          find "${{ github.workspace }}/packages" -print -exec touch \{} \;
+
+      - name: 'Download x86_64 package archives'
+        uses: actions/download-artifacts@v3
+        with:
+          path: ./built-packages-x86_64
+          name: packages-x86_64
+
+      - name: 'Download aarch64 package archives'
+        uses: actions/download-artifacts@v3
+        with:
+          path: ./built-packages-aarch64
+          name: packages-aarch64
+
+      - run: echo "${{ secrets.MELANGE_RSA }}" > ./wolfi-signing.rsa
+      - run: |
+          sudo mkdir -p /etc/apk/keys
+          sudo cp ./wolfi-signing.rsa.pub /etc/apk/keys/wolfi-signing.rsa.pub
+
+      - name: 'Update the APKINDEX'
+        run: |
+          for arch in "x86_64" "aarch64"; do
+            # Consolidate the built artifacts
+            cp -r ./built-packages-${arch}/* ./packages/
+
+            # Rebuild the APKINDEX from the built packages and current packages
+            melange index -o "packages/${arch}/APKINDEX.tar.gz" "packages/${arch}/*.apk"
+
+            # Sign the indexes
+            melange sign-index --signing-key ./wolfi-signing.rsa "packages/${arch}/APKINDEX.tar.gz"
+          done
+
+      # TODO: Enable this when we're ready to go live
+      # - name: 'Upload the repository to the bucket'
+      #   run: |
+      #     cp /etc/apk/keys/wolfi-signing.rsa.pub ${{ github.workspace }}/packages/wolfi-signing.rsa.pub
+      #
+      #     for arch in "x86_64" "aarch64"; do
+      #       # Don't cache the APKINDEX.
+      #       gcloud --quiet storage cp \
+      #           --cache-control=no-store \
+      #           "${{ github.workspace }}/packages/${arch}/APKINDEX.tar.gz" "gs://wolfi-production-registry-destination/os/${arch}/"
+      #
+      #     gcloud --quiet storage cp \
+      #         --cache-control=no-store \
+      #         "${{ github.workspace }}/packages/${arch}/APKINDEX.json" "gs://wolfi-production-registry-destination/os/${arch}/"
+      #
+      #     # apks will be cached in CDN for an hour by default.
+      #     # Don't upload the object if it already exists.
+      #     gcloud --quiet storage cp \
+      #         --no-clobber \
+      #         "${{ github.workspace }}/packages/${arch}/*.apk" "gs://wolfi-production-registry-destination/os/${arch}/"
+      #     done
+
+  # TODO: Enable this when we're ready to go live
+  # postrun:
+  #   name: Build Wolfi OS
+  #   runs-on: ubuntu-latest
+  #   if: failure()
+  #   steps:
+  #     - uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
+  #       id: slack
+  #       with:
+  #         payload: '{"text": "[build-wolfi-os] failure: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
+  #       env:
+  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Use a single workflow for building multiarch with our self hosted runners.

This intentionally isolates the `build` and `upload` step into 2 jobs that run on different workers.

**`build`**

- runs on our self hosted runners
- stores no secrets and requires no GHA permissions
- leverages a RO gcsfuse mount (setup by the self hosted runner) to build missing packages

**`upload`**

- runs on GH hosted runners
- mounts the signing key
- requires GH token permissions to exchange for GCS RW
- syncs, re-indexes/signs, and uploads the repository

This hoists the built apks out of `build -> upload`, which does introduce reliance on GHA to ensure the bits are correct, but seems worth it to me rather than storing keys on our self hosted runners.

This leaves the upload/notification commented out until we can validate the build is WAI. It's also strictly a `workflow_dispatch` action until then.