### PR TITLE
fix: remove use-tag from wavefront-proxy

### DIFF
--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -79,5 +79,3 @@ update:
   github:
     identifier: wavefronthq/wavefront-proxy
     strip-prefix: proxy-
-    use-tag: true
-    tag-filter: proxy-


### PR DESCRIPTION
Remove use-tag from wavefront-proxy since this project uses releases.
