### PR TITLE
Fix argo-cd runtime deps

### DIFF
--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.7
   version: 2.7.13
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -71,7 +71,7 @@ subpackages:
     description: "ArgoCD repo server"
     dependencies:
       runtime:
-        - ${{package.name}}-compat
+        - argo-cd-2.7-compat
         - git
         - git-lfs
         - gnupg

--- a/argo-cd-2.8.yaml
+++ b/argo-cd-2.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.8
   version: 2.8.2
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -71,7 +71,7 @@ subpackages:
     description: "ArgoCD repo server"
     dependencies:
       runtime:
-        - ${{package.name}}-compat
+        - argo-cd-2.8-compat
         - git
         - git-lfs
         - gnupg


### PR DESCRIPTION
This inlines `${{package.name}}` two places because we don't allow substitutions there and the meta variables were being interpreted as literal package names.

```
  │ resolving apk packages: could not find package either named
  │ ${{package.name}}-compat or that provides ${{package.name}}-compat for
  │ argo-cd-2.8-repo-server
```