### PR TITLE
krb5/1.21.2 package update

### DIFF
--- a/krb5.yaml
+++ b/krb5.yaml
@@ -1,6 +1,6 @@
 package:
   name: krb5
-  version: 1.21
+  version: 1.21.2
   epoch: 0
   description: The Kerberos network authentication system
   copyright:
@@ -27,7 +27,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 69f8aaff85484832df67a4bbacd99b9259bd95aab8c651fbbe65cdc9620ea93b
+      expected-sha256: 9560941a9d843c0243a71b17a7ac6fe31c7cebb5bce3983db79e52ae7e850491
       uri: https://web.mit.edu/kerberos/dist/krb5/1.21/krb5-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
@@ -126,6 +126,6 @@ subpackages:
 
 update:
   enabled: true
-  manual: true # need to trim suffix, melange config doesn't yet offer a way to do that
   release-monitor:
     identifier: 13287
+    strip-suffix: -final


### PR DESCRIPTION
also switch from manual updates to automated now that strip-suffix can be used.
- [x] The `epoch` field is reset to 0

fixes #4662