### PR TITLE
alphabetize runtime / build deps for [a-c]*yaml.

### DIFF
--- a/acl.yaml
+++ b/acl.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
+      - attr-dev
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - attr-dev
+      - wolfi-base
 
 pipeline:
   - uses: fetch

--- a/acme.sh.yaml
+++ b/acme.sh.yaml
@@ -7,17 +7,17 @@ package:
     - license: GPL-3.0-only
   dependencies:
     runtime:
+      - curl
       - openssl
       - socat
-      - curl
 
 environment:
   contents:
     packages:
       - busybox
       - ca-certificates-bundle
-      - git
       - curl
+      - git
 
 pipeline:
   - uses: git-checkout

--- a/aerospike.yaml
+++ b/aerospike.yaml
@@ -9,18 +9,18 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
+      - cmake
+      - coreutils
+      - gmp-dev
       - libtool
       - openssl-dev
       - zlib-dev
-      - bash
-      - cmake
-      - gmp-dev
-      - coreutils
 
 pipeline:
   - uses: git-checkout

--- a/alpine-keys.yaml
+++ b/alpine-keys.yaml
@@ -9,8 +9,8 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
 
 pipeline:
   - uses: fetch

--- a/alsa-lib.yaml
+++ b/alsa-lib.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
       - linux-headers
 
 pipeline:

--- a/ant.yaml
+++ b/ant.yaml
@@ -12,9 +12,9 @@ package:
 environment:
   contents:
     packages:
+      - bash
       - busybox
       - ca-certificates-bundle
-      - bash
       - openjdk-8
 
 pipeline:

--- a/aom.yaml
+++ b/aom.yaml
@@ -9,17 +9,17 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
       - cmake
       - perl
       - python3
-      - yasm
       - samurai
       - tree
+      - yasm
 
 pipeline:
   - uses: git-checkout

--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -16,15 +16,15 @@ environment:
     keyring:
       - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
+      - lua5.3
+      - lua5.3-dev
+      - lua5.3-lzlib
+      - openssl-dev
       - scdoc
       - zlib-dev
-      - openssl-dev
-      - lua5.3
-      - lua5.3-lzlib
-      - lua5.3-dev
 
 pipeline:
   - uses: fetch

--- a/argo-cd.yaml
+++ b/argo-cd.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
-      - python3
       - nodejs-16
+      - python3
       - yarn
 
 pipeline:

--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -9,12 +9,12 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
-      - python3
-      - openssl
       - nodejs-20
+      - openssl
+      - python3
       - yarn
 
 pipeline:

--- a/argon2.yaml
+++ b/argon2.yaml
@@ -9,8 +9,8 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
       - build-base
+      - wolfi-base
 
 pipeline:
   - uses: git-checkout

--- a/asciidoc.yaml
+++ b/asciidoc.yaml
@@ -9,17 +9,17 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
-      - ca-certificates-bundle
-      - git
-      - build-base
-      - python3
       - autoconf
       - automake
-      - libxml2-utils
+      - build-base
+      - ca-certificates-bundle
       - docbook-xml
+      - git
+      - libxml2-utils
       - libxslt
       - py3-pip
+      - python3
+      - wolfi-base
 
 pipeline:
   - uses: git-checkout

--- a/asciidoctor.yaml
+++ b/asciidoctor.yaml
@@ -15,10 +15,10 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
       - busybox
       - ca-certificates-bundle
       - ruby-3.1
+      - wolfi-base
 
 pipeline:
   - uses: git-checkout

--- a/at-spi2-core.yaml
+++ b/at-spi2-core.yaml
@@ -9,9 +9,9 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - dbus-dev
       - glib-dev
       - gobject-introspection-dev

--- a/attr.yaml
+++ b/attr.yaml
@@ -9,10 +9,10 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
+      - wolfi-base
 
 pipeline:
   - uses: fetch

--- a/autoconf-archive.yaml
+++ b/autoconf-archive.yaml
@@ -10,11 +10,11 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
 
 pipeline:
   - uses: fetch

