### PR TITLE
[test only] BoringSSL fips

### DIFF
--- a/boringssl-fips.yaml
+++ b/boringssl-fips.yaml
@@ -1,0 +1,47 @@
+package:
+  name: boringssl-fips
+  version: 0.1
+  epoch: 0
+  description: The things I do for love
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-baselayout
+      - binutils
+      - build-base
+      - git
+      - bazel-6
+      - openjdk-11
+      - bash
+      - libtool
+      - cmake
+      - samurai
+      - python3-dev
+      - clang~15
+      - llvm15
+      - llvm15-dev
+      - llvm-lld-15
+      - llvm15-tools
+      - llvm15-cmake-default
+      - coreutils
+      - patch
+      - curl
+      - ncurses~6.4_p20230722
+      - perl
+      # We need to stick to gcc 12 for now, envoy doesn't build with gcc >= 13
+      - gcc-12-default
+
+pipeline:
+
+  - runs: |
+      # This comes from https://github.com/envoyproxy/envoy/blob/main/bazel/external/boringssl_fips.genrule_cmd with a few mods to make old Clang works w/ newer cstdlib
+      ./boringssl-fips.sh
+
+      mkdir -p ${{targets.destdir}}/usr/lib
+      find . -name libcrypto.a -exec cp {} ${{targets.destdir}}/usr/lib \;
+      find . -name libssl.a -exec cp {} ${{targets.destdir}}/usr/lib \;

--- a/boringssl-fips/boringssl-fips.sh
+++ b/boringssl-fips/boringssl-fips.sh
@@ -126,7 +126,6 @@ mkdir build && cd build && cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=${HOME}/toolchai
 ninja
 
 # These aren't required by the cited PDF, but let's run these tests anyway.
-ninja run_tests
 ./crypto/crypto_test
 
 echo "Crypto test done"

