### PR TITLE
build wolfi world using bwrap

### DIFF
--- a/.github/workflows/build-world.yaml
+++ b/.github/workflows/build-world.yaml
@@ -48,6 +48,7 @@ jobs:
               -k https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub \
               -r https://packages.wolfi.dev/bootstrap/stage3 \
               --arch=${{ matrix.arch }} \
+              --runner=bubblewrap \
               -j10
 
   # TODO: enable Slack alerts when this is expected to pass reliably.


### PR DESCRIPTION
This seems to be becoming the standard way to build images (with bwrap, inside a pinned docker image). So use this, instead of using `--runner=docker` (the default, for now)