### PR TITLE
Change buck2 to new tagging and versioning scheme.

### DIFF
--- a/buck2.yaml
+++ b/buck2.yaml
@@ -50,6 +50,9 @@ pipeline:
 
 update:
   enabled: false
+  version-transform:
+    - match: (\d{4})-(\d{2})-(\d{2})
+      replace: 0.0_git$1$2$3
   github:
     identifier: facebook/buck2
     use-tag: true

--- a/buck2.yaml
+++ b/buck2.yaml
@@ -1,8 +1,8 @@
 package:
   name: buck2
-  # When bumping, check that the rust version is still correct.
-  version: 0.0_git20230706
-  epoch: 2
+  # When bumping, bump the tag below
+  version: 0.0_git20230815
+  epoch: 0
   description: "Build system, successor to Buck"
   copyright:
     - license: MIT
@@ -20,16 +20,18 @@ environment:
 vars:
   rust-version: nightly-2023-05-28
 
+var-transforms:
+  - from: ${{package.version}}
+    match: 0.0_git(\d{4})(\d{2})(\d{2})
+    replace: $1-$2-$3
+    to: mangled-package-version
+
 pipeline:
-  # This is a workaround as buck2 is not cutting releases.
-  # This approach allows us to rebuild at a particular commit,
-  # which is preferable to the previous approach which started
-  # failing as soon as things floated forward along the tag
-  # we tracked (called "latest").
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/facebook/buck2/archive/bcbdf2f63bf8397754518ca0536125b79fbfc6b0.tar.gz
-      expected-sha512: 607169c0074f58b1f67ad4ce32c2eabd7fbfcf0616f354198bd0b68a405baa7e4c055909df1e1982c75d47a3cace2bceb023238027148e0efd70c36efa6e2eaf
+      repository: https://github.com/facebook/buck2
+      expected-commit: ad48b25b6a87efa28d2c28529f3ea4601c7e8394
+      tag: ${{vars.mangled-package-version}}
 
   - name: Configure and build
     runs: |
@@ -48,6 +50,6 @@ pipeline:
 
 update:
   enabled: false
-  manual: true # This requires manual updates because of the strange tagging scheme.
   github:
     identifier: facebook/buck2
+    use-tag: true


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist


#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0
