### PR TITLE
Switch jq to github updates instead of release-monitor.

### DIFF
--- a/jq.yaml
+++ b/jq.yaml
@@ -32,9 +32,6 @@ subpackages:
     description: "headers for libjq"
     pipeline:
       - uses: split/dev
-    dependencies:
-      runtime:
-        - jq
 
   - name: "jq-doc"
     description: "jq documentation"
@@ -43,5 +40,7 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 13252
+  github:
+    identifier: jqlang/jq
+    strip-prefix: jq-
+    tag-filter: jq-


### PR DESCRIPTION
We now build from a new github repo which is "official", use that for update checks!

Avoiding epoch bump on purpose.

Fixes:

Related:

### Pre-review Checklist
