### PR TITLE
libmcrypt-2.5.8: Add new package

### DIFF
--- a/libmcrypt.yaml
+++ b/libmcrypt.yaml
@@ -1,0 +1,63 @@
+# cribbed from: https://git.alpinelinux.org/aports/tree/community/libmcrypt/APKBUILD
+package:
+  name: libmcrypt
+  version: 2.5.8
+  epoch: 0
+  description: "A library which provides a uniform interface to several symmetric encryption algorithms"
+  copyright:
+    - license: LGPL-2.1-or-later
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - build-base
+      - binutils
+      - busybox
+      - libtool
+      - automake
+      - autoconf
+      - libtool
+      - gcc
+      - cmake
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://downloads.sourceforge.net/mcrypt/libmcrypt-${{package.version}}.tar.bz2
+      expected-sha512: 6c05c42767401d66af67b0922b207d17cdb1c3efdbfdfb5b0c2e651821c48a8a6c6749debfa0206091b8a801f538fabe9f7d95ebc86d82c6b84c8001031d50fe
+
+  - runs: |
+      # There are two awful hacks here that I can't figure out how to fix:
+      # 1. For some reason this file does not get copied to the right place
+      # manually copy it.
+      mkdir -p libltdl/\$with_auxdir
+      cp ltmain.sh libltdl/\$with_auxdir/
+      autoreconf -v -i --force
+      # 2. These are undefined and they break the configure.
+      sed -i -e '/AC_REQUIRE/d' configure.in
+      sed -i -e '/_LT_CONFIG_LTDL_DIR/d' configure.in
+
+  - name: Configure
+    runs: |
+      ./configure \
+        --build=$CBUILD \
+        --host=$CHOST \
+        --prefix=/usr \
+        --mandir=/usr/share/man \
+        --disable-posix-threads
+
+  - uses: autoconf/make
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: "libmcrypt-dev"
+    description: "headers for libmcrypt"
+    pipeline:
+      - uses: split/dev
+  - name: "libmcrypt-doc"
+    description: "libmcrypt manpages"
+    pipeline:
+      - uses: split/manpages

--- a/libmcrypt.yaml
+++ b/libmcrypt.yaml
@@ -26,6 +26,10 @@ pipeline:
       uri: https://downloads.sourceforge.net/mcrypt/libmcrypt-${{package.version}}.tar.bz2
       expected-sha512: 6c05c42767401d66af67b0922b207d17cdb1c3efdbfdfb5b0c2e651821c48a8a6c6749debfa0206091b8a801f538fabe9f7d95ebc86d82c6b84c8001031d50fe
 
+  - uses: patch
+    with:
+      patches: fix-enigma.patch
+
   - runs: |
       # There are two awful hacks here that I can't figure out how to fix:
       # 1. For some reason this file does not get copied to the right place
@@ -47,6 +51,7 @@ pipeline:
         --disable-posix-threads
 
   - uses: autoconf/make
+
   - uses: autoconf/make-install
 
   - uses: strip
@@ -56,6 +61,7 @@ subpackages:
     description: "headers for libmcrypt"
     pipeline:
       - uses: split/dev
+
   - name: "libmcrypt-doc"
     description: "libmcrypt manpages"
     pipeline:

--- a/libmcrypt.yaml
+++ b/libmcrypt.yaml
@@ -14,7 +14,6 @@ environment:
       - build-base
       - binutils
       - busybox
-      - libtool
       - automake
       - autoconf
       - libtool
@@ -61,3 +60,9 @@ subpackages:
     description: "libmcrypt manpages"
     pipeline:
       - uses: split/manpages
+
+# https://release-monitoring.org/project/10765/
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10765

--- a/libmcrypt/fix-enigma.patch
+++ b/libmcrypt/fix-enigma.patch
@@ -1,0 +1,18 @@
+--- src/modules/algorithms/enigma.h.orig	2002-03-09 21:17:08.000000000 +0100
++++ src/modules/algorithms/enigma.h	2019-04-07 13:54:03.000000000 +0200
+@@ -3,11 +3,11 @@
+ #define MASK 0377
+ 
+ typedef struct crypt_key {
+-	char t1[ROTORSZ];
+-	char t2[ROTORSZ];
+-	char t3[ROTORSZ];
+-	char deck[ROTORSZ];
+-	char cbuf[13];
++	signed char t1[ROTORSZ];
++	signed char t2[ROTORSZ];
++	signed char t3[ROTORSZ];
++	signed char deck[ROTORSZ];
++	signed char cbuf[13];
+ 	int n1, n2, nr1, nr2;
+ } CRYPT_KEY;


### PR DESCRIPTION
This is needed for some other packages. This is a draft to get some feedback, and I need to sort how to get a patch in there as well.

tested with:
```
7b260f9bfffd:/work/packages# apk add libmcrypt libmcrypt-dev libmcrypt-doc
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/3) Installing libmcrypt (2.5.8-r0)
(2/3) Installing libmcrypt-dev (2.5.8-r0)
(3/3) Installing libmcrypt-doc (2.5.8-r0)
OK: 12 MiB in 17 packages
7b260f9bfffd:/work/packages# apk info -L libmcrypt libmcrypt-dev libmcrypt-doc
libmcrypt-2.5.8-r0 contains:
usr/lib/libmcrypt.so.4
usr/lib/libmcrypt.so.4.4.8
var/lib/db/sbom/libmcrypt-2.5.8-r0.spdx.json

libmcrypt-dev-2.5.8-r0 contains:
usr/bin/libmcrypt-config
usr/include/mcrypt.h
usr/include/mutils/mcrypt.h
usr/lib/libmcrypt.so
usr/share/aclocal/libmcrypt.m4
var/lib/db/sbom/libmcrypt-dev-2.5.8-r0.spdx.json

libmcrypt-doc-2.5.8-r0 contains:
usr/share/man/man3/mcrypt.3
var/lib/db/sbom/libmcrypt-doc-2.5.8-r0.spdx.json
```


