### PR TITLE
py3-meson-python

### DIFF
--- a/py3-meson-python.yaml
+++ b/py3-meson-python.yaml
@@ -1,0 +1,50 @@
+package:
+  name: py3-meson-python
+  version: 0.14.0
+  epoch: 0
+  description: Meson Python build backend (PEP 517)
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-colorama
+      - py3-pyproject-metadata
+      - py3-tomli
+      - py3-setuptools
+      - py3-packaging
+      - meson
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-wheel
+      - py3-gpep517
+      - py3-packaging
+      - py3-colorama
+      - py3-pyproject-metadata
+      - py3-tomli
+      - meson
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: b96866690326544dfe452583753ac3f43313227e9fd9416701a8df90af212234
+      uri: https://files.pythonhosted.org/packages/38/a7/ddc350902a1b3b960db8d0e501f61468f925f994e0b4e6d696aeb6a75c00/meson_python-${{package.version}}.tar.gz
+
+  - runs: |
+      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 1
+      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 248985

--- a/py3-pyproject-metadata.yaml
+++ b/py3-pyproject-metadata.yaml
@@ -1,0 +1,40 @@
+package:
+  name: py3-pyproject-metadata
+  version: 0.7.1
+  epoch: 0
+  description: PEP 621 metadata parsing
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-packaging
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-gpep517
+      - py3-wheel
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 0a94f18b108b9b21f3a26a3d541f056c34edcb17dc872a144a15618fed7aef67
+      uri: https://files.pythonhosted.org/packages/38/af/b0e6a9eba989870fd26e10889446d1bec2e6d5be0a1bae2dc4dcda9ce199/pyproject-metadata-${{package.version}}.tar.gz
+
+  - runs: |
+      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 1
+      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 255630


### PR DESCRIPTION
Adds the `py3-meson-python` package, which is a build dependency of pandas.

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
