### PR TITLE
include phpize in php-dev, version subpackages.

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,13 +1,13 @@
 package:
   name: php-8.1
   version: 8.1.23
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
   dependencies:
     provides:
-      - php=${{package.full-version}}
+      - php=${{package.version}}-r${{package.epoch}}}
     runtime:
       - libxml2
 
@@ -177,6 +177,9 @@ subpackages:
   - range: extensions
     name: "php-${{range.key}}"
     description: "The ${{range.value}} extension"
+    dependencies:
+      provides:
+        - php-8.1-${{range.key}}=${{package.version}}-r${{package.epoch}}
     pipeline:
       - runs: |
           export EXTENSIONS_DIR=usr/lib/php/modules
@@ -190,11 +193,20 @@ subpackages:
 
   - name: php-dev
     description: PHP 8.1 development headers
+    dependencies:
+      provides:
+        - ${{package.name}}-dev=${{package.version}}-r${{package.epoch}}
     pipeline:
       - uses: split/dev
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/phpize ${{targets.subpkgdir}}/usr/bin/
 
   - name: php-cgi
     description: PHP 8.1 CGI
+    dependencies:
+      provides:
+        - ${{package.name}}-cgi=${{package.version}}-r${{package.epoch}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -202,6 +214,9 @@ subpackages:
 
   - name: php-dbg
     description: Interactive PHP Debugger
+    dependencies:
+      provides:
+        - ${{package.name}}-dbg=${{package.version}}-r${{package.epoch}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -209,6 +224,9 @@ subpackages:
 
   - name: php-fpm
     description: PHP 8.1 FastCGI Process Manager (FPM)
+    dependencies:
+      provides:
+        - ${{package.name}}-fpm=${{package.version}}-r${{package.epoch}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/sbin ${{targets.subpkgdir}}/etc/php/php-fpm.d

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,46 +1,46 @@
 package:
   name: php-8.2
   version: 8.2.10
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
   dependencies:
     provides:
-      - php=${{package.version}}-r${{package.epoch}}
+      - php=${{package.version}}-r${{package.epoch}}}
     runtime:
       - libxml2
 
 environment:
   contents:
     packages:
+      - bison
       - build-base
       - busybox
-      - file
-      - bison
-      - libtool
-      - ca-certificates-bundle
       - bzip2-dev
-      - libxml2-dev
+      - ca-certificates-bundle
       - curl-dev
-      - openssl-dev
-      - readline-dev
-      - sqlite-dev
-      - libsodium-dev
-      - libpng-dev
-      - libjpeg-turbo-dev
-      - libavif-dev
-      - libwebp-dev
-      - libxpm-dev
-      - libx11-dev
+      - file
       - freetype-dev
       - gmp-dev
       - icu-dev
-      - openldap-dev
-      - oniguruma-dev
+      - libavif-dev
+      - libjpeg-turbo-dev
+      - libpng-dev
+      - libsodium-dev
+      - libtool
+      - libwebp-dev
+      - libx11-dev
+      - libxml2-dev
+      - libxpm-dev
       - libxslt-dev
-      - postgresql-15-dev
       - libzip
+      - oniguruma-dev
+      - openldap-dev
+      - openssl-dev
+      - postgresql-15-dev
+      - readline-dev
+      - sqlite-dev
 
 pipeline:
   - uses: fetch
@@ -177,6 +177,9 @@ subpackages:
   - range: extensions
     name: "php-${{range.key}}"
     description: "The ${{range.value}} extension"
+    dependencies:
+      provides:
+        - php-8.2-${{range.key}}=${{package.version}}-r${{package.epoch}}
     pipeline:
       - runs: |
           export EXTENSIONS_DIR=usr/lib/php/modules
@@ -190,11 +193,20 @@ subpackages:
 
   - name: php-dev
     description: PHP 8.2 development headers
+    dependencies:
+      provides:
+        - ${{package.name}}-dev=${{package.version}}-r${{package.epoch}}
     pipeline:
       - uses: split/dev
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/phpize ${{targets.subpkgdir}}/usr/bin/
 
   - name: php-cgi
     description: PHP 8.2 CGI
+    dependencies:
+      provides:
+        - ${{package.name}}-cgi=${{package.version}}-r${{package.epoch}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -202,6 +214,9 @@ subpackages:
 
   - name: php-dbg
     description: Interactive PHP Debugger
+    dependencies:
+      provides:
+        - ${{package.name}}-dbg=${{package.version}}-r${{package.epoch}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -209,6 +224,9 @@ subpackages:
 
   - name: php-fpm
     description: PHP 8.2 FastCGI Process Manager (FPM)
+    dependencies:
+      provides:
+        - ${{package.name}}-fpm=${{package.version}}-r${{package.epoch}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/sbin ${{targets.subpkgdir}}/etc/php/php-fpm.d


### PR DESCRIPTION
Previously php-dev did not include the phpize even though it should, so add it.
run yam on 8.2, no changes, just sorts the packages.
**note** melange has not been updated, so _not_ using the ${{package.full-version}} because it's not properly expanded yet.
Also, version the subpackages, so that you can install a specific version. Tested with `make local-wolfi`:
```
f6bfde3e73b7:/work/packages# apk add php-8.1-dev
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/1) Installing php-dev (8.1.23-r2)
OK: 17 MiB in 15 packages
f6bfde3e73b7:/work/packages# phpize --version
Configuring for:
PHP Api Version:         20210902
Zend Module Api No:      20210902
Zend Extension Api No:   420210902

9c02c5b46406:/work/packages# apk add php-8.2-dev
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/1) Installing php-dev (8.2.10-r2)
OK: 17 MiB in 15 packages
9c02c5b46406:/work/packages# phpize --version
Configuring for:
PHP Api Version:         20220829
Zend Module Api No:      20220829
Zend Extension Api No:   420220829
```