### PR TITLE
Build traefik with go-1.20.

### DIFF
--- a/traefik.yaml
+++ b/traefik.yaml
@@ -1,7 +1,7 @@
 package:
   name: traefik
   version: 2.10.4
-  epoch: 0
+  epoch: 1
   description: The Cloud Native Application Proxy
   copyright:
     - license: MIT
@@ -10,7 +10,7 @@ environment:
   contents:
     packages:
       - busybox
-      - go
+      - go-1.20 # Pinned to go 1.20 due to transitive dep - try to remove next bump
       - build-base
       - ca-certificates-bundle
       - git


### PR DESCRIPTION
quic-go dep doesn't build with go-1.21
