### PR TITLE
Bump activesupport in kube-fluent-operator to mitigate CVE-2023-38037.

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.17.6
-  epoch: 1
+  epoch: 2
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -56,6 +56,9 @@ pipeline:
       mkdir -p ${GEM_DIR}
       bundle config set --local path ${GEM_DIR}
       bundle config set --local without 'development test'
+
+      # Bump activemodel to mitigate CVE-2023-38037
+      bundle add activemodel --version=7.0.7.2
       bundle install
 
       mkdir -p ${{targets.destdir}}/etc/fluent/plugin


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
