### PR TITLE
iso-codes: add autoreconf step to setup install-sh

### DIFF
--- a/iso-codes.yaml
+++ b/iso-codes.yaml
@@ -1,8 +1,7 @@
-# Generated from https://git.alpinelinux.org/aports/plain/main/iso-codes/APKBUILD
 package:
   name: iso-codes
   version: 4.15.0
-  epoch: 0
+  epoch: 1
   description: ISO codes and their translations
   copyright:
     - license: LGPL-2.1-or-later
@@ -15,6 +14,7 @@ environment:
       - build-base
       - automake
       - autoconf
+      - libtool
       - python3
       - gettext
 
@@ -23,6 +23,9 @@ pipeline:
     with:
       expected-sha256: ca2cadca98ad50af6e0ee4e139ec838695f75729d7a2c6353d31d9dfc6d3f027
       uri: https://salsa.debian.org/iso-codes-team/iso-codes/-/archive/v${{package.version}}/iso-codes-v${{package.version}}.tar.bz2
+
+  - runs: |
+      autoreconf -i
 
   - uses: autoconf/configure
 


### PR DESCRIPTION
iso-codes 4.15.0 needs autoreconf for install-sh