### PR TITLE
Add php-8.1-pecl.raphf.yaml and php-8.1-pecl.raphf.yaml.

### DIFF
--- a/php-8.1-pecl-raphf.yaml
+++ b/php-8.1-pecl-raphf.yaml
@@ -31,7 +31,7 @@ pipeline:
       uri: https://pecl.php.net/get/raphf-${{package.version}}.tgz
       expected-sha512: 0a609fc21a62880963e7afb75297eb75a2598aab2c816cb61e84d665b0453e4952aa9bf25fe2c818cc94492a4b94aed965053c67899fdb984d88661364fffb1e
 
-  - uses: pecl/phpize-8.1
+  - uses: pecl/phpize
 
   - uses: autoconf/make
 

--- a/php-8.1-pecl-raphf.yaml
+++ b/php-8.1-pecl-raphf.yaml
@@ -1,0 +1,46 @@
+package:
+  name: php-8.1-pecl-raphf
+  version: 2.0.1
+  epoch: 0
+  description: "Provides PHP 8.1 resource and persistent handles factory - PECL"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    provides:
+      - php-pecl-raphf=${{package.full-version}}
+    runtime:
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gcc
+      - libtool
+      - php-8.1-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/raphf-${{package.version}}.tgz
+      expected-sha512: 0a609fc21a62880963e7afb75297eb75a2598aab2c816cb61e84d665b0453e4952aa9bf25fe2c818cc94492a4b94aed965053c67899fdb984d88661364fffb1e
+
+  - uses: pecl/phpize-8.1
+
+  - uses: autoconf/make
+
+  - uses: pecl/install
+    with:
+      extension: raphf
+
+  - uses: strip
+
+# TODO(vaikas): I can't find in release-monitoring, or github.
+update:
+  enabled: false

--- a/php-8.2-pecl-raphf.yaml
+++ b/php-8.2-pecl-raphf.yaml
@@ -1,0 +1,46 @@
+package:
+  name: php-8.2-pecl-raphf
+  version: 2.0.1
+  epoch: 0
+  description: "Provides PHP 8.2 resource and persistent handles factory - PECL"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    provides:
+      - php-pecl-raphf=${{package.full-version}}
+    runtime:
+      - php-8.2
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gcc
+      - libtool
+      - php-8.2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/raphf-${{package.version}}.tgz
+      expected-sha512: 0a609fc21a62880963e7afb75297eb75a2598aab2c816cb61e84d665b0453e4952aa9bf25fe2c818cc94492a4b94aed965053c67899fdb984d88661364fffb1e
+
+  - uses: pecl/phpize-8.2
+
+  - uses: autoconf/make
+
+  - uses: pecl/install
+    with:
+      extension: raphf
+
+  - uses: strip
+
+# TODO(vaikas): I can't find in release-monitoring, or github.
+update:
+  enabled: false


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

Note that this can not be merged before the pipelines go in. Just staging here so that PR can be reviewed. Built them with the pipelines locally:
```
54e9eb9f272d:/work/packages# apk info -L php-8.1-pecl-raphf
php-8.1-pecl-raphf-2.0.1-r0 contains:
etc/php/conf.d/raphf.ini
usr/include/php/ext/raphf/php_raphf.h
usr/include/php/ext/raphf/php_raphf_api.h
usr/lib/php/modules/raphf.so
var/lib/db/sbom/php-8.1-pecl-raphf-2.0.1-r0.spdx.json
```

And:
```
9ac7f0d1f877:/work/packages# apk info -L php-8.2-pecl-raphf
php-8.2-pecl-raphf-2.0.1-r1 contains:
etc/php/conf.d/raphf.ini
usr/include/php/ext/raphf/php_raphf.h
usr/include/php/ext/raphf/php_raphf_api.h
usr/lib/php/modules/raphf.so
var/lib/db/sbom/php-8.2-pecl-raphf-2.0.1-r1.spdx.json
```

