### PR TITLE
PHP 8.2 update: including extensions php-odbc and pdo_dblib 

### DIFF
--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -7,7 +7,7 @@ package:
     - license: PHP-3.01
   dependencies:
     provides:
-      - php=${{package.version}}-r${{package.epoch}}}
+      - php=${{package.version}}-r${{package.epoch}}
     runtime:
       - libxml2
 

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,13 +1,13 @@
 package:
   name: php-8.2
   version: 8.2.10
-  epoch: 3
+  epoch: 4
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
   dependencies:
     provides:
-      - php=${{package.version}}-r${{package.epoch}}
+      - php=${{ package.full-version }}
     runtime:
       - libxml2
 

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -21,6 +21,7 @@ environment:
       - ca-certificates-bundle
       - curl-dev
       - file
+      - freetds
       - freetype-dev
       - gmp-dev
       - icu-dev
@@ -41,6 +42,7 @@ environment:
       - postgresql-15-dev
       - readline-dev
       - sqlite-dev
+      - unixodbc-dev
 
 pipeline:
   - uses: fetch
@@ -95,6 +97,8 @@ pipeline:
         --enable-pdo=shared \
             --with-pdo-mysql=shared,mysqlnd \
             --with-pdo-sqlite=shared \
+            --with-pdo-dblib=shared \
+        --with-unixODBC=shared,/usr \
         --enable-pcntl=shared \
         --enable-sockets=shared \
         --with-bz2=shared \
@@ -146,6 +150,7 @@ data:
       openssl: OpenSSL
       pdo_mysql: MySQL driver for PDO
       pdo_sqlite: SQLite 3.x driver for PDO
+      pdo_dblib: PDO driver for Sybase / MS SQL databases
       soap: SOAP
       sodium: Sodium
       calendar: Calendar
@@ -172,6 +177,7 @@ data:
       xmlwriter: XMLWriter
       fileinfo: fileinfo
       zip: Zip
+      odbc: UnixODBC
 
 subpackages:
   - range: extensions


### PR DESCRIPTION
This PR updates the PHP 8.2 build to compile two additional PHP extensions:

- `php-odbc`, via `unixodbc`
- `php-pdo_dblib`, via `freetds`

Related: #5803 