### PR TITLE
add py3-crcmod

### DIFF
--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,13 +1,15 @@
 package:
   name: google-cloud-sdk
   version: 427.0.0
-  epoch: 0
+  epoch: 1
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - python3
+      # Required for cyclic redunancy check (gsutil help crcmod)
+      - py3-crcmod
 
 environment:
   contents:
@@ -45,6 +47,9 @@ pipeline:
       rm -rf google-cloud-sdk/rpm
       rm google-cloud-sdk/install.bat
       rm google-cloud-sdk/data/cli/gcloud.json
+
+      # Remove any third party tests that bloat up the package
+      find google-cloud-sdk -type d \( -name 'tests' -o -name 'test' \) -path '*/third_party/*' -exec rm -rf {} +
 
       # This is a large binary with vulnerabilities in it, users can add it back later.
       google-cloud-sdk/bin/gcloud components remove anthoscli

--- a/py3-crcmod.yaml
+++ b/py3-crcmod.yaml
@@ -1,0 +1,44 @@
+package:
+  name: py3-crcmod
+  version: "1.7"
+  epoch: 0
+  description: Cyclic Redundancy Check (CRC) implementation in Python
+  copyright:
+    - license: 'MIT'
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3-dev
+      - py3-wheel
+      - py3-gpep517
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://files.pythonhosted.org/packages/6b/b0/e595ce2a2527e169c3bcd6c33d2473c1918e0b7f6826a043ca1245dd4e5b/crcmod-${{package.version}}.tar.gz
+      expected-sha256: dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e
+
+  - name: Python Build
+    runs: |
+      python3 -m gpep517 build-wheel \
+      --wheel-dir .dist \
+      --output-fd 3 3>&1 >&2
+
+  - name: Python install
+    runs: python3 -m installer --destdir="${{targets.destdir}}" .dist/*.whl
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 12017


### PR DESCRIPTION
required for cyclical redunancy checking in gsutil.

```bash
32465e451130:/work# gsutil version -l
...
compiled crcmod: True
```