### PR TITLE
Update semgrep autoupdating and fix build

### DIFF
--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1,6 +1,6 @@
 package:
   name: semgrep
-  version: 1.36.0
+  version: 1.38.3
   epoch: 0
   description: "Lightweight static analysis for many languages. Find bug variants with patterns that look like source code."
   copyright:
@@ -34,7 +34,7 @@ pipeline:
     with:
       repository: https://github.com/returntocorp/semgrep
       tag: v${{package.version}}
-      expected-commit: 52543b77abc9cb2ca5122aa2e71593318a368e19
+      expected-commit: 9d48fcc2bd3b574764cb5d753f14525a918064d9
 
   - runs: |
       opam init --compiler=ocaml-base-compiler.4.14.0 -y
@@ -42,7 +42,7 @@ pipeline:
       eval $(opam env --switch=4.14.0+static)
       make dev-setup
       make core
-      make core-install
+      make copy-core-for-cli
 
   - runs: |
       install -Dm755 _build/default/src/main/Main.exe \
@@ -56,5 +56,5 @@ pipeline:
 update:
   enabled: true
   github:
-    identifier: semgrep/semgrep
+    identifier: returntocorp/semgrep
     strip-prefix: v


### PR DESCRIPTION
Sorry, my original PR creating semgrep had the wrong autoupdate information causing a bit of breakage here.

Outside of that the build for semgrep also broke due to changes in their Makefile targets.

* Fix update section w/ proper Github repository name
* Fix build
* Bump version
* Update commit sha

Fixes: 

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

#### For version bump PRs
- [x] The `epoch` field is reset to 0
- [x] Patch source: https://github.com/returntocorp/semgrep/tree/v1.38.3
