### PR TITLE
fix: switch gems that use git ls-files to git-checkout

### DIFF
--- a/ruby3.2-aes_key_wrap.yaml
+++ b/ruby3.2-aes_key_wrap.yaml
@@ -17,21 +17,24 @@ environment:
       - git
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 7025dff44fa37595939948b550507206fb59029e6c3d065bd0927964e9ab7ff2
-      uri: https://github.com/tomdalling/aes_key_wrap/archive/refs/tags/v${{package.version}}.tar.gz
+      destination: ${{vars.gem}}
+      expected-commit: 7749c8d6dbc80a1544aea5d0da09b0380cbd9e57
+      repository: https://github.com/tomdalling/aes_key_wrap
+      tag: v${{package.version}}
 
-  - uses: ruby/build
-    with:
-      gem: ${{vars.gem}}
-
-  - uses: ruby/install
-    with:
-      gem: ${{vars.gem}}
-      version: ${{package.version}}
-
-  - uses: ruby/clean
+  - working-directory: ${{vars.gem}}
+    pipeline:
+      - uses: ruby/unlock-spec
+      - uses: ruby/build
+        with:
+          gem: ${{package.name}}
+      - uses: ruby/install
+        with:
+          gem: ${{package.name}}
+          version: ${{package.version}}
+      - uses: ruby/clean
 
 vars:
   gem: aes_key_wrap

--- a/ruby3.2-aes_key_wrap.yaml
+++ b/ruby3.2-aes_key_wrap.yaml
@@ -19,22 +19,22 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      destination: ${{vars.gem}}
       expected-commit: 7749c8d6dbc80a1544aea5d0da09b0380cbd9e57
       repository: https://github.com/tomdalling/aes_key_wrap
       tag: v${{package.version}}
 
-  - working-directory: ${{vars.gem}}
-    pipeline:
-      - uses: ruby/unlock-spec
-      - uses: ruby/build
-        with:
-          gem: ${{package.name}}
-      - uses: ruby/install
-        with:
-          gem: ${{package.name}}
-          version: ${{package.version}}
-      - uses: ruby/clean
+  - uses: ruby/unlock-spec
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
 
 vars:
   gem: aes_key_wrap

--- a/ruby3.2-aes_key_wrap.yaml
+++ b/ruby3.2-aes_key_wrap.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-aes_key_wrap
   version: 1.1.0
-  epoch: 1
+  epoch: 2
   description: A Ruby implementation of AES Key Wrap, a.k.a RFC 3394, a.k.a NIST Key Wrap.
   copyright:
     - license: MIT

--- a/ruby3.2-attr_required.yaml
+++ b/ruby3.2-attr_required.yaml
@@ -17,10 +17,11 @@ environment:
       - git
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 4197ca7c778515cb739750aad5a70a0777c212b0512e47714bcdcc81b903b368
-      uri: http://github.com/nov/attr_required/archive/refs/tags/v${{package.version}}.tar.gz
+      repository: https://github.com/nov/attr_required
+      tag: v${{package.version}}
+      expected-commit: f413ff13fc998b178eee144ccb9af29ca7b05804
 
   - uses: ruby/build
     with:

--- a/ruby3.2-attr_required.yaml
+++ b/ruby3.2-attr_required.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-attr_required
   version: 1.0.1
-  epoch: 1
+  epoch: 2
   description: attr_required and attr_optional
   copyright:
     - license: MIT

--- a/ruby3.2-json-jwt.yaml
+++ b/ruby3.2-json-jwt.yaml
@@ -24,21 +24,24 @@ environment:
       - git
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: e64a51d3507beafd933cc7982102191b4dd792afdeb5001c90eb7bc23b77ac53
-      uri: https://github.com/nov/json-jwt/archive/refs/tags/v${{package.version}}.tar.gz
+      destination: ${{vars.gem}}
+      expected-commit: 413848c8c93a99093cbb68f198004848f62ecdbd
+      repository: https://github.com/nov/json-jwt
+      tag: v${{package.version}}
 
-  - uses: ruby/build
-    with:
-      gem: ${{vars.gem}}
-
-  - uses: ruby/install
-    with:
-      gem: ${{vars.gem}}
-      version: ${{package.version}}
-
-  - uses: ruby/clean
+  - working-directory: ${{vars.gem}}
+    pipeline:
+      - uses: ruby/unlock-spec
+      - uses: ruby/build
+        with:
+          gem: ${{package.name}}
+      - uses: ruby/install
+        with:
+          gem: ${{package.name}}
+          version: ${{package.version}}
+      - uses: ruby/clean
 
 vars:
   gem: json-jwt

