### PR TITLE
Move newrelic agent back to stable version

### DIFF
--- a/newrelic-infrastructure-agent.yaml
+++ b/newrelic-infrastructure-agent.yaml
@@ -43,4 +43,3 @@ update:
   enabled: true
   github:
     identifier: newrelic/infrastructure-agent
-    use-tag: true

--- a/newrelic-infrastructure-agent.yaml
+++ b/newrelic-infrastructure-agent.yaml
@@ -1,6 +1,6 @@
 package:
   name: newrelic-infrastructure-agent
-  version: 1.46.1
+  version: 1.45.0
   epoch: 0
   description: New Relic Infrastructure Agent
   copyright:
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: https://github.com/newrelic/infrastructure-agent
       tag: ${{package.version}}
-      expected-commit: 5f63f460103e9f8a705144ca0f62fc8953de82fb
+      expected-commit: 1cfd539a4796a48638fcb243bc8a713847b1fc6f
 
   - runs: |
       # Our global LDFLAGS conflict with a Makefile parameter: https://github.com/newrelic/infrastructure-agent/blob/07ab68f181e25a1552588a3953167e0b15f52372/build/build.mk#L20-L22

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -159,3 +159,5 @@ gtk-3.0-3.24.38-r0.apk
 gtk-3.0-dev-3.24.38-r0.apk
 gtk-3.0-doc-3.24.38-r0.apk
 gtk-3.0-lang-3.24.38-r0.apk
+newrelic-infrastructure-agent-1.46.0-r0.apk
+newrelic-infrastructure-agent-1.46.1-r0.apk


### PR DESCRIPTION
The current build doesn't work as the tag doesn't exist. This moves the version _back_ to the current stable version.