### PR TITLE
fix cadvisor, it does not work with go-1.21 yet

### DIFF
--- a/cadvisor.yaml
+++ b/cadvisor.yaml
@@ -1,7 +1,7 @@
 package:
   name: cadvisor
   version: 0.47.3
-  epoch: 3
+  epoch: 4
   description: Analyzes resource usage and performance characteristics of running containers.
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ environment:
       - busybox
       - bash
       - build-base
-      - go
+      - go-1.20 # Pinned to 1.20 due to upstream issues with 1.21
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
cadvisor is broken with go-1.21, a panic is thrown when trying to execute the built binary

example:
```
panic: flag v set at /home/build/cmd/cadvisor.go:105 before being defined

goroutine 1 [running]:
flag.(*FlagSet).Var(0x400016c150, {0x1366da0, 0x1ce2d48}, {0x1358d28, 0x1}, {0x10e3958, 0x22})
	/usr/lib/go/src/flag/flag.go:1031 +0x2b4
k8s.io/klog/v2.InitFlags.func1(0x400019d2f0?)
	/home/build/.cache/go/pkg/mod/k8s.io/klog/v2@v2.80.1/klog.go:439 +0x3c
flag.(*FlagSet).VisitAll(0x4000713ce8?, 0x4000713c88)
	/usr/lib/go/src/flag/flag.go:458 +0x4c
k8s.io/klog/v2.InitFlags(0x40004a9bf0?)
	/home/build/.cache/go/pkg/mod/k8s.io/klog/v2@v2.80.1/klog.go:438 +0x48
main.main()
	/home/build/cmd/cadvisor.go:109 +0x30
```