### PR TITLE
Convert ingress-nginx-controller to version stream

### DIFF
--- a/ingress-nginx-controller-1.8.yaml
+++ b/ingress-nginx-controller-1.8.yaml
@@ -1,12 +1,14 @@
 #nolint:valid-pipeline-fetch-digest
 package:
-  name: ingress-nginx-controller
+  name: ingress-nginx-controller-1.8
   version: 1.8.2
-  epoch: 1
+  epoch: 0
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
   dependencies:
+    provides:
+      - ingress-nginx-controller=1.18.999
     runtime:
       - ca-certificates-bundle
       - ca-certificates
@@ -491,9 +493,11 @@ pipeline:
       rm -rf ${{targets.destdir}}/etc/nginx/owasp-modsecurity-crs/util/regression-tests
 
 subpackages:
-  - name: ingress-nginx-controller-compat
+  - name: ${{package.name}}-compat
     description: Compatibility package for ingress-nginx-controller
     dependencies:
+      provides:
+        - ingress-nginx-controller-compat=1.18.999
       runtime:
         - modsecurity-config
     pipeline:


### PR DESCRIPTION
* "ingress-nginx-controller-1.8: new version stream from current package ingress-nginx-controller"

#### For new version streams
- [ ] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)