### PR TITLE
docs: add a reminder to bump Perl packages epochs

### DIFF
--- a/perl.yaml
+++ b/perl.yaml
@@ -1,6 +1,6 @@
 package:
   name: perl
-  version: 5.38.0
+  version: 5.38.0 # when bumping this version also bump Perl packages epochs to trigger a rebuild
   epoch: 0
   description: "Larry Wall's Practical Extraction and Report Language"
   copyright:


### PR DESCRIPTION
Add a reminder besides the Perl version to bump all the Perl packages epochs. This is needed to trigger a rebuild with the latest Perl version.

Related: #5474