### PR TITLE
WIP: define rust/cargo-build pipeline

### DIFF
--- a/cedar.yaml
+++ b/cedar.yaml
@@ -1,7 +1,7 @@
 package:
   name: cedar
   version: 2.3.2
-  epoch: 0
+  epoch: 1
   description: "Core implementation of the Cedar language"
   copyright:
     - license: Apache-2.0
@@ -22,11 +22,9 @@ pipeline:
       expected-commit: e23299526851f08d816b3df720c7219802458a53
       tag: v${{package.version}}
 
-  - name: Configure and build
-    runs: |
-      cargo build --release -vv
-      mkdir -p ${{targets.destdir}}/usr/bin/
-      mv target/release/cedar ${{targets.destdir}}/usr/bin/
+  - uses: rust/cargo-build
+    with:
+      target: cedar
 
   - uses: strip
 

--- a/deno.yaml
+++ b/deno.yaml
@@ -1,7 +1,7 @@
 package:
   name: deno
   version: 1.36.1
-  epoch: 0
+  epoch: 1
   description: "A modern runtime for JavaScript and TypeScript."
   copyright:
     - license: MIT
@@ -27,11 +27,9 @@ pipeline:
       uri: https://github.com/denoland/deno/releases/download/v${{package.version}}/deno_src.tar.gz
       expected-sha256: d3262bb024eb4aacf2090cdca66059a90a3176c07ebe1fcc0abcd4d83f2b047c
 
-  - name: Configure and build
-    runs: |
-      cargo build --release -vv
-      mkdir -p ${{targets.destdir}}/usr/bin/
-      mv target/release/deno ${{targets.destdir}}/usr/bin/
+  - uses: rust/cargo-build
+    with:
+      target: deno
 
   - uses: strip
 

--- a/just.yaml
+++ b/just.yaml
@@ -1,7 +1,7 @@
 package:
   name: just
   version: 1.14.0
-  epoch: 0
+  epoch: 1
   description: "just is a handy way to save and run project-specific commands."
   copyright:
     - license: CC0
@@ -22,11 +22,9 @@ pipeline:
       expected-commit: 8e3a2a088213692f874ae9314e5ecd9ed56e2bc6
       tag: ${{package.version}}
 
-  - name: Configure and build
-    runs: |
-      cargo build --release
-      mkdir -p ${{targets.destdir}}/usr/bin/
-      mv target/release/just ${{targets.destdir}}/usr/bin/
+  - uses: rust/cargo-build
+    with:
+      target: just
 
   - uses: strip
 

--- a/mdbook.yaml
+++ b/mdbook.yaml
@@ -1,7 +1,7 @@
 package:
   name: mdbook
   version: 0.4.34
-  epoch: 0
+  epoch: 1
   description: "Create book from markdown files. Like Gitbook but implemented in Rust."
   copyright:
     - license: MPL-2.0
@@ -27,11 +27,9 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 56c225bd34760eb6de024b67b42729e4a55b6302
 
-  - name: Configure and build
-    runs: |
-      cargo build --release
-      install -d "${{targets.destdir}}"/usr/bin
-      install -m755 target/release/mdbook "${{targets.destdir}}"/usr/bin/
+  - uses: rust/cargo-build
+    with:
+      target: mdbook
 
   - uses: strip
 

--- a/meilisearch.yaml
+++ b/meilisearch.yaml
@@ -1,7 +1,7 @@
 package:
   name: meilisearch
   version: 1.3.1
-  epoch: 0
+  epoch: 1
   description: "A lightning-fast search engine that fits effortlessly into your apps, websites, and workflow."
   copyright:
     - license: MIT
@@ -21,11 +21,9 @@ pipeline:
       uri: https://github.com/meilisearch/meilisearch/archive/refs/tags/v${{package.version}}.tar.gz
       expected-sha256: 42b71559c014c510412e94263404607e1bedbb4760f3688e35d1acc721cfc33a
 
-  - name: Configure and build
-    runs: |
-      cargo build --release --locked -vv
-      mkdir -p ${{targets.destdir}}/usr/bin/
-      mv target/release/meilisearch ${{targets.destdir}}/usr/bin/
+  - uses: rust/cargo-build
+    with:
+      target: meilisearch
 
   - uses: strip
 

--- a/ntpd-rs.yaml
+++ b/ntpd-rs.yaml
@@ -1,7 +1,7 @@
 package:
   name: ntpd-rs
   version: 0.3.6
-  epoch: 0
+  epoch: 1
   description: "An NTP implementation in Rust."
   copyright:
     - license: MIT
@@ -23,11 +23,9 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 1fe2900096fd44cb275e0e901b18358082d47706
 
-  - name: Configure and build
-    runs: |
-      cargo build --release -vv
-      mkdir -p ${{targets.destdir}}/usr/bin/
-      mv target/release/ntp-daemon ${{targets.destdir}}/usr/bin/
+  - uses: rust/cargo-build
+    with:
+      target: ntp-daemon
 
   - uses: strip
 

--- a/pgcat.yaml
+++ b/pgcat.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgcat
   version: 1.1.1
-  epoch: 0
+  epoch: 1
   description: "PostgreSQL pooler with sharding, load balancing and failover support."
   copyright:
     - license: MIT
@@ -23,11 +23,9 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 1f2c6507f7fb5461df1a599c0b380aa114597bb5
 
