### PR TITLE
Add `provides` block for node-problem-detector-0.8 subpkgs

### DIFF
--- a/node-problem-detector-0.8.yaml
+++ b/node-problem-detector-0.8.yaml
@@ -50,19 +50,25 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: health-checker
+  - name: health-checker-0.8
     description: A health checker for node-problem-detector to check kubelet and container runtime health
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin/
           install -m755 -D ./output/$(go env GOOS)_$(go env GOARCH)/bin/health-checker "${{targets.subpkgdir}}"/usr/bin/health-checker
+    dependencies:
+      provides:
+        - health-checker=0.8.999
 
-  - name: log-counter
+  - name: log-counter-0.8
     description: A log couter for journald to count the number of logs in a time window
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin/
           install -m755 -D ./output/$(go env GOOS)_$(go env GOARCH)/bin/log-counter "${{targets.subpkgdir}}"/usr/bin/log-counter
+    dependencies:
+      provides:
+        - log-counter=0.8.999
 
   - name: ${{package.name}}-compat
     pipeline:

--- a/node-problem-detector-0.8.yaml
+++ b/node-problem-detector-0.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: node-problem-detector-0.8
   version: 0.8.14
-  epoch: 0
+  epoch: 1
   description: node-problem-detector aims to make various node problems visible to the upstream layers in the cluster management stack.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Missed in #5079 