### PR TITLE
use make all for building

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
     # permissions:
 
     container:
-      image: ghcr.io/wolfi-dev/sdk:latest@sha256:a360a3c166c64398edfaa08916950ccf80e1ee4b774b5a26a53145fccb8fb7a6
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:228a7b2d145f5fe64da22948feab8137bd46bdd418ca1993467373b7b363a453
       # TODO: Deprivilege
       options: |
         --cap-add NET_ADMIN --cap-add SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor:unconfined
@@ -48,25 +48,33 @@ jobs:
       # Build with a local key, we'll resign this with the real key later
       - name: 'Generate local signing key'
         run: |
-          make MELANGE="melange" local-melange.rsa
+          make local-melange.rsa
 
-      - name: 'Prepare package repository'
-        run: |
-          mkdir -p "${{ github.workspace }}/packages"
-          cp /etc/apk/keys/wolfi-signing.rsa.pub ${{ github.workspace }}/packages/wolfi-signing.rsa.pub
+          # Touch it with the epoch date to convince `make` that we don't need to
+          # rebuild the targets that depend on this (all)
+          touch -d @0 local-melange.rsa
 
       # Use a gcsfuse RO mount set up by the self-hosted runner. This prevents
       # needing to exchange tokens and avoids storing keys (even ephemeral
       # ones) on the self hosted runner. The gcsfuse mount is set up with RO
       # via workload identity federation.
+      - name: 'Prepare package repository'
+        run: |
+          mkdir -p ${{ github.workspace }}/packages/${{ matrix.arch }}
+          # Symlink the gcsfuse mount to ./packages/ to workaround the Makefile CWD assumptions
+          ln -s /gcsfuse/wolfi-registry/${{ matrix.arch }}/* ${{ github.workspace }}/packages/${{ matrix.arch }}/
+
       # TODO: Replace this with wolfictl build
       - name: 'Build Wolfi'
         run: |
-          make MELANGE="melange" \
-            KEY=wolfi-signing.rsa \
+          make \
             ARCH=${{ matrix.arch }} \
-            MELANGE_EXTRA_OPTS="--repository-append=/gcsfuse/wolfi-registry" \
-            package/$package -j1
+            MELANGE_EXTRA_OPTS="--keyring-append=/gcsfuse/wolfi-registry/wolfi-signing.rsa.pub" \
+            all -j1
+
+      # Remove the temporary symlinks so the artifact upload only includes the built packages
+      - run: |
+          find ${{ github.workspace }}/packages/${{ matrix.arch }} -type l -exec rm -f {} \;
 
       - name: 'Normalize repository permissions'
         run: |


### PR DESCRIPTION
I went through these changes on a similar box to try and test out the fuse mount better. things seem to be working on the box, so we'll see how they do in CI.

it's worth noting that this is drastically simpler with a RW gcsfuse mount, but I'm still not confident in the self hosted runner to do that. alternatively, we could perform the `upload` step with a gcsfuse mount on the GH hosted runners 🤔 but that's a future optimization problem.