### PR TITLE
[conda] Rebuild from source instead of using miniconda installer.

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -1,7 +1,7 @@
 package:
   name: conda
   version: 23.7.2
-  epoch: 0
+  epoch: 1
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause
@@ -17,6 +17,10 @@ environment:
       - ca-certificates-bundle
       - bash
       - wget
+      - python3
+      - py3-pip
+      - py3-hatchling
+      - py3-wheel
 
 pipeline:
   - uses: git-checkout
@@ -25,25 +29,10 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: b63f152aaf78a014afab66ee48eae663cf563cd6
 
-  - if: ${{build.arch}} == 'x86_64'
-    runs: |
-      export TARGETARCH="amd64"
-      bash dev/linux/install_miniconda.sh
-
-  - if: ${{build.arch}} == 'aarch64'
-    runs: |
-      export TARGETARCH="arm64"
-      bash dev/linux/install_miniconda.sh
-
   - runs: |
-      export LANG=C.UTF-8 LC_ALL=C.UTF-8
-      /opt/conda/bin/conda install --update-all -y \
-        python=3.10
-
-      /opt/conda/bin/conda clean --all --yes
-
-      mkdir -p ${{targets.destdir}}/opt/
-      mv /opt/conda ${{targets.destdir}}/opt/
+      pip install hatch
+      hatch build
+      python3 -m installer -d "${{targets.destdir}}" dist/conda*.whl
 
 update:
   enabled: true


### PR DESCRIPTION
Miniconda installer does things like side-loads it's own version of python, which is what is being flagged for vulnerabilities.

This installs conda from source using it's build tool hatch, which mitigates the reported vulns in the process.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/chainguard-dev/temp-cve-issues-by-package/issues/385


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