--- a/autoconf.yaml
+++ b/autoconf.yaml
@@ -17,9 +17,9 @@ environment:
     keyring:
       - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - m4
       - perl
 

--- a/automake.yaml
+++ b/automake.yaml
@@ -15,10 +15,10 @@ environment:
     keyring:
       - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
+      - autoconf
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - autoconf
 
 pipeline:
   - uses: fetch

--- a/avahi.yaml
+++ b/avahi.yaml
@@ -9,23 +9,23 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
-      - intltool
+      - dbus-dev
+      - expat-dev
+      - gdbm-dev
       - gettext-dev
       - glib-dev
       - gobject-introspection-dev
-      - expat-dev
-      - dbus-dev
+      - gtk-2.0-dev
+      - intltool
       - libcap-dev
       - libdaemon-dev
-      - libtool
       - libevent-dev
-      - gtk-2.0-dev
-      - gdbm-dev
+      - libtool
 
 pipeline:
   - uses: fetch

--- a/aws-c-auth.yaml
+++ b/aws-c-auth.yaml
@@ -9,19 +9,19 @@ package:
 environment:
   contents:
     packages:
-      - busybox
-      - ca-certificates-bundle
-      - build-base
-      - cmake
-      - samurai
       - aws-c-cal-dev
       - aws-c-common-dev
       - aws-c-compression-dev
       - aws-c-http-dev
       - aws-c-io-dev
       - aws-c-sdkutils-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
       - openssl-dev
       - s2n-tls-dev
+      - samurai
 
 pipeline:
   - uses: fetch

--- a/aws-c-common.yaml
+++ b/aws-c-common.yaml
@@ -9,12 +9,12 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - cmake
-      - samurai
       - python3-dev
+      - samurai
 
 pipeline:
   - uses: fetch

--- a/aws-c-io.yaml
+++ b/aws-c-io.yaml
@@ -11,12 +11,12 @@ environment:
     packages:
       - aws-c-cal-dev
       - aws-c-common-dev
-      - busybox
       - build-base
+      - busybox
       - ca-certificates-bundle
       - cmake
-      - s2n-tls-dev
       - openssl-dev
+      - s2n-tls-dev
       - samurai
 
 pipeline:

--- a/aws-c-mqtt.yaml
+++ b/aws-c-mqtt.yaml
@@ -9,18 +9,18 @@ package:
 environment:
   contents:
     packages:
-      - busybox
-      - ca-certificates-bundle
-      - build-base
-      - cmake
-      - samurai
       - aws-c-cal-dev
       - aws-c-common-dev
       - aws-c-compression-dev
       - aws-c-http-dev
       - aws-c-io-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
       - openssl-dev
       - s2n-tls-dev
+      - samurai
 
 pipeline:
   - uses: fetch

--- a/aws-cli.yaml
+++ b/aws-cli.yaml
@@ -7,27 +7,27 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - python3
-      - py3-setuptools
-      - py3-yaml
+      - groff
       - py3-botocore
+      - py3-colorama
       - py3-docutils
       - py3-jmespath
       - py3-rsa
       - py3-s3transfer
-      - py3-colorama
-      - groff
+      - py3-setuptools
+      - py3-yaml
+      - python3
 
 environment:
   contents:
     packages:
-      - wolfi-base
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
+      - py3-setuptools
       - python3
       - python3-dev
-      - py3-setuptools
+      - wolfi-base
 
 pipeline:
   - uses: fetch

--- a/aws-ebs-csi-driver.yaml
+++ b/aws-ebs-csi-driver.yaml
@@ -7,22 +7,22 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - mount
-      - lsblk
       - blkid
       - blockdev
-      - xfsprogs
       - e2fsprogs
       - e2fsprogs-extra
+      - lsblk
+      - mount
+      - xfsprogs
 
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - busybox
       - build-base
-      - go
+      - busybox
       - ca-certificates-bundle
+      - go
+      - wolfi-baselayout
 
 pipeline:
   # We can't use go/install because this requires specific ldflags to set the version

