### PR TITLE
wavefront-proxy: add reminder to check patches

### DIFF
--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -1,5 +1,6 @@
 package:
   name: wavefront-proxy
+  # When version is bumped, check if patches are still needed to address CVE-2023-34462
   version: "13.1"
   epoch: 1
   description: Wavefront Proxy Project


### PR DESCRIPTION
Add a reminder to check if patches will still be required when the next version is released.
