### PR TITLE
Create `default-{component}` packages.

### DIFF
--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.24
   version: 1.24.17
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -182,17 +182,42 @@ subpackages:
           CFLAGS="$CFLAGS -static -DVERSION=${{vars.pause-version}}-${{package.version}}"
           gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.7 linux/pause.c
 
-  - name: kubernetes-1.24-default
-    description: "Compatibility package to set 1.24 as the default kubernetes, and add packages to their shortened path"
+  - range: components
+    name: "default-${{range.key}}-1.24"
+    description: "Makes this version of ${{range.key}} the default."
+    dependencies:
+      runtime:
+        - ${{range.key}}-1.24
+      provides:
+        - default-${{range.key}}=1.24
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -s kubectl-1.24 ${{targets.subpkgdir}}/usr/bin/kubectl
-          ln -s kubelet-1.24 ${{targets.subpkgdir}}/usr/bin/kubelet
-          ln -s kube-scheduler-1.24 ${{targets.subpkgdir}}/usr/bin/kube-scheduler
-          ln -s kube-proxy-1.24 ${{targets.subpkgdir}}/usr/bin/kube-proxy
-          ln -s kube-controller-manager-1.24 ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
-          ln -s kube-apiserver-1.24 ${{targets.subpkgdir}}/usr/bin/kube-apiserver
+          ln -s ${{range.key}}-1.24 ${{targets.subpkgdir}}/usr/bin/${{range.key}}
+
+  - name: kubernetes-1.24-default
+    description: "Compatibility package to set 1.24 as the default kubernetes, and add packages to their shortened path"
+    dependencies:
+      runtime:
+        - default-kubectl-1.24
+        - default-kubeadm-1.24
+        - default-kubelet-1.24
+        - default-kube-scheduler-1.24
+        - default-kube-proxy-1.24
+        - default-kube-controller-manager-1.24
+        - default-kube-apiserver-1.24
+
+data:
+  - name: components
+    items:
+      # Only the keys matter
+      kubectl:
+      kubeadm:
+      kubelet:
+      kube-scheduler:
+      kube-proxy:
+      kube-controller-manager:
+      kube-apiserver:
 
 update:
   enabled: true

--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -183,13 +183,13 @@ subpackages:
           gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.7 linux/pause.c
 
   - range: components
-    name: "default-${{range.key}}-1.24"
+    name: "${{range.key}}-1.24-default"
     description: "Makes this version of ${{range.key}} the default."
     dependencies:
       runtime:
         - ${{range.key}}-1.24
       provides:
-        - default-${{range.key}}=1.24
+        - ${{range.key}}-default=1.24
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -199,13 +199,13 @@ subpackages:
     description: "Compatibility package to set 1.24 as the default kubernetes, and add packages to their shortened path"
     dependencies:
       runtime:
-        - default-kubectl-1.24
-        - default-kubeadm-1.24
-        - default-kubelet-1.24
-        - default-kube-scheduler-1.24
-        - default-kube-proxy-1.24
-        - default-kube-controller-manager-1.24
-        - default-kube-apiserver-1.24
+        - kubectl-1.24-default
+        - kubeadm-1.24-default
+        - kubelet-1.24-default
+        - kube-scheduler-1.24-default
+        - kube-proxy-1.24-default
+        - kube-controller-manager-1.24-default
+        - kube-apiserver-1.24-default
 
 data:
   - name: components

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -183,13 +183,13 @@ subpackages:
           gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.8 linux/pause.c
 
   - range: components
-    name: "default-${{range.key}}-1.25"
+    name: "${{range.key}}-1.25-default"
     description: "Makes this version of ${{range.key}} the default."
     dependencies:
       runtime:
         - ${{range.key}}-1.25
       provides:
-        - default-${{range.key}}=1.25
+        - ${{range.key}}-default=1.25
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -199,13 +199,13 @@ subpackages:
     description: "Compatibility package to set 1.25 as the default kubernetes, and add packages to their shortened path"
     dependencies:
       runtime:
-        - default-kubectl-1.25
-        - default-kubeadm-1.25
-        - default-kubelet-1.25
-        - default-kube-scheduler-1.25
-        - default-kube-proxy-1.25
-        - default-kube-controller-manager-1.25
-        - default-kube-apiserver-1.25
+        - kubectl-1.25-default
+        - kubeadm-1.25-default
+        - kubelet-1.25-default
+        - kube-scheduler-1.25-default
+        - kube-proxy-1.25-default
+        - kube-controller-manager-1.25-default
+        - kube-apiserver-1.25-default
 
 data:
   - name: components

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.25
   version: 1.25.13
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -182,17 +182,42 @@ subpackages:
           CFLAGS="$CFLAGS -static -DVERSION=${{vars.pause-version}}-${{package.version}}"
           gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.8 linux/pause.c
 
