### PR TITLE
Erlang bump.

### DIFF
--- a/erlang-26.yaml
+++ b/erlang-26.yaml
@@ -1,6 +1,6 @@
 package:
   name: erlang-26
-  version: 26.0.2
+  version: "26.1"
   epoch: 0
   description: General-purpose programming language and runtime environment
   copyright:
@@ -28,27 +28,27 @@ environment:
 data:
   - name: subpackages
     items:
-      xmerl: 1.3.32
+      xmerl: 1.3.31.1
       tools: 3.6
       tftp: 1.1
       syntax_tools: 3.1
-      ssl: 11.0.2
-      snmp: 5.14
+      ssl: 11.0.3
+      snmp: 5.15
       runtime_tools: 2.0
-      public_key: 1.14
+      public_key: 1.14.1
       parsetools: 2.5
       os_mon: 2.9
-      mnesia: 4.22
-      inets: 9.0.1
+      mnesia: 4.22.1
+      inets: 9.0.2
       ftp: 1.2
       eldap: 1.2.11
-      crypto: 5.2
-      asn1: 5.1
+      crypto: 5.3
+      asn1: 5.2
 
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 47853ea9230643a0a31004433f07a71c1b92d6e0094534f629e3b75dbc62f193
+      expected-sha256: f914ddea79019ab2533911cdd4f91653726ac9b0561b3ec57aa6ecbcc3df3f55
       uri: https://github.com/erlang/otp/releases/download/OTP-${{package.version}}/otp_src_${{package.version}}.tar.gz
 
   - runs: |


### PR DESCRIPTION
This included a bunch of internal dep updates so our automation didn't catch it.

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
