### PR TITLE
py3-pandas: new package

### DIFF
--- a/py3-pandas.yaml
+++ b/py3-pandas.yaml
@@ -1,0 +1,52 @@
+package:
+  name: py3-pandas
+  version: 2.0.3
+  epoch: 0
+  description: Powerful data structures for data analysis, time series, and statistics
+  copyright:
+    - license: 'BSD-3-Clause'
+  dependencies:
+    runtime:
+      - numpy
+      - py3-dateutil
+      - py3-tz
+      - py3-tzdata
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - python-3-dev
+      - numpy
+      - py3-dateutil
+      - py3-tz
+      - py3-tzdata
+      - py3-wheel
+      - py3-gpep517
+      - py3-setuptools
+      - py3-meson-python
+      - py3-versioneer
+      - cython
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: c02f372a88e0d17f36d3093a644c73cfc1788e876a7c4bcb4020a77512e2043c
+      uri: https://github.com/pandas-dev/pandas/releases/download/v${{package.version}}/pandas-${{package.version}}.tar.gz
+
+  - runs: |
+      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 1
+      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
+
+  - uses: strip
+
+update:
+  # Pandas 2.1.0 fails to build from source, so skip updates for now.
+  enabled: false
+  release-monitor:
+    identifier: 7578

--- a/py3-versioneer.yaml
+++ b/py3-versioneer.yaml
@@ -1,0 +1,39 @@
+package:
+  name: py3-versioneer
+  version: "0.29"
+  epoch: 0
+  description: Easy VCS-based management of project version strings
+  copyright:
+    - license: 'Unlicense'
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-wheel
+      - py3-gpep517
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 5ab283b9857211d61b53318b7c792cf68e798e765ee17c27ade9f6c924235731
+      uri: https://files.pythonhosted.org/packages/32/d7/854e45d2b03e1a8ee2aa6429dd396d002ce71e5d88b77551b2fb249cb382/versioneer-${{package.version}}.tar.gz
+
+  - runs: |
+      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 1
+      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 221177


### PR DESCRIPTION
Presently we package version 2.0.3, as 2.1.0 fails to build from source.

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates