### PR TITLE
wolfictl world build: only build for the runner arch

### DIFF
--- a/.github/workflows/build-world.yaml
+++ b/.github/workflows/build-world.yaml
@@ -47,6 +47,7 @@ jobs:
           wolfictl build \
               -k https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub \
               -r https://packages.wolfi.dev/bootstrap/stage3 \
+              --arch=${{ matrix.arch }} \
               -j10
 
   postrun:


### PR DESCRIPTION
Otherwise we'll run for both archs on both runners, which is unnecessarily slow due to qemu.