### PR TITLE
Fix the PHP extension for pecl_http.

### DIFF
--- a/php-8.1-pecl-http.yaml
+++ b/php-8.1-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-http
   version: 4.2.3
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.1 HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -42,7 +42,7 @@ pipeline:
 
   - uses: pecl/install
     with:
-      extension: pecl_http
+      extension: http
 
   - uses: strip
 

--- a/php-8.2-pecl-http.yaml
+++ b/php-8.2-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-http
   version: 4.2.3
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.2 HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -42,7 +42,7 @@ pipeline:
 
   - uses: pecl/install
     with:
-      extension: pecl_http
+      extension: http
 
   - uses: strip
 


### PR DESCRIPTION
```
│ PHP Warning:  PHP Startup: Unable to load dynamic library 'pecl_http' (tried: /usr/lib/php/modules/pecl_http (/usr/lib/php/modules/pecl_http: cannot open shared object file: No such file or directory),
│ /usr/lib/php/modules/pecl_http.so (/usr/lib/php/modules/pecl_http.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
│ Could not open input file: version
```

It's actually installed as:
```
usr/lib/php/modules/http.so
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