-  - name: kubernetes-1.25-default
-    description: "Compatibility package to set 1.25 as the default kubernetes, and add packages to their shortened path"
+  - range: components
+    name: "default-${{range.key}}-1.25"
+    description: "Makes this version of ${{range.key}} the default."
+    dependencies:
+      runtime:
+        - ${{range.key}}-1.25
+      provides:
+        - default-${{range.key}}=1.25
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -s kubectl-1.25 ${{targets.subpkgdir}}/usr/bin/kubectl
-          ln -s kubelet-1.25 ${{targets.subpkgdir}}/usr/bin/kubelet
-          ln -s kube-scheduler-1.25 ${{targets.subpkgdir}}/usr/bin/kube-scheduler
-          ln -s kube-proxy-1.25 ${{targets.subpkgdir}}/usr/bin/kube-proxy
-          ln -s kube-controller-manager-1.25 ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
-          ln -s kube-apiserver-1.25 ${{targets.subpkgdir}}/usr/bin/kube-apiserver
+          ln -s ${{range.key}}-1.25 ${{targets.subpkgdir}}/usr/bin/${{range.key}}
+
+  - name: kubernetes-1.25-default
+    description: "Compatibility package to set 1.25 as the default kubernetes, and add packages to their shortened path"
+    dependencies:
+      runtime:
+        - default-kubectl-1.25
+        - default-kubeadm-1.25
+        - default-kubelet-1.25
+        - default-kube-scheduler-1.25
+        - default-kube-proxy-1.25
+        - default-kube-controller-manager-1.25
+        - default-kube-apiserver-1.25
+
+data:
+  - name: components
+    items:
+      # Only the keys matter
+      kubectl:
+      kubeadm:
+      kubelet:
+      kube-scheduler:
+      kube-proxy:
+      kube-controller-manager:
+      kube-apiserver:
 
 update:
   enabled: true

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.26
   version: 1.26.8
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -182,17 +182,42 @@ subpackages:
           CFLAGS="$CFLAGS -static -DVERSION=${{vars.pause-version}}-${{package.version}}"
           gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.9 linux/pause.c
 
-  - name: kubernetes-1.26-default
-    description: "Compatibility package to set 1.26 as the default kubernetes, and add packages to their shortened path"
+  - range: components
+    name: "default-${{range.key}}-1.26"
+    description: "Makes this version of ${{range.key}} the default."
+    dependencies:
+      runtime:
+        - ${{range.key}}-1.26
+      provides:
+        - default-${{range.key}}=1.26
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -s kubectl-1.26 ${{targets.subpkgdir}}/usr/bin/kubectl
-          ln -s kubelet-1.26 ${{targets.subpkgdir}}/usr/bin/kubelet
-          ln -s kube-scheduler-1.26 ${{targets.subpkgdir}}/usr/bin/kube-scheduler
-          ln -s kube-proxy-1.26 ${{targets.subpkgdir}}/usr/bin/kube-proxy
-          ln -s kube-controller-manager-1.26 ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
-          ln -s kube-apiserver-1.26 ${{targets.subpkgdir}}/usr/bin/kube-apiserver
+          ln -s ${{range.key}}-1.26 ${{targets.subpkgdir}}/usr/bin/${{range.key}}
+
+  - name: kubernetes-1.26-default
+    description: "Compatibility package to set 1.26 as the default kubernetes, and add packages to their shortened path"
+    dependencies:
+      runtime:
+        - default-kubectl-1.26
+        - default-kubeadm-1.26
+        - default-kubelet-1.26
+        - default-kube-scheduler-1.26
+        - default-kube-proxy-1.26
+        - default-kube-controller-manager-1.26
+        - default-kube-apiserver-1.26
+
+data:
+  - name: components
+    items:
+      # Only the keys matter
+      kubectl:
+      kubeadm:
+      kubelet:
+      kube-scheduler:
+      kube-proxy:
+      kube-controller-manager:
+      kube-apiserver:
 
 update:
   enabled: true

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -183,13 +183,13 @@ subpackages:
           gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.9 linux/pause.c
 
   - range: components
