### PR TITLE
libsecret/0.21.0 package update

### DIFF
--- a/libsecret.yaml
+++ b/libsecret.yaml
@@ -1,10 +1,18 @@
 package:
   name: libsecret
-  version: 0.20.5
+  version: 0.21.0
   epoch: 0
   description: Library for storing and retrieving passwords and other secrets
   copyright:
     - license: LGPL-2.0-or-later
+
+# creates a new var that contains only the major and minor version to be used in the fetch URL
+# e.g. 0.21.0 will create a new var mangled-package-version=0.21
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d+\.\d+)\.\d+
+    replace: $1
+    to: mangled-package-version
 
 environment:
   contents:
@@ -26,8 +34,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 3fb3ce340fcd7db54d87c893e69bfc2b1f6e4d4b279065ffe66dac9f0fd12b4d
-      uri: https://download.gnome.org/sources/libsecret/0.20/libsecret-${{package.version}}.tar.xz
+      expected-sha256: 2735b29d1cc0e5b12ba90bee88bd21774ac8db4ae1a4b716f46c409c19a14613
+      uri: https://download.gnome.org/sources/libsecret/${{vars.mangled-package-version}}/libsecret-${{package.version}}.tar.xz
 
   - uses: meson/configure
     with:


### PR DESCRIPTION
- [x] The `epoch` field is reset to 0

Also use var transform to automate future updates

fixes #4679