### PR TITLE
crossplane provider for AWS

### DIFF
--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -18,6 +18,7 @@ environment:
       - go
       - busybox
       - curl
+      - gzip
   environment:
     CGO_ENABLED: 0
 
@@ -34,12 +35,29 @@ pipeline:
       UP_VERSION=$(up --version)
       echo "Using up ${UP_VERSION}"
       mkdir -p ./.cache/tools/linux_${GOARCH}
-      mv $(which up) ./.cache/tools/linux_${GOARCH}/up-${UP_VERSION}
+      cp $(which up) ./.cache/tools/linux_${GOARCH}/up-${UP_VERSION}
 
       make UP_VERSION=${UP_VERSION}
 
       mkdir -p "${{targets.destdir}}"/usr/local/bin/
       cp ./_output/bin/linux_${GOARCH}/monolith "${{targets.destdir}}"/usr/local/bin/provider
+
+data:
+  - name: packages
+    items:
+      family: 'provider-family-aws'
+      s3: 'provider-aws-s3'
+      iam: 'provider-aws-iam'
+      rds: 'provider-aws-rds'
+
+subpackages:
+  - name: crossplane-provider-aws-${{range.key}}
+    range: packages
+    pipeline:
+      - runs: |
+          up xpkg xp-extract xpkg.upbound.io/upbound/${{range.value}}:v${{package.version}}
+          mkdir -p "${{targets.subpkgdir}}"
+          gunzip out.gz -c > "${{targets.subpkgdir}}"/package.yaml
 
 update:
   enabled: true

--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -1,0 +1,48 @@
+package:
+  name: crossplane-provider-aws
+  version: 0.38.0
+  epoch: 0
+  description: Official AWS Provider for Crossplane by Upbound
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - terraform-provider-aws
+
+environment:
+  contents:
+    packages:
+      - up
+      - build-base
+      - bash
+      - go
+      - busybox
+      - curl
+  environment:
+    CGO_ENABLED: 0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/upbound/provider-aws
+      tag: v${{package.version}}
+      expected-commit: 55b04472dc4f84bfa4259bef7e7ad779d0b13a93
+
+  - runs: |
+      # `make` downloads `up`, unless we move our prebuilt `up` to where it expects it.
+      GOARCH=$(go env GOARCH)
+      UP_VERSION=$(up --version)
+      echo "Using up ${UP_VERSION}"
+      mkdir -p ./.cache/tools/linux_${GOARCH}
+      mv $(which up) ./.cache/tools/linux_${GOARCH}/up-${UP_VERSION}
+
+      make UP_VERSION=${UP_VERSION}
+
+      mkdir -p "${{targets.destdir}}"/usr/local/bin/
+      cp ./_output/bin/linux_${GOARCH}/monolith "${{targets.destdir}}"/usr/local/bin/provider
+
+update:
+  enabled: true
+  github:
+    identifier: upbound/provider-aws
+    strip-prefix: v

--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -1,6 +1,6 @@
 package:
   name: crossplane-provider-aws
-  version: 0.38.0
+  version: 0.39.0
   epoch: 0
   description: Official AWS Provider for Crossplane by Upbound
   copyright:
@@ -26,7 +26,7 @@ pipeline:
     with:
       repository: https://github.com/upbound/provider-aws
       tag: v${{package.version}}
-      expected-commit: 55b04472dc4f84bfa4259bef7e7ad779d0b13a93
+      expected-commit: 7c83b7b45cdbf2e6ca36316662c4d29338a253e4
 
   - runs: |
       # `make` downloads `up`, unless we move our prebuilt `up` to where it expects it.

--- a/terraform-provider-aws.yaml
+++ b/terraform-provider-aws.yaml
@@ -1,6 +1,6 @@
 package:
   name: terraform-provider-aws
-  version: 5.12.0
+  version: 5.14.0
   epoch: 0
   description: Terraform AWS provider
   copyright:
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: https://github.com/hashicorp/terraform-provider-aws
       tag: v${{package.version}}
-      expected-commit: ba9babf992f3052e8d1581441be9ff424e05738e
+      expected-commit: 8aebcb61aa37f33f47606097cce23e5aa1783121
 
   - uses: go/build
     with:

