### PR TITLE
Add neon database.

### DIFF
--- a/neon.yaml
+++ b/neon.yaml
@@ -1,0 +1,71 @@
+package:
+  name: neon
+  version: 3819
+  epoch: 0
+  description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - rust
+      - openssl-dev
+      - build-base
+      - libtool
+      - readline-dev
+      - zlib-dev
+      - flex
+      - bison
+      - libseccomp-dev
+      - clang
+      - pkgconf
+      - libpq-15
+      - cmake
+      - postgresql-15-client
+      - protoc
+      - libcurl-openssl4
+      - poetry
+      - perl
+      - bash
+      - coreutils
+      - protobuf
+      - curl-dev
+      - protobuf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/neondatabase/neon
+      tag: release-${{package.version}}
+      expected-commit: 1804111a020390ac83d3517e5a4ef3c15f1656a7
+
+  - runs: |
+      git submodule update --init --recursive
+
+      make -j$(nproc) -s BUILD_TYPE=release
+
+      mkdir -p "${{targets.destdir}}"/usr/bin
+      for f in pg_sni_router pageserver pagectl safekeeper storage_broker proxy neon_local; do
+        mv target/release/$f "${{targets.destdir}}"/usr/bin
+      done
+
+      # This has to be used in conjunction with the POSTGRES_DISTRIB_DIR env var to tell
+      # neon where to find the postgres binaries.
+      # POSTGRES_DISTRIB_DIR=/usr/libexec
+      mkdir -p "${{targets.destdir}}"/usr/libexec/neon
+      mv pg_install/v14 "${{targets.destdir}}"/usr/libexec/neon/v14
+      mv pg_install/v15 "${{targets.destdir}}"/usr/libexec/neon/v15
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: neondatabase/neon
+    strip-prefix: release-
+    use-tag: true


### PR DESCRIPTION
This vendors postgres, but they actually fork it and modify it so it doesn't seem possible to use our own, this is just how the neon stuff works.


Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
