### PR TITLE
Fix vuln in grpcurl

### DIFF
--- a/grpcurl.yaml
+++ b/grpcurl.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpcurl
   version: 1.8.7
-  epoch: 6
+  epoch: 7
   description: CLI tool to interact with gRPC servers
   target-architecture:
     - all
@@ -26,6 +26,18 @@ pipeline:
     with:
       expected-sha256: 7f7a59f8a5ef8833d30a94e1c36ddb0d76bab1ae64cd5c8bcb87d42e877c3bca
       uri: https://github.com/fullstorydev/grpcurl/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - runs: |
+      # Mitigate CVE-2022-27664, CVE-2021-33194, CVE-2021-31525, CVE-2022-41723
+      go mod edit -replace golang.org/x/net=golang.org/x/net@v0.7.0
+
+      # Mitigate CVE-2022-29526
+      go get golang.org/x/sys@v0.7.0
+
+      # Mitigate CVE-2022-32149
+      go mod edit -replace golang.org/x/text=golang.org/x/text@v0.3.8
+
+      go mod tidy
 
   - uses: go/build
     with:


### PR DESCRIPTION
Fixes:
- [GHSA-69cg-p879-7622](https://github.com/advisories/GHSA-69cg-p879-7622) / [GO-2022-0969](https://pkg.go.dev/vuln/GO-2022-0969)
- [GHSA-83g2-8m93-v3w7](https://github.com/advisories/GHSA-83g2-8m93-v3w7) / [GO-2021-0238](https://pkg.go.dev/vuln/GO-2021-0238)
- [GHSA-h86h-8ppg-mxmh](https://github.com/advisories/GHSA-h86h-8ppg-mxmh) / [GO-2022-0236](https://pkg.go.dev/vuln/GO-2022-0236)
- [GHSA-vvpx-j8f3-3w6h](https://github.com/advisories/GHSA-vvpx-j8f3-3w6h) / [GO-2023-1571](https://pkg.go.dev/vuln/GO-2023-1571)
- [GHSA-p782-xgp4-8hr8](https://github.com/advisories/GHSA-p782-xgp4-8hr8) / [GO-2022-0493](https://pkg.go.dev/vuln/GO-2022-0493)
- [GHSA-69ch-w2m2-3vjp](https://github.com/advisories/GHSA-69ch-w2m2-3vjp) / [GO-2022-1059](https://pkg.go.dev/vuln/GO-2022-1059)

Verified with `wolfictl scan`:
```
$ wolfictl scan packages/aarch64/grpcurl-1.8.7-r7.apk
Will process: grpcurl-1.8.7-r7.apk
✅ No vulnerabilities found
```
Advisory PR: https://github.com/wolfi-dev/advisories/pull/157