### PR TITLE
rebuild 124 packages to remove unwanted security.csm xattrs

### DIFF
--- a/aactl.yaml
+++ b/aactl.yaml
@@ -1,7 +1,7 @@
 package:
   name: aactl
   version: 0.4.12
-  epoch: 0
+  epoch: 1
   description: Google Container Analysis data import utility, supports OSS vulnerability scanner reports, SLSA provenance and sigstore attestations.
   copyright:
     - license: Apache-2.0

--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.7
   version: 2.7.13
-  epoch: 1
+  epoch: 2
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0

--- a/argo-cd-2.8.yaml
+++ b/argo-cd-2.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.8
   version: 2.8.2
-  epoch: 1
+  epoch: 2
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,7 +1,7 @@
 package:
   name: atlantis
   version: 0.25.0
-  epoch: 0
+  epoch: 1
   description: Terraform Pull Request Automation
   copyright:
     - license: Apache-2.0

--- a/aws-c-s3.yaml
+++ b/aws-c-s3.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-s3
   version: 0.3.16
-  epoch: 0
+  epoch: 1
   description: "AWS C99 library implementation for communicating with the S3 service"
   copyright:
     - license: Apache-2.0

--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.26.1
-  epoch: 12
+  epoch: 13
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64

--- a/cedar.yaml
+++ b/cedar.yaml
@@ -1,7 +1,7 @@
 package:
   name: cedar
   version: 2.3.3
-  epoch: 0
+  epoch: 1
   description: "Core implementation of the Cedar language"
   copyright:
     - license: Apache-2.0

--- a/clamav.yaml
+++ b/clamav.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav
   version: 1.2.0
-  epoch: 0
+  epoch: 1
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only WITH OpenSSL-Exception

--- a/cmake.yaml
+++ b/cmake.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake
   version: 3.27.1
-  epoch: 1
+  epoch: 2
   description: "CMake is an open-source, cross-platform family of tools designed to build, test and package software"
   copyright:
     - license: BSD-3-Clause

--- a/conda.yaml
+++ b/conda.yaml
@@ -1,7 +1,7 @@
 package:
   name: conda
   version: 23.7.3
-  epoch: 1
+  epoch: 2
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause

--- a/corepack.yaml
+++ b/corepack.yaml
@@ -1,7 +1,7 @@
 package:
   name: corepack
   version: 0.20.0
-  epoch: 0
+  epoch: 1
   description: Zero-runtime-dependency package acting as bridge between Node projects and their package managers
   copyright:
     - license: MIT

--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: coreutils
   version: "9.4"
-  epoch: 0
+  epoch: 1
   description: "GNU core utilities"
   copyright:
     - license: GPL-3.0-or-later

--- a/cython.yaml
+++ b/cython.yaml
@@ -1,7 +1,7 @@
 package:
   name: cython
   version: 3.0.2
-  epoch: 0
+  epoch: 1
   description: Cython is an optimising static compiler for both the Python & the extended Cython programming languages.
   copyright:
     - license: Apache-2.0

--- a/doxygen.yaml
+++ b/doxygen.yaml
@@ -1,7 +1,7 @@
 package:
   name: doxygen
   version: 1.9.8
-  epoch: 0
+  epoch: 1
   description: A documentation system for C++, C, Java, IDL and PHP
   copyright:
     - license: GPL-2.0-or-later

--- a/elixir.yaml
+++ b/elixir.yaml
@@ -1,7 +1,7 @@
 package:
   name: elixir
   version: 1.15.5
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0

--- a/eslint.yaml
+++ b/eslint.yaml
@@ -1,7 +1,7 @@
 package:
   name: eslint
   version: 8.48.0
-  epoch: 0
+  epoch: 1
   description: An AST-based pattern checker for JavaScript
   copyright:
     - license: MIT

--- a/ferretdb.yaml
+++ b/ferretdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: ferretdb
   version: 1.9.0
-  epoch: 0
+  epoch: 1
   description: "A truly Open Source MongoDB alternative"
   copyright:
     - license: Apache-2.0

--- a/flatbuffers.yaml
+++ b/flatbuffers.yaml
@@ -2,7 +2,7 @@
 package:
   name: flatbuffers
   version: 23.5.26
-  epoch: 0
+  epoch: 1
   description: The FlatBuffers serialization format
   copyright:
     - license: Apache 2.0

--- a/freerdp.yaml
+++ b/freerdp.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp
   version: 2.11.0
