### PR TITLE
add py3-ruamel-yaml and other runtime deps to conda

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -12,6 +12,10 @@ package:
     runtime:
       - python3
       - py3-packaging
+      - py3-requests
+      - py3-ruamel-yaml
+      - py3-pluggy
+      - py3-tqdm
 
 environment:
   contents:

--- a/py3-ruamel-yaml.yaml
+++ b/py3-ruamel-yaml.yaml
@@ -1,0 +1,32 @@
+# Generated from https://pypi.org/project/ruamel.yaml/
+package:
+  name: py3-ruamel-yaml
+  version: 0.17.32
+  epoch: 0
+  description: ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order
+  copyright:
+    - license: MIT license
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python3
+      - py3-pip
+
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: ec939063761914e14542972a5cba6d33c23b0859ab6342f61cf070cfc600efc2
+      uri: https://files.pythonhosted.org/packages/63/dd/b4719a290e49015536bd0ab06ab13e3b468d8697bec6c2f668ac48b05661/ruamel.yaml-${{package.version}}.tar.gz
+
+  - runs: pip install . --prefix=/usr --root=${{targets.destdir}}
+
+  - uses: strip

--- a/py3-ruamel-yaml.yaml
+++ b/py3-ruamel-yaml.yaml
@@ -20,7 +20,6 @@ environment:
       - python3
       - py3-pip
 
-
 pipeline:
   - uses: fetch
     with:
@@ -30,3 +29,8 @@ pipeline:
   - runs: pip install . --prefix=/usr --root=${{targets.destdir}}
 
   - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 66067


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/4397 changed how conda was built

https://github.com/wolfi-dev/os/pull/4411 and https://github.com/wolfi-dev/os/pull/4411 were previous attempts to get it building correctly.

I've been able to demonstrate the image built with this conda passes its smoke test.