### PR TITLE
disable wolfibot updates for hashicorp repos

### DIFF
--- a/consul-1.15.yaml
+++ b/consul-1.15.yaml
@@ -64,8 +64,4 @@ subpackages:
         - consul-1.15-oci-entrypoint
 
 update:
-  enabled: true
-  github:
-    identifier: hashicorp/consul
-    strip-prefix: v
-    tag-filter: v1.15.
+  enabled: false

--- a/consul-1.16.yaml
+++ b/consul-1.16.yaml
@@ -64,8 +64,4 @@ subpackages:
         - consul-1.16-oci-entrypoint
 
 update:
-  enabled: true
-  github:
-    identifier: hashicorp/consul
-    strip-prefix: v
-    tag-filter: v1.16.
+  enabled: false

--- a/http-echo.yaml
+++ b/http-echo.yaml
@@ -45,7 +45,4 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: true
-  github:
-    identifier: hashicorp/http-echo
-    strip-prefix: v
+  enabled: false

--- a/terraform.yaml
+++ b/terraform.yaml
@@ -28,8 +28,4 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: true
-  github:
-    identifier: hashicorp/terraform
-    strip-prefix: v
-    use-tag: true
+  enabled: false

--- a/vault-csi-provider.yaml
+++ b/vault-csi-provider.yaml
@@ -35,8 +35,4 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: true
-  github:
-    identifier: hashicorp/vault-csi-provider
-    strip-prefix: v
-    use-tag: true
+  enabled: false

--- a/vault-k8s.yaml
+++ b/vault-k8s.yaml
@@ -38,8 +38,4 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: true
-  github:
-    identifier: hashicorp/vault-k8s
-    strip-prefix: v
-    use-tag: true
+  enabled: false

--- a/vault.yaml
+++ b/vault.yaml
@@ -86,7 +86,4 @@ subpackages:
         - libcap-utils
 
 update:
-  enabled: true
-  github:
-    identifier: hashicorp/vault
-    strip-prefix: v
+  enabled: false


### PR DESCRIPTION
> ### What did HashiCorp announce today (Aug 10)?
>
> HashiCorp announced a transition from the Mozilla Public License v2.0 (MPL 2.0) to the Business Source License (BSL, or BUSL) v1.1 for future releases of all products and several libraries. HashiCorp APIs, SDKs, and almost all other libraries will remain MPL 2.0.

https://www.hashicorp.com/license-faq#What-did-HashiCorp-announce-today-(Aug-10)

This means that future releases won't be appropriate for Wolfi, so this disables automatic updates to those versions to avoid accidentally upgrading.