### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This is the main package repository for the Wolfi project.
 
-Named after the [smallest octopus][wiki-ow], Wolfi is a lightweight GNU
+Named after the [smallest octopus][wiki-ow], [Wolfi][wolfi] is a lightweight GNU
 software distribution which is designed around minimalism, making it
 well-suited for containerized environments built with [apko][apko].
 
@@ -13,6 +13,7 @@ It is built using [melange][melange], and is sponsored by [Chainguard][cg],
 which uses it to provide [lightweight GNU/Linux runtime images][cgi].
 
    [wiki-ow]: https://en.wikipedia.org/wiki/Octopus_wolfi
+   [wolfi]: https://wolfi.dev
    [apko]: https://github.com/chainguard-dev/apko
    [melange]: https://github.com/chainguard-dev/melange
    [cg]: https://chainguard.dev/
@@ -20,9 +21,26 @@ which uses it to provide [lightweight GNU/Linux runtime images][cgi].
 
 The Wolfi APK package repository is located at https://packages.wolfi.dev/os and the signing public key is at https://packages.wolfi.dev/os/wolfi-signing.rsa.pub.
 
+## Getting Started
+
+A full guide is available on the [org page](https://github.com/wolfi-dev), but the quickest way to try out Wolfi is with the
+[wolfi-base image](https://github.com/chainguard-images/images/tree/main/images/wolfi-base):
+
+```
+docker run -it cgr.dev/chainguard/wolfi-base
+52aace776b20:/# uname -a
+Linux 52aace776b20 5.15.49-linuxkit-pr #1 SMP PREEMPT Thu May 25 07:27:39 UTC 2023 aarch64 Linux
+52aace776b20:/# cat /etc/os-release
+ID=wolfi
+NAME="Wolfi"
+PRETTY_NAME="Wolfi"
+VERSION_ID="20230201"
+HOME_URL="https://wolfi.dev"
+```
+
 ## Mixing packages with other distributions
 
-Mixing packages with other distributions is not supported and can create security problems.
+Mixing packages with other distributions is not supported and can create security problems. Although both Wolfi and Alpine use the apk package manager, packages are not compatible with each other.
 
 ## If Wolfi is missing a package you require
 


### PR DESCRIPTION
Link back to org page and wolfi-base image.

Also make explicit that you can't use Alpine packages.
