### PR TITLE
kubernetes-1.28 version stream

### DIFF
--- a/kubernetes-1.28.yaml
+++ b/kubernetes-1.28.yaml
@@ -1,13 +1,13 @@
 package:
-  name: kubernetes-1.27
-  version: 1.27.4
-  epoch: 2
+  name: kubernetes-1.28
+  version: 1.28.0
+  epoch: 0
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
-      - kubernetes=1.27
+      - kubernetes=1.28
 
 environment:
   contents:
@@ -40,13 +40,7 @@ pipeline:
     with:
       repository: https://github.com/kubernetes/kubernetes
       tag: v${{package.version}}
-      expected-commit: fa3d7990104d7c1f16943a67f11b154b71f6a132
-
-  - runs: |
-      # Mitigate GHSA-hqxw-f8mx-cpmw / CVE-2023-2253
-      ./hack/pin-dependency.sh github.com/docker/distribution v2.8.2
-      ./hack/update-vendor.sh
-      ./hack/lint-dependencies.sh
+      expected-commit: 855e7c48de7388eb330da0f8d9d2394ee818fb8d
 
   - runs: |
       WHAT=""
@@ -63,26 +57,26 @@ pipeline:
       mkdir -p "${{targets.destdir}}"/etc/kubernetes
 
 subpackages:
-  - name: kubectl-1.27
+  - name: kubectl-1.28
     description: A command line tool for communicating with a Kubernetes API server
     dependencies:
       provides:
-        - kubectl=1.27
+        - kubectl=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl-1.27
+          install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl-1.28
 
-  - name: kubectl-bash-completion-1.27
+  - name: kubectl-bash-completion-1.28
     dependencies:
       runtime:
-        - kubectl-1.27
+        - kubectl-1.28
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
-          _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl-1.27
+          _output/bin/kubectl completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubectl-1.28
 
-  - name: kubeadm-1.27
+  - name: kubeadm-1.28
     description: A tool for quickly installing Kubernetes and setting up a secure cluster
     dependencies:
       runtime:
@@ -92,76 +86,76 @@ subpackages:
         - conntrack-tools
         - crictl
       provides:
-        - kubeadm=1.27
+        - kubeadm=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubeadm ${{targets.subpkgdir}}/usr/bin/kubeadm-1.27
+          install -m755 _output/bin/kubeadm ${{targets.subpkgdir}}/usr/bin/kubeadm-1.28
 
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
           _output/bin/kubeadm completion bash > "${{targets.subpkgdir}}"/usr/share/bash-completion/completions/kubeadm
 
-  - name: kubelet-1.27
+  - name: kubelet-1.28
     description: An agent that runs on each node in a Kubernetes cluster making sure that containers are running in a Pod
     dependencies:
       runtime:
         - ip6tables
       provides:
-        - kubelet=1.27
+        - kubelet=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kubelet ${{targets.subpkgdir}}/usr/bin/kubelet-1.27
+          install -m755 _output/bin/kubelet ${{targets.subpkgdir}}/usr/bin/kubelet-1.28
 
           install -d ${{targets.subpkgdir}}/var/lib/kubelet
           install -d ${{targets.subpkgdir}}/var/log/kubelet
 
-  - name: kube-scheduler-1.27
+  - name: kube-scheduler-1.28
     description: Kubernetes control plane component watching over pods on nodes
     dependencies:
       provides:
-        - kube-scheduler=1.27
+        - kube-scheduler=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-scheduler ${{targets.subpkgdir}}/usr/bin/kube-scheduler-1.27
+          install -m755 _output/bin/kube-scheduler ${{targets.subpkgdir}}/usr/bin/kube-scheduler-1.28
 
           install -d ${{targets.subpkgdir}}/var/log/kube-scheduler
 
-  - name: kube-proxy-1.27
+  - name: kube-proxy-1.28
     description: Kubernetes network proxy that runs on each node
     dependencies:
       provides:
-        - kube-proxy=1.27
+        - kube-proxy=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-proxy ${{targets.subpkgdir}}/usr/bin/kube-proxy-1.27
+          install -m755 _output/bin/kube-proxy ${{targets.subpkgdir}}/usr/bin/kube-proxy-1.28
 
           install -d ${{targets.subpkgdir}}/var/lib/kube-proxy
           install -d ${{targets.subpkgdir}}/var/log/kube-proxy
 
-  - name: kube-controller-manager-1.27
+  - name: kube-controller-manager-1.28
     description: Kubernetes control plane component that runs controller processes
     dependencies:
       provides:
-        - kube-controller-manager=1.27
+        - kube-controller-manager=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-controller-manager ${{targets.subpkgdir}}/usr/bin/kube-controller-manager-1.27
+          install -m755 _output/bin/kube-controller-manager ${{targets.subpkgdir}}/usr/bin/kube-controller-manager-1.28
 
           install -d ${{targets.subpkgdir}}/var/log/kube-controller-manager
 
-  - name: kube-apiserver-1.27
+  - name: kube-apiserver-1.28
     description: Kubernetes control plane component exposing the Kubernetes API
     dependencies:
       provides:
-        - kube-apiserver=1.27
+        - kube-apiserver=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          install -m755 _output/bin/kube-apiserver ${{targets.subpkgdir}}/usr/bin/kube-apiserver-1.27
+          install -m755 _output/bin/kube-apiserver ${{targets.subpkgdir}}/usr/bin/kube-apiserver-1.28
 
           install -d ${{targets.subpkgdir}}/var/log/kube-apiserver
 
@@ -177,21 +171,20 @@ subpackages:
           CFLAGS="$CFLAGS -static -DVERSION=${{vars.pause-version}}-${{package.version}}"
           gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.9 linux/pause.c
 
-  - name: kubernetes-1.27-default
-    description: "Compatibility package to set 1.27 as the default kubernetes, and add packages to their shortened path"
+  - name: kubernetes-1.28-default
+    description: "Compatibility package to set 1.28 as the default kubernetes, and add packages to their shortened path"
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -s kubectl-1.27 ${{targets.subpkgdir}}/usr/bin/kubectl
-          ln -s kubelet-1.27 ${{targets.subpkgdir}}/usr/bin/kubelet
-          ln -s kube-scheduler-1.27 ${{targets.subpkgdir}}/usr/bin/kube-scheduler
-          ln -s kube-proxy-1.27 ${{targets.subpkgdir}}/usr/bin/kube-proxy
-          ln -s kube-controller-manager-1.27 ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
-          ln -s kube-apiserver-1.27 ${{targets.subpkgdir}}/usr/bin/kube-apiserver
+          ln -s kubectl-1.28 ${{targets.subpkgdir}}/usr/bin/kubectl
+          ln -s kubelet-1.28 ${{targets.subpkgdir}}/usr/bin/kubelet
+          ln -s kube-scheduler-1.28 ${{targets.subpkgdir}}/usr/bin/kube-scheduler
+          ln -s kube-proxy-1.28 ${{targets.subpkgdir}}/usr/bin/kube-proxy
+          ln -s kube-controller-manager-1.28 ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
+          ln -s kube-apiserver-1.28 ${{targets.subpkgdir}}/usr/bin/kube-apiserver
 
 update:
   enabled: true
   github:
     identifier: kubernetes/kubernetes
     strip-prefix: v
-    tag-filter: v1.27


### PR DESCRIPTION


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

