### PR TITLE
Add new npm lodash package v4.17.21.

### DIFF
--- a/npm-lodash-compat.yaml
+++ b/npm-lodash-compat.yaml
@@ -1,5 +1,5 @@
 package:
-  name: npm-lodash
+  name: npm-lodash-compat
   version: 4.17.21
   epoch: 0
   description: "A modern JavaScript utility library delivering modularity, performance & extras"

--- a/npm-lodash.yaml
+++ b/npm-lodash.yaml
@@ -1,0 +1,30 @@
+package:
+  name: npm-lodash
+  version: 4.17.21
+  epoch: 0
+  description: "A modern JavaScript utility library delivering modularity, performance & extras"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - nodejs
+
+pipeline:
+  - name: npm install
+    runs: |
+      npm install -g lodash@${{package.version}}
+      mkdir -p ${{targets.destdir}}/usr/local/lib/node_modules/lodash/
+      cp -R /usr/local/lib/node_modules/lodash/* ${{targets.destdir}}/usr/local/lib/node_modules/lodash/
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2374


### PR DESCRIPTION
Adds npm lodash package v4.17.21.

Verified with:
```
1c1df38a2757:/work/packages# apk add npm-lodash-compat
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/1) Installing npm-lodash-compat (4.17.21-r0)
OK: 14 MiB in 15 packages
1c1df38a2757:/work/packages# npm ls -g
/usr/local/lib
└── lodash@4.17.21
```


**NOTE** This is a -compat package as the CI said it should be:
```
Error: failed to build package: package linter error: Linter usrlocal failed at path "usr/local/lib": /usr/local path found in non-compat package; suggest: This package should be a -compat package
2023/09/24 00:02:45 error during command execution: failed to build package: package linter error: Linter usrlocal failed at path "usr/local/lib": /usr/local path found in non-compat package; suggest: This package should be a -compat package
make[1]: *** [Makefile:73: packages/x86_64/npm-async-3.2.4-r0.apk] Error 1

```

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
