### PR TITLE
py3-openai/0.27.9 package update

### DIFF
--- a/py3-openai.yaml
+++ b/py3-openai.yaml
@@ -1,7 +1,7 @@
 # Generated from https://pypi.org/project/openai/
 package:
   name: py3-openai
-  version: 0.27.8
+  version: 0.27.9
   epoch: 0
   description: Python client library for the OpenAI API
   copyright:
@@ -27,11 +27,11 @@ environment:
       - py3-setuptools
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      README: 'CONFIRM WITH: curl -L https://files.pythonhosted.org/packages/89/ee/84bbd0161090f0f24e8a2ac175e6b6a936289ee02e9d5da414ce14d3d332/openai-0.27.8.tar.gz | sha256sum'
-      expected-sha256: 2483095c7db1eee274cebac79e315a986c4e55207bb4fa7b82d185b3a2ed9536
-      uri: https://files.pythonhosted.org/packages/89/ee/84bbd0161090f0f24e8a2ac175e6b6a936289ee02e9d5da414ce14d3d332/openai-${{package.version}}.tar.gz
+      repository: https://github.com/openai/openai-python.git
+      tag: v${{package.version}}
+      expected-commit: df8b0ba7853a2e7345d7506538ae0e57ec0d872b
 
   - name: Python Build
     runs: python setup.py build
@@ -43,5 +43,7 @@ pipeline:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 76577
+  github:
+    identifier: openai/openai-python
+    tag-filter: v
+    strip-prefix: v


### PR DESCRIPTION
also switch to git checkout so that automated updates work in the future

- [x] The `epoch` field is reset to 0

fixes #4738
