### PR TITLE
attempt to fix pulumi-kubernetes-operator updates

### DIFF
--- a/pulumi-kubernetes-operator.yaml
+++ b/pulumi-kubernetes-operator.yaml
@@ -47,3 +47,4 @@ update:
   github:
     identifier: pulumi/pulumi-kubernetes-operator
     strip-prefix: v
+    tag-filter: v1.1


### PR DESCRIPTION
Fixes https://github.com/wolfi-dev/os/issues/3780

The pulumi-kubernetes-operator repo has a tag named [`pulumi-kubernetes-operator-0.1.0`](https://github.com/pulumi/pulumi-kubernetes-operator/releases/tag/pulumi-kubernetes-operator-0.1.0) which seems to trip up our wolfibot update automation.

```

failed to create a version slice for pulumi/pulumi-kubernetes-operator: failed to create a version from pulumi-kubernetes-operator-0.1.0: Malformed version: pulumi-kubernetes-operator-0.1.0
```

Adding a tag filter to ignore this (and future ignorable) tags