### PR TITLE
tekton-pipelines: Fix CVE-2023-1732

### DIFF
--- a/tekton-pipelines.yaml
+++ b/tekton-pipelines.yaml
@@ -24,6 +24,8 @@ pipeline:
       output: tekton-pipelines-controller
       modroot: tekton
       vendor: true
+      # CVE-2023-1732 (can be removed >= v0.51.0)
+      deps: 'github.com/cloudflare/circl@v1.3.3'
 
 data:
   - name: cmds


### PR DESCRIPTION

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

This technically isn't affected, but HEAD already pulls in the new dep and this is easy to update away.

Fixes: https://github.com/chainguard-dev/temp-cve-issues-by-package/issues/392

Related: https://github.com/advisories/GHSA-2q89-485c-9j2x, https://github.com/wolfi-dev/advisories/pull/135

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
