### PR TITLE
conda-build 3.26.1: new package

### DIFF
--- a/conda-build.yaml
+++ b/conda-build.yaml
@@ -35,12 +35,11 @@ pipeline:
       tag: ${{package.version}}
 
   - runs: |
-      pip install hatch conda-package-handling
+      pip install hatch
       hatch build
-      find dist
       python3 -m installer -d "${{targets.destdir}}" dist/conda_build*.whl
 
 update:
   enabled: true
   github:
-    identifier: https://github.com/conda/conda-build
+    identifier: conda/conda-build

--- a/conda-build.yaml
+++ b/conda-build.yaml
@@ -1,0 +1,46 @@
+# Generated from https://pypi.org/project/conda-build/
+package:
+  name: conda-build
+  version: 3.26.1
+  epoch: 0
+  description: tools for building conda packages
+  copyright:
+    - license: BSD 3-clause
+  dependencies:
+    runtime:
+      - conda
+      - py3-filelock
+      - py3-requests
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - conda
+      - py3-hatchling
+      - py3-pip
+      - py3-setuptools
+      - py3-wheel
+      - python-3
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: c2bfe2b44ad34b06d8930aa4239995367f3eaf12
+      repository: https://github.com/conda/conda-build
+      tag: ${{package.version}}
+
+  - runs: |
+      pip install hatch conda-package-handling
+      hatch build
+      find dist
+      python3 -m installer -d "${{targets.destdir}}" dist/conda_build*.whl
+
+update:
+  enabled: true
+  github:
+    identifier: https://github.com/conda/conda-build


### PR DESCRIPTION
Built with:
```
melange --use-github --use-relmon  --wolfi-defaults=false convert python conda-build
```

tested with (make local-wolfi) followed by:
```
0815230746ef:/work/packages# apk add conda-build
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/28) Installing bzip2 (1.0.8-r4)
(2/28) Installing expat (2.5.0-r3)
(3/28) Installing libffi (3.4.4-r2)
(4/28) Installing gdbm (1.23-r3)
(5/28) Installing xz (5.4.4-r0)
(6/28) Installing libgcc (13.2.0-r2)
(7/28) Installing libstdc++ (13.2.0-r2)
(8/28) Installing mpdecimal (2.5.1-r3)
(9/28) Installing ncurses-terminfo-base (6.4_p20230722-r1)
(10/28) Installing ncurses (6.4_p20230722-r1)
(11/28) Installing readline (8.2-r2)
(12/28) Installing sqlite (3.40.0-r1)
(13/28) Installing python-3.11 (3.11.5-r1)
(14/28) Installing py3-parsing (3.1.1-r0)
(15/28) Installing py3-packaging (23.1-r0)
(16/28) Installing py3-pluggy (1.3.0-r1)
(17/28) Installing py3-certifi (2023.7.22-r0)
(18/28) Installing py3-charset-normalizer (3.2.0-r0)
(19/28) Installing py3-idna (3.4-r0)
(20/28) Installing py3-urllib3 (2.0.4-r0)
(21/28) Installing py3-requests (2.31.0-r0)
(22/28) Installing py3-ruamel-yaml (0.17.32-r0)
(23/28) Installing py3-colorama (0.4.6-r1)
(24/28) Installing py3-tqdm (4.66.1-r0)
(25/28) Installing conda (23.7.3-r2)
(26/28) Installing py3-typing-extensions (4.7.1-r0)
(27/28) Installing py3-filelock (3.12.3-r1)
(28/28) Installing conda-build (3.26.1-r0)
OK: 77 MiB in 42 packages
```

Tested update section with:
`wolfictl check update  --override-version 0.0.1 conda-build.yaml`
```
2023/09/05 10:51:26 wolfictl update: request query, to check visit https://docs.github.com/en/graphql/overview/explorer:
query {

  r85a7932a2572e4625d2ac83276abc5fe1007d5e814103b5475c3df96a2cd5670: repository(owner: "conda", name: "conda-build") {
    owner {
      login
    }
    name
    nameWithOwner
    releases(first: 20) {
      totalCount
      nodes {
        tag {
          name
          target {
            commitUrl
          }
        }
        name
        isPrerelease
        isDraft
        isLatest
      }
    }
  },

}
2023/09/05 10:51:27 attempting to bump version to 3.26.1
2023/09/05 10:51:27 processing git-checkout node
2023/09/05 10:51:27   expected-commit: c2bfe2b44ad34b06d8930aa4239995367f3eaf12
2023/09/05 10:51:27 wolfictl check update: cloning sources from https://github.com/conda/conda-build tag 3.26.1 into a temporary directory, this may take a while
Enumerating objects: 8475, done.
Counting objects: 100% (8475/8475), done.
Compressing objects: 100% (4934/4934), done.
Total 8475 (delta 5674), reused 5652 (delta 3172), pack-reused 0
2023/09/05 10:51:29 wolfictl check update: git-checkout was successful
```

#### For new package PRs only
- [ x ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ x ] REQUIRED - The version of the package is still receiving security updates

