### PR TITLE
add a compat package to cover our helm chart basis

### DIFF
--- a/cluster-proportional-autoscaler.yaml
+++ b/cluster-proportional-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-proportional-autoscaler
   version: 1.8.9
-  epoch: 1
+  epoch: 2
   description: Kubernetes Cluster Proportional Autoscaler Container
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,17 @@ pipeline:
       ldflags: -s -w -X github.com/kubernetes-sigs/cluster-proportional-autoscaler/pkg/version.VERSION=v${{package.version}}
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - working-directory: ${{targets.subpkgdir}}
+        runs: |
+          # The helm chart expects to be able to call "./cluster-proportional-autoscaler"
+          ln -s /usr/bin/cluster-proportional-autoscaler "cluster-proportional-autoscaler"
+    dependencies:
+      runtime:
+        - cluster-proportional-autoscaler
 
 update:
   enabled: true


### PR DESCRIPTION
https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler

vs

https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/tree/master/charts/cluster-proportional-autoscaler

which are different for some reason 🤷 