### PR TITLE
add sorting of packages/runtime deps alpha to yam

### DIFF
--- a/.github/workflows/wolfictl-check-update.yaml
+++ b/.github/workflows/wolfictl-check-update.yaml
@@ -24,6 +24,7 @@ jobs:
       with:
         separator: ' '
         files: "*.yaml"
+        files-ignore: ".yam.yaml"
 
     - name: Check
       id: check

--- a/.github/workflows/wolfictl-check-update.yaml
+++ b/.github/workflows/wolfictl-check-update.yaml
@@ -24,7 +24,7 @@ jobs:
       with:
         separator: ' '
         files: "*.yaml"
-        files-ignore: ".yam.yaml"
+        files_ignore: ".yam.yaml"
 
     - name: Check
       id: check

--- a/.yam.yaml
+++ b/.yam.yaml
@@ -4,4 +4,8 @@ gap:
   - ".data"
   - ".pipeline"
 
+sort:
+  - ".package.dependencies.runtime"
+  - ".environment.contents.packages"
+
 indent: 2


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

Now when you ran `yam` it will sort the:
`.environment.contents.packages` and  `.package.dependencies.runtime` for you.