### PR TITLE
argocd-2.8: update nodejs version to match upstream and remove cve fix

### DIFF
--- a/argo-cd-2.8.yaml
+++ b/argo-cd-2.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.8
   version: 2.8.3
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,7 @@ environment:
       - busybox
       - go
       - python3
-      - nodejs-16
+      - nodejs-20
       - yarn
 
 pipeline:
@@ -40,9 +40,6 @@ pipeline:
       # Disable the `-pie` flag here since ArgoCD's helm charts like to copy around the multicall binary to different images (ie: dex)
 
       unset GOFLAGS
-
-      # CVE-2023-2253
-      go get github.com/docker/distribution@v2.8.2
 
       # CVE-2023-2728, CVE-2023-2727
       go get k8s.io/kubernetes@v1.24.15


### PR DESCRIPTION
- node20 used by upstream  https://github.com/argoproj/argo-cd/blob/v2.8.3/Dockerfile#L86
- removing cve fix as it is fixed in [upstream](https://github.com/argoproj/argo-cd/blob/v2.8.3/go.mod#L149) 