### PR TITLE
openssl : bump to version 3.1.3

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,6 +1,6 @@
 package:
   name: openssl
-  version: 3.1.2
+  version: 3.1.3
   epoch: 0
   description: "the OpenSSL cryptography suite"
   copyright:
@@ -36,7 +36,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://www.openssl.org/source/openssl-${{package.version}}.tar.gz
-      expected-sha256: a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539
+      expected-sha256: f0316a2ebd89e7f2352976445458689f80302093788c466692fb2a188b2eacf6
 
   - name: Configure and build
     runs: |


### PR DESCRIPTION

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

