### PR TITLE
feat: add dependencies for Perl DateTime module

### DIFF
--- a/perl-class-inspector.yaml
+++ b/perl-class-inspector.yaml
@@ -1,0 +1,53 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-class-inspector/APKBUILD
+package:
+  name: perl-class-inspector
+  version: "1.36"
+  epoch: 0
+  description: Class::Inspector perl module
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+      - perl-module-install
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-module-install
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 488fcdbc9d135ed833331b0d5feb452997f35400b185341be69996438c278961eeb543648a629940765e779ca5cc87c5c3aa2c61a7fac12d2ecf6c599b68715a
+      uri: https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/Class-Inspector-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-class-inspector-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-class-inspector manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11826

--- a/perl-devel-ppport.yaml
+++ b/perl-devel-ppport.yaml
@@ -1,0 +1,51 @@
+package:
+  name: perl-devel-ppport
+  version: "3.68"
+  epoch: 0
+  description: Devel::PPPort - Perl/Pollution/Portability
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 59f2908386af2eba1a1892c044713727da1131c475e83c0aeb1a111fb81107fe2ff2575e59dc0b83e47fdf84a66677094a9571d062ec66eb5a494b8a5d580376
+      uri: https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/Devel-PPPort-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-devel-ppport-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-devel-ppport manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5760

--- a/perl-dist-checkconflicts.yaml
+++ b/perl-dist-checkconflicts.yaml
@@ -1,0 +1,54 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-dist-checkconflicts/APKBUILD
+package:
+  name: perl-dist-checkconflicts
+  version: "0.11"
+  epoch: 0
+  description: declare version conflicts for your dist
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+      - perl-module-runtime
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+      - perl-module-runtime
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 6c3f8546c1c7904bbc2a3c1135d145cbff95997c3032e9129afc98bdd98578dd9219af444f357dd8e9b1f08442a2fdd9d6f7fe8768f8ef165e71570f5ae246ad
+      uri: https://cpan.metacpan.org/authors/id/D/DO/DOY/Dist-CheckConflicts-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-dist-checkconflicts-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-dist-checkconflicts manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11842

--- a/perl-exception-class.yaml
+++ b/perl-exception-class.yaml
@@ -1,0 +1,55 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-exception-class/APKBUILD
+package:
+  name: perl-exception-class
+  version: "1.45"
+  epoch: 0
+  description: A module that allows you to declare real exception classes in Perl
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+      - perl-devel-stacktrace
+      - perl-class-data-inheritable
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+      - perl-devel-stacktrace
+      - perl-class-data-inheritable
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 8eff70c85c8f1cc9e1db2c47b5a815ef902fddd4989783b9fb7e84e3ce75776564cafddd3aedd2c86a5a8b9627021c9cfd094b95ec4956a60dd6703bba3eaf4d
+      uri: https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/Exception-Class-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-exception-class-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-exception-class manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11845

--- a/perl-file-remove.yaml
+++ b/perl-file-remove.yaml
@@ -1,0 +1,53 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-file-remove/APKBUILD
+package:
+  name: perl-file-remove
+  version: "1.61"
+  epoch: 0
+  description: Remove files and directories
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl-module-build
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-module-build
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 2ff999f7d71349b7e4a7db8728cfe2b5669c76fb27ca42fe006b0e0061bb73a29d556f3e3da88c004a4dd23bf2d9e12a1e1054b85237e8c14fb2b58c1086971f
+      uri: https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF/File-Remove-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-file-remove-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-file-remove manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11946

--- a/perl-file-sharedir.yaml
+++ b/perl-file-sharedir.yaml
@@ -1,0 +1,57 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-file-sharedir/APKBUILD
+package:
+  name: perl-file-sharedir
+  version: "1.118"
+  epoch: 0
+  description: Locate per-dist and per-module shared files
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl-file-sharedir-install
+      - perl-inc-latest
+      - perl
+      - perl-class-inspector
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-file-sharedir-install
+      - perl-inc-latest
+      - perl
+      - perl-class-inspector
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 890f33e96333f7b07707d722e59e7da9a287112062814ef294594ac67f2f7349f905c009e6cd70d3af3a4de85335b074ec5a61194f9b0495f3e793d6ca635853
+      uri: https://cpan.metacpan.org/authors/id/R/RE/REHSACK/File-ShareDir-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-file-sharedir-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-file-sharedir manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2901

