### PR TITLE
Bump minio to upstream release

### DIFF
--- a/minio.yaml
+++ b/minio.yaml
@@ -1,9 +1,9 @@
 package:
   name: minio
-  # minio uses strange versioning, the upstream version is RELEASE.2023-06-19T19-52-50Z
+  # minio uses strange versioning, the upstream version is RELEASE.2023-09-04T19-57-37Z
   # when bumping this, also bump the tag in git-checkout below
-  version: 0.20230619.195250
-  epoch: 1
+  version: 0.20230904.195737
+  epoch: 0
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0
@@ -13,8 +13,7 @@ environment:
     packages:
       - busybox
       - ca-certificates-bundle
-      # Pinned to 1.19 due to upstream issues
-      - go-1.19
+      - go
       - build-base
       - perl
 
@@ -22,8 +21,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/minio/minio
-      tag: RELEASE.2023-06-19T19-52-50Z
-      expected-commit: f9b8d1c6999e65ab31899cbbe0314f5a4e5257c3
+      tag: RELEASE.2023-09-04T19-57-37Z
+      expected-commit: 1c99fb106c3e1448ed92f8465d5695d055d432e7
 
   - runs: |
       make build


### PR DESCRIPTION
This includes:
 * Two feature releases:
   + https://github.com/minio/minio/releases/tag/RELEASE.2023-06-29T05-12-28Z
   + https://github.com/minio/minio/releases/tag/RELEASE.2023-08-31T15-31-16Z
 * Multiple security/bug fix releases

 go-1.21 supported since https://github.com/minio/minio/releases/tag/RELEASE.2023-08-16T20-17-30Z

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
- [ ] Patch source: _patch source here_
