### PR TITLE
Add istio-pilot-agent-1.19 version stream

### DIFF
--- a/istio-pilot-agent-1.19.yaml
+++ b/istio-pilot-agent-1.19.yaml
@@ -1,0 +1,59 @@
+package:
+  name: istio-pilot-agent-1.19
+  version: 1.19.0
+  epoch: 0
+  description: Nanny binary for Istio Envoy
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - istio-pilot-agent=1.19.999
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 3b3ca8ec1632961e355f398f7357ebed9b13aa43
+
+  - uses: go/build
+    with:
+      packages: ./pilot/cmd/pilot-agent
+      output: pilot-agent
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/var/lib/istio/envoy
+      cp ./tools/packaging/common/envoy_bootstrap.json \
+        ${{targets.destdir}}/var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+      cp ./tools/packaging/common/gcp_envoy_bootstrap.json \
+        ${{targets.destdir}}/var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          # link /usr/local/bin/pilot-agent -> /usr/bin/pilot-agent to match
+          # what the Istio Helm charts may expect.
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          ln -sf /usr/bin/pilot-agent ${{targets.subpkgdir}}/usr/local/bin/pilot-agent
+    dependencies:
+      provides:
+        - istio-pilot-agent-compat=1.19.999
+
+update:
+  enabled: true
+  github:
+    identifier: istio/istio
+    tag-filter: 1.19.
+    use-tag: true

--- a/istio-pilot-agent-1.19.yaml
+++ b/istio-pilot-agent-1.19.yaml
@@ -7,7 +7,7 @@ package:
     - license: Apache-2.0
   dependencies:
     provides:
-      - istio-pilot-agent=1.19.999
+      - istio-pilot-agent=${{package.full-version}}
 
 environment:
   contents:


### PR DESCRIPTION
* "istio-pilot-agent-1.19: new version stream for istio-pilot-agent"

This is based on istio-pilot-agent-1.18.yaml with updated tags, versions, epochs and commits.

### Pre-review Checklist

#### For version bump PRs
- [x] The `epoch` field is reset to 0
