### PR TITLE
Put the pecl extensions into common path

### DIFF
--- a/php-8.1-pecl-mcrypt.yaml
+++ b/php-8.1-pecl-mcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-mcrypt
   version: 1.0.6
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.1 bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
@@ -42,8 +42,8 @@ pipeline:
   - name: Install
     runs: |
       make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php81/conf.d
-      echo "extension=mcrypt" > ${{targets.destdir}}/etc/php81/conf.d/mcrypt.ini
+      install -d ${{targets.destdir}}/etc/php/conf.d
+      echo "extension=mcrypt" > ${{targets.destdir}}/etc/php/conf.d/mcrypt.ini
 
   - uses: strip
 

--- a/php-8.1-pecl-mongodb.yaml
+++ b/php-8.1-pecl-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-mongodb
   version: 1.16.2
-  epoch: 1
+  epoch: 2
   description: "PHP 8.1 MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
@@ -46,8 +46,8 @@ pipeline:
   - name: Install
     runs: |
       make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php81/conf.d
-      echo "extension=mongodb" > ${{targets.destdir}}/etc/php81/conf.d/mongodb.ini
+      install -d ${{targets.destdir}}/etc/php/conf.d
+      echo "extension=mongodb" > ${{targets.destdir}}/etc/php/conf.d/mongodb.ini
 
   - uses: strip
 

--- a/php-8.2-pecl-mcrypt.yaml
+++ b/php-8.2-pecl-mcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-mcrypt
   version: 1.0.6
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.2 bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
@@ -42,8 +42,8 @@ pipeline:
   - name: Install
     runs: |
       make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php82/conf.d
-      echo "extension=mcrypt" > ${{targets.destdir}}/etc/php82/conf.d/mcrypt.ini
+      install -d ${{targets.destdir}}/etc/php/conf.d
+      echo "extension=mcrypt" > ${{targets.destdir}}/etc/php/conf.d/mcrypt.ini
 
   - uses: strip
 

--- a/php-8.2-pecl-mongodb.yaml
+++ b/php-8.2-pecl-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-mongodb
   version: 1.16.2
-  epoch: 1
+  epoch: 2
   description: "PHP 8.2 MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
@@ -46,8 +46,8 @@ pipeline:
   - name: Install
     runs: |
       make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php82/conf.d
-      echo "extension=mongodb" > ${{targets.destdir}}/etc/php82/conf.d/mongodb.ini
+      install -d ${{targets.destdir}}/etc/php/conf.d
+      echo "extension=mongodb" > ${{targets.destdir}}/etc/php/conf.d/mongodb.ini
 
   - uses: strip
 


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

This puts the pecl extensions into the common path, so that when you run php --ini they are automatically found.
