### PR TITLE
scala-2: new package

### DIFF
--- a/scala-2.yaml
+++ b/scala-2.yaml
@@ -1,0 +1,52 @@
+package:
+  name: scala-2
+  version: 2.13.12
+  epoch: 0
+  description: Scala 2 compiler and standard library.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - scala=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - build-base
+      - busybox
+      - openjdk-11-jre
+      - openjdk-11-default-jvm
+      - sbt
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/scala/scala
+      tag: v${{package.version}}
+      expected-commit: 80514f73a6c7db32df9887d9a5ca9ae921e25118
+
+  - uses: patch
+    with:
+      patches: builddate.patch
+
+  - runs: |
+      sbt setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal dist/mkPack
+      install -dm755 "${{targets.destdir}}"/usr/share/scala/bin
+      install -dm755 "${{targets.destdir}}"/usr/share/scala/lib
+      rm -rf build/pack/bin/*.bat
+      mkdir -p ${{targets.destdir}}/usr/bin
+
+      mv build/pack/bin/* ${{targets.destdir}}/usr/share/scala/bin/
+      mv build/pack/lib/* ${{targets.destdir}}/usr/share/scala/lib/
+      ln -sf /usr/share/scala/bin/scala ${{targets.destdir}}/usr/bin/scala
+      ln -sf /usr/share/scala/bin/fsc ${{targets.destdir}}/usr/bin/fsc
+      ln -sf /usr/share/scala/bin/scalac ${{targets.destdir}}/usr/bin/scalac
+      ln -sf /usr/share/scala/bin/scaladoc ${{targets.destdir}}/usr/bin/scaladoc
+      ln -sf /usr/share/scala/bin/scalap ${{targets.destdir}}/usr/bin/scalap
+
+update:
+  enabled: true
+  github:
+    identifier: scala/scala
+    strip-prefix: v

--- a/scala-2/builddate.patch
+++ b/scala-2/builddate.patch
@@ -1,0 +1,22 @@
+diff --git a/project/VersionUtil.scala b/project/VersionUtil.scala
+index f177278ee5..a7b96aad3c 100644
+--- a/project/VersionUtil.scala
++++ b/project/VersionUtil.scala
+@@ -3,7 +3,7 @@ package scala.build
+ import sbt._
+ import Keys._
+ 
+-import java.util.{Date, Locale, Properties, TimeZone}
++import java.util.{Calendar, Date, Locale, Properties, TimeZone}
+ import java.io.{File, FileInputStream, StringWriter}
+ import java.text.SimpleDateFormat
+ import java.time.Instant
+@@ -78,7 +78,7 @@ object VersionUtil {
+             // Workaround lack of git worktree support in JGit https://bugs.eclipse.org/bugs/show_bug.cgi?id=477475
+             val sha = List("git", "rev-parse", "HEAD").!!.trim
+             val commitDateIso = List("git", "log", "-1", "--format=%cI", "HEAD").!!.trim
+-            val date = Date.from(ISO_DATE_TIME.parse(commitDateIso, Instant.from _))
++            val date = Date.from(ISO_DATE_TIME.parse("1970-01-01T00:00:00Z", Instant.from _))
+             (date, sha.substring(0, 7))
+           } catch {
+             case ex: Exception =>


### PR DESCRIPTION
#### For new package PRs only

- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
- [x] The upstream project actually supports multiple concurrent versions.


