### PR TITLE
added berg 0.3.5: new package

### DIFF
--- a/berg.yaml
+++ b/berg.yaml
@@ -24,7 +24,7 @@ pipeline:
   - name: Configure and build
     runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin
-      cargo build --all-features
+      cargo build --all-features --release
       install -m755 target/release/berg "${{targets.destdir}}"/usr/bin/
 
   - uses: strip

--- a/berg.yaml
+++ b/berg.yaml
@@ -1,0 +1,33 @@
+package:
+  name: berg
+  version: 0.3.5
+  epoch: 0
+  description: "CLI Tool for Codeberg similar to gh and glab"
+  copyright:
+    - license: AGPL-3.0-only
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - build-base
+      - openssl-dev
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://codeberg.org/RobWalt/codeberg-cli/
+      tag: v${{package.version}}
+      expected-commit: b1850444bef36a16bb9512e73802d7ca2151a0bf
+
+  - name: Configure and build
+    runs: |
+      mkdir -p "${{targets.destdir}}"/usr/bin
+      cargo build --all-features
+      install -m755 target/debug/berg "${{targets.destdir}}"/usr/bin/
+
+  - uses: strip
+
+update:
+  enabled: false #hosted on codeberg and not present at release-monitoring.org. but #1566 is open to provide support for it in the future.

--- a/berg.yaml
+++ b/berg.yaml
@@ -25,7 +25,7 @@ pipeline:
     runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin
       cargo build --all-features
-      install -m755 target/debug/berg "${{targets.destdir}}"/usr/bin/
+      install -m755 target/release/berg "${{targets.destdir}}"/usr/bin/
 
   - uses: strip
 


### PR DESCRIPTION
### Pre-review Checklist
#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

Note:
- The package is hosted at codeberg.org and not present at release-monitoring.org. However, there's an issue (1566) present at the infra repository to add support for it in the future