### PR TITLE
Fix wolfictl semgrep update build PR #5680

### DIFF
--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -40,7 +40,7 @@ pipeline:
       opam init --compiler=ocaml-base-compiler.4.14.0 -y
       opam switch create 4.14.0+static ocaml-base-compiler.4.14.0
       eval $(opam env --switch=4.14.0+static)
-      make dev-setup
+      make setup
       make core
       make copy-core-for-cli
 


### PR DESCRIPTION
Fixes: Wolfictl semgrep update build PR #5680

Related:

### Pre-review Checklist

#### For version bump PRs

- [x] ~~The `epoch` field is reset to 0~~

