### PR TITLE
fluentd-splunk-hec: add runtime dep on multi_json

### DIFF
--- a/fluent-plugin-splunk-hec.yaml
+++ b/fluent-plugin-splunk-hec.yaml
@@ -1,13 +1,15 @@
 package:
   name: fluent-plugin-splunk-hec
   version: 1.3.3
-  epoch: 0
+  epoch: 1
   description: This is the Fluentd output plugin for sending events to Splunk via HEC
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
       - ruby3.2-fluent-plugin-splunk-hec=${{package.version}}-r${{package.epoch}}
+    runtime:
+      - ruby3.2-multi_json
 
 environment:
   contents:


### PR DESCRIPTION
This has been breaking the fluentd image tests, which I've confirmed pass with this change.