### PR TITLE
Fix freetds 'provides' section

### DIFF
--- a/freetds.yaml
+++ b/freetds.yaml
@@ -1,13 +1,10 @@
 package:
   name: freetds
   version: "1.3.20"
-  epoch: 0
+  epoch: 1
   description: FreeTDS is a set of libraries for Unix and Linux that allows programs to natively talk to Microsoft SQL Server and Sybase databases.
   copyright:
     - license: GPL-2.0
-  dependencies:
-    provides:
-      - freetds=${{package.version}}-r${{package.epoch}}
 
 environment:
   contents:

--- a/freetds.yaml
+++ b/freetds.yaml
@@ -7,7 +7,7 @@ package:
     - license: GPL-2.0
   dependencies:
     provides:
-      - freetds=${{package.version}}-r${{package.epoch}}}
+      - freetds=${{package.version}}-r${{package.epoch}}
 
 environment:
   contents:


### PR DESCRIPTION
This PR removes the "provides" section from freetds since it doesn't use version streams.