### PR TITLE
wavefront-proxy: fix CVE-2023-34462

### DIFF
--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: wavefront-proxy
   version: "13.1"
-  epoch: 0
+  epoch: 1
   description: Wavefront Proxy Project
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,10 @@ pipeline:
       repository: https://github.com/wavefronthq/wavefront-proxy
       tag: proxy-${{package.version}}
       expected-commit: bf5b1e8a92c2d7e04ccc19827762a126f631e5f7
+
+  - uses: patch
+    with:
+      patches: 0001-PATCH-netty-version.patch
 
   - runs: |
       export LANG=en_US.UTF-8

--- a/wavefront-proxy/0001-PATCH-netty-version.patch
+++ b/wavefront-proxy/0001-PATCH-netty-version.patch
@@ -1,0 +1,13 @@
+diff --git a/proxy/pom.xml b/proxy/pom.xml
+index 69cdfc50..07c9218c 100644
+--- a/proxy/pom.xml
++++ b/proxy/pom.xml
+@@ -282,7 +282,7 @@
+       <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-bom</artifactId>
+-        <version>4.1.89.Final</version>
++        <version>4.1.94.Final</version>
+         <type>pom</type>
+         <scope>import</scope>
+       </dependency>


### PR DESCRIPTION
Bump the netty-bom dependency version from 4.1.89.Final to 4.1.94.Final to mitigate CVE-2023-34462.

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
