### PR TITLE
Update provides block for istio-pilot-agent

### DIFF
--- a/istio-pilot-agent-1.19.yaml
+++ b/istio-pilot-agent-1.19.yaml
@@ -7,7 +7,7 @@ package:
     - license: Apache-2.0
   dependencies:
     provides:
-      - istio-pilot-agent=${{package.full-version}}
+      - istio-pilot-agent=1.19
 
 environment:
   contents:


### PR DESCRIPTION
* "istio-pilot-agent-1.19: update `provides` block to not use placeholder"

I believe the expansion `${{package.full-version}}` didn't work there. 

```
[12:50 PM] ❯ docker run --privileged --platform=linux/amd64 -it ghcr.io/wolfi-dev/sdk:latest 

Welcome to the development environment![sdk] ❯ apk add istio-pilot-agent
WARNING: opening ./../../packages: No such file or directory
fetch https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
(1/1) Installing istio-pilot-agent-1.18 (1.18.2-r3) <--- this should see 1.19
OK: 936 MiB in 52 packages
```