--- a/perl-module-implementation.yaml
+++ b/perl-module-implementation.yaml
@@ -1,0 +1,57 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-module-implementation/APKBUILD
+package:
+  name: perl-module-implementation
+  version: "0.09"
+  epoch: 0
+  description: Loads one of several alternate underlying implementations for a module
+  copyright:
+    - license: Artistic-2.0
+  dependencies:
+    runtime:
+      - perl
+      - perl-module-runtime
+      - perl-try-tiny
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+      - perl-module-runtime
+      - perl-try-tiny
+      - perl-test-fatal
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/Module-Implementation-${{package.version}}.tar.gz
+      expected-sha512: 049f967ba1bd8a3914968b34006030ae318d99ac629a0f34736f1c2b5392490c30aa0914e777eaefda7f0f58755d2d3363a266b90db59b53fe145ef68e1d953c
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-module-implementation-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-module-implementation manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11871

--- a/perl-module-install.yaml
+++ b/perl-module-install.yaml
@@ -1,0 +1,62 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-module-install/APKBUILD
+package:
+  name: perl-module-install
+  version: "1.21"
+  epoch: 0
+  description: Standalone, extensible Perl module installer
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl-yaml-tiny
+      - perl
+      - perl-module-build
+      - perl-module-scandeps
+      - perl-file-remove
+      - perl-devel-ppport
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl-yaml-tiny
+      - perl
+      - perl-module-build
+      - perl-module-scandeps
+      - perl-file-remove
+      - perl-devel-ppport
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: f3dd1dfcae81704f1aa9ac409abd22c9e0d5d66c048adac13da19ab88559d717427b5471b7a065db8312d4d44e829afea52567cd0993e4016df0e10c760ada85
+      uri: https://cpan.metacpan.org/authors/id/E/ET/ETHER/Module-Install-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-module-install-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-module-install manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 6196

--- a/perl-module-runtime.yaml
+++ b/perl-module-runtime.yaml
@@ -1,0 +1,54 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-module-runtime/APKBUILD
+package:
+  name: perl-module-runtime
+  version: "0.016"
+  epoch: 0
+  description: runtime module handling
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+      - perl-module-build
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl-module-build
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM/Module-Runtime-${{package.version}}.tar.gz
+      expected-sha512: 64a362ee897646173dbbdd8794f863d93379d45d7ac20d3ae890d77b4ec3f5e36aaff66c41b4a6a33b28bf492216283528755550ab09e466ceafb4f0cfbaeb9e
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-module-runtime-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-module-runtime manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3111

--- a/perl-package-stash.yaml
+++ b/perl-package-stash.yaml
@@ -1,0 +1,56 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-package-stash/APKBUILD
+package:
+  name: perl-package-stash
+  version: "0.40"
+  epoch: 0
+  description: Routines for manipulating stashes
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+      - perl-dist-checkconflicts
+      - perl-module-implementation
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+      - perl-dev
+      - perl-dist-checkconflicts
+      - perl-module-implementation
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 1a1e358c8409ba0bcc2fee9b3cc86b6cd42297c9bd0641a57872bec498567ee18075ad71f7e79bb9b3a789cb47ebbf852163886f8babaf3aa23e7ff9eb2e7080
+      uri: https://cpan.metacpan.org/authors/id/E/ET/ETHER/Package-Stash-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-package-stash-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-package-stash manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11885

