### PR TITLE
Add istio-pilot-agent package

### DIFF
--- a/istio-pilot-agent-1.18.yaml
+++ b/istio-pilot-agent-1.18.yaml
@@ -1,0 +1,52 @@
+package:
+  name: istio-pilot-agent-1.18
+  version: 1.18.2
+  epoch: 0
+  description: Nanny binary for Istio Envoy
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - istio-pilot-agent=1.18.999
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 0183f2886bc078e8df4d6bbd21fa452a3a23481d
+
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-agent
+      output: pilot-agent
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          # link /usr/local/bin/proxy-agent -> /usr/bin/proxy-agent to match
+          # what the Istio Helm charts may expect.
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          ln -sf /usr/bin/proxy-agent ${{targets.subpkgdir}}/usr/local/bin/proxy-agent
+    dependencies:
+      provides:
+        - istio-pilot-agent-compat=1.18.999
+
+update:
+  enabled: true
+  github:
+    identifier: istio/istio
+    tag-filter: 1.18.
+    use-tag: true


### PR DESCRIPTION
* "istio-pilot-agent-1.18: new package. This is the nanny binary to bootstraps the Istio Envoy in Istio sidecar or gateway containers."

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates