### PR TITLE
rebuild downstream dependencies of libavif

### DIFF
--- a/gd.yaml
+++ b/gd.yaml
@@ -1,10 +1,10 @@
 package:
   name: gd
   version: 2.3.3
-  epoch: 3
+  epoch: 4
   description: Library for the dynamic creation of images by programmers
   copyright:
-    - license: custom
+    - license: GD
 
 environment:
   contents:

--- a/php.yaml
+++ b/php.yaml
@@ -1,7 +1,7 @@
 package:
   name: php
   version: 8.2.9
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01


### PR DESCRIPTION
libavif 1.0.0 introduces new SONAME, so we need to rebuild the packages which depend on it.