### PR TITLE
attempt to fix fluentd-plugin-splunk-hec again

### DIFF
--- a/fluent-plugin-splunk-hec.yaml
+++ b/fluent-plugin-splunk-hec.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-splunk-hec
   version: 1.3.3
-  epoch: 1
+  epoch: 2
   description: This is the Fluentd output plugin for sending events to Splunk via HEC
   copyright:
     - license: Apache-2.0
@@ -9,7 +9,13 @@ package:
     provides:
       - ruby3.2-fluent-plugin-splunk-hec=${{package.version}}-r${{package.epoch}}
     runtime:
+      - ruby3.2-fluentd
+      - ruby3.2-json-jwt
       - ruby3.2-multi_json
+      - ruby3.2-net-http-persistent
+      - ruby3.2-openid_connect
+      - ruby3.2-prometheus-client
+      - ruby3.2-rack-oauth2
 
 environment:
   contents:


### PR DESCRIPTION
This explicitly and exhaustively lists the runtime deps listed at https://rubygems.org/gems/fluent-plugin-splunk-hec/versions/1.3.2