### PR TITLE
explicitly enable/disable bootstrap-awareness

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -37,7 +37,9 @@ jobs:
         run: |
           printf "packages=" >> $GITHUB_OUTPUT
 
-          wolfictl text -t name --pipeline-dir=./pipelines/ > packages-list
+          wolfictl text -t name --pipeline-dir=./pipelines/ \
+              -r https://packages.wolfi.dev/bootstrap/stage3/ \
+              -k https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub > packages-list
           while read pkg; do
             for file in ${{ steps.changes.outputs.all_changed_files }}; do
               [ "${file%.yaml}" = "$pkg" ] && printf "%s " ${file%.yaml} >> $GITHUB_OUTPUT

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -38,7 +38,7 @@ jobs:
           printf "packages=" >> $GITHUB_OUTPUT
 
           wolfictl text -t name --pipeline-dir=./pipelines/ \
-              -r https://packages.wolfi.dev/bootstrap/stage3/ \
+              -r https://packages.wolfi.dev/bootstrap/stage3 \
               -k https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub > packages-list
           while read pkg; do
             for file in ${{ steps.changes.outputs.all_changed_files }}; do

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: 'Build Wolfi'
         run: |
           for package in ${{needs.changes.outputs.packages}}; do
-            make MELANGE="melange" MELANGE_EXTRA_OPTS="--create-build-log" REPO="$GITHUB_WORKSPACE/packages" BUILDWORLD=no package/$package -j1
+            make MELANGE="melange" MELANGE_EXTRA_OPTS="--create-build-log" REPO="$GITHUB_WORKSPACE/packages" package/$package -j1
           done
 
       - name: Check for file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,10 @@ Once you're done writing the new package configuration file, you can test it by 
 To build an individual package, you can use a `make` command like this:
 
 ```text
-make package/<your-new-package-name> BUILDWORLD=no USE_CACHE=no
+make package/<your-new-package-name> USE_CACHE=no
 ```
 
