### PR TITLE
More runtime deps for nginx + update mimalloc and enable version stream bot updates

### DIFF
--- a/ingress-nginx-controller.yaml
+++ b/ingress-nginx-controller.yaml
@@ -2,7 +2,7 @@
 package:
   name: ingress-nginx-controller
   version: 1.8.2
-  epoch: 0
+  epoch: 1
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -14,6 +14,7 @@ package:
       - openssh-client
       - openssl
       - openssl-dev
+      - libcrypt1
       - opentracing-cpp
       - jaeger-cpp
       - msgpack
@@ -44,6 +45,7 @@ package:
       - libxslt
       - modsecurity
       - mimalloc
+      - pcre
 
 environment:
   contents:

--- a/mimalloc.yaml
+++ b/mimalloc.yaml
@@ -1,7 +1,7 @@
 package:
   name: mimalloc
-  version: 1.7.6
-  epoch: 1
+  version: 1.8.2
+  epoch: 0
   description: "A compact general purpose allocator with excellent performance"
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/microsoft/mimalloc/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da
+      expected-sha256: 4058d53d6ceb75862f32c30a6ee686c3cbb5e965b2c324b828ca454f7fe064f9
 
   - uses: cmake/configure
 
@@ -36,4 +36,9 @@ subpackages:
         - mimalloc
 
 update:
-  enabled: false
+  enabled: true
+  github:
+    identifier: microsoft/mimalloc
+    strip-prefix: v
+    tag-filter: v1.
+    use-tag: true

--- a/mimalloc2.yaml
+++ b/mimalloc2.yaml
@@ -54,4 +54,4 @@ update:
     identifier: microsoft/mimalloc
     strip-prefix: v
     use-tag: true
-    tag-filter: v
+    tag-filter: v2.


### PR DESCRIPTION
There's two commits in this PR both related to a working nginx ingress controller, using more recent package dependencies

#### For version bump PRs
- [x] The `epoch` field is reset to 0
