### PR TITLE
enable the self hosted wolfi os build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -165,38 +165,38 @@ jobs:
             diff <(curl -sfL https://packages.wolfi.dev/os/${arch}/APKINDEX.tar.gz | tar -xOzf - APKINDEX) <(tar -xOzf packages/${arch}/APKINDEX.tar.gz APKINDEX) || true
           done
 
-      # TODO: Enable this when we're ready to go live
-      # - name: 'Upload the repository to the bucket'
-      #   run: |
-      #     cp /etc/apk/keys/wolfi-signing.rsa.pub ./packages/wolfi-signing.rsa.pub
-      #
-      #     for arch in "x86_64" "aarch64"; do
-      #       # Don't cache the APKINDEX.
-      #       gcloud --quiet storage cp \
-      #           --cache-control=no-store \
-      #           "./packages/${arch}/APKINDEX.tar.gz" "gs://wolfi-production-registry-destination/os/${arch}/"
-      #
-      #     gcloud --quiet storage cp \
-      #         --cache-control=no-store \
-      #         "./packages/${arch}/APKINDEX.json" "gs://wolfi-production-registry-destination/os/${arch}/"
-      #
-      #     # apks will be cached in CDN for an hour by default.
-      #     # Don't upload the object if it already exists.
-      #     gcloud --quiet storage cp \
-      #         --no-clobber \
-      #         "./packages/${arch}/*.apk" "gs://wolfi-production-registry-destination/os/${arch}/"
-      #     done
+      - name: 'Upload the repository to the bucket'
+        run: |
+          for arch in "x86_64" "aarch64"; do
+            # Don't cache the APKINDEX.
+            gcloud --quiet storage cp \
+                --cache-control=no-store \
+                "./packages/${arch}/APKINDEX.tar.gz" "gs://wolfi-production-registry-destination/os/${arch}/"
 
-  # TODO: Enable this when we're ready to go live
-  # postrun:
-  #   name: Build Wolfi OS
-  #   runs-on: ubuntu-latest
-  #   if: failure()
-  #   steps:
-  #     - uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
-  #       id: slack
-  #       with:
-  #         payload: '{"text": "[build-wolfi-os] failure: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
-  #       env:
-  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+            gcloud --quiet storage cp \
+                --cache-control=no-store \
+                "./packages/${arch}/APKINDEX.json" "gs://wolfi-production-registry-destination/os/${arch}/"
+
+            # Only attempt to sign when *.apk's exist
+            apks=$(ls ./packages/${arch}/*.apk 2>/dev/null)
+            if [ -n "$apks" ]; then
+              # apks will be cached in CDN for an hour by default.
+              # Don't upload the object if it already exists.
+              gcloud --quiet storage cp \
+                  --no-clobber \
+                  "./packages/${arch}/*.apk" "gs://wolfi-production-registry-destination/os/${arch}/"
+            fi
+          done
+
+  postrun:
+    name: Build Wolfi OS
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
+        id: slack
+        with:
+          payload: '{"text": "[build-wolfi-os] failure: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
this **does not** remove the existing workflows:

- x86_64: https://github.com/wolfi-dev/os/actions/workflows/push-production.yaml
- aarch64: https://github.com/wolfi-dev/os/actions/workflows/dag-push-production.yaml

the plan is to manually disable this via github until we're confident this workflow is wai. that way we can quickly revert if something goes wrong.