### PR TITLE
chore: re-enable updates for vault and consul

### DIFF
--- a/consul-1.15.yaml
+++ b/consul-1.15.yaml
@@ -13,8 +13,8 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
 
 pipeline:

--- a/consul-1.15.yaml
+++ b/consul-1.15.yaml
@@ -64,4 +64,8 @@ subpackages:
         - consul-1.15-oci-entrypoint
 
 update:
-  enabled: false
+  enabled: true
+  github:
+    identifier: hashicorp/consul
+    strip-prefix: v
+    tag-filter: v1.15.

--- a/consul-1.16.yaml
+++ b/consul-1.16.yaml
@@ -13,8 +13,8 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
 
 pipeline:

--- a/consul-1.16.yaml
+++ b/consul-1.16.yaml
@@ -64,4 +64,8 @@ subpackages:
         - consul-1.16-oci-entrypoint
 
 update:
-  enabled: false
+  enabled: true
+  github:
+    identifier: hashicorp/consul
+    strip-prefix: v
+    tag-filter: v1.16.

--- a/vault-1.13.yaml
+++ b/vault-1.13.yaml
@@ -95,4 +95,4 @@ update:
   github:
     identifier: hashicorp/vault
     strip-prefix: v
-    tag-prefix: v1.13.
+    tag-filter: v1.13.

--- a/vault-1.13.yaml
+++ b/vault-1.13.yaml
@@ -12,13 +12,13 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
-      - python3
-      - nodejs-16
-      - yarn
       - libcap-utils
+      - nodejs-16
+      - python3
+      - yarn
 
 pipeline:
   - uses: git-checkout

--- a/vault-1.13.yaml
+++ b/vault-1.13.yaml
@@ -91,4 +91,8 @@ subpackages:
         - libcap-utils
 
 update:
-  enabled: false
+  enabled: true
+  github:
+    identifier: hashicorp/vault
+    strip-prefix: v
+    tag-prefix: v1.13.

--- a/vault-1.14.yaml
+++ b/vault-1.14.yaml
@@ -95,4 +95,4 @@ update:
   github:
     identifier: hashicorp/vault
     strip-prefix: v
-    tag-prefix: v1.14.
+    tag-filter: v1.14.

--- a/vault-1.14.yaml
+++ b/vault-1.14.yaml
@@ -12,13 +12,13 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
-      - python3
-      - nodejs-16
-      - yarn
       - libcap-utils
+      - nodejs-16
+      - python3
+      - yarn
 
 pipeline:
   - uses: git-checkout

--- a/vault-1.14.yaml
+++ b/vault-1.14.yaml
@@ -91,4 +91,8 @@ subpackages:
         - libcap-utils
 
 update:
-  enabled: false
+  enabled: true
+  github:
+    identifier: hashicorp/vault
+    strip-prefix: v
+    tag-prefix: v1.14.


### PR DESCRIPTION
We turned off some auto-updates for HashiCorp packages in response to the BUSL change: https://github.com/wolfi-dev/os/pull/4357

But `consul` 1.15 and 1.16 still use the MPLv2.0 license, so those didn't need to be turned off.

And we've since version streamed `vault`. Versions 1.13 and 1.14 also still use MPLv2.0.

cc: @mattmoor 

_(We'll let the update bot handle the consequent version updates themselves.)_