### PR TITLE
new package: java 21

### DIFF
--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -1,0 +1,233 @@
+package:
+  name: openjdk-21
+  version: 21.35
+  epoch: 0
+  description:
+  copyright:
+    - license: GPL-2.0-with-classpath-exception
+  dependencies:
+    runtime:
+      - openjdk-21-jre
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - file
+      - freetype-dev
+      - cups-dev
+      - libx11-dev
+      - libxext-dev
+      - libxrender-dev
+      - libxrandr-dev
+      - libxtst-dev
+      - libxt-dev
+      - alsa-lib-dev
+      - libffi-dev
+      - bash
+      - zip
+      - fontconfig-dev
+      - libxi-dev
+      - libjpeg-turbo-dev
+      - giflib-dev
+      - lcms2-dev
+      - openjdk-20-default-jvm
+      - openjdk-20
+
+# transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
+var-transforms:
+  - from: ${{package.version}}
+    match: \.(\d+)$
+    replace: +$1
+    to: mangled-package-version
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
+      expected-sha512: 492a37fc73fda00c95e388e5ed894ed35f1631057401b4c5f7943a73f544fa595f1e89846b64dd7b757cea509d50d5e3a76b7e73d931a26ea9e5f20b89975572
+
+  - working-directory: /home/build/googletest
+    pipeline:
+      - uses: fetch
+        with:
+          uri: https://github.com/google/googletest/archive/v1.13.0.tar.gz
+          expected-sha512: 70c0cfb1b4147bdecb467ecb22ae5b5529eec0abc085763213a796b7cdbd81d1761d12b342060539b936fa54f345d33f060601544874d6213fdde79111fa813e
+
+  - runs: chmod +x configure
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --with-boot-jdk=/usr/lib/jvm/java-20-openjdk \
+        --prefix=/usr/lib/jvm/java-21-openjdk \
+        --with-vendor-name=wolfi \
+        --with-vendor-url=https://wolfi.dev \
+        --with-vendor-bug-url=https://github.com/wolfi-dev/os/issues \
+        --with-version-opt="wolfi-r${{package.epoch}}" \
+        --disable-warnings-as-errors \
+        --disable-precompiled-headers \
+        --enable-dtrace=no \
+        --with-zlib=system \
+        --with-debug-level=release \
+        --with-native-debug-symbols=internal \
+        --with-jvm-variants=server \
+        --with-jtreg=no  \
+        --with-libpng=system \
+        --with-jvm-variants=server \
+        --with-libjpeg=system \
+        --with-giflib=system \
+        --with-lcms=system \
+        --with-gtest="/home/build/googletest" \
+        --with-version-string="${{vars.mangled-package-version}}"
+
+  - runs: make jdk-image
+
+  # Check we built something valid
+  - runs: |
+      _java_bin="./build/*-server-release/images/jdk/bin"
+
+      $_java_bin/javac -d . HelloWorld.java
+      $_java_bin/java HelloWorld
+
+      # NOTE: Disable flakey tests for now as we're seeing builds hang on aarch64
+      # # run the gtest unittest suites
+      # make test-hotspot-gtest
+
+  - runs: |
+      _java_home="usr/lib/jvm/java-21-openjdk"
+
+      mkdir -p "${{targets.destdir}}"/$_java_home
+      cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
+      rm "${{targets.destdir}}"/$_java_home/lib/src.zip
+
+subpackages:
+  - name: "openjdk-21-dbg"
+    description: "OpenJDK 21 Java Debug Symbols"
+    pipeline:
+      - uses: split/debug
+    dependencies:
+      runtime:
+        - openjdk-21
+
+  - name: "openjdk-21-jre"
+    description: "OpenJDK 21 Java Runtime Environment"
+    dependencies:
+      runtime:
+        - freetype
+        - libfontconfig1
+        - openjdk-21-jre-base
+    pipeline:
+      - runs: |
+          _java_home="usr/lib/jvm/java-21-openjdk"
+
+          mkdir -p "${{targets.subpkgdir}}"/$_java_home/lib
+          mv "${{targets.destdir}}"/$_java_home/lib/libawt_xawt.so \
+              "${{targets.destdir}}"/$_java_home/lib/libfontmanager.so \
+              "${{targets.destdir}}"/$_java_home/lib/libjavajpeg.so \
+              "${{targets.destdir}}"/$_java_home/lib/libjawt.so \
+              "${{targets.destdir}}"/$_java_home/lib/libjsound.so \
+              "${{targets.destdir}}"/$_java_home/lib/liblcms.so \
+              "${{targets.destdir}}"/$_java_home/lib/libsplashscreen.so \
+              "${{targets.subpkgdir}}"/$_java_home/lib
+
+  - name: "openjdk-21-jre-base"
+    description: "OpenJDK 21 Java Runtime Environment (headless)"
+    dependencies:
+      runtime:
+        - java-common
+        - java-cacerts
+    pipeline:
+      - runs: |
+          _java_home="usr/lib/jvm/java-21-openjdk"
+
+          mkdir -p "${{targets.subpkgdir}}"/$_java_home
+          mv "${{targets.destdir}}"/$_java_home/lib \
+             "${{targets.subpkgdir}}"/$_java_home
+
+          mkdir -p "${{targets.subpkgdir}}"/$_java_home/bin
+          for i in java \
+                    jfr \
+                    jrunscript \
+                    jwebserver \
+                    keytool \
+                    rmiregistry; do
+            mv "${{targets.destdir}}"/$_java_home/bin/$i "${{targets.subpkgdir}}"/$_java_home/bin/$i
+          done
+
+          mv "${{targets.destdir}}"/$_java_home/legal "${{targets.subpkgdir}}"/$_java_home
+          mv "${{targets.destdir}}"/$_java_home/conf "${{targets.subpkgdir}}"/$_java_home
+          mv "${{targets.destdir}}"/$_java_home/release "${{targets.subpkgdir}}"/$_java_home
+          cp ASSEMBLY_EXCEPTION \
+              LICENSE \
+              README.md \
+             "${{targets.subpkgdir}}"/$_java_home
+
+          # symlink to shared java cacerts store
+          rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
+          ln -sf /etc/ssl/certs/java/cacerts \
+            "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
+
+          # symlink for `java-common` to work (which expects jre in $_java_home/jre)
+          ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+
+  - name: "openjdk-21-jmods"
+    description: "OpenJDK 21 jmods"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-21-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-21-openjdk/jmods \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-21-openjdk
+
+  - name: "openjdk-21-doc"
+    description: "OpenJDK 21 Documentation"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-21-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-21-openjdk/man \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-21-openjdk
+
+  - name: "openjdk-21-demos"
+    description: "OpenJDK 21 Demos"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-21-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-21-openjdk/demo \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-21-openjdk
+
+  - name: "openjdk-21-default-jvm"
+    description: "Use the openjdk-21 JVM as the default JVM"
+    dependencies:
+      runtime:
+        - openjdk-21-jre
+      provides:
+        - default-jvm=1.21
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-21-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-21-default-jdk"
+    description: "Use the openjdk-21 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-21-default-jvm
+        - openjdk-21
+      provides:
+        - default-jdk=1.21
+
+update:
+  enabled: true
+  shared: true
+  version-transform:
+    - match: \+(\d+)$
+      replace: .$1
+  github:
+    identifier: openjdk/jdk21u
+    strip-prefix: jdk-
+    tag-filter: jdk-21
+    use-tag: true

--- a/openjdk-21/HelloWorld.java
+++ b/openjdk-21/HelloWorld.java
@@ -1,0 +1,3 @@
+public class HelloWorld {
+  public static void main(String[] args) { System.out.println("Hello World!"); }
+}


### PR DESCRIPTION

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)


