### PR TITLE
Add rye python installer.

### DIFF
--- a/rye.yaml
+++ b/rye.yaml
@@ -1,0 +1,38 @@
+package:
+  name: rye
+  version: 0.12.0
+  epoch: 0
+  description: "An Experimental Package Management Solution for Python"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - rust
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - perl
+      - openssl-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/mitsuhiko/rye
+      expected-commit: f5525c985d7d35f635419083a0e46af0ed5eaf61
+      tag: ${{package.version}}
+
+  - name: Configure and build
+    runs: |
+      cargo build --release
+      mkdir -p ${{targets.destdir}}/usr/bin/
+      mv target/release/${{package.name}} ${{targets.destdir}}/usr/bin/
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: mitsuhiko/rye


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
