### PR TITLE
new lua-haproxy-auth-request

### DIFF
--- a/lua-haproxy-auth-request.yaml
+++ b/lua-haproxy-auth-request.yaml
@@ -1,0 +1,29 @@
+package:
+  name: lua-haproxy-auth-request
+  version: 0.0_git20230822
+  epoch: 0
+  description: Control your HTTP services based on a subrequest to a configured HAProxy backend
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/TimWolla/haproxy-auth-request/archive/530cdda68ac682c8d3d4e676f7f6ef72e76b3cbe.tar.gz
+      expected-sha256: fde22861f8a889aa36dfe415548af8e7ab0c26901cc22c50fd02993d986d1e99
+      strip-components: 1
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/lua/common
+      install -D -m 644 auth-request.lua ${{targets.destdir}}/usr/share/lua/common/
+
+  - uses: strip
+
+update:
+  enabled: false # no releases or tags available


### PR DESCRIPTION
#### For new package PRs only
<!-- remove if unrelated -->
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
