### PR TITLE
simplify redis packaging

### DIFF
--- a/redis-6.2.yaml
+++ b/redis-6.2.yaml
@@ -1,13 +1,17 @@
 package:
   name: redis-6.2
   version: 6.2.13
-  epoch: 2
+  epoch: 3
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
   dependencies:
     provides:
       - redis=6.2.99
+      # Kept for compatibility with `redis-sentinel-6.2-compat`
+      - redis-sentinel-6.2
+    runtime:
+      - posix-libc-utils # `getent` is required on startup in ha mode for ip introspection cluster formation
 
 environment:
   contents:
@@ -43,7 +47,6 @@ pipeline:
 subpackages:
   - name: redis-cli-6.2
     pipeline:
-      - uses: split/dev
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/redis-cli "${{targets.subpkgdir}}"/usr/bin/redis-cli
@@ -54,7 +57,6 @@ subpackages:
 
   - name: redis-benchmark-6.2
     pipeline:
-      - uses: split/dev
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/redis-benchmark "${{targets.subpkgdir}}"/usr/bin/redis-benchmark
@@ -62,41 +64,6 @@ subpackages:
     dependencies:
       provides:
         - redis-benchmark=6.2.99
-
-  - name: redis-sentinel-6.2
-    pipeline:
-      - uses: split/dev
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/redis-sentinel "${{targets.subpkgdir}}"/usr/bin/redis-sentinel
-    description: redis-sentinel provides High availability for non-clustered Redis
-    dependencies:
-      runtime:
-        - redis=6.2.99
-      provides:
-        - redis-sentinel=6.2.99
-
-  - name: redis-check-aof-6.2
-    pipeline:
-      - uses: split/dev
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/redis-check-aof "${{targets.subpkgdir}}"/usr/bin/redis-check-aof
-    description: redis-check-aof
-    dependencies:
-      provides:
-        - redis-check-aof=6.2.99
-
-  - name: redis-check-rdb-6.2
-    pipeline:
-      - uses: split/dev
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/redis-check-rdb "${{targets.subpkgdir}}"/usr/bin/redis-check-rdb
-    description: redis-check-rdb
-    dependencies:
-      provides:
-        - redis-check-rdb=6.2.99
 
 update:
   enabled: true

--- a/redis-7.0.yaml
+++ b/redis-7.0.yaml
@@ -1,13 +1,15 @@
 package:
   name: redis-7.0
   version: 7.0.13
-  epoch: 0
+  epoch: 1
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
   dependencies:
     provides:
       - redis=7.0.99
+    runtime:
+      - posix-libc-utils # `getent` is required on startup in ha mode for ip introspection cluster formation
 
 environment:
   contents:
@@ -43,7 +45,6 @@ pipeline:
 subpackages:
   - name: redis-cli-7.0
     pipeline:
-      - uses: split/dev
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/redis-cli "${{targets.subpkgdir}}"/usr/bin/redis-cli
@@ -54,7 +55,6 @@ subpackages:
 
   - name: redis-benchmark-7.0
     pipeline:
-      - uses: split/dev
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/redis-benchmark "${{targets.subpkgdir}}"/usr/bin/redis-benchmark
@@ -62,41 +62,6 @@ subpackages:
     dependencies:
       provides:
         - redis-benchmark=7.0.99
-
-  - name: redis-sentinel-7.0
-    pipeline:
-      - uses: split/dev
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/redis-sentinel "${{targets.subpkgdir}}"/usr/bin/redis-sentinel
-    description: redis-sentinel provides High availability for non-clustered Redis
-    dependencies:
-      runtime:
-        - redis=7.0.99
-      provides:
-        - redis-sentinel=7.0.99
-
-  - name: redis-check-aof-7.0
-    pipeline:
-      - uses: split/dev
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/redis-check-aof "${{targets.subpkgdir}}"/usr/bin/redis-check-aof
-    description: redis-check-aof
-    dependencies:
-      provides:
-        - redis-check-aof=7.0.99
-
-  - name: redis-check-rdb-7.0
-    pipeline:
-      - uses: split/dev
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/redis-check-rdb "${{targets.subpkgdir}}"/usr/bin/redis-check-rdb
-    description: redis-check-rdb
-    dependencies:
-      provides:
-        - redis-check-rdb=7.0.99
 
 update:
   enabled: true

--- a/redis.yaml
+++ b/redis.yaml
@@ -1,10 +1,13 @@
 package:
   name: redis
   version: 7.2.1
-  epoch: 0
+  epoch: 1
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - posix-libc-utils # `getent` is required on startup in ha mode for ip introspection cluster formation
 
 environment:
   contents:
@@ -40,7 +43,6 @@ pipeline:
 subpackages:
   - name: redis-cli
     pipeline:
-      - uses: split/dev
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/redis-cli "${{targets.subpkgdir}}"/usr/bin/redis-cli
@@ -48,38 +50,10 @@ subpackages:
 
   - name: redis-benchmark
     pipeline:
-      - uses: split/dev
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mv "${{targets.destdir}}"/usr/bin/redis-benchmark "${{targets.subpkgdir}}"/usr/bin/redis-benchmark
     description: redis-benchmark utility that simulates running commands done by N clients while at the same time sending M total queries.
-
-  - name: redis-sentinel
-    pipeline:
-      - uses: split/dev
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/redis-sentinel "${{targets.subpkgdir}}"/usr/bin/redis-sentinel
-    description: redis-sentinel provides High availability for non-clustered Redis
-    dependencies:
-      runtime:
-        - redis
-
-  - name: redis-check-aof
-    pipeline:
-      - uses: split/dev
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/redis-check-aof "${{targets.subpkgdir}}"/usr/bin/redis-check-aof
-    description: redis-check-aof
-
-  - name: redis-check-rdb
-    pipeline:
-      - uses: split/dev
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/redis-check-rdb "${{targets.subpkgdir}}"/usr/bin/redis-check-rdb
-    description: redis-check-rdb
 
 update:
   enabled: true


### PR DESCRIPTION
this removes the bespoke subpackages that are merely symlinks to `redis-server`. this makes it easier for downstream consumers of this package to use, specifically for `redis-sentinel`, which is required for `ha` operations, but is just a symlink to `redis-server`.

additionally, the redis build doesn't produce any dev headers, so remove the unnecessary `split/dev`.