### PR TITLE
adds perl packages needed for lcov

### DIFF
--- a/perl-capture-tiny.yaml
+++ b/perl-capture-tiny.yaml
@@ -1,0 +1,46 @@
+package:
+  name: perl-capture-tiny
+  version: "0.48"
+  epoch: 0
+  description: Capture STDOUT and STDERR from Perl, XS or external programs
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 96d140b33a5ee147804925353ec5b49b806fa9c98b4ac23ec9c9494828f52ac72fd6f69c08e14ada18e5187dc4cece3d72901ce07b12eef20595322161a98437
+      uri: https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/Capture-Tiny-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+subpackages:
+  - name: perl-capture-tiny-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-capture-tiny manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2677

--- a/perl-date-format.yaml
+++ b/perl-date-format.yaml
@@ -1,0 +1,46 @@
+package:
+  name: perl-date-format
+  version: "2.33"
+  epoch: 0
+  description: Perl - Date formating subroutines
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: a3a20a0d9439e68bf621c66fad0598e6257345727be79c87c7cc99994b3a58eb738787fedb720beb069e9758ad1347c15313f64411806dd0f4dfbcca5061c820
+      uri: https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/TimeDate-${{package.version}}.tar.gz
+
+  - runs: |
+      PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-date-format-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-date-format manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3463

--- a/perl-digest-md5.yaml
+++ b/perl-digest-md5.yaml
@@ -1,0 +1,46 @@
+package:
+  name: perl-digest-md5
+  version: "2.58"
+  epoch: 0
+  description: Perl interface to the MD-5 algorithm
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: d1f186c0aa4145f6429e06e998c57e93b19e69e0194adcac18410daf18d653e9efe1fade99561fefe25a1dab16e88dccb1e0590a9932829c7c63ded0ba5a4d3e
+      uri: https://cpan.metacpan.org/authors/id/T/TO/TODDR/Digest-MD5-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+subpackages:
+  - name: perl-digest-md5-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-digest-md5 manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2841

--- a/perl-time-hires.yaml
+++ b/perl-time-hires.yaml
@@ -1,0 +1,46 @@
+package:
+  name: perl-time-hires
+  version: "1.9764"
+  epoch: 0
+  description: High resolution alarm, sleep, gettimeofday, interval timers
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 2c250784e0375539690173eaf19390389c59c218dade036ff150e2e4445e7916438d9598000bc3dbffaa2da5ee183850dedf0b6d9c99d76bfc75bb23fa7022bc
+      uri: https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/Time-HiRes-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+subpackages:
+  - name: perl-time-hires-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-time-hires manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3466


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

adds perl some packages needed for lcov 

	perl-capture-tiny ✅ 
	perl-date-format ✅ 
	perl-datetime 🔜 (it needs more perl packages so will create another PR for this?)
	perl-digest-md5 ✅ 
	perl-json-xs 🔜  (it needs more perl packages so will create another PR for this?)
	perl-memory-process (APK build not found yet on https://git.alpinelinux.org)
	perl-time-hires ✅ 

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
