### PR TITLE
gradle-8: update dependency comment in the patch file

### DIFF
--- a/gradle-8/0001-PATCH-override-Guava-version.patch
+++ b/gradle-8/0001-PATCH-override-Guava-version.patch
@@ -212,7 +212,7 @@ index a6703549b02..a020a8726a2 100644
          api(libs.gcs)                   { version { strictly("v1-rev20220705-1.32.1") }}
          api(libs.googleApiClient)       { version { strictly("1.34.0"); because("our GCS version requires 1.34.0") }}
 -        api(libs.guava)                 { version { strictly("31.1-jre"); because("our Google API Client version requires 31.1-jre")  }}
-+        api(libs.guava)                 { version { strictly("32.1.2-jre"); because("our Google API Client version requires 32.1.2-jre")  }}
++        api(libs.guava)                 { version { strictly("32.1.2-jre"); because("it mitigates CVE-2023-2976")  }}
          api(libs.googleHttpClientGson)  { version { strictly("1.42.2"); because("our Google API Client version requires 1.42.2")  }}
          api(libs.googleHttpClientApacheV2) { version { strictly("1.42.2"); because("our Google API Client version requires 1.42.2")  }}
          api(libs.googleHttpClient)      { version { strictly("1.42.2"); because("our Google API Client version requires 1.42.2") }}


### PR DESCRIPTION
Update the dependency comment because the previous one does not really deliver the reason why this dependency version was bumped.

Fixes: N/A

Related: wolfi-dev/advisories#124

### Pre-review Checklist

#### For security-related PRs
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
