### PR TITLE
fix missing deployment manifests for kubeflow cache-deployer

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: 2.1.3
-  epoch: 2
+  epoch: 3
   description: Machine Learning Pipelines for Kubeflow
   copyright:
     - license: Apache-2.0
@@ -106,8 +106,15 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mkdir -p ${{targets.subpkgdir}}/etc/cache-deployer
           mkdir -p ${{targets.subpkgdir}}/third_party
+
           install -m755 -D third_party/license.txt ${{targets.subpkgdir}}/third_party/license.txt
+
+          install -m755 -D backend/src/cache/deployer/cache-webhook-config.v1.yaml.template ${{targets.subpkgdir}}/etc/cache-deployer/cache-webhook-config.v1.yaml.template
+          install -m755 -D backend/src/cache/deployer/cache-webhook-config.v1beta1.v1.15.yaml.template ${{targets.subpkgdir}}/etc/cache-deployer/cache-webhook-config.v1beta1.v1.15.yaml.template
+          install -m755 -D backend/src/cache/deployer/cache-webhook-config.v1beta1.yaml.template ${{targets.subpkgdir}}/etc/cache-deployer/cache-webhook-config.v1beta1.yaml.template
+
           install -m755 -D backend/src/cache/deployer/deploy-cache-service.sh ${{targets.subpkgdir}}/usr/bin/deploy-cache-service.sh
           install -m755 -D backend/src/cache/deployer/webhook-create-signed-cert.sh ${{targets.subpkgdir}}/usr/bin/webhook-create-signed-cert.sh
           install -m755 -D backend/src/cache/deployer/webhook-patch-ca-bundle.sh ${{targets.subpkgdir}}/usr/bin/webhook-patch-ca-bundle.sh
@@ -122,6 +129,9 @@ subpackages:
           ln -s /usr/bin/deploy-cache-service.sh "${{targets.subpkgdir}}"/kfp/cache/deployer/deploy-cache-service.sh
           ln -s /usr/bin/webhook-create-signed-cert.sh "${{targets.subpkgdir}}"/kfp/cache/deployer/webhook-create-signed-cert.sh
           ln -s /usr/bin/webhook-patch-ca-bundle.sh "${{targets.subpkgdir}}"/kfp/cache/deployer/webhook-patch-ca-bundle.sh
+          ln -s /etc/cache-deployer/cache-webhook-config.v1.yaml.template "${{targets.subpkgdir}}"/kfp/cache/deployer/cache-webhook-config.v1.yaml.template
+          ln -s /etc/cache-deployer/cache-webhook-config.v1beta1.v1.15.yaml.template "${{targets.subpkgdir}}"/kfp/cache/deployer/cache-webhook-config.v1beta1.v1.15.yaml.template
+          ln -s /etc/cache-deployer/cache-webhook-config.v1beta1.yaml.template "${{targets.subpkgdir}}"/kfp/cache/deployer/cache-webhook-config.v1beta1.yaml.template
 
   - name: "kubeflow-pipelines-frontend"
     description: "Kubeflow Pipelines frontend"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: an issue where missing manifests for kubeflow cache-deployer

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
