### PR TITLE
Drop vestigial dependencies on apk-tools

### DIFF
--- a/apko.yaml
+++ b/apko.yaml
@@ -2,10 +2,13 @@ package:
   name: apko
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
   version: 0.10.0
-  epoch: 1
+  epoch: 2
   description: Build OCI images using APK directly without Dockerfile
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
 
 environment:
   contents:

--- a/melange.yaml
+++ b/melange.yaml
@@ -2,13 +2,13 @@ package:
   name: melange
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
   version: 0.4.0
-  epoch: 2
+  epoch: 3
   description: build APKs from source code
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - apk-tools
+      - ca-certificates-bundle
       - bubblewrap
       - busybox
 


### PR DESCRIPTION
Both apko and melange no longer rely on shelling out to apk.
