### PR TITLE
Remove exa-doc package, it's empty and has nothing in it.

### DIFF
--- a/exa.yaml
+++ b/exa.yaml
@@ -32,13 +32,6 @@ pipeline:
 
   - uses: strip
 
-subpackages:
-  - name: ${{package.name}}-doc
-    pipeline:
-      - uses: split/manpages
-      - uses: split/infodir
-    description: ${{package.name}} manpages
-
 update:
   enabled: true
   github:


### PR DESCRIPTION
This has no reason to exist as there are no useful docs in the package. Send exa-doc to the shadow realm.