### PR TITLE
fix k3s, it does not work with go-1.21 yet

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.27.4
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - go
+      - go-1.20 # Pinned to 1.20 due to upstream issues with 1.21
       - curl
       - libseccomp-dev
       - sqlite-dev


### PR DESCRIPTION
this fixes k3s until it works with go 1.21 and avoid this panic when executing the binary

```
panic: flag alsologtostderr set at /home/build/pkg/cli/cmds/log.go:78 before being defined

goroutine 4415 [running]:
flag.(*FlagSet).Var(0x4000172150, {0x7b00aa8, 0xaa7bac9}, {0x6f75c54, 0xf}, {0x70f958d, 0x49})
	/usr/lib/go/src/flag/flag.go:1031 +0x2b4
k8s.io/klog/v2.InitFlags.func1(0x40002f2510?)
	/home/build/.cache/go/pkg/mod/github.com/k3s-io/klog/v2@v2.90.1-k3s1/klog.go:437 +0x3c
flag.(*FlagSet).VisitAll(0xaa78d80?, 0x4008a70f28)
	/usr/lib/go/src/flag/flag.go:458 +0x4c
k8s.io/klog/v2.InitFlags(0x7b368d0?)
	/home/build/.cache/go/pkg/mod/github.com/k3s-io/klog/v2@v2.90.1-k3s1/klog.go:436 +0x48
github.com/k3s-io/k3s/pkg/daemons/executor.(*Embedded).Bootstrap.func1()
	/home/build/pkg/daemons/executor/embed.go:61 +0x58
created by github.com/k3s-io/k3s/pkg/daemons/executor.(*Embedded).Bootstrap in goroutine 1
	/home/build/pkg/daemons/executor/embed.go:54 +0x90
```