### PR TITLE
run the prod builds on dedicated runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
         arch: [ "x86_64", "aarch64" ]
       fail-fast: false
 
-    runs-on: wolfi-builder-${{ matrix.arch }}
+    runs-on: wolfi-os-builder-${{ matrix.arch }}
 
     # Ensure this is deprivileged, isolated job
     # permissions:


### PR DESCRIPTION
ensure the prod builds happen on dedicated and isolated runners with ~maximum compute