### PR TITLE
istio-pilot-discovery-1.18, 1.19: Istio controller binary

### DIFF
--- a/istio-pilot-agent-1.19.yaml
+++ b/istio-pilot-agent-1.19.yaml
@@ -7,7 +7,7 @@ package:
     - license: Apache-2.0
   dependencies:
     provides:
-      - istio-pilot-agent=${{package.full-version}}
+      - istio-pilot-agent=1.19
 
 environment:
   contents:

--- a/istio-pilot-discovery-1.18.yaml
+++ b/istio-pilot-discovery-1.18.yaml
@@ -1,13 +1,13 @@
 package:
-  name: istio-pilot-agent-1.19
-  version: 1.19.0
-  epoch: 1
-  description: Nanny binary for Istio Envoy
+  name: istio-pilot-discovery-1.18
+  version: 1.18.2
+  epoch: 0
+  description: Istio controller
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
-      - istio-pilot-agent=${{package.full-version}}
+      - istio-pilot-discovery=1.18
 
 environment:
   contents:
@@ -23,12 +23,12 @@ pipeline:
     with:
       repository: https://github.com/istio/istio
       tag: ${{package.version}}
-      expected-commit: 3b3ca8ec1632961e355f398f7357ebed9b13aa43
+      expected-commit: 0183f2886bc078e8df4d6bbd21fa452a3a23481d
 
   - uses: go/build
     with:
-      packages: ./pilot/cmd/pilot-agent
-      output: pilot-agent
+      packages: ./pilot/cmd/pilot-discovery
+      output: pilot-discovery
 
   - runs: |
       mkdir -p ${{targets.destdir}}/var/lib/istio/envoy
@@ -43,17 +43,17 @@ subpackages:
   - name: ${{package.name}}-compat
     pipeline:
       - runs: |
-          # link /usr/local/bin/pilot-agent -> /usr/bin/pilot-agent to match
+          # link /usr/local/bin/pilot-discovery -> /usr/bin/pilot-discovery to match
           # what the Istio Helm charts may expect.
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin
-          ln -sf /usr/bin/pilot-agent ${{targets.subpkgdir}}/usr/local/bin/pilot-agent
+          ln -sf /usr/bin/pilot-discovery ${{targets.subpkgdir}}/usr/local/bin/pilot-discovery
     dependencies:
       provides:
-        - istio-pilot-agent-compat=1.19.999
+        - istio-pilot-discovery-compat=1.18
 
 update:
   enabled: true
   github:
     identifier: istio/istio
-    tag-filter: 1.19.
+    tag-filter: 1.18.
     use-tag: true

--- a/istio-pilot-discovery-1.19.yaml
+++ b/istio-pilot-discovery-1.19.yaml
@@ -1,13 +1,13 @@
 package:
-  name: istio-pilot-agent-1.19
+  name: istio-pilot-discovery-1.19
   version: 1.19.0
-  epoch: 1
-  description: Nanny binary for Istio Envoy
+  epoch: 0
+  description: Istio controller
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
-      - istio-pilot-agent=${{package.full-version}}
+      - istio-pilot-discovery=1.19
 
 environment:
   contents:
@@ -27,8 +27,8 @@ pipeline:
 
   - uses: go/build
     with:
-      packages: ./pilot/cmd/pilot-agent
-      output: pilot-agent
+      packages: ./pilot/cmd/pilot-discovery
+      output: pilot-discovery
 
   - runs: |
       mkdir -p ${{targets.destdir}}/var/lib/istio/envoy
@@ -43,13 +43,13 @@ subpackages:
   - name: ${{package.name}}-compat
     pipeline:
       - runs: |
-          # link /usr/local/bin/pilot-agent -> /usr/bin/pilot-agent to match
+          # link /usr/local/bin/pilot-discovery -> /usr/bin/pilot-discovery to match
           # what the Istio Helm charts may expect.
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin
-          ln -sf /usr/bin/pilot-agent ${{targets.subpkgdir}}/usr/local/bin/pilot-agent
+          ln -sf /usr/bin/pilot-discovery ${{targets.subpkgdir}}/usr/local/bin/pilot-discovery
     dependencies:
       provides:
-        - istio-pilot-agent-compat=1.19.999
+        - istio-discovery-compat=1.19
 
 update:
   enabled: true


### PR DESCRIPTION
* "istio-pilot-discovery-1.18, 1.19: new package for Istio controller binary"

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

