### PR TITLE
Create more virtual java packages.

### DIFF
--- a/openjdk-10.yaml
+++ b/openjdk-10.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-10
   version: 10.0.2
-  epoch: 3
+  epoch: 4
   description: "Oracle OpenJDK 10"
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -213,6 +213,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-10-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-10-default-jdk"
+    description: "Use the openjdk-10 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-10-default-jvm
+        - openjdk-10
+      provides:
+        - default-jdk=1.10
 
 update:
   # OpenJDK 10 is EOL.

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
   version: 11.0.21.5
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-only
@@ -204,10 +204,21 @@ subpackages:
         - openjdk-11-jre
       provides:
         - default-jvm=1.11
+        - default-jvm-lts=1.11
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-11-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-11-default-jdk"
+    description: "Use the openjdk-11 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-11-default-jvm
+        - openjdk-11
+      provides:
+        - default-jdk=1.11
+        - default-jdk-lts=1.11
 
 update:
   enabled: true

--- a/openjdk-12.yaml
+++ b/openjdk-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-12
   version: 12.0.2.10
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-only
@@ -212,6 +212,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-12-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-12-default-jdk"
+    description: "Use the openjdk-12 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-12-default-jvm
+        - openjdk-12
+      provides:
+        - default-jdk=1.12
 
 update:
   # OpenJDK 12 is EOL

--- a/openjdk-13.yaml
+++ b/openjdk-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-13
   version: 13.0.14.5
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-only
@@ -208,6 +208,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-13-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-13-default-jdk"
+    description: "Use the openjdk-13 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-13-default-jvm
+        - openjdk-13
+      provides:
+        - default-jdk=1.13
 
 update:
   # OpenJDK 13 is EOL

--- a/openjdk-14.yaml
+++ b/openjdk-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-14
   version: 14.0.2.12
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-only
@@ -203,6 +203,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-14-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-14-default-jdk"
+    description: "Use the openjdk-14 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-14-default-jvm
+        - openjdk-14
+      provides:
+        - default-jdk=1.14
 
 update:
   # OpenJDK 14 is EOL

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-15
   version: 15.0.10.5
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-only
@@ -210,6 +210,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-15-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-15-default-jdk"
+    description: "Use the openjdk-15 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-15-default-jvm
+        - openjdk-15
+      provides:
+        - default-jdk=1.15
 
 update:
   # OpenJDK 15 is EOL

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-16
   version: 16.0.2.7
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-only
@@ -210,6 +210,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-16-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-16-default-jdk"
+    description: "Use the openjdk-16 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-16-default-jvm
+        - openjdk-16
+      provides:
+        - default-jdk=1.16
 
 update:
   # OpenJDK 16 is EOL

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
   version: 17.0.9.5
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-only
@@ -209,10 +209,21 @@ subpackages:
         - openjdk-17-jre
       provides:
         - default-jvm=1.17
+        - default-jvm-lts=1.17
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-17-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-17-default-jdk"
+    description: "Use the openjdk-17 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-17-default-jvm
+        - openjdk-17
+      provides:
+        - default-jdk=1.17
+        - default-jdk-lts=1.17
 
 update:
   enabled: true

--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-18
   version: 18.0.2.1.0
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -208,6 +208,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-18-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-18-default-jdk"
+    description: "Use the openjdk-18 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-18-default-jvm
+        - openjdk-18
+      provides:
+        - default-jdk=1.18
 
 update:
   # OpenJDK 18 is EOL

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-19
   version: 19.0.2.7
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -208,6 +208,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-19-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-19-default-jdk"
+    description: "Use the openjdk-19 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-19-default-jvm
+        - openjdk-19
+      provides:
+        - default-jdk=1.19
 
 update:
   # OpenJDK 19 is EOL

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-20
   version: 20.0.2.9
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -214,6 +214,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-20-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-20-default-jdk"
+    description: "Use the openjdk-20 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-20-default-jvm
+        - openjdk-20
+      provides:
+        - default-jdk=1.20
 
 update:
   enabled: true

--- a/openjdk-7.yaml
+++ b/openjdk-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-7
   version: 7.321.2.6.28
-  epoch: 2
+  epoch: 3
   description: "IcedTea distribution of OpenJDK 7 (UNSUPPORTED)"
   copyright:
     - license: GPL-2.0-or-later
@@ -275,6 +275,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-1.7-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-7-default-jdk"
+    description: "Use the openjdk-7 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-7-default-jvm
+        - openjdk-7
+      provides:
+        - default-jdk=1.7
 
 update:
   # OpenJDK 7 is EOL.

--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.382.05
-  epoch: 0
+  epoch: 1
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later
@@ -183,10 +183,21 @@ subpackages:
         - openjdk-8-jre
       provides:
         - default-jvm=1.8
+        - default-jvm-lts=1.8
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-1.8-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-8-default-jdk"
+    description: "Use the openjdk-8 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-8-default-jvm
+        - openjdk-8
+      provides:
+        - default-jdk=1.8
+        - default-jdk-lts=1.8
 
 update:
   enabled: true

--- a/openjdk-9.yaml
+++ b/openjdk-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-9
   version: 9.0.4
-  epoch: 3
+  epoch: 4
   description: "Oracle OpenJDK 9"
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -208,6 +208,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
           ln -sf java-1.9-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-9-default-jdk"
+    description: "Use the openjdk-9 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-9-default-jvm
+        - openjdk-9
+      provides:
+        - default-jdk=1.9
 
 update:
   # OpenJDK 9 is EOL.


### PR DESCRIPTION
Today we have a virtual `default-jvm` package, which installs its JRE, and sets up that JRE as the default.

The above package is of somewhat limited use for us in images (currently) because we track LTS and we don't have a similar virtual that JUST tracks LTS.  So the first piece of this change is introducing a new LTS virtual `default-jvm-lts` which is provided by the same packages, but only on LTS versions (8, 11, 17).

We are also missing a virtual package that aggregates the JDK into a single logical package.  So the next two pieces of this change are to introduce a similar concept to the above for installing a default JDK (and a similar LTS form) called `default-jdk` and `default-jdk-lts` respectively.  These are provided by a new empty subpackage, which has a runtime dependency on the appropriately versioned `default-jvm` and `openjdk-X` packages.

For context, I would love to have `default-jdk-lts` replace [this](https://github.com/chainguard-images/images/blob/fc964c7de0ebdaa17d242efb517b3052d11b0c78/images/jdk/config/main.tf#L7-L13) and `default-jvm-lts` replace [this](https://github.com/chainguard-images/images/pull/1305/files#diff-b5e0524f13f5fd6bbd21cfbe9edf03c8697dfee7906329c87ecc562f5eff5efcR7-R13) so that we don't have to touch our images repo when a new LTS version of Java drops.