### PR TITLE
py3-certifi: use actual versions and transform when needed

### DIFF
--- a/py3-certifi.yaml
+++ b/py3-certifi.yaml
@@ -49,6 +49,7 @@ pipeline:
   - runs: |
       python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
 
+      # TODO: Need to update this path when building using python-3.12
       sed -i 's/Version: ${{vars.normalized-package-version}}/Version: ${{package.version}}/' "${{targets.destdir}}"/usr/lib/python3.11/site-packages/certifi-${{vars.normalized-package-version}}-py3.11.egg-info/PKG-INFO
 
   - uses: strip

--- a/py3-certifi.yaml
+++ b/py3-certifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-certifi
-  version: 2023.7.22
-  epoch: 0
+  version: 2023.07.22
+  epoch: 1
   description: "Python3 package for providing Mozilla's CA Bundle"
   copyright:
     - license: MPL-2.0
@@ -20,11 +20,24 @@ environment:
       - python3
       - py3-setuptools
 
+# certifi uses a special versioning scheme where the version is a date like "2023.07.22". During the
+# build process, the version is "normalized" (and importantly, changed) to a form like "2023.7.22",
+# which creates problems with vulnerability scanners, since vulnerability data for certifi is filed
+# using its actual version numbers (the "2023.07.22" form). This transform creates the "normalized"
+# version, so that we can use it when needed to update the version string back to its original form in
+# the Python package's metadata.
+var-transforms:
+  - from: ${{package.version}}
+    match: ([0-9]{4})\.0*([0-9]{1,2})\.0*([0-9]{1,2})
+    replace: $1.$2.$3
+    to: normalized-package-version
+
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://files.pythonhosted.org/packages/source/c/certifi/certifi-${{package.version}}.tar.gz
-      expected-sha256: 539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082
+      repository: https://github.com/certifi/python-certifi.git
+      tag: ${{package.version}}
+      expected-commit: 8fb96ed81f71e7097ed11bc4d9b19afd7ea5c909
 
   - uses: patch
     with:
@@ -36,9 +49,13 @@ pipeline:
   - runs: |
       python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
 
+      sed -i 's/Version: ${{vars.normalized-package-version}}/Version: ${{package.version}}/' "${{targets.destdir}}"/usr/lib/python3.11/site-packages/certifi-${{vars.normalized-package-version}}-py3.11.egg-info/PKG-INFO
+
   - uses: strip
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 7995
+  github:
+    identifier: certifi/python-certifi
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
This adjusts `py3-certifi` to use _GitHub_ to retrieve the source code, and for package update information.

This means the "correct" package versions (in the form of `2023.07.22`) can now be used with the APK.

This also improves vulnerability scanner results, because some scanners have been sorting `2023.07.22` and `2023.7.22` inconsistently from one another. Vulnerability data is filed with the former version format (e.g. [here](https://github.com/advisories/GHSA-xqr8-7jwr-rhp7)), but the Python installation step "normalizes" the version to the latter version format, which introduces confusion, particularly with scanners.

I also bumped the epoch because of said version comparison confusion.

Before:

```console
$ w scan ./packages/aarch64/py3-certifi-2023.7.22-r0.apk
Will process: py3-certifi-2023.7.22-r0.apk
└── 📄 /usr/lib/python3.11/site-packages/certifi-2023.7.22-py3.11.egg-info/PKG-INFO, /usr/lib/python3.11/site-packages/certifi-2023.7.22-py3.11.egg-info/top_level.txt
        📦 certifi 2023.7.22 (python)
            High CVE-2023-37920 GHSA-xqr8-7jwr-rhp7 fixed in 2023.07.22
```

After:

```console
$ w scan ./packages/aarch64/py3-certifi-2023.07.22-r1.apk
Will process: py3-certifi-2023.07.22-r1.apk
✅ No vulnerabilities found
```

