### PR TITLE
cassandra: add maven central mirror to help builds be more reliable

### DIFF
--- a/cassandra.yaml
+++ b/cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra
   version: 4.1.3
-  epoch: 2
+  epoch: 3
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0

--- a/cassandra/build.properties
+++ b/cassandra/build.properties
@@ -1,0 +1,1 @@
+artifact.remoteRepository.central=https://maven-central.storage-download.googleapis.com/repos/central/data/


### PR DESCRIPTION
We are seeing failures on main. By adding this cassandra/build.properties file we now start resolving dependencies from the mirror

```
ℹ️  aarch64   | [resolver:resolve] Resolving artifacts
ℹ️  aarch64   | [resolver:resolve] Downloading https://maven-central.storage-download.googleapis.com/repos/central/data/org/apache/rat/apache-rat-tasks/0.6/apache-rat-tasks-0.6.jar
ℹ️  aarch64   | [resolver:resolve] Downloading https://maven-central.storage-download.googleapis.com/repos/central/data/org/apache/rat/apache-rat-core/0.6/apache-rat-core-0.6.jar
ℹ️  aarch64   | [resolver:resolve] Downloading https://maven-central.storage-download.googleapis.com/repos/central/data/commons-collections/commons-collections/3.2/commons-collections-3.2.jar
```