### PR TITLE
feat: add Perl's DateTime module dependencies

### DIFF
--- a/perl-class-singleton.yaml
+++ b/perl-class-singleton.yaml
@@ -1,0 +1,51 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-class-singleton/APKBUILD
+package:
+  name: perl-class-singleton
+  version: "1.6"
+  epoch: 0
+  description: "Implementation of a Singleton class "
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 68b637ba57d5da70ac8e7a8a5e1874481681d6a217bb0c58a232d4329c582f32d29b5ac4c60a131bc863c8faf2852c5249bced9d286e87fefe4960e95f35b1ec
+      uri: https://cpan.metacpan.org/authors/id/S/SH/SHAY/Class-Singleton-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-class-singleton-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-class-singleton manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11828

--- a/perl-inc-latest.yaml
+++ b/perl-inc-latest.yaml
@@ -1,0 +1,51 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-inc-latest/APKBUILD
+package:
+  name: perl-inc-latest
+  version: "0.500"
+  epoch: 0
+  description: use modules bundled in inc/ if they are newer than installed ones
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: b312d1dfce963322796bc0127f0ecd82c12baacf9e5df40d9acc093221edd80f3696ce6d9f185ed24b21983147363d1d0ff3e273b8b5ce7559a6f16983a1385c
+      uri: https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/inc-latest-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-inc-latest-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-inc-latest manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 6718

--- a/perl-role-tiny.yaml
+++ b/perl-role-tiny.yaml
@@ -1,0 +1,51 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-role-tiny/APKBUILD
+package:
+  name: perl-role-tiny
+  version: "2.002004"
+  epoch: 0
+  description: "Roles: a nouvelle cuisine portion size slice of Moose"
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: f66a799a0cd4e989adc173f6d913967df7aa6b9ffda934c2a80c0a91dcfe4edce606bd27cf1b4d857d52d0aa770224315ae4e915e4e735c6a9483a6cf5ce02f1
+      uri: https://cpan.metacpan.org/authors/id/H/HA/HAARG/Role-Tiny-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-role-tiny-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-role-tiny manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10665

--- a/perl-scope-guard.yaml
+++ b/perl-scope-guard.yaml
@@ -1,0 +1,51 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-scope-guard/APKBUILD
+package:
+  name: perl-scope-guard
+  version: "0.21"
+  epoch: 0
+  description: Scope::Guard perl module
+  copyright:
+    - license: GPL-2.0 or Artistic
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 65492e08ab79dc323649166e83ffc13c6f1fffaa9c60d581d8854dfe427a54a3c3c5e4d8b90308d4b1a31a1a54c7977b4e1d36fc9005c6e716c2361ce187fc9f
+      uri: https://cpan.metacpan.org/authors/id/C/CH/CHOCOLATE/Scope-Guard-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-scope-guard-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-scope-guard manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11896

--- a/perl-sub-identify.yaml
+++ b/perl-sub-identify.yaml
@@ -1,0 +1,52 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-sub-identify/APKBUILD
+package:
+  name: perl-sub-identify
+  version: "0.14"
+  epoch: 0
+  description: Retrieve names of code references
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: f69f542c84c5c3ca1f1c7f5f58fd2cf19279a65229f43117c31f24ab0e49d5f329bef2bc00f22252fd2e52b4e17f16b279dac438920668e046e59f2e22e52c14
+      uri: https://cpan.metacpan.org/authors/id/R/RG/RGARCIA/Sub-Identify-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-sub-identify-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-sub-identify manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11902

--- a/perl-sub-quote.yaml
+++ b/perl-sub-quote.yaml
@@ -1,0 +1,52 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-sub-quote/APKBUILD
+package:
+  name: perl-sub-quote
+  version: "2.006008"
+  epoch: 0
+  description: Efficient generation of subroutines via string eval
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 474c02953555e815c64270299a2ea36a172c11ff739d77a3f5133f4c40d5ec48ad60c09465bd93864c254f180ba73d8381752ac649f8d4f729199f3088e71e26
+      uri: https://cpan.metacpan.org/authors/id/H/HA/HAARG/Sub-Quote-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-sub-quote-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-sub-quote manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 12678

--- a/perl-test-simple.yaml
+++ b/perl-test-simple.yaml
@@ -1,0 +1,45 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-test-simple/APKBUILD
+package:
+  name: perl-test-simple
+  version: "1.302195"
+  epoch: 0
+  description: Basic utilities for writing tests
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: eb39f28c65e7592fb6464a32161ae4f402a32bc1f458e991d6fac17828605985533a649ea976654ef9cef4ec903f752aa4b6228540c953628b0b63cc70e4515f
+      uri: https://cpan.metacpan.org/authors/id/E/EX/EXODIST/Test-Simple-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11977

--- a/perl-test-without-module.yaml
+++ b/perl-test-without-module.yaml
@@ -1,0 +1,51 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-test-without-module/APKBUILD
+package:
+  name: perl-test-without-module
+  version: "0.21"
+  epoch: 0
+  description: Test::Without::Module perl module
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 0d9230e15fa46001458a8e4a1ad97d24a8766b9df8326d166da92763a01624d01972d023951d3c58e9bbfd4e0d23e92d610565873a622eaaf87c8ec2a4f0a7f7
+      uri: https://cpan.metacpan.org/authors/id/C/CO/CORION/Test-Without-Module-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-test-without-module-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-test-without-module manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11980


### PR DESCRIPTION
Add more of the DateTime module dependencies.

Related: #5051, #5159 

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
