### PR TITLE
cloudwatch-exporter: bump jetty to address CVEs

### DIFF
--- a/cloudwatch-exporter.yaml
+++ b/cloudwatch-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudwatch-exporter
   version: "0.15.4" # Check if the version bump in the mvn command is still needed next time this package is updated
-  epoch: 2
+  epoch: 3
   description: Metrics exporter for Amazon AWS CloudWatch
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,10 @@ pipeline:
       repository: https://github.com/prometheus/cloudwatch_exporter
       tag: v${{package.version}}
       expected-commit: af4e8aea04a02c858c19e2ddbaa2cd87ef46e971
+
+  - uses: patch
+    with:
+      patches: bump-jetty-to-11.0.16.patch
 
   - runs: |
       # This change is being introduced in https://github.com/prometheus/cloudwatch_exporter/pull/567 (still unmerged)

--- a/cloudwatch-exporter/bump-jetty-to-11.0.16.patch
+++ b/cloudwatch-exporter/bump-jetty-to-11.0.16.patch
@@ -1,0 +1,21 @@
+This resolves a handful of CVEs:
+
+* CVE-2023-36479
+* CVE-2023-40167
+* CVE-2023-41900
+* GHSA-hmr7-m48g-48f6
+
+---
+diff --git a/pom.xml b/pom.xml
+index 591d9cd..c3a35af 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -99,7 +99,7 @@
+     <dependency>
+       <groupId>org.eclipse.jetty</groupId>
+       <artifactId>jetty-servlet</artifactId>
+-      <version>11.0.15</version>
++      <version>11.0.16</version>
+     </dependency>
+     <dependency>
+       <groupId>com.github.ben-manes.caffeine</groupId>


### PR DESCRIPTION
Before:

```console
$ w scan packages/aarch64/cloudwatch-exporter-0.15.4-r2.apk
Will process: cloudwatch-exporter-0.15.4-r2.apk
└── 📄 /usr/share/java/cloudwatch_exporter/cloudwatch_exporter.jar
        📦 jetty-http 11.0.15 (java-archive)
            Medium CVE-2023-36479
            Medium CVE-2023-40167
            Medium CVE-2023-41900
            Medium CVE-2023-40167 GHSA-hmr7-m48g-48f6 fixed in 11.0.16
        📦 jetty-io 11.0.15 (java-archive)
            Medium CVE-2023-36479
            Medium CVE-2023-40167
            Medium CVE-2023-41900
        📦 jetty-security 11.0.15 (java-archive)
            Medium CVE-2023-36479
            Medium CVE-2023-40167
            Medium CVE-2023-41900
        📦 jetty-server 11.0.15 (java-archive)
            Medium CVE-2023-36479
            Medium CVE-2023-40167
            Medium CVE-2023-41900
        📦 jetty-servlet 11.0.15 (java-archive)
            Medium CVE-2023-36479
            Medium CVE-2023-40167
            Medium CVE-2023-41900
        📦 jetty-util 11.0.15 (java-archive)
            Medium CVE-2023-36479
            Medium CVE-2023-40167
            Medium CVE-2023-41900
```

After:

```console
w scan packages/aarch64/cloudwatch-exporter-0.15.4-r3.apk
Will process: cloudwatch-exporter-0.15.4-r3.apk
✅ No vulnerabilities found
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->
ckage (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

https://github.com/wolfi-dev/advisories/pull/259

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
