### PR TITLE
jq: migrate to jqlang/jq and update to 1.7

### DIFF
--- a/jq.yaml
+++ b/jq.yaml
@@ -1,7 +1,7 @@
 package:
   name: jq
-  version: 1.6
-  epoch: 2
+  version: 1.7
+  epoch: 0
   description: "a lightweight and flexible JSON processor"
   copyright:
     - license: MIT
@@ -18,8 +18,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://github.com/stedolan/jq/releases/download/jq-${{package.version}}/jq-${{package.version}}.tar.gz
-      expected-sha256: 5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72
+      uri: https://github.com/jqlang/jq/releases/download/jq-${{package.version}}/jq-${{package.version}}.tar.gz
+      expected-sha256: 402a0d6975d946e6f4e484d1a84320414a0ff8eb6cf49d2c11d144d4d344db62
 
   - uses: autoconf/configure
 


### PR DESCRIPTION
Fixes:
* Possibly #4678

Related:
* https://github.com/jqlang/jq/releases/tag/jq-1.7

The `jq` tool has migrated from https://github.com/stedolan/jq to https://github.com/jqlang/jq and the first new release in many years is available.
