### PR TITLE
Chase melange ${{targets.contextdir}} changes

### DIFF
--- a/bank-vaults.yaml
+++ b/bank-vaults.yaml
@@ -37,9 +37,6 @@ subpackages:
           modroot: .
           packages: ./cmd/template
           output: template
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv ${{targets.destdir}}/usr/bin/template ${{targets.subpkgdir}}/usr/bin/
 
 update:
   enabled: true

--- a/gitlab-runner.yaml
+++ b/gitlab-runner.yaml
@@ -34,9 +34,6 @@ subpackages:
           packages: ./apps/gitlab-runner-helper
           output: gitlab-runner-helper
           ldflags: -s -w -X gitlab.com/gitlab-org/gitlab-runner/common.NAME=${{package.name}} -X gitlab.com/gitlab-org/gitlab-runner/common.VERSION=v${{package.version}}
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/gitlab-runner-helper "${{targets.subpkgdir}}"/usr/bin
 
 update:
   enabled: true

--- a/guac.yaml
+++ b/guac.yaml
@@ -35,9 +35,6 @@ subpackages:
           ldflags: -s -w -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
           packages: ./cmd/guacingest
           output: guacingest
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv ${{targets.destdir}}/usr/bin/guacingest ${{targets.subpkgdir}}/usr/bin
 
   - name: guacone
     pipeline:
@@ -46,9 +43,6 @@ subpackages:
           ldflags: -s -w -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
           packages: ./cmd/guacone
           output: guacone
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv ${{targets.destdir}}/usr/bin/guacone ${{targets.subpkgdir}}/usr/bin
 
   - name: guacgql
     pipeline:
@@ -57,9 +51,6 @@ subpackages:
           ldflags: -s -w -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
           packages: ./cmd/guacgql
           output: guacgql
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv ${{targets.destdir}}/usr/bin/guacgql ${{targets.subpkgdir}}/usr/bin
 
   - name: guaccsub
     pipeline:
@@ -68,9 +59,6 @@ subpackages:
           ldflags: -s -w -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
           packages: ./cmd/guaccsub
           output: guaccsub
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv ${{targets.destdir}}/usr/bin/guaccsub ${{targets.subpkgdir}}/usr/bin
 
 update:
   enabled: true


### PR DESCRIPTION
Some packages used `mv` to move files into the subpkgdir after building them.  Now that we have ${{targets.contextdir}}, this extra `mv` step is no longer needed: the go/build pipeline now follows the context dir instead.