### PR TITLE
gflags: new package

### DIFF
--- a/gflags.yaml
+++ b/gflags.yaml
@@ -1,0 +1,55 @@
+package:
+  name: gflags
+  version: 2.2.2
+  epoch: 0
+  description: "The gflags package contains a C++ library that implements commandline flags processing."
+  copyright:
+    - license: "BSD-3-Clause"
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - cmake
+      - build-base
+      - samurai
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/gflags/gflags/
+      tag: v${{package.version}}
+      expected-commit: e171aa2d15ed9eb17054558e0b3a6a413bb01067
+
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DCMAKE_BUILD_TYPE=None \
+        -DBUILD_STATIC_LIBS=ON \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_TESTING=ON \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DREGISTER_INSTALL_PREFIX=OFF \
+        -G Ninja
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+subpackages:
+  - name: "gflags-dev"
+    description: "The gflags package contains a C++ library that implements commandline flags processing (development files)"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      provides:
+        - glog-dev=${{package.full-version}}
+
+update:
+  enabled: true
+  github:
+    identifier: gflags/gflags
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
- gflags: new package


Related: https://github.com/chainguard-dev/image-requests/issues/359

### Pre-review Checklist

#### For new package PRs only

- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

#### For new version streams

- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)


