### PR TITLE
add some package dependencies for aws-cli-v2

### DIFF
--- a/aws-c-event-stream.yaml
+++ b/aws-c-event-stream.yaml
@@ -1,0 +1,68 @@
+package:
+  name: aws-c-event-stream
+  version: 0.3.1
+  epoch: 0
+  description: "AWS C99 implementation of the vnd.amazon.eventstream content-type"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - cmake
+      - samurai
+      - aws-c-cal-dev
+      - aws-c-common-dev
+      - aws-c-io-dev
+      - aws-checksums-dev
+      - openssl-dev
+      - s2n-tls-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/awslabs/aws-c-event-stream
+      tag: v${{package.version}}
+      expected-commit: ec1716c726babd1381560aa8d28941fffc987394
+
+  - runs: |
+      if [ "$CBUILD" != "$CHOST" ]; then
+        CMAKE_CROSSOPTS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_NAME=Linux"
+      fi
+      CFLAGS="$CFLAGS -flto=auto" \
+      CXXFLAGS="$CXXFLAGS -flto=auto" \
+      cmake -B build -G Ninja \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+        -DBUILD_SHARED_LIBS=True \
+        -DCMAKE_BUILD_TYPE=None \
+        -DBUILD_TESTING="OFF" \
+        $CMAKE_CROSSOPTS
+      cmake --build build
+
+  - runs: |
+      DESTDIR="${{targets.destdir}}" cmake --install build
+
+  - uses: strip
+
+subpackages:
+  - name: aws-c-event-stream-dev
+    pipeline:
+      - uses: split/dev
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/aws-c-event-stream "${{targets.subpkgdir}}"/usr/lib/
+    dependencies:
+      runtime:
+        - aws-c-event-stream
+    description: aws-c-event-stream dev
+
+update:
+  enabled: true
+  github:
+    identifier: awslabs/aws-c-event-stream
+    strip-prefix: v
+    use-tag: true

--- a/aws-crt-cpp.yaml
+++ b/aws-crt-cpp.yaml
@@ -1,0 +1,87 @@
+package:
+  name: aws-crt-cpp
+  version: 0.23.0
+  epoch: 0
+  description: "C++ wrapper around the aws-c-* libraries. Provides Cross-Platform Transport Protocols and SSL/TLS implementations for C++"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - cmake
+      - samurai
+      - aws-c-auth-dev
+      - aws-c-cal-dev
+      - aws-c-common-dev
+      - aws-c-compression-dev
+      - aws-c-event-stream-dev
+      - aws-c-http-dev
+      - aws-c-io-dev
+      - aws-c-mqtt-dev
+      - aws-c-s3-dev
+      - aws-c-sdkutils-dev
+      - aws-checksums-dev
+      - s2n-tls-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/awslabs/aws-crt-cpp
+      tag: v${{package.version}}
+      expected-commit: 363d09e8a3509f663327d6e8414d0b2e052c815d
+
+  - runs: |
+      if [ "$CBUILD" != "$CHOST" ]; then
+        CMAKE_CROSSOPTS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_NAME=Linux"
+      fi
+      CFLAGS="$CFLAGS -flto=auto" \
+      CXXFLAGS="$CXXFLAGS -flto=auto" \
+      cmake -B build -G Ninja \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+        -DBUILD_SHARED_LIBS=True \
+        -DCMAKE_BUILD_TYPE=None \
+        -DBUILD_DEPS=OFF \
+        -DBUILD_TESTING="OFF" \
+        $CMAKE_CROSSOPTS
+      cmake --build build
+
+  - runs: |
+      DESTDIR="${{targets.destdir}}" cmake --install build
+
+  - uses: strip
+
+subpackages:
+  - name: aws-crt-cpp-dev
+    description: aws-crt-cpp dev
+    pipeline:
+      - uses: split/dev
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/aws-crt-cpp "${{targets.subpkgdir}}"/usr/lib/
+    dependencies:
+      runtime:
+        - aws-crt-cpp
+        - aws-c-auth-dev
+        - aws-c-cal-dev
+        - aws-c-common-dev
+        - aws-c-compression-dev
+        - aws-c-event-stream-dev
+        - aws-c-http-dev
+        - aws-c-io-dev
+        - aws-c-mqtt-dev
+        - aws-c-s3-dev
+        - aws-c-sdkutils-dev
+        - aws-checksums-dev
+        - s2n-tls-dev
+
+update:
+  enabled: true
+  github:
+    identifier: awslabs/aws-crt-cpp
+    strip-prefix: v
+    use-tag: true

--- a/py3-awscrt.yaml
+++ b/py3-awscrt.yaml
@@ -1,0 +1,54 @@
+package:
+  name: py3-awscrt
+  version: 0.19.0
+  epoch: 0
+  description: "Python bindings for the AWS Common Runtime"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - py3-gpep517
+      - py3-wheel
+      - python3-dev
+      - py3-setuptools
+      - openssl-dev
+      - samurai
+      - aws-crt-cpp-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/awslabs/aws-crt-python
+      tag: v${{package.version}}
+      expected-commit: 4ba26faa0d72ad4b56891e6fa6d8821a589cee18
+
+  - runs: |
+      # Allow linking to shared libraries
+      sed -i '/:lib/d' setup.py
+
+      export AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO=1
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+
+  - runs: |
+      python3 -m installer -d "${{targets.destdir}}" \
+      dist/*.whl
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: awslabs/aws-crt-python
+    use-tag: true
+    strip-prefix: v

--- a/py3-distro.yaml
+++ b/py3-distro.yaml
@@ -1,0 +1,44 @@
+package:
+  name: py3-distro
+  version: 1.8.0
+  epoch: 0
+  description: "A Linux OS platform information API"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - py3-gpep517
+      - py3-wheel
+      - python3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://files.pythonhosted.org/packages/source/d/distro/distro-${{package.version}}.tar.gz
+      expected-sha512: 027fe8bc50e263dc49451932774f32cea7900820b6e30cc80afcdc84374777ba733137fdd8d27fec76f66ce9c579bc172721e7ae0f43e72dffbc092126b26af2
+
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+
+  - runs: |
+      python3 -m installer -d "${{targets.destdir}}" \
+      dist/*.whl
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 12202

--- a/py3-urllib3-1.yaml
+++ b/py3-urllib3-1.yaml
@@ -1,0 +1,48 @@
+package:
+  name: py3-urllib3-1
+  version: 1.26.16
+  epoch: 0
+  description: "HTTP library with thread-safe connection pooling, file post, and more"
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - py3-urllib3=1.999
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - py3-gpep517
+      - py3-setuptools
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/urllib3/urllib3.git
+      tag: ${{package.version}}
+      expected-commit: d94029b7e2193ff47b627906a70e06377a09aae8
+
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+
+  - runs: |
+      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
+
+  - uses: strip
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - (\d+\.\d+)\.\da\d+ # urllib3 releases alpha versions with a suffix "a" followed by a digit, let's ignore these
+  github:
+    identifier: urllib3/urllib3
+    use-tag: true
+    tag-filter: "1"


### PR DESCRIPTION
state saving the set of packages ultimately needed for `aws-cli-v2`

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

some prior art #1848 #2272 
