### PR TITLE
openai: fix dependency on py3-certifi

### DIFF
--- a/openai.yaml
+++ b/openai.yaml
@@ -2,13 +2,14 @@ package:
   name: openai
   # When bumping, remove version upgrades to fix CVEs below.
   version: 0.27.8
-  epoch: 1
+  epoch: 2
   description: The OpenAI Python library provides convenient access to the OpenAI API from applications written in the Python language.
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - python3
+      - py3-certifi
 
 environment:
   contents:
@@ -33,10 +34,7 @@ pipeline:
   - runs: |
       python setup.py bdist_wheel
 
-      pip3 install llhttp -U   # https://github.com/advisories/GHSA-45c4-8wx5-qw6w
-      pip3 install certifi -U  # https://github.com/advisories/GHSA-xqr8-7jwr-rhp7
-
-      pip3 install . --prefix=/usr --root="${{targets.destdir}}"
+      pip install . --prefix=/usr --root="${{targets.destdir}}"
 
       # Cleanup some unused files
       find ${{targets.destdir}}/usr/lib -type f -name '*.pyc' -exec rm -rf '{}' +


### PR DESCRIPTION
I broke this in #4343 

Instead of `pip3 install -U`ing at build-time, we should be depending on our own up-to-date `certifi` package. With that change, the package built, but wouldn't work at runtime.