### PR TITLE
Apply Envoy build patch to use make 4.4

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -61,6 +61,9 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv bazel-bin/source/exe/envoy-static ${{targets.destdir}}/usr/bin/envoy
 
+      # We no longer need this cache dir, which has some writable files.
+      rm -rf ../.cache/bazel/_bazel_root
+
   - uses: strip
 
 subpackages:

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -42,6 +42,10 @@ pipeline:
       destination: envoy
 
   - runs: |
+      # Apply https://github.com/envoyproxy/envoy/pull/29261/files so build
+      # can work with make > 4.3
+      cp -f luajit.patch envoy/bazel/foreign_cc
+
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
       mkdir -p .cache/bazel/_bazel_root
 

--- a/envoy/luajit.patch
+++ b/envoy/luajit.patch
@@ -1,0 +1,189 @@
+diff --git a/src/Makefile b/src/Makefile
+index 30d64be2..ae7ec875 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -27,7 +27,7 @@ NODOTABIVER= 51
+ DEFAULT_CC = gcc
+ #
+ # LuaJIT builds as a native 32 or 64 bit binary by default.
+-CC= $(DEFAULT_CC)
++CC ?= $(DEFAULT_CC)
+ #
+ # Use this if you want to force a 32 bit build on a 64 bit multilib OS.
+ #CC= $(DEFAULT_CC) -m32
+@@ -71,10 +71,10 @@ CCWARN= -Wall
+ # as dynamic mode.
+ #
+ # Mixed mode creates a static + dynamic library and a statically linked luajit.
+-BUILDMODE= mixed
++#BUILDMODE= mixed
+ #
+ # Static mode creates a static library and a statically linked luajit.
+-#BUILDMODE= static
++BUILDMODE= static
+ #
+ # Dynamic mode creates a dynamic library and a dynamically linked luajit.
+ # Note: this executable will only run when the library is installed!
+@@ -99,7 +99,7 @@ XCFLAGS=
+ # enabled by default. Some other features that *might* break some existing
+ # code (e.g. __pairs or os.execute() return values) can be enabled here.
+ # Note: this does not provide full compatibility with Lua 5.2 at this time.
+-#XCFLAGS+= -DLUAJIT_ENABLE_LUA52COMPAT
++XCFLAGS+= -DLUAJIT_ENABLE_LUA52COMPAT
+ #
+ # Disable the JIT compiler, i.e. turn LuaJIT into a pure interpreter.
+ #XCFLAGS+= -DLUAJIT_DISABLE_JIT
+@@ -212,7 +212,7 @@ TARGET_STCC= $(STATIC_CC)
+ TARGET_DYNCC= $(DYNAMIC_CC)
+ TARGET_LD= $(CROSS)$(CC)
+ TARGET_AR= $(CROSS)ar rcus
+-TARGET_STRIP= $(CROSS)strip
++TARGET_STRIP?= $(CROSS)strip
+ 
+ TARGET_LIBPATH= $(or $(PREFIX),/usr/local)/$(or $(MULTILIB),lib)
+ TARGET_SONAME= libluajit-$(ABIVER).so.$(MAJVER)
+@@ -598,7 +598,7 @@ endif
+ 
+ Q= @
+ E= @echo
+-#Q=
++Q=
+ #E= @:
+ 
+ ##############################################################################
+diff --git a/src/msvcbuild.bat b/src/msvcbuild.bat
+index d323d8d4..2e08a3a1 100644
+--- a/src/msvcbuild.bat
++++ b/src/msvcbuild.bat
+@@ -13,9 +13,7 @@
+ @if not defined INCLUDE goto :FAIL
+ 
+ @setlocal
+-@rem Add more debug flags here, e.g. DEBUGCFLAGS=/DLUA_USE_APICHECK
+-@set DEBUGCFLAGS=
+-@set LJCOMPILE=cl /nologo /c /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline
++@set LJCOMPILE=cl /nologo /c /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline /DLUAJIT_ENABLE_LUA52COMPAT
+ @set LJLINK=link /nologo
+ @set LJMT=mt /nologo
+ @set LJLIB=lib /nologo /nodefaultlib
+@@ -24,10 +22,9 @@
+ @set DASC=vm_x64.dasc
+ @set LJDLLNAME=lua51.dll
+ @set LJLIBNAME=lua51.lib
+-@set BUILDTYPE=release
+ @set ALL_LIB=lib_base.c lib_math.c lib_bit.c lib_string.c lib_table.c lib_io.c lib_os.c lib_package.c lib_debug.c lib_jit.c lib_ffi.c lib_buffer.c
+ 
+-%LJCOMPILE% host\minilua.c
++%LJCOMPILE% /O2 host\minilua.c
+ @if errorlevel 1 goto :BAD
+ %LJLINK% /out:minilua.exe minilua.obj
+ @if errorlevel 1 goto :BAD
+@@ -51,7 +48,7 @@ if exist minilua.exe.manifest^
+ minilua %DASM% -LN %DASMFLAGS% -o host\buildvm_arch.h %DASC%
+ @if errorlevel 1 goto :BAD
+ 
+-%LJCOMPILE% /I "." /I %DASMDIR% host\buildvm*.c
++%LJCOMPILE% /O2 /I "." /I %DASMDIR% host\buildvm*.c
+ @if errorlevel 1 goto :BAD
+ %LJLINK% /out:buildvm.exe buildvm*.obj
+ @if errorlevel 1 goto :BAD
+@@ -75,26 +72,35 @@ buildvm -m folddef -o lj_folddef.h lj_opt_fold.c
+ 
+ @if "%1" neq "debug" goto :NODEBUG
+ @shift
+-@set BUILDTYPE=debug
+-@set LJCOMPILE=%LJCOMPILE% /Zi %DEBUGCFLAGS%
+-@set LJLINK=%LJLINK% /opt:ref /opt:icf /incremental:no
++@set LJCOMPILE=%LJCOMPILE% /O0 /Z7
++@set LJLINK=%LJLINK% /debug /opt:ref /opt:icf /incremental:no
++@set LJCRTDBG=d
++@goto :ENDDEBUG
+ :NODEBUG
+-@set LJLINK=%LJLINK% /%BUILDTYPE%
++@set LJCOMPILE=%LJCOMPILE% /O2 /Z7
++@set LJLINK=%LJLINK% /release /incremental:no
++@set LJCRTDBG=
++:ENDDEBUG
+ @if "%1"=="amalg" goto :AMALGDLL
+ @if "%1"=="static" goto :STATIC
+-%LJCOMPILE% /MD /DLUA_BUILD_AS_DLL lj_*.c lib_*.c
++@set LJCOMPILE=%LJCOMPILE% /MD%LJCRTDBG% 
++%LJCOMPILE% /DLUA_BUILD_AS_DLL lj_*.c lib_*.c
+ @if errorlevel 1 goto :BAD
+ %LJLINK% /DLL /out:%LJDLLNAME% lj_*.obj lib_*.obj
+ @if errorlevel 1 goto :BAD
+ @goto :MTDLL
+ :STATIC
++@shift
++@set LJCOMPILE=%LJCOMPILE% /MT%LJCRTDBG%
+ %LJCOMPILE% lj_*.c lib_*.c
+ @if errorlevel 1 goto :BAD
+ %LJLIB% /OUT:%LJLIBNAME% lj_*.obj lib_*.obj
+ @if errorlevel 1 goto :BAD
+ @goto :MTDLL
+ :AMALGDLL
+-%LJCOMPILE% /MD /DLUA_BUILD_AS_DLL ljamalg.c
++@shift
++@set LJCOMPILE=%LJCOMPILE% /MD%LJCRTDBG% 
++%LJCOMPILE% /DLUA_BUILD_AS_DLL ljamalg.c
+ @if errorlevel 1 goto :BAD
+ %LJLINK% /DLL /out:%LJDLLNAME% ljamalg.obj lj_vm.obj
+ @if errorlevel 1 goto :BAD
+diff --git a/build.py b/build.py
+new file mode 100755
+index 00000000..1201542c
+--- /dev/null
++++ b/build.py
+@@ -0,0 +1,52 @@
++#!/usr/bin/env python3
++
++import argparse
++import os
++import shutil
++
++def main():
++    parser = argparse.ArgumentParser()
++    parser.add_argument("--prefix")
++    args = parser.parse_args()
++    src_dir = os.path.dirname(os.path.realpath(__file__))
++    shutil.copytree(src_dir, os.path.basename(src_dir))
++    os.chdir(os.path.basename(src_dir))
++
++    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.8"
++    os.environ["DEFAULT_CC"] = os.environ.get("CC", "")
++    os.environ["TARGET_CFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
++    os.environ["TARGET_LDFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
++    os.environ["CFLAGS"] = ""
++    os.environ["LDFLAGS"] = ""
++
++    # Don't strip the binary - it doesn't work when cross-compiling, and we don't use it anyway.
++    os.environ["TARGET_STRIP"] = "@echo"
++
++    # Remove LuaJIT from ASAN for now.
++    # TODO(htuch): Remove this when https://github.com/envoyproxy/envoy/issues/6084 is resolved.
++    if "ENVOY_CONFIG_ASAN" in os.environ or "ENVOY_CONFIG_MSAN" in os.environ:
++      os.environ["TARGET_CFLAGS"] += " -fsanitize-blacklist=%s/com_github_luajit_luajit/clang-asan-blocklist.txt" % os.environ["PWD"]
++      with open("clang-asan-blocklist.txt", "w") as f:
++        f.write("fun:*\n")
++
++    os.system('"{}" -j{} V=1 PREFIX="{}" install'.format(os.environ["MAKE"], os.cpu_count(), args.prefix))
++
++def win_main():
++    src_dir = os.path.dirname(os.path.realpath(__file__))
++    dst_dir = os.getcwd() + "/luajit"
++    shutil.copytree(src_dir, os.path.basename(src_dir))
++    os.chdir(os.path.basename(src_dir) + "/src")
++    os.system('msvcbuild.bat ' + os.getenv('WINDOWS_DBG_BUILD', '') + ' static')
++    os.makedirs(dst_dir + "/lib", exist_ok=True)
++    shutil.copy("lua51.lib", dst_dir + "/lib")
++    os.makedirs(dst_dir + "/include/luajit-2.1", exist_ok=True)
++    for header in ["lauxlib.h", "luaconf.h", "lua.h", "lua.hpp", "luajit.h", "lualib.h"]:
++      shutil.copy(header, dst_dir + "/include/luajit-2.1")
++    os.makedirs(dst_dir + "/bin", exist_ok=True)
++    shutil.copy("luajit.exe", dst_dir + "/bin")
++
++if os.name == 'nt':
++  win_main()
++else:
++  main()
++


### PR DESCRIPTION
Currently the build failed as HEAD: https://github.com/wolfi-dev/os/actions/runs/6254675611/job/16982663689?pr=5779, this is because the Bazel `rules_foreign_cc` also create its own `make` versioned 4.3 causing inconsistencies when one `make`'s flags are passed to the other.

We apply this [patch](https://github.com/envoyproxy/envoy/pull/29261) to consistently use the same `make`.

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