--- a/aws-efs-csi-driver.yaml
+++ b/aws-efs-csi-driver.yaml
@@ -7,22 +7,22 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - py3-botocore # required for cross account mount: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/Dockerfile#L52
       # Ref: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/Dockerfile#L61-L78
       - efs-utils # pull in nfs-utils & busybox
       - mount
-      - umount
       - openssl
+      - py3-botocore # required for cross account mount: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/Dockerfile#L52
       - tcpdump
+      - umount
 
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - busybox
       - build-base
-      - go
+      - busybox
       - ca-certificates-bundle
+      - go
+      - wolfi-baselayout
 
 pipeline:
   # We can't use go/install because this requires specific ldflags to set the version

--- a/aws-flb-cloudwatch.yaml
+++ b/aws-flb-cloudwatch.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - busybox
       - build-base
-      - go
+      - busybox
       - ca-certificates-bundle
+      - go
+      - wolfi-baselayout
 
 pipeline:
   - uses: git-checkout

--- a/aws-flb-firehose.yaml
+++ b/aws-flb-firehose.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - busybox
       - build-base
-      - go
+      - busybox
       - ca-certificates-bundle
+      - go
+      - wolfi-baselayout
 
 pipeline:
   - uses: git-checkout

--- a/aws-flb-kinesis.yaml
+++ b/aws-flb-kinesis.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - busybox
       - build-base
-      - go
+      - busybox
       - ca-certificates-bundle
+      - go
+      - wolfi-baselayout
 
 pipeline:
   - uses: git-checkout

--- a/aws-for-fluent-bit.yaml
+++ b/aws-for-fluent-bit.yaml
@@ -7,14 +7,14 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - ca-certificates-bundle
-      - fluent-bit
-      - aws-flb-kinesis
-      - aws-flb-kinesis-compat
-      - aws-flb-firehose
-      - aws-flb-firehose-compat
       - aws-flb-cloudwatch
       - aws-flb-cloudwatch-compat
+      - aws-flb-firehose
+      - aws-flb-firehose-compat
+      - aws-flb-kinesis
+      - aws-flb-kinesis-compat
+      - ca-certificates-bundle
+      - fluent-bit
 
 environment:
   contents:

--- a/aws-load-balancer-controller.yaml
+++ b/aws-load-balancer-controller.yaml
@@ -9,10 +9,10 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - busybox
       - bash
       - build-base
+      - busybox
+      - ca-certificates-bundle
       - go
 
 pipeline:

--- a/bank-vaults.yaml
+++ b/bank-vaults.yaml
@@ -9,9 +9,9 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - go
 
 pipeline:

--- a/bash.yaml
+++ b/bash.yaml
@@ -11,9 +11,9 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - ncurses-dev
 
 pipeline:

--- a/bat.yaml
+++ b/bat.yaml
@@ -12,8 +12,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - rust
       - libgit2-dev
+      - rust
       - zlib-dev
 
 pipeline:

--- a/bazel-5.yaml
+++ b/bazel-5.yaml
@@ -9,16 +9,16 @@ package:
 environment:
   contents:
     packages:
+      - bash
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - python3
-      - zip
-      - bash
       - gcc-6
       - libstdc++-6
       - libstdc++-6-dev
       - openjdk-11
+      - python3
+      - zip
 
 pipeline:
   - uses: fetch

--- a/bazel-6.yaml
+++ b/bazel-6.yaml
@@ -9,16 +9,16 @@ package:
 environment:
   contents:
     packages:
+      - bash
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - python3
-      - zip
-      - bash
       - gcc-6
       - libstdc++-6
       - libstdc++-6-dev
       - openjdk-11
+      - python3
+      - zip
 
 pipeline:
   - uses: fetch

--- a/binaryen.yaml
+++ b/binaryen.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
       - cmake
       - samurai
 

--- a/bind.yaml
+++ b/bind.yaml
@@ -9,12 +9,14 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
-      - bash
+      - dns-root-hints
+      - dnssec-root
       - fstrm-dev
       - krb5-dev
       - libcap-dev
@@ -25,8 +27,6 @@ environment:
       - openssl-dev
       - perl
       - protobuf-c-dev
