### PR TITLE
openssl-fips-test: new package

### DIFF
--- a/openssl-fips-test.yaml
+++ b/openssl-fips-test.yaml
@@ -1,0 +1,34 @@
+package:
+  name: openssl-fips-test
+  version: 0.1
+  epoch: 0
+  description: utility for validating an OpenSSL FIPS configuration
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - build-base
+      - openssl-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/chainguard-dev/openssl-fips-test
+      tag: v${{package.version}}
+      expected-commit: bc21ac50ed20074d9f45e7338f91c7af9df4c3ef
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: chainguard-dev/openssl-fips-test
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates