### PR TITLE
feat: add version/commit/date to boring-registry binary

### DIFF
--- a/boring-registry.yaml
+++ b/boring-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: boring-registry
   version: 0.11.4
-  epoch: 0
+  epoch: 1
   description: Terraform Provider and Module Registry
   copyright:
     - license: MIT
@@ -27,7 +27,11 @@ pipeline:
     with:
       packages: .
       output: boring-registry
-      ldflags: -s -w
+      ldflags: |
+        -s -w
+        -X github.com/TierMobility/boring-registry/version.Version="${{package.version}}"
+        -X github.com/TierMobility/boring-registry/version.Commit="$(git rev-parse --verify HEAD --short)"
+        -X github.com/TierMobility/boring-registry/version.Date="$(date -u +'%FT%T%z')"
 
   - uses: strip
 


### PR DESCRIPTION
Update the `boring-registry` package to include the version, commit, and date metadata in the binary.