### PR TITLE
Apply patch to istio-envoy to use make 4.4

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -1,7 +1,8 @@
 package:
   name: envoy
+  # On the next version bump, please remove the make 4.4 patch.
   version: 1.27.0
-  epoch: 0
+  epoch: 1
   description: Cloud-native high-performance edge/middle/service proxy
   copyright:
     - license: Apache-2.0

--- a/istio-envoy-1.18.yaml
+++ b/istio-envoy-1.18.yaml
@@ -52,10 +52,11 @@ pipeline:
 
       echo "build --config=clang" >> user.bazelrc
 
-      # When patching to 1.18.2, the PR
-      # https://github.com/istio/proxy/commit/3c27a1b0cf381ca854ccc3a2034e88c206928da2 updated
-      # the Envoy commit without updating its checksum.
-      sed -i s/0a932fd090feed587d82b4b943a1032a5a424587f65455a37236cffefc8648ef/8795a73871ce8bd4138191f746d4f1f5d0935d5e65b2b6f1803f966f13065211/g WORKSPACE
+      # Patch Envoy to be able to use make 4.4
+      #
+      # This patch is from https://github.com/envoyproxy/envoy/commit/1b576a103463ca008c76800d1f67929c2a2ffaeb.diff
+      sed -i "/sha256 = ENVOY_SHA256/a\\
+          patches = [\"//:1b576a103463ca008c76800d1f67929c2a2ffaeb.diff\"], patch_args = [\"-p1\"]," WORKSPACE
 
       bazel build --verbose_failures -c opt envoy
 

--- a/istio-envoy-1.18.yaml
+++ b/istio-envoy-1.18.yaml
@@ -1,5 +1,6 @@
 package:
   name: istio-envoy-1.18
+  # On the next version bump, please remove the make 4.4 patch.
   version: 1.18.3
   epoch: 1
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
@@ -62,6 +63,9 @@ pipeline:
 
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv bazel-bin/envoy ${{targets.destdir}}/usr/bin/envoy
+
+      # We no longer need this cache dir, which has some writable files.
+      rm -rf .cache/bazel
 
   - uses: strip
 

--- a/istio-envoy-1.18.yaml
+++ b/istio-envoy-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-envoy-1.18
   version: 1.18.3
-  epoch: 0
+  epoch: 1
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
   copyright:
     - license: Apache-2.0

--- a/istio-envoy-1.18/1b576a103463ca008c76800d1f67929c2a2ffaeb.diff
+++ b/istio-envoy-1.18/1b576a103463ca008c76800d1f67929c2a2ffaeb.diff
@@ -1,0 +1,13 @@
+diff --git a/bazel/foreign_cc/luajit.patch b/bazel/foreign_cc/luajit.patch
+index 98fc8f6ded92..f7781067b4ab 100644
+--- a/bazel/foreign_cc/luajit.patch
++++ b/bazel/foreign_cc/luajit.patch
+@@ -166,7 +166,7 @@ index 00000000..1201542c
+ +      with open("clang-asan-blocklist.txt", "w") as f:
+ +        f.write("fun:*\n")
+ +
+-+    os.system('make -j{} V=1 PREFIX="{}" install'.format(os.cpu_count(), args.prefix))
+++    os.system('"{}" -j{} V=1 PREFIX="{}" install'.format(os.environ["MAKE"], os.cpu_count(), args.prefix))
+ +
+ +def win_main():
+ +    src_dir = os.path.dirname(os.path.realpath(__file__))

--- a/istio-envoy-1.19.yaml
+++ b/istio-envoy-1.19.yaml
@@ -50,6 +50,12 @@ pipeline:
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
       mkdir -p .cache/bazel/_bazel_root
 
+      # Patch Envoy to be able to use make 4.4
+      #
+      # This patch is from https://github.com/envoyproxy/envoy/commit/1b576a103463ca008c76800d1f67929c2a2ffaeb.diff
+      sed -i "/sha256 = ENVOY_SHA256/a\\
+          patches = [\"//:1b576a103463ca008c76800d1f67929c2a2ffaeb.diff\"], patch_args = [\"-p1\"]," WORKSPACE
+
       echo "build --config=clang" >> user.bazelrc
 
       bazel build --verbose_failures -c opt envoy

--- a/istio-envoy-1.19.yaml
+++ b/istio-envoy-1.19.yaml
@@ -1,5 +1,6 @@
 package:
   name: istio-envoy-1.19
+  # On the next version bump, please remove the make 4.4 patch.
   version: 1.19.0
   epoch: 1
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
@@ -62,6 +63,9 @@ pipeline:
 
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv bazel-bin/envoy ${{targets.destdir}}/usr/bin/envoy
+
+      # We no longer need this cache dir, which has some writable files.
+      rm -rf .cache/bazel
 
   - uses: strip
 

--- a/istio-envoy-1.19.yaml
+++ b/istio-envoy-1.19.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-envoy-1.19
   version: 1.19.0
-  epoch: 0
+  epoch: 1
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
   copyright:
     - license: Apache-2.0

--- a/istio-envoy-1.19/1b576a103463ca008c76800d1f67929c2a2ffaeb.diff
+++ b/istio-envoy-1.19/1b576a103463ca008c76800d1f67929c2a2ffaeb.diff
@@ -1,0 +1,13 @@
+diff --git a/bazel/foreign_cc/luajit.patch b/bazel/foreign_cc/luajit.patch
+index 98fc8f6ded92..f7781067b4ab 100644
+--- a/bazel/foreign_cc/luajit.patch
++++ b/bazel/foreign_cc/luajit.patch
+@@ -166,7 +166,7 @@ index 00000000..1201542c
+ +      with open("clang-asan-blocklist.txt", "w") as f:
+ +        f.write("fun:*\n")
+ +
+-+    os.system('make -j{} V=1 PREFIX="{}" install'.format(os.cpu_count(), args.prefix))
+++    os.system('"{}" -j{} V=1 PREFIX="{}" install'.format(os.environ["MAKE"], os.cpu_count(), args.prefix))
+ +
+ +def win_main():
+ +    src_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
* "istio-envoy-1.8,1.9: patch to use make 4.4"

This is the same with https://github.com/wolfi-dev/os/pull/5779/. However this time Envoy is a dependency (of istio/proxy): we need to apply patch of a patch.

See https://github.com/envoyproxy/envoy/pull/29261 , https://github.com/envoyproxy/envoy/commit/1b576a103463ca008c76800d1f67929c2a2ffaeb 

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
