### PR TITLE
Add py3-build package and use it instead of pip3 install build.

### DIFF
--- a/py3-build.yaml
+++ b/py3-build.yaml
@@ -1,0 +1,46 @@
+package:
+  name: py3-build
+  version: 0.10.0
+  epoch: 0
+  description: A simple, correct Python build frontend
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+      - py3-pyproject-hooks
+      - py3-packaging
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - python3
+      - py3-setuptools
+      - py3-installer
+      - py3-pip
+      - py3-flit-core
+      - py3-gpep517
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pypa/build
+      tag: ${{package.version}}
+      expected-commit: cd06da25481b9a610f846fa60cb67b5a5fa9a051
+
+  - runs: |
+      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 1
+      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
+      find ${{targets.destdir}} -name "*.pyc" -exec rm -rf '{}' +
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pypa/build
+    use-tag: true
+    strip-suffix: .post1

--- a/py3-contourpy.yaml
+++ b/py3-contourpy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-contourpy
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: Python library for calculating contours of 2D quadrilateral grids
   copyright:
     - license: BSD-3-Clause
@@ -23,6 +23,7 @@ environment:
       - py3-pip
       - py3-installer
       - py3-pybind11
+      - py3-build
 
 pipeline:
   - uses: git-checkout
@@ -33,7 +34,6 @@ pipeline:
 
   - name: Python Build
     runs: |
-      pip3 install build
       python3 -m build
 
   - runs: |

--- a/py3-kiwisolver.yaml
+++ b/py3-kiwisolver.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-kiwisolver
   version: 1.4.5
-  epoch: 0
+  epoch: 1
   description: A fast implementation of the Cassowary constraint solver
   copyright:
     - license: BSD-3-Clause-Attribution
@@ -24,6 +24,7 @@ environment:
       - py3-setuptools-scm
       - py3-installer
       - py3-pip
+      - py3-build
 
 pipeline:
   - uses: git-checkout
@@ -38,8 +39,6 @@ pipeline:
 
   - name: Python Build
     runs: |
-      python -m pip install --upgrade pip
-      python -m pip install build
       python -m build
 
   - name: Python Install

--- a/py3-pyproject-hooks.yaml
+++ b/py3-pyproject-hooks.yaml
@@ -1,0 +1,44 @@
+package:
+  name: py3-pyproject-hooks
+  version: 1.0.0
+  epoch: 0
+  description: A low-level library for calling build-backends in `pyproject.toml`-based project
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - python3
+      - py3-setuptools
+      - py3-installer
+      - py3-pip
+      - py3-flit-core
+      - py3-gpep517
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pypa/pyproject-hooks
+      tag: v${{package.version}}
+      expected-commit: 4c9325f4e594bfc7178452d0d01eb8da6c3dbbdb
+
+  - runs: |
+      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 1
+      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
+      find ${{targets.destdir}} -name "*.pyc" -exec rm -rf '{}' +
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pypa/pyproject-hooks
+    use-tag: true
+    strip-prefix: v

--- a/py3-sphinxcontrib-applehelp.yaml
+++ b/py3-sphinxcontrib-applehelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-applehelp
   version: 1.0.7
-  epoch: 0
+  epoch: 1
   description: sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books
   copyright:
     - license: BSD-2-Clause
@@ -21,6 +21,7 @@ environment:
       - py3-setuptools
       - py3-pip
       - py3-installer
+      - py3-build
 
 pipeline:
   - uses: git-checkout
@@ -31,7 +32,6 @@ pipeline:
 
   - name: Python Build
     runs: |
-      pip3 install build
       python3 -m build
 
   - runs: |

--- a/py3-sphinxcontrib-devhelp.yaml
+++ b/py3-sphinxcontrib-devhelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-devhelp
   version: 1.0.5
-  epoch: 0
+  epoch: 1
   description: sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp documents
   copyright:
     - license: BSD-2-Clause
@@ -21,6 +21,7 @@ environment:
       - py3-setuptools
       - py3-pip
       - py3-installer
+      - py3-build
 
 pipeline:
   - uses: git-checkout
@@ -31,7 +32,6 @@ pipeline:
 
   - name: Python Build
     runs: |
-      pip3 install build
       python3 -m build
 
   - runs: |

--- a/py3-sphinxcontrib-htmlhelp.yaml
+++ b/py3-sphinxcontrib-htmlhelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-htmlhelp
   version: 2.0.4
-  epoch: 0
+  epoch: 1
   description: sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files
   copyright:
     - license: BSD-2-Clause
@@ -21,6 +21,7 @@ environment:
       - py3-setuptools
       - py3-pip
       - py3-installer
+      - py3-build
 
 pipeline:
   - uses: git-checkout
@@ -31,7 +32,6 @@ pipeline:
 
   - name: Python Build
     runs: |
-      pip3 install build
       python3 -m build
 
   - runs: |

--- a/py3-sphinxcontrib-jsmath.yaml
+++ b/py3-sphinxcontrib-jsmath.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-jsmath
   version: 1.0.1
-  epoch: 0
+  epoch: 1
   description: A sphinx extension which renders display math in HTML via JavaScript
   copyright:
     - license: BSD
@@ -20,6 +20,7 @@ environment:
       - py3-setuptools
       - py3-pip
       - py3-installer
+      - py3-build
 
 pipeline:
   - uses: git-checkout
@@ -30,7 +31,6 @@ pipeline:
 
   - name: Python Build
     runs: |
-      pip3 install build
       python3 -m build
 
   - runs: |

--- a/py3-sphinxcontrib-packages.yaml
+++ b/py3-sphinxcontrib-packages.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-packages
   version: 1.1.2
-  epoch: 0
+  epoch: 1
   description: This packages contains the Packages sphinx extension, which provides directives to display packages installed on the host machine
   copyright:
     - license: AGPLv3 or any later version
@@ -22,6 +22,7 @@ environment:
       - py3-setuptools
       - py3-pip
       - py3-installer
+      - py3-build
 
 pipeline:
   - uses: git-checkout
@@ -32,7 +33,6 @@ pipeline:
 
   - name: Python Build
     runs: |
-      pip3 install build
       python3 -m build
 
   - runs: |

--- a/py3-sphinxcontrib-qthelp.yaml
+++ b/py3-sphinxcontrib-qthelp.yaml
@@ -21,6 +21,7 @@ environment:
       - py3-setuptools
       - py3-pip
       - py3-installer
+      - py3-build
 
 pipeline:
   - uses: git-checkout
@@ -31,7 +32,6 @@ pipeline:
 
   - name: Python Build
     runs: |
-      pip3 install build
       python3 -m build
 
   - runs: |

--- a/py3-sphinxcontrib-serializinghtml.yaml
+++ b/py3-sphinxcontrib-serializinghtml.yaml
@@ -21,6 +21,7 @@ environment:
       - py3-setuptools
       - py3-pip
       - py3-installer
+      - py3-build
 
 pipeline:
   - uses: git-checkout
@@ -31,7 +32,6 @@ pipeline:
 
   - name: Python Build
     runs: |
-      pip3 install build
       python3 -m build
 
   - runs: |


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
