### PR TITLE
remove runtime dependency on ca-certificates-bundle.

### DIFF
--- a/alpine-keys.yaml
+++ b/alpine-keys.yaml
@@ -1,13 +1,10 @@
 package:
   name: alpine-keys
   version: 2.4
-  epoch: 1
+  epoch: 2
   description: Public keys for Alpine Linux packages
   copyright:
     - license: MIT
-  options:
-    # There are no executables in this package.
-    no-commands: true
 
 environment:
   contents:

--- a/alpine-keys.yaml
+++ b/alpine-keys.yaml
@@ -5,9 +5,9 @@ package:
   description: Public keys for Alpine Linux packages
   copyright:
     - license: MIT
-  dependencies:
-    runtime:
-      - ca-certificates-bundle
+  options:
+    # There are no executables in this package.
+    no-commands: true
 
 environment:
   contents:


### PR DESCRIPTION
There is no reason to have the ca-certificates-bundle as a runtime dependency, so remove it.

Fixes:

Related:
