### PR TITLE
version stream : tomcat

### DIFF
--- a/tomcat-10.yaml
+++ b/tomcat-10.yaml
@@ -1,0 +1,60 @@
+package:
+  name: tomcat-10
+  version: 10.1.13
+  epoch: 1
+  description: Apache Tomcat Web Server
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - tomcat=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - build-base
+      - busybox
+      - openjdk-17
+      - ant
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/tomcat
+      tag: ${{package.version}}
+      expected-commit: 71dddc8a1b8fe1175a14e6dd98bb8af56c9ad75d
+
+  - runs: |
+      cat <<EOF > build.properties
+      skip.installer=true
+      base.path=$PWD
+      compile.debug=false
+      EOF
+
+  - runs: |
+      ant
+
+      mkdir -p ${{targets.destdir}}/usr/share/tomcat/bin
+      cp output/build/bin/* ${{targets.destdir}}/usr/share/tomcat/bin
+
+      mkdir -p ${{targets.destdir}}/usr/share/tomcat/conf
+      cp output/build/conf/* ${{targets.destdir}}/usr/share/tomcat/conf
+
+      mkdir -p ${{targets.destdir}}/usr/share/tomcat/lib
+      cp output/build/lib/* ${{targets.destdir}}/usr/share/tomcat/lib
+
+      mkdir -p ${{targets.destdir}}/usr/share/tomcat/logs
+      mkdir -p ${{targets.destdir}}/usr/share/tomcat/temp
+      mkdir -p ${{targets.destdir}}/usr/share/tomcat/webapps
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - '-M\d+$'
+  github:
+    identifier: apache/tomcat
+    use-tag: true
+    tag-filter: 10.

--- a/tomcat-8.yaml
+++ b/tomcat-8.yaml
@@ -1,0 +1,60 @@
+package:
+  name: tomcat-8
+  version: 8.5.93
+  epoch: 0
+  description: Apache Tomcat Web Server
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - tomcat=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - build-base
+      - busybox
+      - openjdk-17
+      - ant
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/tomcat
+      tag: ${{package.version}}
+      expected-commit: 9d9aea65c435a38c737c1e600e6513f9d0980cf1
+
+  - runs: |
+      cat <<EOF > build.properties
+      skip.installer=true
+      base.path=$PWD
+      compile.debug=false
+      EOF
+
+  - runs: |
+      ant
+
+      mkdir -p ${{targets.destdir}}/usr/share/tomcat/bin
+      cp output/build/bin/* ${{targets.destdir}}/usr/share/tomcat/bin
+
+      mkdir -p ${{targets.destdir}}/usr/share/tomcat/conf
+      cp output/build/conf/* ${{targets.destdir}}/usr/share/tomcat/conf
+
+      mkdir -p ${{targets.destdir}}/usr/share/tomcat/lib
+      cp output/build/lib/* ${{targets.destdir}}/usr/share/tomcat/lib
+
+      mkdir -p ${{targets.destdir}}/usr/share/tomcat/logs
+      mkdir -p ${{targets.destdir}}/usr/share/tomcat/temp
+      mkdir -p ${{targets.destdir}}/usr/share/tomcat/webapps
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - '-M\d+$'
+  github:
+    identifier: apache/tomcat
+    use-tag: true
+    tag-filter: 8.

--- a/tomcat-9.yaml
+++ b/tomcat-9.yaml
@@ -1,10 +1,13 @@
 package:
-  name: tomcat
-  version: 10.1.13
+  name: tomcat-9
+  version: 9.0.80
   epoch: 0
   description: Apache Tomcat Web Server
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - tomcat=${{package.full-version}}
 
 environment:
   contents:
@@ -22,7 +25,7 @@ pipeline:
     with:
       repository: https://github.com/apache/tomcat
       tag: ${{package.version}}
-      expected-commit: 71dddc8a1b8fe1175a14e6dd98bb8af56c9ad75d
+      expected-commit: 0ea24187a89ca09f3841e4690f931cca56e222fd
 
   - runs: |
       cat <<EOF > build.properties
@@ -54,3 +57,4 @@ update:
   github:
     identifier: apache/tomcat
     use-tag: true
+    tag-filter: 9.


### PR DESCRIPTION
Add tomcat version stream 

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

