### PR TITLE
feat: fix clang-16 and llvm-lld-16 builds on MacOS

### DIFF
--- a/clang-16.yaml
+++ b/clang-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-16
   version: 16.0.6
-  epoch: 0
+  epoch: 1
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,14 @@ environment:
       - help2man
       - llvm16
       - llvm16-dev
+      - llvm-cmake-16
       - libLLVM-16
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
 
 pipeline:
   - uses: fetch
@@ -41,15 +48,6 @@ pipeline:
       expected-sha256: 174c7844db2590b18b2a59a9ce503f8fe439edc2de2f0f625006501c99736f31
       strip-components: 0
 
-  - uses: fetch
-    with:
-      uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/cmake-${{package.version}}.src.tar.xz
-      expected-sha256: 39d342a4161095d2f28fb1253e4585978ac50521117da666e2b1f6f28b62f514
-      strip-components: 0
-
-  - runs: |
-      mv cmake-${{package.version}}.src ../cmake
-
   - runs: |
       mv clang-tools-extra-${{package.version}}.src tools/extra
 
@@ -59,10 +57,11 @@ pipeline:
       cmake -B build -G Ninja -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
-        -DCMAKE_MODULE_PATH="../cmake/Modules" \
+        -DCMAKE_MODULE_PATH=/usr/lib/llvm${{vars.major-version}}/share/cmake/Modules \
         -DCLANG_BUILT_STANDALONE=TRUE \
-        -DCLANG_CONFIG_FILE_SYSTEM_DIR=/etc/clang16 \
-        -DLLVM_CONFIG=/usr/lib/llvm16/bin/llvm-config \
+        -DLLVM_COMMON_CMAKE_UTILS="/usr/lib/llvm${{vars.major-version}}/share/cmake" \
+        -DCLANG_CONFIG_FILE_SYSTEM_DIR=/etc/clang${{vars.major-version}} \
+        -DLLVM_CONFIG=/usr/lib/llvm${{vars.major-version}}/bin/llvm-config \
         -DCLANG_ENABLE_ARCMT=ON \
         -DCLANG_ENABLE_STATIC_ANALYZER=ON \
         -DCLANG_INCLUDE_TESTS=OFF \
@@ -72,7 +71,7 @@ pipeline:
         -DCLANG_VENDOR=Wolfi \
         -DENABLE_LINKER_BUILD_ID=ON \
         -DLIBCLANG_BUILD_STATIC=ON \
-        -DLLVM_INCLUDE_DIRS=/usr/lib/llvm16/include
+        -DLLVM_INCLUDE_DIRS=/usr/lib/llvm${{vars.major-version}}/include
 
   - runs: |
       cmake --build build --target clang-tblgen

--- a/llvm-lld-16.yaml
+++ b/llvm-lld-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-lld-16
   version: 16.0.6
-  epoch: 2
+  epoch: 3
   description: The LLVM Linker
   copyright:
     - license: Apache-2.0
@@ -19,6 +19,7 @@ environment:
       - autoconf
       - clang-16
       - cmake
+      - llvm-cmake-16
       - libedit-dev
       - llvm16
       - llvm16-dev
@@ -28,31 +29,30 @@ environment:
       - llvm-libunwind-dev
       - curl
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
 pipeline:
   - uses: fetch
     with:
       expected-sha256: a127e334dd267f2e20d5a0c6b15aa9651f3fbbdfe3dc7d2573c617fad1155fcb
       uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/lld-${{package.version}}.src.tar.xz
 
-  - uses: fetch
-    with:
-      expected-sha256: 39d342a4161095d2f28fb1253e4585978ac50521117da666e2b1f6f28b62f514
-      uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/cmake-${{package.version}}.src.tar.xz
-      strip-components: 0
-
   - runs: |
-      mv cmake-${{package.version}}.src ../cmake
-
       cmake -B build -G Ninja -Wno-dev \
         -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_MODULE_PATH="..cmake/Modules" \
+        -DCMAKE_MODULE_PATH=/usr/lib/llvm${{vars.major-version}}/share/cmake/Modules \
+        -DLLVM_COMMON_CMAKE_UTILS="/usr/lib/llvm${{vars.major-version}}/share/cmake" \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_SKIP_INSTALL_RPATH=ON \
         -DBUILD_SHARED_LIBS=OFF \
         -DLLVM_INCLUDE_TESTS=OFF \
         -DLLD_BUILT_STANDALONE=ON \
-        -DLLVM_CONFIG=/usr/lib/llvm16/bin/llvm-config \
-        -DLLVM_INCLUDE_DIRS=/usr/lib/llvm16/include
+        -DLLVM_CONFIG=/usr/lib/llvm${{vars.major-version}}/bin/llvm-config \
+        -DLLVM_INCLUDE_DIRS=/usr/lib/llvm${{vars.major-version}}/include
 
   - runs: |
       cmake --build build


### PR DESCRIPTION
`clang-16` and `llvm-lld-16` won't build successfully in MacOS due to rootless mode. Updating both packages so they build successfully without relying on the `../cmake` path anymore.