-      - dnssec-root
-      - dns-root-hints
 
 pipeline:
   - uses: fetch

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -15,12 +15,12 @@ environment:
     keyring:
       - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
-      - wolfi-baselayout
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - isl
       - texinfo
+      - wolfi-baselayout
 
 pipeline:
   - uses: fetch

--- a/bison.yaml
+++ b/bison.yaml
@@ -16,11 +16,11 @@ environment:
     keyring:
       - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
-      - wolfi-baselayout
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - m4
+      - wolfi-baselayout
 
 pipeline:
   - uses: fetch

--- a/bluez.yaml
+++ b/bluez.yaml
@@ -10,23 +10,23 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
+      - dbus
       - dbus-dev
       - ell-dev
       - eudev-dev
       - glib-dev
-      - json-c-dev
       - icu-dev
+      - json-c-dev
       - libical-dev
       - libtool
       - linux-headers
       - py3-docutils
       - readline-dev
-      - dbus
 
 pipeline:
   - uses: fetch

--- a/boost.yaml
+++ b/boost.yaml
@@ -9,12 +9,12 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - python3
       - python3-dev
+      - wolfi-base
 
 data:
   - name: libs

--- a/botan.yaml
+++ b/botan.yaml
@@ -9,16 +9,16 @@ package:
 environment:
   contents:
     packages:
-      - python3
-      - zlib-dev
-      - xz-dev
-      - bzip2-dev
-      - wolfi-base
-      - busybox
       - boost-dev
-      - sqlite-dev
-      - ca-certificates-bundle
       - build-base
+      - busybox
+      - bzip2-dev
+      - ca-certificates-bundle
+      - python3
+      - sqlite-dev
+      - wolfi-base
+      - xz-dev
+      - zlib-dev
 
 pipeline:
   - uses: git-checkout

--- a/brotli.yaml
+++ b/brotli.yaml
@@ -9,13 +9,13 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
-      - busybox
-      - ca-certificates-bundle
-      - build-base
       - autoconf
       - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
       - libtool
+      - wolfi-base
 
 pipeline:
   - uses: fetch

--- a/btrfs-progs.yaml
+++ b/btrfs-progs.yaml
@@ -9,28 +9,28 @@ package:
 environment:
   contents:
     packages:
+      - asciidoc
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
+      - e2fsprogs-dev
+      - eudev-dev
+      - libgcrypt-dev
       - linux-headers
+      - lzo-dev
       - pkgconf-dev
-      - python3-dev
-      - py3-sphinx
-      - py3-setuptools
-      - py3-docutils
-      - py3-pygments
       - py3-babel
+      - py3-docutils
       - py3-jinja2
       - py3-packaging
-      - asciidoc
-      - e2fsprogs-dev
-      - libgcrypt-dev
+      - py3-pygments
+      - py3-setuptools
+      - py3-sphinx
+      - python3-dev
       - zlib-dev
       - zstd-dev
-      - lzo-dev
-      - eudev-dev
 
 pipeline:
   - uses: fetch

--- a/bubblewrap.yaml
+++ b/bubblewrap.yaml
@@ -11,12 +11,12 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - busybox
-      - build-base
       - bash
-      - meson
+      - build-base
+      - busybox
+      - ca-certificates-bundle
       - libcap-dev
+      - meson
 
 pipeline:
   - uses: fetch

--- a/buck2.yaml
+++ b/buck2.yaml
@@ -10,12 +10,12 @@ package:
 environment:
   contents:
     packages:
-      - libLLVM-15
-      - wolfi-base
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
+      - libLLVM-15
       - rustup
+      - wolfi-base
 
 vars:
   rust-version: nightly-2023-05-28

--- a/build-base.yaml
+++ b/build-base.yaml
@@ -7,12 +7,12 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - wolfi-baselayout
       - binutils
       - gcc
-      - pkgconf
-      - make
       - glibc-dev
+      - make
+      - pkgconf
+      - wolfi-baselayout
 
 environment:
   contents:
@@ -21,8 +21,8 @@ environment:
     keyring:
       - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
