### PR TITLE
workerd: new package

### DIFF
--- a/workerd.yaml
+++ b/workerd.yaml
@@ -1,0 +1,58 @@
+package:
+  name: workerd
+  version: 1.20230904.0
+  epoch: 0
+  description: The JavaScript / Wasm runtime that powers Cloudflare Workers
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-baselayout
+      - binutils
+      - build-base
+      - git
+
+      - bazel-6
+      - openjdk-11
+
+      - bash
+      - gnutar
+
+      - python3
+      - clang-16
+      - clang-16-dev
+      - llvm16
+      - llvm16-dev
+      - llvm-lld-16
+
+      - llvm-libcxx-16-dev
+      - llvm-libcxx-16
+      # - llvm-libcxxabi-16
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cloudflare/workerd
+      tag: v${{package.version}}
+      expected-commit: b4b25357f47e737621098dde66fa0d0c6cb58450
+      destination: workerd
+
+  - runs: |
+      ln -s /var/cache/melange .cache
+      cd workerd
+      JAVA_HOME=/usr/lib/jvm/java-11-openjdk bazel sync --configure
+      JAVA_HOME=/usr/lib/jvm/java-11-openjdk bazel build --config=thin-lto --verbose_failures //src/workerd/server:workerd
+      mkdir -p ${{targets.destdir}}/usr/bin/
+      mv bazel-bin/src/workerd/server/workerd ${{targets.destdir}}/usr/bin/workerd
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: cloudflare/workerd
+    strip-prefix: v


### PR DESCRIPTION
[workerd](https://github.com/cloudflare/workerd) is yet another JavaScript runtime for the server, like [node](https://github.com/wolfi-dev/os/blob/main/nodejs-20.yaml), [deno](https://github.com/wolfi-dev/os/blob/main/deno.yaml), etc.

This PR is incomplete, the build fails with obscure linker problems, related to [workerd's static linkage against libc++](https://github.com/cloudflare/workerd#building-workerd).  I'm posting it because I'm at the limit of my abilities to fight native build tooling 🌞.  Feel free to close it at any time.

This package builds against the libc++ package recently added in https://github.com/wolfi-dev/os/pull/4852.

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
