### PR TITLE
Add boring-registry package.

### DIFF
--- a/boring-registry.yaml
+++ b/boring-registry.yaml
@@ -1,0 +1,38 @@
+package:
+  name: boring-registry
+  version: 0.11.4
+  epoch: 0
+  description: Terraform Provider and Module Registry
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/TierMobility/boring-registry
+      expected-commit: 083aa721311a3745ee0e5bd3b68bfce7ed2c1f4c
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      packages: .
+      output: boring-registry
+      ldflags: -s -w
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: TierMobility/boring-registry
+    strip-prefix: v


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
