### PR TITLE
feat: bump perl-uri to v5.20 and use built-in pipelines

### DIFF
--- a/perl-uri.yaml
+++ b/perl-uri.yaml
@@ -1,6 +1,6 @@
 package:
   name: perl-uri
-  version: 5.19
+  version: 5.20
   epoch: 0
   description: Uniform Resource Identifiers (absolute and relative)
   copyright:
@@ -20,19 +20,16 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 8fed5f819905c8a8e18f4447034322d042c3536b43c13ac1f09ba92e1a50a394
-      uri: https://cpan.metacpan.org/authors/id/S/SI/SIMBABQUE/URI-${{package.version}}.tar.gz
+      expected-sha512: d9a92a4dfffbf9ada50165d66dc958487baa3d518c871daaa1c135995ca7f03e3ed2c5f9c7e8301abf1350c1c99d2afcd95db58e5d2eab8c7441ecb3dd621464
+      uri: https://cpan.metacpan.org/authors/id/O/OA/OALDERS/URI-${{package.version}}.tar.gz
 
-  - runs: |
-      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
-      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+  - uses: perl/make
 
   - uses: autoconf/make
 
   - uses: autoconf/make-install
 
-  - runs: |
-      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+  - uses: perl/cleanup
 
   - uses: strip
 


### PR DESCRIPTION
Bump version of perl-uri to v5.20 (latest on release-monitoring.org) and use built-in pipelines instead of repetitive commands.

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
- [ ] ~Patch source: _patch source here_~ _(not applicable)_
