### PR TITLE
Create 1.26 and 1.27 version streams for telegraf

### DIFF
--- a/telegraf-1.26.yaml
+++ b/telegraf-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: telegraf-1.26
   version: 1.26.3
-  epoch: 1
+  epoch: 0
   description:
   copyright:
     - license: MIT

--- a/telegraf-1.26.yaml
+++ b/telegraf-1.26.yaml
@@ -1,0 +1,55 @@
+package:
+  name: telegraf-1.26
+  version: 1.26.3
+  epoch: 1
+  description:
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - telegraf=1.26.999 # This is because we had a 1.26.0 telegraf package, remove in 1.28+
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - go
+      - gnutar
+
+pipeline:
+  - uses: git-checkout
+    with:
+      tag: v${{package.version}}
+      expected-commit: 90f4eb296bf44b26959b136ef050445da64e85fa
+      repository: https://github.com/influxdata/telegraf
+
+  - if: ${{build.arch}} == 'x86_64'
+    runs: |
+      make package include_packages="linux_amd64.tar.gz"
+
+  - if: ${{build.arch}} == 'aarch64'
+    runs: |
+      make package include_packages="linux_arm64.tar.gz"
+
+  - runs: |
+      tar -xf build/dist/telegraf-${{package.version}}*.tar.gz
+      mkdir -p ${{targets.destdir}}/etc/
+      mv telegraf-${{package.version}}/etc/* ${{targets.destdir}}/etc/
+
+      mkdir -p ${{targets.destdir}}/usr/
+      mv telegraf-${{package.version}}/usr/* ${{targets.destdir}}/usr
+
+      mkdir -p ${{targets.destdir}}/var
+      mv telegraf-${{package.version}}/var/* ${{targets.destdir}}/var
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: influxdata/telegraf
+    strip-prefix: v
+    tag-filter: v1.26.
+    use-tag: true

--- a/telegraf-1.27.yaml
+++ b/telegraf-1.27.yaml
@@ -1,10 +1,13 @@
 package:
-  name: telegraf
+  name: telegraf-1.27
   version: 1.27.4
   epoch: 0
   description:
   copyright:
     - license: MIT
+  dependencies:
+    provides:
+      - telegraf=1.27.999 # This is because we had a 1.27.0 telegraf package, remove in 1.28+
 
 environment:
   contents:
@@ -48,3 +51,5 @@ update:
   github:
     identifier: influxdata/telegraf
     strip-prefix: v
+    tag-filter: v1.27.
+    use-tag: true


### PR DESCRIPTION
### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