-  - name: Configure and build
-    runs: |
-      cargo build --release -vv
-      mkdir -p ${{targets.destdir}}/usr/bin/
-      mv target/release/pgcat ${{targets.destdir}}/usr/bin/
+  - uses: rust/cargo-build
+    with:
+      target: pgcat
 
   - uses: strip
 

--- a/pipelines/rust/cargo-build.yaml
+++ b/pipelines/rust/cargo-build.yaml
@@ -1,0 +1,30 @@
+name: Build a release binary using cargo build
+
+needs:
+  packages:
+    - rust
+    - busybox
+    - ca-certificates-bundle
+
+inputs:
+  target:
+    description: |
+      The name of the binary to build
+
+  subpackage:
+    description: |
+      Indicates that the build will write to a subpackage target folder
+    default: "false"
+
+pipeline:
+  - runs: |
+      cargo build --release -vv
+
+      if [ "${{inputs.subpackage}}" == "true" ]; then
+        DEST_DIR="${{targets.subpkgdir}}"/usr/bin/
+      else
+        DEST_DIR="${{targets.destdir}}"/usr/bin/
+      fi
+
+      mkdir -p ${DEST_DIR}
+      mv target/release/${{inputs.target}} ${DEST_DIR}

--- a/pixi.yaml
+++ b/pixi.yaml
@@ -1,7 +1,7 @@
 package:
   name: pixi
   version: 0.1.0
-  epoch: 0
+  epoch: 1
   description: "Package management made easy"
   copyright:
     - license: BSD-3-Clause
@@ -23,11 +23,9 @@ pipeline:
       expected-commit: 6fcd570094b0141ce9b3af10e52cee25aa28a6ff
       tag: v${{package.version}}
 
-  - name: Configure and build
-    runs: |
-      cargo build --release
-      mkdir -p ${{targets.destdir}}/usr/bin/
-      mv target/release/pixi ${{targets.destdir}}/usr/bin/
+  - uses: rust/cargo-build
+    with:
+      target: pixi
 
   - uses: strip
 

--- a/pulumi-watch.yaml
+++ b/pulumi-watch.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-watch
   version: 0.1.5
-  epoch: 0
+  epoch: 1
   description: Supports the functionality of the pulumi watch command
   copyright:
     - license: Apache-2.0
@@ -21,17 +21,12 @@ pipeline:
     with:
       repository: https://github.com/pulumi/watchutil-rs.git
       tag: v${{package.version}}
-      destination: ${{package.name}}
       expected-commit: bae2913e89662fbd0bf3264cb2985ea6b6c73c59
 
-  - working-directory: ${{package.name}}
-    pipeline:
-      - runs: |
-          set -x
-          cargo build --release -vv
-          mkdir -p "${{targets.destdir}}/usr/bin/"
-          mv target/release/pulumi-watch "${{targets.destdir}}/usr/bin/"
-      - uses: strip
+  - uses: rust/cargo-build
+    with:
+      target: pulumi-watch
+  - uses: strip
 
 update:
   enabled: true

--- a/ruff.yaml
+++ b/ruff.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruff
   version: 0.0.285
-  epoch: 0
+  epoch: 1
   description: An extremely fast Python linter, written in Rust.
   copyright:
     - license: MIT
@@ -21,10 +21,9 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 5892c691ea6389dcf53b2212bae7a3acd61ca15f
 
-  - runs: |
-      cargo build --release
-      mkdir -p ${{targets.destdir}}/usr/bin
-      mv target/release/ruff ${{targets.destdir}}/usr/bin/
+  - uses: rust/cargo-build
+    with:
+      target: ruff
 
   - uses: strip
 

--- a/wasm-tools.yaml
+++ b/wasm-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasm-tools
   version: 1.0.39
-  epoch: 0
+  epoch: 1
   description: "Low level tooling for WebAssembly in Rust"
   copyright:
     - license: Apache-2.0
@@ -23,11 +23,9 @@ pipeline:
       tag: wasm-tools-${{package.version}}
       expected-commit: 2e63788ad535724e49a0da036281d9663b6d5294
 
-  - name: Configure and build
-    runs: |
-      cargo build --release -vv
-      mkdir -p ${{targets.destdir}}/usr/bin/
-      mv target/release/wasm-tools ${{targets.destdir}}/usr/bin/
+  - uses: rust/cargo-build
+    with:
+      target: wasm-tools
 
   - uses: strip
 

--- a/wit-bindgen.yaml
+++ b/wit-bindgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: wit-bindgen
   version: 0.10.0
-  epoch: 0
+  epoch: 1
   description: "A language binding generator for WebAssembly interface types"
   copyright:
     - license: Apache-2.0
@@ -23,11 +23,9 @@ pipeline:
       tag: wit-bindgen-cli-${{package.version}}
       expected-commit: e32a150f876c291784d9cead97c58fac97cf216c
 
-  - name: Configure and build
-    runs: |
-      cargo build --release -vv
-      mkdir -p ${{targets.destdir}}/usr/bin/
-      mv target/release/wit-bindgen ${{targets.destdir}}/usr/bin/
+  - uses: rust/cargo-build
+    with:
+      target: wit-bindgen
 
   - uses: strip
 


### PR DESCRIPTION
This demonstrates a `rust/cargo-build` pipeline that shares come very common workflows we have for Rust builds in the codebase.

To make it easier to review and iterate, the pipeline is defined in Wolfi, but it should probably go in Melange itself like `go/build` etc. If this looks good we can move it to Melange, wait for a digest bump, and remove it from `pipelines/`.