### PR TITLE
php-8.1: new package

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -233,8 +233,8 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    # Note this is the same as the php8 since they seem to list all the versions
-    # there:
-    # https://release-monitoring.org/project/3627/
-    identifier: 3627
+  github:
+    identifier: php/php-src
+    strip-prefix: php-
+    tag-filter: php-8.1
+    use-tag: true

--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,0 +1,240 @@
+package:
+  name: php-8.1
+  version: 8.1.23
+  epoch: 0
+  description: "the PHP programming language"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    provides:
+      - php=8.1.999
+    runtime:
+      - libxml2
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - file
+      - bison
+      - libtool
+      - ca-certificates-bundle
+      - bzip2-dev
+      - libxml2-dev
+      - curl-dev
+      - openssl-dev
+      - readline-dev
+      - sqlite-dev
+      - libsodium-dev
+      - libpng-dev
+      - libjpeg-turbo-dev
+      - libavif-dev
+      - libwebp-dev
+      - libxpm-dev
+      - libx11-dev
+      - freetype-dev
+      - gmp-dev
+      - icu-dev
+      - openldap-dev
+      - oniguruma-dev
+      - libxslt-dev
+      - postgresql-15-dev
+      - libzip
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://www.php.net/distributions/php-${{package.version}}.tar.gz
+      expected-sha256: ec5330b3978edc8fe2f78830720505bf69d12542622b5cddccee63ae3a0e5b58
+      extract: false
+
+  - name: Prepare Build Folder
+    runs: |
+      mv php-${{package.version}}.tar.gz $HOME/
+      tar zxf $HOME/php-${{package.version}}.tar.gz
+
+  - name: Configure
+    runs: |
+      cd $HOME/php-${{package.version}}
+      EXTENSION_DIR=/usr/lib/php/modules ./configure \
+        --prefix=/usr \
+        --libdir=/usr/lib/php \
+        --datadir=/usr/share/php \
+        --sysconfdir=/etc/php \
+        --localstatedir=/var \
+        --with-layout=GNU \
+        --with-pic \
+        --with-config-file-path=/etc/php \
+        --with-config-file-scan-dir=/etc/php/conf.d \
+        --enable-cli \
+        --enable-ctype=shared \
+        --enable-bcmath=shared \
+        --with-curl=shared \
+        --enable-dom=shared \
+        --enable-fileinfo=shared \
+        --with-iconv=shared \
+        --with-openssl=shared \
+        --with-readline \
+        --with-sodium=shared \
+        --enable-fpm \
+        --with-pear \
+        --enable-gd=shared \
+            --with-avif \
+            --with-freetype \
+            --with-jpeg \
+            --with-webp \
+            --with-xpm \
+            --disable-gd-jis-conv \
+        --with-libxml \
+        --enable-phar=shared \
+        --enable-mbstring=shared \
+      	--with-mysqli=shared \
+            --with-mysql-sock=/run/mysqld/mysqld.sock \
+        --enable-mysqlnd=shared \
+        --enable-pdo=shared \
+            --with-pdo-mysql=shared,mysqlnd \
+            --with-pdo-sqlite=shared \
+        --enable-pcntl=shared \
+        --enable-sockets=shared \
+        --with-bz2=shared \
+        --enable-calendar=shared \
+        --enable-exif=shared  \
+        --with-gettext=shared  \
+        --with-gmp=shared  \
+        --enable-intl=shared  \
+        --with-ldap=shared  \
+        --enable-opcache=shared  \
+        --enable-soap=shared  \
+        --with-xsl=shared \
+        --with-zlib \
+        --enable-xml=shared \
+        --enable-simplexml=shared \
+        --enable-xml=shared \
+        --enable-xmlreader=shared \
+        --enable-xmlwriter=shared \
+        --enable-posix=shared \
+        --with-pgsql=shared \
+        --with-zip=shared
+
+  - uses: autoconf/make
+    with:
+      dir: $HOME/php-${{package.version}}
+
+  - name: Make Install
+    runs: |
+      cd $HOME/php-${{package.version}}
+      INSTALL_ROOT=${{targets.destdir}} DESTDIR=${{targets.destdir}} make install
+
+  - uses: strip
+
+  - name: Copy configuration and set up alias on /bin
+    runs: |
+      mkdir -p "${{targets.destdir}}/etc/php/conf.d"
+      mv $HOME/php-${{package.version}}/php.ini-production ${{targets.destdir}}/etc/php/php.ini
+      mkdir -p "${{targets.destdir}}/bin" && ln -s /usr/bin/php "${{targets.destdir}}/bin/php"
+
+data:
+  - name: extensions
+    items:
+      bz2: Bzip2
+      curl: cURL
+      gd: GD imaging
+      gmp: GNU GMP support
+      ldap: LDAP
+      mysqlnd: MySQLnd
+      openssl: OpenSSL
+      pdo_mysql: MySQL driver for PDO
+      pdo_sqlite: SQLite 3.x driver for PDO
+      soap: SOAP
+      sodium: Sodium
+      calendar: Calendar
+      exif: EXIF
+      gettext: GetText
+      intl: Internationalization
+      mbstring: Multibyte String Functions
+      opcache: Opcache
+      pcntl: pcntl
+      pdo: PHP Data Objects
+      phar: PHP Archive
+      sockets: Sockets
+      xsl: XSL
+      bcmath: BC Math
+      ctype: ctype
+      iconv: Iconv
+      dom: DOM
+      pgsql: PostgreSQL
+      posix: Posix
+      simplexml: SimpleXML
+      mysqli: MySQLi
+      xml: XML
+      xmlreader: XMLReader
+      xmlwriter: XMLWriter
+      fileinfo: fileinfo
+      zip: Zip
+
+subpackages:
+  - range: extensions
+    name: "php-${{range.key}}"
+    description: "The ${{range.value}} extension"
+    pipeline:
+      - runs: |
+          export EXTENSIONS_DIR=usr/lib/php/modules
+          export CONF_DIR="${{targets.subpkgdir}}/etc/php/conf.d"
+          mkdir -p "${{targets.subpkgdir}}"/$EXTENSIONS_DIR $CONF_DIR
+          mv "${{targets.destdir}}/$EXTENSIONS_DIR/${{range.key}}.so" \
+            "${{targets.subpkgdir}}/$EXTENSIONS_DIR/${{range.key}}.so"
+          prefix=
+          [ "${{range.key}}" != "opcache" ] || prefix="zend_"
+          echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"${{range.key}}.ini"
+
+  - name: php-dev
+    description: PHP 8.1 development headers
+    pipeline:
+      - uses: split/dev
+
+  - name: php-cgi
+    description: PHP 8.1 CGI
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/php-cgi ${{targets.subpkgdir}}/usr/bin/
+
+  - name: php-dbg
+    description: Interactive PHP Debugger
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/phpdbg ${{targets.subpkgdir}}/usr/bin/
+
+  - name: php-fpm
+    description: PHP 8.1 FastCGI Process Manager (FPM)
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/sbin ${{targets.subpkgdir}}/etc/php/php-fpm.d
+          mv ${{targets.destdir}}/usr/sbin/php-fpm ${{targets.subpkgdir}}/usr/sbin/
+          mv ${{targets.destdir}}/etc/php/php-fpm.conf.default ${{targets.subpkgdir}}/etc/php/php-fpm.conf
+          mv ${{targets.destdir}}/etc/php/php-fpm.d/www.conf.default ${{targets.subpkgdir}}/etc/php/php-fpm.d/www.conf \
+          && { \
+          	echo '[global]'; \
+          	echo 'error_log = /proc/self/fd/2'; \
+            echo 'daemonize = no'; \
+          	echo; \
+          	echo '[www]'; \
+            echo 'listen = [::]:9000'; \
+          	echo 'access.log = /proc/self/fd/2'; \
+            echo; \
+          	echo 'clear_env = no'; \
+          	echo; \
+          	echo 'catch_workers_output = yes'; \
+            echo; \
+          	echo 'decorate_workers_output = no'; \
+          } | tee ${{targets.subpkgdir}}/etc/php/php-fpm.d/zz-apko.conf
+
+update:
+  enabled: true
+  release-monitor:
+    # Note this is the same as the php8 since they seem to list all the versions
+    # there:
+    # https://release-monitoring.org/project/3627/
+    identifier: 3627


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

