### PR TITLE
add actions-runner-controller scaleset

### DIFF
--- a/actions-runner-controller.yaml
+++ b/actions-runner-controller.yaml
@@ -1,0 +1,73 @@
+package:
+  name: actions-runner-controller
+  version: 0.5.0
+  epoch: 0
+  description: Kubernetes controller for GitHub Actions self-hosted runners
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/actions/actions-runner-controller
+      tag: gha-runner-scale-set-${{package.version}}
+      expected-commit: abc0b678d323b9016af467bdedd2c4fea85a7769
+
+  # This technically builds twice, but this ensures we perform all prereq stpes (like codegen)
+  - runs: |
+      make manager
+
+  # Ref: https://github.com/actions/actions-runner-controller/blob/gha-runner-scale-set-0.5.0/Dockerfile#L35
+  - uses: go/build
+    with:
+      packages: .
+      output: manager
+      ldflags: -s -w
+
+  - uses: go/build
+    with:
+      packages: ./cmd/githubrunnerscalesetlistener
+      output: github-runnerscaleset-listener
+      ldflags: -s -w -X 'github.com/actions/actions-runner-controller/build.Version=${{package.version}}'
+
+  - uses: go/build
+    with:
+      packages: ./cmd/githubwebhookserver
+      output: github-webhook-server
+      ldflags: -s -w
+
+  - uses: go/build
+    with:
+      packages: ./cmd/actionsmetricsserver
+      output: actions-metrics-server
+      ldflags: -s -w
+
+  - uses: go/build
+    with:
+      packages: ./cmd/sleep
+      output: sleep
+      ldflags: -s -w
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/manager ${{targets.subpkgdir}}/manager
+
+update:
+  enabled: true
+  github:
+    identifier: actions/actions-runner-controller
+    strip-prefix: gha-runner-scale-set-
+    use-tag: true


### PR DESCRIPTION
this _only_ builds the [`scale-set`](https://github.com/actions/actions-runner-controller/releases/tag/gha-runner-scale-set-0.5.0), not the legacy `actions-runner-controller`.

if at some point in the future we need the legacy, we can repurpose the repo with some more subpackages