### PR TITLE
fix --modules-path in nginx package

### DIFF
--- a/nginx.yaml
+++ b/nginx.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx
-  version: 1.25.1
-  epoch: 1
+  version: 1.25.2
+  epoch: 0
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause
@@ -44,7 +44,7 @@ data:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: f09071ac46e0ea3adc0008ef0baca229fc6b4be4533baef9bbbfba7de29a8602
+      expected-sha256: 05dd6d9356d66a74e61035f2a42162f8c754c97cf1ba64e7a801ba158d6c0711
       uri: https://nginx.org/download/nginx-${{package.version}}.tar.gz
   - name: configure
     runs: |

--- a/nginx.yaml
+++ b/nginx.yaml
@@ -54,7 +54,7 @@ pipeline:
       ./configure \
           --prefix=/var/lib/nginx \
           --sbin-path=/usr/sbin/nginx \
-          --modules-path=/$_modules_dir \
+          --modules-path=/usr/lib/nginx/modules \
           --conf-path=/etc/nginx/nginx.conf \
           --pid-path=/run/nginx/nginx.pid \
           --lock-path=/run/nginx/nginx.lock \
@@ -138,7 +138,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/lib/nginx/modules
           mkdir -p ${{targets.subpkgdir}}/etc/nginx/modules
 
-          mv ${{targets.destdir}}/ngx_${{range.key}}_module.so ${{targets.subpkgdir}}/usr/lib/nginx/modules/
+          mv ${{targets.destdir}}/usr/lib/nginx/modules/ngx_${{range.key}}_module.so ${{targets.subpkgdir}}/usr/lib/nginx/modules/
 
           # TODO may need to rework the prefix here if we add other module subpackages like alpine does https://git.alpinelinux.org/aports/tree/main/nginx/APKBUILD#n417
           echo "load_module \"modules/ngx_${{range.key}}_module.so\";" >> ${{targets.subpkgdir}}/etc/nginx/modules/${{range.value}}_${{range.key}}.conf


### PR DESCRIPTION
This PR fix:


`modules-path` was setted by default on */var/lib/nginx* while module subpackages install modules over */usr/local/nginx/modules*.

When you to add module have this error:

<img width="1416" alt="image" src="https://github.com/wolfi-dev/os/assets/51416834/1c4007c6-e5c7-48fd-bb13-949f4a98806d">

`--modules-path` is not taking [$_modules_dir](https://github.com/wolfi-dev/os/blob/main/nginx.yaml#L57) var

<img width="642" alt="image" src="https://github.com/wolfi-dev/os/assets/51416834/3ddbc4fa-fc31-44e9-a47b-539b045b89b0">

