### PR TITLE
glog: new package

### DIFF
--- a/glog.yaml
+++ b/glog.yaml
@@ -1,0 +1,59 @@
+package:
+  name: glog
+  version: 0.6.0
+  epoch: 0
+  description: "C++ implementation of the Google logging module"
+  copyright:
+    - license: "BSD-3-Clause"
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - cmake
+      - build-base
+      - libucontext-dev
+      - libunwind-dev
+      - samurai
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/google/glog
+      tag: v${{package.version}}
+      expected-commit: b33e3bad4c46c8a6345525fd822af355e5ef9446
+
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DWITH_GFLAGS=ON \
+        -DWITH_THREADS=ON \
+        -DWITH_TLS=ON \
+        -DPRINT_UNSYMBOLIZED_STACK_TRACES=OFF \
+        -G Ninja
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+subpackages:
+  - name: "glog-dev"
+    description: "C++ implementation of the Google logging module (development files)"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - glog
+
+update:
+  enabled: true
+  github:
+    identifier: google/glog
+    tag-filter: v
+    strip-prefix: v


### PR DESCRIPTION
- glog: new package


Related: https://github.com/chainguard-dev/image-requests/issues/359

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)