-      - wolfi-baselayout
       - busybox
+      - wolfi-baselayout
 
 pipeline:
   - name: Install

--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -9,8 +9,8 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
       - libseccomp-dev
       - libseccomp-static

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -25,9 +25,9 @@ environment:
     keyring:
       - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
 
 pipeline:
   - uses: fetch

--- a/bzip2.yaml
+++ b/bzip2.yaml
@@ -15,11 +15,11 @@ environment:
     keyring:
       - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
-      - wolfi-baselayout
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - make
+      - wolfi-baselayout
 
 pipeline:
   - uses: fetch

--- a/c-ares.yaml
+++ b/c-ares.yaml
@@ -9,10 +9,10 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
+      - wolfi-base
 
 pipeline:
   - uses: fetch

--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -15,11 +15,11 @@ environment:
     keyring:
       - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
-      - busybox
-      - perl
       - build-base
+      - busybox
       - ca-certificates-bundle
       - openssl-dev
+      - perl
 
 pipeline:
   - uses: fetch

--- a/cadvisor.yaml
+++ b/cadvisor.yaml
@@ -9,10 +9,10 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - busybox
       - bash
       - build-base
+      - busybox
+      - ca-certificates-bundle
       - go-1.20 # Pinned to 1.20 due to upstream issues with 1.21
 
 pipeline:

--- a/cairo.yaml
+++ b/cairo.yaml
@@ -9,22 +9,22 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
+      - expat-dev
       - fontconfig-dev
       - freetype-dev
+      - glib-dev
+      - libpng-dev
       - libxext-dev
       - libxrender-dev
+      - meson
       - pixman-dev
       - xcb-util
       - xcb-util-dev
-      - expat-dev
-      - glib-dev
-      - libpng-dev
-      - meson
       - zlib-dev
 
 pipeline:

--- a/calico.yaml
+++ b/calico.yaml
@@ -12,29 +12,29 @@ package:
 environment:
   contents:
     packages:
-      - busybox
-      - ca-certificates-bundle
-      - build-base
-      - bash
-      - go
-      # for felix
-      - elfutils-dev
-      - zlib-dev
-      - iproute2
-      - zstd-dev
-      - llvm15
-      - llvm15-tools
-      - clang-15
-      - clang-15-default
-      - libbpf
-      - linux-headers
-      # for BIRD
-      - flex
-      - bison
       - autoconf
       - automake
+      - bash
+      - bison
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang-15
+      - clang-15-default
       # TODO: Can remove this when cni-plugins are built from source
       - curl
+      # for felix
+      - elfutils-dev
+      # for BIRD
+      - flex
+      - go
+      - iproute2
+      - libbpf
+      - linux-headers
+      - llvm15
+      - llvm15-tools
+      - zlib-dev
+      - zstd-dev
 
 # The calico build process is heavily tailored towards using Makefiles to
 # orchestrate docker commands. This makes for a less than ideal

--- a/cassandra.yaml
+++ b/cassandra.yaml
@@ -7,18 +7,18 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - openjdk-8-jre
       - openjdk-8-default-jvm
+      - openjdk-8-jre
 
 environment:
   contents:
     packages:
+      - ant
+      - bash
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - bash
       - openjdk-8
-      - build-base
-      - ant
       - python3
 
 pipeline:

--- a/cdparanoia.yaml
+++ b/cdparanoia.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
       - libtool
       - linux-headers
 

--- a/cedar.yaml
+++ b/cedar.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
-      - rust
-      - wolfi-base
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
+      - rust
+      - wolfi-base
 
 pipeline:
   - uses: git-checkout

--- a/cert-manager.yaml
+++ b/cert-manager.yaml
@@ -9,12 +9,12 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
-      - go
-      - make
+      - ca-certificates-bundle
       - curl
+      - go
       - jq
+      - make
 
 pipeline:
   - uses: git-checkout

--- a/chartmuseum.yaml
+++ b/chartmuseum.yaml
@@ -12,10 +12,10 @@ package:
 environment:
   contents:
     packages:
+      - bash
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - bash
       - go
 
 pipeline:

