### PR TITLE
kafka: fix CVEs via jetty bump

### DIFF
--- a/kafka.yaml
+++ b/kafka.yaml
@@ -2,7 +2,7 @@ package:
   name: kafka
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.5.1
-  epoch: 1
+  epoch: 2
   description: Apache Kafka is a distributed event streaming platformm
   copyright:
     - paths:
@@ -30,6 +30,10 @@ pipeline:
       repository: https://github.com/apache/kafka
       tag: ${{package.version}}
       expected-commit: 2c6fb6c54472e90ae17439e62540ef3cb0426fe3
+
+  - uses: patch
+    with:
+      patches: bump-jetty-to-9.4.52.patch
 
   - runs: |
       export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8

--- a/kafka/bump-jetty-to-9.4.52.patch
+++ b/kafka/bump-jetty-to-9.4.52.patch
@@ -1,0 +1,51 @@
+This patches a handful of CVEs:
+
+* CVE-2023-36479
+* CVE-2023-40167
+* CVE-2023-41900
+
+---
+diff --git a/LICENSE-binary b/LICENSE-binary
+index 233c99ecb4..10ef6d7037 100644
+--- a/LICENSE-binary
++++ b/LICENSE-binary
+@@ -220,16 +220,16 @@ jackson-module-scala_2.13-2.13.5
+ jackson-module-scala_2.12-2.13.5
+ jakarta.validation-api-2.0.2
+ javassist-3.29.2-GA
+-jetty-client-9.4.51.v20230217
+-jetty-continuation-9.4.51.v20230217
+-jetty-http-9.4.51.v20230217
+-jetty-io-9.4.51.v20230217
+-jetty-security-9.4.51.v20230217
+-jetty-server-9.4.51.v20230217
+-jetty-servlet-9.4.51.v20230217
+-jetty-servlets-9.4.51.v20230217
+-jetty-util-9.4.51.v20230217
+-jetty-util-ajax-9.4.51.v20230217
++jetty-client-9.4.52.v20230823
++jetty-continuation-9.4.52.v20230823
++jetty-http-9.4.52.v20230823
++jetty-io-9.4.52.v20230823
++jetty-security-9.4.52.v20230823
++jetty-server-9.4.52.v20230823
++jetty-servlet-9.4.52.v20230823
++jetty-servlets-9.4.52.v20230823
++jetty-util-9.4.52.v20230823
++jetty-util-ajax-9.4.52.v20230823
+ jose4j-0.9.3
+ lz4-java-1.8.0
+ maven-artifact-3.8.8
+diff --git a/gradle/dependencies.gradle b/gradle/dependencies.gradle
+index 28d17ac138..1509065e22 100644
+--- a/gradle/dependencies.gradle
++++ b/gradle/dependencies.gradle
+@@ -72,7 +72,7 @@ versions += [
+   jacksonDatabind: "2.13.5",
+   jacoco: "0.8.10",
+   javassist: "3.29.2-GA",
+-  jetty: "9.4.51.v20230217",
++  jetty: "9.4.52.v20230823",
+   jersey: "2.39.1",
+   jline: "3.22.0",
+   jmh: "1.36",


### PR DESCRIPTION
Before:

```console
$ w scan packages/aarch64/kafka-3.5.1-r1.apk      
Will process: kafka-3.5.1-r1.apk
├── 📄 /usr/lib/kafka/libs/jackson-databind-2.13.5.jar
│       📦 jackson-databind 2.13.5 (java-archive)
│           Medium CVE-2023-35116
│
├── 📄 /usr/lib/kafka/libs/jetty-client-9.4.51.v20230217.jar
│       📦 jetty-client 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
├── 📄 /usr/lib/kafka/libs/jetty-continuation-9.4.51.v20230217.jar
│       📦 jetty-continuation 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
├── 📄 /usr/lib/kafka/libs/jetty-http-9.4.51.v20230217.jar
│       📦 jetty-http 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
├── 📄 /usr/lib/kafka/libs/jetty-io-9.4.51.v20230217.jar
│       📦 jetty-io 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
├── 📄 /usr/lib/kafka/libs/jetty-security-9.4.51.v20230217.jar
│       📦 jetty-security 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
├── 📄 /usr/lib/kafka/libs/jetty-server-9.4.51.v20230217.jar
│       📦 jetty-server 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
├── 📄 /usr/lib/kafka/libs/jetty-servlet-9.4.51.v20230217.jar
│       📦 jetty-servlet 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
├── 📄 /usr/lib/kafka/libs/jetty-servlets-9.4.51.v20230217.jar
│       📦 jetty-servlets 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
├── 📄 /usr/lib/kafka/libs/jetty-util-9.4.51.v20230217.jar
│       📦 jetty-util 9.4.51.v20230217 (java-archive)
│           Medium CVE-2023-36479
│           Medium CVE-2023-40167
│           Medium CVE-2023-41900
│
└── 📄 /usr/lib/kafka/libs/jetty-util-ajax-9.4.51.v20230217.jar
        📦 jetty-util-ajax 9.4.51.v20230217 (java-archive)
            Medium CVE-2023-36479
            Medium CVE-2023-40167
            Medium CVE-2023-41900
```

After:

```console
$ w scan packages/aarch64/kafka-3.5.1-r2.apk
Will process: kafka-3.5.1-r2.apk
└── 📄 /usr/lib/kafka/libs/jackson-databind-2.13.5.jar
        📦 jackson-databind 2.13.5 (java-archive)
            Medium CVE-2023-35116
```

The remaining CVE is already marked as a FP in the advisory data.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

https://github.com/wolfi-dev/advisories/pull/261

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
