### PR TITLE
argocd-2.7: move to nodejs-18

### DIFF
--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.7
   version: 2.7.14
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,7 @@ environment:
       - busybox
       - go
       - python3
-      - nodejs-16
+      - nodejs-18
       - yarn
 
 pipeline:


### PR DESCRIPTION
Upstream uses node-18 https://github.com/argoproj/argo-cd/blob/v2.7.14/Dockerfile#L86