### PR TITLE
gradle: fix CVE-2023-2976

### DIFF
--- a/gradle-8.yaml
+++ b/gradle-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: gradle-8
   version: 8.2.1 # When bumping this, also bump the provides below!
-  epoch: 0
+  epoch: 1
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0
@@ -35,8 +35,13 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: a38ec64d3c4612da9083cc506a1ccb212afeecaa
 
+  - uses: patch
+    with:
+      patches: 0001-PATCH-override-Guava-version.patch
+
   - runs: |
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+
       # Do not use the gradle wrapper, ensure we're using the bootstrap version.
       ./gradlew :distributions-full:binDistributionZip
 

--- a/gradle-8/0001-PATCH-override-Guava-version.patch
+++ b/gradle-8/0001-PATCH-override-Guava-version.patch
@@ -1,0 +1,231 @@
+diff --git a/build-logic/basics/build.gradle.kts b/build-logic/basics/build.gradle.kts
+index 32adafb9c66..e3b0e2efa4b 100644
+--- a/build-logic/basics/build.gradle.kts
++++ b/build-logic/basics/build.gradle.kts
+@@ -5,7 +5,7 @@ plugins {
+ description = "Provides plugins for configuring miscellaneous things (repositories, reproducibility, minify)"
+ 
+ dependencies {
+-    implementation("com.google.guava:guava") {
++    implementation("com.google.guava:guava:32.1.2-jre") {
+         because("Used by class analysis")
+     }
+     implementation("org.ow2.asm:asm") {
+diff --git a/build-logic/binary-compatibility/build.gradle.kts b/build-logic/binary-compatibility/build.gradle.kts
+index 98aa5d45c2a..1e9d99316b5 100644
+--- a/build-logic/binary-compatibility/build.gradle.kts
++++ b/build-logic/binary-compatibility/build.gradle.kts
+@@ -12,7 +12,7 @@ dependencies {
+     implementation(project(":module-identity"))
+ 
+     implementation("com.google.code.gson:gson")
+-    implementation("com.google.guava:guava")
++    implementation("com.google.guava:guava:32.1.2-jre")
+     implementation("org.javassist:javassist")
+     implementation("com.github.javaparser:javaparser-core")
+     implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm")
+diff --git a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/JapicmpTask.java b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/JapicmpTask.java
+index 5488203700f..4085cfb7d24 100644
+--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/JapicmpTask.java
++++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/JapicmpTask.java
+@@ -183,7 +183,7 @@ private Configuration resolveGuava() {
+         Project project = getProject();
+         DependencyHandler dependencies = project.getDependencies();
+         return project.getConfigurations().detachedConfiguration(
+-                dependencies.create("com.google.guava:guava:30.1.1-jre")
++                dependencies.create("com.google.guava:guava:32.1.2-jre")
+         );
+     }
+ 
+diff --git a/build-logic/build-platform/build.gradle.kts b/build-logic/build-platform/build.gradle.kts
+index 899c09af650..f845b537ea6 100644
+--- a/build-logic/build-platform/build.gradle.kts
++++ b/build-logic/build-platform/build.gradle.kts
+@@ -37,7 +37,7 @@ dependencies {
+         // Java Libraries
+         api("com.github.javaparser:javaparser-core:$javaParserVersion")
+         api("com.github.javaparser:javaparser-symbol-solver-core:$javaParserVersion")
+-        api("com.google.guava:guava:27.1-jre")
++        api("com.google.guava:guava:32.1.2-jre")
+         api("com.google.errorprone:error_prone_annotations:2.5.1")
+         api("com.google.code.gson:gson:2.8.9")
+         api("com.nhaarman:mockito-kotlin:1.6.0")
+diff --git a/build-logic/documentation/build.gradle.kts b/build-logic/documentation/build.gradle.kts
+index 0f44d4f8a46..f0e6bf069f2 100644
+--- a/build-logic/documentation/build.gradle.kts
++++ b/build-logic/documentation/build.gradle.kts
+@@ -11,7 +11,7 @@ dependencies {
+     implementation(project(":build-update-utils"))
+ 
+     implementation("com.github.javaparser:javaparser-core")
+-    implementation("com.google.guava:guava")
++    implementation("com.google.guava:guava:32.1.2-jre")
+     implementation("com.uwyn:jhighlight") {
+         exclude(module = "servlet-api")
+     }
+diff --git a/build-logic/jvm/build.gradle.kts b/build-logic/jvm/build.gradle.kts
+index 291694ea48d..d7b8ed3d3ee 100644
+--- a/build-logic/jvm/build.gradle.kts
++++ b/build-logic/jvm/build.gradle.kts
+@@ -11,7 +11,7 @@ dependencies {
+ 
+     implementation("org.eclipse.jgit:org.eclipse.jgit")
+     implementation("org.jsoup:jsoup")
+-    implementation("com.google.guava:guava")
++    implementation("com.google.guava:guava:32.1.2-jre")
+     implementation("org.ow2.asm:asm")
+     implementation("org.ow2.asm:asm-commons")
+     implementation("com.google.code.gson:gson")
+diff --git a/build-logic/performance-testing/build.gradle.kts b/build-logic/performance-testing/build.gradle.kts
+index a8f94a32c44..40cbf2f8a3f 100644
+--- a/build-logic/performance-testing/build.gradle.kts
++++ b/build-logic/performance-testing/build.gradle.kts
+@@ -15,7 +15,7 @@ dependencies {
+     implementation("org.openmbee.junit:junit-xml-parser") {
+         exclude(module = "lombok") // don't need it at runtime
+     }
+-    implementation("com.google.guava:guava")
++    implementation("com.google.guava:guava:32.1.2-jre")
+     implementation("com.google.code.gson:gson")
+     implementation("commons-io:commons-io")
+     implementation("javax.activation:activation")
+diff --git a/gradle/verification-keyring.keys b/gradle/verification-keyring.keys
+index b652edb432b..c7b0ff62398 100644
+--- a/gradle/verification-keyring.keys
++++ b/gradle/verification-keyring.keys
+@@ -3175,6 +3175,48 @@ Vvawk7av3ES981yzCPqSxjmWAi0TWugIjrW6eRqMfhWIeF6otn/vBGbp44U=
+ =ii6z
+ -----END PGP PUBLIC KEY BLOCK-----
+ 
++pub    D364ABAA39A47320
++sub    3F606403DCA455C8
++-----BEGIN PGP PUBLIC KEY BLOCK-----
++Version: BCPG v1.68
++
++mQINBGH0NlsBEACnLJ3vl/aV+4ytkJ6QSfDFHrwzSo1eEXyuFZ85mLijvgGuaKRr
++c9/lKed0MuyhLJ7YD752kcFCEIyPbjeqEFsBcgU/RWa1AEfaay4eMLBzLSOwCvhD
++m+1zSFswH2bOqeLSbFZPQ9sVIOzO6AInaOTOoecHChHnUztAhRIOIUYmhABJGiu5
++jCP5SStoXm8YtRWT1unJcduHQ51EztQe02k+RTratQ31OSkeJORle7k7cudCS+yp
++z5gTaS1Bx02v0Y8Qaw17vY9Pn8DmsECRvXL6K7ItX6zKkSdJYVGMtiF/kp4rg94I
++XodrlzrMGPGPga9fTcqMPvx/3ffwgIsgtgaKg7te++L3db/xx48XgZ2qYAU8GssE
++N14xRFQmr8sg+QiCIHL0Az88v9mILYOqgxa3RvQ79tTqAKwPg0o2w/wF/WU0Rw53
++mdNy9JTUjetWKuoTmDaXVZO4LQ2g4W2dQTbgHyomiIgV7BnLFUiqOLPo+imruSCs
++W31Arjpb8q6XGTwjySa8waJxHhyV2AvEdAHUIdNuhD4dmPKXszlfFZwXbo1OOuIF
++tUZ9lsOQiCpuO7IpIprLc8L9d1TRnCrfM8kxMbX4KVGajWL+c8FlLnUwR4gSxT1G
++qIgZZ09wL5QiTeGF3biS5mxvn+gF9ns2Ahr2QmMqA2k5AMBTJimmY/OSWwARAQAB
++uQINBGH0NlsBEAC9o6m+D2LubGjOJxLQB1BnfBOkFHadsbkb82QFdrCNsd44fJie
++aqZVP+6XHKVRHSPktwpE1FnjThBJJsLwwcvwWXwDwvED57n4bATPlrPGuG7x+LRV
++bxFBTd+LQUCcHd3puruvbEjQdV54mbgdMqAp5dSA4Fc6h2hMWVBX4EdLiH/0ui3l
++UoqYTJcB73U1/jbKcbs0+cVuXIpmAPQpIs30p0wWLOKiJqn9tTZpwfntnrdfLvKL
++3FZcRQeWZjqH1Ywt4zWlCRqGEp7yVqhK5gn4nfEdSX2koxr53OOsGk2Pjhzs/5XJ
++Li1FTOcnja5kkqOPiPGB/BxAnjPCEsSiOFmF3Af4WdYa3+TK8+ggBSEeLjjLa5zy
++qexfhADwgb5ASZitUErJZDhAvqHGwfz3VPENy3K2kJLH+maWwOT1ZRoJnz3fxwIu
++gKhPx1MzlwhTclIknK7q2CNcB61pC9lg70ICW090NgknE2DtmjrRMONhcSkuWGLZ
++BKBgRqNwITJFcAdg6+ffZzGLsnEd+6A29PdsXfLS9KJqiabvpiBg8RaAAWiv5Tqs
++Nu9YSWUQUzBZO43u8AxTtThuHYZrxasoC3sCGIcRy2V9eaq480DRJ9uotONMutIH
++UDVSdqViPmmit0+PyRiCX/DOeBHumaEOm+RqIxPE8h6W8sHrYAQ7J1a3AQARAQAB
++iQI2BBgBCgAgFiEE7gyocwdAkvgG9Ztl02SrqjmkcyAFAmH0NlsCGwwACgkQ02Sr
++qjmkcyAsehAAps6j+qpjyNGUet/B6Z7nJcobSxnCIP/c+uUPD1oB6Uuht6NTYWQd
++wmEqL5BGz8WNTsBd0cQYvSztrMiz5tCDoiGGrWcgWxrrNxc1EVydhBbT4PpiG6CB
++WFCoEXN76/f0ndxZbjjobElTXbQ6oaLh2812OavgMdiJUVBgXrtfgi5/h49Wpc5o
++/IDM3bfujfrn5nvPIkd7Ee+GaK2YSCT7pfK4N/eW1g1SusqRQxBKCU3C5MVgVjkp
++Ba82U0kTxUGDFYUUcS+Yjhi/w4uynwIXW0pSl5wvxVVxNBfGFH5fkprkpcuVXp9B
++6SRVM85uUoZJFaIFyoAhU9uQQfVe6ugwP9BbhzRzDpJe9tiOcaazwzNnP5Zj31nI
++V6UltZu7mVSl1JwIcWxW3b36p4Ht9G5jIPQc8xS+oMd//p8r4sYFB4KOYas1ukRN
++iCshn9tJfeohkKj9ewxyUNf1rS8uOUJvZC3c3XRF8CJXRpxmHu2pPNf0QxFVhghL
++Y2cJU1OWGi6NyZN65EdfmkTbeDxdlSNv89STD4Vp6MmFtrA4JZDSR0Bp1zEPKiSx
++jpG5FpfVv6lXmFboa5qkXAHG9+bcaRYoXun+wJ3ioWo+cQEdy/bsX03+MHMsms8l
++ikmfPIGVw73RF3HXjJ8GVqTkqbo4ZpgTw/7Z3+fAYE/vxquhnpl2HvE=
++=5tlI
++-----END PGP PUBLIC KEY BLOCK-----
++
+ pub    D6131C504DEBCC09
+ sub    D66472CF54179CC4
+ sub    D69FB34D422A57F7
+@@ -3998,6 +4040,32 @@ Nsl5KWNiQw==
+ =jFkb
+ -----END PGP PUBLIC KEY BLOCK-----
+ 
++pub    EE92349AD86DE446
++sub    E68665C8F91BDE69
++-----BEGIN PGP PUBLIC KEY BLOCK-----
++Version: BCPG v1.68
++
++mQENBGO91akBCADDDpIrW/IohUSJNDu9VOUlnfEOm5VS49uqM0uucLi0BeAhy1Fo
++P6Yg1cJkcK66DtnUoTM/JJLyDzJRlKnniLrYCkw8ScvtPdA5cQKJTY5ecn+9ouR2
++SC9GkBMgagbCScP1xE45q5FO+z4kwmcERIKOQ687VAk64QM6hJCupfAd6SqS/X0Q
++SGttTNtmj7YBpfnU5iFX05Hj8Zkk7CX439xltO8uJNyBlDVbuUZc3/kRowKPVuuo
++TK2mzllVPzE/YT6NUY04wQPmRJx0uWZQUyDBZeckdurpSImdd7sik6Wf6zVGvxvg
++MC4oMufZ3EM8R4dssRSIUfnBaQ2o1LS+GVxjABEBAAG5AQ0EY73VqQEIANJPIYj9
++IsxKKOWLOkWvxAg9o9krIkohBMaOGRsx4RxQyArOCUoaG/qsG3aVOi8wML8hQK6q
++oXADJ6FBGxQ67G8pperzRSj1O3BJILB6Fd1X8w40S6hSvUAZs+DM1FMuD4mf6ydu
++yZUVIghGRExNeSb/vfn4KVPqdSAD7uWeQiIUYveaXrwot8+U8tRNgv+LQpCjhm5h
++vWyIuxxpI+k5N07V9y0yRGWiBbgqdmfHVwdEbUSM0sMYUJUZKW+iwf5tZig9LZu3
++HAf/vyXjBWG6zkkjwO8onKFLuhL4jkygHGSawJHwYRgtlknUZ0DMVc451bbhuFHE
++0dcgQCdAYJsI66MAEQEAAYkBPAQYAQgAJhYhBOsbPecXE8nsLofMJu6SNJrYbeRG
++BQJjvdWpAhsMBQkDwmcAAAoJEO6SNJrYbeRGNC0H/1JBKZZ8+JLGcGefchsEWxcN
++RN8yBtDtDM8pEsC99Pt+vzLaAYYFbPVKpzr57zIxZvtm8mUbWOa4Z8eHtzLRQEFi
++rKuvd47YUPOyHtfdeccr0e7iQQ2rpRmOVrnkKu4LHI+f4jFEm+Pe+3CyLYe/tBKK
++eBOKjRAWpQi7Jz1GQUuu9JFu4fUphzz0z5LybGHa1T7QZ+2ew8kqLl8EEeZAq4x/
++bulbaX050vfsgULn1X9AECW0CX/OafvFuSrEZsLUSw0KzmzqMPOLMXOh/EZsop17
++DqhGe5NO7GoCns3XxqjpggME9eCEQooeKHlLCAkX2/XttwVSRlrNsdVb82iKy7E=
++=M4QQ
++-----END PGP PUBLIC KEY BLOCK-----
++
+ pub    EFEC7EA866CC43AE
+ uid    scala-xml <scala-internals@googlegroups.com>
+ 
+diff --git a/gradle/verification-metadata.xml b/gradle/verification-metadata.xml
+index bf9a7525bd7..28bb5719249 100644
+--- a/gradle/verification-metadata.xml
++++ b/gradle/verification-metadata.xml
+@@ -555,6 +555,11 @@
+             <pgp value="f05e5f90e43e837f9dd8c781bf935c771a8474f8"/>
+          </artifact>
+       </component>
++      <component group="com.google.errorprone" name="error_prone_annotations" version="2.18.0">
++         <artifact name="error_prone_annotations-2.18.0.jar">
++            <pgp value="ee0ca873074092f806f59b65d364abaa39a47320"/>
++         </artifact>
++      </component>
+       <component group="com.google.errorprone" name="error_prone_annotations" version="2.3.4">
+          <artifact name="error_prone_annotations-2.3.4.jar">
+             <pgp value="7615ad56144df2376f49d98b1669c4bb543e0445"/>
+@@ -574,6 +579,11 @@
+             <sha256 value="2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6" origin="Verified by Bo"/>
+          </artifact>
+       </component>
++      <component group="com.google.j2objc" name="j2objc-annotations" version="2.8">
++         <artifact name="j2objc-annotations-2.8.jar">
++            <pgp value="eb1b3de71713c9ec2e87cc26ee92349ad86de446"/>
++         </artifact>
++      </component>
+       <component group="com.google.protobuf" name="protobuf-java" version="3.0.0">
+          <artifact name="protobuf-java-3.0.0.jar">
+             <pgp value="d75e25b78ebb19e47c0a99bca7764f502a938c99"/>
+diff --git a/subprojects/distributions-dependencies/build.gradle.kts b/subprojects/distributions-dependencies/build.gradle.kts
+index a6703549b02..a020a8726a2 100644
+--- a/subprojects/distributions-dependencies/build.gradle.kts
++++ b/subprojects/distributions-dependencies/build.gradle.kts
+@@ -71,7 +71,7 @@ dependencies {
+         api(libs.gradleEnterpriseTestAnnotation) { version { strictly("1.0") }}
+         api(libs.gcs)                   { version { strictly("v1-rev20220705-1.32.1") }}
+         api(libs.googleApiClient)       { version { strictly("1.34.0"); because("our GCS version requires 1.34.0") }}
+-        api(libs.guava)                 { version { strictly("31.1-jre"); because("our Google API Client version requires 31.1-jre")  }}
++        api(libs.guava)                 { version { strictly("32.1.2-jre"); because("our Google API Client version requires 32.1.2-jre")  }}
+         api(libs.googleHttpClientGson)  { version { strictly("1.42.2"); because("our Google API Client version requires 1.42.2")  }}
+         api(libs.googleHttpClientApacheV2) { version { strictly("1.42.2"); because("our Google API Client version requires 1.42.2")  }}
+         api(libs.googleHttpClient)      { version { strictly("1.42.2"); because("our Google API Client version requires 1.42.2") }}
+diff --git a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ProjectInternalViewDependencyIntegrationTest.groovy b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ProjectInternalViewDependencyIntegrationTest.groovy
+index de349636f79..90f24ad0a04 100644
+--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ProjectInternalViewDependencyIntegrationTest.groovy
++++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ProjectInternalViewDependencyIntegrationTest.groovy
+@@ -61,7 +61,7 @@ class ProjectInternalViewDependencyIntegrationTest extends AbstractIntegrationSp
+                 compileOnly "org.apache.commons:commons-lang3:3.12.0"
+ 
+                 api "org.springframework:spring-core:5.3.22"
+-                compileOnlyApi "com.google.guava:guava:31.1-jre"
++                compileOnlyApi "com.google.guava:guava:32.1.2-jre"
+             }
+         """
+         writeBaseBuildFile()


### PR DESCRIPTION
Add a patch to bump dependency `com.google.guava:guava` to version 32.1.2-jre to mitigate CVE-2023-2976.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: wolfi-dev/advisories#124

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
