### PR TITLE
use baseline target for broader CPU compatability

### DIFF
--- a/zig.yaml
+++ b/zig.yaml
@@ -1,7 +1,7 @@
 package:
   name: zig
   version: 0.11.0
-  epoch: 0
+  epoch: 1
   description: "General-purpose programming language designed for robustness, optimality, and maintainability"
   copyright:
     - license: MIT
@@ -38,7 +38,8 @@ pipeline:
         -DCMAKE_PREFIX_PATH=/usr \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DZIG_VERSION="${{package.version}}" \
-        -DZIG_SHARED_LLVM=ON
+        -DZIG_SHARED_LLVM=ON \
+        -DZIG_TARGET_MCPU=baseline
 
       # Limit builds to one core because it uses a lot of memory
       cmake --build build -j$(nproc)


### PR DESCRIPTION
explicitly compile with `baseline` target for broader CPU compatibility. for example, this materializes on 9th gen intel cpu's with the following:

```
40c88caaed42:/# zig init-exe
info: Created build.zig
info: Created src/main.zig
info: Next, try `zig build --help` or `zig build run`
40c88caaed42:/# zig build
Illegal instruction (core dumped)
```

all kudos for this goes to @kaniini 

ref: https://github.com/NixOS/nixpkgs/pull/215994