### PR TITLE
fix: add back tag filter in wavefront-proxy

### DIFF
--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -79,3 +79,4 @@ update:
   github:
     identifier: wavefronthq/wavefront-proxy
     strip-prefix: proxy-
+    tag-filter: proxy-


### PR DESCRIPTION
Add `tag-filter` back to wavefront-proxy (it should not have been removed in #5590)