--- a/check.yaml
+++ b/check.yaml
@@ -9,13 +9,13 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
-      - texinfo
       - libtool
+      - texinfo
 
 pipeline:
   - uses: fetch

--- a/checkov.yaml
+++ b/checkov.yaml
@@ -12,14 +12,14 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
       - ca-certificates-bundle
-      - python3
-      - py3-setuptools
-      - py3.11-installer
       - py3-gpep517
+      - py3-setuptools
       - py3-wheel
       - py3-yaml
+      - py3.11-installer
+      - python3
+      - wolfi-base
 
 pipeline:
   - uses: fetch

--- a/chrony.yaml
+++ b/chrony.yaml
@@ -9,17 +9,17 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - ca-certificates-bundle
-      - build-base
       - asciidoctor
-      - libcap-dev
-      - texinfo
-      - nettle-dev
-      - gnutls-dev
-      - libseccomp-dev
       - bash
+      - build-base
       - busybox
+      - ca-certificates-bundle
+      - gnutls-dev
+      - libcap-dev
+      - libseccomp-dev
+      - nettle-dev
+      - texinfo
+      - wolfi-baselayout
   accounts:
     groups:
       - groupname: chrony

--- a/cilium-cli.yaml
+++ b/cilium-cli.yaml
@@ -11,8 +11,8 @@ environment:
     packages:
       - busybox
       - ca-certificates-bundle
-      - go
       - git
+      - go
 
 pipeline:
   - uses: git-checkout

--- a/cjson.yaml
+++ b/cjson.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
       - cmake
       - samurai
 

--- a/clamav.yaml
+++ b/clamav.yaml
@@ -9,14 +9,12 @@ package:
 environment:
   contents:
     packages:
-      - busybox
-      - ca-certificates-bundle
-      - build-base
-      - automake
       - autoconf
-      - openssl-dev
+      - automake
+      - build-base
+      - busybox
       - bzip2-dev
-      - rust
+      - ca-certificates-bundle
       - check-dev
       - cmake
       - curl-dev
@@ -26,8 +24,10 @@ environment:
       - libxml2-dev
       - linux-headers
       - ncurses-dev
+      - openssl-dev
       - pcre2-dev
       - python3
+      - rust
       - samurai
       - zlib-dev
       # - clamav-scanner

--- a/clang-15.yaml
+++ b/clang-15.yaml
@@ -12,25 +12,25 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
+      - binutils-dev
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - cmake
-      - samurai
-      - binutils-dev
+      - help2man
+      - libLLVM-15
       - libffi-dev
-      - zlib-dev
       - libxml2-dev
+      - llvm-cmake-15
+      - llvm15
+      - llvm15-cmake-default
+      - llvm15-dev
+      - llvm15-tools
       - pkgconf
       - python3
-      - help2man
-      - llvm15
-      - llvm15-dev
-      - llvm-cmake-15
-      - libLLVM-15
-      - llvm15-cmake-default
-      - llvm15-tools
+      - samurai
+      - wolfi-base
+      - zlib-dev
 
 var-transforms:
   - from: ${{package.version}}

--- a/clang-16.yaml
+++ b/clang-16.yaml
@@ -12,22 +12,22 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
+      - binutils-dev
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - cmake
-      - samurai
-      - binutils-dev
-      - libffi-dev
-      - zlib-dev
-      - libxml2-dev
-      - pkgconf
-      - python3
       - help2man
+      - libLLVM-16
+      - libffi-dev
+      - libxml2-dev
       - llvm16
       - llvm16-dev
-      - libLLVM-16
+      - pkgconf
+      - python3
+      - samurai
+      - wolfi-base
+      - zlib-dev
 
 pipeline:
   - uses: fetch

--- a/clickhouse.yaml
+++ b/clickhouse.yaml
@@ -9,21 +9,21 @@ package:
 environment:
   contents:
     packages:
+      - bash
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - git
-      - ninja
-      - build-base
-      - cmake
       - clang-15
+      - cmake
       - coreutils
+      - findutils
+      - git
       - grep
