### PR TITLE
feat: add dependencies for Perl DateTime module

### DIFF
--- a/perl-class-data-inheritable.yaml
+++ b/perl-class-data-inheritable.yaml
@@ -1,0 +1,51 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-class-data-inheritable/APKBUILD
+package:
+  name: perl-class-data-inheritable
+  version: "0.09"
+  epoch: 0
+  description: Inheritable, overridable class data
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 2e76aaf12c8d26442d53746e5d74636bb35c55461efb6d9b5ea50a635e3f781707b2d7f9cb3da9113ed31de464d3931f9734c29ace2a7ee5c6e111392b6a97cf
+      uri: https://cpan.metacpan.org/authors/id/R/RS/RSHERER/Class-Data-Inheritable-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-class-data-inheritable-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-class-data-inheritable manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11825

--- a/perl-devel-stacktrace.yaml
+++ b/perl-devel-stacktrace.yaml
@@ -1,0 +1,52 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-devel-stacktrace/APKBUILD
+package:
+  name: perl-devel-stacktrace
+  version: "2.04"
+  epoch: 0
+  description: An object representing a stack trace
+  copyright:
+    - license: Artistic-2.0
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 2330c1d8619cdcb42b5919090e6eaabbe34ab26b50d5c09c4cfd7ed099829817a50ffe582bd1f2a19a7d5be050819796f22dee32b10e175259e6df177ce6d0a9
+      uri: https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/Devel-StackTrace-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-devel-stacktrace-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-devel-stacktrace manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11840

--- a/perl-eval-closure.yaml
+++ b/perl-eval-closure.yaml
@@ -1,0 +1,52 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-eval-closure/APKBUILD
+package:
+  name: perl-eval-closure
+  version: "0.14"
+  epoch: 0
+  description: safely and cleanly create closures via string eval
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: fc55206bd39c4cb39360d06b6f39a65743f34b5e59d1a1ce99bf5831b9d88a03fb6dadf32fa9f0868e140fce719d53a7b13027f397cdd7f6ca05cc81277bdc08
+      uri: https://cpan.metacpan.org/authors/id/D/DO/DOY/Eval-Closure-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-eval-closure-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-eval-closure manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11942

--- a/perl-file-sharedir-install.yaml
+++ b/perl-file-sharedir-install.yaml
@@ -1,0 +1,52 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-file-sharedir-install/APKBUILD
+package:
+  name: perl-file-sharedir-install
+  version: "0.14"
+  epoch: 0
+  description: Install shared files
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 92c1c3899bc58d3e1686fef775ac09e9aab7e3ce6b61d1a8e754127dc1f84627cf1e23e78a5d0042934e011685c0676c706ef7964778c06e073e8725155af34d
+      uri: https://cpan.metacpan.org/authors/id/E/ET/ETHER/File-ShareDir-Install-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-file-sharedir-install-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-file-sharedir-install manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11851

--- a/perl-importer.yaml
+++ b/perl-importer.yaml
@@ -1,0 +1,51 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-importer/APKBUILD
+package:
+  name: perl-importer
+  version: "0.026"
+  epoch: 0
+  description: Alternative but compatible interface to modules that export symbols.
+  copyright:
+    - license: PerlArtistic
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: f6726b204ee358af00b5c72120bd2131ed575c100a9946b1772552e42b98f78dd38ffcc0119e2cdf721c39e2d83547bc5778adb61c5f84089caf11949c7ef045
+      uri: https://cpan.metacpan.org/authors/id/E/EX/EXODIST/Importer-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-importer-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-importer manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 9160

--- a/perl-ipc-run3.yaml
+++ b/perl-ipc-run3.yaml
@@ -1,0 +1,51 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-ipc-run3/APKBUILD
+package:
+  name: perl-ipc-run3
+  version: "0.048"
+  epoch: 0
+  description: IPC::Run3 perl module
+  copyright:
+    - license: GPL-2.0 or Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 50432850d8dccd2e59aa6684d34f3e3242fd7df3eb4d9a5eb02dae389aa46b5fd68cc54114a157c3fe99956e68e74d575ab3db5009b7bf7d5c325f1f109b1262
+      uri: https://cpan.metacpan.org/authors/id/R/RJ/RJBS/IPC-Run3-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-ipc-run3-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-ipc-run3 manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11861

