### PR TITLE
Add patch to correct k3s build so go embeds version information.

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.28.1
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -48,6 +48,11 @@ pipeline:
       repository: https://github.com/k3s-io/k3s
       tag: v${{vars.full-package-version}}
       expected-commit: 0d23cfe038ef22d7ca899764e9aaeea8a39d4874
+  - uses: patch
+    with:
+      # The upstream build uses server/main.go, which embeds information in the binary differently and confuses scanners.
+      # This switches it to just server/ to build the package instead of the file.
+      patches: package.patch
   # Build things (almost) identical to upstream, with the k3s components
   # embedded in the "outer" multicall binary.
   - runs: |

--- a/k3s/package.patch
+++ b/k3s/package.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/build b/scripts/build
+index 9acc17a2a2..0172e9aaef 100755
+--- a/scripts/build
++++ b/scripts/build
+@@ -134,7 +134,7 @@ if [ ! -x ${INSTALLBIN}/cni ]; then
+ fi
+ 
+ echo Building k3s
+-CGO_ENABLED=1 "${GO}" build $BLDFLAGS -tags "$TAGS" -gcflags="all=${GCFLAGS}" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/k3s ./cmd/server/main.go
++CGO_ENABLED=1 "${GO}" build $BLDFLAGS -tags "$TAGS" -gcflags="all=${GCFLAGS}" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/k3s ./cmd/server
+ ln -s k3s ./bin/containerd
+ ln -s k3s ./bin/crictl
+ ln -s k3s ./bin/ctr


### PR DESCRIPTION
This doesn't really fix any CVEs, but does make it so grype will accurately detect the version.

Followup to https://github.com/wolfi-dev/advisories/pull/235/files

Fixes:

Related:

### Pre-review Checklist