--- a/ruby3.2-json-jwt.yaml
+++ b/ruby3.2-json-jwt.yaml
@@ -31,13 +31,16 @@ pipeline:
       tag: v${{package.version}}
 
   - uses: ruby/unlock-spec
+
   - uses: ruby/build
     with:
       gem: ${{vars.gem}}
+
   - uses: ruby/install
     with:
       gem: ${{vars.gem}}
       version: ${{package.version}}
+
   - uses: ruby/clean
 
 vars:

--- a/ruby3.2-json-jwt.yaml
+++ b/ruby3.2-json-jwt.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-json-jwt
   version: 1.16.3
-  epoch: 1
+  epoch: 2
   description: JSON Web Token and its family (JSON Web Signature, JSON Web Encryption and JSON Web Key) in Ruby
   copyright:
     - license: MIT

--- a/ruby3.2-json-jwt.yaml
+++ b/ruby3.2-json-jwt.yaml
@@ -26,22 +26,19 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      destination: ${{vars.gem}}
       expected-commit: 413848c8c93a99093cbb68f198004848f62ecdbd
       repository: https://github.com/nov/json-jwt
       tag: v${{package.version}}
 
-  - working-directory: ${{vars.gem}}
-    pipeline:
-      - uses: ruby/unlock-spec
-      - uses: ruby/build
-        with:
-          gem: ${{package.name}}
-      - uses: ruby/install
-        with:
-          gem: ${{package.name}}
-          version: ${{package.version}}
-      - uses: ruby/clean
+  - uses: ruby/unlock-spec
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+  - uses: ruby/clean
 
 vars:
   gem: json-jwt

--- a/ruby3.2-rack-oauth2.yaml
+++ b/ruby3.2-rack-oauth2.yaml
@@ -25,10 +25,11 @@ environment:
       - git
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 0f8a93658ae3772745f29bc346fc8f91f8209a2813fbae898e1350310424b010
-      uri: http://github.com/nov/rack-oauth2/archive/refs/tags/v${{package.version}}.tar.gz
+      repository: http://github.com/nov/rack-oauth2
+      tag: v${{package.version}}
+      expected-commit: 04fe478802eee7586daadf5bc0fd99d0256b9e67
 
   - uses: ruby/build
     with:

--- a/ruby3.2-rack-oauth2.yaml
+++ b/ruby3.2-rack-oauth2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-rack-oauth2
   version: 2.2.0
-  epoch: 1
+  epoch: 2
   description: OAuth 2.0 Server & Client Library. Both Bearer token type are supported.
   copyright:
     - license: MIT

--- a/ruby3.2-swd.yaml
+++ b/ruby3.2-swd.yaml
@@ -23,10 +23,11 @@ environment:
       - git
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 9e65803877ec0f087e4f2a9169bad9e104467d290287073cc0eaeb21c597c686
-      uri: https://github.com/nov/swd/archive/refs/tags/v${{package.version}}.tar.gz
+      repository: http://github.com/nov/swd
+      tag: v${{package.version}}
+      expected-commit: 01473509999b427d081a38979ed35053190bb411
 
   - uses: ruby/build
     with:

--- a/ruby3.2-swd.yaml
+++ b/ruby3.2-swd.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-swd
   version: 2.0.2
-  epoch: 1
+  epoch: 2
   description: SWD (Simple Web Discovery) Client Library
   copyright:
     - license: MIT

--- a/ruby3.2-webfinger.yaml
+++ b/ruby3.2-webfinger.yaml
@@ -22,10 +22,11 @@ environment:
       - git
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: f373199b15c5b01cc6c7f40da6f78dcee0c187d2582d0338bd44d351656962fe
-      uri: https://github.com/nov/webfinger/archive/refs/tags/v${{package.version}}.tar.gz
+      repository: http://github.com/nov/webfinger
+      tag: v${{package.version}}
+      expected-commit: a0d8da20f6ce819eea8c2d2c81bcc90d3f41df6f
 
   - uses: ruby/build
     with:

--- a/ruby3.2-webfinger.yaml
+++ b/ruby3.2-webfinger.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-webfinger
   version: 2.1.2
-  epoch: 1
+  epoch: 2
   description: Ruby WebFinger client library
   copyright:
     - license: MIT

--- a/ruby3.2-webfinger.yaml
+++ b/ruby3.2-webfinger.yaml
@@ -26,7 +26,7 @@ pipeline:
     with:
       repository: http://github.com/nov/webfinger
       tag: v${{package.version}}
-      expected-commit: a0d8da20f6ce819eea8c2d2c81bcc90d3f41df6f
+      expected-commit: a79f140bcd5a0ac2140eefed5316e572625a0563
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

These packages were using `fetch` but the gemspec uses `git ls-files` to determine which files get packaged so they were building empty gems. This PR simply switches to git-checkout to add the git metadata
