### PR TITLE
libwebp: CVE-2023-4863 use specific commit until latest upstream is tagged + released

### DIFF
--- a/libwebp.yaml
+++ b/libwebp.yaml
@@ -1,7 +1,9 @@
+# remove nolint when switching back to released tarball
+#nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: libwebp
-  version: 1.3.1
-  epoch: 1
+  version: 1.3.1 # when upgrading also tidy up the patch in pipeline and address comments in file
+  epoch: 2
   description: Libraries for working with WebP images
   copyright:
     - license: BSD-3-Clause
@@ -13,16 +15,26 @@ environment:
       - ca-certificates-bundle
       - build-base
       - automake
+      - autoconf # remove when switching back to released tarball
       - giflib-dev
       - libjpeg-turbo-dev
       - libpng-dev
       - libtool
 
 pipeline:
-  - uses: fetch
+  # patched version not yet released https://chromium.googlesource.com/webm/libwebp/+/902bc9190331343b2017211debcec8d2ab87e17a
+  # - uses: fetch
+  #   with:
+  #     expected-sha256: fa7995cbae7c49d241fcd65688a3ad2855d06c3fb0ca3c471954a86d28f8397b
+  #     uri: https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${{package.version}}.tar.gz
+  - uses: git-checkout
     with:
-      expected-sha256: b3779627c2dfd31e3d8c4485962c2efe17785ef975e2be5c8c0c9e6cd3c4ef66
-      uri: https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${{package.version}}.tar.gz
+      repository: https://github.com/webmproject/libwebp
+      branch: main
+
+  - runs: git checkout 902bc9190331343b2017211debcec8d2ab87e17a # remove when switching back to released tarball
+
+  - runs: ./autogen.sh # remove when switching back to released tarball
 
   - uses: autoconf/configure
 

--- a/libwebp.yaml
+++ b/libwebp.yaml
@@ -22,7 +22,7 @@ environment:
       - libtool
 
 pipeline:
-  # patched version not yet released https://chromium.googlesource.com/webm/libwebp/+/902bc9190331343b2017211debcec8d2ab87e17a
+  # CVE-2023-4863: patched version not yet released https://chromium.googlesource.com/webm/libwebp/+/902bc9190331343b2017211debcec8d2ab87e17a
   # - uses: fetch
   #   with:
   #     expected-sha256: fa7995cbae7c49d241fcd65688a3ad2855d06c3fb0ca3c471954a86d28f8397b
@@ -31,6 +31,7 @@ pipeline:
     with:
       repository: https://github.com/webmproject/libwebp
       branch: main
+      depth: 50
 
   - runs: git checkout 902bc9190331343b2017211debcec8d2ab87e17a # remove when switching back to released tarball
 


### PR DESCRIPTION
this is so we can pull in this commit https://github.com/webmproject/libwebp/commit/902bc9190331343b2017211debcec8d2ab87e17a

#### For PRs that add patches
- [x] Patch source is documented
