### PR TITLE
Add /usr/lib files to the -dev subpackages too.

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: 8.1.23
-  epoch: 2
+  epoch: 3
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -201,6 +201,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/phpize ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/lib ${{targets.subpkgdir}}/usr
 
   - name: php-cgi
     description: PHP 8.1 CGI

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: 8.2.10
-  epoch: 2
+  epoch: 3
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -201,6 +201,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/phpize ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/lib ${{targets.subpkgdir}}/usr
 
   - name: php-cgi
     description: PHP 8.2 CGI


### PR DESCRIPTION
php-dev was still missing quite a few files from /usr/lib that are necessary to run phpize added in previous PR #5341 so add them here:

```
usr/lib/php/build/Makefile.global
usr/lib/php/build/ax_check_compile_flag.m4
usr/lib/php/build/ax_gcc_func_attribute.m4
usr/lib/php/build/config.guess
usr/lib/php/build/config.sub
usr/lib/php/build/gen_stub.php
usr/lib/php/build/libtool.m4
usr/lib/php/build/ltmain.sh
usr/lib/php/build/php.m4
usr/lib/php/build/php_cxx_compile_stdcxx.m4
usr/lib/php/build/phpize.m4
usr/lib/php/build/pkg.m4
usr/lib/php/build/run-tests.php
usr/lib/php/build/shtool
```
