### PR TITLE
Patch CVE-2023-36617 in Ruby 3.2 and 3.1.

### DIFF
--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.4
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -37,6 +37,12 @@ pipeline:
     with:
       uri: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-${{package.version}}.tar.gz
       expected-sha256: a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6
+
+  - uses: patch
+    with:
+      # Fix a CVE in the embedded uri library.
+      # Patch source: https://github.com/ruby/ruby/commit/dd73fe077cae077808e820f4765a12b1f4660521.patch
+      patches: dd73fe077cae077808e820f4765a12b1f4660521.patch
 
   - name: Configure
     runs: |

--- a/ruby-3.1/dd73fe077cae077808e820f4765a12b1f4660521.patch
+++ b/ruby-3.1/dd73fe077cae077808e820f4765a12b1f4660521.patch
@@ -1,0 +1,83 @@
+From dd73fe077cae077808e820f4765a12b1f4660521 Mon Sep 17 00:00:00 2001
+From: Hiroshi SHIBATA <hsbt@ruby-lang.org>
+Date: Wed, 21 Jun 2023 13:20:54 +0900
+Subject: [PATCH] Merge URI-0.12.2
+
+---
+ lib/uri/rfc2396_parser.rb |  4 ++--
+ lib/uri/rfc3986_parser.rb |  2 +-
+ lib/uri/version.rb        |  2 +-
+ test/uri/test_parser.rb   | 22 ++++++++++++++++++++++
+ 4 files changed, 26 insertions(+), 4 deletions(-)
+
+diff --git a/lib/uri/rfc2396_parser.rb b/lib/uri/rfc2396_parser.rb
+index 76a8f99fd48cc..00c66cf042221 100644
+--- a/lib/uri/rfc2396_parser.rb
++++ b/lib/uri/rfc2396_parser.rb
+@@ -497,8 +497,8 @@ def initialize_regexp(pattern)
+       ret = {}
+ 
+       # for URI::split
+-      ret[:ABS_URI] = Regexp.new('\A\s*' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
+-      ret[:REL_URI] = Regexp.new('\A\s*' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
++      ret[:ABS_URI] = Regexp.new('\A\s*+' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
++      ret[:REL_URI] = Regexp.new('\A\s*+' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
+ 
+       # for URI::extract
+       ret[:URI_REF]     = Regexp.new(pattern[:URI_REF])
+diff --git a/lib/uri/rfc3986_parser.rb b/lib/uri/rfc3986_parser.rb
+index dd24a409ea174..9b1663dbb6efe 100644
+--- a/lib/uri/rfc3986_parser.rb
++++ b/lib/uri/rfc3986_parser.rb
+@@ -100,7 +100,7 @@ def default_regexp # :nodoc:
+         QUERY: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+         FRAGMENT: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+         OPAQUE: /\A(?:[^\/].*)?\z/,
+-        PORT: /\A[\x09\x0a\x0c\x0d ]*\d*[\x09\x0a\x0c\x0d ]*\z/,
++        PORT: /\A[\x09\x0a\x0c\x0d ]*+\d*[\x09\x0a\x0c\x0d ]*\z/,
+       }
+     end
+ 
+diff --git a/lib/uri/version.rb b/lib/uri/version.rb
+index 7497a7d31a5df..f0aca586acab4 100644
+--- a/lib/uri/version.rb
++++ b/lib/uri/version.rb
+@@ -1,6 +1,6 @@
+ module URI
+   # :stopdoc:
+-  VERSION_CODE = '001201'.freeze
++  VERSION_CODE = '001202'.freeze
+   VERSION = VERSION_CODE.scan(/../).collect{|n| n.to_i}.join('.').freeze
+   # :startdoc:
+ end
+diff --git a/test/uri/test_parser.rb b/test/uri/test_parser.rb
+index 72fb5901d963f..cee0acb4b57c8 100644
+--- a/test/uri/test_parser.rb
++++ b/test/uri/test_parser.rb
+@@ -79,4 +79,26 @@ def test_split
+     assert_equal([nil, nil, "example.com", nil, nil, "", nil, nil, nil], URI.split("//example.com"))
+     assert_equal([nil, nil, "[0::0]", nil, nil, "", nil, nil, nil], URI.split("//[0::0]"))
+   end
++
++  def test_rfc2822_parse_relative_uri
++    pre = ->(length) {
++      " " * length + "\0"
++    }
++    parser = URI::RFC2396_Parser.new
++    assert_linear_performance((1..5).map {|i| 10**i}, pre: pre) do |uri|
++      assert_raise(URI::InvalidURIError) do
++        parser.split(uri)
++      end
++    end
++  end
++
++  def test_rfc3986_port_check
++    pre = ->(length) {"\t" * length + "a"}
++    uri = URI.parse("http://my.example.com")
++    assert_linear_performance((1..5).map {|i| 10**i}, pre: pre) do |port|
++      assert_raise(URI::InvalidComponentError) do
++        uri.port = port
++      end
++    end
++  end
+ end

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: 3.2.2
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -40,6 +40,12 @@ pipeline:
     with:
       uri: https://cache.ruby-lang.org/pub/ruby/3.2/ruby-${{package.version}}.tar.gz
       expected-sha256: 96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc
+
+  - uses: patch
+    with:
+      # Fix a CVE in the embedded uri library.
+      # Patch source: https://github.com/ruby/ruby/commit/dd73fe077cae077808e820f4765a12b1f4660521.patch
+      patches: dd73fe077cae077808e820f4765a12b1f4660521.patch
 
   - name: Configure
     runs: |

--- a/ruby-3.2/dd73fe077cae077808e820f4765a12b1f4660521.patch
+++ b/ruby-3.2/dd73fe077cae077808e820f4765a12b1f4660521.patch
@@ -1,0 +1,83 @@
+From dd73fe077cae077808e820f4765a12b1f4660521 Mon Sep 17 00:00:00 2001
+From: Hiroshi SHIBATA <hsbt@ruby-lang.org>
+Date: Wed, 21 Jun 2023 13:20:54 +0900
+Subject: [PATCH] Merge URI-0.12.2
+
+---
+ lib/uri/rfc2396_parser.rb |  4 ++--
+ lib/uri/rfc3986_parser.rb |  2 +-
+ lib/uri/version.rb        |  2 +-
+ test/uri/test_parser.rb   | 22 ++++++++++++++++++++++
+ 4 files changed, 26 insertions(+), 4 deletions(-)
+
+diff --git a/lib/uri/rfc2396_parser.rb b/lib/uri/rfc2396_parser.rb
+index 76a8f99fd48cc..00c66cf042221 100644
+--- a/lib/uri/rfc2396_parser.rb
++++ b/lib/uri/rfc2396_parser.rb
+@@ -497,8 +497,8 @@ def initialize_regexp(pattern)
+       ret = {}
+ 
+       # for URI::split
+-      ret[:ABS_URI] = Regexp.new('\A\s*' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
+-      ret[:REL_URI] = Regexp.new('\A\s*' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
++      ret[:ABS_URI] = Regexp.new('\A\s*+' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
++      ret[:REL_URI] = Regexp.new('\A\s*+' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
+ 
+       # for URI::extract
+       ret[:URI_REF]     = Regexp.new(pattern[:URI_REF])
+diff --git a/lib/uri/rfc3986_parser.rb b/lib/uri/rfc3986_parser.rb
+index dd24a409ea174..9b1663dbb6efe 100644
+--- a/lib/uri/rfc3986_parser.rb
++++ b/lib/uri/rfc3986_parser.rb
+@@ -100,7 +100,7 @@ def default_regexp # :nodoc:
+         QUERY: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+         FRAGMENT: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+         OPAQUE: /\A(?:[^\/].*)?\z/,
+-        PORT: /\A[\x09\x0a\x0c\x0d ]*\d*[\x09\x0a\x0c\x0d ]*\z/,
++        PORT: /\A[\x09\x0a\x0c\x0d ]*+\d*[\x09\x0a\x0c\x0d ]*\z/,
+       }
+     end
+ 
+diff --git a/lib/uri/version.rb b/lib/uri/version.rb
+index 7497a7d31a5df..f0aca586acab4 100644
+--- a/lib/uri/version.rb
++++ b/lib/uri/version.rb
+@@ -1,6 +1,6 @@
+ module URI
+   # :stopdoc:
+-  VERSION_CODE = '001201'.freeze
++  VERSION_CODE = '001202'.freeze
+   VERSION = VERSION_CODE.scan(/../).collect{|n| n.to_i}.join('.').freeze
+   # :startdoc:
+ end
+diff --git a/test/uri/test_parser.rb b/test/uri/test_parser.rb
+index 72fb5901d963f..cee0acb4b57c8 100644
+--- a/test/uri/test_parser.rb
++++ b/test/uri/test_parser.rb
+@@ -79,4 +79,26 @@ def test_split
+     assert_equal([nil, nil, "example.com", nil, nil, "", nil, nil, nil], URI.split("//example.com"))
+     assert_equal([nil, nil, "[0::0]", nil, nil, "", nil, nil, nil], URI.split("//[0::0]"))
+   end
++
++  def test_rfc2822_parse_relative_uri
++    pre = ->(length) {
++      " " * length + "\0"
++    }
++    parser = URI::RFC2396_Parser.new
++    assert_linear_performance((1..5).map {|i| 10**i}, pre: pre) do |uri|
++      assert_raise(URI::InvalidURIError) do
++        parser.split(uri)
++      end
++    end
++  end
++
++  def test_rfc3986_port_check
++    pre = ->(length) {"\t" * length + "a"}
++    uri = URI.parse("http://my.example.com")
++    assert_linear_performance((1..5).map {|i| 10**i}, pre: pre) do |port|
++      assert_raise(URI::InvalidComponentError) do
++        uri.port = port
++      end
++    end
++  end
+ end


### PR DESCRIPTION
This was fixed upstream but hadn't made it in a release yet, so backport it.

Fixes:

Related:

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