-    name: "default-${{range.key}}-1.26"
+    name: "${{range.key}}-1.26-default"
     description: "Makes this version of ${{range.key}} the default."
     dependencies:
       runtime:
         - ${{range.key}}-1.26
       provides:
-        - default-${{range.key}}=1.26
+        - ${{range.key}}-default=1.26
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -199,13 +199,13 @@ subpackages:
     description: "Compatibility package to set 1.26 as the default kubernetes, and add packages to their shortened path"
     dependencies:
       runtime:
-        - default-kubectl-1.26
-        - default-kubeadm-1.26
-        - default-kubelet-1.26
-        - default-kube-scheduler-1.26
-        - default-kube-proxy-1.26
-        - default-kube-controller-manager-1.26
-        - default-kube-apiserver-1.26
+        - kubectl-1.26-default
+        - kubeadm-1.26-default
+        - kubelet-1.26-default
+        - kube-scheduler-1.26-default
+        - kube-proxy-1.26-default
+        - kube-controller-manager-1.26-default
+        - kube-apiserver-1.26-default
 
 data:
   - name: components

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.27
   version: 1.27.5
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -185,17 +185,42 @@ subpackages:
           CFLAGS="$CFLAGS -static -DVERSION=${{vars.pause-version}}-${{package.version}}"
           gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.9 linux/pause.c
 
-  - name: kubernetes-1.27-default
-    description: "Compatibility package to set 1.27 as the default kubernetes, and add packages to their shortened path"
+  - range: components
+    name: "default-${{range.key}}-1.27"
+    description: "Makes this version of ${{range.key}} the default."
+    dependencies:
+      runtime:
+        - ${{range.key}}-1.27
+      provides:
+        - default-${{range.key}}=1.27
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -s kubectl-1.27 ${{targets.subpkgdir}}/usr/bin/kubectl
-          ln -s kubelet-1.27 ${{targets.subpkgdir}}/usr/bin/kubelet
-          ln -s kube-scheduler-1.27 ${{targets.subpkgdir}}/usr/bin/kube-scheduler
-          ln -s kube-proxy-1.27 ${{targets.subpkgdir}}/usr/bin/kube-proxy
-          ln -s kube-controller-manager-1.27 ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
-          ln -s kube-apiserver-1.27 ${{targets.subpkgdir}}/usr/bin/kube-apiserver
+          ln -s ${{range.key}}-1.27 ${{targets.subpkgdir}}/usr/bin/${{range.key}}
+
+  - name: kubernetes-1.27-default
+    description: "Compatibility package to set 1.27 as the default kubernetes, and add packages to their shortened path"
+    dependencies:
+      runtime:
+        - default-kubectl-1.27
+        - default-kubeadm-1.27
+        - default-kubelet-1.27
+        - default-kube-scheduler-1.27
+        - default-kube-proxy-1.27
+        - default-kube-controller-manager-1.27
+        - default-kube-apiserver-1.27
+
+data:
+  - name: components
+    items:
+      # Only the keys matter
+      kubectl:
+      kubeadm:
+      kubelet:
+      kube-scheduler:
+      kube-proxy:
+      kube-controller-manager:
+      kube-apiserver:
 
 update:
   enabled: true

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -186,13 +186,13 @@ subpackages:
           gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.9 linux/pause.c
 
   - range: components
-    name: "default-${{range.key}}-1.27"
+    name: "${{range.key}}-1.27-default"
     description: "Makes this version of ${{range.key}} the default."
     dependencies:
       runtime:
         - ${{range.key}}-1.27
       provides:
-        - default-${{range.key}}=1.27
+        - ${{range.key}}-default=1.27
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -202,13 +202,13 @@ subpackages:
     description: "Compatibility package to set 1.27 as the default kubernetes, and add packages to their shortened path"
     dependencies:
       runtime:
-        - default-kubectl-1.27
-        - default-kubeadm-1.27
-        - default-kubelet-1.27
-        - default-kube-scheduler-1.27
-        - default-kube-proxy-1.27
-        - default-kube-controller-manager-1.27
-        - default-kube-apiserver-1.27
+        - kubectl-1.27-default
+        - kubeadm-1.27-default
+        - kubelet-1.27-default
+        - kube-scheduler-1.27-default
+        - kube-proxy-1.27-default
+        - kube-controller-manager-1.27-default
+        - kube-apiserver-1.27-default
 
 data:
   - name: components

