### PR TITLE
fluent-plugin-kubernetes_metadata_filter: new package

### DIFF
--- a/fluent-plugin-kubernetes_metadata_filter.yaml
+++ b/fluent-plugin-kubernetes_metadata_filter.yaml
@@ -1,0 +1,54 @@
+package:
+  name: fluent-plugin-kubernetes_metadata_filter
+  version: 3.3.0
+  epoch: 0
+  description: This is the Fluentd output plugin to enable kubernetes metadata
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - ruby3.2-fluent-plugin-kubernetes_metadata_filter=${{package.version}}-r${{package.epoch}}
+    runtime:
+      - ruby3.2-fluentd
+      - ruby3.2-json-jwt
+      - ruby3.2-multi_json
+      - ruby3.2-net-http-persistent
+      - ruby3.2-openid_connect-1.1.8
+      - ruby3.2-prometheus-client
+      - ruby3.2-rack-oauth2
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 69462b6dcc3267b40f19bc540f86946870c28233da979931c8723f81ddf116fd
+      uri: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/unlock-spec
+
+  - uses: ruby/build
+    with:
+      gem: ${{package.name}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{package.name}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+update:
+  enabled: true
+  github:
+    identifier: fabric8io/fluent-plugin-kubernetes_metadata_filter
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
Package needed to ensure liveness/readiness probes for fluentd and solve error when using fluentd.

Fixes:

2023-09-20 15:45:41 +0000 [error]: config error file="/etc/fluent/fluent.conf" error_class=Fluent::NotFoundPluginError error="Unknown filter plugin 'kubernetes_metadata'. Run 'gem search -rd fluent-plugin' to find plugins"

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
