### PR TITLE
Add python-3 for consistency with our other naming conventions.

### DIFF
--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -8,6 +8,7 @@ package:
   dependencies:
     provides:
       - python3=3.11.999
+      - python-3=3.11.999
 
 environment:
   contents:


### PR DESCRIPTION
Provide `python-3` package just like we provide `python3`. Reason being that for "explicit" python versions, say "3.11", the package is python-3.11, but currently if you use version "3" the package we provide is "python3" which makes it little inconsistent.
So, add "python-3" package and then you can use "3" and "3.11" interchangeably.