### PR TITLE
sign the APKINDEX on upload

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -151,6 +151,9 @@ jobs:
             # Consolidate with the built artifacts
             tar xvf /tmp/artifacts/packages-${arch}.tar.gz
 
+            # Sign the APK index
+            melange sign-index -f --signing-key ./wolfi-signing.rsa packages/${arch}/APKINDEX.tar.gz
+
             # Only attempt to sign when *.apk's exist
             apks=$(ls ./packages/${arch}/*.apk 2>/dev/null)
             if [ -n "$apks" ]; then


### PR DESCRIPTION
depends on a new sdk build with https://github.com/chainguard-dev/melange/pull/626