-      - bash
+      - nasm
+      - ninja
+      - perl
       - python3
       - yasm
-      - nasm
-      - perl
-      - findutils
 
 pipeline:
   - uses: git-checkout

--- a/cloudflared.yaml
+++ b/cloudflared.yaml
@@ -9,10 +9,10 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
+      - wolfi-baselayout
 
 pipeline:
   - uses: git-checkout

--- a/cluster-autoscaler.yaml
+++ b/cluster-autoscaler.yaml
@@ -9,9 +9,9 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - go
   environment:
     CGO_ENABLED: 0

--- a/cluster-proportional-autoscaler.yaml
+++ b/cluster-proportional-autoscaler.yaml
@@ -9,9 +9,9 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - go
 
 pipeline:

--- a/cmake.yaml
+++ b/cmake.yaml
@@ -9,11 +9,10 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
-      - busybox
-      - ca-certificates-bundle
       - build-base
+      - busybox
       - bzip2-dev
+      - ca-certificates-bundle
       - curl-dev
       - expat-dev
       - libarchive-dev
@@ -21,6 +20,7 @@ environment:
       - ncurses-dev
       - rhash-dev
       - samurai
+      - wolfi-base
       - xz-dev
       - zlib-dev
 

--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -9,9 +9,9 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - go
 
 pipeline:

--- a/composer.yaml
+++ b/composer.yaml
@@ -7,14 +7,14 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - php
       - git
+      - php
 
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
 
 pipeline:
   - uses: fetch

--- a/conda.yaml
+++ b/conda.yaml
@@ -10,25 +10,25 @@ package:
     no-depends: true
   dependencies:
     runtime:
-      - python3
       - py3-packaging
+      - py3-pluggy
       - py3-requests
       - py3-ruamel-yaml
-      - py3-pluggy
       - py3-tqdm
+      - python3
 
 environment:
   contents:
     packages:
-      - wolfi-base
+      - bash
       - busybox
       - ca-certificates-bundle
-      - bash
-      - wget
-      - python3
-      - py3-pip
       - py3-hatchling
+      - py3-pip
       - py3-wheel
+      - python3
+      - wget
+      - wolfi-base
 
 pipeline:
   - uses: git-checkout

--- a/configmap-reload.yaml
+++ b/configmap-reload.yaml
@@ -12,8 +12,8 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
 
 pipeline:

--- a/conntrack-tools.yaml
+++ b/conntrack-tools.yaml
@@ -11,8 +11,8 @@ environment:
     packages:
       - bash
       - build-base
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - libmnl-dev
       - libnetfilter_conntrack-dev
       - libnetfilter_cthelper-dev

--- a/consul-1.15.yaml
+++ b/consul-1.15.yaml
@@ -13,8 +13,8 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
 
 pipeline:

--- a/consul-1.16.yaml
+++ b/consul-1.16.yaml
@@ -13,8 +13,8 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
 
 pipeline:

--- a/container-entrypoint.yaml
+++ b/container-entrypoint.yaml
@@ -12,8 +12,8 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
 
 pipeline:
   - uses: fetch

--- a/containerd.yaml
+++ b/containerd.yaml
@@ -12,10 +12,10 @@ package:
 environment:
   contents:
     packages:
+      - bash
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - bash
       - go
 
 pipeline:

--- a/coredns.yaml
+++ b/coredns.yaml
@@ -12,14 +12,14 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - build-base
-      - ca-certificates-bundle
-      - busybox
       - bash
-      - make
+      - build-base
+      - busybox
+      - ca-certificates-bundle
       - go
       - libcap-utils
+      - make
+      - wolfi-baselayout
   environment:
     CGO_ENABLED: 0
 

--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -13,13 +13,13 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
-      - busybox
-      - ca-certificates-bundle
-      - build-base
       - acl-dev
       - attr-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
       - texinfo
+      - wolfi-base
 
 pipeline:
   - uses: fetch

--- a/cortex.yaml
+++ b/cortex.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - busybox
-      - go
       - build-base
+      - busybox
+      - ca-certificates-bundle
       - git
