### PR TITLE
fluent-plugin-out-http using git checkout

### DIFF
--- a/fluent-plugin-out-http.yaml
+++ b/fluent-plugin-out-http.yaml
@@ -25,7 +25,6 @@ environment:
       - busybox
       - git
 
-
 vars:
   gem: fluent-plugin-out-http
 
@@ -35,7 +34,7 @@ pipeline:
   - uses: git-checkout
     with:
       destination: ${{vars.gem}}
-      expected-commit: d5685ada81ac89a35a79965f1e94bbe5952a5d3a
+      expected-commit: 04e715e6bd7ef02d64da0a64e452bd73ce679050
       repository: https://github.com/fluent-plugins-nursery/fluent-plugin-out-http.git
       tag: v${{package.version}}
 
@@ -64,4 +63,3 @@ update:
     identifier: fluent-plugins-nursery/fluent-plugin-out-http
     strip-prefix: v
     use-tag: true
-

--- a/fluent-plugin-out-http.yaml
+++ b/fluent-plugin-out-http.yaml
@@ -1,13 +1,11 @@
 package:
   name: fluent-plugin-out-http
   version: 1.3.4
-  epoch: 0
+  epoch: 1
   description: This is the Fluentd output plugin for enabling http access to the container
   copyright:
     - license: Apache-2.0
   dependencies:
-    provides:
-      - ruby3.2-fluent-plugin-out-http=${{package.version}}-r${{package.epoch}}
     runtime:
       - ruby3.2-fluentd
       - ruby3.2-json-jwt
@@ -27,24 +25,38 @@ environment:
       - busybox
       - git
 
+
+vars:
+  gem: fluent-plugin-out-http
+
 pipeline:
-  - uses: fetch
+  # This package makes use of `git ls-files` in its gemspec so the git repo
+  # must be checked out in order for the gem to build with all files.
+  - uses: git-checkout
     with:
-      expected-sha256: f97af77141c16a5f3f7027516d521fc7caa546c97b53165a5fb1a1ee39ee749b
-      uri: https://github.com/fluent-plugins-nursery/fluent-plugin-out-http/archive/refs/tags/v${{package.version}}.tar.gz
+      destination: ${{vars.gem}}
+      expected-commit: d5685ada81ac89a35a79965f1e94bbe5952a5d3a
+      repository: https://github.com/fluent-plugins-nursery/fluent-plugin-out-http.git
+      tag: v${{package.version}}
 
-  - uses: ruby/unlock-spec
-
-  - uses: ruby/build
-    with:
-      gem: ${{package.name}}
-
-  - uses: ruby/install
-    with:
-      gem: ${{package.name}}
-      version: ${{package.version}}
+  - working-directory: ${{vars.gem}}
+    pipeline:
+      - uses: ruby/build
+        with:
+          gem: ${{vars.gem}}
+      - uses: ruby/install
+        with:
+          gem: ${{vars.gem}}
+          version: ${{package.version}}
 
   - uses: ruby/clean
+
+  - runs: |-
+      GEM_DIR=${{targets.destdir}}$(ruby -e 'puts Gem.default_dir')/gems/${{vars.gem}}-${{package.version}}
+      rm -rf ${GEM_DIR}/test \
+             ${GEM_DIR}/docs \
+             ${GEM_DIR}/*.md \
+             ${GEM_DIR}/.github
 
 update:
   enabled: true
@@ -52,3 +64,4 @@ update:
     identifier: fluent-plugins-nursery/fluent-plugin-out-http
     strip-prefix: v
     use-tag: true
+


### PR DESCRIPTION
Hopefully builds a plugin that's not empty

Fixes: empty plugin that was merged

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
