### PR TITLE
erlang-26: get rid of application subpackages

### DIFF
--- a/erlang-26.yaml
+++ b/erlang-26.yaml
@@ -1,7 +1,7 @@
 package:
   name: erlang-26
   version: "26.1"
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -24,26 +24,6 @@ environment:
       - openssl-dev
       - ncurses-dev
       - zlib-dev
-
-data:
-  - name: subpackages
-    items:
-      xmerl: 1.3.31.1
-      tools: 3.6
-      tftp: 1.1
-      syntax_tools: 3.1
-      ssl: 11.0.3
-      snmp: 5.15
-      runtime_tools: 2.0
-      public_key: 1.14.1
-      parsetools: 2.5
-      os_mon: 2.9
-      mnesia: 4.22.1
-      inets: 9.0.2
-      ftp: 1.2
-      eldap: 1.2.11
-      crypto: 5.3
-      asn1: 5.2
 
 pipeline:
   - uses: fetch
@@ -83,13 +63,6 @@ subpackages:
         - erlang
       provides:
         - erlang-dev=26.999.0
-
-  - range: subpackages
-    name: "erlang-26-${{range.key}}"
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/lib
-          mv ${{targets.destdir}}/usr/lib/erlang/lib/${{range.key}}-${{range.value}} ${{targets.subpkgdir}}/usr/lib/
 
 update:
   enabled: true


### PR DESCRIPTION
Missing applications are causing large amounts of instability with Erlang 26.