### PR TITLE
don't fail when no .apk's exist to sign

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -146,19 +146,23 @@ jobs:
       - name: 'Update the APKINDEX'
         run: |
           for arch in "x86_64" "aarch64"; do
-            mkdir -p ./packages/${{ matrix.arch }}
+            mkdir -p ./packages/${arch}
 
             # Consolidate with the built artifacts
             tar xvf /tmp/artifacts/packages-${arch}.tar.gz
 
-            # Sign the apks built in the `build` step with the real key
-            melange sign --signing-key ./wolfi-signing.rsa ./packages/${{ matrix.arch }}/*.apk
+            # Only attempt to sign when *.apk's exist
+            apks=$(ls ./packages/${arch}/*.apk 2>/dev/null)
+            if [ -n "$apks" ]; then
+              # Sign the apks built in the `build` step with the real key
+              melange sign --signing-key ./wolfi-signing.rsa ./packages/${arch}/*.apk
+            fi
 
             # NOTE: Everything below is for debugging purposes, we can chose to remove it in the future if we'd like
-            ls -lah ./packages/${{ matrix.arch }}
+            ls -lah ./packages/${arch}
 
             # Compare the "old" APKIDNEX.tar.gz with the new one
-            diff <(curl -sfL https://packages.wolfi.dev/os/${{ matrix.arch }}/APKINDEX.tar.gz | tar -xOzf - APKINDEX) <(tar -xOzf packages/${{ matrix.arch }}/APKINDEX.tar.gz APKINDEX)
+            diff <(curl -sfL https://packages.wolfi.dev/os/${arch}/APKINDEX.tar.gz | tar -xOzf - APKINDEX) <(tar -xOzf packages/${arch}/APKINDEX.tar.gz APKINDEX)
           done
 
       # TODO: Enable this when we're ready to go live


### PR DESCRIPTION
this should only happen during dev when we have 2 other actions resolving the makefile targets, but it's probably good hygiene to include anyways.