### PR TITLE
thrift: new package

### DIFF
--- a/thrift.yaml
+++ b/thrift.yaml
@@ -1,0 +1,105 @@
+package:
+  name: thrift
+  version: 0.19.0
+  epoch: 0
+  description: "Language-independent software stack for RPC implementation"
+  copyright:
+    - license: "Apache-2.0"
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - cmake
+      - build-base
+      - samurai
+      - bison
+      - flex
+      - glib-dev
+      - libevent-dev
+      - openssl-dev
+      - zlib-dev
+      - boost-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/thrift
+      tag: v${{package.version}}
+      expected-commit: 5656208a202ca0be4d4dc44125b5ca0485f91bf0
+
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DCMAKE_BUILD_TYPE=None \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DBUILD_SHARED_LIBS=ON \
+        -DWITH_AS3=OFF \
+        -DWITH_JAVA=OFF \
+        -DWITH_JAVASCRIPT=OFF \
+        -DWITH_NODEJS=OFF \
+        -DWITH_PYTHON=OFF \
+        -G Ninja
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+subpackages:
+  - name: "thrift-dev"
+    description: "Language-independent software stack for RPC implementation (development files)"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - thrift
+
+  - name: "libthrift"
+    description: "Language-independent software stack for RPC implementation (libthrift library)"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          cp /home/build/melange-out/thrift/usr/lib/libthrift.so.* ${{targets.subpkgdir}}/usr/lib
+    dependencies:
+      runtime:
+        - thrift
+
+  - name: "libthrift-glib"
+    description: "Language-independent software stack for RPC implementation (libthrift-glib library)"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          cp /home/build/melange-out/thrift/usr/lib/libthrift_c_glib*.so.* ${{targets.subpkgdir}}/usr/lib
+    dependencies:
+      runtime:
+        - thrift
+
+  - name: "libthriftnb"
+    description: "Language-independent software stack for RPC implementation (libthriftnb library)"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          cp /home/build/melange-out/thrift/usr/lib/libthriftnb.so.* ${{targets.subpkgdir}}/usr/lib
+    dependencies:
+      runtime:
+        - thrift
+
+  - name: "libthriftz"
+    description: "Language-independent software stack for RPC implementation (libthriftz library)"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          cp /home/build/melange-out/thrift/usr/lib/libthriftz.so.* ${{targets.subpkgdir}}/usr/lib
+    dependencies:
+      runtime:
+        - thrift
+
+update:
+  enabled: true
+  github:
+    identifier: apache/thrift
+    use-tag: true
+    tag-filter: v
+    strip-prefix: v


### PR DESCRIPTION
- thrift: new package


Related: https://github.com/chainguard-dev/image-requests/issues/359

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)


