### PR TITLE
go-fips-1.20: improve FIPS patches so they work as expected

### DIFF
--- a/go-fips-1.20.yaml
+++ b/go-fips-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-fips-1.20
   version: 1.20.8
-  epoch: 0
+  epoch: 1
   description: "the Go programming language with OpenSSL cryptography"
   copyright:
     - license: BSD-3-Clause
@@ -41,6 +41,12 @@ pipeline:
       - uses: patch
         with:
           patches: /home/build/001-initial-openssl-for-fips.patch
+      - uses: patch
+        with:
+          patches: /home/build/0003-openssl-fips-unconditionally-use-openssl-backend.patch
+      - uses: patch
+        with:
+          patches: /home/build/0004-boring-always-enable-access-to-boring.Enabled-functi.patch
 
   - runs: |
       cd go/src

--- a/go-fips-1.20/0003-openssl-fips-unconditionally-use-openssl-backend.patch
+++ b/go-fips-1.20/0003-openssl-fips-unconditionally-use-openssl-backend.patch
@@ -1,0 +1,54 @@
+From ed1dac0a0a4bd86b2ea50bbb1dbea3b2ff6a05f8 Mon Sep 17 00:00:00 2001
+From: Ariadne Conill <ariadne@dereferenced.org>
+Date: Mon, 18 Sep 2023 13:13:49 -0700
+Subject: [PATCH 3/5] openssl-fips: unconditionally use openssl backend
+
+Signed-off-by: Ariadne Conill <ariadne@dereferenced.org>
+---
+ .../openssl-fips/openssl/openssl.go           | 22 +++----------------
+ 1 file changed, 3 insertions(+), 19 deletions(-)
+
+diff --git a/src/vendor/github.com/golang-fips/openssl-fips/openssl/openssl.go b/src/vendor/github.com/golang-fips/openssl-fips/openssl/openssl.go
+index e93b042e5e..6da12da6b2 100644
+--- a/src/vendor/github.com/golang-fips/openssl-fips/openssl/openssl.go
++++ b/src/vendor/github.com/golang-fips/openssl-fips/openssl/openssl.go
+@@ -72,11 +72,8 @@ func init() {
+ 	// Initialize the OpenSSL library.
+ 	C._goboringcrypto_OPENSSL_setup()
+ 
+-	// Check to see if the system is running in FIPS mode, if so
+-	// enable "boring" mode to call into OpenSSL for FIPS compliance.
+-	if fipsModeEnabled() {
+-		enableBoringFIPSMode()
+-	}
++	// Switch to OpenSSL crypto backend.
++	enableBoringFIPSMode()
+ }
+ 
+ func openSSLVersion() uint64 {
+@@ -96,21 +93,8 @@ func enableBoringFIPSMode() {
+ }
+ 
+ func fipsModeEnabled() bool {
+-	// Due to the way providers work in openssl 3, the FIPS methods are not
+-	// necessarily going to be available for us to load based on the GOLANG_FIPS
+-	// environment variable alone. For now, we must rely on the config to tell
+-	// us if the provider is configured and active.
+ 	fipsConfigured := C._goboringcrypto_FIPS_mode() == fipsOn
+-	openSSLVersion := openSSLVersion()
+-	if openSSLVersion >= OPENSSL_VERSION_3_0_0 {
+-		if !fipsConfigured && os.Getenv("GOLANG_FIPS") == "1" {
+-			panic("GOLANG_FIPS=1 specified but OpenSSL FIPS provider is not configured")
+-		}
+-		return fipsConfigured
+-
+-	} else {
+-		return os.Getenv("GOLANG_FIPS") == "1" || fipsConfigured
+-	}
++	return fipsConfigured
+ }
+ 
+ var randstub bool
+-- 
+2.39.2 (Apple Git-143)
+

--- a/go-fips-1.20/0004-boring-always-enable-access-to-boring.Enabled-functi.patch
+++ b/go-fips-1.20/0004-boring-always-enable-access-to-boring.Enabled-functi.patch
@@ -1,0 +1,33 @@
+From 50d7c545876bd29e1f434de5f9e766e947b58d3b Mon Sep 17 00:00:00 2001
+From: Ariadne Conill <ariadne@dereferenced.org>
+Date: Mon, 18 Sep 2023 13:16:30 -0700
+Subject: [PATCH 4/5] boring: always enable access to boring.Enabled() function
+
+Signed-off-by: Ariadne Conill <ariadne@dereferenced.org>
+---
+ src/crypto/boring/boring.go | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/src/crypto/boring/boring.go b/src/crypto/boring/boring.go
+index 47618fe3c6..e171df3871 100644
+--- a/src/crypto/boring/boring.go
++++ b/src/crypto/boring/boring.go
+@@ -2,15 +2,10 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build boringcrypto
+-
+ // Package boring exposes functions that are only available when building with
+ // Go+BoringCrypto. This package is available on all targets as long as the
+ // Go+BoringCrypto toolchain is used. Use the Enabled function to determine
+ // whether the BoringCrypto core is actually in use.
+-//
+-// Any time the Go+BoringCrypto toolchain is used, the "boringcrypto" build tag
+-// is satisfied, so that applications can tag files that use this package.
+ package boring
+ 
+ import boring "crypto/internal/backend"
+-- 
+2.39.2 (Apple Git-143)
+


### PR DESCRIPTION
This brings us to a current state where:

- Building packages with normal `go` uses built-in Go cryptography (as expected)
- Building packages with `go-fips` uses OpenSSL `libcrypto` unconditionally where redirection stubs exist (mostly as expected, but Google did not redirect all crypto to BoringCrypto sadly)

Deviations from upstream golang-fips:

- It is always using libcrypto, regardless of FIPS mode being enabled or not

Maybe future work:

- Writing more redirection stubs to libcrypto, e.g. for `crypto/md5`, so we can block it in FIPS mode.