### PR TITLE
new pkg: gn, teapot-tools, dart-stage0 and dart

### DIFF
--- a/dart-stage0.yaml
+++ b/dart-stage0.yaml
@@ -1,0 +1,58 @@
+package:
+  name: dart-stage0
+  version: 3.1.0
+  epoch: 0
+  description: "Dart is a client-optimized language for fast apps on any platform (temporary bootstrap package)"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - zip
+
+pipeline:
+  - assertions:
+      required-steps: 1
+    pipeline:
+      - if: ${{build.arch}} == 'x86_64'
+        uses: fetch
+        with:
+          uri: https://storage.googleapis.com/dart-archive/channels/stable/release/${{package.version}}/sdk/dartsdk-linux-x64-release.zip
+          expected-sha256: 7ce5c1560b1d8ea5ee0e6d44f1c3e7b804ddc5377b38d72fe4d43009a6c67e84
+          extract: false
+      - if: ${{build.arch}} == 'aarch64'
+        uses: fetch
+        with:
+          uri: https://storage.googleapis.com/dart-archive/channels/stable/release/${{package.version}}/sdk/dartsdk-linux-arm64-release.zip
+          expected-sha256: fd4fcc05f1d1c82fd618b83c7d877968460c5bd425774d89add438be12a20795
+          extract: false
+
+  - if: ${{build.arch}} == 'x86_64'
+    runs: |
+      unzip dartsdk-linux-x64-release.zip
+
+  - if: ${{build.arch}} == 'aarch64'
+    runs: |
+      unzip dartsdk-linux-arm64-release.zip
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/lib
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/usr/include
+
+      mv dart-sdk ${{targets.destdir}}/usr/lib/dart
+
+  - runs: |
+      ln -s /usr/lib/dart/bin/dart "${{targets.destdir}}"/usr/bin/dart
+      ln -s /usr/lib/dart/bin/dart "${{targets.destdir}}"/usr/bin/dartaotruntime
+      ln -s /usr/lib/dart/include "${{targets.destdir}}"/usr/include/dart
+
+  - uses: strip
+
+update:
+  enabled: false # don't auto update stage 0 packages

--- a/dart.yaml
+++ b/dart.yaml
@@ -50,7 +50,7 @@ pipeline:
       patch '-p1' < gcc-13.patch
       patch '-p1' < build-config.patch
 
-  - working-directory: sdk
+  - working-directory: /home/build/sdk
     runs: |
       rm -rf tools/sdks/dart-sdk
       ln -s /usr/lib/dart tools/sdks/dart-sdk

--- a/dart.yaml
+++ b/dart.yaml
@@ -42,13 +42,10 @@ pipeline:
 
       gclient sync --no-history --nohooks --tpot-cipd-ignore-platformed
 
-  # apply patches (src is in sdk folder hence we cannot use patch action from melange)
-  - runs: |
-      cp -R *.patch sdk/
-      cd sdk
-      patch '-p1' < no-werror.patch
-      patch '-p1' < gcc-13.patch
-      patch '-p1' < build-config.patch
+  - working-directory: /home/build/sdk
+    uses: patch
+    with:
+      patches: /home/build/no-werror.patch /home/build/gcc-13.patch /home/build/build-config.patch
 
   - working-directory: /home/build/sdk
     runs: |

--- a/dart.yaml
+++ b/dart.yaml
@@ -71,7 +71,7 @@ pipeline:
         ln -sf /usr/bin/$i /usr/bin/aarch64-linux-gnu-$i
       done
 
-  - working-directory: sdk
+  - working-directory: /home/build/sdk
     runs: |
       # default LDFLAGS cause an issue with dart. We need to remove '-z, noexecheap' from LDFLAGS
       LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"

--- a/dart.yaml
+++ b/dart.yaml
@@ -119,7 +119,7 @@ subpackages:
   - name: "dart-sdk"
     description: "dart SDK"
     pipeline:
-      - working-directory: sdk
+      - working-directory: /home/build/sdk
         runs: |
           case ${{build.arch}} in
             aarch64)