+      - go
 
 pipeline:
   - uses: git-checkout

--- a/couchdb.yaml
+++ b/couchdb.yaml
@@ -10,19 +10,19 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
       - erlang-25
       - erlang-25-dev
-      - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
-      - busybox
-      - openssl-dev
-      - nodejs-16
       - icu-dev
       - libtool
-      - mozjs91-dev
       - mozjs91
+      - mozjs91-dev
+      - nodejs-16
+      - openssl-dev
       - python3
 
 pipeline:

--- a/cqlsh.yaml
+++ b/cqlsh.yaml
@@ -9,13 +9,13 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - py3-setuptools
-      - python3-dev
-      - python3
       - cython
+      - py3-setuptools
+      - python3
+      - python3-dev
 
 pipeline:
   - uses: fetch

--- a/crane.yaml
+++ b/crane.yaml
@@ -12,8 +12,8 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
   environment:
     CGO_ENABLED: "0"

--- a/cri-tools.yaml
+++ b/cri-tools.yaml
@@ -9,9 +9,9 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - go
 
 pipeline:

--- a/cronie.yaml
+++ b/cronie.yaml
@@ -9,12 +9,12 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
-      - bash
 
 pipeline:
   - uses: git-checkout

--- a/crun.yaml
+++ b/crun.yaml
@@ -9,17 +9,17 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - python3
+      - go-md2man
       - libcap-dev
-      - yajl
-      - yajl-dev
       - libseccomp
       - libseccomp-dev
-      - go-md2man
+      - python3
+      - wolfi-base
+      - yajl
+      - yajl-dev
 
 pipeline:
   - uses: fetch

--- a/ctop.yaml
+++ b/ctop.yaml
@@ -14,12 +14,12 @@ package:
 environment:
   contents:
     packages:
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - go
       - git
+      - go
 
 pipeline:
   - uses: fetch

--- a/cups.yaml
+++ b/cups.yaml
@@ -9,22 +9,22 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
-      - zlib-dev
-      - libpaper-dev
       - dbus
       - dbus-dev
-      - libusb-dev
       - libgcrypt-dev
+      - libpaper-dev
+      - libusb-dev
       - openssl-dev
       # - poppler-utils TODO add for CUPS to be useful for printing.
       # - libjpeg-turbo-dev TODO add for CUPS to be useful for printing.
       # - avahi-dev TODO add for CUPS to be useful for printing.
       # - gnutls-dev TODO add for CUPS to be useful for printing.
+      - zlib-dev
 
 pipeline:
   - uses: fetch

--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -12,15 +12,15 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
+      - brotli-dev
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - nghttp2-dev
       - openssl-dev
-      - zlib-dev
-      - brotli-dev
       - rustls-ffi
+      - wolfi-base
+      - zlib-dev
 
 pipeline:
   - uses: fetch

--- a/curl.yaml
+++ b/curl.yaml
@@ -9,14 +9,14 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
+      - brotli-dev
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - nghttp2-dev
       - openssl-dev
+      - wolfi-base
       - zlib-dev
-      - brotli-dev
 
 pipeline:
   - uses: fetch

--- a/cyrus-sasl.yaml
+++ b/cyrus-sasl.yaml
@@ -9,16 +9,16 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - openssl-dev
-      - sqlite-dev
-      - py3-sphinx
-      - libtool
-      - heimdal-dev
       - gdbm-dev
+      - heimdal-dev
+      - libtool
+      - openssl-dev
+      - py3-sphinx
+      - sqlite-dev
+      - wolfi-base
 
 pipeline:
   - uses: fetch

--- a/cython.yaml
+++ b/cython.yaml
@@ -9,12 +9,12 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - py3-setuptools
-      - python3-dev
       - python3
+      - python3-dev
 
 pipeline:
   - uses: fetch


### PR DESCRIPTION
As discussed in: https://github.com/chainguard-dev/yam/issues/27

run the following mechanical cleanup for packages sorting for [a-c]*yaml:
```
yam --sort .environment.contents.packages
yam --sort .package.dependencies.runtime
```

No functional changes, only cosmetic.