### PR TITLE
Correct tofu binary name.

### DIFF
--- a/opentofu.yaml
+++ b/opentofu.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentofu
   version: 0.0_git20230920
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MPL-2.0
 
@@ -27,7 +27,7 @@ pipeline:
     with:
       modroot: opentofu
       packages: .
-      output: opentofu
+      output: tofu
       ldflags: -s -w
 
   - uses: strip


### PR DESCRIPTION
It used to be called opentf before the rename, the new binary name is just tofu, not opentofu.

This will require some coordination with the image build here: https://github.com/chainguard-images/images/pull/1422