### PR TITLE
Pull in a patch to bump a dep to fix CVE-2023-42503 in opensearch-2.

### DIFF
--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-2
   version: 2.9.0
-  epoch: 0
+  epoch: 1
   description:
   target-architecture:
     - all
@@ -30,6 +30,11 @@ pipeline:
       repository: https://github.com/opensearch-project/OpenSearch
       tag: ${{package.version}}
       expected-commit: 1164221ee2b8ba3560f0ff492309867beea28433
+
+  # Patch CVE-2023-42503
+  - uses: patch
+    with:
+      patches: 05544ae2b9d8a7d4cd6dc0241dc31126a154fa4d.patch
 
   - runs: |
       export LANG=en_US.UTF-8

--- a/opensearch-2/05544ae2b9d8a7d4cd6dc0241dc31126a154fa4d.patch
+++ b/opensearch-2/05544ae2b9d8a7d4cd6dc0241dc31126a154fa4d.patch
@@ -1,0 +1,138 @@
+From 05544ae2b9d8a7d4cd6dc0241dc31126a154fa4d Mon Sep 17 00:00:00 2001
+From: Andriy Redko <andriy.redko@aiven.io>
+Date: Mon, 11 Sep 2023 13:58:11 -0400
+Subject: [PATCH] Bump org.apache.commons:commons-compress from 1.23.0 to
+ 1.24.0 (#9973)
+
+Signed-off-by: Andriy Redko <andriy.redko@aiven.io>
+---
+ CHANGELOG.md                                                    | 1 +
+ buildSrc/version.properties                                     | 1 +
+ distribution/tools/plugin-cli/build.gradle                      | 2 +-
+ .../tools/plugin-cli/licenses/commons-compress-1.23.0.jar.sha1  | 1 -
+ .../tools/plugin-cli/licenses/commons-compress-1.24.0.jar.sha1  | 1 +
+ plugins/ingest-attachment/build.gradle                          | 2 +-
+ .../ingest-attachment/licenses/commons-compress-1.23.0.jar.sha1 | 1 -
+ .../ingest-attachment/licenses/commons-compress-1.24.0.jar.sha1 | 1 +
+ plugins/repository-hdfs/build.gradle                            | 2 +-
+ .../repository-hdfs/licenses/commons-compress-1.23.0.jar.sha1   | 1 -
+ .../repository-hdfs/licenses/commons-compress-1.24.0.jar.sha1   | 1 +
+ 11 files changed, 8 insertions(+), 6 deletions(-)
+ delete mode 100644 distribution/tools/plugin-cli/licenses/commons-compress-1.23.0.jar.sha1
+ create mode 100644 distribution/tools/plugin-cli/licenses/commons-compress-1.24.0.jar.sha1
+ delete mode 100644 plugins/ingest-attachment/licenses/commons-compress-1.23.0.jar.sha1
+ create mode 100644 plugins/ingest-attachment/licenses/commons-compress-1.24.0.jar.sha1
+ delete mode 100644 plugins/repository-hdfs/licenses/commons-compress-1.23.0.jar.sha1
+ create mode 100644 plugins/repository-hdfs/licenses/commons-compress-1.24.0.jar.sha1
+
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+index 1edd7bb20de2..f6d25133d3be 100644
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+ ### Dependencies
+ - Bump `peter-evans/create-or-update-comment` from 2 to 3 ([#9575](https://github.com/opensearch-project/OpenSearch/pull/9575))
+ - Bump `actions/checkout` from 2 to 4 ([#9968](https://github.com/opensearch-project/OpenSearch/pull/9968))
++- Bump `org.apache.commons:commons-compress` from 1.23.0 to 1.24.0 ([#9973](https://github.com/opensearch-project/OpenSearch/pull/9973))
+ 
+ ### Changed
+ - Add instrumentation in rest and network layer. ([#9415](https://github.com/opensearch-project/OpenSearch/pull/9415))
+diff --git a/buildSrc/version.properties b/buildSrc/version.properties
+index 500727e90949..b658d45b815c 100644
+--- a/buildSrc/version.properties
++++ b/buildSrc/version.properties
+@@ -40,6 +40,7 @@ httpasyncclient   = 4.1.5
+ commonslogging    = 1.2
+ commonscodec      = 1.15
+ commonslang       = 3.13.0
++commonscompress   = 1.24.0
+ # plugin dependencies
+ aws               = 2.20.55
+ reactivestreams   = 1.0.4
+diff --git a/distribution/tools/plugin-cli/build.gradle b/distribution/tools/plugin-cli/build.gradle
+index 510399942881..2db3fef55d02 100644
+--- a/distribution/tools/plugin-cli/build.gradle
++++ b/distribution/tools/plugin-cli/build.gradle
+@@ -45,7 +45,7 @@ dependencies {
+     transitive = false
+   }
+ 
+-  implementation 'org.apache.commons:commons-compress:1.23.0'
++  implementation "org.apache.commons:commons-compress:${versions.commonscompress}"
+ }
+ 
+ tasks.named("dependencyLicenses").configure {
+diff --git a/distribution/tools/plugin-cli/licenses/commons-compress-1.23.0.jar.sha1 b/distribution/tools/plugin-cli/licenses/commons-compress-1.23.0.jar.sha1
+deleted file mode 100644
+index 48dba88409c1..000000000000
+--- a/distribution/tools/plugin-cli/licenses/commons-compress-1.23.0.jar.sha1
++++ /dev/null
+@@ -1 +0,0 @@
+-4af2060ea9b0c8b74f1854c6cafe4d43cfc161fc
+\ No newline at end of file
+diff --git a/distribution/tools/plugin-cli/licenses/commons-compress-1.24.0.jar.sha1 b/distribution/tools/plugin-cli/licenses/commons-compress-1.24.0.jar.sha1
+new file mode 100644
+index 000000000000..23999d1bfbde
+--- /dev/null
++++ b/distribution/tools/plugin-cli/licenses/commons-compress-1.24.0.jar.sha1
+@@ -0,0 +1 @@
++b4b1b5a3d9573b2970fddab236102c0a4d27d35e
+\ No newline at end of file
+diff --git a/plugins/ingest-attachment/build.gradle b/plugins/ingest-attachment/build.gradle
+index 2fe5b9370458..f54c80e9f76c 100644
+--- a/plugins/ingest-attachment/build.gradle
++++ b/plugins/ingest-attachment/build.gradle
+@@ -84,7 +84,7 @@ dependencies {
+   // MS Office
+   api "org.apache.poi:poi-scratchpad:${versions.poi}"
+   // Apple iWork
+-  api 'org.apache.commons:commons-compress:1.23.0'
++  api "org.apache.commons:commons-compress:${versions.commonscompress}"
+   // Outlook documents
+   api "org.apache.james:apache-mime4j-core:${versions.mime4j}"
+   api "org.apache.james:apache-mime4j-dom:${versions.mime4j}"
+diff --git a/plugins/ingest-attachment/licenses/commons-compress-1.23.0.jar.sha1 b/plugins/ingest-attachment/licenses/commons-compress-1.23.0.jar.sha1
+deleted file mode 100644
+index 48dba88409c1..000000000000
+--- a/plugins/ingest-attachment/licenses/commons-compress-1.23.0.jar.sha1
++++ /dev/null
+@@ -1 +0,0 @@
+-4af2060ea9b0c8b74f1854c6cafe4d43cfc161fc
+\ No newline at end of file
+diff --git a/plugins/ingest-attachment/licenses/commons-compress-1.24.0.jar.sha1 b/plugins/ingest-attachment/licenses/commons-compress-1.24.0.jar.sha1
+new file mode 100644
+index 000000000000..23999d1bfbde
+--- /dev/null
++++ b/plugins/ingest-attachment/licenses/commons-compress-1.24.0.jar.sha1
+@@ -0,0 +1 @@
++b4b1b5a3d9573b2970fddab236102c0a4d27d35e
+\ No newline at end of file
+diff --git a/plugins/repository-hdfs/build.gradle b/plugins/repository-hdfs/build.gradle
+index 1fdb3d2fb41e..e2f5707ca439 100644
+--- a/plugins/repository-hdfs/build.gradle
++++ b/plugins/repository-hdfs/build.gradle
+@@ -73,7 +73,7 @@ dependencies {
+   api 'commons-cli:commons-cli:1.5.0'
+   api "commons-codec:commons-codec:${versions.commonscodec}"
+   api 'commons-collections:commons-collections:3.2.2'
+-  api 'org.apache.commons:commons-compress:1.23.0'
++  api "org.apache.commons:commons-compress:${versions.commonscompress}"
+   api 'org.apache.commons:commons-configuration2:2.9.0'
+   api 'commons-io:commons-io:2.13.0'
+   api 'org.apache.commons:commons-lang3:3.13.0'
+diff --git a/plugins/repository-hdfs/licenses/commons-compress-1.23.0.jar.sha1 b/plugins/repository-hdfs/licenses/commons-compress-1.23.0.jar.sha1
+deleted file mode 100644
+index 48dba88409c1..000000000000
+--- a/plugins/repository-hdfs/licenses/commons-compress-1.23.0.jar.sha1
++++ /dev/null
+@@ -1 +0,0 @@
+-4af2060ea9b0c8b74f1854c6cafe4d43cfc161fc
+\ No newline at end of file
+diff --git a/plugins/repository-hdfs/licenses/commons-compress-1.24.0.jar.sha1 b/plugins/repository-hdfs/licenses/commons-compress-1.24.0.jar.sha1
+new file mode 100644
+index 000000000000..23999d1bfbde
+--- /dev/null
++++ b/plugins/repository-hdfs/licenses/commons-compress-1.24.0.jar.sha1
+@@ -0,0 +1 @@
++b4b1b5a3d9573b2970fddab236102c0a4d27d35e
+\ No newline at end of file


### PR DESCRIPTION
This has been merged upstream but hasn't made it out in a release yet.

Fixes:

Related:

### Pre-review Checklist


#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo


#### For PRs that add patches
<!-- remove if unrelated -->
- [X] Patch source is documented