-  epoch: 0
+  epoch: 1
   description: FreeRDP client
   copyright:
     - license: Apache-2.0

--- a/freetype.yaml
+++ b/freetype.yaml
@@ -1,7 +1,7 @@
 package:
   name: freetype
   version: 2.13.2
-  epoch: 0
+  epoch: 1
   description: TrueType font rendering library
   copyright:
     - license: FTL GPL-2.0-or-later

--- a/frp.yaml
+++ b/frp.yaml
@@ -1,7 +1,7 @@
 package:
   name: frp
   version: 0.51.3
-  epoch: 0
+  epoch: 1
   description: A fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet.
   copyright:
     - license: Apache-2.0

--- a/fuse-overlayfs.yaml
+++ b/fuse-overlayfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs
   version: "1.13"
-  epoch: 0
+  epoch: 1
   description: FUSE implementation for overlayfs
   copyright:
     - license: GPL-2.0-or-later

--- a/gatekeeper-3.12.yaml
+++ b/gatekeeper-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gatekeeper-3.12
   version: 3.12.0
-  epoch: 0
+  epoch: 1
   description: Gatekeeper - Policy Controller for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/gatekeeper-3.13.yaml
+++ b/gatekeeper-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: gatekeeper-3.13
   version: 3.13.0
-  epoch: 0
+  epoch: 1
   description: Gatekeeper - Policy Controller for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/gd.yaml
+++ b/gd.yaml
@@ -1,7 +1,7 @@
 package:
   name: gd
   version: 2.3.3
-  epoch: 4
+  epoch: 5
   description: Library for the dynamic creation of images by programmers
   copyright:
     - license: GD

--- a/glslang.yaml
+++ b/glslang.yaml
@@ -2,7 +2,7 @@
 package:
   name: glslang
   version: 1.3.261.1
-  epoch: 0
+  epoch: 1
   description: Khronos reference front-end for GLSL, ESSL, and sample SPIR-V generator
   copyright:
     - license: BSD-3-Clause

--- a/k8s-sidecar.yaml
+++ b/k8s-sidecar.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8s-sidecar
   version: 1.25.1
-  epoch: 0
+  epoch: 1
   description: "container intended to run inside a kubernetes cluster to collect config maps with a specified label and store the included files in a local folder"
   copyright:
     - license: MIT

--- a/k8sgpt-operator.yaml
+++ b/k8sgpt-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8sgpt-operator
   version: 0.0.21
-  epoch: 0
+  epoch: 1
   description: Automatic SRE Superpowers within your Kubernetes cluster
   copyright:
     - license: Apache-2.0

--- a/kaniko.yaml
+++ b/kaniko.yaml
@@ -1,7 +1,7 @@
 package:
   name: kaniko
   version: 1.15.0
-  epoch: 0
+  epoch: 1
   description: Build Container Images In Kubernetes
   copyright:
     - license: Apache-2.0

--- a/kube-downscaler.yaml
+++ b/kube-downscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-downscaler
   version: 23.2.0
-  epoch: 3
+  epoch: 4
   description: Scale down Kubernetes deployments after work hours
   copyright:
     - license: GPL-3.0-or-later

--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.17.6
-  epoch: 2
+  epoch: 3
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT

--- a/kubeflow-volumes-web-app.yaml
+++ b/kubeflow-volumes-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-volumes-web-app
   version: 1.7.0
-  epoch: 1
+  epoch: 2
   description: Kubeflow volumes web app component
   copyright:
     - license: Apache-2.0

--- a/libavif.yaml
+++ b/libavif.yaml
@@ -1,7 +1,7 @@
 package:
   name: libavif
   version: 1.0.1
-  epoch: 0
+  epoch: 1
   description: Library for encoding and decoding .avif files
   copyright:
     - license: BSD-2-Clause

--- a/llvm-libcxx-16.yaml
+++ b/llvm-libcxx-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-libcxx-16
   version: 16.0.6
-  epoch: 0
+  epoch: 1
   description: The LLVM libc++ libraries
   copyright:
     - license: Apache-2.0

--- a/llvm-libunwind.yaml
+++ b/llvm-libunwind.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-libunwind
   version: 16.0.6
-  epoch: 0
+  epoch: 1
   description: LLVM version of libunwind library
   copyright:
     - license: MIT

--- a/loki.yaml
+++ b/loki.yaml
@@ -1,7 +1,7 @@
 package:
   name: loki
   version: 2.8.4