--- a/kubernetes-1.28.yaml
+++ b/kubernetes-1.28.yaml
@@ -181,29 +181,29 @@ subpackages:
           gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.9 linux/pause.c
 
   - range: components
-    name: "default-${{range.key}}-1.27"
+    name: "${{range.key}}-1.28-default"
     description: "Makes this version of ${{range.key}} the default."
     dependencies:
       runtime:
-        - ${{range.key}}-1.27
+        - ${{range.key}}-1.28
       provides:
-        - default-${{range.key}}=1.27
+        - ${{range.key}}-default=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -s ${{range.key}}-1.27 ${{targets.subpkgdir}}/usr/bin/${{range.key}}
+          ln -s ${{range.key}}-1.28 ${{targets.subpkgdir}}/usr/bin/${{range.key}}
 
-  - name: kubernetes-1.27-default
-    description: "Compatibility package to set 1.27 as the default kubernetes, and add packages to their shortened path"
+  - name: kubernetes-1.28-default
+    description: "Compatibility package to set 1.28 as the default kubernetes, and add packages to their shortened path"
     dependencies:
       runtime:
-        - default-kubectl-1.27
-        - default-kubeadm-1.27
-        - default-kubelet-1.27
-        - default-kube-scheduler-1.27
-        - default-kube-proxy-1.27
-        - default-kube-controller-manager-1.27
-        - default-kube-apiserver-1.27
+        - kubectl-1.28-default
+        - kubeadm-1.28-default
+        - kubelet-1.28-default
+        - kube-scheduler-1.28-default
+        - kube-proxy-1.28-default
+        - kube-controller-manager-1.28-default
+        - kube-apiserver-1.28-default
 
 data:
   - name: components

--- a/kubernetes-1.28.yaml
+++ b/kubernetes-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.28
   version: 1.28.1
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -180,17 +180,42 @@ subpackages:
           CFLAGS="$CFLAGS -static -DVERSION=${{vars.pause-version}}-${{package.version}}"
           gcc -o "${{targets.subpkgdir}}"/usr/bin/pause-3.9 linux/pause.c
 
-  - name: kubernetes-1.28-default
-    description: "Compatibility package to set 1.28 as the default kubernetes, and add packages to their shortened path"
+  - range: components
+    name: "default-${{range.key}}-1.27"
+    description: "Makes this version of ${{range.key}} the default."
+    dependencies:
+      runtime:
+        - ${{range.key}}-1.27
+      provides:
+        - default-${{range.key}}=1.27
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -s kubectl-1.28 ${{targets.subpkgdir}}/usr/bin/kubectl
-          ln -s kubelet-1.28 ${{targets.subpkgdir}}/usr/bin/kubelet
-          ln -s kube-scheduler-1.28 ${{targets.subpkgdir}}/usr/bin/kube-scheduler
-          ln -s kube-proxy-1.28 ${{targets.subpkgdir}}/usr/bin/kube-proxy
-          ln -s kube-controller-manager-1.28 ${{targets.subpkgdir}}/usr/bin/kube-controller-manager
-          ln -s kube-apiserver-1.28 ${{targets.subpkgdir}}/usr/bin/kube-apiserver
+          ln -s ${{range.key}}-1.27 ${{targets.subpkgdir}}/usr/bin/${{range.key}}
+
+  - name: kubernetes-1.27-default
+    description: "Compatibility package to set 1.27 as the default kubernetes, and add packages to their shortened path"
+    dependencies:
+      runtime:
+        - default-kubectl-1.27
+        - default-kubeadm-1.27
+        - default-kubelet-1.27
+        - default-kube-scheduler-1.27
+        - default-kube-proxy-1.27
+        - default-kube-controller-manager-1.27
+        - default-kube-apiserver-1.27
+
+data:
+  - name: components
+    items:
+      # Only the keys matter
+      kubectl:
+      kubeadm:
+      kubelet:
+      kube-scheduler:
+      kube-proxy:
+      kube-controller-manager:
+      kube-apiserver:
 
 update:
   enabled: true


### PR DESCRIPTION
These virtual packages are provided by versioned forms to install that version's components as the latest.

I believe that these packages largely render the subpackages of `kubernetes-latest` redundant, and that we could achieve what `kubernetes-latest` itself does by having the `kubernetes-X.Y-default` packages provide the `kubernetes-latest` package (or something else suitably named, e.g. `default-kubernetes` :shrug:).

I did this because I wanted something similar to the versioned `default-jvm` packages, so that I can install a kubectl at any version as the default, and not just "latest".
