### PR TITLE
use gcsfuse within the runner instead of prepopulating

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,12 +54,17 @@ jobs:
           # rebuild the targets that depend on this (all)
           touch -d @0 local-melange.rsa
 
-      # Use a gcsfuse RO mount set up by the self-hosted runner. This prevents
-      # needing to exchange tokens and avoids storing keys (even ephemeral
-      # ones) on the self hosted runner. The gcsfuse mount is set up with RO
-      # via workload identity federation.
       - name: 'Prepare package repository'
         run: |
+          # yay wolfi!
+          apk add gcsfuse
+
+          # Set up a gcsfuse RO mount to the public bucket. This is a cheap and
+          # cheerful way to recreate the make targets (class A HEADs) locally
+          # without syncing the whole bucket (class A+B).
+          mkdir -p /gcsfuse/wolfi-registry
+          gcsfuse -o ro --implicit-dirs --only-dir os wolfi-production-registry-destination /gcsfuse/wolfi-registry
+
           mkdir -p ${{ github.workspace }}/packages/${{ matrix.arch }}
           # Symlink the gcsfuse mount to ./packages/ to workaround the Makefile CWD assumptions
           ln -s /gcsfuse/wolfi-registry/${{ matrix.arch }}/* ${{ github.workspace }}/packages/${{ matrix.arch }}/
@@ -78,7 +83,7 @@ jobs:
 
       - name: 'Normalize repository permissions'
         run: |
-          sudo chown -R $(id -u):$(id -g) "${{ github.workspace }}/packages"
+          chown -R $(id -u):$(id -g) "${{ github.workspace }}/packages"
 
       - name: 'Archive built packages to Github Artifacts'
         uses: actions/upload-artifact@v3
@@ -88,7 +93,8 @@ jobs:
           retention-days: 1 # Low ttl since this is just an intermediary used once
 
   upload:
-    runs-on: ubuntu-latest
+    # reindexing is cpu intensive
+    runs-on: ubuntu-16-core
     needs: build
 
     permissions:
@@ -141,7 +147,7 @@ jobs:
             cp -r ./built-packages-${arch}/* ./packages/
 
             # Rebuild the APKINDEX from the built packages and current packages
-            melange index -o "packages/${arch}/APKINDEX.tar.gz" "packages/${arch}/*.apk"
+            melange index -o "packages/${arch}/APKINDEX.tar.gz" -a $arch "packages/${arch}/*.apk"
 
             # Sign the indexes
             melange sign-index --signing-key ./wolfi-signing.rsa "packages/${arch}/APKINDEX.tar.gz"


### PR DESCRIPTION
reduce some dependence on the self hosted runners, turns out for public buckets you don't need any permissions for a RO mount