### PR TITLE
use new version stream format.

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,46 +1,46 @@
 package:
   name: php-8.1
   version: 8.1.23
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
   dependencies:
     provides:
-      - php=8.1.999
+      - php=${{package.full-version}}
     runtime:
       - libxml2
 
 environment:
   contents:
     packages:
+      - bison
       - build-base
       - busybox
-      - file
-      - bison
-      - libtool
-      - ca-certificates-bundle
       - bzip2-dev
-      - libxml2-dev
+      - ca-certificates-bundle
       - curl-dev
-      - openssl-dev
-      - readline-dev
-      - sqlite-dev
-      - libsodium-dev
-      - libpng-dev
-      - libjpeg-turbo-dev
-      - libavif-dev
-      - libwebp-dev
-      - libxpm-dev
-      - libx11-dev
+      - file
       - freetype-dev
       - gmp-dev
       - icu-dev
-      - openldap-dev
-      - oniguruma-dev
+      - libavif-dev
+      - libjpeg-turbo-dev
+      - libpng-dev
+      - libsodium-dev
+      - libtool
+      - libwebp-dev
+      - libx11-dev
+      - libxml2-dev
+      - libxpm-dev
       - libxslt-dev
-      - postgresql-15-dev
       - libzip
+      - oniguruma-dev
+      - openldap-dev
+      - openssl-dev
+      - postgresql-15-dev
+      - readline-dev
+      - sqlite-dev
 
 pipeline:
   - uses: fetch


### PR DESCRIPTION
Replace the provides with the ${{package.full-version}}

tested with:
```
wolfictl check update  --override-version 0.0.1 php-8.1.yaml
2023/09/06 18:27:41 wolfictl update: request query, to check visit https://docs.github.com/en/graphql/overview/explorer:
query {

  r2d8be40d5a5fcec3c08fd5a9a6f4d8521e599f6fae02b6b767c1929db914f122: repository(owner: "php", name: "php-src") {
    nameWithOwner
    refs(refPrefix: "refs/tags/", query: "php-8.1", orderBy: {field: TAG_COMMIT_DATE, direction: DESC}, first: 50) {
      totalCount
      nodes {
        name
        target {
          commitUrl
        }
      }
    }
  },

}
2023/09/06 18:27:42 attempting to bump version to 8.1.23
2023/09/06 18:27:42 processing fetch node:
2023/09/06 18:27:42   uri: https://www.php.net/distributions/php-${{package.version}}.tar.gz
2023/09/06 18:27:42   evaluated: https://www.php.net/distributions/php-8.1.23.tar.gz
2023/09/06 18:27:45   fetched-as: /var/folders/58/jvmk7c016fx9p6j1717qcv3c0000gn/T/melange-update-2050033643
2023/09/06 18:27:45   expected-sha256: ec5330b3978edc8fe2f78830720505bf69d12542622b5cddccee63ae3a0e5b58
2023/09/06 18:27:45   expected-sha512: ba3e18c6f5efc0e8ba72bc62b01f84c873ee34df936b58196a145276de8aa81b6eddc748f9b87ab60a84e0e92470bd4dba4ed80721dae9667bf88df5a10ad8b9
2023/09/06 18:27:45 wolfictl check update: downloading sources from https://www.php.net/distributions/php-8.1.23.tar.gz into a temporary directory, this may take a while
2023/09/06 18:27:46 wolfictl check update: fetch was successful
```

