### PR TITLE
place the multicall links in $PATH

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.27.4
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: Apache-2.0
@@ -82,8 +82,12 @@ pipeline:
       mkdir -p "${{targets.destdir}}"/bin/
       mv bin/k3s "${{targets.destdir}}"/bin/_k3s-inner
 
+      # ensure `ctr` is also packaged
+      sed -i 's/for i in containerd crictl/for i in containerd crictl ctr/' ./scripts/package-cli
+
       # Modify the packaging script to exclusively use symlinks to our moved "inner" binary
-      sed -i 's|ln -s k3s bin/$i|ln -s /bin/_k3s-inner bin/$i|g' ./scripts/package-cli
+      # Also create a copy of the symlink in /bin/ to support callers depending on $PATH
+      sed -i 's|ln -s k3s bin/$i|ln -s /bin/_k3s-inner ${{targets.destdir}}/bin/$i|g' ./scripts/package-cli
 
       # Remove the upload portion from the upstream package-cli script
       sed -e '/scripts\/build-upload/d' -i scripts/package-cli


### PR DESCRIPTION
the packaged multicalls were previously in the k3s `data` dir, which were unpacked into `/var/lib/rancher/k3s/data`.

this change places them instead directly in `/bin/$i`, so that callers can access them directly without adjusting their $PATH.

worth noting that accessing them via the outer `k3s` (`k3s kubectl ...`) will still work