### PR TITLE
Add php-8.1-pecl-mongodb, and php-8.1-pecl-mongodb v1.16.2

### DIFF
--- a/php-8.1-pecl-mongodb.yaml
+++ b/php-8.1-pecl-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-mongodb
   version: 1.16.2
-  epoch: 0
+  epoch: 1
   description: "PHP 8.1 MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
@@ -51,6 +51,7 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can't find in release-monitoring, or github.
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 11158

--- a/php-8.1-pecl-mongodb.yaml
+++ b/php-8.1-pecl-mongodb.yaml
@@ -1,0 +1,56 @@
+package:
+  name: php-8.1-pecl-mongodb
+  version: 1.16.2
+  epoch: 0
+  description: "PHP 8.1 MongoDB driver - PECL"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    provides:
+      - php-pecl-mongodb=${{package.full-version}}
+    runtime:
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - cyrus-sasl-dev
+      - gcc
+      - icu-dev
+      - libtool
+      - openssl-dev>3
+      - php-8.1-dev
+      - snappy-dev
+      - zstd-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/mongodb-${{package.version}}.tgz
+      expected-sha512: 3c81882c609b09cde534315aa4b1fe3c47e18e4ed26a940bf60a6bdbf4e53b2204d8e4e113a9b0a3469b60793ead9f8dff703920b86280e78448e07d6535a277
+
+  - name: phpize and configure
+    runs: |
+      phpize
+      ./configure --prefix=/usr --with-php-config=php-config
+
+  - uses: autoconf/make
+
+  - name: Install
+    runs: |
+      make INSTALL_ROOT="${{targets.destdir}}" install
+      install -d ${{targets.destdir}}/etc/php81/conf.d
+      echo "extension=mongodb" > ${{targets.destdir}}/etc/php81/conf.d/mongodb.ini
+
+  - uses: strip
+
+# TODO(vaikas): I can't find in release-monitoring, or github.
+update:
+  enabled: false

--- a/php-8.2-pecl-mongodb.yaml
+++ b/php-8.2-pecl-mongodb.yaml
@@ -1,0 +1,56 @@
+package:
+  name: php-8.2-pecl-mongodb
+  version: 1.16.2
+  epoch: 0
+  description: "PHP 8.2 MongoDB driver - PECL"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    provides:
+      - php-pecl-mongodb=${{package.full-version}}
+    runtime:
+      - php-8.2
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - cyrus-sasl-dev
+      - gcc
+      - icu-dev
+      - libtool
+      - openssl-dev>3
+      - php-8.2-dev
+      - snappy-dev
+      - zstd-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/mongodb-${{package.version}}.tgz
+      expected-sha512: 3c81882c609b09cde534315aa4b1fe3c47e18e4ed26a940bf60a6bdbf4e53b2204d8e4e113a9b0a3469b60793ead9f8dff703920b86280e78448e07d6535a277
+
+  - name: phpize and configure
+    runs: |
+      phpize
+      ./configure --prefix=/usr --with-php-config=php-config
+
+  - uses: autoconf/make
+
+  - name: Install
+    runs: |
+      make INSTALL_ROOT="${{targets.destdir}}" install
+      install -d ${{targets.destdir}}/etc/php82/conf.d
+      echo "extension=mongodb" > ${{targets.destdir}}/etc/php82/conf.d/mongodb.ini
+
+  - uses: strip
+
+# TODO(vaikas): I can't find in release-monitoring, or github.
+update:
+  enabled: false

--- a/php-8.2-pecl-mongodb.yaml
+++ b/php-8.2-pecl-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-mongodb
   version: 1.16.2
-  epoch: 0
+  epoch: 1
   description: "PHP 8.2 MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
@@ -51,6 +51,7 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can't find in release-monitoring, or github.
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 11158


### PR DESCRIPTION
FWIW, I'll see about creating a pecl build/install pipeline for the next one, seems fairly straightforward.

Tested with `make dev-container`:
```
3886571abe9f:/work/packages# apk add php-8.1-pecl-mongodb
<SNIP>
3886571abe9f:/work/packages# apk info -L php-8.1-pecl-mongodb
php-8.1-pecl-mongodb-1.16.2-r0 contains:
etc/php81/conf.d/mongodb.ini
usr/lib/php/modules/mongodb.so
var/lib/db/sbom/php-8.1-pecl-mongodb-1.16.2-r0.spdx.json

3886571abe9f:/work/packages# exit
vaikas@vaikas-MBP os % make local-wolfi
21a491ab27de:/work/packages# apk add php-8.2-pecl-mongodb
<SNIP>
21a491ab27de:/work/packages# apk info -L php-8.2-pecl-mongodb
php-8.2-pecl-mongodb-1.16.2-r0 contains:
etc/php82/conf.d/mongodb.ini
usr/lib/php/modules/mongodb.so
var/lib/db/sbom/php-8.2-pecl-mongodb-1.16.2-r0.spdx.json
```

And the files match:
https://pkgs.alpinelinux.org/contents?branch=edge&name=php81%2dpecl%2dmongodb&arch=aarch64&repo=community
https://pkgs.alpinelinux.org/contents?branch=edge&name=php82%2dpecl%2dmongodb&arch=aarch64&repo=community