### PR TITLE
semgrep: config update to point to returncorp/semgrep repository

### DIFF
--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1,6 +1,6 @@
 package:
   name: semgrep
-  version: 1.36.0
+  version: 1.38.3
   epoch: 0
   description: "Lightweight static analysis for many languages. Find bug variants with patterns that look like source code."
   copyright:
@@ -34,7 +34,7 @@ pipeline:
     with:
       repository: https://github.com/returntocorp/semgrep
       tag: v${{package.version}}
-      expected-commit: 52543b77abc9cb2ca5122aa2e71593318a368e19
+      expected-commit: 9d48fcc2bd3b574764cb5d753f14525a918064d9
 
   - runs: |
       opam init --compiler=ocaml-base-compiler.4.14.0 -y
@@ -56,5 +56,5 @@ pipeline:
 update:
   enabled: true
   github:
-    identifier: semgrep/semgrep
+    identifier: returntocorp/semgrep
     strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
Melange update section pointed to the wrong repository for automatic updates

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->
#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
- [x] Patch source: https://github.com/returntocorp/semgrep/tree/v1.38.3