-  epoch: 2
+  epoch: 3
   description: Like Prometheus, but for logs.
   copyright:
     - license: AGPL-3.0

--- a/metacontroller.yaml
+++ b/metacontroller.yaml
@@ -1,7 +1,7 @@
 package:
   name: metacontroller
   version: 4.11.0
-  epoch: 0
+  epoch: 1
   description: Writing kubernetes controllers can be simple
   copyright:
     - paths:

--- a/minify.yaml
+++ b/minify.yaml
@@ -1,7 +1,7 @@
 package:
   name: minify
   version: 2.12.8
-  epoch: 0
+  epoch: 1
   description: "Go minifiers for web formats"
   copyright:
     - license: MIT

--- a/newrelic-infrastructure-agent.yaml
+++ b/newrelic-infrastructure-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-infrastructure-agent
   version: 1.47.0
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Agent
   copyright:
     - license: Apache-2.0

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-mainline
   version: 1.25.2
-  epoch: 1
+  epoch: 2
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-stable
   version: 1.24.0
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause

--- a/node-problem-detector.yaml
+++ b/node-problem-detector.yaml
@@ -1,7 +1,7 @@
 package:
   name: node-problem-detector
   version: 0.8.14
-  epoch: 0
+  epoch: 1
   description: node-problem-detector aims to make various node problems visible to the upstream layers in the cluster management stack.
   copyright:
     - license: Apache-2.0

--- a/nuclei.yaml
+++ b/nuclei.yaml
@@ -1,7 +1,7 @@
 package:
   name: nuclei
   version: 2.9.13
-  epoch: 0
+  epoch: 1
   description: "yaml based vulnerability scanner"
   copyright:
     - license: MIT

--- a/ollama.yaml
+++ b/ollama.yaml
@@ -1,7 +1,7 @@
 package:
   name: ollama
   version: 0.0.16
-  epoch: 0
+  epoch: 1
   description: Get up and running with Llama 2 and other large language models locally
   copyright:
     - license: MIT

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
   version: 11.0.21.5
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
   version: 17.0.9.5
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only

--- a/opentelemetry-collector-contrib.yaml
+++ b/opentelemetry-collector-contrib.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-collector-contrib
   version: 0.84.0
-  epoch: 0
+  epoch: 1
   description: Contrib repository for the OpenTelemetry Collector
   copyright:
     - license: Apache-2.0

--- a/php.yaml
+++ b/php.yaml
@@ -1,7 +1,7 @@
 package:
   name: php
   version: 8.2.9
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/poetry.yaml
+++ b/poetry.yaml
@@ -1,7 +1,7 @@
 package:
   name: poetry
   version: 1.6.1
-  epoch: 0
+  epoch: 1
   description: "Python packaging and dependency management made easy"
   copyright:
     - license: MIT

--- a/prometheus-redis-exporter.yaml
+++ b/prometheus-redis-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-redis-exporter
   version: 1.53.0
-  epoch: 0
+  epoch: 1
   description: Prometheus Exporter for Redis Metrics.
   copyright:
     - license: MIT

--- a/protobuf.yaml
+++ b/protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf
   version: 3.24.2
-  epoch: 0
+  epoch: 1
   description: Library for extensible, efficient structure packing
   copyright:
     - license: BSD-3-Clause

--- a/pulumi-language-dotnet.yaml
+++ b/pulumi-language-dotnet.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-dotnet
   version: 3.56.2
-  epoch: 0
+  epoch: 1
   description: Pulumi Language SDK for Dotnet
   copyright:
     - license: Apache-2.0

--- a/pulumi-language-java.yaml
+++ b/pulumi-language-java.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-java
   version: 0.9.7
-  epoch: 0
+  epoch: 1
   description: Pulumi Language SDK for Java
   copyright:
     - license: Apache-2.0

--- a/pulumi-language-yaml.yaml
+++ b/pulumi-language-yaml.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-yaml
   version: 1.3.0
-  epoch: 0
+  epoch: 1
   description: Pulumi Language SDK for YAML
   copyright:
     - license: Apache-2.0

--- a/pulumi.yaml
+++ b/pulumi.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi
   version: 3.79.0
-  epoch: 0
+  epoch: 1
   description: Infrastructure as Code in any programming language
   copyright:
     - license: Apache-2.0

--- a/py3-alembic.yaml
+++ b/py3-alembic.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-alembic
   version: 1.11.3
