### PR TITLE
kube-downscaler: Bump to epoch to pick up a fix for CVE-2023-37920

### DIFF
--- a/kube-downscaler.yaml
+++ b/kube-downscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-downscaler
   version: 23.2.0
-  epoch: 2
+  epoch: 3
   description: Scale down Kubernetes deployments after work hours
   copyright:
     - license: GPL-3.0-or-later
@@ -27,7 +27,7 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/lib/python3.11/site-packages
       poetry config virtualenvs.create false
 
-      # Patch CVE-2022-23491 and CVE-2023-32681
+      # Patch CVE-2022-23491, CVE-2023-32681 and CVE-2023-37920
       poetry update certifi requests --only main
 
       poetry install --no-interaction --only main --no-ansi -vvv


### PR DESCRIPTION
Forces a rebuild to pickup the latest version of certifi.

We'll need to address this package build to use our own packages, but in this specific case, it requires more work.

### Pre-review Checklist

#### For security-related PRs
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo - PR in progress