### PR TITLE
go: stop updating 1.19, update thanos' go dep

### DIFF
--- a/go-1.19.yaml
+++ b/go-1.19.yaml
@@ -77,10 +77,4 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
 
 update:
-  enabled: true
-  shared: true
-  github:
-    identifier: golang/go
-    strip-prefix: go
-    tag-filter: go1.19
-    use-tag: true
+  enabled: false

--- a/thanos.yaml
+++ b/thanos.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos
   version: 0.31.0
-  epoch: 3
+  epoch: 4
   description: Highly available Prometheus setup with long term storage capabilities.
   copyright:
     - license: Apache-2.0
@@ -12,7 +12,7 @@ environment:
       - ca-certificates-bundle
       - busybox
       - bash
-      - go-1.19 # Thanos needs go 1.19 for this version, it can be bumped next release
+      - go
       - curl
 
 pipeline:


### PR DESCRIPTION
Go 1.19 is unsupported after 1.21 was released, so we don't expect any more 1.19 updates.

Thanos had depended on 1.19 to build an older version, but builds fine with 1.21 now.