### PR TITLE
kubernetes-csi-external-attacher version streams

### DIFF
--- a/kubernetes-csi-external-attacher-4.3.yaml
+++ b/kubernetes-csi-external-attacher-4.3.yaml
@@ -1,10 +1,13 @@
 package:
-  name: kubernetes-csi-external-attacher
-  version: 4.4.0
+  name: kubernetes-csi-external-attacher-4.3
+  version: 4.3.0
   epoch: 0
   description: Sidecar container that watches Kubernetes VolumeAttachment objects and triggers ControllerPublish/Unpublish against a CSI endpoint
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - kubernetes-csi-external-attacher=4.3.999
 
 environment:
   contents:
@@ -21,7 +24,7 @@ pipeline:
     with:
       repository: https://github.com/kubernetes-csi/external-attacher
       tag: v${{package.version}}
-      expected-commit: 0ad858f55382553c41983727100c630582ed6075
+      expected-commit: 910cd35d72e6a99cc7b8451a5065aecc11bd7fff
 
   - runs: |
       make build
@@ -36,4 +39,4 @@ update:
     identifier: kubernetes-csi/external-attacher
     strip-prefix: v
     use-tag: true
-    tag-filter: v
+    tag-filter: v4.3.

--- a/kubernetes-csi-external-attacher-4.3.yaml
+++ b/kubernetes-csi-external-attacher-4.3.yaml
@@ -1,13 +1,13 @@
 package:
   name: kubernetes-csi-external-attacher-4.3
   version: 4.3.0
-  epoch: 0
+  epoch: 6
   description: Sidecar container that watches Kubernetes VolumeAttachment objects and triggers ControllerPublish/Unpublish against a CSI endpoint
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
-      - kubernetes-csi-external-attacher=4.3.999
+      - kubernetes-csi-external-attacher=${{package.full-version}}
 
 environment:
   contents:

--- a/kubernetes-csi-external-attacher-4.4.yaml
+++ b/kubernetes-csi-external-attacher-4.4.yaml
@@ -1,0 +1,42 @@
+package:
+  name: kubernetes-csi-external-attacher-4.4
+  version: 4.4.0
+  epoch: 0
+  description: Sidecar container that watches Kubernetes VolumeAttachment objects and triggers ControllerPublish/Unpublish against a CSI endpoint
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - kubernetes-csi-external-attacher=4.4.999
+
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+
+pipeline:
+  # We can't use go/install because this requires specific ldflags to set the version
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-csi/external-attacher
+      tag: v${{package.version}}
+      expected-commit: 0ad858f55382553c41983727100c630582ed6075
+
+  - runs: |
+      make build
+      mkdir -p ${{targets.destdir}}/usr/bin
+      install -Dm755 ./bin/csi-attacher ${{targets.destdir}}/usr/bin/csi-attacher
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-csi/external-attacher
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v4.4.

--- a/kubernetes-csi-external-attacher-4.4.yaml
+++ b/kubernetes-csi-external-attacher-4.4.yaml
@@ -1,13 +1,13 @@
 package:
   name: kubernetes-csi-external-attacher-4.4
   version: 4.4.0
-  epoch: 0
+  epoch: 1
   description: Sidecar container that watches Kubernetes VolumeAttachment objects and triggers ControllerPublish/Unpublish against a CSI endpoint
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
-      - kubernetes-csi-external-attacher=4.4.999
+      - kubernetes-csi-external-attacher=${{package.full-version}}
 
 environment:
   contents:


### PR DESCRIPTION
* "kubernetes-csi-external-attacher-4.3,4.4: convert to version streams"

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
