### PR TITLE
new package geos/3.12.0

### DIFF
--- a/geos.yaml
+++ b/geos.yaml
@@ -1,0 +1,45 @@
+package:
+  name: geos
+  version: 3.12.0
+  epoch: 0
+  description: GEOS is a library providing OpenGIS and JTS spatial operations in C++.
+  copyright:
+    - license: LGPL-2.1-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - cmake
+      - samurai
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/libgeos/geos
+      tag: ${{package.version}}
+      expected-commit: 0d636b600de985a05fa84e744273c79e7d3ab57e
+
+  - uses: cmake/configure
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+subpackages:
+  - name: geos-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - geos
+    description: geos dev
+
+update:
+  enabled: true
+  github:
+    identifier: libgeos/geos


### PR DESCRIPTION
#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

fixes #5422 

```
➜  wolfi-os git:(geos) ✗ wolfictl scan packages/aarch64/geos-3.12.0-r0.apk
Will process: geos-3.12.0-r0.apk
✅ No vulnerabilities found
➜  wolfi-os git:(geos) ✗ wolfictl scan packages/aarch64/geos-dev-3.12.0-r0.apk
Will process: geos-dev-3.12.0-r0.apk
✅ No vulnerabilities found
```
