### PR TITLE
node-problem-detector: address CVE-2019-11253 in k8s.io/apimachinery dep

### DIFF
--- a/node-problem-detector.yaml
+++ b/node-problem-detector.yaml
@@ -1,7 +1,7 @@
 package:
   name: node-problem-detector
   version: 0.8.13
-  epoch: 5
+  epoch: 6
   description: node-problem-detector aims to make various node problems visible to the upstream layers in the cluster management stack.
   copyright:
     - license: Apache-2.0
@@ -54,6 +54,9 @@ pipeline:
 
       # Mitigate CVE-2022-21698, GHSA-cg3q-j54f-5p7p
       go get github.com/prometheus/client_golang@v1.11.1
+
+      # Mitigate GHSA-74fp-r6jw-h4mp, CVE-2019-11253
+      go get k8s.io/apimachinery@v0.0.0-20190927203648-9ce6eca90e73
 
       go mod tidy
       go mod vendor


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

k8s.io/apimachinery: fix CVE-2019-11253, GHSA-74fp-r6jw-h4mp

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: CVE-2019-11253, GHSA-74fp-r6jw-h4mp

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
