### PR TITLE
Use our absl package for protobuf instead of the git submodule.

### DIFF
--- a/protobuf.yaml
+++ b/protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf
   version: 3.24.1
-  epoch: 0
+  epoch: 1
   description: Library for extensible, efficient structure packing
   copyright:
     - license: BSD-3-Clause
@@ -19,6 +19,7 @@ environment:
       - cmake
       - samurai
       - git
+      - abseil-cpp-dev
 
 pipeline:
   - uses: git-checkout
@@ -37,6 +38,7 @@ pipeline:
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DBUILD_SHARED_LIBS=True \
         -DCMAKE_BUILD_TYPE=Release \
+        -Dprotobuf_ABSL_PROVIDER=package \
         -Dprotobuf_BUILD_TESTS=OFF
       ninja -C build
       DESTDIR=${{targets.destdir}} ninja -C build install


### PR DESCRIPTION
At the time we built protobuf, we didn't have an absl package and the build happily used it's own vendored copy. That meant absl was present in our protobuf package.

This popped up as an issue when building grpc - our absl package and our protobuf packages can't be installed at the same time because they conflict. This change switches protobuf to use our new absl package, which should make them stop conflicting.

Fixes:

Related:

### Pre-review Checklist

