### PR TITLE
php: Add version stream to php 8.2, rename to php-8.2, also now provides php

### DIFF
--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,11 +1,13 @@
 package:
-  name: php
+  name: php-8.2
   version: 8.2.10
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
   dependencies:
+    provides:
+      - php=${{package.version}}-r${{package.epoch}}
     runtime:
       - libxml2
 
@@ -231,5 +233,8 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 3627
+  github:
+    identifier: php/php-src
+    strip-prefix: php-
+    tag-filter: php-8.2
+    use-tag: true


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

As I noticed in the #5165 the release-monitor lumps all the releases into the same thing. It's also my understanding from talking with @rawlingsj that the github is the preferred method. Lastly, there's a new 8.3.RC train rolling in, so figured to convert the 8.2 to use github, and provide a version stream while at it.

Tested with (installing both 'existing' php as well as php-8.2 to verify we get the same stuff. Also test with php-8.1 to make sure folks can get that to install as well.

```
vaikas@vaikas-MBP os % make local-wolfi
<SNIP>
1984fcb2cd0d:/work/packages# apk add php
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/7) Installing xz (5.4.4-r0)
(2/7) Installing libxml2 (2.11.5-r0)
(3/7) Installing ncurses-terminfo-base (6.4_p20230722-r1)
(4/7) Installing ncurses (6.4_p20230722-r1)
(5/7) Installing readline (8.2-r2)
(6/7) Installing sqlite (3.40.0-r1)
(7/7) Installing php-8.2 (8.2.10-r1)
OK: 31 MiB in 21 packages
1984fcb2cd0d:/work/packages# exit
vaikas@vaikas-MBP os % make local-wolfi
<SNIP>
102d527a14af:/work/packages# apk add php-8.2
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/7) Installing xz (5.4.4-r0)
(2/7) Installing libxml2 (2.11.5-r0)
(3/7) Installing ncurses-terminfo-base (6.4_p20230722-r1)
(4/7) Installing ncurses (6.4_p20230722-r1)
(5/7) Installing readline (8.2-r2)
(6/7) Installing sqlite (3.40.0-r1)
(7/7) Installing php-8.2 (8.2.10-r1)
OK: 31 MiB in 21 packages
102d527a14af:/work/packages# exit
vaikas@vaikas-MBP os % make local-wolfi
<SNIP>
5b08df9863ad:/work/packages# apk add php-8.1
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/7) Installing xz (5.4.4-r0)
(2/7) Installing libxml2 (2.11.5-r0)
(3/7) Installing ncurses-terminfo-base (6.4_p20230722-r1)
(4/7) Installing ncurses (6.4_p20230722-r1)
(5/7) Installing readline (8.2-r2)
(6/7) Installing sqlite (3.40.0-r1)
(7/7) Installing php-8.1 (8.1.23-r0)
OK: 31 MiB in 21 packages
```

And to test the upgrade path:
```
wolfictl check update  --override-version 0.0.1 php-8.2.yaml
2023/09/06 10:42:40 wolfictl update: request query, to check visit https://docs.github.com/en/graphql/overview/explorer:
query {

  rb71ea198489c77596c2b8968736ff16db42f1484b680d0cf7502c5207a31b602: repository(owner: "php", name: "php-src") {
    nameWithOwner
    refs(refPrefix: "refs/tags/", query: "php-8.2", orderBy: {field: TAG_COMMIT_DATE, direction: DESC}, first: 50) {
      totalCount
      nodes {
        name
        target {
          commitUrl
        }
      }
    }
  },

}
2023/09/06 10:42:41 attempting to bump version to 8.2.10
2023/09/06 10:42:41 processing fetch node:
2023/09/06 10:42:41   uri: https://www.php.net/distributions/php-${{package.version}}.tar.gz
2023/09/06 10:42:41   evaluated: https://www.php.net/distributions/php-8.2.10.tar.gz
2023/09/06 10:42:43   fetched-as: /var/folders/58/jvmk7c016fx9p6j1717qcv3c0000gn/T/melange-update-4263081964
2023/09/06 10:42:43   expected-sha256: 7e3e277d6eab652616f90bc7c75991179c0512953933ceba27496fb5514f7e78
2023/09/06 10:42:43   expected-sha512: 52946160afae13847f98f0f119c60b0bdec1e96869568b55ff38047ac7c62df20348e92c0208c4978747cb007816af921ff3edf7b5f16924ad112f15aa3df28e
2023/09/06 10:42:43 wolfictl check update: downloading sources from https://www.php.net/distributions/php-8.2.10.tar.gz into a temporary directory, this may take a while
2023/09/06 10:42:44 wolfictl check update: fetch was successful
```
