### PR TITLE
alphabetize a*yaml deps.

### DIFF
--- a/acl.yaml
+++ b/acl.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
+      - attr-dev
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - attr-dev
+      - wolfi-base
 
 pipeline:
   - uses: fetch

--- a/acme.sh.yaml
+++ b/acme.sh.yaml
@@ -7,17 +7,17 @@ package:
     - license: GPL-3.0-only
   dependencies:
     runtime:
+      - curl
       - openssl
       - socat
-      - curl
 
 environment:
   contents:
     packages:
       - busybox
       - ca-certificates-bundle
-      - git
       - curl
+      - git
 
 pipeline:
   - uses: git-checkout

--- a/aerospike.yaml
+++ b/aerospike.yaml
@@ -9,18 +9,18 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
+      - cmake
+      - coreutils
+      - gmp-dev
       - libtool
       - openssl-dev
       - zlib-dev
-      - bash
-      - cmake
-      - gmp-dev
-      - coreutils
 
 pipeline:
   - uses: git-checkout

--- a/alpine-keys.yaml
+++ b/alpine-keys.yaml
@@ -9,8 +9,8 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
 
 pipeline:
   - uses: fetch

--- a/alsa-lib.yaml
+++ b/alsa-lib.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
       - linux-headers
 
 pipeline:

--- a/ant.yaml
+++ b/ant.yaml
@@ -12,9 +12,9 @@ package:
 environment:
   contents:
     packages:
+      - bash
       - busybox
       - ca-certificates-bundle
-      - bash
       - openjdk-8
 
 pipeline:

--- a/aom.yaml
+++ b/aom.yaml
@@ -9,17 +9,17 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
       - cmake
       - perl
       - python3
-      - yasm
       - samurai
       - tree
+      - yasm
 
 pipeline:
   - uses: git-checkout

--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -16,15 +16,15 @@ environment:
     keyring:
       - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
+      - lua5.3
+      - lua5.3-dev
+      - lua5.3-lzlib
+      - openssl-dev
       - scdoc
       - zlib-dev
-      - openssl-dev
-      - lua5.3
-      - lua5.3-lzlib
-      - lua5.3-dev
 
 pipeline:
   - uses: fetch

--- a/argo-cd.yaml
+++ b/argo-cd.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
-      - python3
       - nodejs-16
+      - python3
       - yarn
 
 pipeline:

--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -9,12 +9,12 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
-      - python3
-      - openssl
       - nodejs-20
+      - openssl
+      - python3
       - yarn
 
 pipeline:

--- a/argon2.yaml
+++ b/argon2.yaml
@@ -9,8 +9,8 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
       - build-base
+      - wolfi-base
 
 pipeline:
   - uses: git-checkout

--- a/asciidoc.yaml
+++ b/asciidoc.yaml
@@ -9,17 +9,17 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
-      - ca-certificates-bundle
-      - git
-      - build-base
-      - python3
       - autoconf
       - automake
-      - libxml2-utils
+      - build-base
+      - ca-certificates-bundle
       - docbook-xml
+      - git
+      - libxml2-utils
       - libxslt
       - py3-pip
+      - python3
+      - wolfi-base
 
 pipeline:
   - uses: git-checkout

--- a/asciidoctor.yaml
+++ b/asciidoctor.yaml
@@ -15,10 +15,10 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
       - busybox
       - ca-certificates-bundle
       - ruby-3.1
+      - wolfi-base
 
 pipeline:
   - uses: git-checkout

--- a/at-spi2-core.yaml
+++ b/at-spi2-core.yaml
@@ -9,9 +9,9 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - dbus-dev
       - glib-dev
       - gobject-introspection-dev

--- a/attr.yaml
+++ b/attr.yaml
@@ -9,10 +9,10 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
+      - wolfi-base
 
 pipeline:
   - uses: fetch

--- a/autoconf-archive.yaml
+++ b/autoconf-archive.yaml
@@ -10,11 +10,11 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
 
 pipeline:
   - uses: fetch

--- a/autoconf.yaml
+++ b/autoconf.yaml
@@ -17,9 +17,9 @@ environment:
     keyring:
       - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - m4
       - perl
 

--- a/automake.yaml
+++ b/automake.yaml
@@ -15,10 +15,10 @@ environment:
     keyring:
       - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
+      - autoconf
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - autoconf
 
 pipeline:
   - uses: fetch

--- a/avahi.yaml
+++ b/avahi.yaml
@@ -9,23 +9,23 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
-      - intltool
+      - dbus-dev
+      - expat-dev
+      - gdbm-dev
       - gettext-dev
       - glib-dev
       - gobject-introspection-dev
-      - expat-dev
-      - dbus-dev
+      - gtk-2.0-dev
+      - intltool
       - libcap-dev
       - libdaemon-dev
-      - libtool
       - libevent-dev
-      - gtk-2.0-dev
-      - gdbm-dev
+      - libtool
 
 pipeline:
   - uses: fetch

--- a/aws-c-auth.yaml
+++ b/aws-c-auth.yaml
@@ -9,19 +9,19 @@ package:
 environment:
   contents:
     packages:
-      - busybox
-      - ca-certificates-bundle
-      - build-base
-      - cmake
-      - samurai
       - aws-c-cal-dev
       - aws-c-common-dev
       - aws-c-compression-dev
       - aws-c-http-dev
       - aws-c-io-dev
       - aws-c-sdkutils-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
       - openssl-dev
       - s2n-tls-dev
