### PR TITLE
libucontext: new package

### DIFF
--- a/libucontext.yaml
+++ b/libucontext.yaml
@@ -41,3 +41,4 @@ update:
     identifier: kaniini/libucontext
     strip-prefix: v
     tag-filter: v
+    use-tag: true

--- a/libucontext.yaml
+++ b/libucontext.yaml
@@ -1,0 +1,43 @@
+package:
+  name: libucontext
+  version: 1.2
+  epoch: 0
+  description: "ucontext function implementations"
+  copyright:
+    - license: "ISC"
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - cmake
+      - build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kaniini/libucontext
+      tag: v${{package.version}}
+      expected-commit: 4dde3417b4bb4b1b1545bd913be337680b5e28c3
+
+  - runs: |
+      make
+      make DESTDIR="${{targets.destdir}}" install
+
+  - uses: strip
+
+subpackages:
+  - name: "libucontext-dev"
+    description: "ucontext function implementations (development files)"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      provides:
+        - libucontext-dev=${{package.full-version}}
+
+update:
+  enabled: true
+  github:
+    identifier: kaniini/libucontext
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
- libucontext: new package


Related: https://github.com/chainguard-dev/image-requests/issues/359

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)


