### PR TITLE
Add missing go.env file to go-fips-1.21

### DIFF
--- a/go-fips-1.21.yaml
+++ b/go-fips-1.21.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-fips-1.21
   version: 1.21.1
-  epoch: 0
+  epoch: 1
   description: "the Go programming language with OpenSSL cryptography"
   copyright:
     - license: BSD-3-Clause
@@ -65,6 +65,7 @@ pipeline:
       cp -a pkg lib "${{targets.destdir}}"/usr/lib/go/
       cp -r doc misc "${{targets.destdir}}"/usr/share/doc/go
       cp -a src "${{targets.destdir}}"/usr/lib/go/
+      cp -p go.env "${{targets.destdir}}"/usr/lib/go/go.env
 
       rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/obj
       rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/bootstrap


### PR DESCRIPTION
Similar to https://github.com/wolfi-dev/os/commit/b9f91cb3604a9014386b03fb2399a575b501ba8f . See https://github.com/golang/go/issues/61928 .

* "go-fips-1.21: add missing go.env file"