### PR TITLE
feat: add vscode workspace folder entry to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dag.svg
 .idea
 .packagerules
 .melange.k8s.yaml
+.vscode/*


### PR DESCRIPTION
Add a line to ignore the `.vscode` configuration folder.