### PR TITLE
Fix the install location for pdo_snowflake.

### DIFF
--- a/php-8.1-pdo_snowflake.yaml
+++ b/php-8.1-pdo_snowflake.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pdo_snowflake
   version: 1.2.7
-  epoch: 0
+  epoch: 1
   description: "Snowflake driver that uses the PHP Data Objects (PDO) extension"
   copyright:
     - license: Apache-2.0
@@ -56,11 +56,11 @@ pipeline:
     runs: |
       # https://github.com/snowflakedb/pdo_snowflake#installing-the-driver-on-linux-and-macos
       mkdir -p ${{targets.destdir}}
-      mkdir -p ${{targets.destdir}}/usr/lib/php
+      mkdir -p ${{targets.destdir}}/usr/lib/php/modules
       install -d ${{targets.destdir}}/etc/php/conf.d
       echo "extension=pdo_snowflake" > ${{targets.destdir}}/etc/php/conf.d/20-pdo_snowflake.ini
       echo "pdo_snowflake.cacert=/etc/php/conf.d/cacert.pem" >> ${{targets.destdir}}/etc/php/conf.d/20-pdo_snowflake.ini
-      cp ./modules/pdo_snowflake.so ${{targets.destdir}}/usr/lib/php/
+      cp ./modules/pdo_snowflake.so ${{targets.destdir}}/usr/lib/php/modules/
       cp ./libsnowflakeclient/cacert.pem ${{targets.destdir}}/etc/php/conf.d
 
   - uses: strip

--- a/php-8.2-pdo_snowflake.yaml
+++ b/php-8.2-pdo_snowflake.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pdo_snowflake
   version: 1.2.7
-  epoch: 0
+  epoch: 1
   description: "Snowflake driver that uses the PHP Data Objects (PDO) extension"
   copyright:
     - license: Apache-2.0
@@ -56,11 +56,11 @@ pipeline:
     runs: |
       # https://github.com/snowflakedb/pdo_snowflake#installing-the-driver-on-linux-and-macos
       mkdir -p ${{targets.destdir}}
-      mkdir -p ${{targets.destdir}}/usr/lib/php
+      mkdir -p ${{targets.destdir}}/usr/lib/php/modules
       install -d ${{targets.destdir}}/etc/php/conf.d
       echo "extension=pdo_snowflake" > ${{targets.destdir}}/etc/php/conf.d/20-pdo_snowflake.ini
       echo "pdo_snowflake.cacert=/etc/php/conf.d/cacert.pem" >> ${{targets.destdir}}/etc/php/conf.d/20-pdo_snowflake.ini
-      cp ./modules/pdo_snowflake.so ${{targets.destdir}}/usr/lib/php/
+      cp ./modules/pdo_snowflake.so ${{targets.destdir}}/usr/lib/php/modules/
       cp ./libsnowflakeclient/cacert.pem ${{targets.destdir}}/etc/php/conf.d
 
   - uses: strip


### PR DESCRIPTION
```
│ WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
│ PHP Warning:  PHP Startup: Unable to load dynamic library 'pdo_snowflake' (tried: /usr/lib/php/modules/pdo_snowflake (/usr/lib/php/modules/pdo_snowflake: cannot open shared object file: No such file or directory),
│ /usr/lib/php/modules/pdo_snowflake.so (/usr/lib/php/modules/pdo_snowflake.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
```

I installed it in the wrong location:
```
usr/lib/php/pdo_snowflake.so
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
