### PR TITLE
Improve ncurses package.

### DIFF
--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
   version: 6.4_p20230722
-  epoch: 0
+  epoch: 1
   description: "console display library"
   copyright:
     - license: MIT
@@ -51,6 +51,7 @@ pipeline:
         --enable-pc-files \
         --with-shared \
         --enable-widec \
+        --with-termlib=tinfo \
         --with-xterm-kbs=DEL
 
   - uses: autoconf/make
@@ -72,6 +73,11 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: "ncurses-static"
+    description: "ncurses static"
+    pipeline:
+      - uses: split/static
+
   - name: "ncurses-dev"
     description: "ncurses headers"
     pipeline:


### PR DESCRIPTION
Add a static subpackage
Compile with libtinfo


Fixes:

Related:

### Pre-review Checklist
