### PR TITLE
memcached-exporter: Bump epoch to build with new Go

### DIFF
--- a/memcached-exporter.yaml
+++ b/memcached-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached-exporter
   version: 0.13.0
-  epoch: 2
+  epoch: 3
   description: Exports metrics from memcached servers for consumption by Prometheus.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

User requested memchaed-exporter package rebuilt with new Go version.

