### PR TITLE
Add libjudy 1.0.5

### DIFF
--- a/libjudy.yaml
+++ b/libjudy.yaml
@@ -1,0 +1,57 @@
+package:
+  name: libjudy
+  version: 1.0.5
+  epoch: 0
+  description: "Judy is a general purpose dynamic array implemented as a C callable library"
+  copyright:
+    - license: LGPL-2.1-or-later
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - busybox
+      - build-base
+      - libtool
+      - linux-headers
+      - m4
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://sourceforge.net/projects/judy/files/judy/Judy-${{package.version}}/Judy-${{package.version}}.tar.gz
+      expected-sha256: d2704089f85fdb6f2cd7e77be21170ced4b4375c03ef1ad4cf1075bd414a63eb
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --infodir=/usr/share/info \
+        --localstatedir=/var
+
+  - uses: autoconf/make
+    with:
+      opts: -j1
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: libjudy-dev
+    pipeline:
+      - uses: split/dev
+    description: libjudy dev
+
+  - name: libjudy-doc
+    pipeline:
+      - uses: split/manpages
+      - uses: split/infodir
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 23331


### PR DESCRIPTION
judy is a C library for creating and working with dynamic arrays. I've packaged it here to get `stress-ng` built with a complete set of dependencies.

### Pre-review Checklist


#### For new package PRs only
  - [X] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
