### PR TITLE
Version stream `cluster-autoscaler`.

### DIFF
--- a/cluster-autoscaler-1.25.yaml
+++ b/cluster-autoscaler-1.25.yaml
@@ -1,0 +1,58 @@
+package:
+  name: cluster-autoscaler-1.25
+  version: 1.25.3
+  epoch: 0
+  description: Autoscaling components for Kubernetes
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - cluster-autoscaler=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - go
+  environment:
+    CGO_ENABLED: 0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes/autoscaler
+      tag: cluster-autoscaler-${{package.version}}
+      expected-commit: 5a4d7d25a3c902a664fac39360b3e4635a74fdbd
+
+  - uses: go/build
+    with:
+      modroot: cluster-autoscaler
+      packages: .
+      output: cluster-autoscaler
+      ldflags: -s -w
+      deps: github.com/docker/distribution@v2.8.2
+      vendor: true
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}
+          # The upstream helm chart assumes the binary is in /.
+          ln -sf /usr/bin/cluster-autoscaler ${{targets.subpkgdir}}/cluster-autoscaler
+    dependencies:
+      provides:
+        - cluster-autoscaler-compat=${{package.full-version}}
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes/autoscaler
+    strip-prefix: cluster-autoscaler-
+    use-tag: true
+    # There are other tags like "cluster-autoscaler-chart-FOO"
+    tag-filter: cluster-autoscaler-1.25.

--- a/cluster-autoscaler-1.26.yaml
+++ b/cluster-autoscaler-1.26.yaml
@@ -1,0 +1,58 @@
+package:
+  name: cluster-autoscaler-1.26
+  version: 1.26.4
+  epoch: 0
+  description: Autoscaling components for Kubernetes
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - cluster-autoscaler=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - go
+  environment:
+    CGO_ENABLED: 0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes/autoscaler
+      tag: cluster-autoscaler-${{package.version}}
+      expected-commit: 4256b234be902d9697537ffa226a6df445151bc3
+
+  - uses: go/build
+    with:
+      modroot: cluster-autoscaler
+      packages: .
+      output: cluster-autoscaler
+      ldflags: -s -w
+      deps: github.com/docker/distribution@v2.8.2
+      vendor: true
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}
+          # The upstream helm chart assumes the binary is in /.
+          ln -sf /usr/bin/cluster-autoscaler ${{targets.subpkgdir}}/cluster-autoscaler
+    dependencies:
+      provides:
+        - cluster-autoscaler-compat=${{package.full-version}}
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes/autoscaler
+    strip-prefix: cluster-autoscaler-
+    use-tag: true
+    # There are other tags like "cluster-autoscaler-chart-FOO"
+    tag-filter: cluster-autoscaler-1.26.

--- a/cluster-autoscaler-1.27.yaml
+++ b/cluster-autoscaler-1.27.yaml
@@ -1,10 +1,13 @@
 package:
-  name: cluster-autoscaler
-  version: 1.28.0
-  epoch: 1
+  name: cluster-autoscaler-1.27
+  version: 1.27.3
+  epoch: 2
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - cluster-autoscaler=${{package.full-version}}
 
 environment:
   contents:
@@ -21,7 +24,7 @@ pipeline:
     with:
       repository: https://github.com/kubernetes/autoscaler
       tag: cluster-autoscaler-${{package.version}}
-      expected-commit: 5bcb526e08c17ff93cc6093ee89a95730a90e45b
+      expected-commit: ea4976f31c797c1ded86fbe8a3899e59a5ada1b1
 
   - uses: go/build
     with:
@@ -35,12 +38,15 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: cluster-autoscaler-compat
+  - name: ${{package.name}}-compat
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}
           # The upstream helm chart assumes the binary is in /.
           ln -sf /usr/bin/cluster-autoscaler ${{targets.subpkgdir}}/cluster-autoscaler
+    dependencies:
+      provides:
+        - cluster-autoscaler-compat=${{package.full-version}}
 
 update:
   enabled: true
@@ -49,4 +55,4 @@ update:
     strip-prefix: cluster-autoscaler-
     use-tag: true
     # There are other tags like "cluster-autoscaler-chart-FOO"
-    tag-filter: cluster-autoscaler-1
+    tag-filter: cluster-autoscaler-1.27.

--- a/cluster-autoscaler-1.28.yaml
+++ b/cluster-autoscaler-1.28.yaml
@@ -1,0 +1,58 @@
+package:
+  name: cluster-autoscaler-1.28
+  version: 1.28.0
+  epoch: 2
+  description: Autoscaling components for Kubernetes
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - cluster-autoscaler=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - go
+  environment:
+    CGO_ENABLED: 0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes/autoscaler
+      tag: cluster-autoscaler-${{package.version}}
+      expected-commit: 5bcb526e08c17ff93cc6093ee89a95730a90e45b
+
+  - uses: go/build
+    with:
+      modroot: cluster-autoscaler
+      packages: .
+      output: cluster-autoscaler
+      ldflags: -s -w
+      deps: github.com/docker/distribution@v2.8.2
+      vendor: true
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}
+          # The upstream helm chart assumes the binary is in /.
+          ln -sf /usr/bin/cluster-autoscaler ${{targets.subpkgdir}}/cluster-autoscaler
+    dependencies:
+      provides:
+        - cluster-autoscaler-compat=${{package.full-version}}
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes/autoscaler
+    strip-prefix: cluster-autoscaler-
+    use-tag: true
+    # There are other tags like "cluster-autoscaler-chart-FOO"
+    tag-filter: cluster-autoscaler-1.28.


### PR DESCRIPTION
This component is expected to be co-versioned with Kubernetes components, so this should track the same streams as Kubernetes itself.

