### PR TITLE
attempt to fix fluentd-plugin-splunk-hec again again again

### DIFF
--- a/fluent-plugin-splunk-hec.yaml
+++ b/fluent-plugin-splunk-hec.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-splunk-hec
   version: 1.3.3
-  epoch: 3
+  epoch: 4
   description: This is the Fluentd output plugin for sending events to Splunk via HEC
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,8 @@ pipeline:
     with:
       expected-sha256: c393c25da76870c8641546cece3301bd3d3a3ae6531ab9e1803267659c9830c5
       uri: https://github.com/splunk/fluent-plugin-splunk-hec/archive/refs/tags/${{package.version}}.tar.gz
+
+  - uses: ruby/unlock-spec
 
   - uses: ruby/build
     with:

--- a/pipelines/ruby/unlock-spec.yaml
+++ b/pipelines/ruby/unlock-spec.yaml
@@ -1,0 +1,10 @@
+name: Unlock ruby dependencies
+
+needs:
+  packages:
+    - busybox
+
+pipeline:
+  - runs: |
+      find . -name '*.gemspec' -exec sed -e 's/~>/>=/' -i {} \;
+      find . -name 'Gemfile.lock' -exec sed -e 's/~>/>=/' -i {} \;


### PR DESCRIPTION
This time by unlocking the deps from the pessimistic (`~>`) to the more permissive (but not recommended) `>=`

Without this, the package doesn't run in the image due to

```
can't satisfy 'json-jwt (~> 1.15.0)', already activated 'json-jwt-1.16.3'
```

See https://guides.rubygems.org/patterns/

I've factored this out into a pipeline we can use elsewhere, if this works.

Previously https://github.com/wolfi-dev/os/pull/5203