### PR TITLE
wolfi-baselayout: enable happy eyeballs support

### DIFF
--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 5
+  epoch: 6
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
@@ -58,6 +58,8 @@ pipeline:
       ln -s /etc/crontabs "${{targets.destdir}}"/var/spool/cron/crontabs
       ln -s /proc/mounts "${{targets.destdir}}"/etc/mtab
       ln -s /var/mail "${{targets.destdir}}"/var/spool/mail
+
+      echo 'multi on' > "${{targets.destdir}}"/etc/host.conf
 
       chmod 0700 "${{targets.destdir}}"/root
 


### PR DESCRIPTION
On glibc, adding 'multi on' to `/etc/host.conf` is a necessary prerequisite for happy eyeballs support.