### PR TITLE
Add visualization-server transitive deps vol1

### DIFF
--- a/py3-appnope.yaml
+++ b/py3-appnope.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/appnope/
+package:
+  name: py3-appnope
+  version: 0.1.3
+  epoch: 0
+  description: Disable App Nap on macOS >= 10.9
+  copyright:
+    - license: BSD
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 38e1e1252c263e4f110b427fd13cb81ac6fe56cb
+      repository: https://github.com/minrk/appnope
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: minrk/appnope

--- a/py3-asttokens.yaml
+++ b/py3-asttokens.yaml
@@ -1,0 +1,43 @@
+# Generated from https://pypi.org/project/asttokens/
+package:
+  name: py3-asttokens
+  version: 2.4.0
+  epoch: 0
+  description: Annotate AST trees with source code positions
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-six
+      - py3-typing
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 0af0b06b811bad492302dd2f889c5ddbdc699671
+      repository: https://github.com/gristlabs/asttokens
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: gristlabs/asttokens
+    strip-prefix: v
+    use-tag: true

--- a/py3-async-lru.yaml
+++ b/py3-async-lru.yaml
@@ -1,0 +1,42 @@
+# Generated from https://pypi.org/project/async-lru/
+package:
+  name: py3-async-lru
+  version: 2.0.4
+  epoch: 0
+  description: Simple LRU cache for asyncio
+  copyright:
+    - license: MIT License
+  dependencies:
+    runtime:
+      - py3-typing-extensions
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 2051f7b012f38d02ae304209816c828690399b33
+      repository: https://github.com/aio-libs/async-lru
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: aio-libs/async-lru
+    strip-prefix: v
+    use-tag: true

--- a/py3-avro-python3.yaml
+++ b/py3-avro-python3.yaml
@@ -1,0 +1,37 @@
+# Generated from https://pypi.org/project/avro-python3/
+package:
+  name: py3-avro-python3
+  version: 1.10.2
+  epoch: 0
+  description: Avro is a serialization and RPC framework.
+  copyright:
+    - license: Apache License 2.0
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 3b63f24e6b04368c3e4a6f923f484be0230d821aad65ac36108edbff29e9aaab
+      uri: https://files.pythonhosted.org/packages/cc/97/7a6970380ca8db9139a3cc0b0e3e0dd3e4bc584fb3644e1d06e71e1a55f0/avro-python3-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 73324

--- a/py3-backcall.yaml
+++ b/py3-backcall.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/backcall/
+package:
+  name: py3-backcall
+  version: 0.2.0
+  epoch: 0
+  description: Specifications for callback functions passed in to an API
+  copyright:
+    - license: "BSD 3-Clause"
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 76faffb16e2169606209255ef9e9d684d11c1e81
+      repository: https://github.com/takluyver/backcall
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: takluyver/backcall

--- a/py3-bleach.yaml
+++ b/py3-bleach.yaml
@@ -1,0 +1,43 @@
+# Generated from https://pypi.org/project/bleach/
+package:
+  name: py3-bleach
+  version: 6.0.0
+  epoch: 0
+  description: An easy safelist-based HTML-sanitizing tool.
+  copyright:
+    - license: Apache Software License
+  dependencies:
+    runtime:
+      - py3-six
+      - py3-webencodings
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 324b03d82a25f0852fba5ee44913a040acebf3c5
+      repository: https://github.com/mozilla/bleach
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: mozilla/bleach
+    strip-prefix: v
+    use-tag: true

--- a/py3-cached-property.yaml
+++ b/py3-cached-property.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/cached-property/
+package:
+  name: py3-cached-property
+  version: 1.5.2
+  epoch: 0
+  description: A decorator for caching properties in classes.
+  copyright:
+    - license: BSD
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 9cb55ecb394a7e82ebb97a9099b7e87766eadddf
+      repository: https://github.com/pydanny/cached-property
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: pydanny/cached-property

--- a/py3-comm.yaml
+++ b/py3-comm.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/comm/
+package:
+  name: py3-comm
+  version: 0.1.4
+  epoch: 0
+  description: Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc.
+  copyright:
+    - license: 'BSD 3-Clause License  Copyright (c) 2022, Jupyter All rights reserved.  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.'
+  dependencies:
+    runtime:
+      - py3-traitlets
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 234c93d4d4c61d67301273e31cba23a504dc0aac
+      repository: https://github.com/ipython/comm
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: ipython/comm
+    strip-prefix: v

