### PR TITLE
fix: bump provides clause for Gradle 8

### DIFF
--- a/gradle-8.yaml
+++ b/gradle-8.yaml
@@ -1,16 +1,15 @@
 package:
   name: gradle-8
-  # When bumping version, also bump the provides below!
+  version: 8.3.0 # When bumping version, also bump the provides below!
   # For version upgrades check whether patches are still needed.
   # Upstream changes are being tracked in https://github.com/gradle/gradle/issues/25945
-  version: 8.3.0
   epoch: 0
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
-      - gradle=8.2.1
+      - gradle=8.3.0
 
 environment:
   contents:


### PR DESCRIPTION
Bump the provides clause to accurately represent the current version provided by this package.

Related: #4510