### PR TITLE
remove target architecture as it is deprecated

### DIFF
--- a/aerospike.yaml
+++ b/aerospike.yaml
@@ -3,8 +3,6 @@ package:
   version: 6.4.0.1
   epoch: 0
   description: Aerospike Database Server - flash-optimized, in-memory, nosql database
-  target-architecture:
-    - all
   copyright:
     - license: AGPL-3.0-only
 

--- a/asciidoctor.yaml
+++ b/asciidoctor.yaml
@@ -3,8 +3,6 @@ package:
   version: 2.0.20
   epoch: 0
   description: A fast, open source text processor and publishing toolchain, written in Ruby, for converting AsciiDoc content to HTML 5, DocBook 5, and other formats.
-  target-architecture:
-    - all
   copyright:
     - paths:
         - "*"

--- a/avahi.yaml
+++ b/avahi.yaml
@@ -3,8 +3,6 @@ package:
   version: 0.8
   epoch: 1
   description: A multicast/unicast DNS-SD framework
-  target-architecture:
-    - all
   copyright:
     - license: LGPL-2.0-or-later
 

--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,10 +1,8 @@
 package:
   name: coredns
   version: 1.11.0
-  epoch: 0
+  epoch: 1
   description: CoreDNS is a DNS server that chains plugins
-  target-architecture:
-    - all
   copyright:
     - license: Apache-2.0
   dependencies:
@@ -34,6 +32,10 @@ pipeline:
 
   - runs: |
       # Ensures plugins get included
+      # go1.21 hot fix for quic , remove this in the next version bump
+      # as it is fixed in the main branch
+      go get github.com/quic-go/quic-go@v0.37.4
+      go mod tidy
       make check
 
   - uses: go/build

--- a/external-dns.yaml
+++ b/external-dns.yaml
@@ -3,8 +3,6 @@ package:
   version: 0.13.5
   epoch: 2
   description: Configure external DNS servers (AWS Route53, Google CloudDNS and others) for Kubernetes Ingresses and Services.
-  target-architecture:
-    - all
   copyright:
     - license: Apache-2.0
       paths:

--- a/grpcurl.yaml
+++ b/grpcurl.yaml
@@ -3,8 +3,6 @@ package:
   version: 1.8.7
   epoch: 7
   description: CLI tool to interact with gRPC servers
-  target-architecture:
-    - all
   copyright:
     - license: MIT
       paths:

--- a/hello-wolfi.yaml
+++ b/hello-wolfi.yaml
@@ -3,8 +3,6 @@ package:
   version: 2.12.1
   epoch: 1
   description: "the GNU hello world program"
-  target-architecture:
-    - all
   copyright:
     - paths:
         - "*"

--- a/karpenter.yaml
+++ b/karpenter.yaml
@@ -3,8 +3,6 @@ package:
   version: 0.29.2
   epoch: 0
   description: Karpenter is a Kubernetes Node Autoscaler built for flexibility, performance, and simplicity.
-  target-architecture:
-    - all
   copyright:
     - license: Apache-2.0
       paths:


### PR DESCRIPTION
- removes deprecated target architecture 
- coredns needs an update to one of the libraries to work on go1.21 