--- a/py3-comm.yaml
+++ b/py3-comm.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 0
   description: Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc.
   copyright:
-    - license: 'BSD 3-Clause License  Copyright (c) 2022, Jupyter All rights reserved.  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.'
+    - license: 'BSD 3-Clause'
   dependencies:
     runtime:
       - py3-traitlets

--- a/py3-debugpy.yaml
+++ b/py3-debugpy.yaml
@@ -1,0 +1,42 @@
+# Generated from https://pypi.org/project/debugpy/
+package:
+  name: py3-debugpy
+  version: 1.8.0
+  epoch: 0
+  description: An implementation of the Debug Adapter Protocol for Python
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 4a03787784c5e44a957317ff82122b6d9227b749
+      repository: https://github.com/microsoft/debugpy
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  ignore-regex-patterns:
+    - 1.6.7.post1
+  github:
+    identifier: microsoft/debugpy
+    strip-prefix: v

--- a/py3-decorator.yaml
+++ b/py3-decorator.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/decorator/
+package:
+  name: py3-decorator
+  version: 5.1.1
+  epoch: 0
+  description: Decorators for Humans
+  copyright:
+    - license: new BSD License
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: ad013a2c1ad7969963acf3dea948632be387f5a0
+      repository: https://github.com/micheles/decorator
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: micheles/decorator

