### PR TITLE
temporal : add temporal server and temporal cli new packages

### DIFF
--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -1,0 +1,66 @@
+package:
+  name: temporal-server
+  version: 1.22.0
+  epoch: 0
+  description: Temporal server executes units of application logic, Workflows, in a resilient manner that automatically handles intermittent failures, and retries failed operations
+  copyright:
+    - license: MIT License
+
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+  environment:
+    CGO_ENABLED: 0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/temporalio/temporal
+      tag: v${{package.version}}
+      expected-commit: 9b877fae2dffc7721e70e7f7457c96e3570c379e
+
+  - runs: |
+      make bins
+
+  - runs: |
+      install -Dm755 temporal-server "${{targets.destdir}}"/usr/bin/temporal-server
+
+  - uses: strip
+
+subpackages:
+  - name: temporal-cassandra-tool
+    description: "temporal-cassandra-tool"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          install -Dm755 temporal-cassandra-tool "${{targets.subpkgdir}}"/usr/bin/temporal-cassandra-tool
+      - uses: strip
+
+  - name: tdbg
+    description: "tdbg"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          install -Dm755 tdbg "${{targets.subpkgdir}}"/usr/bin/tdbg
+      - uses: strip
+
+  - name: temporal-sql-tool
+    description: "temporal-sql-tool"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          install -Dm755 temporal-sql-tool "${{targets.subpkgdir}}"/usr/bin/temporal-sql-tool
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: temporalio/temporal
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v

--- a/temporal.yaml
+++ b/temporal.yaml
@@ -1,0 +1,51 @@
+package:
+  name: temporal
+  version: 0.10.5
+  epoch: 0
+  description: Command-line interface for running Temporal Server and interacting with Workflows, Activities, Namespaces, and other parts of Temporal
+  copyright:
+    - license: MIT License
+
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+  environment:
+    CGO_ENABLED: 0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/temporalio/cli
+      tag: v${{package.version}}
+      expected-commit: 924a12cf2087c1c68b9e970783f65fe49971770a
+
+  - uses: go/build
+    with:
+      packages: ./cmd/temporal
+      output: temporal
+      ldflags: -s -w
+
+  - uses: strip
+
+subpackages:
+  - name: temporal-docgen
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/docgen
+          output: temporal-docgen
+          ldflags: -s -w
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: temporalio/cli
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v


### PR DESCRIPTION
#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

