### PR TITLE
Add php-8.1-pecl-mcrypt, and php-8.1-pecl-mcrypt v1.0.6

### DIFF
--- a/php-8.1-pecl-mcrypt.yaml
+++ b/php-8.1-pecl-mcrypt.yaml
@@ -1,0 +1,52 @@
+package:
+  name: php-8.1-pecl-mcrypt
+  version: 1.0.6
+  epoch: 0
+  description: "Provides PHP 8.1 bindings for the unmaintained libmcrypt - PECL"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    provides:
+      - php-pecl-mcrypt=${{package.full-version}}
+    runtime:
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gcc
+      - libmcrypt-dev
+      - libtool
+      - php-8.1-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/mcrypt-${{package.version}}.tgz
+      expected-sha512: 506d5eb5b52aea6d48ab1800326fdd46af7992511bd9ac6604bb090d3724e058c936265da064cd6188bc0445d646a3678a7540498925ae7d119f821b2bd43880
+
+  - name: phpize and configure
+    runs: |
+      phpize
+      ./configure --prefix=/usr --with-php-config=php-config
+
+  - uses: autoconf/make
+
+  - name: Install
+    runs: |
+      make INSTALL_ROOT="${{targets.destdir}}" install
+      install -d ${{targets.destdir}}/etc/php81/conf.d
+      echo "extension=mcrypt" > ${{targets.destdir}}/etc/php81/conf.d/mcrypt.ini
+
+  - uses: strip
+
+# TODO(vaikas): I can't find in release-monitoring, or github.
+update:
+  enabled: false

--- a/php-8.2-pecl-mcrypt.yaml
+++ b/php-8.2-pecl-mcrypt.yaml
@@ -1,0 +1,52 @@
+package:
+  name: php-8.2-pecl-mcrypt
+  version: 1.0.6
+  epoch: 0
+  description: "Provides PHP 8.2 bindings for the unmaintained libmcrypt - PECL"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    provides:
+      - php-pecl-mcrypt=${{package.full-version}}
+    runtime:
+      - php-8.2
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gcc
+      - libmcrypt-dev
+      - libtool
+      - php-8.2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/mcrypt-${{package.version}}.tgz
+      expected-sha512: 506d5eb5b52aea6d48ab1800326fdd46af7992511bd9ac6604bb090d3724e058c936265da064cd6188bc0445d646a3678a7540498925ae7d119f821b2bd43880
+
+  - name: phpize and configure
+    runs: |
+      phpize
+      ./configure --prefix=/usr --with-php-config=php-config
+
+  - uses: autoconf/make
+
+  - name: Install
+    runs: |
+      make INSTALL_ROOT="${{targets.destdir}}" install
+      install -d ${{targets.destdir}}/etc/php82/conf.d
+      echo "extension=mcrypt" > ${{targets.destdir}}/etc/php82/conf.d/mcrypt.ini
+
+  - uses: strip
+
+# TODO(vaikas): I can't find in release-monitoring, or github.
+update:
+  enabled: false


### PR DESCRIPTION
Tested with `make dev-container`:
```
bd1dc764860d:/work/packages# apk add php-8.1-pecl-mcrypt
<SNIP>
bd1dc764860d:/work/packages# apk info -L php-8.1-pecl-mcrypt
php-8.1-pecl-mcrypt-1.0.6-r0 contains:
etc/php81/conf.d/mcrypt.ini
usr/lib/php/modules/mcrypt.so
var/lib/db/sbom/php-8.1-pecl-mcrypt-1.0.6-r0.spdx.json
```

And:
```
9b3670973916:/work/packages# apk add php-8.2-pecl-mcrypt
<SNIP>
9b3670973916:/work/packages# apk info -L php-8.2-pecl-mcrypt
php-8.2-pecl-mcrypt-1.0.6-r0 contains:
etc/php82/conf.d/mcrypt.ini
usr/lib/php/modules/mcrypt.so
var/lib/db/sbom/php-8.2-pecl-mcrypt-1.0.6-r0.spdx.json
```

And the files match:
https://pkgs.alpinelinux.org/contents?branch=edge&name=php82%2dpecl%2dmcrypt&arch=aarch64&repo=testing
https://pkgs.alpinelinux.org/contents?branch=edge&name=php81%2dpecl%2dmcrypt&arch=aarch64&repo=testing