### PR TITLE
`ip-masq-agent`: new package

### DIFF
--- a/ip-masq-agent.yaml
+++ b/ip-masq-agent.yaml
@@ -1,0 +1,39 @@
+package:
+  name: ip-masq-agent
+  version: 2.9.3
+  epoch: 0
+  description: Manage IP masquerade on nodes
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/ip-masq-agent.git
+      tag: v${{package.version}}
+      expected-commit: 576894798cdde72ac9f9c619cda74238110f69d1
+
+  - uses: go/build
+    with:
+      packages: ./cmd/ip-masq-agent
+      output: ip-masq-agent
+      ldflags: -s -w -X k8s.io/ip-masq-agent/pkg/version.Version=${{package.version}}
+      deps: k8s.io/kubernetes@v1.26.6
+      vendor: true
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/ip-masq-agent
+    strip-prefix: v


### PR DESCRIPTION
#### For new package PRs only
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