--- a/dart.yaml
+++ b/dart.yaml
@@ -1,0 +1,142 @@
+package:
+  name: dart
+  version: 3.1.1
+  epoch: 0
+  description: "Dart is a client-optimized language for fast apps on any platform"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - dart-stage0
+      - gcc
+      - git
+      - gn
+      - llvm-lld-16
+      - llvm16
+      - patch
+      - python-3.11
+      - samurai
+      - teapot-tools
+      - zip
+      - zlib-dev
+      - zstd
+
+pipeline:
+  - runs: |
+      cat <<EOT >> .gclient
+      solutions = [{
+        'name': 'sdk',
+        'url': 'https://dart.googlesource.com/sdk.git@${{package.version}}',
+      }]
+      target_cpu = ['x64', 'arm64']
+      target_cpu_only = True
+      EOT
+
+      gclient sync --no-history --nohooks --tpot-cipd-ignore-platformed
+
+  # apply patches (src is in sdk folder hence we cannot use patch action from melange)
+  - runs: |
+      cp -R *.patch sdk/
+      cd sdk
+      patch '-p1' < no-werror.patch
+      patch '-p1' < gcc-13.patch
+      patch '-p1' < build-config.patch
+
+  - working-directory: sdk
+    runs: |
+      rm -rf tools/sdks/dart-sdk
+      ln -s /usr/lib/dart tools/sdks/dart-sdk
+
+      mkdir -p buildtools/ninja
+      ln -s /usr/bin/gn buildtools/gn
+      ln -s /usr/bin/samu buildtools/ninja/ninja
+
+      python3 tools/generate_package_config.py
+      python3 tools/generate_sdk_version_file.py
+
+      echo '' > tools/bots/dartdoc_footer.html
+      rm third_party/devtools/web/devtools_analytics.js
+
+  - if: ${{build.arch}} == "aarch64"
+    runs: |
+      for i in gcc g++ strip ar; do
+        ln -sf /usr/bin/$i /usr/bin/aarch64-linux-gnu-$i
+      done
+
+  - working-directory: sdk
+    runs: |
+      # default LDFLAGS cause an issue with dart. We need to remove '-z, noexecheap' from LDFLAGS
+      LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"
+
+      export gn_args="
+        create_kernel_service_snapshot=true
+        dart_snapshot_kind=\"app-jit\"
+        dart_sysroot=\"\"
+        dart_use_tcmalloc=false
+      "
+      case ${{build.arch}} in
+        aarch64)
+          _arch=arm64
+          _out="$(pwd)/out/ReleaseARM64"
+          ;;
+        x86_64)
+          _arch=x64
+          _out="$(pwd)/out/ReleaseX64"
+          ;;
+        *)
+          echo "unsupported arch"
+          exit -1
+          ;;
+      esac
+
+      python3 ./tools/build.py \
+        --no-clang \
+        --arch="$_arch" \
+        --mode=release \
+        --no-goma \
+        --no-verify-sdk-hash \
+        --gn-args="$(echo $gn_args)" \
+        create_sdk runtime
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/usr/include
+
+      ln -s ../lib/dart/include ${{targets.destdir}}/usr/include/dart
+      ln -s ../lib/dart/bin/dart ${{targets.destdir}}/usr/bin/dart
+      ln -s ../lib/dart/bin/dartaotruntime ${{targets.destdir}}/usr/bin/dartaotruntime
+
+  - uses: strip
+
+subpackages:
+  - name: "dart-sdk"
+    description: "dart SDK"
+    pipeline:
+      - working-directory: sdk
+        runs: |
+          case ${{build.arch}} in
+            aarch64)
+              _out="$(pwd)/out/ReleaseARM64"
+              ;;
+            x86_64)
+              _out="$(pwd)/out/ReleaseX64"
+              ;;
+            *)
+              echo "unsupported arch"
+              exit -1
+              ;;
+          esac
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          cp -r "$_out"/dart-sdk ${{targets.subpkgdir}}/usr/lib/dart
+
+# turn off for now, since wolfictl doesnt seem to support tag filter regex yet (we only want major release, not -dev suffix tag)
+update:
+  enabled: false

