### PR TITLE
crossplane: rewrite package.yaml to depend on our image

### DIFF
--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-aws
   version: 0.39.0
-  epoch: 0
+  epoch: 1
   description: Official AWS Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -19,6 +19,8 @@ environment:
       - busybox
       - curl
       - gzip
+      - terraform-provider-aws
+      - terraform
   environment:
     CGO_ENABLED: 0
 
@@ -57,7 +59,8 @@ subpackages:
       - runs: |
           up xpkg xp-extract xpkg.upbound.io/upbound/${{range.value}}:v${{package.version}}
           mkdir -p "${{targets.subpkgdir}}"
-          gunzip out.gz -c > "${{targets.subpkgdir}}"/package.yaml
+          # Rewrite the package.yaml to use our Crossplane AWS image.
+          gunzip out.gz -c | sed -e 's|xpkg.upbound.io/upbound/provider-family-aws|cgr.dev/chainguard/crossplane-aws|g' > "${{targets.subpkgdir}}"/package.yaml
 
 update:
   enabled: true


### PR DESCRIPTION
The package.yaml we include tells crossplane to install the upstream xpkg.upbound.io provider for AWS, instead of using ours.

By rewriting the config, installing our S3 provider (for example) will tell Crossplane to install our AWS provider.