### PR TITLE
Refactor `kubernetes-csi-node-driver-registrar` to version streams.

### DIFF
--- a/kubernetes-csi-node-driver-registrar-2.9.yaml
+++ b/kubernetes-csi-node-driver-registrar-2.9.yaml
@@ -1,10 +1,14 @@
 package:
-  name: kubernetes-csi-node-driver-registrar
+  # Supported versions policy: https://kubernetes-csi.github.io/docs/node-driver-registrar.html
+  name: kubernetes-csi-node-driver-registrar-2.9
   version: 2.9.0
-  epoch: 0
+  epoch: 1
   description: Sidecar container that registers a CSI driver with the kubelet using the kubelet plugin registration mechanism.
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - kubernetes-csi-node-driver-registrar=${{package.full-version}}
 
 environment:
   contents:
@@ -30,13 +34,16 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: kubernetes-csi-node-driver-registrar-compat
+  - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"
     pipeline:
       - runs: |
           # The helm chart expects the binaries to be in / instead of /usr/bin
           mkdir -p "${{targets.subpkgdir}}"
           ln -sf /usr/bin/csi-node-driver-registrar ${{targets.subpkgdir}}/csi-node-driver-registrar
+    dependencies:
+      provides:
+        - kubernetes-csi-node-driver-registrar-compat=${{package.full-version}}
 
 update:
   enabled: true


### PR DESCRIPTION
It appears that upstream supports three versions.
