### PR TITLE
Bump bash epoch

### DIFF
--- a/bash.yaml
+++ b/bash.yaml
@@ -1,12 +1,10 @@
 package:
   name: bash
   version: 5.2.15
-  epoch: 2
+  epoch: 3
   description: "GNU bourne again shell"
   copyright:
     - license: GPL-3.0-or-later
-  dependencies:
-    runtime:
 
 environment:
   contents:


### PR DESCRIPTION
This hasn't been built in a long time, so we're missing checksums in the APK file headers and some metadata in .PKGINFO from melange fixes.