### PR TITLE
Add patch for CVE-2023-4807 to openssl.

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.1.2
-  epoch: 0
+  epoch: 1
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -37,6 +37,10 @@ pipeline:
     with:
       uri: https://www.openssl.org/source/openssl-${{package.version}}.tar.gz
       expected-sha256: a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539
+
+  - uses: patch
+    with:
+      patches: CVE-2023-4807.patch
 
   - name: Configure and build
     runs: |

--- a/openssl/CVE-2023-4807.patch
+++ b/openssl/CVE-2023-4807.patch
@@ -1,0 +1,45 @@
+From 4bfac4471f53c4f74c8d81020beb938f92d84ca5 Mon Sep 17 00:00:00 2001
+From: Bernd Edlinger <bernd.edlinger@hotmail.de>
+Date: Tue, 22 Aug 2023 16:07:30 +0200
+Subject: [PATCH] Avoid clobbering non-volatile XMM registers
+
+This affects some Poly1305 assembler functions
+which are only used for certain CPU types.
+
+Remove those functions for Windows targets,
+as a simple interim solution.
+
+Fixes #21522
+
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Paul Dale <pauli@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/21808)
+
+(cherry picked from commit 7b8e27bc2e02238986d89ef0ece067ec1b48e165)
+---
+ crypto/poly1305/asm/poly1305-x86_64.pl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/poly1305/asm/poly1305-x86_64.pl b/crypto/poly1305/asm/poly1305-x86_64.pl
+index fa9bfb7a7b81..24bab9d0bcf9 100755
+--- a/crypto/poly1305/asm/poly1305-x86_64.pl
++++ b/crypto/poly1305/asm/poly1305-x86_64.pl
+@@ -195,7 +195,7 @@ sub poly1305_iteration {
+ 	bt	\$`5+32`,%r9		# AVX2?
+ 	cmovc	%rax,%r10
+ ___
+-$code.=<<___	if ($avx>3);
++$code.=<<___	if ($avx>3 && !$win64);
+ 	mov	\$`(1<<31|1<<21|1<<16)`,%rax
+ 	shr	\$32,%r9
+ 	and	%rax,%r9
+@@ -2724,7 +2724,7 @@ sub poly1305_iteration {
+ .cfi_endproc
+ .size	poly1305_blocks_avx512,.-poly1305_blocks_avx512
+ ___
+-if ($avx>3) {
++if ($avx>3 && !$win64) {
+ ########################################################################
+ # VPMADD52 version using 2^44 radix.
+ #
+


### PR DESCRIPTION
This is probably unnecessary given it only seems to apply to windows, but it's harmless.

Fixes:

Related:

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

