### PR TITLE
modsecurity: switch to melange pipeline for auto configure, ensures -…

### DIFF
--- a/modsecurity.yaml
+++ b/modsecurity.yaml
@@ -1,7 +1,7 @@
 package:
   name: modsecurity
   version: 3.0.10
-  epoch: 4
+  epoch: 5
   description: "ModSecurity is an open source, cross platform web application firewall (WAF) engine"
   copyright:
     - license: Apache-2.0
@@ -47,10 +47,13 @@ pipeline:
       # https://github.com/SpiderLabs/ModSecurity/issues/1909#issuecomment-465926762
       sed -i '115i LUA_CFLAGS="${LUA_CFLAGS} -DWITH_LUA_JIT_2_1"' build/lua.m4
       sed -i '117i AC_SUBST(LUA_CFLAGS)' build/lua.m4
-      ./configure \
-      --disable-doxygen-doc \
-      --disable-doxygen-html \
-      --disable-examples
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --disable-doxygen-doc \
+        --disable-doxygen-html \
+        --disable-examples
 
   - uses: autoconf/make
 


### PR DESCRIPTION
…-prefix=/usr is used

without --prefix=/usr a default of /usr/local is used which means a recent update to melange means the provides = so:libmodsecurity.so.3=3 was missing.
