### PR TITLE
feat: add version stream for Cython

### DIFF
--- a/cython-0.yaml
+++ b/cython-0.yaml
@@ -7,7 +7,7 @@ package:
     - license: Apache-2.0
   dependencies:
     provides:
-      - cython=0.29.36
+      - cython=${{package.version}}-r${{package.epoch}}
 
 environment:
   contents:
@@ -24,7 +24,7 @@ pipeline:
     with:
       expected-commit: 702bbc80fe2e346c4ddc58f074e0054da56e0ced
       repository: https://github.com/cython/cython
-      tag: 0.29.36
+      tag: ${{package.version}}
 
   - runs: |
       python setup.py build

--- a/cython-0.yaml
+++ b/cython-0.yaml
@@ -1,0 +1,40 @@
+package:
+  name: cython-0
+  version: 0.29.36
+  epoch: 0
+  description: Cython is an optimising static compiler for both the Python & the extended Cython programming languages.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - cython=0.29.36
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - py3-setuptools
+      - python3-dev
+      - python3
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 702bbc80fe2e346c4ddc58f074e0054da56e0ced
+      repository: https://github.com/cython/cython
+      tag: 0.29.36
+
+  - runs: |
+      python setup.py build
+      python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: cython/cython
+    use-tag: true
+    tag-filter: 0.


### PR DESCRIPTION
Create a version stream for Cython 0, since lxml does not work with Cython 3.

Related: required by #4972

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates