### PR TITLE
kubernetes: setcap kube-apiserver to match upstream

### DIFF
--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.24
   version: 1.24.16
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -54,6 +54,11 @@ pipeline:
       done
 
       make WHAT="$WHAT"
+
+  - runs: |
+      # We apply cap_net_bind_service so that kube-apiserver can be run as
+      # non-root and still listen on port less than 1024
+      setcap cap_net_bind_service=+ep _output/bin/kube-apiserver
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin/

--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -21,6 +21,7 @@ environment:
       - coreutils # needed for non busybox version of `mktemp`
       - findutils # needed for non busybox version of `xargs`
       - rsync
+      - libcap-utils
 
 # "transform" the kubernetes version into the corresponding pause version, these don't always line up
 var-transforms:

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.25
   version: 1.25.12
-  epoch: 2
+  epoch: 3
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -54,6 +54,11 @@ pipeline:
       done
 
       make WHAT="$WHAT"
+
+  - runs: |
+      # We apply cap_net_bind_service so that kube-apiserver can be run as
+      # non-root and still listen on port less than 1024
+      setcap cap_net_bind_service=+ep _output/bin/kube-apiserver
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin/

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -21,6 +21,7 @@ environment:
       - coreutils # needed for non busybox version of `mktemp`
       - findutils # needed for non busybox version of `xargs`
       - rsync
+      - libcap-utils
 
 # "transform" the kubernetes version into the corresponding pause version, these don't always line up
 var-transforms:

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.26
   version: 1.26.7
-  epoch: 2
+  epoch: 3
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,7 @@ environment:
       - coreutils # needed for non busybox version of `mktemp`
       - findutils # needed for non busybox version of `xargs`
       - rsync
+      - libcap-utils
 
 # "transform" the kubernetes version into the corresponding pause version, these don't always line up
 var-transforms:
@@ -54,6 +55,11 @@ pipeline:
       done
 
       make WHAT="$WHAT"
+
+  - runs: |
+      # We apply cap_net_bind_service so that kube-apiserver can be run as
+      # non-root and still listen on port less than 1024
+      setcap cap_net_bind_service=+ep _output/bin/kube-apiserver
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin/

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -24,6 +24,7 @@ environment:
       - coreutils # needed for non busybox version of `mktemp`
       - findutils # needed for non busybox version of `xargs`
       - rsync
+      - libcap-utils
 
 # "transform" the kubernetes version into the corresponding pause version, these don't always line up
 var-transforms:

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.27
   version: 1.27.4
-  epoch: 3
+  epoch: 4
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -57,6 +57,11 @@ pipeline:
       done
 
       make WHAT="$WHAT"
+
+  - runs: |
+      # We apply cap_net_bind_service so that kube-apiserver can be run as
+      # non-root and still listen on port less than 1024
+      setcap cap_net_bind_service=+ep _output/bin/kube-apiserver
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin/

--- a/kubernetes-1.28.yaml
+++ b/kubernetes-1.28.yaml
@@ -24,6 +24,7 @@ environment:
       - coreutils # needed for non busybox version of `mktemp`
       - findutils # needed for non busybox version of `xargs`
       - rsync
+      - libcap-utils
 
 # "transform" the kubernetes version into the corresponding pause version, these don't always line up
 var-transforms:

--- a/kubernetes-1.28.yaml
+++ b/kubernetes-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.28
   version: 1.28.0
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -52,6 +52,11 @@ pipeline:
       done
 
       make WHAT="$WHAT"
+
+  - runs: |
+      # We apply cap_net_bind_service so that kube-apiserver can be run as
+      # non-root and still listen on port less than 1024
+      setcap cap_net_bind_service=+ep _output/bin/kube-apiserver
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin/


### PR DESCRIPTION
The upstream kube-apiserver image `setcap`s the binary during the image build:

> We apply cap_net_bind_service so that kube-apiserver can be run as
> non-root and still listen on port less than 1024
> `RUN setcap cap_net_bind_service=+ep /${BINARY}`

https://github.com/kubernetes/kubernetes/blob/v1.28.0/build/server-image/kube-apiserver/Dockerfile#L24-L26

(also as far back as [`v1.24.0`](https://github.com/kubernetes/kubernetes/blob/v1.21.0/build/server-image/kube-apiserver/Dockerfile#L24-L26), I didn't look further back)