### PR TITLE
add prometheus-node-exporter-compat

### DIFF
--- a/prometheus-node-exporter.yaml
+++ b/prometheus-node-exporter.yaml
@@ -31,7 +31,6 @@ pipeline:
 
   - uses: strip
 
-
 subpackages:
   - name: "prometheus-node-exporter-compat"
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"

--- a/prometheus-node-exporter.yaml
+++ b/prometheus-node-exporter.yaml
@@ -1,8 +1,7 @@
 package:
   name: prometheus-node-exporter
-  # When bumping this version you can remove the `go get` line in the build script
   version: 1.6.1
-  epoch: 2
+  epoch: 3
   description: Prometheus Exporter for machine metrics
   copyright:
     - license: Apache-2.0
@@ -31,6 +30,17 @@ pipeline:
       install -Dm755 node_exporter "${{targets.destdir}}"/usr/bin/node_exporter
 
   - uses: strip
+
+
+subpackages:
+  - name: "prometheus-node-exporter-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          # The helm chart expects the node_exporter binaries to be in /bin instead of /usr/bin
+          mkdir -p "${{targets.subpkgdir}}"/bin
+          ln -sf /usr/bin/node_exporter ${{targets.subpkgdir}}/bin/node_exporter
+      - uses: strip
 
 update:
   enabled: true


### PR DESCRIPTION
This adds a compat package so that prometheus-node-exporter can be compatible with upstream helm charts

We have this in a few other places, tied to versions, but the simple symlink doesn't need to be tied to a version.