### PR TITLE
Add php-8.[1,2]-pecl-pdosqlsrv

### DIFF
--- a/php-8.1-pecl-pdosqlsrv.yaml
+++ b/php-8.1-pecl-pdosqlsrv.yaml
@@ -32,7 +32,7 @@ pipeline:
       uri: https://pecl.php.net/get/pdo_sqlsrv-${{package.version}}.tgz
       expected-sha512: 6bcf39b9948fdc06261f4e901de988c33b27422d5677c6ec8234625f49ad702186e5e02bcb5264945e0bc5fd4de3389ec014e125856625837dbd884776747faa
 
-  - uses: pecl/phpize-8.1
+  - uses: pecl/phpize
 
   - uses: autoconf/make
 

--- a/php-8.1-pecl-pdosqlsrv.yaml
+++ b/php-8.1-pecl-pdosqlsrv.yaml
@@ -1,0 +1,50 @@
+package:
+  name: php-8.1-pecl-pdosqlsrv
+  version: 5.11.1
+  epoch: 0
+  description: "Provides PHP 8.1 Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - php-pecl-pdosqlsrv=${{package.full-version}}
+    runtime:
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gcc
+      - libtool
+      - unixodbc-dev
+      - php-8.1-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/pdo_sqlsrv-${{package.version}}.tgz
+      expected-sha512: 6bcf39b9948fdc06261f4e901de988c33b27422d5677c6ec8234625f49ad702186e5e02bcb5264945e0bc5fd4de3389ec014e125856625837dbd884776747faa
+
+  - uses: pecl/phpize-8.1
+
+  - uses: autoconf/make
+
+  - uses: pecl/install
+    with:
+      extension: pdo_sqlsrv
+
+  - uses: strip
+
+# TODO(vaikas): I can find the releases in github but building it does not work
+# with fetching from there like it does when you use fetch.
+# Also seems like I can't watch the github repo for new releases, yet use
+# the fetch above together?
+update:
+  enabled: false

--- a/php-8.2-pecl-pdosqlsrv.yaml
+++ b/php-8.2-pecl-pdosqlsrv.yaml
@@ -32,7 +32,7 @@ pipeline:
       uri: https://pecl.php.net/get/pdo_sqlsrv-${{package.version}}.tgz
       expected-sha512: 6bcf39b9948fdc06261f4e901de988c33b27422d5677c6ec8234625f49ad702186e5e02bcb5264945e0bc5fd4de3389ec014e125856625837dbd884776747faa
 
-  - uses: pecl/phpize-8.2
+  - uses: pecl/phpize
 
   - uses: autoconf/make
 

--- a/php-8.2-pecl-pdosqlsrv.yaml
+++ b/php-8.2-pecl-pdosqlsrv.yaml
@@ -1,0 +1,50 @@
+package:
+  name: php-8.2-pecl-pdosqlsrv
+  version: 5.11.1
+  epoch: 0
+  description: "Provides PHP 8.2 Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - php-pecl-pdosqlsrv=${{package.full-version}}
+    runtime:
+      - php-8.2
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gcc
+      - libtool
+      - unixodbc-dev
+      - php-8.2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/pdo_sqlsrv-${{package.version}}.tgz
+      expected-sha512: 6bcf39b9948fdc06261f4e901de988c33b27422d5677c6ec8234625f49ad702186e5e02bcb5264945e0bc5fd4de3389ec014e125856625837dbd884776747faa
+
+  - uses: pecl/phpize-8.2
+
+  - uses: autoconf/make
+
+  - uses: pecl/install
+    with:
+      extension: pdo_sqlsrv
+
+  - uses: strip
+
+# TODO(vaikas): I can find the releases in github but building it does not work
+# with fetching from there like it does when you use fetch.
+# Also seems like I can't watch the github repo for new releases, yet use
+# the fetch above together?
+update:
+  enabled: false


### PR DESCRIPTION
Can't go in before these pipelines are available: https://github.com/chainguard-dev/melange/pull/679

Tested with wolfi-local:
```
\de89600e7f50:/work/packages# apk add php-8.1-pecl-pdosqlsrv
<SNIP>
OK: 34 MiB in 25 packages
de89600e7f50:/work/packages# apk info -L  php-8.1-pecl-pdosqlsrv
php-8.1-pecl-pdosqlsrv-5.11.1-r0 contains:
etc/php/conf.d/pdo_sqlsrv.ini
usr/lib/php/modules/pdo_sqlsrv.so
var/lib/db/sbom/php-8.1-pecl-pdosqlsrv-5.11.1-r0.spdx.json

065d1a070c78:/work/packages# apk add php-8.2-pecl-pdosqlsrv
<SNIP>
OK: 34 MiB in 25 packages
065d1a070c78:/work/packages# apk info -L php-8.2-pecl-pdosqlsrv
php-8.2-pecl-pdosqlsrv-5.11.1-r0 contains:
etc/php/conf.d/pdo_sqlsrv.ini
usr/lib/php/modules/pdo_sqlsrv.so
var/lib/db/sbom/php-8.2-pecl-pdosqlsrv-5.11.1-r0.spdx.json
```


<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ X ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ X ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
