### PR TITLE
[cloudwatch-exporter] fix CVE-2023-34462/GHSA-6mjq-h674-j845

### DIFF
--- a/cloudwatch-exporter.yaml
+++ b/cloudwatch-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudwatch-exporter
   version: "0.15.4"
-  epoch: 1
+  epoch: 2
   description: Metrics exporter for Amazon AWS CloudWatch
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,9 @@ pipeline:
       expected-commit: af4e8aea04a02c858c19e2ddbaa2cd87ef46e971
 
   - runs: |
-      mvn package
+      # This change is being introduced in https://github.com/prometheus/cloudwatch_exporter/pull/567 (still unmerged)
+      # Check if the version bump below is still needed next time this package is updated
+      mvn -Dsoftware.amazon.awssdk.version=2.20.124 package
       ls target/
       mkdir -p ${{targets.destdir}}/usr/share/java/cloudwatch_exporter
       mv target/cloudwatch_exporter-${{package.version}}-jar-with-dependencies.jar  ${{targets.destdir}}/usr/share/java/cloudwatch_exporter/cloudwatch_exporter.jar

--- a/cloudwatch-exporter.yaml
+++ b/cloudwatch-exporter.yaml
@@ -1,6 +1,6 @@
 package:
   name: cloudwatch-exporter
-  version: "0.15.4"
+  version: "0.15.4" # Check if the version bump in the mvn command is still needed next time this package is updated
   epoch: 2
   description: Metrics exporter for Amazon AWS CloudWatch
   copyright:
@@ -28,7 +28,6 @@ pipeline:
 
   - runs: |
       # This change is being introduced in https://github.com/prometheus/cloudwatch_exporter/pull/567 (still unmerged)
-      # Check if the version bump below is still needed next time this package is updated
       mvn -Dsoftware.amazon.awssdk.version=2.20.124 package
       ls target/
       mkdir -p ${{targets.destdir}}/usr/share/java/cloudwatch_exporter


### PR DESCRIPTION
Bump aws-sdk version to v2.20.124 in cloudwatch-exporter package to suppress CVE-2023-34462/GHSA-6mjq-h674-j845.

Fixes:

Related: wolfi-dev/advisories#159, wolfi-dev/advisories#172

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
