### PR TITLE
Add new npm async package 3.2.4.

### DIFF
--- a/npm-async-compat.yaml
+++ b/npm-async-compat.yaml
@@ -1,5 +1,5 @@
 package:
-  name: npm-async
+  name: npm-async-compat
   version: 3.2.4
   epoch: 0
   description: "Async is a utility module which provides straight-forward, powerful functions for working with asynchronous JavaScript"

--- a/npm-async.yaml
+++ b/npm-async.yaml
@@ -1,0 +1,30 @@
+package:
+  name: npm-async
+  version: 3.2.4
+  epoch: 0
+  description: "Async is a utility module which provides straight-forward, powerful functions for working with asynchronous JavaScript"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - nodejs
+
+pipeline:
+  - name: npm install
+    runs: |
+      npm install -g async@${{package.version}}
+      mkdir -p ${{targets.destdir}}/usr/local/lib/node_modules/async/
+      cp -R /usr/local/lib/node_modules/async/* ${{targets.destdir}}/usr/local/lib/node_modules/async/
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2375


### PR DESCRIPTION
Verified with:

```
43d1db25cbc1:/work/packages# apk add npm-async-compat
(1/1) Installing npm-async-compat (3.2.4-r0)
OK: 108 MiB in 25 packages
43d1db25cbc1:/work/packages# npm ls -g
/usr/local/lib
└── async@3.2.4
```

**NOTE** This is a -compat package as the CI said it should be:
```
Error: failed to build package: package linter error: Linter usrlocal failed at path "usr/local/lib": /usr/local path found in non-compat package; suggest: This package should be a -compat package
2023/09/24 00:02:45 error during command execution: failed to build package: package linter error: Linter usrlocal failed at path "usr/local/lib": /usr/local path found in non-compat package; suggest: This package should be a -compat package
make[1]: *** [Makefile:73: packages/x86_64/npm-async-3.2.4-r0.apk] Error 1

```



<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
