### PR TITLE
thanos-operator: fix CVE-2022-28948

### DIFF
--- a/thanos-operator.yaml
+++ b/thanos-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-operator
   version: 0.3.7
-  epoch: 3
+  epoch: 4
   description: Kubernetes operator for deploying Thanos
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,9 @@ pipeline:
       go get github.com/prometheus/client_golang@v1.11.1
       go get golang.org/x/text@v0.3.8
       go get golang.org/x/net@v0.7.0
+
+      # Mitigate CVE-2022-28948
+      go get gopkg.in/yaml.v3@v3.0.0-20220521103104-8f96da9f5d5e
 
       go mod tidy
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

https://github.com/wolfi-dev/advisories/pull/219