### PR TITLE
pango/1.6.1 package update

### DIFF
--- a/pango.yaml
+++ b/pango.yaml
@@ -1,13 +1,14 @@
+# source is gitlab so we can't use github updates to get expected commit
+# let's still auto create the PR, it will fail as epected commit will be wrong
+# however it will be easy to fix
+#nolint:git-checkout-must-use-github-updates
 package:
   name: pango
-  version: 1.50.14
+  version: 1.51.1
   epoch: 0
   description: library for layout and rendering of text
   copyright:
     - license: LGPL-2.1-or-later
-  scriptlets:
-    trigger:
-      script: FIXME
 
 environment:
   contents:
@@ -27,14 +28,15 @@ environment:
       - help2man
       - libxft-dev
       - meson
-      - posix-libc-utils # manually added
-      - bash # manually added
+      - posix-libc-utils
+      - bash
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 1d67f205bfc318c27a29cfdfb6828568df566795df0cb51d2189cde7f2d581e8
-      uri: https://download.gnome.org/sources/pango/1.50/pango-${{package.version}}.tar.xz
+      repository: https://gitlab.gnome.org/GNOME/pango.git
+      tag: ${{package.version}}
+      expected-commit: dfdbb8b55effc0feb72a1981944acaf20ee71354
 
   - uses: meson/configure
     with:
@@ -67,7 +69,7 @@ subpackages:
   - name: pango-tools
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mkdir -p "${{targets.subpkgdir}}"/usr
           mv ${{targets.destdir}}/usr/bin ${{targets.subpkgdir}}/usr/
     description: pango (tools)
 


### PR DESCRIPTION
also switch to git-checkout as release monitor found 1.51.1 using gitlab tags, however that version is not available at https://download.gnome.org/sources/pango/1.51/

- [x] The `epoch` field is reset to 0

fixes #4680
