### PR TITLE
pango/1.6.1 package update

### DIFF
--- a/pango.yaml
+++ b/pango.yaml
@@ -1,13 +1,18 @@
 package:
   name: pango
-  version: 1.50.14
+  version: 1.6.1
   epoch: 0
   description: library for layout and rendering of text
   copyright:
     - license: LGPL-2.1-or-later
-  scriptlets:
-    trigger:
-      script: FIXME
+
+# creates a new var that contains only the major and minor version to be used in the fetch URL
+# e.g. 1.6.1 will create a new var mangled-package-version=1.6
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d+\.\d+)\.\d+
+    replace: $1
+    to: mangled-package-version
 
 environment:
   contents:
@@ -27,14 +32,14 @@ environment:
       - help2man
       - libxft-dev
       - meson
-      - posix-libc-utils # manually added
-      - bash # manually added
+      - posix-libc-utils
+      - bash
 
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 1d67f205bfc318c27a29cfdfb6828568df566795df0cb51d2189cde7f2d581e8
-      uri: https://download.gnome.org/sources/pango/1.50/pango-${{package.version}}.tar.xz
+      expected-sha256: 5653d6905c378703089fb500f7a85b58bf3b439c61cabb377a11df5495407f9f
+      uri: https://download.gnome.org/sources/pango${{vars.mangled-package-version}}/pango-${{package.version}}.tar.xz
 
   - uses: meson/configure
     with:


### PR DESCRIPTION
#### For version bump PRs
- [x] The `epoch` field is reset to 0

fixes #4680