### PR TITLE
Fix the provides in `go-fips-1.21.yaml`

### DIFF
--- a/go-fips-1.21.yaml
+++ b/go-fips-1.21.yaml
@@ -1,13 +1,13 @@
 package:
   name: go-fips-1.21
   version: 1.21.1
-  epoch: 1
+  epoch: 2
   description: "the Go programming language with OpenSSL cryptography"
   copyright:
     - license: BSD-3-Clause
   dependencies:
     provides:
-      - go-fips=${{package.version}}-${{package.epoch}}
+      - go-fips=${{package.full-version}}
     runtime:
       - build-base
       - bash


### PR DESCRIPTION
It was missing the `r` before epoch, this uses `package.full-version`
