### PR TITLE
gradle-8: add comment for version check reminder

### DIFF
--- a/gradle-8.yaml
+++ b/gradle-8.yaml
@@ -1,6 +1,9 @@
 package:
   name: gradle-8
-  version: 8.2.1 # When bumping this, also bump the provides below!
+  # When bumping version, also bump the provides below!
+  # For version upgrades check whether patches are still needed.
+  # Upstream changes are being tracked in https://github.com/gradle/gradle/issues/25945
+  version: 8.2.1
   epoch: 1
   description: A Java project management and project comprehension tool.
   copyright:


### PR DESCRIPTION
Add a comment to remind that the patches must be checked when this package is bumped to the next version of Gradle.

Fixes: N/A

Related: wolfi-dev/advisories#124

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