Introduce php-8.1 cribbing heavily from php.yaml

Tested with `make local-wolfi` followed by:
```
fccd495f9873:/work/packages# apk add php-8.1
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/7) Installing xz (5.4.4-r0)
(2/7) Installing libxml2 (2.11.5-r0)
(3/7) Installing ncurses-terminfo-base (6.4_p20230722-r1)
(4/7) Installing ncurses (6.4_p20230722-r1)
(5/7) Installing readline (8.2-r2)
(6/7) Installing sqlite (3.40.0-r1)
(7/7) Installing php-8.1 (8.1.23-r0)
OK: 31 MiB in 21 packages
fccd495f9873:/work/packages# php -v
PHP 8.1.23 (cli) (built: Sep  6 2023 00:16:27) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.23, Copyright (c) Zend Technologies
```

Tested with, `wolfictl check update  --override-version 0.0.1 php-8.1.yaml`
```
2023/09/05 19:57:20 wolfictl update: request query, to check visit https://docs.github.com/en/graphql/overview/explorer:
query {

  r2d8be40d5a5fcec3c08fd5a9a6f4d8521e599f6fae02b6b767c1929db914f122: repository(owner: "php", name: "php-src") {
    nameWithOwner
    refs(refPrefix: "refs/tags/", query: "php-8.1", orderBy: {field: TAG_COMMIT_DATE, direction: DESC}, first: 50) {
      totalCount
      nodes {
        name
        target {
          commitUrl
        }
      }
    }
  },

}
2023/09/05 19:57:20 attempting to bump version to 8.1.23
2023/09/05 19:57:20 processing fetch node:
2023/09/05 19:57:20   uri: https://www.php.net/distributions/php-${{package.version}}.tar.gz
2023/09/05 19:57:20   evaluated: https://www.php.net/distributions/php-8.1.23.tar.gz
2023/09/05 19:57:23   fetched-as: /var/folders/58/jvmk7c016fx9p6j1717qcv3c0000gn/T/melange-update-2294942607
2023/09/05 19:57:23   expected-sha256: ec5330b3978edc8fe2f78830720505bf69d12542622b5cddccee63ae3a0e5b58
2023/09/05 19:57:23   expected-sha512: ba3e18c6f5efc0e8ba72bc62b01f84c873ee34df936b58196a145276de8aa81b6eddc748f9b87ab60a84e0e92470bd4dba4ed80721dae9667bf88df5a10ad8b9
2023/09/05 19:57:23 wolfictl check update: downloading sources from https://www.php.net/distributions/php-8.1.23.tar.gz into a temporary directory, this may take a while
2023/09/05 19:57:24 wolfictl check update: fetch was successful
```

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
- [ x ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ x ] REQUIRED - The version of the package is still receiving security updates

