### PR TITLE
Break cert-manager into version streams.

### DIFF
--- a/cert-manager-1.11.yaml
+++ b/cert-manager-1.11.yaml
@@ -1,10 +1,14 @@
 package:
-  name: cert-manager
-  version: 1.12.3
-  epoch: 1
+  name: cert-manager-1.11
+  # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
+  version: 1.11.2
+  epoch: 0
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - cert-manager=1.11.999 # This is because we had a 1.11.2 cert-manager package, remove in 1.13+
 
 environment:
   contents:
@@ -21,7 +25,7 @@ pipeline:
     with:
       repository: https://github.com/cert-manager/cert-manager
       tag: v${{package.version}}
-      expected-commit: 9479c8157dd876e2fc828850b429a4b4f734c871
+      expected-commit: 4767427a40e0e193c976fd6bc228f50de8950572
 
   # the makefile hardcodes the requirement for some container runtime (CTR), even when we don't need it
   # to workaround, set CTR to anything $(command -v)able
@@ -41,32 +45,49 @@ subpackages:
     pipeline:
       - runs: |
           install -Dm755 ${{targets.destdir}}/usr/bin/controller-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/controller
+    dependencies:
+      provides:
+        - cert-manager-controller=1.11.999 # This is because we had a 1.11.2 cert-manager package, remove in 1.13+
 
   - name: ${{package.name}}-webhook
     pipeline:
       - runs: |
           install -Dm755 ${{targets.destdir}}/usr/bin/webhook-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/webhook
+    dependencies:
+      provides:
+        - cert-manager-webhook=1.11.999 # This is because we had a 1.11.2 cert-manager package, remove in 1.13+
 
   - name: ${{package.name}}-cainjector
     pipeline:
       - runs: |
           install -Dm755 ${{targets.destdir}}/usr/bin/cainjector-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/cainjector
+    dependencies:
+      provides:
+        - cert-manager-cainjector=1.11.999 # This is because we had a 1.11.2 cert-manager package, remove in 1.13+
 
   - name: ${{package.name}}-acmesolver
     pipeline:
       - runs: |
           install -Dm755 ${{targets.destdir}}/usr/bin/acmesolver-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/acmesolver
+    dependencies:
+      provides:
+        - cert-manager-acmesolver=1.11.999 # This is because we had a 1.11.2 cert-manager package, remove in 1.13+
 
-  - name: cmctl
+  - name: cmctl-1.11
     pipeline:
       - runs: |
           make CTR=make cmctl-linux
       - runs: |
           install -Dm755 _bin/cmctl/cmctl-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/cmctl
       - uses: strip
+    dependencies:
+      provides:
+        - cmctl=1.11.999 # This is because we had a 1.11.2 cert-manager package, remove in 1.13+
 
 update:
   enabled: true
   github:
     identifier: cert-manager/cert-manager
     strip-prefix: v
+    tag-filter: v1.11.
+    use-tag: true

--- a/cert-manager-1.12.yaml
+++ b/cert-manager-1.12.yaml
@@ -1,0 +1,93 @@
+package:
+  name: cert-manager-1.12
+  # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
+  version: 1.12.3
+  epoch: 0
+  description: Automatically provision and manage TLS certificates in Kubernetes
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - cert-manager=1.12.999 # This is because we had a 1.12.3 cert-manager package, remove in 1.13+
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+      - make
+      - curl
+      - jq
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cert-manager/cert-manager
+      tag: v${{package.version}}
+      expected-commit: 9479c8157dd876e2fc828850b429a4b4f734c871
+
+  # the makefile hardcodes the requirement for some container runtime (CTR), even when we don't need it
+  # to workaround, set CTR to anything $(command -v)able
+  - runs: |
+      make CTR=make _bin/server/controller-linux-$(go env GOARCH)
+      make CTR=make _bin/server/webhook-linux-$(go env GOARCH)
+      make CTR=make _bin/server/cainjector-linux-$(go env GOARCH)
+      make CTR=make _bin/server/acmesolver-linux-$(go env GOARCH)
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv _bin/server/* ${{targets.destdir}}/usr/bin/
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-controller
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/controller-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/controller
+    dependencies:
+      provides:
+        - cert-manager-controller=1.12.999 # This is because we had a 1.12.3 cert-manager package, remove in 1.13+
+
+  - name: ${{package.name}}-webhook
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/webhook-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/webhook
+    dependencies:
+      provides:
+        - cert-manager-webhook=1.12.999 # This is because we had a 1.12.3 cert-manager package, remove in 1.13+
+
+  - name: ${{package.name}}-cainjector
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/cainjector-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/cainjector
+    dependencies:
+      provides:
+        - cert-manager-cainjector=1.12.999 # This is because we had a 1.12.3 cert-manager package, remove in 1.13+
+
+  - name: ${{package.name}}-acmesolver
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/acmesolver-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/acmesolver
+    dependencies:
+      provides:
+        - cert-manager-acmesolver=1.12.999 # This is because we had a 1.12.3 cert-manager package, remove in 1.13+
+
+  - name: cmctl-1.12
+    pipeline:
+      - runs: |
+          make CTR=make cmctl-linux
+      - runs: |
+          install -Dm755 _bin/cmctl/cmctl-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/cmctl
+      - uses: strip
+    dependencies:
+      provides:
+        - cmctl=1.12.999 # This is because we had a 1.12.3 cert-manager package, remove in 1.13+
+
+update:
+  enabled: true
+  github:
+    identifier: cert-manager/cert-manager
+    strip-prefix: v
+    tag-filter: v1.12.
+    use-tag: true


### PR DESCRIPTION
This also adds a link to where to find the supported versions, since it isn't on endoflife.date.

🚨 I'm going to add `cert-manager-1.11` here as well, but I'm using CI to test things since I'm on a plane 😄 

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

#### For version bump PRs
- [x] The `epoch` field is reset to 0
