### PR TITLE
re2: improve packaging quality

### DIFF
--- a/re2.yaml
+++ b/re2.yaml
@@ -1,7 +1,7 @@
 package:
   name: re2
   version: 2023.08.01
-  epoch: 0
+  epoch: 1
   description: Efficient, principled regular expression library
   copyright:
     - license: BSD-3-Clause
@@ -22,8 +22,6 @@ environment:
       - autoconf
       - icu-dev
       - abseil-cpp-dev
-      - samurai
-      - cmake
 
 pipeline:
   - uses: fetch
@@ -31,31 +29,18 @@ pipeline:
       expected-sha256: d82d0efe2389949244445e7a6ac9a10fccc3d6a3d267ec4652991a51291647b0
       uri: https://github.com/google/re2/archive/${{vars.mangled-package-version}}.tar.gz
 
-  - runs: |
-      export CXXFLAGS="$CXXFLAGS -O2"
-      cmake -B build -G Ninja \
-      	-DCMAKE_BUILD_TYPE=None \
-      	-DCMAKE_INSTALL_PREFIX=/usr \
-      	-DBUILD_SHARED_LIBS=ON \
-      	-DRE2_USE_ICU=ON \
-      	-DRE2_BUILD_TESTING="$(want_check && echo ON || echo OFF)"
-      cmake --build build
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DBUILD_SHARED_LIBS=ON \
+        -DRE2_USE_ICU=ON \
+        -DRE2_BUILD_TESTING="OFF"
 
-      DESTDIR="${{targets.destdir}}" cmake --install build
+  - uses: cmake/build
+
+  - uses: cmake/install
 
   - uses: strip
-
-data:
-  - name: libs
-    items:
-      gles: libGLES*
-      egl: libEGL
-      gl: libGL
-      glapi: libglapi
-      xatracker: libxatracker*
-      osmesa: libOSMesa
-      gbm: libgbm
-      libd3dadapter9: d3d/d3dadapter9
 
 subpackages:
   - name: re2-dev


### PR DESCRIPTION
- use cmake pipelines instead of runs statements
- remove irrelevant data block copied from mesa
- remove variable expansion for -DRE2_BUILD_TESTING cmake option

Fixes #4580.