### PR TITLE
Add istio-operator package.

### DIFF
--- a/istio-operator-1.19.yaml
+++ b/istio-operator-1.19.yaml
@@ -1,0 +1,44 @@
+package:
+  name: istio-operator-1.19
+  version: 1.19.0
+  epoch: 0
+  description: Istio operator provides user friendly options to operate the Istio service mesh
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - istio-operator=1.19
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 3b3ca8ec1632961e355f398f7357ebed9b13aa43
+
+  - uses: go/build
+    with:
+      packages: ./operator/cmd/operator
+      output: oeprator
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/var/lib/istio
+      mv manifests ${{targets.destdir}}/var/lib/istio/manifests
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: istio/istio
+    tag-filter: 1.19.
+    use-tag: true


### PR DESCRIPTION


Fixes:

Related:

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [X] The upstream project actually supports multiple concurrent versions.
- [X] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
