### PR TITLE
feat: bump ruby3.2-async-io package to v1.36.0

### DIFF
--- a/ruby3.2-async-io.yaml
+++ b/ruby3.2-async-io.yaml
@@ -1,6 +1,6 @@
 package:
   name: ruby3.2-async-io
-  version: 1.35.0
+  version: 1.36.0
   epoch: 0
   description: Provides support for asynchonous TCP, UDP, UNIX and SSL sockets.
   copyright:
@@ -26,8 +26,12 @@ vars:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 0c51170ad99ebc3dd12324ee5b0c53313bc0869081062549e7f4e0698691ed43
+      expected-sha256: 47a95e23845cf3fb0f8571ed088cc70698f265a58adca221c4b5d922726bb1c1
       uri: https://github.com/socketry/async-io/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: patch
+    with:
+      patches: 001-remove-signing-key.patch
 
   - uses: ruby/build
     with:

--- a/ruby3.2-async-io/001-remove-signing-key.patch
+++ b/ruby3.2-async-io/001-remove-signing-key.patch
@@ -1,0 +1,12 @@
+diff --git a/async-io.gemspec b/async-io.gemspec
+index 85ce5d1..b2d17e8 100644
+--- a/async-io.gemspec
++++ b/async-io.gemspec
+@@ -11,7 +11,6 @@ Gem::Specification.new do |spec|
+ 	spec.license = "MIT"
+ 	
+ 	spec.cert_chain  = ['release.cert']
+-	spec.signing_key = File.expand_path('~/.gem/release.pem')
+ 	
+ 	spec.homepage = "https://github.com/socketry/async-io"
+ 	

--- a/ruby3.2-async/001-remove-signing-key.patch
+++ b/ruby3.2-async/001-remove-signing-key.patch
@@ -1,3 +1,5 @@
+# remove the signing key requirement in gemspec
+---
 diff --git a/async.gemspec b/async.gemspec
 index ded8f15..4a77dd5 100644
 --- a/async.gemspec


### PR DESCRIPTION
Update the ruby3.2-async-io package and add a patch to remove the signing key.

Related: #5372

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] ~The `epoch` field is reset to 0~ _not applicable_

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
