### PR TITLE
GOTOOLCHAIN=local to ensure our Go version is used

### DIFF
--- a/build-aarch64.env
+++ b/build-aarch64.env
@@ -4,3 +4,4 @@ export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
 export GOFLAGS=""
+export GOTOOLCHAIN=local

--- a/build-armv7l.env
+++ b/build-armv7l.env
@@ -4,3 +4,4 @@ export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
 export GOFLAGS=""
+export GOTOOLCHAIN=local

--- a/build-x86_64.env
+++ b/build-x86_64.env
@@ -3,3 +3,4 @@ export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
 export GOFLAGS=""
+export GOTOOLCHAIN=local


### PR DESCRIPTION
## Go 1.21 changes

Go 1.21 introduced a change to how `go build` works that matters to us. Full details here: https://go.dev/doc/toolchain

tl;dr: when building a module, `go build` will look at that module's `go.mod` and can be directed to use the version of `go` specified by the module. If that version is not available, that version of `go` will be downloaded and used, having been previously built by the Go team.

## Why we care

We build our own `go` packages (`go-1.21`, `go-1.20`, previously older versions), and take care to keep them up to date, and are able to apply patches to resolve issues or vulnerabilities. If there was a future `go.1.21.3-r6` that included a vulnerability patch we applied, we'd want to be sure we can use that version exactly, and that `go build` won't download an older pre-built version from Go itself to use instead.

We also want to have a complete record of what version of (our) `go` was used to build our packages, and relying on Go's detection and fallback.

This might mean that some packages, that don't work with "our latest Go", will have to be pinned to a specific Go version in their package config, to be able to build (incl patch version, or even epoch). We expect "our latest Go" is a sane default in most cases.

--- 

This PR doesn't bump epochs for things built with Go, and I don't think it should, since this is currently a pretty disruptive and noisy change. Package updates will continue to be built with Go 1.21 as they're updated.