### PR TITLE
sysstat: switch to use GitHub

### DIFF
--- a/sysstat.yaml
+++ b/sysstat.yaml
@@ -1,7 +1,7 @@
 package:
   name: sysstat
   version: 12.6.2
-  epoch: 0
+  epoch: 1
   description: Performance monitoring tools
   copyright:
     - license: GPL-2.0-or-later
@@ -17,10 +17,11 @@ environment:
       - linux-headers
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: f3e246ab2e63e4d1a37d8135abce85101d736842d4ebae209db562086dd391cf
-      uri: https://github.com/sysstat/sysstat/archive/v${{package.version}}.tar.gz
+      repository: https://github.com/sysstat/sysstat
+      tag: v${{package.version}}
+      expected-commit: a073cef8b38cab0840930fc53f81440718efb010
 
   - uses: autoconf/configure
     with:
@@ -41,5 +42,7 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 4931
+  github:
+    identifier: sysstat/sysstat
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
Sysstat hadn't been receiving updates, because it was using release-monitoring, and presumably because it has recent releases marked as pre-release (although I haven't figured out why).

Sysstat was also using `fetch` even though it was pulling source from GitHub.

This PR switches both the source checkout and the updates to use GitHub.

🤞  The hope is that this triggers the update bot to move this package to the latest release: `12.7.4`.