--- a/terraform-provider-aws.yaml
+++ b/terraform-provider-aws.yaml
@@ -1,0 +1,41 @@
+package:
+  name: terraform-provider-aws
+  version: 5.12.0
+  epoch: 0
+  description: Terraform AWS provider
+  copyright:
+    - license: MPL-2.0
+  dependencies:
+    runtime:
+      - terraform
+      - terraform-local-provider-config
+      - terraform-compat
+
+environment:
+  environment:
+    CGO_ENABLED: 0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hashicorp/terraform-provider-aws
+      tag: v${{package.version}}
+      expected-commit: ba9babf992f3052e8d1581441be9ff424e05738e
+
+  - uses: go/build
+    with:
+      packages: .
+      output: terraform-provider-aws
+      ldflags: -s -w
+
+  - runs: |
+      GOARCH=$(go env GOARCH)
+      mkdir -p "${{targets.destdir}}"/terraform/provider-mirror/registry.terraform.io/hashicorp/aws/${{package.version}}/linux_${GOARCH}/
+      ln -s "${{targets.destdir}}"/usr/bin/terraform-provider-aws \
+          "${{targets.destdir}}"/terraform/provider-mirror/registry.terraform.io/hashicorp/aws/${{package.version}}/linux_${GOARCH}/terraform-provider-aws_v${{package.version}}_x5
+
+update:
+  enabled: true
+  github:
+    identifier: hashicorp/terraform-provider-aws
+    strip-prefix: v

--- a/terraform.yaml
+++ b/terraform.yaml
@@ -1,16 +1,13 @@
 package:
   name: terraform
   version: 1.5.5
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MPL-2.0
 
 environment:
-  contents:
-    packages:
-      - ca-certificates-bundle
-      - busybox
-      - go
+  environment:
+    CGO_ENABLED: 0
 
 pipeline:
   - uses: git-checkout
@@ -26,6 +23,31 @@ pipeline:
       ldflags: -s -w
 
   - uses: strip
+
+subpackages:
+  - name: terraform-compat
+    description: Compat package for terraform
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
+          ln -s /usr/bin/terraform "${{targets.subpkgdir}}"/usr/local/bin
+
+  - name: terraform-local-provider-config
+    description: Configure Terraform to use local providers
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/terraform/provider-mirror
+          cat > "${{targets.subpkgdir}}"/terraform/.terraformrc <<EOF
+          provider_installation {
+            filesystem_mirror {
+              path    = "/terraform/provider-mirror"
+              include = ["*/*"]
+            }
+            direct {
+              exclude = ["*/*"]
+            }
+          }
+          EOF
 
 update:
   enabled: false

--- a/up.yaml
+++ b/up.yaml
@@ -1,6 +1,6 @@
 package:
   name: up
-  version: 0.18.0
+  version: 0.19.1
   epoch: 0
   description: The Upbound CLI
   copyright:
@@ -21,7 +21,7 @@ pipeline:
     with:
       repository: https://github.com/upbound/up
       tag: v${{package.version}}
-      expected-commit: e1e24a6927012ad3fe7e9f57dc49960bcc40ec9b
+      expected-commit: e9d8bddb2eadaee601514821606c4178b812c15a
 
   - runs: |
       make submodules

--- a/up.yaml
+++ b/up.yaml
@@ -1,0 +1,38 @@
+package:
+  name: up
+  version: 0.18.0
+  epoch: 0
+  description: The Upbound CLI
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - build-base
+      - bash
+      - go
+  environment:
+    CGO_ENABLED: 0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/upbound/up
+      tag: v${{package.version}}
+      expected-commit: e1e24a6927012ad3fe7e9f57dc49960bcc40ec9b
+
+  - runs: |
+      make submodules
+      make install
+
+      # This installs `up` into `$GOPATH/bin/up`, but we want it in `/usr/bin/up`.
+      mkdir -p "${{targets.destdir}}"/usr/bin
+      install -Dm755 $(go env GOPATH)/bin/up "${{targets.destdir}}"/usr/bin/up
+
+update:
+  enabled: true
+  github:
+    identifier: upbound/up
+    strip-prefix: v


### PR DESCRIPTION
- package `up` which is used during provider builds
- package `terraform-provider-aws` which is used by `crossplane-provider-aws`
- add subpackages for `terraform` to use local providers (i.e., our own providers; instead of having `terraform init` download them from registry.terraform.io)
- package `crossplane-provider-aws` which we can put in an image to act as the Upbound official Crossplane provider for AWS

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
