### PR TITLE
add /var/lib/mysql to fix mysqld init

### DIFF
--- a/mariadb-10.11.yaml
+++ b/mariadb-10.11.yaml
@@ -2,7 +2,7 @@ package:
   name: mariadb-10.11
   # Latest LTS
   version: 10.11.5
-  epoch: 0
+  epoch: 1
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -142,6 +142,10 @@ pipeline:
       rm -rf "${{targets.destdir}}"/usr/lib/libmysqlclient_r.so
       rm -rf "${{targets.destdir}}"/usr/lib/libmariadb.so*
       rm -rf "${{targets.destdir}}"/usr/lib/pkgconfig/libmariadb.pc
+
+  - name: "make mysql data dir "
+    runs: |
+      mkdir -p "${{targets.destdir}}"/var/lib/mysql
 
 subpackages:
   - name: "mariadb-10.11-dev"

--- a/mariadb-10.6.yaml
+++ b/mariadb-10.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-10.6
   version: 10.6.15
-  epoch: 0
+  epoch: 1
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -141,6 +141,10 @@ pipeline:
       rm -rf "${{targets.destdir}}"/usr/lib/libmysqlclient_r.so
       rm -rf "${{targets.destdir}}"/usr/lib/libmariadb.so*
       rm -rf "${{targets.destdir}}"/usr/lib/pkgconfig/libmariadb.pc
+
+  - name: "make mysql data dir "
+    runs: |
+      mkdir -p "${{targets.destdir}}"/var/lib/mysql
 
 subpackages:
   - name: "mariadb-10.6-dev"


### PR DESCRIPTION
Fix: 

- mysqld: Can't change dir to '/var/lib/mysql/' (Errcode: 2 "No such file or directory")