### PR TITLE
Add libgcc as a runtime dependency to stunnel.

### DIFF
--- a/stunnel.yaml
+++ b/stunnel.yaml
@@ -1,10 +1,13 @@
 package:
   name: stunnel
   version: 5.70
-  epoch: 0
+  epoch: 1
   description: SSL encryption wrapper between network client and server
   copyright:
     - license: GPL-2.0-or-later with OpenSSL exception
+  dependencies:
+    runtime:
+      - libgcc # This isn't detected by melange for some reason
 
 environment:
   contents:


### PR DESCRIPTION
This isn't detected by melange, but the program fails with:

```
stunnel
libgcc_s.so.1 must be installed for pthread_exit to work
Aborted
```
without it.


Fixes:

Related:

### Pre-review Checklist
