### PR TITLE
docs: build command example and recommend not using cache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,7 @@ What it does is start the `ghcr.io/wolfi-dev/sdk` image and mount the current wo
 
 Wolfi packages are built using melange. If you want to learn how packages are built, you can see all the details in the [`ci-build`](.github/workflows/ci-build.yaml) workflow and in the [Makefile](Makefile).
 
-Start by cloning this repository and create a YAML file named `<your-package-name>.yaml` in its root directory. If you have any patches, create a folder at the root of the repository with the same name as the package and put the patches there.
-
+Start by cloning this repository and create a build configuration YAML file named `<your-new-package-name>.yaml` in its root directory. If you have any patch files that are needed to build this package, create a folder at the root of the repository with the same name as the package and put the patches there.
 
 Once you're done writing the new package configuration file, you can test it by building the new package.
 
@@ -33,13 +32,15 @@ Once you're done writing the new package configuration file, you can test it by 
 
 To build an individual package, you can use a `make` command like this:
 
-```shell
-make package/your-package-name BUILDWORLD=no
+```text
+make package/<your-new-package-name> BUILDWORLD=no USE_CACHE=no
 ```
+
+For example, if your package name is "foo", run `make package/foo BUILDWORLD=no USE_CACHE=no`.
 
 This will build the package by invoking [melange](https://github.com/chainguard-dev/melange) in a particular way. This invocation is defined in the [Makefile](Makefile), if you're interested to see how this is wired up. Also, you can run Melange _directly_ without using `make` if you understand what you're doing.
 
-**Note:** If you encounter an authentication error, it might be caused by a Melange caching feature. You can append `USE_CACHE=no` to the make commmand, so that it won't ask Melange to retrieve cached pipeline sources from a GCP cloud bucket.
+**Note:** The buildsystem has a cache of source files that may help reduce the time your build takes. Feel free to see if this cache helps you by removing `USE_CACHE=no` from the command above. If you encounter issues with this approach, the best advice is to restore the `USE_CACHE=no` to your command and carry on with your builds.
 
 When the build finishes, your package(s) should be found in the generated `./packages` directory.
 


### PR DESCRIPTION
This is a docs-only update, responding to recent friction log notes for folks trying to build packages and help us with CVE count reduction.

Feedback welcome!