### PR TITLE
New package: version 1.2.7: php-8.1-pdo_snowflake and php-8.2-pdo_snowflake.

### DIFF
--- a/php-8.1-pdo_snowflake.yaml
+++ b/php-8.1-pdo_snowflake.yaml
@@ -1,0 +1,49 @@
+package:
+  name: php-8.1-pdo_swowflake
+  version: 1.2.7
+  epoch: 0
+  description: "Snowflake driver that uses the PHP Data Objects (PDO) extension"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - binutils
+      - bison
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gcc
+      - libtool
+      - php-8.1
+      - php-8.1-dev
+      - php-8.1-pdo
+      - unixodbc-dev
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/snowflakedb/pdo_snowflake
+      expected-commit: b68db720b2babdcc4ef8923ee2f35293296e0ced
+      tag: v${{package.version}}
+
+  - name: Run and build
+    runs: |
+      PHP_HOME=/usr ./scripts/build_pdo_snowflake.sh
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: snowflakedb/pdo_snowflake
+    strip-prefix: v

--- a/php-8.1-pdo_snowflake.yaml
+++ b/php-8.1-pdo_snowflake.yaml
@@ -48,6 +48,7 @@ pipeline:
       # a script, we can't just set CFLAGS, so we have to edit the script.
       # Note. This also modifies the make clean target, but since we do not use
       # it, it is not a problem.
+      # https://github.com/snowflakedb/pdo_snowflake/issues/339
       sed -i -e 's@make@make CFLAGS="-Wno-unused-function $CFLAGS"@' ./scripts/build_pdo_snowflake.sh
       PHP_HOME=/usr ./scripts/build_pdo_snowflake.sh
 

--- a/php-8.2-pdo_snowflake.yaml
+++ b/php-8.2-pdo_snowflake.yaml
@@ -1,5 +1,5 @@
 package:
-  name: php-8.1-pdo_snowflake
+  name: php-8.2-pdo_snowflake
   version: 1.2.7
   epoch: 0
   description: "Snowflake driver that uses the PHP Data Objects (PDO) extension"
@@ -11,7 +11,7 @@ package:
     - x86_64
   dependencies:
     runtime:
-      - php-8.1
+      - php-8.2
 
 environment:
   contents:
@@ -27,9 +27,9 @@ environment:
       - cmake
       - gcc
       - libtool
-      - php-8.1
-      - php-8.1-dev
-      - php-8.1-pdo
+      - php-8.2
+      - php-8.2-dev
+      - php-8.2-pdo
       - unixodbc-dev
       - zlib-dev
 

--- a/php-8.2-pdo_snowflake.yaml
+++ b/php-8.2-pdo_snowflake.yaml
@@ -48,6 +48,7 @@ pipeline:
       # a script, we can't just set CFLAGS, so we have to edit the script.
       # Note. This also modifies the make clean target, but since we do not use
       # it, it is not a problem.
+      # https://github.com/snowflakedb/pdo_snowflake/issues/339
       sed -i -e 's@make@make CFLAGS="-Wno-unused-function $CFLAGS"@' ./scripts/build_pdo_snowflake.sh
       PHP_HOME=/usr ./scripts/build_pdo_snowflake.sh
 


### PR DESCRIPTION
**Note** I fat fingered the package name (swowflake) and only when I was ready to update realized the mistake, which I fixed, but the things below show swowflake, but I corrected it to snowflake 🤣 

Build instructions are from here:
https://github.com/snowflakedb/pdo_snowflake#building-the-driver-on-linux-and-macos