--- a/dart/build-config.patch
+++ b/dart/build-config.patch
@@ -1,0 +1,20 @@
+--- ./build/config/linux/BUILD.gn.orig
++++ ./build/config/linux/BUILD.gn
+@@ -13,14 +13,9 @@
+     ldflags += [ "-Wl,--exclude-libs=libc++.a" ]
+   }
+ 
+-  # Explicitly use static linking for libstdc++ and libgcc to minimize
+-  # dependencies.
+-  if (!use_flutter_cxx) {
+-    ldflags += [
+-      "-static-libgcc",
+-      "-static-libstdc++",
+-    ]
+-  }
++  ldflags += [ "-L/lib", "-fuse-ld=lld" ]
++  ldflags += string_split(getenv("LDFLAGS"), " ")
++  cflags += string_split(getenv("CFLAGS"), " ")
+ 
+   if (sysroot != "") {
+     cflags += [ "--sysroot=" + sysroot ]

--- a/dart/gcc-13.patch
+++ b/dart/gcc-13.patch
@@ -1,0 +1,40 @@
+--- a/runtime/bin/ffi_test/ffi_test_functions_generated.cc
++++ b/runtime/bin/ffi_test/ffi_test_functions_generated.cc
+@@ -11,6 +11,7 @@
+ #include <sys/types.h>
+ 
+ #include <cmath>
++#include <cstdint>
+ #include <iostream>
+ #include <limits>
+ 
+--- a/runtime/bin/ffi_test/ffi_test_functions.cc
++++ b/runtime/bin/ffi_test/ffi_test_functions.cc
+@@ -13,6 +13,7 @@
+ #include <sys/types.h>
+ 
+ #include <cmath>
++#include <cstdint>
+ #include <iostream>
+ #include <limits>
+ 
+--- a/runtime/bin/ffi_test/ffi_test_dynamic_library.cc
++++ b/runtime/bin/ffi_test/ffi_test_dynamic_library.cc
+@@ -2,6 +2,7 @@
+ // for details. All rights reserved. Use of this source code is governed by a
+ // BSD-style license that can be found in the LICENSE file.
+ 
++#include <cstdint>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <iostream>
+--- ./third_party/perfetto/include/perfetto/ext/base/uuid.h.orig
++++ ./third_party/perfetto/include/perfetto/ext/base/uuid.h
+@@ -18,6 +18,7 @@
+ #define INCLUDE_PERFETTO_EXT_BASE_UUID_H_
+ 
+ #include <array>
++#include <cstdint>
+ #include <string>
+ 
+ #include "perfetto/ext/base/optional.h"

--- a/dart/no-werror.patch
+++ b/dart/no-werror.patch
@@ -1,0 +1,13 @@
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -672,10 +672,6 @@
+       "-Wextra",
+     ]
+ 
+-    if (dart_sysroot != "alpine") {
+-      cflags += [ "-Werror" ]
+-    }
+-
+     defines = []
+     if (!using_sanitizer && !is_clang) {
+       # _FORTIFY_SOURCE isn't really supported by Clang now, see

--- a/gn.yaml
+++ b/gn.yaml
@@ -1,0 +1,54 @@
+package:
+  name: gn
+  version: 0_git20230709
+  epoch: 0
+  description: "Meta-build system that generates build files for Ninja"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang-15
+      - clang-15-default
+      - git
+      - patch
+      - python-3.11
+      - samurai
+
+vars:
+  COMMIT_HASH: "fae280eabe5d31accc53100137459ece19a7a295"
+
+pipeline:
+  - runs: |
+      git clone https://gn.googlesource.com/gn --recursive --depth 9999
+      cd gn
+      git checkout -q ${{vars.COMMIT_HASH}}
+
+  - runs: |
+      cp -R *.patch gn/
+      cd gn
+      patch '-p1' < lfs64.patch
+
+  - working-directory: gn
+    runs: |
+      python3 ./build/gen.py \
+      --no-static-libstdc++ \
+      --no-strip \
+      --allow-warnings
+
+      ninja -C out
+
+  - working-directory: gn
+    runs: |
+      install -Dm755 out/gn "${{targets.destdir}}"/usr/bin/gn
+
+  - uses: strip
+
+update:
+  enabled: false # no release or tag

--- a/gn/lfs64.patch
+++ b/gn/lfs64.patch
@@ -1,0 +1,39 @@
+diff --git a/src/base/files/file.h b/src/base/files/file.h
+index 82c4f9e..4234399 100644
+--- a/src/base/files/file.h
++++ b/src/base/files/file.h
+@@ -21,7 +21,7 @@
+ 
+ namespace base {
+ 
+-#if defined(OS_BSD) || defined(OS_MACOSX) || defined(OS_NACL) || \
++#if 1 || defined(OS_BSD) || defined(OS_MACOSX) || defined(OS_NACL) || \
+     defined(OS_HAIKU) || defined(OS_MSYS) || defined(OS_ZOS) ||  \
+     defined(OS_ANDROID) && __ANDROID_API__ < 21 || defined(OS_SERENITY)
+ typedef struct stat stat_wrapper_t;
+diff --git a/src/base/files/file_posix.cc b/src/base/files/file_posix.cc
+index e837b69..52b838f 100644
+--- a/src/base/files/file_posix.cc
++++ b/src/base/files/file_posix.cc
+@@ -24,7 +24,7 @@ static_assert(File::FROM_BEGIN == SEEK_SET && File::FROM_CURRENT == SEEK_CUR &&
+ 
+ namespace {
+ 
+-#if defined(OS_BSD) || defined(OS_MACOSX) || defined(OS_NACL) || \
++#if 1 || defined(OS_BSD) || defined(OS_MACOSX) || defined(OS_NACL) || \
+     defined(OS_HAIKU) || defined(OS_MSYS) || defined(OS_ZOS) || \
+     defined(OS_ANDROID) && __ANDROID_API__ < 21 || defined(OS_SERENITY)
+ int CallFstat(int fd, stat_wrapper_t* sb) {
+diff --git a/src/base/files/file_util_posix.cc b/src/base/files/file_util_posix.cc
+index 08de845..d8a7508 100644
+--- a/src/base/files/file_util_posix.cc
++++ b/src/base/files/file_util_posix.cc
+@@ -59,7 +59,7 @@ namespace base {
+ 
+ namespace {
+ 
+-#if defined(OS_BSD) || defined(OS_MACOSX) || defined(OS_NACL) || \
++#if 1 || defined(OS_BSD) || defined(OS_MACOSX) || defined(OS_NACL) || \
+     defined(OS_HAIKU) || defined(OS_MSYS) || defined(OS_ZOS) ||  \
+     defined(OS_ANDROID) && __ANDROID_API__ < 21 || defined(OS_SERENITY)
+ int CallStat(const char* path, stat_wrapper_t* sb) {

--- a/teapot-tools.yaml
+++ b/teapot-tools.yaml
@@ -1,0 +1,39 @@
+package:
+  name: teapot-tools
+  version: 0.4.2
+  epoch: 0
+  description: "Replacement for depot_tools (gclient) and luci-go (cipd)"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - rust
+      - openssl-dev
+      - protoc
+      - protobuf-dev
+      - python-3.11-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://codeberg.org/selfisekai/teapot_tools/archive/v${{package.version}}.tar.gz
+      expected-sha256: d01337c3745b0ae4d2e2b3e5bf80490bb54d234b35317486313b53c53f9dafea
+
+  - runs: |
+      cargo fetch
+      cargo build --frozen --release --bin gclient
+      cargo build --frozen --release --bin download_from_google_storage
+
+  - runs: |
+      install -Dm755 target/release/gclient "${{targets.destdir}}"/usr/bin/gclient
+      install -Dm755 target/release/download_from_google_storage "${{targets.destdir}}"/usr/bin/download_from_google_storage
+
+  - uses: strip
+
+update:
+  enabled: false


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #159 

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
