### PR TITLE
use wolfi-builders in presubmit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,9 +23,7 @@ jobs:
         arch: [ "x86_64", "aarch64" ]
       fail-fast: false
 
-    runs-on: 
-      - self-hosted
-      - ${{ matrix.arch }}
+    runs-on: wolfi-builder-${{ matrix.arch }}
 
     # Ensure this is deprivileged, isolated job
     # permissions:

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -52,9 +52,7 @@ jobs:
       matrix:
         arch: [ "x86_64", "aarch64" ]
       fail-fast: false
-    runs-on:
-      - self-hosted
-      - ${{ matrix.arch }}
+    runs-on: wolfi-builder-spot-${{ matrix.arch }}
     needs: changes
     container:
       image: ghcr.io/wolfi-dev/sdk:latest@sha256:7ae93303568317dbcc9d5c623220282f15cd5bbcfaab968c12d54c31e25d5602

--- a/py3-tz.yaml
+++ b/py3-tz.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tz
   version: 2023.3
-  epoch: 0
+  epoch: 1
   description: Python3 definitions of world timezone
   copyright:
     - license: MIT


### PR DESCRIPTION
enable new autoscaling pool of self hosted wolfi runners. the runners are designated into 2 categories:

- presubmit (`ci-build.yaml`):
  - gke spot instances
  - scales within 0-10 nodes (~2 build jobs per node)
- postsubmit (`build.yaml`):
  - gke instances
  - scales within 1-2 nodes (1 build job per node per workflow)

non scientific time to job start for spots is:

- cold (no node): ~80s
- warm (node without image): ~20s
- hot (node with image): ~<2s

it varies slightly depending on the arch (aarch64 is faster). times above are for x86_64