### PR TITLE
Add php-http PECL packages for php-8.1, and php-8.2

### DIFF
--- a/php-8.1-pecl-http.yaml
+++ b/php-8.1-pecl-http.yaml
@@ -1,0 +1,50 @@
+package:
+  name: php-8.1-pecl-http
+  version: 4.2.3
+  epoch: 0
+  description: "Provides PHP 8.1 HTTP module for PHP Extended HTTP Support- PECL"
+  copyright:
+    - license: BSD-2-Clause
+  dependencies:
+    provides:
+      - php-pecl-http=${{package.full-version}}
+    runtime:
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - curl-dev
+      - gcc
+      - icu-dev
+      - libtool
+      - openssl-dev
+      - php-8.1-dev
+      - php-8.1-pecl-raphf
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/pecl_http-${{package.version}}.tgz
+      expected-sha512: be8bac0947e9fb63da5afa3eaf7b75a70775ca59a8a8c24b5f4b1875909dd8b6b2f4b25bf462acef78f18d5dd739c02352786853d9963cb71f3c1b114f113558
+
+  - uses: pecl/phpize
+
+  - uses: autoconf/make
+
+  - uses: pecl/install
+    with:
+      extension: pecl_http
+
+  - uses: strip
+
+update:
+  enabled: false

--- a/php-8.2-pecl-http.yaml
+++ b/php-8.2-pecl-http.yaml
@@ -1,0 +1,50 @@
+package:
+  name: php-8.2-pecl-http
+  version: 4.2.3
+  epoch: 0
+  description: "Provides PHP 8.2 HTTP module for PHP Extended HTTP Support- PECL"
+  copyright:
+    - license: BSD-2-Clause
+  dependencies:
+    provides:
+      - php-pecl-http=${{package.full-version}}
+    runtime:
+      - php-8.2
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - curl-dev
+      - gcc
+      - icu-dev
+      - libtool
+      - openssl-dev
+      - php-8.2-dev
+      - php-8.2-pecl-raphf
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/pecl_http-${{package.version}}.tgz
+      expected-sha512: be8bac0947e9fb63da5afa3eaf7b75a70775ca59a8a8c24b5f4b1875909dd8b6b2f4b25bf462acef78f18d5dd739c02352786853d9963cb71f3c1b114f113558
+
+  - uses: pecl/phpize
+
+  - uses: autoconf/make
+
+  - uses: pecl/install
+    with:
+      extension: pecl_http
+
+  - uses: strip
+
+update:
+  enabled: false


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
