### PR TITLE
tflint v0.47.0: New package

### DIFF
--- a/tflint.yaml
+++ b/tflint.yaml
@@ -1,0 +1,36 @@
+package:
+  name: tflint
+  version: 0.47.0
+  epoch: 0
+  description: A Pluggable Terraform Linter
+  copyright:
+    - license: MPL 2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/terraform-linters/tflint
+      expected-commit: 3e1937a0b2f2c309f7cc43a6ce560d02861218ed
+      tag: v${{package.version}}
+
+  - runs: |
+      make build
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv tflint ${{targets.destdir}}/usr/bin
+
+update:
+  enabled: true
+  github:
+    identifier: terraform-linters/tflint
+    strip-prefix: tflint/v
+    tag-filter: tflint/v
+    use-tag: true

--- a/tflint.yaml
+++ b/tflint.yaml
@@ -32,3 +32,4 @@ update:
   github:
     identifier: terraform-linters/tflint
     use-tag: true
+    strip-prefix: v

--- a/tflint.yaml
+++ b/tflint.yaml
@@ -31,6 +31,4 @@ update:
   enabled: true
   github:
     identifier: terraform-linters/tflint
-    strip-prefix: tflint/v
-    tag-filter: tflint/v
     use-tag: true


### PR DESCRIPTION
"tflint is a pluggable terraform linter." This is specially useful in CI workflows.

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates

