### PR TITLE
adds nested perl deps of lcov

### DIFF
--- a/perl-algorithm-diff.yaml
+++ b/perl-algorithm-diff.yaml
@@ -1,0 +1,46 @@
+# Generated from https://git.alpinelinux.org/aports/plain/community/perl-algorithm-diff/APKBUILD
+package:
+  name: perl-algorithm-diff
+  version: "1.201"
+  epoch: 0
+  description: Compute 'intelligent' differences between two files / lists
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 0022da5982645d9ef0207f3eb9ef63e70e9713ed2340ed7b3850779b0d842a7d
+      uri: https://cpan.metacpan.org/authors/id/R/RJ/RJBS/Algorithm-Diff-${{package.version}}.tar.gz
+
+  - uses: perl/make
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: perl/cleanup
+
+  - uses: strip
+
+subpackages:
+  - name: perl-algorithm-diff-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-algorithm-diff manpages
+
+update:
+  enabled: false # latest releases mismatches in release monitor and github release is not maintained to latest version

--- a/perl-appconfig.yaml
+++ b/perl-appconfig.yaml
@@ -1,0 +1,48 @@
+# Generated from https://git.alpinelinux.org/aports/plain/community/perl-appconfig/APKBUILD
+package:
+  name: perl-appconfig
+  version: "1.71"
+  epoch: 0
+  description: AppConfig is a bundle of Perl5 modules for reading configuration files and parsing command line arguments.
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 1177027025ecb09ee64d9f9f255615c04db5e14f7536c344af632032eb887b0f
+      uri: https://cpan.metacpan.org/authors/id/N/NE/NEILB/AppConfig-${{package.version}}.tar.gz
+
+  - uses: perl/make
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: perl/cleanup
+
+  - uses: strip
+
+subpackages:
+  - name: perl-appconfig-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-appconfig manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5853

--- a/perl-json-maybexs.yaml
+++ b/perl-json-maybexs.yaml
@@ -1,0 +1,49 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-json-maybexs/APKBUILD
+package:
+  name: perl-json-maybexs
+  version: "1.004005"
+  epoch: 0
+  description: Use L<Cpanel::JSON::XS> with a fallback to L<JSON::XS> and L<JSON::PP>
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: f5b6bc19f579e66b7299f8748b8ac3e171936dc4e7fcb72a8a257a9bd482a331
+      uri: https://cpan.metacpan.org/authors/id/E/ET/ETHER/JSON-MaybeXS-${{package.version}}.tar.gz
+
+  - uses: perl/make
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: perl/cleanup
+
+  - uses: strip
+
+subpackages:
+  - name: perl-json-maybexs-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-json-maybexs manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11953

--- a/perl-parallel-iterator.yaml
+++ b/perl-parallel-iterator.yaml
@@ -1,0 +1,42 @@
+package:
+  name: perl-parallel-iterator
+  version: "1.002"
+  epoch: 0
+  description: Simple parallel execution
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 83749a5293cd76c55963cc11b1cfe89ba8c3223e83c8b1b8b52fe9f672e6d931
+      uri: https://cpan.metacpan.org/authors/id/A/AR/ARISTOTLE/Parallel-Iterator-${{package.version}}.tar.gz
+
+  - uses: perl/make
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: perl/cleanup
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 12769

--- a/perl-pod-parser.yaml
+++ b/perl-pod-parser.yaml
@@ -1,0 +1,48 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-pod-parser/APKBUILD
+package:
+  name: perl-pod-parser
+  version: "1.66"
+  epoch: 0
+  description: Modules for parsing/translating POD format documents
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 22928a7bffe61b452c05bbbb8f5216d4b9cf9fe2a849b776c25500d24d20df7c
+      uri: https://cpan.metacpan.org/authors/id/M/MA/MAREKR/Pod-Parser-${{package.version}}.tar.gz
+
+  - uses: perl/make
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: perl/cleanup
+
+  - uses: strip
+
+subpackages:
+  - name: perl-pod-parser-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-pod-parser manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3244

--- a/perl-template-toolkit.yaml
+++ b/perl-template-toolkit.yaml
@@ -1,0 +1,51 @@
+# Generated from https://git.alpinelinux.org/aports/plain/community/perl-template-toolkit/APKBUILD
+package:
+  name: perl-template-toolkit
+  version: "3.101"
+  epoch: 0
+  description: comprehensive template processing system
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+      - perl-appconfig
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl-dev
+      - perl
+      - perl-appconfig
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: d2a32dd6c21e4b37c6a93df8087ca9e880cfae613a3e5efaea307b0bdcaedb58
+      uri: https://cpan.metacpan.org/authors/id/A/AB/ABW/Template-Toolkit-${{package.version}}.tar.gz
+
+  - uses: perl/make
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: perl/cleanup
+
+  - uses: strip
+
+subpackages:
+  - name: perl-template-toolkit-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-template-toolkit manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11970

--- a/perl-text-diff.yaml
+++ b/perl-text-diff.yaml
@@ -1,0 +1,50 @@
+# Generated from https://git.alpinelinux.org/aports/plain/community/perl-text-diff/APKBUILD
+package:
+  name: perl-text-diff
+  version: "1.45"
+  epoch: 0
+  description: Perform diffs on files and record sets
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+      - perl-algorithm-diff
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+      - perl-algorithm-diff
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: e8baa07b1b3f53e00af3636898bbf73aec9a0ff38f94536ede1dbe96ef086f04
+      uri: https://cpan.metacpan.org/authors/id/N/NE/NEILB/Text-Diff-${{package.version}}.tar.gz
+
+  - uses: perl/make
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: perl/cleanup
+
+  - uses: strip
+
+subpackages:
+  - name: perl-text-diff-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-text-diff manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3435

--- a/perl-tidy.yaml
+++ b/perl-tidy.yaml
@@ -1,0 +1,48 @@
+# Generated from https://git.alpinelinux.org/aports/plain/testing/perl-tidy/APKBUILD
+package:
+  name: perl-tidy
+  version: "20230912"
+  epoch: 0
+  description: Parses and beautifies perl source
+  copyright:
+    - license: GPL-2.0-only
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 0c57888f206f987777e16640e72574aa0a777846719f8e3ed0413c35325f5540
+      uri: https://cpan.metacpan.org/authors/id/S/SH/SHANCOCK/Perl-Tidy-${{package.version}}.tar.gz
+
+  - uses: perl/make
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: perl/cleanup
+
+  - uses: strip
+
+subpackages:
+  - name: perl-tidy-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-tidy manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3553


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
