### PR TITLE
Add virtual packages for dotnet

### DIFF
--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-6
   version: 6.0.121
-  epoch: 0
+  epoch: 1
   description: ".NET SDK, version 6"
   target-architecture:
     - all
@@ -107,6 +107,13 @@ subpackages:
       runtime:
         - dotnet-6
 
+  - name: dotnet-6-runtime-default
+    dependencies:
+      runtime:
+        - dotnet-6-runtime
+      provides:
+        - dotnet-runtime=6
+
   - name: aspnet-6-runtime
     description: "The ASP.NET Core Runtime, version 6"
     pipeline:
@@ -116,6 +123,13 @@ subpackages:
     dependencies:
       runtime:
         - dotnet-6-runtime
+
+  - name: aspnet-6-runtime-default
+    dependencies:
+      runtime:
+        - aspnet-6-runtime
+      provides:
+        - aspnet-runtime=6
 
   - name: dotnet-6-targeting-pack
     description: "The .NET Core targeting pack, version 6"
@@ -148,6 +162,13 @@ subpackages:
       runtime:
         - dotnet-6-runtime
         - dotnet-6-targeting-pack
+
+  - name: dotnet-6-sdk-default
+    dependencies:
+      runtime:
+        - dotnet-6-sdk
+      provides:
+        - dotnet-sdk=6
 
 update:
   enabled: true

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-7
   version: 7.0.110
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   target-architecture:
     - all
@@ -95,6 +95,13 @@ subpackages:
       runtime:
         - dotnet-7
 
+  - name: dotnet-7-runtime-default
+    dependencies:
+      runtime:
+        - dotnet-7-runtime
+      provides:
+        - dotnet-runtime=7
+
   - name: aspnet-7-runtime
     description: "The ASP.NET Core Runtime, version 7"
     pipeline:
@@ -104,6 +111,13 @@ subpackages:
     dependencies:
       runtime:
         - dotnet-7-runtime
+
+  - name: aspnet-7-runtime-default
+    dependencies:
+      runtime:
+        - aspnet-7-runtime
+      provides:
+        - aspnet-runtime=7
 
   - name: dotnet-7-targeting-pack
     description: "The .NET Core targeting pack, version 7"
@@ -136,6 +150,13 @@ subpackages:
       runtime:
         - dotnet-7-runtime
         - dotnet-7-targeting-pack
+
+  - name: dotnet-7-sdk-default
+    dependencies:
+      runtime:
+        - dotnet-7-sdk
+      provides:
+        - dotnet-sdk=7
 
 update:
   enabled: true


### PR DESCRIPTION
This change adds a new virtual package that we can use to track the latest dotnet release in public images downstream, so that we don't have to bump the version there when a new version is released here.

ref: https://github.com/chainguard-images/images/pull/1314
