### PR TITLE
Fix the provides of the consul subpackages

### DIFF
--- a/consul-1.15.yaml
+++ b/consul-1.15.yaml
@@ -2,7 +2,7 @@ package:
   name: consul-1.15
   version: 1.15.5
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
-  epoch: 1
+  epoch: 2
   description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
   copyright:
     - license: MPL-2.0
@@ -44,7 +44,7 @@ subpackages:
           mv ${{package.name}}/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/"
     dependencies:
       provides:
-        - consul-oci-entrypoint=1.15
+        - consul-oci-entrypoint=1.15.999 # This is because we had a 1.15.0 consul package, remove in 1.17+
       runtime:
         - consul-1.15
         - busybox
@@ -59,7 +59,7 @@ subpackages:
           ln -s /usr/bin/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/local/bin/"
     dependencies:
       provides:
-        - consul-oci-entrypoint-compat=1.15
+        - consul-oci-entrypoint-compat=1.15.999 # This is because we had a 1.15.0 consul package, remove in 1.17+
       runtime:
         - consul-1.15-oci-entrypoint
 

--- a/consul-1.16.yaml
+++ b/consul-1.16.yaml
@@ -2,7 +2,7 @@ package:
   name: consul-1.16
   version: 1.16.1
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
-  epoch: 1
+  epoch: 2
   description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
   copyright:
     - license: MPL-2.0
@@ -44,7 +44,7 @@ subpackages:
           mv ${{package.name}}/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/"
     dependencies:
       provides:
-        - consul-oci-entrypoint=1.16
+        - consul-oci-entrypoint=1.16.999 # This is because we had a 1.16.0 consul package, remove in 1.17+
       runtime:
         - consul-1.16
         - busybox
@@ -59,7 +59,7 @@ subpackages:
           ln -s /usr/bin/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/local/bin/"
     dependencies:
       provides:
-        - consul-oci-entrypoint-compat=1.16
+        - consul-oci-entrypoint-compat=1.16.999 # This is because we had a 1.16.0 consul package, remove in 1.17+
       runtime:
         - consul-1.16-oci-entrypoint
 


### PR DESCRIPTION
We did this for the main package's provides already, but not for the subpackages, so I see us pulling in the older entrypoint in our images:
```
-rw-r--r--  0 root   root      2098 Dec 31  1969 var/lib/db/sbom/consul-1.16-1.16.1-r1.spdx.json
-rw-r--r--  0 root   root      2239 Dec 31  1969 var/lib/db/sbom/consul-oci-entrypoint-1.16.0-r1.spdx.json
-rw-r--r--  0 root   root      1305 Dec 31  1969 var/lib/db/sbom/consul-oci-entrypoint-compat-1.16.0-r1.spdx.json
```
