### PR TITLE
Add istio-cni and istio-install-cni packages

### DIFF
--- a/istio-cni-1.19.yaml
+++ b/istio-cni-1.19.yaml
@@ -1,0 +1,72 @@
+package:
+  name: istio-cni-1.19
+  version: 1.19.0
+  epoch: 0
+  description:
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - istio-cni=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/istio/istio
+      tag: ${{package.version}}
+      expected-commit: 3b3ca8ec1632961e355f398f7357ebed9b13aa43
+
+  - uses: go/build
+    with:
+      packages: ./cni/cmd/istio-cni
+      output: istio-cni
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          # See https://github.com/istio/istio/blob/1.19.0/cni/deployments/kubernetes/Dockerfile.install-cni
+          mkdir -p ${{targets.subpkgdir}}/opt/cni/bin
+          ln -sf /usr/bin/istio-cni ${{targets.subpkgdir}}/opt/cni/bin/istio-cni
+    dependencies:
+      provides:
+        - istio-cni-compat=${{package.full-version}}
+
+  - name: istio-install-cni-1.19
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cni/cmd/install-cni
+          output: install-cni
+      - uses: strip
+    dependencies:
+      provides:
+        - istio-install-cni=${{package.full-version}}
+
+  - name: istio-install-cni-1.19-compat
+    pipeline:
+      - runs: |
+          # See https://github.com/istio/istio/blob/1.19.0/cni/deployments/kubernetes/Dockerfile.install-cni
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          ln -sf /usr/bin/install-cni ${{targets.subpkgdir}}/usr/local/bin/install-cni
+    dependencies:
+      provides:
+        - istio-install-cni-compat=${{package.full-version}}
+
+update:
+  enabled: true
+  github:
+    identifier: istio/istio
+    tag-filter: 1.19.
+    use-tag: true


### PR DESCRIPTION
* "istio-cni-1.19: new package"
* "istio-install-cni-1.19: new package"

1.19 is the latest version https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases

### Pre-review Checklist
#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

```
❯ wolfictl scan packages/aarch64/istio-install-cni-1.19-1.19.0-r0.apk
Will process: istio-install-cni-1.19-1.19.0-r0.apk
✅ No vulnerabilities found

❯ wolfictl scan packages/aarch64/istio-cni-1.19-1.19.0-r0.apk        
Will process: istio-cni-1.19-1.19.0-r0.apk
✅ No vulnerabilities found
```