### PR TITLE
New package: freetds

### DIFF
--- a/freetds.yaml
+++ b/freetds.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: FreeTDS is a set of libraries for Unix and Linux that allows programs to natively talk to Microsoft SQL Server and Sybase databases.
   copyright:
-    - license: GNU-LGPL
+    - license: GPL-2.0
   dependencies:
     provides:
       - freetds=${{package.version}}-r${{package.epoch}}}
@@ -28,7 +28,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/FreeTDS/${{package.name}}
+      repository: https://github.com/FreeTDS/freetds
       tag: "v${{package.version}}"
       expected-commit: "31a349e41d582822be850eb3bdbbc74c2f1ec05d"
       destination: "$HOME/${{package.name}}-${{package.version}}"

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -30,23 +30,20 @@ pipeline:
     with:
       repository: https://github.com/FreeTDS/freetds
       tag: "v${{package.version}}"
-      expected-commit: "31a349e41d582822be850eb3bdbbc74c2f1ec05d"
-      destination: "$HOME/${{package.name}}-${{package.version}}"
+      expected-commit: 31a349e41d582822be850eb3bdbbc74c2f1ec05d
+      destination: "${{package.name}}"
 
-  - name: Configure
-    runs: |
-      cd $HOME/${{package.name}}-${{package.version}}
-      ./autogen.sh --prefix=/usr --with-unixodbc=/usr --disable-libiconv --with-gnutls=/usr
+  - working-directory: ${{package.name}}
+    pipeline:
+      - name: Configure
+        runs: |
+          ./autogen.sh --prefix=/usr --with-unixodbc=/usr --disable-libiconv --with-gnutls=/usr
 
-  - uses: autoconf/make
-    with:
-      dir: $HOME/${{package.name}}-${{package.version}}
+      - uses: autoconf/make
 
-  - uses: autoconf/make-install
-    with:
-      dir: $HOME/${{package.name}}-${{package.version}}
+      - uses: autoconf/make-install
 
-  - uses: strip
+      - uses: strip
 
 update:
   enabled: true

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -13,17 +13,17 @@ package:
 environment:
   contents:
     packages:
-      - build-base
       - autoconf
       - automake
-      - libtool
+      - build-base
       - busybox
+      - gettext-dev
       - gnutls-dev
       - gperf
-      - unixodbc-dev
-      - pkgconf-dev
-      - gettext-dev
       - libgcrypt-dev
+      - libtool
+      - pkgconf-dev
+      - unixodbc-dev
 
 pipeline:
   - uses: git-checkout
@@ -38,11 +38,8 @@ pipeline:
       - name: Configure
         runs: |
           ./autogen.sh --prefix=/usr --with-unixodbc=/usr --disable-libiconv --with-gnutls=/usr
-
       - uses: autoconf/make
-
       - uses: autoconf/make-install
-
       - uses: strip
 
 update:

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -1,0 +1,56 @@
+package:
+  name: freetds
+  version: "v1.3.20"
+  epoch: 0
+  description: FreeTDS is a set of libraries for Unix and Linux that allows programs to natively talk to Microsoft SQL Server and Sybase databases.
+  copyright:
+    - license: GNU-LGPL
+  dependencies:
+    runtime:
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - autoconf
+      - automake
+      - libtool
+      - busybox
+      - gnutls-dev
+      - gperf
+      - unixodbc-dev
+      - pkgconf-dev
+      - gettext-dev
+      - libgcrypt-dev
+
+pipeline:
+  - name: Prepare Build Folder
+    runs: "mkdir $HOME/${{package.name}}-${{package.version}}"
+
+  - uses: git-checkout
+    with:
+      repository: https://github.com/freetds/${{package.name}}
+      tag: ${{package.version}}
+      expected-commit: "31a349e41d582822be850eb3bdbbc74c2f1ec05d"
+      destination: "$HOME/${{package.name}}-${{package.version}}"
+
+  - name: Configure
+    runs: |
+      set -x
+      cd $HOME/${{package.name}}-${{package.version}}
+      ./autogen.sh --prefix=/usr --with-unixodbc=/usr --disable-libiconv --with-gnutls=/usr
+
+  - uses: autoconf/make
+    with:
+      dir: $HOME/${{package.name}}-${{package.version}}
+
+  - uses: autoconf/make-install
+    with:
+      dir: $HOME/${{package.name}}-${{package.version}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: freetds/freetds

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -12,6 +12,10 @@ package:
 
 environment:
   contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - build-base
       - autoconf
@@ -26,9 +30,6 @@ environment:
       - libgcrypt-dev
 
 pipeline:
-  - name: Prepare Build Folder
-    runs: "mkdir $HOME/${{package.name}}-${{package.version}}"
-
   - uses: git-checkout
     with:
       repository: https://github.com/freetds/${{package.name}}
@@ -55,3 +56,6 @@ update:
   enabled: true
   github:
     identifier: freetds/freetds
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -1,6 +1,6 @@
 package:
   name: freetds
-  version: "v1.3.20"
+  version: "1.3.20"
   epoch: 0
   description: FreeTDS is a set of libraries for Unix and Linux that allows programs to natively talk to Microsoft SQL Server and Sybase databases.
   copyright:
@@ -32,7 +32,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/freetds/${{package.name}}
-      tag: ${{package.version}}
+      tag: "v${{package.version}}"
       expected-commit: "31a349e41d582822be850eb3bdbbc74c2f1ec05d"
       destination: "$HOME/${{package.name}}-${{package.version}}"
 

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -8,7 +8,6 @@ package:
   dependencies:
     provides:
       - freetds=${{package.version}}-r${{package.epoch}}}
-    runtime:
 
 environment:
   contents:

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -6,6 +6,8 @@ package:
   copyright:
     - license: GNU-LGPL
   dependencies:
+    provides:
+      - freetds=${{package.version}}-r${{package.epoch}}}
     runtime:
 
 environment:
@@ -36,7 +38,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      set -x
       cd $HOME/${{package.name}}-${{package.version}}
       ./autogen.sh --prefix=/usr --with-unixodbc=/usr --disable-libiconv --with-gnutls=/usr
 

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -12,10 +12,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - build-base
       - autoconf
@@ -32,7 +28,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/freetds/${{package.name}}
+      repository: https://github.com/FreeTDS/${{package.name}}
       tag: "v${{package.version}}"
       expected-commit: "31a349e41d582822be850eb3bdbbc74c2f1ec05d"
       destination: "$HOME/${{package.name}}-${{package.version}}"
@@ -55,7 +51,7 @@ pipeline:
 update:
   enabled: true
   github:
-    identifier: freetds/freetds
+    identifier: FreeTDS/freetds
     strip-prefix: v
     tag-filter: v
     use-tag: true


### PR DESCRIPTION
This PR adds the `freetds` package, required to build PHP with support to Sybase / MS SQL servers via the PDO_DBLIB extension.

EDIT: The package is building fine locally, I am not quite sure why the CI build is failing. It seems that the `git-checkout` pipeline is not creating the `destination` directory and moving the files to that location. 

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
