### PR TITLE
fzf: new package

### DIFF
--- a/fzf.yaml
+++ b/fzf.yaml
@@ -1,0 +1,37 @@
+package:
+  name: fzf
+  version: 0.42.0
+  epoch: 0
+  description: A command-line fuzzy finder
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - go
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com//junegunn/fzf
+      tag: ${{package.version}}
+      expected-commit: d471067e3f46f64e6401d1c5717424535fe4c96c
+
+  - uses: go/build
+    with:
+      packages: .
+      output: fzf
+      ldflags: -s -w  -X main.version=v${{ package.version }} -X main.revision=$(git rev-parse --short HEAD)
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: junegunn/fzf
+    use-tag: true


### PR DESCRIPTION
#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

