### PR TITLE
use local paths to ensure they work within a container

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           # This is to avoid fatal errors about "dubious ownership" because we are
           # running inside of a container action with the workspace mounted in.
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory .
 
       # Build with a local key, we'll resign this with the real key later
       - name: 'Generate local signing key'
@@ -65,9 +65,9 @@ jobs:
           mkdir -p /gcsfuse/wolfi-registry
           gcsfuse -o ro --implicit-dirs --only-dir os wolfi-production-registry-destination /gcsfuse/wolfi-registry
 
-          mkdir -p ${{ github.workspace }}/packages/${{ matrix.arch }}
+          mkdir -p ./packages/${{ matrix.arch }}
           # Symlink the gcsfuse mount to ./packages/ to workaround the Makefile CWD assumptions
-          ln -s /gcsfuse/wolfi-registry/${{ matrix.arch }}/* ${{ github.workspace }}/packages/${{ matrix.arch }}/
+          ln -s /gcsfuse/wolfi-registry/${{ matrix.arch }}/* ./packages/${{ matrix.arch }}/
 
       # TODO: Replace this with wolfictl build
       - name: 'Build Wolfi'
@@ -79,11 +79,11 @@ jobs:
 
       # Remove the temporary symlinks so the artifact upload only includes the built packages
       - run: |
-          find ${{ github.workspace }}/packages/${{ matrix.arch }} -type l -exec rm -f {} \;
+          find ./packages/${{ matrix.arch }} -type l -exec rm -f {} \;
 
       - name: 'Normalize repository permissions'
         run: |
-          chown -R $(id -u):$(id -g) "${{ github.workspace }}/packages"
+          chown -R $(id -u):$(id -g) ./packages
 
       - name: 'Archive built packages to Github Artifacts'
         uses: actions/upload-artifact@v3
@@ -119,9 +119,9 @@ jobs:
 
       - name: 'Sync public package repository'
         run: |
-          mkdir -p "${{ github.workspace }}/packages/"
-          gsutil -m rsync -r gs://wolfi-production-registry-destination/os/ "${{ github.workspace }}/packages/"
-          find "${{ github.workspace }}/packages" -print -exec touch \{} \;
+          mkdir -p ./packages/
+          gsutil -m rsync -r gs://wolfi-production-registry-destination/os/ ./packages/
+          find ./packages -print -exec touch \{} \;
 
       - name: 'Download x86_64 package archives'
         uses: actions/download-artifacts@v3
@@ -147,32 +147,32 @@ jobs:
             cp -r ./built-packages-${arch}/* ./packages/
 
             # Rebuild the APKINDEX from the built packages and current packages
-            melange index -o "packages/${arch}/APKINDEX.tar.gz" -a $arch "packages/${arch}/*.apk"
+            melange index -o "./packages/${arch}/APKINDEX.tar.gz" -a $arch "./packages/${arch}/*.apk"
 
             # Sign the indexes
-            melange sign-index --signing-key ./wolfi-signing.rsa "packages/${arch}/APKINDEX.tar.gz"
+            melange sign-index --signing-key ./wolfi-signing.rsa "./packages/${arch}/APKINDEX.tar.gz"
           done
 
       # TODO: Enable this when we're ready to go live
       # - name: 'Upload the repository to the bucket'
       #   run: |
-      #     cp /etc/apk/keys/wolfi-signing.rsa.pub ${{ github.workspace }}/packages/wolfi-signing.rsa.pub
+      #     cp /etc/apk/keys/wolfi-signing.rsa.pub ./packages/wolfi-signing.rsa.pub
       #
       #     for arch in "x86_64" "aarch64"; do
       #       # Don't cache the APKINDEX.
       #       gcloud --quiet storage cp \
       #           --cache-control=no-store \
-      #           "${{ github.workspace }}/packages/${arch}/APKINDEX.tar.gz" "gs://wolfi-production-registry-destination/os/${arch}/"
+      #           "./packages/${arch}/APKINDEX.tar.gz" "gs://wolfi-production-registry-destination/os/${arch}/"
       #
       #     gcloud --quiet storage cp \
       #         --cache-control=no-store \
-      #         "${{ github.workspace }}/packages/${arch}/APKINDEX.json" "gs://wolfi-production-registry-destination/os/${arch}/"
+      #         "./packages/${arch}/APKINDEX.json" "gs://wolfi-production-registry-destination/os/${arch}/"
       #
       #     # apks will be cached in CDN for an hour by default.
       #     # Don't upload the object if it already exists.
       #     gcloud --quiet storage cp \
       #         --no-clobber \
-      #         "${{ github.workspace }}/packages/${arch}/*.apk" "gs://wolfi-production-registry-destination/os/${arch}/"
+      #         "./packages/${arch}/*.apk" "gs://wolfi-production-registry-destination/os/${arch}/"
       #     done
 
   # TODO: Enable this when we're ready to go live


### PR DESCRIPTION
`${{ github.workspace }}` is not what we want it to be within a container, so just use relative paths and depend on sane CWD