### PR TITLE
clickhouse: ensure stable package updates ignores LTS versions

### DIFF
--- a/clickhouse.yaml
+++ b/clickhouse.yaml
@@ -72,6 +72,8 @@ subpackages:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - "-lts$" # Ignore LTS releases as this package tracks stable releases.
   github:
     identifier: ClickHouse/ClickHouse
     strip-prefix: v


### PR DESCRIPTION
This will prevent mixing up automated package updates for the LTS version like this PR https://github.com/wolfi-dev/os/pull/5121