+      - samurai
 
 pipeline:
   - uses: fetch

--- a/aws-c-common.yaml
+++ b/aws-c-common.yaml
@@ -9,12 +9,12 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - cmake
-      - samurai
       - python3-dev
+      - samurai
 
 pipeline:
   - uses: fetch

--- a/aws-c-io.yaml
+++ b/aws-c-io.yaml
@@ -11,12 +11,12 @@ environment:
     packages:
       - aws-c-cal-dev
       - aws-c-common-dev
-      - busybox
       - build-base
+      - busybox
       - ca-certificates-bundle
       - cmake
-      - s2n-tls-dev
       - openssl-dev
+      - s2n-tls-dev
       - samurai
 
 pipeline:

--- a/aws-c-mqtt.yaml
+++ b/aws-c-mqtt.yaml
@@ -9,18 +9,18 @@ package:
 environment:
   contents:
     packages:
-      - busybox
-      - ca-certificates-bundle
-      - build-base
-      - cmake
-      - samurai
       - aws-c-cal-dev
       - aws-c-common-dev
       - aws-c-compression-dev
       - aws-c-http-dev
       - aws-c-io-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
       - openssl-dev
       - s2n-tls-dev
+      - samurai
 
 pipeline:
   - uses: fetch

--- a/aws-cli.yaml
+++ b/aws-cli.yaml
@@ -7,27 +7,27 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - python3
-      - py3-setuptools
-      - py3-yaml
+      - groff
       - py3-botocore
+      - py3-colorama
       - py3-docutils
       - py3-jmespath
       - py3-rsa
       - py3-s3transfer
-      - py3-colorama
-      - groff
+      - py3-setuptools
+      - py3-yaml
+      - python3
 
 environment:
   contents:
     packages:
-      - wolfi-base
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
+      - py3-setuptools
       - python3
       - python3-dev
-      - py3-setuptools
+      - wolfi-base
 
 pipeline:
   - uses: fetch

--- a/aws-ebs-csi-driver.yaml
+++ b/aws-ebs-csi-driver.yaml
@@ -7,22 +7,22 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - mount
-      - lsblk
       - blkid
       - blockdev
-      - xfsprogs
       - e2fsprogs
       - e2fsprogs-extra
+      - lsblk
+      - mount
+      - xfsprogs
 
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - busybox
       - build-base
-      - go
+      - busybox
       - ca-certificates-bundle
+      - go
+      - wolfi-baselayout
 
 pipeline:
   # We can't use go/install because this requires specific ldflags to set the version

--- a/aws-efs-csi-driver.yaml
+++ b/aws-efs-csi-driver.yaml
@@ -7,22 +7,22 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - py3-botocore # required for cross account mount: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/Dockerfile#L52
       # Ref: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/Dockerfile#L61-L78
       - efs-utils # pull in nfs-utils & busybox
       - mount
-      - umount
       - openssl
+      - py3-botocore # required for cross account mount: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/Dockerfile#L52
       - tcpdump
+      - umount
 
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - busybox
       - build-base
-      - go
+      - busybox
       - ca-certificates-bundle
+      - go
+      - wolfi-baselayout
 
 pipeline:
   # We can't use go/install because this requires specific ldflags to set the version

--- a/aws-flb-cloudwatch.yaml
+++ b/aws-flb-cloudwatch.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - busybox
       - build-base
-      - go
+      - busybox
       - ca-certificates-bundle
+      - go
+      - wolfi-baselayout
 
 pipeline:
   - uses: git-checkout

--- a/aws-flb-firehose.yaml
+++ b/aws-flb-firehose.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - busybox
       - build-base
-      - go
+      - busybox
       - ca-certificates-bundle
+      - go
+      - wolfi-baselayout
 
 pipeline:
   - uses: git-checkout

--- a/aws-flb-kinesis.yaml
+++ b/aws-flb-kinesis.yaml
@@ -9,11 +9,11 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - busybox
       - build-base
-      - go
+      - busybox
       - ca-certificates-bundle
+      - go
+      - wolfi-baselayout
 
 pipeline:
   - uses: git-checkout

--- a/aws-for-fluent-bit.yaml
+++ b/aws-for-fluent-bit.yaml
@@ -7,14 +7,14 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - ca-certificates-bundle
-      - fluent-bit
-      - aws-flb-kinesis
-      - aws-flb-kinesis-compat
-      - aws-flb-firehose
-      - aws-flb-firehose-compat
       - aws-flb-cloudwatch
       - aws-flb-cloudwatch-compat
+      - aws-flb-firehose
+      - aws-flb-firehose-compat
+      - aws-flb-kinesis
+      - aws-flb-kinesis-compat
+      - ca-certificates-bundle
+      - fluent-bit
 
 environment:
   contents:

--- a/aws-load-balancer-controller.yaml
+++ b/aws-load-balancer-controller.yaml
@@ -9,10 +9,10 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - busybox
       - bash
       - build-base
+      - busybox
+      - ca-certificates-bundle
       - go
 
 pipeline:


### PR DESCRIPTION
As discussed in: https://github.com/chainguard-dev/yam/issues/27

run the following mechanical cleanup for packages sorting for [a-c]*yaml:

```
yam --sort .environment.contents.packages
yam --sort .package.dependencies.runtime
```

No functional changes, only cosmetic.

Trying to see if having too many changes is causing grief in #4522 