-  epoch: 0
+  epoch: 1
   description: A database migration tool for SQLAlchemy.
   copyright:
     - license: MIT License

--- a/py3-annotated-types.yaml
+++ b/py3-annotated-types.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-annotated-types
   version: 0.5.0
-  epoch: 0
+  epoch: 1
   description: Reusable constraint types to use with typing.Annotated
   copyright:
     - license: MIT

--- a/py3-awscrt.yaml
+++ b/py3-awscrt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-awscrt
   version: 0.19.1
-  epoch: 0
+  epoch: 1
   description: "Python bindings for the AWS Common Runtime"
   copyright:
     - license: Apache-2.0

--- a/py3-botocore.yaml
+++ b/py3-botocore.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-botocore
   version: 1.31.36
-  epoch: 0
+  epoch: 1
   description: "The low-level, core functionality of Boto3"
   copyright:
     - license: Apache-2.0

--- a/py3-build.yaml
+++ b/py3-build.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-build
   version: 0.10.0
-  epoch: 0
+  epoch: 1
   description: A simple, correct Python build frontend
   copyright:
     - license: MIT

--- a/py3-cmaes.yaml
+++ b/py3-cmaes.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cmaes
   version: 0.10.0
-  epoch: 0
+  epoch: 1
   description: Lightweight Covariance Matrix Adaptation Evolution Strategy (CMA-ES) implementation for Python 3.
   copyright:
     - license: MIT License

--- a/py3-colorlog.yaml
+++ b/py3-colorlog.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-colorlog
   version: 6.7.0
-  epoch: 0
+  epoch: 1
   description: Add colours to the output of Python's logging module.
   copyright:
     - license: MIT License

--- a/py3-conda-package-handling.yaml
+++ b/py3-conda-package-handling.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-conda-package-handling
   version: 2.2.0
-  epoch: 0
+  epoch: 1
   description: Create and extract conda packages of various formats.
   copyright:
     - license: "BSD-3-Clause"

--- a/py3-conda-package-streaming.yaml
+++ b/py3-conda-package-streaming.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-conda-package-streaming
   version: 0.9.0
-  epoch: 0
+  epoch: 1
   description: An efficient library to read from new and old format .conda and .tar.bz2 conda packages.
   copyright:
     - license: "BSD-3-Clause"

--- a/py3-contourpy.yaml
+++ b/py3-contourpy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-contourpy
   version: 1.1.0
-  epoch: 1
+  epoch: 2
   description: Python library for calculating contours of 2D quadrilateral grids
   copyright:
     - license: BSD-3-Clause

--- a/py3-distlib.yaml
+++ b/py3-distlib.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-distlib
   version: 0.3.7
-  epoch: 0
+  epoch: 1
   description: Distribution utilities
   copyright:
     - license: PSF-2.0

--- a/py3-editables.yaml
+++ b/py3-editables.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-editables
   version: "0.5"
-  epoch: 0
+  epoch: 1
   description: Editable installations
   copyright:
     - license: "MIT"

--- a/py3-exceptiongroup.yaml
+++ b/py3-exceptiongroup.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-exceptiongroup
   version: 1.1.3
-  epoch: 0
+  epoch: 1
   description: Backport of PEP 654 (exception groups)
   copyright:
     - license: "MIT"

--- a/py3-filelock.yaml
+++ b/py3-filelock.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-filelock
   version: 3.12.3
-  epoch: 0
+  epoch: 1
   description: A platform independent file lock.
   copyright:
     - license: Unlicense

--- a/py3-forestci.yaml
+++ b/py3-forestci.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-forestci
   version: "0.6"
-  epoch: 0
+  epoch: 1
   description: 'forestci: confidence intervals for scikit-learn forest algorithms'
   copyright:
     - license: MIT

--- a/py3-gpep517.yaml
+++ b/py3-gpep517.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-gpep517
   version: "15"
-  epoch: 0
+  epoch: 1
   description: "PEP517 build system support for distros"
   copyright:
     - license: MIT

--- a/py3-h11.yaml
+++ b/py3-h11.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-h11
   version: 0.14.0
-  epoch: 0
+  epoch: 1
   description: A pure-Python, bring-your-own-I/O implementation of HTTP/1.1
   copyright:
     - license: MIT

--- a/py3-humanfriendly.yaml
+++ b/py3-humanfriendly.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-humanfriendly
   version: "10.0"