--- a/perl-sub-info.yaml
+++ b/perl-sub-info.yaml
@@ -1,0 +1,54 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-sub-info/APKBUILD
+package:
+  name: perl-sub-info
+  version: "0.002"
+  epoch: 0
+  description: Tool for inspecting subroutines.
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+      - perl-importer
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+      - perl-importer
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: e3ad2c8b270a44f9de2d5b71845a4a21f363a234edf2ddb9942c2fb2e4d765eedff3653a047f025b9d1dfaeff32ddd58aeff7f81fa42e6f4b57f5ca6311519b3
+      uri: https://cpan.metacpan.org/authors/id/E/EX/EXODIST/Sub-Info-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-sub-info-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-sub-info manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 12780

--- a/perl-term-table.yaml
+++ b/perl-term-table.yaml
@@ -1,0 +1,54 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-term-table/APKBUILD
+package:
+  name: perl-term-table
+  version: "0.016"
+  epoch: 0
+  description: Format a header and rows into a table
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+      - perl-importer
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+      - perl-importer
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: b35700fba336f57e479d818ef74fc746979b3acb081a7cde816b39c5fb65bedd5217257426ba22bdcaf8d73292cd98efd23295144a996f7bd117ada775cdfe5b
+      uri: https://cpan.metacpan.org/authors/id/E/EX/EXODIST/Term-Table-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-term-table-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-term-table manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 12715

--- a/perl-test-fatal.yaml
+++ b/perl-test-fatal.yaml
@@ -1,0 +1,54 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-test-fatal/APKBUILD
+package:
+  name: perl-test-fatal
+  version: "0.017"
+  epoch: 0
+  description: incredibly simple helpers for testing code with exceptions
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+      - perl-try-tiny
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+      - perl-try-tiny
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: e88bb9749bd1cbc4ed169e13bcd5a1ac7411873d8ae00d8b7ecf1dfc39ed9a02f0286d885876913c69b5c90033144d5fda6a5517ef64175d13e284d3c971a6e7
+      uri: https://cpan.metacpan.org/authors/id/R/RJ/RJBS/Test-Fatal-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-test-fatal-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-test-fatal manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11908

--- a/perl-test2-plugin-nowarnings.yaml
+++ b/perl-test2-plugin-nowarnings.yaml
@@ -1,0 +1,58 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-test2-plugin-nowarnings/APKBUILD
+package:
+  name: perl-test2-plugin-nowarnings
+  version: "0.09"
+  epoch: 0
+  description: Test2::Plugin::NoWarnings perl module
+  copyright:
+    - license: Artistic-2.0
+  dependencies:
+    runtime:
+      - perl
+      - perl-ipc-run3
+      - perl-test2-suite
+      - perl-test-simple
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+      - perl-dev
+      - perl-ipc-run3
+      - perl-test2-suite
+      - perl-test-simple
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 3b93d6c4522e913c4bc9d589b650f784327bed1a36a0dc18943dd2ea34654215333753cb532d5ffff6f0ef0af9ce0859e9744637cff89a1a1a5b936149f9b455
+      uri: https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/Test2-Plugin-NoWarnings-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-test2-plugin-nowarnings-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-test2-plugin-nowarnings manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 12452

--- a/perl-test2-suite.yaml
+++ b/perl-test2-suite.yaml
@@ -1,0 +1,62 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-test2-suite/APKBUILD
+package:
+  name: perl-test2-suite
+  version: "0.000155"
+  epoch: 0
+  description: Distribution with a rich set of tools built upon the Test2 framework.
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+      - perl-term-table
+      - perl-scope-guard
+      - perl-sub-info
+      - perl-importer
+      - perl-module-pluggable
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+      - perl-dev
+      - perl-term-table
+      - perl-scope-guard
+      - perl-sub-info
+      - perl-importer
+      - perl-module-pluggable
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: d9b9866c53185fed9b67a76f38fbe2527b7e1796937d91b0ea7efc1b3df525d07142b53b030c659ffed72fb41a6334b4d963a2d13f58684364c8cf571898bf31
+      uri: https://cpan.metacpan.org/authors/id/E/EX/EXODIST/Test2-Suite-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-test2-suite-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-test2-suite manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 9536


### PR DESCRIPTION
Add more dependencies required by Perl DateTime.

Related: #5051, #5159, #5161

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates