### PR TITLE
pnpm: new package

### DIFF
--- a/pnpm.yaml
+++ b/pnpm.yaml
@@ -1,0 +1,51 @@
+package:
+  name: pnpm
+  version: 8.7.5
+  epoch: 0
+  description: "Fast, disk space efficient package manager"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - build-base
+      - nodejs-18
+      - ca-certificates-bundle
+      - curl
+      - git
+      - npm
+      - gcc-12
+      - make
+      - automake
+      - autoconf
+      - pnpm
+      - python3
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pnpm/pnpm
+      tag: v${{package.version}}
+      expected-commit: 10cb4b3245d597a7e9b1b4bca2889421cd19bcdb
+
+  - runs: |
+      /usr/bin/pnpm install
+      /usr/bin/pnpm run compile
+      mkdir -p "${{targets.destdir}}"/usr/lib/node_modules/pnpm
+      mkdir -p "${{targets.destdir}}"/usr/bin/
+      cd pnpm
+
+      ln -sf /usr/lib/node_modules/pnpm/bin/pnpm.cjs  "${{targets.destdir}}"/usr/bin/pnpm
+      ln -sf /usr/lib/node_modules/pnpm/bin/pnpx.cjs  "${{targets.destdir}}"/usr/bin/pnpx
+      mv bin  "${{targets.destdir}}"/usr/lib/node_modules/pnpm
+      mv dist "${{targets.destdir}}"/usr/lib/node_modules/pnpm
+
+update:
+  enabled: true
+  github:
+    identifier: pnpm/pnpm
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true


### PR DESCRIPTION
depends on #5638 to be merged first 

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