-  epoch: 0
+  epoch: 1
   description: Human friendly output for text interfaces using Python
   copyright:
     - license: MIT

--- a/py3-hyperlink.yaml
+++ b/py3-hyperlink.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-hyperlink
   version: 21.0.0
-  epoch: 0
+  epoch: 1
   description: A featureful, immutable, and correct URL for Python.
   copyright:
     - license: MIT

--- a/py3-jeepney.yaml
+++ b/py3-jeepney.yaml
@@ -7,7 +7,7 @@ package:
   # Other tags do have all three numbers, so I've skipped the var-transform since this appears to
   # be an exception.
   version: 0.8.0
-  epoch: 0
+  epoch: 1
   description: Low-level, pure Python DBus protocol wrapper.
   copyright:
     - license: MIT

--- a/py3-kiwisolver.yaml
+++ b/py3-kiwisolver.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-kiwisolver
   version: 1.4.5
-  epoch: 1
+  epoch: 2
   description: A fast implementation of the Cassowary constraint solver
   copyright:
     - license: BSD-3-Clause-Attribution

--- a/py3-openai.yaml
+++ b/py3-openai.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-openai
   version: 0.27.10
-  epoch: 0
+  epoch: 1
   description: Python client library for the OpenAI API
   copyright:
     - license: MIT

--- a/py3-optuna.yaml
+++ b/py3-optuna.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-optuna
   version: 3.3.0
-  epoch: 0
+  epoch: 1
   description: A hyperparameter optimization framework
   copyright:
     - license: MIT License

--- a/py3-pluggy.yaml
+++ b/py3-pluggy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pluggy
   version: 1.3.0
-  epoch: 0
+  epoch: 1
   description: "Plugin management and hook calling for Python"
   copyright:
     - license: MIT

--- a/py3-protobuf.yaml
+++ b/py3-protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-protobuf
   version: 4.24.2
-  epoch: 0
+  epoch: 1
   copyright:
     - license: 3-Clause BSD License
   dependencies:

--- a/py3-psutil.yaml
+++ b/py3-psutil.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-psutil
   version: 5.9.5
-  epoch: 0
+  epoch: 1
   description: Cross-platform lib for process and system monitoring in Python.
   copyright:
     - license: BSD-3-Clause

--- a/py3-pyproject-hooks.yaml
+++ b/py3-pyproject-hooks.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyproject-hooks
   version: 1.0.0
-  epoch: 0
+  epoch: 1
   description: A low-level library for calling build-backends in `pyproject.toml`-based project
   copyright:
     - license: MIT

--- a/py3-python-editor.yaml
+++ b/py3-python-editor.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-editor
   version: 1.0.4
-  epoch: 0
+  epoch: 1
   description: Programmatically open an editor, capture the result.
   copyright:
     - license: Apache-2.0

--- a/py3-rfc3339.yaml
+++ b/py3-rfc3339.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rfc3339
   version: 1.1
-  epoch: 0
+  epoch: 1
   description: Generate and parse RFC 3339 timestamps
   copyright:
     - license: MIT

--- a/py3-rpds-py.yaml
+++ b/py3-rpds-py.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rpds-py
   version: 0.10.0
-  epoch: 0
+  epoch: 1
   description: "Python bindings to Rust's persistent data structures (rpds)."
   copyright:
     - license: MIT

--- a/py3-setuptools-rust.yaml
+++ b/py3-setuptools-rust.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-setuptools-rust
   version: 1.7.0
-  epoch: 0
+  epoch: 1
   description: Setuptools Rust extension plugin
   copyright:
     - license: MIT

--- a/py3-sphinx.yaml
+++ b/py3-sphinx.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinx
   version: 7.2.4
-  epoch: 0
+  epoch: 1
   description: "Python Documentation Generator"
   copyright:
     - license: MIT

--- a/py3-sphinxcontrib-applehelp.yaml
+++ b/py3-sphinxcontrib-applehelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-applehelp
   version: 1.0.7
-  epoch: 1
+  epoch: 2
   description: sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books
   copyright:
     - license: BSD-2-Clause

--- a/py3-sphinxcontrib-devhelp.yaml
+++ b/py3-sphinxcontrib-devhelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-devhelp
   version: 1.0.5
-  epoch: 1
+  epoch: 2
   description: sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp documents
   copyright:
     - license: BSD-2-Clause

