### PR TITLE
calico: add pod2daemon-flexvol-compat

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.26.1
-  epoch: 11
+  epoch: 12
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64
@@ -429,6 +429,13 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           install -m755 ./pod2daemon/flexvol/docker/flexvol.sh "${{targets.subpkgdir}}"/usr/bin/flexvol.sh
+
+  - name: calico-pod2daemon-flexvol-compat
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
+          ln -sf /usr/bin/calico-pod2daemon-flexvol "${{targets.subpkgdir}}"/usr/local/bin/flexvol
+          ln -sf /usr/bin/flexvol.sh "${{targets.subpkgdir}}"/usr/local/bin/flexvol.sh
 
   - name: "calicoctl"
     pipeline:


### PR DESCRIPTION
The upstream `calico/pod2daemon-flexvol` image has these:

```
crane export calico/pod2daemon-flexvol - | tar -tvf - | grep flexvol              
-rwxr-xr-x  0 0      0     4987070 Nov 22  2021 usr/local/bin/flexvol
-rwxrwxr-x  0 0      0        1703 Nov  9  2021 usr/local/bin/flexvol.sh
```

And ours has these:

```
crane export cgr.dev/chainguard/calico-pod2daemon - | tar -tvf - | grep flexvol
-rwxr-xr-x  0 root    root  3870720 Dec 31  1969 usr/bin/calico-pod2daemon-flexvol
-rwxr-xr-x  0 root    root     1703 Dec 31  1969 usr/bin/flexvol.sh
```

The Tigera operator (and maybe Calico itself) seems to expect the former.