### PR TITLE
haproxy: Upgrade to 2.8.2 to fix CVE-2023-40225

### DIFF
--- a/haproxy.yaml
+++ b/haproxy.yaml
@@ -1,6 +1,6 @@
 package:
   name: haproxy
-  version: 2.8.0
+  version: 2.8.2
   epoch: 0
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
@@ -33,7 +33,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://www.haproxy.org/download/${{vars.mangled-package-version}}/src/haproxy-${{package.version}}.tar.gz
-      expected-sha256: 61cdafb5db7e9174d0757b8e4bcde938352306fb7cc8ff2b5f55c26dd48a6cf7
+      expected-sha256: 698d6906d170946a869769964e57816ba3da3adf61ff75e89972b137f4658db0
 
   - uses: autoconf/make
     with:


### PR DESCRIPTION
CVE-2023-40225

### Pre-review Checklist

#### For version bump PRs

- [x] The `epoch` field is reset to 0
