### PR TITLE
fix cves

### DIFF
--- a/spark-operator.yaml
+++ b/spark-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-operator
   version: 1.1.27
-  epoch: 7
+  epoch: 8
   description: Kubernetes operator for managing the lifecycle of Apache Spark applications on Kubernetes.
   copyright:
     - paths:
@@ -27,6 +27,20 @@ pipeline:
       expected-commit: bd2eda216b79733c992861f257b28dad36bb4c62
 
   - runs: |
+      # GHSA-ppp9-7jff-5vj2
+      # GHSA-69ch-w2m2-3vjp
+      go get -u golang.org/x/text@v0.3.8
+
+      # GHSA-h86h-8ppg-mxmh
+      # GHSA-83g2-8m93-v3w7
+      # GHSA-69cg-p879-7622
+      # GHSA-vvpx-j8f3-3w6h
+      go get -u golang.org/x/net@v0.7.0
+
+      # Remediate GHSA-qc2g-gmh6-95p4
+      go mod edit -replace k8s.io/kubernetes=k8s.io/kubernetes@v1.19.15
+
+      go mod tidy
       mkdir -p ${{targets.destdir}}/usr/bin
       go build -o ${{targets.destdir}}/usr/bin/spark-operator .
 
@@ -54,6 +68,7 @@ subpackages:
         - openssl
         - tini
         - posix-libc-utils
+        - coreutils
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

While I was testing the helm chart with the given package, I noticed that there was an error `id: command not found` by entrypoint.sh, so, I saw that the `id` command comes from the `coreutils` package, so, I added it as well. 

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
