### PR TITLE
Apply patch to istio-envoy-1.8 to use make 4.4

### DIFF
--- a/istio-envoy-1.18.yaml
+++ b/istio-envoy-1.18.yaml
@@ -1,7 +1,8 @@
 package:
   name: istio-envoy-1.18
+  # On the next version bump, please remove the make 4.4 patch.
   version: 1.18.3
-  epoch: 0
+  epoch: 1
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
   copyright:
     - license: Apache-2.0
@@ -52,15 +53,19 @@ pipeline:
 
       echo "build --config=clang" >> user.bazelrc
 
-      # When patching to 1.18.2, the PR
-      # https://github.com/istio/proxy/commit/3c27a1b0cf381ca854ccc3a2034e88c206928da2 updated
-      # the Envoy commit without updating its checksum.
-      sed -i s/0a932fd090feed587d82b4b943a1032a5a424587f65455a37236cffefc8648ef/8795a73871ce8bd4138191f746d4f1f5d0935d5e65b2b6f1803f966f13065211/g WORKSPACE
+      # Patch Envoy to be able to use make 4.4
+      #
+      # This patch is from https://github.com/envoyproxy/envoy/commit/1b576a103463ca008c76800d1f67929c2a2ffaeb.diff
+      sed -i "/sha256 = ENVOY_SHA256/a\\
+          patches = [\"//:1b576a103463ca008c76800d1f67929c2a2ffaeb.diff\"], patch_args = [\"-p1\"]," WORKSPACE
 
       bazel build --verbose_failures -c opt envoy
 
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv bazel-bin/envoy ${{targets.destdir}}/usr/bin/envoy
+
+      # We no longer need this cache dir, which has some writable files.
+      rm -rf .cache/bazel
 
   - uses: strip
 

--- a/istio-envoy-1.18/1b576a103463ca008c76800d1f67929c2a2ffaeb.diff
+++ b/istio-envoy-1.18/1b576a103463ca008c76800d1f67929c2a2ffaeb.diff
@@ -1,0 +1,13 @@
+diff --git a/bazel/foreign_cc/luajit.patch b/bazel/foreign_cc/luajit.patch
+index 98fc8f6ded92..f7781067b4ab 100644
+--- a/bazel/foreign_cc/luajit.patch
++++ b/bazel/foreign_cc/luajit.patch
+@@ -166,7 +166,7 @@ index 00000000..1201542c
+ +      with open("clang-asan-blocklist.txt", "w") as f:
+ +        f.write("fun:*\n")
+ +
+-+    os.system('make -j{} V=1 PREFIX="{}" install'.format(os.cpu_count(), args.prefix))
+++    os.system('"{}" -j{} V=1 PREFIX="{}" install'.format(os.environ["MAKE"], os.cpu_count(), args.prefix))
+ +
+ +def win_main():
+ +    src_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
* "istio-envoy-1.8: patch to use make 4.4"

This is the same with https://github.com/wolfi-dev/os/pull/5779/. However this time Envoy is a dependency (of istio/proxy): we need to apply patch of a patch.

See https://github.com/envoyproxy/envoy/pull/29261 , https://github.com/envoyproxy/envoy/commit/1b576a103463ca008c76800d1f67929c2a2ffaeb 

At first I put this PR and https://github.com/wolfi-dev/os/pull/5821 together, but each envoy build takes 1h+ so it is hard to pass CI and the merge tests. As a result I am sending two separate PRs.

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented