### PR TITLE
Set the root password to '*' to make scanners happy that we have one.

### DIFF
--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 4
+  epoch: 5
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
@@ -22,9 +22,10 @@ environment:
 pipeline:
   - name: Generate /etc/shadow
     runs: |
+      # Set a '*' for the root password to make scanners happy
       awk -F: '{
           pw = ":!:"
-          if ($1 == "root") { pw = "::" }
+          if ($1 == "root") { pw = ":*:" }
           print($1 pw ":0:::::")
       }' vendor/etc/passwd > vendor/etc/shadow
 


### PR DESCRIPTION
hunter2

Fixes:

Related:

### Pre-review Checklist

