### PR TITLE
enable it on pushes to HEAD without actually publishing anything yet

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,11 @@
 name: Build Wolfi OS
 
 on:
-  # TODO: Enable this when we're ready to go live
-  # push:
-  #   branches: ['main']
-  #   paths-ignore:
-  #     - README.md
+  push:
+    branches: ['main']
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
 
   workflow_dispatch:
 
@@ -162,7 +162,7 @@ jobs:
             ls -lah ./packages/${arch}
 
             # Compare the "old" APKIDNEX.tar.gz with the new one
-            diff <(curl -sfL https://packages.wolfi.dev/os/${arch}/APKINDEX.tar.gz | tar -xOzf - APKINDEX) <(tar -xOzf packages/${arch}/APKINDEX.tar.gz APKINDEX)
+            diff <(curl -sfL https://packages.wolfi.dev/os/${arch}/APKINDEX.tar.gz | tar -xOzf - APKINDEX) <(tar -xOzf packages/${arch}/APKINDEX.tar.gz APKINDEX) || true
           done
 
       # TODO: Enable this when we're ready to go live


### PR DESCRIPTION
enables the workflow to run on HEAD, but doesn't publish anything yet.

plan is to let this run for a while now that it's ~stable and see how we fare.