### PR TITLE
openai: bump some deps to account for CVEs

### DIFF
--- a/openai.yaml
+++ b/openai.yaml
@@ -1,7 +1,8 @@
 package:
   name: openai
+  # When bumping, remove version upgrades to fix CVEs below.
   version: 0.27.8
-  epoch: 0
+  epoch: 1
   description: The OpenAI Python library provides convenient access to the OpenAI API from applications written in the Python language.
   copyright:
     - license: MIT
@@ -19,6 +20,8 @@ environment:
       - py3-wheel
       - py3-pip
       - python3
+      - python3-dev
+      - gcc
 
 pipeline:
   - uses: git-checkout
@@ -29,6 +32,10 @@ pipeline:
 
   - runs: |
       python setup.py bdist_wheel
+
+      pip3 install llhttp -U   # https://github.com/advisories/GHSA-45c4-8wx5-qw6w
+      pip3 install certifi -U  # https://github.com/advisories/GHSA-xqr8-7jwr-rhp7
+
       pip3 install . --prefix=/usr --root="${{targets.destdir}}"
 
       # Cleanup some unused files


### PR DESCRIPTION
```
wolfictl scan packages/aarch64/openai-0.27.8-r1.apk
openai-0.27.8-r1.apk
✅ No vulnerabilities found
```

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
