### PR TITLE
include pre-built sample manifests for kfp

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: 2.1.3
-  epoch: 3
+  epoch: 4
   description: Machine Learning Pipelines for Kubeflow
   copyright:
     - license: Apache-2.0
@@ -50,6 +50,10 @@ pipeline:
   - uses: patch
     with:
       patches: bump_requirements.patch
+
+  - uses: patch
+    with:
+      patches: add-samples.patch
 
 subpackages:
   - range: backends-go-builds

--- a/kubeflow-pipelines/add-samples.patch
+++ b/kubeflow-pipelines/add-samples.patch
@@ -1,0 +1,926 @@
+# The following patch are generated using pre-built sample manifests using the upstream kfp image.
+# Please check the corresponding digest of the requested image version.
+# https://oci.dag.dev/fs/gcr.io/ml-pipeline/api-server@sha256:40972bc58d63bcd9687a67c81eca0cb5866f4f8e563b70e42784730bb603b9a6/samples/tutorials/Data%20passing%20in%20python%20components/Data%20passing%20in%20python%20components%20-%20Files.py.yaml
+# https://oci.dag.dev/fs/gcr.io/ml-pipeline/api-server@sha256:40972bc58d63bcd9687a67c81eca0cb5866f4f8e563b70e42784730bb603b9a6/samples/tutorials/DSL%20-%20Control%20structures/DSL%20-%20Control%20structures.py.yaml
+diff --git a/samples/tutorials/DSL - Control structures/DSL - Control structures.py b/samples/tutorials/DSL - Control structures/DSL - Control structures.py
+deleted file mode 100644
+index 894355c..0000000
+--- a/samples/tutorials/DSL - Control structures/DSL - Control structures.py	
++++ /dev/null
+@@ -1,100 +0,0 @@
+-#!/usr/bin/env python3
+-# Copyright 2020-2023 The Kubeflow Authors
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#      http://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-
+-# %% [markdown]
+-# # DSL control structures tutorial
+-# Shows how to use conditional execution, loops, and exit handlers.
+-
+-# %%
+-
+-import kfp
+-from kfp import dsl
+-
+-
+-@dsl.component
+-def get_random_int_op(minimum: int, maximum: int) -> int:
+-    """Generate a random number between minimum and maximum (inclusive)."""
+-    import random
+-    result = random.randint(minimum, maximum)
+-    print(result)
+-    return result
+-
+-
+-@dsl.component
+-def flip_coin_op() -> str:
+-    """Flip a coin and output heads or tails randomly."""
+-    import random
+-    result = random.choice(['heads', 'tails'])
+-    print(result)
+-    return result
+-
+-
+-@dsl.component
+-def print_op(message: str):
+-    """Print a message."""
+-    print(message)
+-
+-
+-@dsl.component
+-def fail_op(message: str):
+-    """Fails."""
+-    import sys
+-    print(message)
+-    sys.exit(1)
+-
+-
+-# %% [markdown]
+-# ## Parallel execution
+-# You can use the `with dsl.ParallelFor(task1.outputs) as items:` context to execute tasks in parallel
+-
+-# ## Conditional execution
+-# You can use the `with dsl.Condition(task1.outputs["output_name"] = "value"):` context to execute parts of the pipeline conditionally
+-
+-# ## Exit handlers
+-# You can use `with dsl.ExitHandler(exit_task):` context to execute a task when the rest of the pipeline finishes (succeeds or fails)
+-
+-# %%
+-
+-
+-@dsl.pipeline(
+-    name='tutorial-control-flows',
+-    description='Shows how to use dsl.Condition(), dsl.ParallelFor, and dsl.ExitHandler().'
+-)
+-def control_flows_pipeline():
+-    exit_task = print_op(message='Exit handler has worked!')
+-    with dsl.ExitHandler(exit_task):
+-        fail_op(
+-            message="Failing the run to demonstrate that exit handler still gets executed."
+-        )
+-
+-    flip = flip_coin_op()
+-
+-    with dsl.ParallelFor(['heads', 'tails']) as expected_result:
+-
+-        with dsl.Condition(flip.output == expected_result):
+-            random_num_head = get_random_int_op(minimum=0, maximum=9)
+-            with dsl.Condition(random_num_head.output > 5):
+-                print_op(
+-                    message=f'{expected_result} and {random_num_head.output} > 5!'
+-                )
+-            with dsl.Condition(random_num_head.output <= 5):
+-                print_op(
+-                    message=f'{expected_result} and {random_num_head.output} <= 5!'
+-                )
+-
+-
+-if __name__ == '__main__':
+-    # Compiling the pipeline
+-    kfp.compiler.Compiler().compile(control_flows_pipeline, __file__ + '.yaml')
+diff --git a/samples/tutorials/DSL - Control structures/DSL - Control structures.py.yaml b/samples/tutorials/DSL - Control structures/DSL - Control structures.py.yaml
+new file mode 100644
+index 0000000..a4ed7dd
+--- /dev/null
++++ b/samples/tutorials/DSL - Control structures/DSL - Control structures.py.yaml	
+@@ -0,0 +1,427 @@
++# PIPELINE DEFINITION
++# Name: tutorial-control-flows
++# Description: Shows how to use dsl.Condition(), dsl.ParallelFor, and dsl.ExitHandler().
++components:
++  comp-condition-4:
++    dag:
++      tasks:
++        condition-5:
++          componentRef:
++            name: comp-condition-5
++          dependentTasks:
++          - get-random-int-op
++          inputs:
++            parameters:
++              pipelinechannel--flip-coin-op-Output:
++                componentInputParameter: pipelinechannel--flip-coin-op-Output
++              pipelinechannel--get-random-int-op-Output:
++                taskOutputParameter:
++                  outputParameterKey: Output
++                  producerTask: get-random-int-op
++              pipelinechannel--loop-item-param-2:
++                componentInputParameter: pipelinechannel--loop-item-param-2
++          taskInfo:
++            name: condition-5
++          triggerPolicy:
++            condition: int(inputs.parameter_values['pipelinechannel--get-random-int-op-Output'])
++              > 5
++        condition-6:
++          componentRef:
++            name: comp-condition-6
++          dependentTasks:
++          - get-random-int-op
++          inputs:
++            parameters:
++              pipelinechannel--flip-coin-op-Output:
++                componentInputParameter: pipelinechannel--flip-coin-op-Output
++              pipelinechannel--get-random-int-op-Output:
++                taskOutputParameter:
++                  outputParameterKey: Output
++                  producerTask: get-random-int-op
++              pipelinechannel--loop-item-param-2:
++                componentInputParameter: pipelinechannel--loop-item-param-2
++          taskInfo:
++            name: condition-6
++          triggerPolicy:
++            condition: int(inputs.parameter_values['pipelinechannel--get-random-int-op-Output'])
++              <= 5
++        get-random-int-op:
++          cachingOptions:
++            enableCache: true
++          componentRef:
++            name: comp-get-random-int-op
++          inputs:
++            parameters:
++              maximum:
++                runtimeValue:
++                  constant: 9.0
++              minimum:
++                runtimeValue:
++                  constant: 0.0
++          taskInfo:
++            name: get-random-int-op
++    inputDefinitions:
++      parameters:
++        pipelinechannel--flip-coin-op-Output:
++          parameterType: STRING
++        pipelinechannel--loop-item-param-2:
++          parameterType: STRING
++  comp-condition-5:
++    dag:
++      tasks:
++        print-op-2:
++          cachingOptions:
++            enableCache: true
++          componentRef:
++            name: comp-print-op-2
++          inputs:
++            parameters:
++              message:
++                runtimeValue:
++                  constant: '{{$.inputs.parameters[''pipelinechannel--loop-item-param-2'']}}
++                    and {{$.inputs.parameters[''pipelinechannel--get-random-int-op-Output'']}}
++                    > 5!'
++              pipelinechannel--get-random-int-op-Output:
++                componentInputParameter: pipelinechannel--get-random-int-op-Output
++              pipelinechannel--loop-item-param-2:
++                componentInputParameter: pipelinechannel--loop-item-param-2
++          taskInfo:
++            name: print-op-2
++    inputDefinitions:
++      parameters:
++        pipelinechannel--flip-coin-op-Output:
++          parameterType: STRING
++        pipelinechannel--get-random-int-op-Output:
++          parameterType: NUMBER_INTEGER
++        pipelinechannel--loop-item-param-2:
++          parameterType: STRING
++  comp-condition-6:
++    dag:
++      tasks:
++        print-op-3:
++          cachingOptions:
++            enableCache: true
++          componentRef:
++            name: comp-print-op-3
++          inputs:
++            parameters:
++              message:
++                runtimeValue:
++                  constant: '{{$.inputs.parameters[''pipelinechannel--loop-item-param-2'']}}
++                    and {{$.inputs.parameters[''pipelinechannel--get-random-int-op-Output'']}}
++                    <= 5!'
++              pipelinechannel--get-random-int-op-Output:
++                componentInputParameter: pipelinechannel--get-random-int-op-Output
++              pipelinechannel--loop-item-param-2:
++                componentInputParameter: pipelinechannel--loop-item-param-2
++          taskInfo:
++            name: print-op-3
++    inputDefinitions:
++      parameters:
++        pipelinechannel--flip-coin-op-Output:
++          parameterType: STRING
++        pipelinechannel--get-random-int-op-Output:
++          parameterType: NUMBER_INTEGER
++        pipelinechannel--loop-item-param-2:
++          parameterType: STRING
++  comp-exit-handler-1:
++    dag:
++      tasks:
++        fail-op:
++          cachingOptions:
++            enableCache: true
++          componentRef:
++            name: comp-fail-op
++          inputs:
++            parameters:
++              message:
++                runtimeValue:
++                  constant: Failing the run to demonstrate that exit handler still
++                    gets executed.
++          taskInfo:
++            name: fail-op
++  comp-fail-op:
++    executorLabel: exec-fail-op
++    inputDefinitions:
++      parameters:
++        message:
++          parameterType: STRING
++  comp-flip-coin-op:
++    executorLabel: exec-flip-coin-op
++    outputDefinitions:
++      parameters:
++        Output:
++          parameterType: STRING
++  comp-for-loop-3:
++    dag:
++      tasks:
++        condition-4:
++          componentRef:
++            name: comp-condition-4
++          inputs:
++            parameters:
++              pipelinechannel--flip-coin-op-Output:
++                componentInputParameter: pipelinechannel--flip-coin-op-Output
++              pipelinechannel--loop-item-param-2:
++                componentInputParameter: pipelinechannel--loop-item-param-2
++          taskInfo:
++            name: condition-4
++          triggerPolicy:
++            condition: inputs.parameter_values['pipelinechannel--loop-item-param-2']
++              == inputs.parameter_values['pipelinechannel--flip-coin-op-Output']
++    inputDefinitions:
++      parameters:
++        pipelinechannel--flip-coin-op-Output:
++          parameterType: STRING
++        pipelinechannel--loop-item-param-2:
++          parameterType: STRING
++  comp-get-random-int-op:
++    executorLabel: exec-get-random-int-op
++    inputDefinitions:
++      parameters:
++        maximum:
++          parameterType: NUMBER_INTEGER
++        minimum:
++          parameterType: NUMBER_INTEGER
++    outputDefinitions:
++      parameters:
++        Output:
++          parameterType: NUMBER_INTEGER
++  comp-print-op:
++    executorLabel: exec-print-op
++    inputDefinitions:
++      parameters:
++        message:
++          parameterType: STRING
++  comp-print-op-2:
++    executorLabel: exec-print-op-2
++    inputDefinitions:
++      parameters:
++        message:
++          parameterType: STRING
++  comp-print-op-3:
++    executorLabel: exec-print-op-3
++    inputDefinitions:
++      parameters:
++        message:
++          parameterType: STRING
++deploymentSpec:
++  executors:
++    exec-fail-op:
++      container:
++        args:
++        - --executor_input
++        - '{{$}}'
++        - --function_to_execute
++        - fail_op
++        command:
++        - sh
++        - -c
++        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
++          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
++          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-rc.1'\
++          \ && \"$0\" \"$@\"\n"
++        - sh
++        - -ec
++        - 'program_path=$(mktemp -d)
++
++          printf "%s" "$0" > "$program_path/ephemeral_component.py"
++
++          python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
++
++          '
++        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
++          \ *\n\ndef fail_op(message: str):\n    \"\"\"Fails.\"\"\"\n    import sys\n\
++          \    print(message)\n    sys.exit(1)\n\n"
++        image: python:3.7
++    exec-flip-coin-op:
++      container:
++        args:
++        - --executor_input
++        - '{{$}}'
++        - --function_to_execute
++        - flip_coin_op
++        command:
++        - sh
++        - -c
++        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
++          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
++          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-rc.1'\
++          \ && \"$0\" \"$@\"\n"
++        - sh
++        - -ec
++        - 'program_path=$(mktemp -d)
++
++          printf "%s" "$0" > "$program_path/ephemeral_component.py"
++
++          python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
++
++          '
++        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
++          \ *\n\ndef flip_coin_op() -> str:\n    \"\"\"Flip a coin and output heads\
++          \ or tails randomly.\"\"\"\n    import random\n    result = random.choice(['heads',\
++          \ 'tails'])\n    print(result)\n    return result\n\n"
++        image: python:3.7
++    exec-get-random-int-op:
++      container:
++        args:
++        - --executor_input
++        - '{{$}}'
++        - --function_to_execute
++        - get_random_int_op
++        command:
++        - sh
++        - -c
++        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
++          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
++          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-rc.1'\
++          \ && \"$0\" \"$@\"\n"
++        - sh
++        - -ec
++        - 'program_path=$(mktemp -d)
++
++          printf "%s" "$0" > "$program_path/ephemeral_component.py"
++
++          python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
++
++          '
++        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
++          \ *\n\ndef get_random_int_op(minimum: int, maximum: int) -> int:\n    \"\
++          \"\"Generate a random number between minimum and maximum (inclusive).\"\"\
++          \"\n    import random\n    result = random.randint(minimum, maximum)\n \
++          \   print(result)\n    return result\n\n"
++        image: python:3.7
++    exec-print-op:
++      container:
++        args:
++        - --executor_input
++        - '{{$}}'
++        - --function_to_execute
++        - print_op
++        command:
++        - sh
++        - -c
++        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
++          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
++          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-rc.1'\
++          \ && \"$0\" \"$@\"\n"
++        - sh
++        - -ec
++        - 'program_path=$(mktemp -d)
++
++          printf "%s" "$0" > "$program_path/ephemeral_component.py"
++
++          python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
++
++          '
++        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
++          \ *\n\ndef print_op(message: str):\n    \"\"\"Print a message.\"\"\"\n \
++          \   print(message)\n\n"
++        image: python:3.7
++    exec-print-op-2:
++      container:
++        args:
++        - --executor_input
++        - '{{$}}'
++        - --function_to_execute
++        - print_op
++        command:
++        - sh
++        - -c
++        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
++          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
++          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-rc.1'\
++          \ && \"$0\" \"$@\"\n"
++        - sh
++        - -ec
++        - 'program_path=$(mktemp -d)
++
++          printf "%s" "$0" > "$program_path/ephemeral_component.py"
++
++          python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
++
++          '
++        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
++          \ *\n\ndef print_op(message: str):\n    \"\"\"Print a message.\"\"\"\n \
++          \   print(message)\n\n"
++        image: python:3.7
++    exec-print-op-3:
++      container:
++        args:
++        - --executor_input
++        - '{{$}}'
++        - --function_to_execute
++        - print_op
++        command:
++        - sh
++        - -c
++        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
++          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
++          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-rc.1'\
++          \ && \"$0\" \"$@\"\n"
++        - sh
++        - -ec
++        - 'program_path=$(mktemp -d)
++
++          printf "%s" "$0" > "$program_path/ephemeral_component.py"
++
++          python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
++
++          '
++        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
++          \ *\n\ndef print_op(message: str):\n    \"\"\"Print a message.\"\"\"\n \
++          \   print(message)\n\n"
++        image: python:3.7
++pipelineInfo:
++  description: Shows how to use dsl.Condition(), dsl.ParallelFor, and dsl.ExitHandler().
++  name: tutorial-control-flows
++root:
++  dag:
++    tasks:
++      exit-handler-1:
++        componentRef:
++          name: comp-exit-handler-1
++        taskInfo:
++          name: exit-handler-1
++      flip-coin-op:
++        cachingOptions:
++          enableCache: true
++        componentRef:
++          name: comp-flip-coin-op
++        taskInfo:
++          name: flip-coin-op
++      for-loop-3:
++        componentRef:
++          name: comp-for-loop-3
++        dependentTasks:
++        - flip-coin-op
++        inputs:
++          parameters:
++            pipelinechannel--flip-coin-op-Output:
++              taskOutputParameter:
++                outputParameterKey: Output
++                producerTask: flip-coin-op
++        parameterIterator:
++          itemInput: pipelinechannel--loop-item-param-2
++          items:
++            raw: '["heads", "tails"]'
++        taskInfo:
++          name: for-loop-3
++      print-op:
++        cachingOptions:
++          enableCache: true
++        componentRef:
++          name: comp-print-op
++        dependentTasks:
++        - exit-handler-1
++        inputs:
++          parameters:
++            message:
++              runtimeValue:
++                constant: Exit handler has worked!
++        taskInfo:
++          name: print-op
++        triggerPolicy:
++          strategy: ALL_UPSTREAM_TASKS_COMPLETED
++schemaVersion: 2.1.0
++sdkVersion: kfp-2.0.0-rc.1
+diff --git a/samples/tutorials/Data passing in python components/Data passing in python components - Files.py b/samples/tutorials/Data passing in python components/Data passing in python components - Files.py
+deleted file mode 100644
+index 005f21a..0000000
+--- a/samples/tutorials/Data passing in python components/Data passing in python components - Files.py	
++++ /dev/null
+@@ -1,145 +0,0 @@
+-#!/usr/bin/env python3
+-# Copyright 2020-2023 The Kubeflow Authors
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#      http://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-
+-# %% [markdown]
+-# # Data passing tutorial
+-# Data passing is the most important aspect of Pipelines.
+-#
+-# In Kubeflow Pipelines, the pipeline authors compose pipelines by creating component instances (tasks) and connecting them together.
+-#
+-# Components have inputs and outputs. They can consume and produce arbitrary data.
+-#
+-# Pipeline authors establish connections between component tasks by connecting their data inputs and outputs - by passing the output of one task as an argument to another task's input.
+-#
+-# The system takes care of storing the data produced by components and later passing that data to other components for consumption as instructed by the pipeline.
+-#
+-# This tutorial shows how to create python components that produce, consume and transform data.
+-# It shows how to create data passing pipelines by instantiating components and connecting them together.
+-
+-# %%
+-
+-from typing import Dict, List
+-
+-from kfp import compiler
+-from kfp import dsl
+-from kfp.dsl import Input, InputPath, Output, OutputPath, Dataset, Model, component
+-
+-
+-@component
+-def preprocess(
+-    # An input parameter of type string.
+-    message: str,
+-    # Use Output[T] to get a metadata-rich handle to the output artifact
+-    # of type `Dataset`.
+-    output_dataset_one: Output[Dataset],
+-    # A locally accessible filepath for another output artifact of type
+-    # `Dataset`.
+-    output_dataset_two_path: OutputPath('Dataset'),
+-    # A locally accessible filepath for an output parameter of type string.
+-    output_parameter_path: OutputPath(str),
+-    # A locally accessible filepath for an output parameter of type bool.
+-    output_bool_parameter_path: OutputPath(bool),
+-    # A locally accessible filepath for an output parameter of type dict.
+-    output_dict_parameter_path: OutputPath(Dict[str, int]),
+-    # A locally accessible filepath for an output parameter of type list.
+-    output_list_parameter_path: OutputPath(List[str]),
+-):
+-    """Dummy preprocessing step."""
+-
+-    # Use Dataset.path to access a local file path for writing.
+-    # One can also use Dataset.uri to access the actual URI file path.
+-    with open(output_dataset_one.path, 'w') as f:
+-        f.write(message)
+-
+-    # OutputPath is used to just pass the local file path of the output artifact
+-    # to the function.
+-    with open(output_dataset_two_path, 'w') as f:
+-        f.write(message)
+-
+-    with open(output_parameter_path, 'w') as f:
+-        f.write(message)
+-
+-    with open(output_bool_parameter_path, 'w') as f:
+-        f.write(
+-            str(True))  # use either `str()` or `json.dumps()` for bool values.
+-
+-    import json
+-    with open(output_dict_parameter_path, 'w') as f:
+-        f.write(json.dumps({'A': 1, 'B': 2}))
+-
+-    with open(output_list_parameter_path, 'w') as f:
+-        f.write(json.dumps(['a', 'b', 'c']))
+-
+-
+-@component
+-def train(
+-    # Use InputPath to get a locally accessible path for the input artifact
+-    # of type `Dataset`.
+-    dataset_one_path: InputPath('Dataset'),
+-    # Use Input[T] to get a metadata-rich handle to the input artifact
+-    # of type `Dataset`.
+-    dataset_two: Input[Dataset],
+-    # An input parameter of type string.
+-    message: str,
+-    # Use Output[T] to get a metadata-rich handle to the output artifact
+-    # of type `Model`.
+-    model: Output[Model],
+-    # An input parameter of type bool.
+-    input_bool: bool,
+-    # An input parameter of type dict.
+-    input_dict: Dict[str, int],
+-    # An input parameter of type List[str].
+-    input_list: List[str],
+-    # An input parameter of type int with a default value.
+-    num_steps: int = 100,
+-):
+-    """Dummy Training step."""
+-    with open(dataset_one_path, 'r') as input_file:
+-        dataset_one_contents = input_file.read()
+-
+-    with open(dataset_two.path, 'r') as input_file:
+-        dataset_two_contents = input_file.read()
+-
+-    line = (f'dataset_one_contents: {dataset_one_contents} || '
+-            f'dataset_two_contents: {dataset_two_contents} || '
+-            f'message: {message} || '
+-            f'input_bool: {input_bool}, type {type(input_bool)} || '
+-            f'input_dict: {input_dict}, type {type(input_dict)} || '
+-            f'input_list: {input_list}, type {type(input_list)} \n')
+-
+-    with open(model.path, 'w') as output_file:
+-        for i in range(num_steps):
+-            output_file.write('Step {}\n{}\n=====\n'.format(i, line))
+-
+-    # model is an instance of Model artifact, which has a .metadata dictionary
+-    # to store arbitrary metadata for the output artifact.
+-    model.metadata['accuracy'] = 0.9
+-
+-
+-@dsl.pipeline(pipeline_root='', name='tutorial-data-passing')
+-def data_passing_pipeline(message: str = 'message'):
+-    preprocess_task = preprocess(message=message)
+-    train_task = train(
+-        dataset_one_path=preprocess_task.outputs['output_dataset_one'],
+-        dataset_two=preprocess_task.outputs['output_dataset_two_path'],
+-        message=preprocess_task.outputs['output_parameter_path'],
+-        input_bool=preprocess_task.outputs['output_bool_parameter_path'],
+-        input_dict=preprocess_task.outputs['output_dict_parameter_path'],
+-        input_list=preprocess_task.outputs['output_list_parameter_path'],
+-    )
+-
+-
+-if __name__ == '__main__':
+-    compiler.Compiler().compile(data_passing_pipeline, __file__ + '.yaml')
+diff --git a/samples/tutorials/Data passing in python components/Data passing in python components - Files.py.yaml b/samples/tutorials/Data passing in python components/Data passing in python components - Files.py.yaml
+new file mode 100644
+index 0000000..5b0d621
+--- /dev/null
++++ b/samples/tutorials/Data passing in python components/Data passing in python components - Files.py.yaml	
+@@ -0,0 +1,223 @@
++# PIPELINE DEFINITION
++# Name: tutorial-data-passing
++# Inputs:
++#    message: str [Default: 'message']
++components:
++  comp-preprocess:
++    executorLabel: exec-preprocess
++    inputDefinitions:
++      parameters:
++        message:
++          parameterType: STRING
++    outputDefinitions:
++      artifacts:
++        output_dataset_one:
++          artifactType:
++            schemaTitle: system.Dataset
++            schemaVersion: 0.0.1
++        output_dataset_two_path:
++          artifactType:
++            schemaTitle: system.Dataset
++            schemaVersion: 0.0.1
++      parameters:
++        output_bool_parameter_path:
++          parameterType: BOOLEAN
++        output_dict_parameter_path:
++          parameterType: STRUCT
++        output_list_parameter_path:
++          parameterType: LIST
++        output_parameter_path:
++          parameterType: STRING
++  comp-train:
++    executorLabel: exec-train
++    inputDefinitions:
++      artifacts:
++        dataset_one_path:
++          artifactType:
++            schemaTitle: system.Dataset
++            schemaVersion: 0.0.1
++        dataset_two:
++          artifactType:
++            schemaTitle: system.Dataset
++            schemaVersion: 0.0.1
++      parameters:
++        input_bool:
++          parameterType: BOOLEAN
++        input_dict:
++          parameterType: STRUCT
++        input_list:
++          parameterType: LIST
++        message:
++          parameterType: STRING
++        num_steps:
++          defaultValue: 100.0
++          isOptional: true
++          parameterType: NUMBER_INTEGER
++    outputDefinitions:
++      artifacts:
++        model:
++          artifactType:
++            schemaTitle: system.Model
++            schemaVersion: 0.0.1
++deploymentSpec:
++  executors:
++    exec-preprocess:
++      container:
++        args:
++        - --executor_input
++        - '{{$}}'
++        - --function_to_execute
++        - preprocess
++        command:
++        - sh
++        - -c
++        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
++          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
++          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-rc.1'\
++          \ && \"$0\" \"$@\"\n"
++        - sh
++        - -ec
++        - 'program_path=$(mktemp -d)
++
++          printf "%s" "$0" > "$program_path/ephemeral_component.py"
++
++          python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
++
++          '
++        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
++          \ *\n\ndef preprocess(\n    # An input parameter of type string.\n    message:\
++          \ str,\n    # Use Output[T] to get a metadata-rich handle to the output\
++          \ artifact\n    # of type `Dataset`.\n    output_dataset_one: Output[Dataset],\n\
++          \    # A locally accessible filepath for another output artifact of type\n\
++          \    # `Dataset`.\n    output_dataset_two_path: OutputPath('Dataset'),\n\
++          \    # A locally accessible filepath for an output parameter of type string.\n\
++          \    output_parameter_path: OutputPath(str),\n    # A locally accessible\
++          \ filepath for an output parameter of type bool.\n    output_bool_parameter_path:\
++          \ OutputPath(bool),\n    # A locally accessible filepath for an output parameter\
++          \ of type dict.\n    output_dict_parameter_path: OutputPath(Dict[str, int]),\n\
++          \    # A locally accessible filepath for an output parameter of type list.\n\
++          \    output_list_parameter_path: OutputPath(List[str]),\n):\n    \"\"\"\
++          Dummy preprocessing step.\"\"\"\n\n    # Use Dataset.path to access a local\
++          \ file path for writing.\n    # One can also use Dataset.uri to access the\
++          \ actual URI file path.\n    with open(output_dataset_one.path, 'w') as\
++          \ f:\n        f.write(message)\n\n    # OutputPath is used to just pass\
++          \ the local file path of the output artifact\n    # to the function.\n \
++          \   with open(output_dataset_two_path, 'w') as f:\n        f.write(message)\n\
++          \n    with open(output_parameter_path, 'w') as f:\n        f.write(message)\n\
++          \n    with open(output_bool_parameter_path, 'w') as f:\n        f.write(\n\
++          \            str(True))  # use either `str()` or `json.dumps()` for bool\
++          \ values.\n\n    import json\n    with open(output_dict_parameter_path,\
++          \ 'w') as f:\n        f.write(json.dumps({'A': 1, 'B': 2}))\n\n    with\
++          \ open(output_list_parameter_path, 'w') as f:\n        f.write(json.dumps(['a',\
++          \ 'b', 'c']))\n\n"
++        image: python:3.7
++    exec-train:
++      container:
++        args:
++        - --executor_input
++        - '{{$}}'
++        - --function_to_execute
++        - train
++        command:
++        - sh
++        - -c
++        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
++          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
++          \ python3 -m pip install --quiet     --no-warn-script-location 'kfp==2.0.0-rc.1'\
++          \ && \"$0\" \"$@\"\n"
++        - sh
++        - -ec
++        - 'program_path=$(mktemp -d)
++
++          printf "%s" "$0" > "$program_path/ephemeral_component.py"
++
++          python3 -m kfp.components.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
++
++          '
++        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
++          \ *\n\ndef train(\n    # Use InputPath to get a locally accessible path\
++          \ for the input artifact\n    # of type `Dataset`.\n    dataset_one_path:\
++          \ InputPath('Dataset'),\n    # Use Input[T] to get a metadata-rich handle\
++          \ to the input artifact\n    # of type `Dataset`.\n    dataset_two: Input[Dataset],\n\
++          \    # An input parameter of type string.\n    message: str,\n    # Use\
++          \ Output[T] to get a metadata-rich handle to the output artifact\n    #\
++          \ of type `Model`.\n    model: Output[Model],\n    # An input parameter\
++          \ of type bool.\n    input_bool: bool,\n    # An input parameter of type\
++          \ dict.\n    input_dict: Dict[str, int],\n    # An input parameter of type\
++          \ List[str].\n    input_list: List[str],\n    # An input parameter of type\
++          \ int with a default value.\n    num_steps: int = 100,\n):\n    \"\"\"Dummy\
++          \ Training step.\"\"\"\n    with open(dataset_one_path, 'r') as input_file:\n\
++          \        dataset_one_contents = input_file.read()\n\n    with open(dataset_two.path,\
++          \ 'r') as input_file:\n        dataset_two_contents = input_file.read()\n\
++          \n    line = (f'dataset_one_contents: {dataset_one_contents} || '\n    \
++          \        f'dataset_two_contents: {dataset_two_contents} || '\n         \
++          \   f'message: {message} || '\n            f'input_bool: {input_bool}, type\
++          \ {type(input_bool)} || '\n            f'input_dict: {input_dict}, type\
++          \ {type(input_dict)} || '\n            f'input_list: {input_list}, type\
++          \ {type(input_list)} \\n')\n\n    with open(model.path, 'w') as output_file:\n\
++          \        for i in range(num_steps):\n            output_file.write('Step\
++          \ {}\\n{}\\n=====\\n'.format(i, line))\n\n    # model is an instance of\
++          \ Model artifact, which has a .metadata dictionary\n    # to store arbitrary\
++          \ metadata for the output artifact.\n    model.metadata['accuracy'] = 0.9\n\
++          \n"
++        image: python:3.7
++pipelineInfo:
++  name: tutorial-data-passing
++root:
++  dag:
++    tasks:
++      preprocess:
++        cachingOptions:
++          enableCache: true
++        componentRef:
++          name: comp-preprocess
++        inputs:
++          parameters:
++            message:
++              componentInputParameter: message
++        taskInfo:
++          name: preprocess
++      train:
++        cachingOptions:
++          enableCache: true
++        componentRef:
++          name: comp-train
++        dependentTasks:
++        - preprocess
++        inputs:
++          artifacts:
++            dataset_one_path:
++              taskOutputArtifact:
++                outputArtifactKey: output_dataset_one
++                producerTask: preprocess
++            dataset_two:
++              taskOutputArtifact:
++                outputArtifactKey: output_dataset_two_path
++                producerTask: preprocess
++          parameters:
++            input_bool:
++              taskOutputParameter:
++                outputParameterKey: output_bool_parameter_path
++                producerTask: preprocess
++            input_dict:
++              taskOutputParameter:
++                outputParameterKey: output_dict_parameter_path
++                producerTask: preprocess
++            input_list:
++              taskOutputParameter:
++                outputParameterKey: output_list_parameter_path
++                producerTask: preprocess
++            message:
++              taskOutputParameter:
++                outputParameterKey: output_parameter_path
++                producerTask: preprocess
++        taskInfo:
++          name: train
++  inputDefinitions:
++    parameters:
++      message:
++        defaultValue: message
++        isOptional: true
++        parameterType: STRING
++schemaVersion: 2.1.0
++sdkVersion: kfp-2.0.0-rc.1
+-- 
+2.39.2 (Apple Git-143)
+


### PR DESCRIPTION
Instead of re-compiling all of the sample manifests for kfp, patch all of them. This is a trivial way to use pre-built sample manifests from the official upstream image.