This only builds for x86_64, so tested with tarring / inspecting compared against the ☝️ instructions.
```
vaikas@vaikas-MBP os % tar -ztvf packages/x86_64/php-8.1-pdo_swowflake-1.2.7-r0.apk
-rwxrwxrwx  0 root   root      512 Dec 31  1969 .SIGN.RSA.local-melange.rsa.pub
-rw-r--r--  0 root   root      543 Dec 31  1969 .PKGINFO
drwxr-xr-x  0 root   root        0 Dec 31  1969 etc
drwxr-xr-x  0 root   root        0 Dec 31  1969 etc/php
drwxr-xr-x  0 root   root        0 Dec 31  1969 etc/php/conf.d
-rw-r--r--  0 root   root       72 Dec 31  1969 etc/php/conf.d/20-pdo_snowflake.ini
-rw-r--r--  0 root   root   236061 Dec 31  1969 etc/php/conf.d/cacert.pem
drwxr-xr-x  0 root   root        0 Dec 31  1969 usr
drwxr-xr-x  0 root   root        0 Dec 31  1969 usr/lib
drwxr-xr-x  0 root   root        0 Dec 31  1969 usr/lib/php
-rwxr-xr-x  0 root   root  9774640 Dec 31  1969 usr/lib/php/pdo_snowflake.so
drwxr-xr-x  0 root   root        0 Dec 31  1969 var
drwxr-xr-x  0 root   root        0 Dec 31  1969 var/lib
drwxr-xr-x  0 root   root        0 Dec 31  1969 var/lib/db
drwxr-xr-x  0 root   root        0 Dec 31  1969 var/lib/db/sbom
-rw-r--r--  0 root   root     4130 Dec 31  1969 var/lib/db/sbom/php-8.1-pdo_swowflake-1.2.7-r0.spdx.json
```

Then check the .ini file:
```
vaikas@vaikas-MBP snow % tar zxf ../php-8.1-pdo_swowflake-1.2.7-r0.apk
vaikas@vaikas-MBP snow % cat etc/php/conf.d/20-pdo_snowflake.ini
extension=pdo_snowflake
pdo_snowflake.cacert=/etc/php/conf.d/cacert.pem
```

8.2:
```
vaikas@vaikas-MBP os % tar -ztvf packages/x86_64/php-8.2-pdo_swowflake-1.2.7-r0.apk
-rwxrwxrwx  0 root   root      512 Dec 31  1969 .SIGN.RSA.local-melange.rsa.pub
-rw-r--r--  0 root   root      543 Dec 31  1969 .PKGINFO
drwxr-xr-x  0 root   root        0 Dec 31  1969 etc
drwxr-xr-x  0 root   root        0 Dec 31  1969 etc/php
drwxr-xr-x  0 root   root        0 Dec 31  1969 etc/php/conf.d
-rw-r--r--  0 root   root       72 Dec 31  1969 etc/php/conf.d/20-pdo_snowflake.ini
-rw-r--r--  0 root   root   236061 Dec 31  1969 etc/php/conf.d/cacert.pem
drwxr-xr-x  0 root   root        0 Dec 31  1969 usr
drwxr-xr-x  0 root   root        0 Dec 31  1969 usr/lib
drwxr-xr-x  0 root   root        0 Dec 31  1969 usr/lib/php
-rwxr-xr-x  0 root   root  9774640 Dec 31  1969 usr/lib/php/pdo_snowflake.so
drwxr-xr-x  0 root   root        0 Dec 31  1969 var
drwxr-xr-x  0 root   root        0 Dec 31  1969 var/lib
drwxr-xr-x  0 root   root        0 Dec 31  1969 var/lib/db
drwxr-xr-x  0 root   root        0 Dec 31  1969 var/lib/db/sbom
-rw-r--r--  0 root   root     4130 Dec 31  1969 var/lib/db/sbom/php-8.2-pdo_swowflake-1.2.7-r0.spdx.json
```

and .ini:
```
vaikas@vaikas-MBP snow % tar zxf ../php-8.2-pdo_swowflake-1.2.7-r0.apk
vaikas@vaikas-MBP snow % cat etc/php/conf.d/20-pdo_snowflake.ini
extension=pdo_snowflake
pdo_snowflake.cacert=/etc/php/conf.d/cacert.pem

Also checked the update for both files successfully with:
```
wolfictl check update  --override-version 0.0.1 php-8.1-pdo_snowflake.yaml
wolfictl check update  --override-version 0.0.1 php-8.2-pdo_snowflake.yaml
```

Scans:
```
vaikas@vaikas-MBP os % wolfictl scan packages/x86_64/php-8.1-pdo_swowflake-1.2.7-r0.apk
Will process: php-8.1-pdo_swowflake-1.2.7-r0.apk
✅ No vulnerabilities found
vaikas@vaikas-MBP os % wolfictl scan packages/x86_64/php-8.2-pdo_swowflake-1.2.7-r0.apk
Will process: php-8.2-pdo_swowflake-1.2.7-r0.apk
✅ No vulnerabilities found
```


Related:
#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ X ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ X ] REQUIRED - The version of the package is still receiving security updates
