### PR TITLE
fix cve GHSA-jm77-qphf-c4w8

### DIFF
--- a/py3-cryptography.yaml
+++ b/py3-cryptography.yaml
@@ -1,7 +1,7 @@
 # Generated from https://pypi.org/project/cryptography/
 package:
   name: py3-cryptography
-  version: 41.0.2
+  version: 41.0.3
   epoch: 0
   description: cryptography is a package which provides cryptographic recipes and primitives to Python developers.
   copyright:
@@ -31,7 +31,7 @@ pipeline:
     with:
       repository: https://github.com/pyca/cryptography/
       tag: ${{package.version}}
-      expected-commit: 7431db737cf0407560fac689d24f1d2e5efc349d
+      expected-commit: b22271cf3c3dd8dc8978f8f4b00b5c7060b6538d
 
   - name: Python Build
     runs: python setup.py build
@@ -45,3 +45,4 @@ update:
   enabled: true
   github:
     identifier: pyca/cryptography
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/advisories/GHSA-jm77-qphf-c4w8

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