--- a/perl-module-build.yaml
+++ b/perl-module-build.yaml
@@ -1,0 +1,52 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-module-build/APKBUILD
+package:
+  name: perl-module-build
+  version: "0.4234"
+  epoch: 0
+  description: Build and install Perl modules
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: e2bbdd64f98b424ea7fd20e2ba301d34b77c9f2ecec28e3191fda63a056a12c0fb1cab1496419e9e9b8054db1a8d3fe92e1f033cdcdf021e1a086c8859905eca
+      uri: https://cpan.metacpan.org/authors/id/L/LE/LEONT/Module-Build-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-module-build-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-module-build manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3077

--- a/perl-module-pluggable.yaml
+++ b/perl-module-pluggable.yaml
@@ -1,0 +1,52 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-module-pluggable/APKBUILD
+package:
+  name: perl-module-pluggable
+  version: "5.2"
+  epoch: 0
+  description: automatically give your module the ability to have plugins
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 7df8ee6713c8e0d4df756736c43c2033632cb8887c82ed5b9f38476dbf402b5daa3af83d3b2bd1228afb020ce5855831812f86299b63518e04e0929390b0c5f5
+      uri: https://cpan.metacpan.org/authors/id/S/SI/SIMONW/Module-Pluggable-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-module-pluggable-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-module-pluggable manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3109

--- a/perl-module-scandeps.yaml
+++ b/perl-module-scandeps.yaml
@@ -1,0 +1,51 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-module-scandeps/APKBUILD
+package:
+  name: perl-module-scandeps
+  version: "1.33"
+  epoch: 0
+  description: Recursively scan Perl code for dependencies
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 96c345414d6fd1adc8eba14d0682fcf82e769c70fd9124350f37a9e4ff34acff8a47e4c428ddc64645de91277f0e76d987a67187b2be84bffaa9a2911f3bd34f
+      uri: https://cpan.metacpan.org/authors/id/R/RS/RSCHUPP/Module-ScanDeps-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-module-scandeps-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-module-scandeps manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3112

--- a/perl-mro-compat.yaml
+++ b/perl-mro-compat.yaml
@@ -1,0 +1,52 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-mro-compat/APKBUILD
+package:
+  name: perl-mro-compat
+  version: "0.15"
+  epoch: 0
+  description: mro::* interface compatibility for Perls < 5.9.5
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 0767ea5e98414ce55607c599eecde686fe2defed99ade156ce8db63e508bfcd150aea48952eed7624f969c0ca185652a85eedb8dbcae82b826152d18d4152545
+      uri: https://cpan.metacpan.org/authors/id/H/HA/HAARG/MRO-Compat-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-mro-compat-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-mro-compat manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11957

--- a/perl-sub-exporter-progressive.yaml
+++ b/perl-sub-exporter-progressive.yaml
@@ -1,0 +1,52 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-sub-exporter-progressive/APKBUILD
+package:
+  name: perl-sub-exporter-progressive
+  version: "0.001013"
+  epoch: 0
+  description: Only use Sub::Exporter if you need it
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://cpan.metacpan.org/authors/id/F/FR/FREW/Sub-Exporter-Progressive-${{package.version}}.tar.gz
+      expected-sha512: 28d0ac6a380a4fc1515bd69320bcfd073c0c0e92ea34bb924972aa46fb2f6912485d686f0eca5d5b885d8b06927250dfaacd1a7ff86ba029f879a183cba546c4
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-sub-exporter-progressive-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-sub-exporter-progressive manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11901

--- a/perl-yaml-tiny.yaml
+++ b/perl-yaml-tiny.yaml
@@ -1,0 +1,49 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-yaml-tiny/APKBUILD
+package:
+  name: perl-yaml-tiny
+  version: "1.74"
+  epoch: 0
+  description: Read/Write YAML files with as little code as possible
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 2da59bf583b09a60e8e1bac7c21fc4300ae3ee2092ffd77cbf3778c65c7d0bdf68fa3616665d276f4d4df2437526d36d497ac53be79baa182f84f37640bfcad4
+      uri: https://cpan.metacpan.org/authors/id/E/ET/ETHER/YAML-Tiny-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-yaml-tiny-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-yaml-tiny manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3549


### PR DESCRIPTION
Add part of the required dependencies for the Perl `DateTime` module. This PR includes 12 dependencies that do not depend on other modules. More PRs to come with the remaining dependencies.

Related: #5051

### Pre-review Checklist

#### For new package PRs only

- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
