### PR TITLE
fix: caddy, cloudflared, coredns do not yet work with go-1.21 so pin …

### DIFF
--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: caddy
   version: 2.7.4
-  epoch: 0
+  epoch: 1
   description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,6 @@ environment:
     packages:
       - busybox
       - ca-certificates-bundle
-      - go
 
 pipeline:
   - uses: git-checkout
@@ -23,6 +22,7 @@ pipeline:
   # TODO: Add support for plugins
   - uses: go/build
     with:
+      go-package: go-1.20 # pin to a specific version of Go as not working with go-1.21 yet
       packages: ./cmd/caddy
       output: caddy
       ldflags: -s -w

--- a/cloudflared.yaml
+++ b/cloudflared.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudflared
   version: 2023.5.1
-  epoch: 1
+  epoch: 2
   description: Cloudflare Tunnel client
   copyright:
     - license: Apache-2.0
@@ -12,7 +12,6 @@ environment:
       - wolfi-baselayout
       - ca-certificates-bundle
       - busybox
-      - go
 
 pipeline:
   - uses: git-checkout
@@ -23,6 +22,7 @@ pipeline:
 
   - uses: go/build
     with:
+      go-package: go-1.20 # pin to a specific version of Go as not working with go-1.21 yet
       packages: ./cmd/cloudflared
       output: cloudflared
       ldflags: -s -w -extldflags=-static -X "main.Version=${{package.version}}"

--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: 1.11.1
-  epoch: 0
+  epoch: 1
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,6 @@ environment:
       - busybox
       - bash
       - make
-      - go
       - libcap-utils
   environment:
     CGO_ENABLED: 0
@@ -36,6 +35,7 @@ pipeline:
 
   - uses: go/build
     with:
+      go-package: go-1.20 # pin to a specific version of Go as not working with go-1.21 yet
       packages: .
       output: coredns
       ldflags: -s -w -X github.com/coredns/coredns/coremain.GitCommit=v${{package.version}}


### PR DESCRIPTION
…to 1.20

fixes #4437
