### PR TITLE
conda: add python3 as a runtime dependency

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -1,13 +1,16 @@
 package:
   name: conda
   version: 23.7.2
-  epoch: 1
+  epoch: 2
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause
   options:
     no-provides: true
     no-depends: true
+  dependencies:
+    runtime:
+      - python3
 
 environment:
   contents:


### PR DESCRIPTION
#4397 dropped the prebuilt python install (which is good!) but this meant the package didn't have a python (which is bad!)