### PR TITLE
py3-pybind11: fix development headers location

### DIFF
--- a/py3-pybind11.yaml
+++ b/py3-pybind11.yaml
@@ -1,8 +1,7 @@
-# Generated from https://pypi.org/project/pybind11/
 package:
   name: py3-pybind11
   version: 2.11.1
-  epoch: 0
+  epoch: 1
   description: Seamless operability between C++11 and Python
   copyright:
     - license: BSD
@@ -18,7 +17,10 @@ environment:
       - busybox
       - build-base
       - python3
+      - python3-dev
       - py3-setuptools
+      - py3-gpep517
+      - py3-wheel
       - cmake
 
 pipeline:
@@ -31,10 +33,32 @@ pipeline:
   - name: Python Build
     runs: python setup.py build
 
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DPYTHON_EXECUTABLE=/usr/bin/python3 \
+        -DUSE_PYTHON_INCLUDE_DIR=FALSE
+
+  - uses: cmake/build
+
   - name: Python Install
-    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+    runs: |
+      python -m gpep517 build-wheel \
+        --wheel-dir .dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer -d "${{targets.destdir}}" .dist/*.whl
+
+  - uses: cmake/install
 
   - uses: strip
+
+subpackages:
+  - name: py3-pybind11-dev
+    description: pybind11 development headers
+    pipeline:
+      - uses: split/dev
+      - runs: |
+          mv "${{targets.destdir}}"/usr/share "${{targets.contextdir}}"/usr/share
 
 update:
   enabled: true


### PR DESCRIPTION
pybind11 is not a typical python module, there is a C++ component which must also be built and installed to the correct location.