### PR TITLE
kubernetes: use our Go to build

### DIFF
--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -13,7 +13,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go
+      - go=1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.24.16/.go-version
       - go-bindata
       - linux-headers
       - grep
@@ -46,6 +46,8 @@ pipeline:
       ./hack/lint-dependencies.sh
 
   - runs: |
+      export FORCE_HOST_GO=true
+
       WHAT=""
       for c in ${{vars.components}} ; do
         WHAT="$WHAT cmd/$c"

--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -13,7 +13,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go-1.20~==1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.24.16/.go-version
+      - go-1.20~=1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.24.16/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.24
   version: 1.24.16
-  epoch: 2
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go=1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.24.16/.go-version
+      - go-1.20~==1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.24.16/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.24
   version: 1.24.16
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -13,7 +13,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go
+      - go=1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.25.12/.go-version
       - go-bindata
       - linux-headers
       - grep
@@ -46,6 +46,8 @@ pipeline:
       ./hack/lint-dependencies.sh
 
   - runs: |
+      export FORCE_HOST_GO=true
+
       WHAT=""
       for c in ${{vars.components}} ; do
         WHAT="$WHAT cmd/$c"

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -13,7 +13,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go=1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.25.12/.go-version
+      - go-1.20~=1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.25.12/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.25
   version: 1.25.12
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.26
   version: 1.26.7
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -13,7 +13,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go=1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.26.7/.go-version
+      - go-1.20~=1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.26.7/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -13,7 +13,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go
+      - go=1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.26.7/.go-version
       - go-bindata
       - linux-headers
       - grep
@@ -46,6 +46,8 @@ pipeline:
       ./hack/lint-dependencies.sh
 
   - runs: |
+      export FORCE_HOST_GO=true
+
       WHAT=""
       for c in ${{vars.components}} ; do
         WHAT="$WHAT cmd/$c"

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -16,7 +16,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go=1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.27.4/.go-version
+      - go-1.20~=1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.24.16/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -16,7 +16,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go
+      - go=1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.27.4/.go-version
       - go-bindata
       - linux-headers
       - grep
@@ -49,6 +49,8 @@ pipeline:
       ./hack/lint-dependencies.sh
 
   - runs: |
+      export FORCE_HOST_GO=true
+
       WHAT=""
       for c in ${{vars.components}} ; do
         WHAT="$WHAT cmd/$c"

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.27
   version: 1.27.4
-  epoch: 2
+  epoch: 3
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.28.yaml
+++ b/kubernetes-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.28
   version: 1.28.0
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.28.yaml
+++ b/kubernetes-1.28.yaml
@@ -16,7 +16,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go
+      - go=1.20.7 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.28.0/.go-version
       - go-bindata
       - linux-headers
       - grep
@@ -43,6 +43,9 @@ pipeline:
       expected-commit: 855e7c48de7388eb330da0f8d9d2394ee818fb8d
 
   - runs: |
+      # Use our Go, otherwise make will install another version which might not have our vuln fixes.
+      export FORCE_HOST_GO=true
+
       WHAT=""
       for c in ${{vars.components}} ; do
         WHAT="$WHAT cmd/$c"

--- a/kubernetes-1.28.yaml
+++ b/kubernetes-1.28.yaml
@@ -16,7 +16,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go=1.20.7 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.28.0/.go-version
+      - go-1.20~=1.20.7 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.28.0/.go-version
       - go-bindata
       - linux-headers
       - grep


### PR DESCRIPTION
K8s prefers to control the version of Go used to build it, and keeps track of that in `.go-version` in the root of their repo.

If the current Go version doesn't match that version, `make` will download and install the required version of Go. We don't want this, since it means any fixes we apply to our Go packages won't be used -- the upstream Go will be used instead.

This change sets `FORCE_HOST_GO=true` so that our version is used, and pins the version used to the one used upstream, to avoid inconsistencies and surprises. If we're feeling 🕺 saucy 💃 we can try to use a newer Go than upstream, but it might lead to ✨ surprises ✨ later.

This change is not expected to have any real changes -- we'd been building each version with the same Go version anyway, we'd just been doing it with the upstream `go` and not ours.

cc @eddiezane @joshrwolf 