### PR TITLE
Fluentd plugin for http-out

### DIFF
--- a/fluent-plugin-out-http.yaml
+++ b/fluent-plugin-out-http.yaml
@@ -31,7 +31,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 821f4468c2db1ddcfaad8520b1d9a5b33f5d6eda89a2fc931da735b3d42a6f44
-      uri: https://github.com/fluent-plugins-nursery/fluent-plugin-out-http/archive/refs/tags/${{package.version}}.tar.gz
+      uri: https://github.com/fluent-plugins-nursery/fluent-plugin-out-http/archive/refs/tags/v${{package.version}}.tar.gz
 
   - uses: ruby/unlock-spec
 
@@ -50,4 +50,5 @@ update:
   enabled: true
   github:
     identifier: fluent-plugins-nursery/fluent-plugin-out-http
+    strip-prefix: v
     use-tag: true

--- a/fluent-plugin-out-http.yaml
+++ b/fluent-plugin-out-http.yaml
@@ -49,4 +49,4 @@ pipeline:
 update:
   enabled: true
   github:
-    identifier: splunk/fluent-plugin-out-http
+    identifier: fluent-plugins-nursery/fluent-plugin-out-http

--- a/fluent-plugin-out-http.yaml
+++ b/fluent-plugin-out-http.yaml
@@ -1,0 +1,52 @@
+package:
+  name: fluent-plugin-out-http
+  version: 1.3.4
+  epoch: 0
+  description: This is the Fluentd output plugin for enabling http access
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - ruby3.2-fluent-plugin-out-http=${{package.version}}-r${{package.epoch}}
+    runtime:
+      - ruby3.2-fluentd
+      - ruby3.2-json-jwt
+      - ruby3.2-multi_json
+      - ruby3.2-net-http-persistent
+      - ruby3.2-openid_connect-1.1.8
+      - ruby3.2-prometheus-client
+      - ruby3.2-rack-oauth2
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 821f4468c2db1ddcfaad8520b1d9a5b33f5d6eda89a2fc931da735b3d42a6f44
+      uri: https://github.com/fluent-plugins-nursery/fluent-plugin-out-http/archive/refs/tags/${{package.version}}.tar.gz
+
+  - uses: ruby/unlock-spec
+
+  - uses: ruby/build
+    with:
+      gem: ${{package.name}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{package.name}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+update:
+  enabled: true
+  github:
+    identifier: splunk/fluent-plugin-out-http

--- a/fluent-plugin-out-http.yaml
+++ b/fluent-plugin-out-http.yaml
@@ -51,3 +51,4 @@ update:
   enabled: true
   github:
     identifier: fluent-plugins-nursery/fluent-plugin-out-http
+    use-tag: true

--- a/fluent-plugin-out-http.yaml
+++ b/fluent-plugin-out-http.yaml
@@ -30,7 +30,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 821f4468c2db1ddcfaad8520b1d9a5b33f5d6eda89a2fc931da735b3d42a6f44
+      expected-sha256: f97af77141c16a5f3f7027516d521fc7caa546c97b53165a5fb1a1ee39ee749b
       uri: https://github.com/fluent-plugins-nursery/fluent-plugin-out-http/archive/refs/tags/v${{package.version}}.tar.gz
 
   - uses: ruby/unlock-spec

--- a/fluent-plugin-out-http.yaml
+++ b/fluent-plugin-out-http.yaml
@@ -31,7 +31,6 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 821f4468c2db1ddcfaad8520b1d9a5b33f5d6eda89a2fc931da735b3d42a6f44
-      uri: https://github.com/fluent-plugins-nursery/fluent-plugin-out-http/archive/refs/tags/${{package.version}}.tar.gz
       uri: https://github.com/fluent-plugins-nursery/fluent-plugin-out-http/archive/refs/tags/v${{package.version}}.tar.gz
 
   - uses: ruby/unlock-spec

--- a/fluent-plugin-out-http.yaml
+++ b/fluent-plugin-out-http.yaml
@@ -32,6 +32,7 @@ pipeline:
     with:
       expected-sha256: 821f4468c2db1ddcfaad8520b1d9a5b33f5d6eda89a2fc931da735b3d42a6f44
       uri: https://github.com/fluent-plugins-nursery/fluent-plugin-out-http/archive/refs/tags/${{package.version}}.tar.gz
+      uri: https://github.com/fluent-plugins-nursery/fluent-plugin-out-http/archive/refs/tags/v${{package.version}}.tar.gz
 
   - uses: ruby/unlock-spec
 

--- a/fluent-plugin-out-http.yaml
+++ b/fluent-plugin-out-http.yaml
@@ -31,7 +31,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 821f4468c2db1ddcfaad8520b1d9a5b33f5d6eda89a2fc931da735b3d42a6f44
-      uri: https://github.com/fluent-plugins-nursery/fluent-plugin-out-http/archive/refs/tags/v${{package.version}}.tar.gz
+      uri: https://github.com/fluent-plugins-nursery/fluent-plugin-out-http/archive/refs/tags/${{package.version}}.tar.gz
 
   - uses: ruby/unlock-spec
 

--- a/fluent-plugin-out-http.yaml
+++ b/fluent-plugin-out-http.yaml
@@ -2,7 +2,7 @@ package:
   name: fluent-plugin-out-http
   version: 1.3.4
   epoch: 0
-  description: This is the Fluentd output plugin for enabling http access
+  description: This is the Fluentd output plugin for enabling http access to the container
   copyright:
     - license: Apache-2.0
   dependencies:


### PR DESCRIPTION
Attempt to add ruby gem for fluentd to enable http out traffic for /metrics

### Pre-review Checklist

#### For version bump PRs

- [X] The `epoch` field is reset to 0