--- a/py3-sphinxcontrib-htmlhelp.yaml
+++ b/py3-sphinxcontrib-htmlhelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-htmlhelp
   version: 2.0.4
-  epoch: 1
+  epoch: 2
   description: sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files
   copyright:
     - license: BSD-2-Clause

--- a/py3-sphinxcontrib-jsmath.yaml
+++ b/py3-sphinxcontrib-jsmath.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-jsmath
   version: 1.0.1
-  epoch: 1
+  epoch: 2
   description: A sphinx extension which renders display math in HTML via JavaScript
   copyright:
     - license: BSD

--- a/py3-sphinxcontrib-packages.yaml
+++ b/py3-sphinxcontrib-packages.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-packages
   version: 1.1.2
-  epoch: 1
+  epoch: 2
   description: This packages contains the Packages sphinx extension, which provides directives to display packages installed on the host machine
   copyright:
     - license: AGPLv3 or any later version

--- a/py3-sqlalchemy.yaml
+++ b/py3-sqlalchemy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sqlalchemy
   version: 2.0.20
-  epoch: 0
+  epoch: 1
   description: Database Abstraction Library
   copyright:
     - license: MIT

--- a/py3-sqlglot.yaml
+++ b/py3-sqlglot.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-sqlglot
   version: 18.0.0
-  epoch: 0
+  epoch: 1
   description: An easily customizable SQL parser and transpiler
   copyright:
     - license: MIT

--- a/py3-zstandard.yaml
+++ b/py3-zstandard.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-zstandard
   version: 0.21.0
-  epoch: 0
+  epoch: 1
   description: Zstandard bindings for Python
   copyright:
     - license: BSD

--- a/redis-7.0.yaml
+++ b/redis-7.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis-7.0
   version: 7.0.12
-  epoch: 0
+  epoch: 1
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause

--- a/redis.yaml
+++ b/redis.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis
   version: 7.2.0
-  epoch: 1
+  epoch: 2
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause

--- a/rhash.yaml
+++ b/rhash.yaml
@@ -1,7 +1,7 @@
 package:
   name: rhash
   version: 1.4.4
-  epoch: 0
+  epoch: 1
   description: "cross-platform asynchronous I/O library"
   copyright:
     - license: 0BSD

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.4
-  epoch: 2
+  epoch: 3
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: 3.2.2
-  epoch: 2
+  epoch: 3
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.3
   version: 3.3.0_p1
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruff.yaml
+++ b/ruff.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruff
   version: 0.0.286
-  epoch: 0
+  epoch: 1
   description: An extremely fast Python linter, written in Rust.
   copyright:
     - license: MIT

--- a/rye.yaml
+++ b/rye.yaml
@@ -1,7 +1,7 @@
 package:
   name: rye
   version: 0.13.0
-  epoch: 0
+  epoch: 1
   description: "An Experimental Package Management Solution for Python"
   copyright:
     - license: Apache-2.0

--- a/s2n-tls.yaml
+++ b/s2n-tls.yaml
@@ -1,7 +1,7 @@
 package:
   name: s2n-tls
   version: 1.3.50
-  epoch: 0
+  epoch: 1
   description: AWS C99 implementation of the TLS/SSL protocols
   copyright:
     - license: Apache-2.0

--- a/slsa-verifier.yaml
+++ b/slsa-verifier.yaml
@@ -1,7 +1,7 @@
 package:
   name: slsa-verifier
   version: 2.4.0
-  epoch: 0
+  epoch: 1
   description: Verify provenance from SLSA compliant builders
   copyright:
     - license: Apache-2.0

--- a/src-fingerprint.yaml
+++ b/src-fingerprint.yaml
@@ -1,7 +1,7 @@
 package:
   name: src-fingerprint
   version: 0.19.0
-  epoch: 0
+  epoch: 1
   description: A command-line tool to perform health-checks for gRPC applications in Kubernetes and elsewhere
   copyright:
     - license: Apache-2.0

--- a/stakater-reloader.yaml
+++ b/stakater-reloader.yaml
@@ -1,7 +1,7 @@
 package:
   name: stakater-reloader
   version: 1.0.39
-  epoch: 0
+  epoch: 1
   description: A Kubernetes controller to watch changes in ConfigMap and Secrets and do rolling upgrades on Pods
   copyright:
     - license: Apache-2.0

--- a/sudo-rs.yaml
+++ b/sudo-rs.yaml
@@ -1,7 +1,7 @@
 package:
   name: sudo-rs
   version: 0.2.0
