### PR TITLE
feat: upgrade version of perl-libwww

### DIFF
--- a/perl-libwww.yaml
+++ b/perl-libwww.yaml
@@ -1,6 +1,6 @@
 package:
   name: perl-libwww
-  version: 6.70
+  version: 6.72
   epoch: 0
   description: The World-Wide Web library for Perl
   copyright:
@@ -46,19 +46,16 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 34f00d2344757b9c0b55ad35808d53e93d7d92f7a464ec837fe6a73c51fb5969
-      uri: https://cpan.metacpan.org/authors/id/S/SI/SIMBABQUE/libwww-perl-${{package.version}}.tar.gz
+      expected-sha512: 2dd7052e2105b7bc8abe81742707e6a9aa9891316755171c275e8f547c65f97354a133027eeac93f1a1657ae986bdd9a74a9c887518acb8b5ea634e96910e57d
+      uri: https://cpan.metacpan.org/authors/id/O/OA/OALDERS/libwww-perl-${{package.version}}.tar.gz
 
-  - runs: |
-      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
-      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+  - uses: perl/make
 
   - uses: autoconf/make
 
   - uses: autoconf/make-install
 
-  - runs: |
-      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+  - uses: perl/cleanup
 
   - uses: strip
 


### PR DESCRIPTION
Bump `perl-libwww` to v6.72 and replace repetitive commands with the newly created built-in pipelines.

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
- [ ] ~Patch source: _patch source here_~ _(not applicable)_
