### PR TITLE
Install missing package conda-package-handling.

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -1,7 +1,7 @@
 package:
   name: conda
   version: 23.7.3
-  epoch: 0
+  epoch: 1
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause
@@ -38,7 +38,7 @@ pipeline:
       expected-commit: a9b1838f059501528e6f48c35972fd5f379dec0a
 
   - runs: |
-      pip install hatch
+      pip install hatch conda-package-handling
       hatch build
       python3 -m installer -d "${{targets.destdir}}" dist/conda*.whl
 


### PR DESCRIPTION

Fixes: #4888 

Add missing dependency that now allows one to install packages. Tested with conda search and conda install which was not previously working.

One still has to do `conda init` before this works, but I'll tackle that in another PR.