### PR TITLE
Add php-common subpackage to php-8.1

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: 8.1.23
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -173,6 +173,16 @@ data:
       fileinfo: fileinfo
       zip: Zip
 
+vars:
+  # Ideally these would look like this, but I can't figure out to do so.
+  #_libdir: "/usr/lib/${{package.name}}"
+  #_extension_dir: ${{vars._libdir}}/modules
+  #_extension_confd: "/etc/${{package.name}}/conf.d"
+  # Note there's no leading slashes because they get appended later.
+  _libdir: "usr/lib/php-8.1"
+  _extension_dir: ${{vars._libdir}}/modules
+  _extension_confd: "etc/php-8.1/conf.d"
+
 subpackages:
   - range: extensions
     name: "php-${{range.key}}"
@@ -230,6 +240,23 @@ subpackages:
             echo; \
           	echo 'decorate_workers_output = no'; \
           } | tee ${{targets.subpkgdir}}/etc/php/php-fpm.d/zz-apko.conf
+
+  - name: php-common
+    description: ${{package.description}} common config
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc
+          mv ${{targets.destdir}}/etc ${{targets.subpkgdir}}
+          mkdir -p ${{targets.subpkgdir}}/${{vars._extension_confd}} ${{targets.subpkgdir}}/${{vars._extension_dir}}
+    dependencies:
+      provides:
+        # This is for backward compatibility as per:
+        # https://git.alpinelinux.org/aports/plain/community/php81/APKBUILD
+        # Not sure if it refers to the php-8.1-zlib or php-zlib or both?
+        - ${{package.name}}-zlib
+        - php-zlib
+        - ${{package.name}}-json
+        - php-json
 
 update:
   enabled: true

--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -241,7 +241,7 @@ subpackages:
           	echo 'decorate_workers_output = no'; \
           } | tee ${{targets.subpkgdir}}/etc/php/php-fpm.d/zz-apko.conf
 
-  - name: php-common
+  - name: ${{package.name}}-config
     description: ${{package.description}} common config
     pipeline:
       - runs: |


### PR DESCRIPTION

Used the following to figure out how it may / should look like:
https://git.alpinelinux.org/aports/plain/community/php81/APKBUILD

And also, checked what the expected package outputs:
https://pkgs.alpinelinux.org/contents?branch=edge&name=php81%2dcommon&arch=aarch64&repo=community

Tested with `make local-wolfi`
```
40364132da67:/work/packages# apk add php-8.1
(1/7) Installing xz (5.4.4-r0)
(2/7) Installing libxml2 (2.11.5-r0)
(3/7) Installing ncurses-terminfo-base (6.4_p20230722-r1)
(4/7) Installing ncurses (6.4_p20230722-r1)
(5/7) Installing readline (8.2-r2)
(6/7) Installing sqlite (3.40.0-r1)
(7/7) Installing php-8.1 (8.1.23-r0)
OK: 31 MiB in 21 packages
40364132da67:/work/packages# apk add php-common
(1/1) Installing php-common (8.1.23-r0)
OK: 31 MiB in 22 packages
40364132da67:/work/packages# apk info -L php-common
php-common-8.1.23-r0 contains:
etc/php/php.ini
var/lib/db/sbom/php-common-8.1.23-r0.spdx.json
40364132da67:/work/packages# ls -l /etc/php/php.ini
-rw-r--r--    1 root     root         73603 Sep  6 22:46 /etc/php/php.ini
```

You can also install it individually with `apk add php-8.1`


### Pre-review Checklist

#### For new package PRs only
- [ X ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ X ] REQUIRED - The version of the package is still receiving security updates