-For example, if your package name is "foo", run `make package/foo BUILDWORLD=no USE_CACHE=no`.
+For example, if your package name is "foo", run `make package/foo USE_CACHE=no`.
 
 This will build the package by invoking [melange](https://github.com/chainguard-dev/melange) in a particular way. This invocation is defined in the [Makefile](Makefile), if you're interested to see how this is wired up. Also, you can run Melange _directly_ without using `make` if you understand what you're doing.
 

--- a/HOW_TO_PATCH_CVES.md
+++ b/HOW_TO_PATCH_CVES.md
@@ -61,7 +61,7 @@ For the ease of explanation, we'll assume we're addressing a single reported vul
     Note that currently, this will build the **entire world**. If you want to build just a single package, you can run the following to build the package:
 
     ```shell
-    BUILDWORLD=no make packages/${ARCH}/${PACKAGE_NAME}-${PACKAGE_VERSION}.apk
+    make package/${PACKAGE_NAME}
     ```
 
 1. Open a PR.

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,6 @@ KEY ?= local-melange.rsa
 REPO ?= $(shell pwd)/packages
 CACHE_DIR ?= gs://wolfi-sources/
 
-WOLFI_SIGNING_PUBKEY ?= https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-WOLFI_PROD ?= https://packages.wolfi.dev/os
-
 MELANGE_OPTS += --repository-append ${REPO}
 MELANGE_OPTS += --keyring-append ${KEY}.pub
 MELANGE_OPTS += --signing-key ${KEY}
@@ -28,16 +25,29 @@ ifeq (${USE_CACHE}, yes)
 	MELANGE_OPTS += --cache-source ${CACHE_DIR}
 endif
 
-ifeq (${BUILDWORLD}, no)
-MELANGE_OPTS += -k ${WOLFI_SIGNING_PUBKEY}
-MELANGE_OPTS += -r ${WOLFI_PROD}
-endif
-
 # The list of packages to be built. The order matters.
 # wolfictl determines the list and order
 # set only to be called when needed, so make can be instant to run
 # when it is not
 PKGLISTCMD ?= $(WOLFICTL) text --dir . --type name --pipeline-dir=./pipelines/
+
+BOOTSTRAP_REPO ?= https://packages.wolfi.dev/bootstrap/stage3
+BOOTSTRAP_KEY ?= https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
+WOLFI_REPO ?= https://packages.wolfi.dev/os
+WOLFI_KEY ?= https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+BOOTSTRAP ?= no
+
+ifeq (${BOOTSTRAP}, yes)
+	MELANGE_OPTS += -k ${BOOTSTRAP_KEY}
+	MELANGE_OPTS += -r ${BOOTSTRAP_REPO}
+	PKGLISTCMD += -k ${BOOTSTRAP_KEY}
+	PKGLISTCMD += -r ${BOOTSTRAP_REPO}
+else
+	MELANGE_OPTS += -k ${WOLFI_KEY}
+	MELANGE_OPTS += -r ${WOLFI_REPO}
+	PKGLISTCMD += -k ${WOLFI_KEY}
+	PKGLISTCMD += -r ${WOLFI_REPO}
+endif
 
 all: ${KEY} .build-packages
 ifeq ($(MAKECMDGOALS),all)

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -46,14 +46,12 @@ comparing the package directories.
 # Reproducing individual Wolfi packages
 
 If you just want to test an individual Wolfi package for reproducibility,
-the same caveats above still apply.  But you can ask the build system to
-build just a single package, without building dependencies, by using the
-`BUILDWORLD=no` knob.  For example, with `execline`:
+the same caveats above still apply. For example, with `execline`:
 
-    # doas make packages/execline BUILDWORLD=no
+    # doas make package/execline
     ...
     # doas mv packages packages-1
-    # doas make packages/execline BUILDWORLD=no
+    # doas make package/execline
     ...
     # doas mv packages packages-2
     # sha256sum packages-1/$(uname -m)/*.apk | sed -e s:packages-1:packages-2:g | sha256sum -c

--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/autoconf.yaml
+++ b/autoconf.yaml
@@ -12,10 +12,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/automake.yaml
+++ b/automake.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/bison.yaml
+++ b/bison.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/build-base.yaml
+++ b/build-base.yaml
@@ -16,10 +16,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -20,10 +20,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/bzip2.yaml
+++ b/bzip2.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - perl

--- a/expat.yaml
+++ b/expat.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/file.yaml
+++ b/file.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/flex.yaml
+++ b/flex.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/gawk.yaml
+++ b/gawk.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -13,10 +13,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/gdbm.yaml
+++ b/gdbm.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -23,10 +23,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/gmp.yaml
+++ b/gmp.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/grep.yaml
+++ b/grep.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/gzip.yaml
+++ b/gzip.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/help2man.yaml
+++ b/help2man.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/isl.yaml
+++ b/isl.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/libffi.yaml
+++ b/libffi.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/libtool.yaml
+++ b/libtool.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/linenoise.yaml
+++ b/linenoise.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/linux-headers.yaml
+++ b/linux-headers.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/lua5.3-lzlib.yaml
+++ b/lua5.3-lzlib.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/lua5.3.yaml
+++ b/lua5.3.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/m4.yaml
+++ b/m4.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/make.yaml
+++ b/make.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/mpc.yaml
+++ b/mpc.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/mpdecimal.yaml
+++ b/mpdecimal.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/mpfr.yaml
+++ b/mpfr.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -22,10 +22,6 @@ options:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/patch.yaml
+++ b/patch.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/pax-utils.yaml
+++ b/pax-utils.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/perl.yaml
+++ b/perl.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/pkgconf.yaml
+++ b/pkgconf.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -12,10 +12,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -9,10 +9,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/readline.yaml
+++ b/readline.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/scdoc.yaml
+++ b/scdoc.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/sed.yaml
+++ b/sed.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/sqlite.yaml
+++ b/sqlite.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/texinfo.yaml
+++ b/texinfo.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/wget.yaml
+++ b/wget.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
       - ca-certificates-bundle

--- a/wolfi-base.yaml
+++ b/wolfi-base.yaml
@@ -13,10 +13,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
 

--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -11,10 +11,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/wolfi-keys.yaml
+++ b/wolfi-keys.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - busybox
 

--- a/xz.yaml
+++ b/xz.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/bootstrap/stage3
-    keyring:
-      - https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
     packages:
       - wolfi-baselayout
       - busybox


### PR DESCRIPTION
Opening this to gather comments

This changes our interactions with the bootstrap/stage3 repo to be an opt-in at `make`-time, rather than something we implicitly support if available for packages that need bootstrapping.

When `BOOTSTRAP=yes`, the bootstrap/stage3 repo+keyring are added to all `melange build` invocations.

When `BOOTSTRAP=no` (or non-`yes`), the repo+keyring are not appended, and if as a result the package is not available, the build will not be able to resolve dependencies and fail.

The canonical case is: `busybox` needs `busybox` to build itself. When `BOOTSTRAP=yes`, `melange build busybox.yaml` is taught about the existence of the bootstrap/stage3 repo, where it finds a `busybox`, and it can happily build itself. When `BOOTSTRAP=no`, `melange build busybox.yaml` only knows about `packages.wolfi.dev/os`, where we better hope `busybox` is available already.

When `BOOTSTRAP=yes`, package builds are _not aware that `packages.wolfi.dev/os` exists_. This is fine, because `wolfictl text` constructs a build order that is bootstrap-aware (wolfictl PR incoming), and packages will be built in order -- `busybox` is built from bootstrap-`busybox`, that's used to build `go`, then that's used to build `crane` from the local 
`go` package. They don't need to know that `wolfi` exists during bootstrap mode.

What we lose in this is a signal in our melange YAMLs that a package _might_ depend on bootstrapping. `apk-tools` now no longer has any indication that it depends on bootstrap packages. Improvements to `wolfictl`'s graph UX can make this clearer in a more generalized, automated way, based on observed dep requirements.

This also removes `BUILDWORLD` and replaces it with the opposite-semantics `BOOTSTRAP`. We can change this back so that `BUILDWORLD=yes` means `BOOTSTRAP=yes`, if that seems like a smaller lift.