### PR TITLE
cert-manager-1.13: new package

### DIFF
--- a/cert-manager-1.13.yaml
+++ b/cert-manager-1.13.yaml
@@ -1,0 +1,75 @@
+package:
+  name: cert-manager-1.13
+  # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
+  version: 1.13.0
+  epoch: 0
+  description: Automatically provision and manage TLS certificates in Kubernetes
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+      - make
+      - curl
+      - jq
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cert-manager/cert-manager
+      tag: v${{package.version}}
+      expected-commit: d34bd7aa15055b428bf865851bc420412f3710e6
+
+  # the makefile hardcodes the requirement for some container runtime (CTR), even when we don't need it
+  # to workaround, set CTR to anything $(command -v)able
+  - runs: |
+      make CTR=make _bin/server/controller-linux-$(go env GOARCH)
+      make CTR=make _bin/server/webhook-linux-$(go env GOARCH)
+      make CTR=make _bin/server/cainjector-linux-$(go env GOARCH)
+      make CTR=make _bin/server/acmesolver-linux-$(go env GOARCH)
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv _bin/server/* ${{targets.destdir}}/usr/bin/
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-controller
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/controller-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/controller
+
+  - name: ${{package.name}}-webhook
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/webhook-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/webhook
+
+  - name: ${{package.name}}-cainjector
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/cainjector-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/cainjector
+
+  - name: ${{package.name}}-acmesolver
+    pipeline:
+      - runs: |
+          install -Dm755 ${{targets.destdir}}/usr/bin/acmesolver-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/acmesolver
+
+  - name: cmctl-1.13
+    pipeline:
+      - runs: |
+          make CTR=make cmctl-linux
+      - runs: |
+          install -Dm755 _bin/cmctl/cmctl-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/cmctl
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: cert-manager/cert-manager
+    strip-prefix: v
+    tag-filter: v1.13.
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: 


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