--- a/py3-dill.yaml
+++ b/py3-dill.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/dill/
+package:
+  name: py3-dill
+  version: 0.3.7
+  epoch: 0
+  description: serialize all of Python
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: d33477195e0433b5add1c16e4ea7c54747b2feaa
+      repository: https://github.com/uqfoundation/dill
+      tag: dill-${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: uqfoundation/dill
+    strip-prefix: dill-

--- a/py3-dnspython.yaml
+++ b/py3-dnspython.yaml
@@ -1,0 +1,37 @@
+# Generated from https://pypi.org/project/dnspython/
+package:
+  name: py3-dnspython
+  version: 2.4.2
+  epoch: 0
+  description: DNS toolkit
+  copyright:
+    - license: ISC
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 8dcfae8c7460a2f84b4072e26f1c9f4101ca20c071649cb7c34e8b6a93d58984
+      uri: https://files.pythonhosted.org/packages/65/2d/372a20e52a87b2ba0160997575809806111a72e18aa92738daccceb8d2b9/dnspython-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 13190

--- a/py3-docopt.yaml
+++ b/py3-docopt.yaml
@@ -1,0 +1,37 @@
+# Generated from https://pypi.org/project/docopt/
+package:
+  name: py3-docopt
+  version: 0.6.2
+  epoch: 0
+  description: Pythonic argument parser, that will make you smile
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491
+      uri: https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 8436

--- a/py3-entrypoints.yaml
+++ b/py3-entrypoints.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/entrypoints/
+package:
+  name: py3-entrypoints
+  version: "0.4"
+  epoch: 0
+  description: Discover and load entry points from installed packages.
+  copyright:
+    - license: "MIT License"
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: ebdf2d8edc9921427ea07688851999796093c240
+      repository: https://github.com/takluyver/entrypoints
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: takluyver/entrypoints

--- a/py3-executing.yaml
+++ b/py3-executing.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/executing/
+package:
+  name: py3-executing
+  version: 1.2.0
+  epoch: 0
+  description: Get the currently executing AST node of a frame, and other information
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-typing
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 70d0d7b94e677c3724ba0963766731d191640e5d
+      repository: https://github.com/alexmojaki/executing
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: alexmojaki/executing
+    strip-prefix: v

--- a/py3-fastavro.yaml
+++ b/py3-fastavro.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/fastavro/
+package:
+  name: py3-fastavro
+  version: 1.8.3
+  epoch: 0
+  description: Fast read/write of AVRO files
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+      - python-3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 4ff1e7ebc96029de65724b3f0794bd2b4459b1a6
+      repository: https://github.com/fastavro/fastavro
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: fastavro/fastavro

--- a/py3-fasteners.yaml
+++ b/py3-fasteners.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/fasteners/
+package:
+  name: py3-fasteners
+  version: "0.19"
+  epoch: 0
+  description: A python package that provides useful locks
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 06c3f06cab4e135b8d921932019a231c180eb9f4
+      repository: https://github.com/harlowja/fasteners
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: harlowja/fasteners

--- a/py3-fastjsonschema.yaml
+++ b/py3-fastjsonschema.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/fastjsonschema/
+package:
+  name: py3-fastjsonschema
+  version: 2.18.0
+  epoch: 0
+  description: Fastest Python implementation of JSON schema
+  copyright:
+    - license: BSD
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 756540088687cda351390f687b92e602feaa7dc6
+      repository: https://github.com/horejsek/python-fastjsonschema
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: horejsek/python-fastjsonschema
+    strip-prefix: v
+    use-tag: true

--- a/py3-fsspec.yaml
+++ b/py3-fsspec.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/fsspec/
+package:
+  name: py3-fsspec
+  version: 2023.9.1
+  epoch: 0
+  description: File-system specification
+  copyright:
+    - license: BSD
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 247b249a008990c584d2619f030bd42916a82e4a
+      repository: https://github.com/fsspec/filesystem_spec
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: fsspec/filesystem_spec

--- a/py3-google-api-core.yaml
+++ b/py3-google-api-core.yaml
@@ -1,0 +1,44 @@
+# Generated from https://pypi.org/project/google-api-core/
+package:
+  name: py3-google-api-core
+  version: 2.11.1
+  epoch: 0
+  description: Google API client core library
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-googleapis-common-protos
+      - py3-protobuf
+      - py3-google-auth
+      - py3-requests
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 0acda8c96b23af2238ae0f4536e4fbb98bc7d787
+      repository: https://github.com/googleapis/python-api-core
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: googleapis/python-api-core
+    strip-prefix: v

--- a/py3-google-api-core.yaml
+++ b/py3-google-api-core.yaml
@@ -1,7 +1,7 @@
 # Generated from https://pypi.org/project/google-api-core/
 package:
   name: py3-google-api-core
-  version: 2.11.1
+  version: 2.12.0
   epoch: 0
   description: Google API client core library
   copyright:
@@ -27,7 +27,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 0acda8c96b23af2238ae0f4536e4fbb98bc7d787
+      expected-commit: 887751e114fd6ae8276529c0b9b726a0d5d7c8eb
       repository: https://github.com/googleapis/python-api-core
       tag: v${{package.version}}
 

--- a/py3-google-auth-oauthlib.yaml
+++ b/py3-google-auth-oauthlib.yaml
@@ -1,0 +1,42 @@
+# Generated from https://pypi.org/project/google-auth-oauthlib/
+package:
+  name: py3-google-auth-oauthlib
+  version: 1.1.0
+  epoch: 0
+  description: Google Authentication Library
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-google-auth
+      - py3-requests-oauthlib
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: d8aead77ed6f9cb6ee5527994cb6c58aea32761f
+      repository: https://github.com/GoogleCloudPlatform/google-auth-library-python-oauthlib
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: GoogleCloudPlatform/google-auth-library-python-oauthlib
+    strip-prefix: v

--- a/py3-google-crc32c.yaml
+++ b/py3-google-crc32c.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/google-crc32c/
+package:
+  name: py3-google-crc32c
+  version: 1.5.0
+  epoch: 0
+  description: A python wrapper of the C library 'Google CRC32C'
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 55e54f7a081b91a2601d0f5a64d712c449ed81f1
+      repository: https://github.com/googleapis/python-crc32c
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: googleapis/python-crc32c
+    strip-prefix: v

--- a/py3-google-pasta.yaml
+++ b/py3-google-pasta.yaml
@@ -1,0 +1,42 @@
+# Generated from https://pypi.org/project/google-pasta/
+package:
+  name: py3-google-pasta
+  version: 0.2.0
+  epoch: 0
+  description: pasta is an AST-based Python refactoring library
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-six
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 3eccb2ed20d0cf82b5083ac16b25b45570403531
+      repository: https://github.com/google/pasta
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: google/pasta
+    strip-prefix: v
+    use-tag: true

--- a/py3-grpc-google-iam-v1.yaml
+++ b/py3-grpc-google-iam-v1.yaml
@@ -1,0 +1,43 @@
+# Generated from https://pypi.org/project/grpc-google-iam-v1/
+package:
+  name: py3-grpc-google-iam-v1
+  version: 0.12.6
+  epoch: 0
+  description: IAM API client library
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-grpcio
+      - py3-googleapis-common-protos
+      - py3-protobuf
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: a3bdf6c669270c8efe9c93a637a669d11753e0f2
+      repository: https://github.com/googleapis/python-grpc-google-iam-v1
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: googleapis/python-grpc-google-iam-v1
+    strip-prefix: v

--- a/py3-grpcio-gcp.yaml
+++ b/py3-grpcio-gcp.yaml
@@ -1,0 +1,38 @@
+# Generated from https://pypi.org/project/grpcio-gcp/
+package:
+  name: py3-grpcio-gcp
+  version: 0.2.2
+  epoch: 0
+  description: gRPC extensions for Google Cloud Platform
+  copyright:
+    - license: Apache License 2.0
+  dependencies:
+    runtime:
+      - py3-grpcio
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: e292605effc7da39b7a8734c719afb12ec4b5362add3528d8afad3aa3aa9057c
+      uri: https://files.pythonhosted.org/packages/3c/a2/69a79b928e4a6abb5979945be9382f8aaf4580a7496ad4389371bbc0c9eb/grpcio-gcp-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 100779

--- a/py3-grpcio-status.yaml
+++ b/py3-grpcio-status.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/grpcio-status/
+package:
+  name: py3-grpcio-status
+  version: 1.58.0
+  epoch: 0
+  description: Status proto mapping for gRPC
+  copyright:
+    - license: Apache License 2.0
+  dependencies:
+    runtime:
+      - py3-protobuf
+      - py3-grpcio
+      - py3-googleapis-common-protos
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 0b42e70c0405a66a82d9e9867fa255fe59e618964a6099b20568c31dd9099766
+      uri: https://files.pythonhosted.org/packages/85/75/4126cf49ecb4991de5e90f3801151eb24a1dcf37cf30720324f19a081e9e/grpcio-status-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 30541

--- a/py3-hdfs.yaml
+++ b/py3-hdfs.yaml
@@ -1,0 +1,37 @@
+# Generated from https://pypi.org/project/hdfs/
+package:
+  name: py3-hdfs
+  version: 2.7.2
+  epoch: 0
+  description: 'HdfsCLI: API and command line interface for HDFS.'
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 829b659f4ed8f114923690f5b1aa51d295e590bb25eb59ffee00acc1ce493a93
+      uri: https://files.pythonhosted.org/packages/a8/9f/723bf4d4c92e85562430b21b096fb8baa87ff39cd5d784ddd17df2b0146f/hdfs-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 155413

--- a/py3-httplib2.yaml
+++ b/py3-httplib2.yaml
@@ -1,0 +1,42 @@
+# Generated from https://pypi.org/project/httplib2/
+package:
+  name: py3-httplib2
+  version: 0.22.0
+  epoch: 0
+  description: A comprehensive HTTP client library.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-parsing
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 09eee8a81f552cbaa74f603f2dd9bcc3311ff6d7
+      repository: https://github.com/httplib2/httplib2
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: httplib2/httplib2
+    strip-prefix: v
+    use-tag: true

--- a/py3-ipython-genutils.yaml
+++ b/py3-ipython-genutils.yaml
@@ -1,0 +1,37 @@
+# Generated from https://pypi.org/project/ipython_genutils/
+package:
+  name: py3-ipython-genutils
+  version: 0.2.0
+  epoch: 0
+  description: Vestigial utilities from IPython
+  copyright:
+    - license: BSD
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8
+      uri: https://files.pythonhosted.org/packages/e8/69/fbeffffc05236398ebfcfb512b6d2511c622871dca1746361006da310399/ipython_genutils-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 19997

--- a/py3-json5.yaml
+++ b/py3-json5.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/json5/
+package:
+  name: py3-json5
+  version: 0.9.14
+  epoch: 0
+  description: A Python implementation of the JSON5 data format.
+  copyright:
+    - license: Apache
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 2154e31bbae71b6a8ae69e5e5a3350528825f0fc
+      repository: https://github.com/dpranke/pyjson5
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: dpranke/pyjson5
+    strip-prefix: v
+    use-tag: true

--- a/py3-jupyterlab-pygments.yaml
+++ b/py3-jupyterlab-pygments.yaml
@@ -1,0 +1,43 @@
+# Generated from https://pypi.org/project/jupyterlab-pygments/
+package:
+  name: py3-jupyterlab-pygments
+  version: 0.2.2
+  epoch: 0
+  description: Pygments theme using JupyterLab CSS variables
+  copyright:
+    - license: BSD
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - python-3-dev
+      - py3-setuptools
+      - yarn
+      - nodejs
+      - npm
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 7070bc1e858bb531cabb296278a74738cdc1639d
+      repository: https://github.com/jupyterlab/jupyterlab_pygments
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: jupyterlab/jupyterlab_pygments

--- a/py3-keras.yaml
+++ b/py3-keras.yaml
@@ -1,0 +1,37 @@
+# Generated from https://pypi.org/project/keras/
+package:
+  name: py3-keras
+  version: 2.14.0
+  epoch: 0
+  description: Deep learning for humans.
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 22788bdbc86d9988794fe9703bb5205141da797c4faeeb59497c58c3d94d34ed
+      uri: https://files.pythonhosted.org/packages/bf/85/d52a86eb5ae700e1f8694157019249eb33350ae9e477cd03ecdb50939d22/keras-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 215741

--- a/py3-libclang.yaml
+++ b/py3-libclang.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/libclang/
+package:
+  name: py3-libclang
+  version: 16.0.6
+  epoch: 0
+  description: 'Clang Python Bindings, mirrored from the official LLVM repo: https://github.com/llvm/llvm-project/tree/main/clang/bindings/python, to make the installation process easier.'
+  copyright:
+    - license: Apache License 2.0
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: d0dd8d145bb99d2313c400efbd3e52a3635a1472
+      repository: https://github.com/sighingnow/libclang
+      tag: llvm-${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: sighingnow/libclang
+    strip-prefix: llvm-

--- a/py3-matplotlib-inline.yaml
+++ b/py3-matplotlib-inline.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/matplotlib-inline/
+package:
+  name: py3-matplotlib-inline
+  version: 0.1.6
+  epoch: 0
+  description: Inline Matplotlib backend for Jupyter
+  copyright:
+    - license: BSD 3-Clause
+  dependencies:
+    runtime:
+      - py3-traitlets
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: fbf0ab8f2d81993ff8e319a003f58896c77f2443
+      repository: https://github.com/ipython/matplotlib-inline
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: ipython/matplotlib-inline

--- a/py3-mistune.yaml
+++ b/py3-mistune.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/mistune/
+package:
+  name: py3-mistune
+  version: 3.0.1
+  epoch: 0
+  description: A sane and fast Markdown parser with useful plugins and renderers
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 7f6bd7c16baf61d63dabc3f5ac123ba150e834d3
+      repository: https://github.com/lepture/mistune
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: lepture/mistune
+    strip-prefix: v

--- a/py3-mypy-extensions.yaml
+++ b/py3-mypy-extensions.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/mypy-extensions/
+package:
+  name: py3-mypy-extensions
+  version: 1.0.0
+  epoch: 0
+  description: Type system extensions for programs checked with the mypy type checker.
+  copyright:
+    - license: MIT License
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 4161db8f25f87b034a7498bfc575ef2df3e2b3fe
+      repository: https://github.com/python/mypy_extensions
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: python/mypy_extensions

--- a/py3-nest-asyncio.yaml
+++ b/py3-nest-asyncio.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/nest-asyncio/
+package:
+  name: py3-nest-asyncio
+  version: 1.5.8
+  epoch: 0
+  description: Patch asyncio to allow nested event loops
+  copyright:
+    - license: BSD
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: d5591176f5e3da559696a4361d4b4acf4d15f175
+      repository: https://github.com/erdewit/nest_asyncio
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: erdewit/nest_asyncio
+    strip-prefix: v
+    use-tag: true

--- a/py3-objsize.yaml
+++ b/py3-objsize.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/objsize/
+package:
+  name: py3-objsize
+  version: 0.7.0
+  epoch: 0
+  description: Traversal over Python's objects subtree and calculate the total size of the subtree in bytes (deep size).
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 0e3547f91468f821ab9f2248860276b9bb079c83
+      repository: https://github.com/liran-funaro/objsize
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: liran-funaro/objsize

--- a/py3-orjson.yaml
+++ b/py3-orjson.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/orjson/
+package:
+  name: py3-orjson
+  version: 3.9.7
+  epoch: 0
+  description: Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy
+  copyright:
+    - license: Apache-2.0 OR MIT
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 46d1181ee538305450081e36b68ef3e0c217b79b
+      repository: https://github.com/ijl/orjson
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: ijl/orjson

--- a/py3-overrides.yaml
+++ b/py3-overrides.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/overrides/
+package:
+  name: py3-overrides
+  version: 7.4.0
+  epoch: 0
+  description: A decorator to automatically detect mismatch when overriding a method.
+  copyright:
+    - license: Apache License, Version 2.0
+  dependencies:
+    runtime:
+      - py3-typing
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 3c13af14eb380c028737eb9bff644549255ba9b2
+      repository: https://github.com/mkorpela/overrides
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: mkorpela/overrides

--- a/py3-pandocfilters.yaml
+++ b/py3-pandocfilters.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/pandocfilters/
+package:
+  name: py3-pandocfilters
+  version: 1.5.0
+  epoch: 0
+  description: Utilities for writing pandoc filters in python
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 1beda668a764c8aa8e1c4e0cebce4323d4181f92
+      repository: https://github.com/jgm/pandocfilters
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: jgm/pandocfilters

--- a/py3-parso.yaml
+++ b/py3-parso.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/parso/
+package:
+  name: py3-parso
+  version: 0.8.3
+  epoch: 0
+  description: A Python Parser
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: ee5edaf22ff3941cbdfa4efd8cb3e8f69779fd56
+      repository: https://github.com/davidhalter/parso
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: davidhalter/parso
+    strip-prefix: v
+    use-tag: true

--- a/py3-prometheus-client.yaml
+++ b/py3-prometheus-client.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/prometheus-client/
+package:
+  name: py3-prometheus-client
+  version: 0.17.1
+  epoch: 0
+  description: Python client for the Prometheus monitoring system.
+  copyright:
+    - license: Apache Software License 2.0
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: c72c4f3937c3e153987f1868922fb9ea180fad36
+      repository: https://github.com/prometheus/client_python
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: prometheus/client_python
+    strip-prefix: v

--- a/py3-proto-plus.yaml
+++ b/py3-proto-plus.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/proto-plus/
+package:
+  name: py3-proto-plus
+  version: 1.22.3
+  epoch: 0
+  description: Beautiful, Pythonic protocol buffers.
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-protobuf
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 6d82d420858253afef883f38fea53b60d121a9a4
+      repository: https://github.com/googleapis/proto-plus-python
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: googleapis/proto-plus-python
+    strip-prefix: v

--- a/py3-pure-eval.yaml
+++ b/py3-pure-eval.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/pure-eval/
+package:
+  name: py3-pure-eval
+  version: 0.2.2
+  epoch: 0
+  description: Safely evaluate AST nodes without side effects
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 84c34b6d63a57f5b02ac2bb8984c5252001c0add
+      repository: https://github.com/alexmojaki/pure_eval
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: alexmojaki/pure_eval
+    strip-prefix: v
+    use-tag: true

--- a/py3-pyfarmhash.yaml
+++ b/py3-pyfarmhash.yaml
@@ -1,0 +1,37 @@
+# Generated from https://pypi.org/project/pyfarmhash/
+package:
+  name: py3-pyfarmhash
+  version: 0.3.2
+  epoch: 0
+  description: Google FarmHash Bindings for Python
+  copyright:
+    - license: "MIT License"
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+      - python-3-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 4146308a0ed0b37d69003199c90fa59b155666c9deb0249b40e594cee10551ea
+      uri: https://files.pythonhosted.org/packages/c3/7f/256f1954343fc44641d04292e1410470337db3720bd57b510782e449d6db/pyfarmhash-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: false
+  manual: true # no releases, tags, and release-monitor id

--- a/py3-pyrsistent.yaml
+++ b/py3-pyrsistent.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/pyrsistent/
+# Something is wrong with the releases and tags with this project.
+# Lint tests are passing on local machine, but failing on CI.
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: py3-pyrsistent
+  version: 0.19.3
+  epoch: 0
+  description: Persistent/Functional/Immutable data structures
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: cc90f3e2b339653fde0df422aaf3ccdb3fc1225d
+      repository: https://github.com/tobgu/pyrsistent
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 19676

--- a/py3-python-json-logger.yaml
+++ b/py3-python-json-logger.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/python-json-logger/
+package:
+  name: py3-python-json-logger
+  version: 2.0.7
+  epoch: 0
+  description: A python library adding a json log formatter
+  copyright:
+    - license: BSD
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 213ce50c2f3b6f516bbdaba196b1b18fcc5ee81b
+      repository: https://github.com/madzak/python-json-logger
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: madzak/python-json-logger
+    strip-prefix: v

--- a/py3-pyzmq.yaml
+++ b/py3-pyzmq.yaml
@@ -1,0 +1,45 @@
+# Generated from https://pypi.org/project/pyzmq/
+package:
+  name: py3-pyzmq
+  version: 25.1.1
+  epoch: 0
+  description: Python bindings for 0MQ
+  copyright:
+    - license: LGPL+BSD
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+      - python-3-dev
+      - zeromq
+      - libzmq-static
+      - zeromq-dev
+      - pkgconf
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 7777f2fa9461e0dd82c86d5c8303a1f5ff41cf53
+      repository: https://github.com/zeromq/pyzmq
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: zeromq/pyzmq
+    strip-prefix: v

--- a/py3-regex.yaml
+++ b/py3-regex.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/regex/
+package:
+  name: py3-regex
+  version: 2023.8.8
+  epoch: 0
+  description: Alternative regular expression module, to replace re.
+  copyright:
+    - license: Apache Software License
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+      - python-3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: bc73ebb5d794668fe272c6f869cfa01add91ed83
+      repository: https://github.com/mrabarnett/mrab-regex
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: mrabarnett/mrab-regex

--- a/py3-rfc3339-validator.yaml
+++ b/py3-rfc3339-validator.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/rfc3339-validator/
+package:
+  name: py3-rfc3339-validator
+  version: 0.1.4
+  epoch: 0
+  description: A pure python RFC3339 validator
+  copyright:
+    - license: MIT license
+  dependencies:
+    runtime:
+      - py3-six
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 5ebeb83a83ae5a65e610ffd90de36d30d7161aec
+      repository: https://github.com/naimetti/rfc3339-validator
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: naimetti/rfc3339-validator
+    strip-prefix: v

--- a/py3-rfc3986-validator.yaml
+++ b/py3-rfc3986-validator.yaml
@@ -1,0 +1,37 @@
+# Generated from https://pypi.org/project/rfc3986-validator/
+package:
+  name: py3-rfc3986-validator
+  version: 0.1.1
+  epoch: 0
+  description: Pure python rfc3986 validator
+  copyright:
+    - license: MIT license
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055
+      uri: https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 32700

--- a/py3-scandir.yaml
+++ b/py3-scandir.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/scandir/
+package:
+  name: py3-scandir
+  version: 1.10.0
+  epoch: 0
+  description: scandir, a better directory iterator and faster os.walk()
+  copyright:
+    - license: New BSD License
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 982e6ba60e7165ef965567eacd7138149c9ce292
+      repository: https://github.com/benhoyt/scandir
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: benhoyt/scandir
+    strip-prefix: v

--- a/py3-send2trash.yaml
+++ b/py3-send2trash.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/Send2Trash/
+package:
+  name: py3-send2trash
+  version: 1.8.2
+  epoch: 0
+  description: Send file to trash natively under Mac OS X, Windows and Linux
+  copyright:
+    - license: BSD License
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 0244f53e2e5da6642599acc5e9329669f1caf145
+      repository: https://github.com/arsenetar/send2trash
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: arsenetar/send2trash

--- a/py3-soupsieve.yaml
+++ b/py3-soupsieve.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/soupsieve/
+package:
+  name: py3-soupsieve
+  version: 2.5
+  epoch: 0
+  description: A modern CSS selector implementation for Beautiful Soup.
+  copyright:
+    - license: "MIT License"
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 51ec317ada7e34f70fad6bfddaef8a2cfac1aebd
+      repository: https://github.com/facelessuser/soupsieve
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  ignore-regex-patterns:
+    - 2.3.2.post1
+  github:
+    identifier: facelessuser/soupsieve

--- a/py3-tensorflow-io-gcs-filesystem.yaml
+++ b/py3-tensorflow-io-gcs-filesystem.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/tensorflow-io-gcs-filesystem/
+package:
+  name: py3-tensorflow-io-gcs-filesystem
+  version: 0.34.0
+  epoch: 0
+  description: TensorFlow IO
+  copyright:
+    - license: "Apache License 2.0"
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 2b8f277b41152e0fd4c820139caa19d73969373f
+      repository: https://github.com/tensorflow/io
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: tensorflow/io
+    strip-prefix: v

--- a/py3-testpath.yaml
+++ b/py3-testpath.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/testpath/
+package:
+  name: py3-testpath
+  version: 0.6.0
+  epoch: 0
+  description: Test utilities for code working with files and commands
+  copyright:
+    - license: "BSD 3-Clause"
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: de8ca59539eb23b9781e55848b7d2646c8c61df9
+      repository: https://github.com/jupyter/testpath
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: jupyter/testpath

--- a/py3-tinycss2.yaml
+++ b/py3-tinycss2.yaml
@@ -1,0 +1,38 @@
+# Generated from https://pypi.org/project/tinycss2/
+package:
+  name: py3-tinycss2
+  version: 1.2.1
+  epoch: 0
+  description: A tiny CSS parser
+  copyright:
+    - license: "BSD 3-Clause"
+  dependencies:
+    runtime:
+      - py3-webencodings
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 8cff3a8f066c2ec677c06dbc7b45619804a6938478d9d73c284b29d14ecb0627
+      uri: https://files.pythonhosted.org/packages/75/be/24179dfaa1d742c9365cbd0e3f0edc5d3aa3abad415a2327c5a6ff8ca077/tinycss2-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 16655

--- a/py3-tornado.yaml
+++ b/py3-tornado.yaml
@@ -1,7 +1,7 @@
 # Generated from https://pypi.org/project/tornado/
 package:
   name: py3-tornado
-  version: 6.3.3
+  version: 6.4.0b1
   epoch: 0
   description: Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed.
   copyright:
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: e4d698433b44f350d4908da9ca2cac475c92dfdc
+      expected-commit: dbba24ae520dec121909335dcac386d8e5ab5fff
       repository: https://github.com/tornadoweb/tornado
       tag: v${{package.version}}
 

--- a/py3-tornado.yaml
+++ b/py3-tornado.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/tornado/
+package:
+  name: py3-tornado
+  version: 6.3.3
+  epoch: 0
+  description: Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: e4d698433b44f350d4908da9ca2cac475c92dfdc
+      repository: https://github.com/tornadoweb/tornado
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: tornadoweb/tornado
+    strip-prefix: v
+    use-tag: true

--- a/py3-tornado.yaml
+++ b/py3-tornado.yaml
@@ -1,7 +1,7 @@
 # Generated from https://pypi.org/project/tornado/
 package:
   name: py3-tornado
-  version: 6.4.0b1
+  version: 6.3.3
   epoch: 0
   description: Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed.
   copyright:
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: dbba24ae520dec121909335dcac386d8e5ab5fff
+      expected-commit: e4d698433b44f350d4908da9ca2cac475c92dfdc
       repository: https://github.com/tornadoweb/tornado
       tag: v${{package.version}}
 
@@ -35,6 +35,8 @@ pipeline:
 update:
   enabled: true
   manual: false
+  ignore-regex-patterns:
+    - v*b\d*
   github:
     identifier: tornadoweb/tornado
     strip-prefix: v

--- a/py3-uritemplate.yaml
+++ b/py3-uritemplate.yaml
@@ -1,0 +1,37 @@
+# Generated from https://pypi.org/project/uritemplate/
+package:
+  name: py3-uritemplate
+  version: 4.1.1
+  epoch: 0
+  description: Implementation of RFC 6570 URI Templates
+  copyright:
+    - license: BSD 3-Clause License or Apache License, Version 2.0
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0
+      uri: https://files.pythonhosted.org/packages/d2/5a/4742fdba39cd02a56226815abfa72fe0aa81c33bed16ed045647d6000eba/uritemplate-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 58459

--- a/py3-widgetsnbextension.yaml
+++ b/py3-widgetsnbextension.yaml
@@ -1,0 +1,37 @@
+# Generated from https://pypi.org/project/widgetsnbextension/
+package:
+  name: py3-widgetsnbextension
+  version: 4.0.9
+  epoch: 0
+  description: Jupyter interactive widgets for Jupyter Notebook
+  copyright:
+    - license: BSD 3-Clause License
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 3c1f5e46dc1166dfd40a42d685e6a51396fd34ff878742a3e47c6f0cc4a2a385
+      uri: https://files.pythonhosted.org/packages/a1/e4/684abbfeb7a7a2e6a17aa8a5815e954a069edc0f567d912d2d3ffee800a9/widgetsnbextension-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 84223

--- a/py3-xyzservices.yaml
+++ b/py3-xyzservices.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/xyzservices/
+package:
+  name: py3-xyzservices
+  version: 2023.7.0
+  epoch: 0
+  description: Source of XYZ tiles providers
+  copyright:
+    - license: 3-Clause BSD
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: e05c7e98a3a36e4c258ce9e39c51960dd4d19617
+      repository: https://github.com/geopandas/xyzservices
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: geopandas/xyzservices


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
