### PR TITLE
zookeeper: fix CVEs via jetty bump

### DIFF
--- a/zookeeper.yaml
+++ b/zookeeper.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper
   version: 3.9.0.1
-  epoch: 0
+  epoch: 1
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - paths:
@@ -44,7 +44,8 @@ pipeline:
       export LANG=en_US.UTF-8
       export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
-      mvn install -DskipTests
+      # The jetty bump fixes a handful of CVEs: CVE-2023-36479, CVE-2023-40167, CVE-2023-41900
+      mvn install -DskipTests -Djetty.version=9.4.52.v20230823
       tar -xf zookeeper-assembly/target/apache-zookeeper-${{vars.short-package-version}}-bin.tar.gz
 
       mkdir -p ${{targets.destdir}}/usr/share/java/zookeeper


### PR DESCRIPTION
Before:

```console
w scan packages/aarch64/zookeeper-3.9.0.1-r0.apk
Will process: zookeeper-3.9.0.1-r0.apk
├── 📄 /usr/share/java/zookeeper/lib/jackson-databind-2.15.2.jar
│       📦 jackson-databind 2.15.2 (java-archive)
│           Medium CVE-2023-35116
│
├── 📄 /usr/share/java/zookeeper/lib/jetty-http-9.4.51.v20230217.jar
│       📦 jetty-http 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
├── 📄 /usr/share/java/zookeeper/lib/jetty-io-9.4.51.v20230217.jar
│       📦 jetty-io 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
├── 📄 /usr/share/java/zookeeper/lib/jetty-security-9.4.51.v20230217.jar
│       📦 jetty-security 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
├── 📄 /usr/share/java/zookeeper/lib/jetty-server-9.4.51.v20230217.jar
│       📦 jetty-server 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
├── 📄 /usr/share/java/zookeeper/lib/jetty-servlet-9.4.51.v20230217.jar
│       📦 jetty-servlet 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
├── 📄 /usr/share/java/zookeeper/lib/jetty-util-9.4.51.v20230217.jar
│       📦 jetty-util 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
└── 📄 /usr/share/java/zookeeper/lib/jetty-util-ajax-9.4.51.v20230217.jar
        📦 jetty-util-ajax 9.4.51.v20230217 (java-archive)
            Medium CVE-2023-36479
            Medium CVE-2023-40167
            Medium CVE-2023-41900
```

After:

```console
w scan packages/aarch64/zookeeper-3.9.0.1-r1.apk
Will process: zookeeper-3.9.0.1-r1.apk
└── 📄 /usr/share/java/zookeeper/lib/jackson-databind-2.15.2.jar
        📦 jackson-databind 2.15.2 (java-archive)
            Medium CVE-2023-35116
```

The remaining CVE is disputed — already marked as FP in advisories.

<!--
Please include references to any related issues or delete this section otherwise.
 -->

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

https://github.com/wolfi-dev/advisories/pull/260