### PR TITLE
istio-envoy-1.18.2: an Envoy build with Istio plugins

### DIFF
--- a/istio-envoy.yaml
+++ b/istio-envoy.yaml
@@ -56,12 +56,19 @@ pipeline:
 
       bazel build --verbose_failures -c opt envoy
 
-      # Istio proxy-agent expects Envoy here
-      # See https://github.com/istio/istio/blob/1.18.0/pkg/config/constants/constants.go#L59-L60
-      mkdir -p ${{targets.destdir}}/usr/local/bin/
-      mv bazel-bin/envoy ${{targets.destdir}}/usr/local/bin/envoy
+      mkdir -p ${{targets.destdir}}/usr/bin/
+      mv bazel-bin/envoy ${{targets.destdir}}/usr/bin/envoy
 
   - uses: strip
+
+subpackages:
+  - name: istio-envoy-compat
+    pipeline:
+      - runs: |
+          # link /usr/bin/envoy /usr/local/bin/envoy because Istio proxy-agent expects Envoy here
+          # See https://github.com/istio/istio/blob/1.18.0/pkg/config/constants/constants.go#L59-L60
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          ln -sf /usr/bin/envoy ${{targets.subpkgdir}}/usr/local/bin/envoy
 
 update:
   enabled: true

--- a/istio-envoy.yaml
+++ b/istio-envoy.yaml
@@ -42,15 +42,14 @@ pipeline:
       repository: https://github.com/istio/proxy
       tag: ${{package.version}}
       expected-commit: 3c27a1b0cf381ca854ccc3a2034e88c206928da2
-      destination: proxy
 
   - runs: |
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
       mkdir -p .cache/bazel/_bazel_root
 
-      cd proxy
       echo "build --config=clang" >> user.bazelrc
 
+      # When patching to 1.18.2, the PR
       # https://github.com/istio/proxy/commit/3c27a1b0cf381ca854ccc3a2034e88c206928da2 updated
       # the Envoy commit without updating its checksum.
       sed -i s/0a932fd090feed587d82b4b943a1032a5a424587f65455a37236cffefc8648ef/8795a73871ce8bd4138191f746d4f1f5d0935d5e65b2b6f1803f966f13065211/g WORKSPACE

--- a/istio-envoy.yaml
+++ b/istio-envoy.yaml
@@ -1,0 +1,67 @@
+package:
+  name: istio-envoy
+  version: 1.18.0
+  epoch: 0
+  description: Envoy with additional Istio plugins (wasm, telemetry, etc)
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      # We don't use automake/autoconf directly, but the Bazel rule uses them
+      - autoconf
+      - automake
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-baselayout
+      - binutils
+      - build-base
+      - git
+      - bazel-6
+      - openjdk-11
+      - bash
+      - libtool
+      - cmake
+      - samurai
+      - python3-dev
+      - clang~15
+      - llvm15
+      - llvm15-dev
+      - llvm-lld-15
+      - llvm15-tools
+      - llvm15-cmake-default
+      - coreutils
+      - patch
+      # We need to stick to gcc 12 for now, envoy doesn't build with gcc >= 13
+      - gcc-12-default
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/proxy
+      tag: ${{package.version}}
+      expected-commit: e9ff5fc6ab89d0383d2db9e3a45ca13d96e58729
+      destination: proxy
+
+  - runs: |
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+      mkdir -p .cache/bazel/_bazel_root
+
+      cd proxy
+      echo "build --config=clang" >> user.bazelrc
+
+      bazel build --verbose_failures -c opt envoy
+
+      # Istio proxy-agent expects Envoy here
+      # See https://github.com/istio/istio/blob/1.18.0/pkg/config/constants/constants.go#L59-L60
+      mkdir -p ${{targets.destdir}}/usr/local/bin/
+      mv bazel-bin/envoy ${{targets.destdir}}/usr/local/bin/envoy
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: istio/proxy
+    use-tag: true

--- a/istio-envoy.yaml
+++ b/istio-envoy.yaml
@@ -1,6 +1,6 @@
 package:
   name: istio-envoy
-  version: 1.18.0
+  version: 1.18.2
   epoch: 0
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
   copyright:
@@ -41,7 +41,7 @@ pipeline:
     with:
       repository: https://github.com/istio/proxy
       tag: ${{package.version}}
-      expected-commit: e9ff5fc6ab89d0383d2db9e3a45ca13d96e58729
+      expected-commit: 3c27a1b0cf381ca854ccc3a2034e88c206928da2
       destination: proxy
 
   - runs: |
@@ -50,6 +50,10 @@ pipeline:
 
       cd proxy
       echo "build --config=clang" >> user.bazelrc
+
+      # https://github.com/istio/proxy/commit/3c27a1b0cf381ca854ccc3a2034e88c206928da2 updated
+      # the Envoy commit without updating its checksum.
+      sed -i s/0a932fd090feed587d82b4b943a1032a5a424587f65455a37236cffefc8648ef/8795a73871ce8bd4138191f746d4f1f5d0935d5e65b2b6f1803f966f13065211/g WORKSPACE
 
       bazel build --verbose_failures -c opt envoy
 


### PR DESCRIPTION
Adding Istio's envoy build. It is based on upstream Envoy with additional policy and telemetry plugins.

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates