### PR TITLE
Add php-8.1-pecl-sqlsrv and php-8.2-pecl-sqlsrv

### DIFF
--- a/php-8.1-pecl-sqlsrv.yaml
+++ b/php-8.1-pecl-sqlsrv.yaml
@@ -1,0 +1,50 @@
+package:
+  name: php-8.1-pecl-sqlsrv
+  version: 5.11.1
+  epoch: 0
+  description: "Provides PHP 8.1 Microsoft Drivers for SQL Server (SQLSRV) - PECL"
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - php-pecl-sqlsrv=${{package.full-version}}
+    runtime:
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gcc
+      - libtool
+      - unixodbc-dev
+      - php-8.1-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/sqlsrv-${{package.version}}.tgz
+      expected-sha512: ee63d7225b7ea8d26e8f53ed25e94fb356cefd3c463405bad1a3543edb820c6b5e3c554842b0190352c521c7aa314f42b6590b8b3cb859fead1f05348fb43f46
+
+  - uses: pecl/phpize-8.1
+
+  - uses: autoconf/make
+
+  - uses: pecl/install
+    with:
+      extension: sqlsrv
+
+  - uses: strip
+
+# TODO(vaikas): I can find the releases in github but building it does not work
+# with fetching from there like it does when you use fetch.
+# Also seems like I can't watch the github repo for new releases, yet use
+# the fetch above together?
+update:
+  enabled: false

--- a/php-8.1-pecl-sqlsrv.yaml
+++ b/php-8.1-pecl-sqlsrv.yaml
@@ -32,7 +32,7 @@ pipeline:
       uri: https://pecl.php.net/get/sqlsrv-${{package.version}}.tgz
       expected-sha512: ee63d7225b7ea8d26e8f53ed25e94fb356cefd3c463405bad1a3543edb820c6b5e3c554842b0190352c521c7aa314f42b6590b8b3cb859fead1f05348fb43f46
 
-  - uses: pecl/phpize-8.1
+  - uses: pecl/phpize
 
   - uses: autoconf/make
 

--- a/php-8.2-pecl-sqlsrv.yaml
+++ b/php-8.2-pecl-sqlsrv.yaml
@@ -1,0 +1,50 @@
+package:
+  name: php-8.2-pecl-sqlsrv
+  version: 5.11.1
+  epoch: 0
+  description: "Provides PHP 8.2 Microsoft Drivers for SQL Server (SQLSRV) - PECL"
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - php-pecl-sqlsrv=${{package.full-version}}
+    runtime:
+      - php-8.2
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gcc
+      - libtool
+      - unixodbc-dev
+      - php-8.2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/sqlsrv-${{package.version}}.tgz
+      expected-sha512: ee63d7225b7ea8d26e8f53ed25e94fb356cefd3c463405bad1a3543edb820c6b5e3c554842b0190352c521c7aa314f42b6590b8b3cb859fead1f05348fb43f46
+
+  - uses: pecl/phpize-8.2
+
+  - uses: autoconf/make
+
+  - uses: pecl/install
+    with:
+      extension: sqlsrv
+
+  - uses: strip
+
+# TODO(vaikas): I can find the releases in github but building it does not work
+# with fetching from there like it does when you use fetch.
+# Also seems like I can't watch the github repo for new releases, yet use
+# the fetch above together?
+update:
+  enabled: false

--- a/php-8.2-pecl-sqlsrv.yaml
+++ b/php-8.2-pecl-sqlsrv.yaml
@@ -32,7 +32,7 @@ pipeline:
       uri: https://pecl.php.net/get/sqlsrv-${{package.version}}.tgz
       expected-sha512: ee63d7225b7ea8d26e8f53ed25e94fb356cefd3c463405bad1a3543edb820c6b5e3c554842b0190352c521c7aa314f42b6590b8b3cb859fead1f05348fb43f46
 
-  - uses: pecl/phpize-8.2
+  - uses: pecl/phpize
 
   - uses: autoconf/make
 


### PR DESCRIPTION
Blocked on: https://github.com/chainguard-dev/melange/pull/679

tested with wolfi-local:
```
2f26b4089757:/work/packages# apk add php-8.1-pecl-sqlsrv
<SNIP>
OK: 34 MiB in 25 packages
2f26b4089757:/work/packages# apk info -L php-8.1-pecl-sqlsrv
php-8.1-pecl-sqlsrv-5.11.1-r2 contains:
etc/php/conf.d/sqlsrv.ini
usr/lib/php/modules/sqlsrv.so
var/lib/db/sbom/php-8.1-pecl-sqlsrv-5.11.1-r2.spdx.json

4ffcea284be6:/work/packages# apk add php-8.2-pecl-sqlsrv
<SNIP>
OK: 34 MiB in 25 packages
4ffcea284be6:/work/packages# apk info -L php-8.2-pecl-sqlsrv
php-8.2-pecl-sqlsrv-5.11.1-r0 contains:
etc/php/conf.d/sqlsrv.ini
usr/lib/php/modules/sqlsrv.so
var/lib/db/sbom/php-8.2-pecl-sqlsrv-5.11.1-r0.spdx.json
```

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ X ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ X ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