--- a/boringssl-fips/boringssl-fips.sh
+++ b/boringssl-fips/boringssl-fips.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -e
+
+export CXXFLAGS=''
+export LDFLAGS=''
+
+# BoringSSL build as described in the Security Policy for BoringCrypto module (2022-05-06):
+# https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4407.pdf
+
+OS=`uname`
+ARCH=`uname -m`
+# This works only on Linux-x86_64 and Linux-aarch64.
+if [[ "$OS" != "Linux" || ("$ARCH" != "x86_64" && "$ARCH" != "aarch64") ]]; then
+  echo "ERROR: BoringSSL FIPS is currently supported only on Linux-x86_64 and Linux-aarch64."
+  exit 1
+fi
+
+# Build tools requirements (from section 12.1 of https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4407.pdf):
+# - Clang compiler version 12.0.0 (https://releases.llvm.org/download.html)
+# - Go programming language version 1.16.5 (https://golang.org/dl/)
+# - Ninja build system version 1.10.2 (https://github.com/ninja-build/ninja/releases)
+# - Cmake version 3.20.1 (https://cmake.org/download/)
+
+# Override $PATH for build tools, to avoid picking up anything else.
+export PATH="$(dirname `which cmake`):/usr/bin:/bin"
+
+# Clang
+VERSION=12.0.0
+if [[ "$ARCH" == "x86_64" ]]; then
+  PLATFORM="x86_64-linux-gnu-ubuntu-20.04"
+  SHA256=a9ff205eb0b73ca7c86afc6432eed1c2d49133bd0d49e47b15be59bbf0dd292e
+else
+  PLATFORM="aarch64-linux-gnu"
+  SHA256=d05f0b04fb248ce1e7a61fcd2087e6be8bc4b06b2cc348792f383abf414dec48
+fi
+
+curl -sLO https://github.com/llvm/llvm-project/releases/download/llvmorg-"$VERSION"/clang+llvm-"$VERSION"-"$PLATFORM".tar.xz
+tar xf clang+llvm-"$VERSION"-"$PLATFORM".tar.xz
+
+export HOME="$PWD"
+printf "set(CMAKE_C_COMPILER \"clang\")\nset(CMAKE_CXX_COMPILER \"clang++\")\n" > ${HOME}/toolchain
+export PATH="$PWD/clang+llvm-$VERSION-$PLATFORM/bin:$PATH"
+
+ln -sf /usr/lib/libtinfo.so.6 /usr/lib/libtinfo.so.5
+if [[ `clang --version | head -1 | awk '{print $3}'` != "$VERSION" ]]; then
+  echo "ERROR: Clang version doesn't match."
+  exit 1
+fi
+
+# Go
+VERSION=1.16.5
+if [[ "$ARCH" == "x86_64" ]]; then
+  PLATFORM="linux-amd64"
+  SHA256=b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061
+else
+  PLATFORM="linux-arm64"
+  SHA256=d5446b46ef6f36fdffa852f73dfbbe78c1ddf010b99fa4964944b9ae8b4d6799
+fi
+
+curl -sLO https://dl.google.com/go/go"$VERSION"."$PLATFORM".tar.gz \
+  && echo "$SHA256" go"$VERSION"."$PLATFORM".tar.gz | sha256sum --check
+tar xf go"$VERSION"."$PLATFORM".tar.gz
+
+export GOPATH="$PWD/gopath"
+export GOROOT="$PWD/go"
+export PATH="$GOPATH/bin:$GOROOT/bin:$PATH"
+
+export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/lib/gcc/x86_64-pc-linux-gnu/12.3.0/include/c++
+export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/lib/gcc/x86_64-pc-linux-gnu/12.3.0/include/c++:/usr/lib/gcc/x86_64-pc-linux-gnu/12.3.0/include/c++/x86_64-pc-linux-gnu/
+export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/lib/gcc/aarch64-unknown-linux-gnu/12.3.0/include/c++
+export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/lib/gcc/aarch64-unknown-linux-gnu/12.3.0/include/c++/aarch64-unknown-linux-gnu
+echo CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH
+
+if [[ `go version | awk '{print $3}'` != "go$VERSION" ]]; then
+  echo "ERROR: Go version doesn't match."
+  exit 1
+fi
+
+# Ninja
+VERSION=1.10.2
+SHA256=ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed
+curl -sLO https://github.com/ninja-build/ninja/archive/refs/tags/v"$VERSION".tar.gz \
+  && echo "$SHA256" v"$VERSION".tar.gz | sha256sum --check
+tar -xvf v"$VERSION".tar.gz
+cd ninja-"$VERSION"
+python3 ./configure.py --bootstrap
+
+export PATH="$PWD:$PATH"
+
+if [[ `ninja --version` != "$VERSION" ]]; then
+  echo "ERROR: Ninja version doesn't match."
+  exit 1
+fi
+cd ..
+
+# CMake
+VERSION=3.20.1
+if [[ "$ARCH" == "x86_64" ]]; then
+  PLATFORM="linux-x86_64"
+  SHA256=b8c141bd7a6d335600ab0a8a35e75af79f95b837f736456b5532f4d717f20a09
+else
+  PLATFORM="linux-aarch64"
+  SHA256=5ad1f8139498a1956df369c401658ec787f63c8cb4e9759f2edaa51626a86512
+fi
+
+curl -sLO https://github.com/Kitware/CMake/releases/download/v"$VERSION"/cmake-"$VERSION"-"$PLATFORM".tar.gz \
+  && echo "$SHA256" cmake-"$VERSION"-"$PLATFORM".tar.gz | sha256sum --check
+tar xf cmake-"$VERSION"-"$PLATFORM".tar.gz
+
+export PATH="$PWD/cmake-$VERSION-$PLATFORM/bin:$PATH"
+
+if [[ `cmake --version | head -n1` != "cmake version $VERSION" ]]; then
+  echo "ERROR: CMake version doesn't match."
+  exit 1
+fi
+
+# Download boring_ssl
+wget https://commondatastorage.googleapis.com/chromium-boringssl-fips/boringssl-853ca1ea1168dff08011e5d42d94609cc0ca2e27.tar.xz
+tar xf boringssl-853ca1ea1168dff08011e5d42d94609cc0ca2e27.tar.xz
+# Clean after previous build.
+rm -rf boringssl/build
+
+# Build BoringSSL.
+cd boringssl
+mkdir build && cd build && cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=${HOME}/toolchain -DFIPS=1 -DCMAKE_BUILD_TYPE=Release ..
+ninja
+
+# These aren't required by the cited PDF, but let's run these tests anyway.
+ninja run_tests
+./crypto/crypto_test
+
+echo "Crypto test done"
+
+# Verify correctness of the FIPS build.
+if [[ `tool/bssl isfips` != "1" ]]; then
+  echo "ERROR: BoringSSL tool didn't report FIPS build."
+  exit 1
+else
+  echo "PASSED: BoringSSL tool reported FIPS build."
+fi
+
+# # Move compiled libraries to the expected destinations.
+# popd
+# mv $ROOT/boringssl/build/crypto/libcrypto.a $1
+# mv $ROOT/boringssl/build/ssl/libssl.a $2
+echo "ALL DONE"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
