### PR TITLE
switch packages that use git-checkout to also use github update config

### DIFF
--- a/aom.yaml
+++ b/aom.yaml
@@ -1,3 +1,7 @@
+# source is googlesource so we can't use github updates to get expected commit
+# let's still auto create the PR, it will fail as epected commit will be wrong
+# however it will be easy to fix
+#nolint:git-checkout-must-use-github-updates
 package:
   name: aom
   version: 3.6.1

--- a/argon2.yaml
+++ b/argon2.yaml
@@ -38,5 +38,6 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 15244
+  github:
+    identifier: P-H-C/phc-winner-argon2
+    use-tag: true

--- a/cassandra.yaml
+++ b/cassandra.yaml
@@ -72,5 +72,8 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 12636
+  github:
+    identifier: apache/cassandra
+    use-tag: true
+    tag-filter: cassandra-
+    strip-prefix: cassandra-

--- a/git-lfs.yaml
+++ b/git-lfs.yaml
@@ -46,5 +46,7 @@ pipeline:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 11551
+  github:
+    identifier: git-lfs/git-lfs
+    tag-filter: v
+    strip-prefix: v

--- a/gitlab-runner.yaml
+++ b/gitlab-runner.yaml
@@ -1,3 +1,7 @@
+# source is gitlab so we can't use github updates to get expected commit
+# let's still auto create the PR, it will fail as epected commit will be wrong
+# however it will be easy to fix
+#nolint:git-checkout-must-use-github-updates
 package:
   name: gitlab-runner
   version: 16.3.0

--- a/glab.yaml
+++ b/glab.yaml
@@ -1,3 +1,7 @@
+# source is gitlab so we can't use github updates to get expected commit
+# let's still auto create the PR, it will fail as epected commit will be wrong
+# however it will be easy to fix
+#nolint:git-checkout-must-use-github-updates
 package:
   name: glab
   version: 1.32.0

--- a/libtelnet.yaml
+++ b/libtelnet.yaml
@@ -39,5 +39,5 @@ pipeline:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 59171
+  github:
+    identifier: seanmiddleditch/libtelnet

--- a/metrics-server.yaml
+++ b/metrics-server.yaml
@@ -34,5 +34,8 @@ pipeline:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 320565
+  github:
+    identifier: kubernetes-sigs/metrics-server
+    use-tag: true
+    tag-filter: v
+    strip-prefix: v

--- a/ndctl.yaml
+++ b/ndctl.yaml
@@ -53,5 +53,7 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 10381
+  github:
+    identifier: pmem/ndctl
+    tag-filter: v
+    strip-prefix: v

--- a/ngrep.yaml
+++ b/ngrep.yaml
@@ -48,6 +48,10 @@ pipeline:
   - uses: strip
 
 update:
+  version-separator: _
   enabled: true
-  release-monitor:
-    identifier: 2084
+  github:
+    identifier: jpr5/ngrep
+    use-tag: true
+    tag-filter: V
+    strip-prefix: V

--- a/py3-invoke.yaml
+++ b/py3-invoke.yaml
@@ -35,6 +35,9 @@ pipeline:
   - uses: strip
 
 update:
+  ignore-regex-patterns:
+    - ^[a-zA-Z]
   enabled: true
-  release-monitor:
-    identifier: 59678
+  github:
+    identifier: pyinvoke/invoke
+    use-tag: true

--- a/py3-jsonschema.yaml
+++ b/py3-jsonschema.yaml
@@ -47,5 +47,7 @@ pipeline:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 3898
+  github:
+    identifier: python-jsonschema/jsonschema
+    tag-filter: v
+    strip-prefix: v

--- a/py3-py4j.yaml
+++ b/py3-py4j.yaml
@@ -66,5 +66,6 @@ pipeline:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 131811
+  github:
+    identifier: py4j/py4j
+    use-tag: true

--- a/py3-referencing.yaml
+++ b/py3-referencing.yaml
@@ -46,5 +46,7 @@ pipeline:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 304263
+  github:
+    identifier: python-jsonschema/referencing
+    tag-filter: v
+    strip-prefix: v

--- a/py3-rpds-py.yaml
+++ b/py3-rpds-py.yaml
@@ -45,5 +45,7 @@ pipeline:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 330423
+  github:
+    identifier: crate-py/rpds
+    tag-filter: v
+    strip-prefix: v

--- a/wireguard-tools.yaml
+++ b/wireguard-tools.yaml
@@ -1,3 +1,7 @@
+# source is git.zx2c4.com so we can't use github updates to get expected commit
+# let's still auto create the PR, it will fail as epected commit will be wrong
+# however it will be easy to fix
+#nolint:git-checkout-must-use-github-updates
 package:
   name: wireguard-tools
   version: 1.0.20210914


### PR DESCRIPTION
This is so we can auto update the expected-commit on updates.

Packages that use git-checkout which are not on github are annotated with
```
#nolint:git-checkout-must-use-github-updates
```
to prepare for a [new linting rule](https://github.com/wolfi-dev/wolfictl/pull/356)

No epoch bumps needed as this is just update config changes.