### PR TITLE
Remove gdk-pixbuf-loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ WOLFICTL ?= $(shell which wolfictl)
 KEY ?= local-melange.rsa
 REPO ?= $(shell pwd)/packages
 CACHE_DIR ?= gs://wolfi-sources/
-DOCKER_HOST ?= unix:///var/run/docker.sock
 
 WOLFI_SIGNING_PUBKEY ?= https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
 WOLFI_PROD ?= https://packages.wolfi.dev/os
@@ -66,12 +65,12 @@ list-yaml:
 package/%:
 	$(eval yamlfile := $*.yaml)
 	$(eval pkgver := $(shell $(MELANGE) package-version $(yamlfile)))
-	$(MAKE) yamlfile=$(yamlfile) pkgname=$* packages/$(ARCH)/$(pkgver).apk DOCKER_HOST=$(DOCKER_HOST) SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)
+	$(MAKE) yamlfile=$(yamlfile) pkgname=$* packages/$(ARCH)/$(pkgver).apk
 
 packages/$(ARCH)/%.apk: $(KEY)
 	@mkdir -p ./$(pkgname)/
 	$(eval SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct --follow $(yamlfile)))
-	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) DOCKER_HOST=$(DOCKER_HOST) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) --source-dir ./$(pkgname)/ --log-policy builtin:stderr,$(TARGETDIR)/buildlogs/$*.log
+	@SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) --source-dir ./$(pkgname)/ --log-policy builtin:stderr,$(TARGETDIR)/buildlogs/$*.log
 
 dev-container:
 	docker run --privileged --rm -it \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ WOLFICTL ?= $(shell which wolfictl)
 KEY ?= local-melange.rsa
 REPO ?= $(shell pwd)/packages
 CACHE_DIR ?= gs://wolfi-sources/
+DOCKER_HOST ?= unix:///var/run/docker.sock
 
 WOLFI_SIGNING_PUBKEY ?= https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
 WOLFI_PROD ?= https://packages.wolfi.dev/os
@@ -65,12 +66,12 @@ list-yaml:
 package/%:
 	$(eval yamlfile := $*.yaml)
 	$(eval pkgver := $(shell $(MELANGE) package-version $(yamlfile)))
-	$(MAKE) yamlfile=$(yamlfile) pkgname=$* packages/$(ARCH)/$(pkgver).apk
+	$(MAKE) yamlfile=$(yamlfile) pkgname=$* packages/$(ARCH)/$(pkgver).apk DOCKER_HOST=$(DOCKER_HOST) SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)
 
 packages/$(ARCH)/%.apk: $(KEY)
 	@mkdir -p ./$(pkgname)/
 	$(eval SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct --follow $(yamlfile)))
-	@SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) --source-dir ./$(pkgname)/ --log-policy builtin:stderr,$(TARGETDIR)/buildlogs/$*.log
+	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) DOCKER_HOST=$(DOCKER_HOST) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) --source-dir ./$(pkgname)/ --log-policy builtin:stderr,$(TARGETDIR)/buildlogs/$*.log
 
 dev-container:
 	docker run --privileged --rm -it \

--- a/gdk-pixbuf.yaml
+++ b/gdk-pixbuf.yaml
@@ -69,9 +69,6 @@ subpackages:
         - tiff-dev
     description: gdk-pixbuf dev
 
-  - name: gdk-pixbuf-loaders
-    description: metapackage to pull in gdk-pixbuf loaders
-
 update:
   enabled: true
   release-monitor:


### PR DESCRIPTION
This package is redundant with gdk-pixbuf which includes the loaders. Send gdk-pixbuf-loader to oblivion.