-  epoch: 0
+  epoch: 1
   description: A memory safe implementation of sudo and su.
   copyright:
     - license: MIT

--- a/syft.yaml
+++ b/syft.yaml
@@ -1,7 +1,7 @@
 package:
   name: syft
   version: 0.88.0
-  epoch: 0
+  epoch: 1
   description: CLI tool and library for generating a Software Bill of Materials from container images and filesystems
   copyright:
     - license: Apache-2.0

--- a/task.yaml
+++ b/task.yaml
@@ -1,7 +1,7 @@
 package:
   name: task
   version: 3.29.1
-  epoch: 0
+  epoch: 1
   description: A task runner / simpler Make alternative written in Go
   target-architecture:
     - all

--- a/terragrunt.yaml
+++ b/terragrunt.yaml
@@ -1,7 +1,7 @@
 package:
   name: terragrunt
   version: 0.50.9
-  epoch: 0
+  epoch: 1
   description: Thin wrapper for Terraform providing extra tools
   copyright:
     - license: MIT

--- a/thanos-0.31.yaml
+++ b/thanos-0.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-0.31
   version: 0.31.0
-  epoch: 0
+  epoch: 1
   description: Highly available Prometheus setup with long term storage capabilities.
   copyright:
     - license: Apache-2.0

--- a/thanos-0.32.yaml
+++ b/thanos-0.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-0.32
   version: 0.32.1
-  epoch: 0
+  epoch: 1
   description: Highly available Prometheus setup with long term storage capabilities.
   copyright:
     - license: Apache-2.0

--- a/vim.yaml
+++ b/vim.yaml
@@ -1,7 +1,7 @@
 package:
   name: vim
   version: 9.0.1825
-  epoch: 0
+  epoch: 1
   description: "Improved vi-style text editor"
   copyright:
     - license: Vim

--- a/vulkan-loader.yaml
+++ b/vulkan-loader.yaml
@@ -1,7 +1,7 @@
 package:
   name: vulkan-loader
   version: 1.3.262
-  epoch: 0
+  epoch: 1
   description: Vulkan Installable Client Driver (ICD) Loader
   copyright:
     - license: Apache-2.0

--- a/wasm-tools.yaml
+++ b/wasm-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasm-tools
   version: 1.0.40
-  epoch: 0
+  epoch: 1
   description: "Low level tooling for WebAssembly in Rust"
   copyright:
     - license: Apache-2.0

--- a/weaviate.yaml
+++ b/weaviate.yaml
@@ -1,7 +1,7 @@
 package:
   name: weaviate
   version: 1.21.2
-  epoch: 0
+  epoch: 1
   description: Weaviate is an open source vector database that stores both objects and vectors, allowing for combining vector search with structured filtering with the fault-tolerance and scalability of a cloud-native database, all accessible through GraphQL, REST, and various language clients.
   copyright:
     - license: BSD-3-Clause

--- a/wildfly-openssl.yaml
+++ b/wildfly-openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: wildfly-openssl
   version: 2.2.5
-  epoch: 0
+  epoch: 1
   description: OpenSSL-based Java Secure Socket Extension implementation
   copyright:
     - license: Apache-2.0

--- a/wit-bindgen.yaml
+++ b/wit-bindgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: wit-bindgen
   version: 0.11.0
-  epoch: 0
+  epoch: 1
   description: "A language binding generator for WebAssembly interface types"
   copyright:
     - license: Apache-2.0

--- a/wolfictl.yaml
+++ b/wolfictl.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfictl
   version: 0.1.6
-  epoch: 0
+  epoch: 1
   description: Helper CLI for managing Wolfi
   copyright:
     - license: Apache-2.0

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -1,7 +1,7 @@
 package:
   name: zarf
   version: 0.29.1
-  epoch: 0
+  epoch: 1
   description: DevSecOps for Air Gap & Limited-Connection Systems.
   copyright:
     - license: Apache-2.0

--- a/zig.yaml
+++ b/zig.yaml
@@ -1,7 +1,7 @@
 package:
   name: zig
   version: 0.11.0
-  epoch: 1
+  epoch: 2
   description: "General-purpose programming language designed for robustness, optimality, and maintainability"
   copyright:
     - license: MIT


### PR DESCRIPTION
the Google Container Threat Detection feature adds these security.csm xattrs to store its own internal state.  we do not want to capture this state into our packages.