### PR TITLE
Spire fix.

### DIFF
--- a/spire-server.yaml
+++ b/spire-server.yaml
@@ -36,6 +36,12 @@ pipeline:
       # using to avoid this.
       goversion=$(go version | cut -d ' ' -f3)
       goversion=${goversion:2}
+      # There's a bug in the spire build script that strips the .0
+      # as presumably previous Go compilers omitted it
+      # Just add an extra one to work around
+      if [[ $str == *".0" ]]; then
+         str="${str}.0"
+      fi
       echo ${goversion} > .go-version
       cat .go-version
 

--- a/spire-server.yaml
+++ b/spire-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: spire-server
   version: 1.7.1
-  epoch: 0
+  epoch: 1
   description: The SPIFFE Runtime Environment (SPIRE) server
   copyright:
     - license: Apache-2.0

--- a/spire-server.yaml
+++ b/spire-server.yaml
@@ -39,9 +39,11 @@ pipeline:
       # There's a bug in the spire build script that strips the .0
       # as presumably previous Go compilers omitted it
       # Just add an extra one to work around
-      if [[ $str == *".0" ]]; then
-         str="${str}.0"
-      fi
+      case "$str" in
+          *.0)
+              str="${str}.0"
+              ;;
+      esac
       echo ${goversion} > .go-version
       cat .go-version
 

--- a/spire-server.yaml
+++ b/spire-server.yaml
@@ -39,9 +39,9 @@ pipeline:
       # There's a bug in the spire build script that strips the .0
       # as presumably previous Go compilers omitted it
       # Just add an extra one to work around
-      case "$str" in
+      case "$goversion" in
           *.0)
-              str="${str}.0"
+              goversion="${goversion}.0"
               ;;
       esac
       echo ${goversion} > .go-version


### PR DESCRIPTION
Fixed go version problem.

Note this seems to build ok on GitHub but fails locally, presumably related to MacOS.