### PR TITLE
prefix the raphf file with `10` so that it runs before others.

### DIFF
--- a/php-8.1-pecl-raphf.yaml
+++ b/php-8.1-pecl-raphf.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-raphf
   version: 2.0.1
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.1 resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
@@ -38,6 +38,13 @@ pipeline:
   - uses: pecl/install
     with:
       extension: raphf
+
+  # PHP initialization is order dependent. So we will explicitly
+  # load this by prefixing the file with 10- so it runs before
+  # other modules which start with letters
+  # starts.
+  - runs: |
+      mv ${{targets.destdir}}/etc/php/conf.d/raphf.ini ${{targets.destdir}}/etc/php/conf.d/10-raphf.ini
 
   - uses: strip
 

--- a/php-8.2-pecl-raphf.yaml
+++ b/php-8.2-pecl-raphf.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-raphf
   version: 2.0.1
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.2 resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
@@ -38,6 +38,13 @@ pipeline:
   - uses: pecl/install
     with:
       extension: raphf
+
+  # PHP initialization is order dependent. So we will explicitly
+  # load this by prefixing the file with 10- so it runs before
+  # other modules which start with letters
+  # starts.
+  - runs: |
+      mv ${{targets.destdir}}/etc/php/conf.d/raphf.ini ${{targets.destdir}}/etc/php/conf.d/10-raphf.ini
 
   - uses: strip
 


### PR DESCRIPTION
PHP initialization is order dependent, so without this when using extensions that require this.

```
PHP Warning:  PHP Startup: Unable to load dynamic library 'http' (tried: /usr/lib/php/modules/http (/usr/lib/php/modules/http: cannot open shared object file: No such file or directory), /usr/lib/php/modules/http.so (/usr/lib/php/modules/http.so: undefined symbol: php_resource_factory_handle_dtor)) in Unknown on line 0
```

So once I rename the file to 10-raphf the error is no longer present. https://beamtic.com/conf-d-and-php-ini

```
93e6a36c026b:/work/packages# apk info -L php-8.1-pecl-raphf
php-8.1-pecl-raphf-2.0.1-r1 contains:
etc/php/conf.d/10-raphf.ini
usr/include/php/ext/raphf/php_raphf.h
usr/include/php/ext/raphf/php_raphf_api.h
usr/lib/php/modules/raphf.so
var/lib/db/sbom/php-8.1-pecl-raphf-2.0.1-r1.spdx.json
```

```
c780be664cb1:/work/packages# apk info -L php-8.2-pecl-raphf
php-8.2-pecl-raphf-2.0.1-r1 contains:
etc/php/conf.d/10-raphf.ini
usr/include/php/ext/raphf/php_raphf.h
usr/include/php/ext/raphf/php_raphf_api.h
usr/lib/php/modules/raphf.so
var/lib/db/sbom/php-8.2-pecl-raphf-2.0.1-r1.spdx.json
```



<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
