### PR TITLE
q 0.12.0: new version and updated build instructions

### DIFF
--- a/q.yaml
+++ b/q.yaml
@@ -1,7 +1,7 @@
 package:
   name: q
   version: 0.12.0
-  epoch: 0
+  epoch: 1
   description: "A tiny command line DNS client with support for UDP, TCP, DoT, DoH, DoQ and ODoH."
   copyright:
     - license: GPL-3.0-only
@@ -11,7 +11,7 @@ environment:
     packages:
       - wolfi-base
       - build-base
-      - go~1.20
+      - go
 
 pipeline:
   - uses: git-checkout

--- a/q.yaml
+++ b/q.yaml
@@ -1,6 +1,6 @@
 package:
   name: q
-  version: 0.11.4
+  version: 0.12.0
   epoch: 0
   description: "A tiny command line DNS client with support for UDP, TCP, DoT, DoH, DoQ and ODoH."
   copyright:
@@ -18,13 +18,13 @@ pipeline:
     with:
       repository: https://github.com/natesales/q
       tag: v${{package.version}}
-      expected-commit: 83c169f40f0895ae4b5b210f20b0a46fda2e0d9d
+      expected-commit: 20119b4c88d1af96acd0a4c4dceb3082c80d28c3
 
   - name: Configure and build
     runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin
       # build package as requested by the upstream author
-      go build -ldflags="-s -w -X main.version=v${{package.version}} -X main.commit=$(git rev-parse --verify HEAD) -X main.date=$(date -Idate)"
+      go build -ldflags="-s -w -X main.version=v${{package.version}}"
       install -m755 q "${{targets.destdir}}"/usr/bin/
 
   - uses: strip


### PR DESCRIPTION
#### For version bump PRs
- [x] The `epoch` field is reset to 0
- [x] Patch source: https://github.com/natesales/q/archive/refs/tags/v0.12.0.tar.gz
