### PR TITLE
ingress-nginx-controller: bump epoch as previous PR seems to not have…

### DIFF
--- a/ingress-nginx-controller.yaml
+++ b/ingress-nginx-controller.yaml
@@ -2,7 +2,7 @@
 package:
   name: ingress-nginx-controller
   version: 1.8.2
-  epoch: 2
+  epoch: 3
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
… been built with latest modsecurity.

previous PR: https://github.com/wolfi-dev/os/pull/5660
