### PR TITLE
gitignore: ignore `melange convert` generated dir: `generated/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 packages/*
 melange-cache/*
+generated/*
 local-melange.rsa*
 melange.rsa*
 dag.svg


### PR DESCRIPTION
`melange convert` usually generates a directory called `generated/`. Let's ignore this to avoid accidental committing of these files.