### PR TITLE
don't re-index the APKINDEX

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           # This is to avoid fatal errors about "dubious ownership" because we are
           # running inside of a container action with the workspace mounted in.
-          git config --global --add safe.directory .
+          git config --global --add safe.directory "$(pwd)"
 
       # Build with a local key, we'll resign this with the real key later
       - name: 'Generate local signing key'
@@ -67,9 +67,13 @@ jobs:
 
           mkdir -p ./packages/${{ matrix.arch }}
           # Symlink the gcsfuse mount to ./packages/ to workaround the Makefile CWD assumptions
-          ln -s /gcsfuse/wolfi-registry/${{ matrix.arch }}/* ./packages/${{ matrix.arch }}/
+          ln -s /gcsfuse/wolfi-registry/${{ matrix.arch }}/*.apk ./packages/${{ matrix.arch }}/
 
-      # TODO: Replace this with wolfictl build
+          # Make a copy of the APKINDEX.* since we'll need to write to it on package builds
+          cp /gcsfuse/wolfi-registry/${{ matrix.arch }}/APKINDEX.* ./packages/${{ matrix.arch }}/
+
+      # TODO: Replace this with wolfictl build, since the current make build
+      # method doesn't trigger new builds for dependent updates.
       - name: 'Build Wolfi'
         run: |
           make \
@@ -143,9 +147,6 @@ jobs:
           for arch in "x86_64" "aarch64"; do
             # Consolidate with the built artifacts
             tar xvf /tmp/artifacts/packages-${arch}.tar.gz
-
-            # Rebuild the APKINDEX from the built packages and current packages
-            melange index -o "./packages/${arch}/APKINDEX.tar.gz" -a $arch "./packages/${arch}/*.apk"
 
             # Sign the indexes
             melange sign-index --signing-key ./wolfi-signing.rsa "./packages/${arch}/APKINDEX.tar.gz"


### PR DESCRIPTION
`melange index` loads every single APK to update the index, whereas the post build index only loads the changed apks