### PR TITLE
Add visualization-server transitive deps vol2

### DIFF
--- a/py3-beautifulsoup4.yaml
+++ b/py3-beautifulsoup4.yaml
@@ -1,0 +1,38 @@
+# Generated from https://pypi.org/project/beautifulsoup4/
+package:
+  name: py3-beautifulsoup4
+  version: 4.12.2
+  epoch: 0
+  description: Screen-scraping library
+  copyright:
+    - license: "MIT License"
+  dependencies:
+    runtime:
+      - py3-soupsieve
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da
+      uri: https://files.pythonhosted.org/packages/af/0b/44c39cf3b18a9280950ad63a579ce395dda4c32193ee9da7ff0aed547094/beautifulsoup4-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3779

--- a/py3-bokeh.yaml
+++ b/py3-bokeh.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 0
   description: Interactive plots and applications in the browser from Python
   copyright:
-    - license: 'Copyright (c) 2012 - 2023, Anaconda, Inc., and Bokeh Contributors All rights reserved.  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.  Neither the name of Anaconda nor the names of any contributors may be used to endorse or promote products derived from this software without specific prior written permission.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '
+    - license: 'BSD 3-Clause License'
   dependencies:
     runtime:
       - py3-jinja2

--- a/py3-bokeh.yaml
+++ b/py3-bokeh.yaml
@@ -1,0 +1,46 @@
+# Generated from https://pypi.org/project/bokeh/
+package:
+  name: py3-bokeh
+  version: 3.2.2
+  epoch: 0
+  description: Interactive plots and applications in the browser from Python
+  copyright:
+    - license: 'Copyright (c) 2012 - 2023, Anaconda, Inc., and Bokeh Contributors All rights reserved.  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.  Neither the name of Anaconda nor the names of any contributors may be used to endorse or promote products derived from this software without specific prior written permission.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '
+  dependencies:
+    runtime:
+      - py3-jinja2
+      - py3-contourpy
+      - numpy
+      - py3-packaging
+      - py3-pandas
+      - py3-pillow
+      - py3-pyyaml
+      - py3-tornado
+      - py3-xyzservices
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: b2959b8524d69ec4e7886bc36407445f0a92e1f19530d3bfc4045236a1b7a6ff
+      uri: https://files.pythonhosted.org/packages/b2/b5/7b422944c31c3259ddf47c854fbdf09bc0c3a64fb9460aac046848234803/bokeh-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 78655

--- a/py3-google-auth-httplib2.yaml
+++ b/py3-google-auth-httplib2.yaml
@@ -1,0 +1,42 @@
+# Generated from https://pypi.org/project/google-auth-httplib2/
+package:
+  name: py3-google-auth-httplib2
+  version: 0.1.1
+  epoch: 0
+  description: 'Google Authentication Library: httplib2 transport'
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-google-auth
+      - py3-httplib2
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 7b27f8e17cca024a975cdb63c2cce27d06ac4f8c
+      repository: https://github.com/GoogleCloudPlatform/google-auth-library-python-httplib2
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: GoogleCloudPlatform/google-auth-library-python-httplib2
+    strip-prefix: v

--- a/py3-google-cloud-bigquery-storage.yaml
+++ b/py3-google-cloud-bigquery-storage.yaml
@@ -1,0 +1,43 @@
+# Generated from https://pypi.org/project/google-cloud-bigquery-storage/
+package:
+  name: py3-google-cloud-bigquery-storage
+  version: 2.22.0
+  epoch: 0
+  description: Google Cloud Bigquery Storage API client library
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-google-api-core
+      - py3-proto-plus
+      - py3-protobuf
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: b94d5fe11620a827369dae1df725c4a547e14358
+      repository: https://github.com/googleapis/python-bigquery-storage
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: googleapis/python-bigquery-storage
+    strip-prefix: v

--- a/py3-google-cloud-core.yaml
+++ b/py3-google-cloud-core.yaml
@@ -1,0 +1,42 @@
+# Generated from https://pypi.org/project/google-cloud-core/
+package:
+  name: py3-google-cloud-core
+  version: 2.3.3
+  epoch: 0
+  description: Google Cloud API client core library
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-google-api-core
+      - py3-google-auth
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: c5f86620142ff1e1b0d200bfb2c22f97f3163363
+      repository: https://github.com/googleapis/python-cloud-core
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: googleapis/python-cloud-core
+    strip-prefix: v

--- a/py3-google-cloud-dlp.yaml
+++ b/py3-google-cloud-dlp.yaml
@@ -1,0 +1,43 @@
+# Generated from https://pypi.org/project/google-cloud-dlp/
+package:
+  name: py3-google-cloud-dlp
+  version: 3.12.3
+  epoch: 0
+  description: Google Cloud Dlp API client library
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-google-api-core
+      - py3-proto-plus
+      - py3-protobuf
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 5f7e8e6bf905882740c772172caa48e6cdc09c72
+      repository: https://github.com/googleapis/python-dlp
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: googleapis/python-dlp
+    strip-prefix: v

--- a/py3-google-cloud-language.yaml
+++ b/py3-google-cloud-language.yaml
@@ -1,0 +1,47 @@
+# Generated from https://pypi.org/project/google-cloud-language/
+package:
+  name: py3-google-cloud-language
+  version: 2.11.1
+  epoch: 0
+  description: Google Cloud Language API client library
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-google-api-core
+      - py3-proto-plus
+      - py3-protobuf
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: d38c91bd1fdec912ef4d27fc7a9ff28f971be63d
+      repository: https://github.com/googleapis/google-cloud-python
+      tag: google-cloud-language-v${{package.version}}
+
+  - working-directory: packages/google-cloud-language
+    pipeline:
+      - name: Python Build
+        uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: googleapis/google-cloud-python
+    strip-prefix: google-cloud-language-v
+    use-tag: true
+    tag-filter: google-cloud-language

--- a/py3-google-cloud-pubsub.yaml
+++ b/py3-google-cloud-pubsub.yaml
@@ -1,0 +1,46 @@
+# Generated from https://pypi.org/project/google-cloud-pubsub/
+package:
+  name: py3-google-cloud-pubsub
+  version: 2.18.4
+  epoch: 0
+  description: Google Cloud Pub/Sub API client library
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-grpcio
+      - py3-google-api-core
+      - py3-proto-plus
+      - py3-protobuf
+      - py3-grpc-google-iam-v1
+      - py3-grpcio-status
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: ba19b634d0ab299490b314c1e176a1d4887b82bb
+      repository: https://github.com/googleapis/python-pubsub
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: googleapis/python-pubsub
+    strip-prefix: v

--- a/py3-google-cloud-recommendations-ai.yaml
+++ b/py3-google-cloud-recommendations-ai.yaml
@@ -1,0 +1,47 @@
+# Generated from https://pypi.org/project/google-cloud-recommendations-ai/
+package:
+  name: py3-google-cloud-recommendations-ai
+  version: 0.10.5
+  epoch: 0
+  description: Google Cloud Recommendations Ai API client library
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-google-api-core
+      - py3-proto-plus
+      - py3-protobuf
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: d38c91bd1fdec912ef4d27fc7a9ff28f971be63d
+      repository: https://github.com/googleapis/google-cloud-python
+      tag: google-cloud-recommendations-ai-v${{package.version}}
+
+  - working-directory: packages/google-cloud-recommendations-ai
+    pipeline:
+      - name: Python Build
+        uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: googleapis/google-cloud-python
+    strip-prefix: google-cloud-recommendations-ai-v
+    use-tag: true
+    tag-filter: google-cloud-recommendations

--- a/py3-google-cloud-videointelligence.yaml
+++ b/py3-google-cloud-videointelligence.yaml
@@ -1,0 +1,43 @@
+# Generated from https://pypi.org/project/google-cloud-videointelligence/
+package:
+  name: py3-google-cloud-videointelligence
+  version: 2.11.4
+  epoch: 0
+  description: Google Cloud Videointelligence API client library
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-google-api-core
+      - py3-proto-plus
+      - py3-protobuf
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: ac23c7627ea59f51e5c0e7923a0e0cd041782226
+      repository: https://github.com/googleapis/python-videointelligence
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: googleapis/python-videointelligence
+    strip-prefix: v

--- a/py3-google-cloud-vision.yaml
+++ b/py3-google-cloud-vision.yaml
@@ -1,0 +1,43 @@
+# Generated from https://pypi.org/project/google-cloud-vision/
+package:
+  name: py3-google-cloud-vision
+  version: 3.4.4
+  epoch: 0
+  description: Google Cloud Vision API client library
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-google-api-core
+      - py3-proto-plus
+      - py3-protobuf
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: b190534ab18a82f85f6a97e3f7f4194f5daf6c7b
+      repository: https://github.com/googleapis/python-vision
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: googleapis/python-vision
+    strip-prefix: v

--- a/py3-google-resumable-media.yaml
+++ b/py3-google-resumable-media.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/google-resumable-media/
+package:
+  name: py3-google-resumable-media
+  version: 2.6.0
+  epoch: 0
+  description: Utilities for Google Media Downloads and Resumable Uploads
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-google-crc32c
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 37cf106a0b3b89dc9985817fafa174fc327c741c
+      repository: https://github.com/googleapis/google-resumable-media-python
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: googleapis/google-resumable-media-python
+    strip-prefix: v

--- a/py3-jedi.yaml
+++ b/py3-jedi.yaml
@@ -1,0 +1,46 @@
+# Generated from https://pypi.org/project/jedi/
+package:
+  name: py3-jedi
+  version: 0.19.0
+  epoch: 0
+  description: An autocompletion tool for Python that can be used for text editors.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-parso
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 51f4a99a1e06a958e3b96b299b18bb1d49d1debe
+      repository: https://github.com/davidhalter/jedi
+      tag: v${{package.version}}
+
+  - runs: git submodule update --init
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  ignore-regex-patterns:
+    - show
+  github:
+    identifier: davidhalter/jedi
+    strip-prefix: v
+    use-tag: true

--- a/py3-jupyter-events.yaml
+++ b/py3-jupyter-events.yaml
@@ -1,0 +1,44 @@
+# Generated from https://pypi.org/project/jupyter-events/
+package:
+  name: py3-jupyter-events
+  version: 0.7.0
+  epoch: 0
+  description: Jupyter Event System library
+  copyright:
+    - license: 'BSD 3-Clause License'
+  dependencies:
+    runtime:
+      - py3-jsonschema
+      - py3-python-json-logger
+      - py3-pyyaml
+      - py3-referencing
+      - py3-rfc3339-validator
+      - py3-rfc3986-validator
+      - py3-traitlets
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 7be27f54b8388c03eefea123a4f79247c5b9381c49fb1cd48615ee191eb12615
+      uri: https://files.pythonhosted.org/packages/3f/0a/1c839290324ab93dc79950eaf26e198578db8b27edb587082b6061f4f9f5/jupyter_events-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 251195

--- a/py3-oauth2client.yaml
+++ b/py3-oauth2client.yaml
@@ -1,0 +1,45 @@
+# Generated from https://pypi.org/project/oauth2client/
+package:
+  name: py3-oauth2client
+  version: 4.1.3
+  epoch: 0
+  description: OAuth 2.0 client library
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - py3-httplib2
+      - py3-asn1
+      - py3-asn1-modules
+      - py3-rsa
+      - py3-six
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 50d20532a748f18e53f7d24ccbe6647132c979a9
+      repository: https://github.com/google/oauth2client
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: google/oauth2client
+    strip-prefix: v

--- a/py3-pathlib2.yaml
+++ b/py3-pathlib2.yaml
@@ -1,0 +1,42 @@
+# Generated from https://pypi.org/project/pathlib2/
+package:
+  name: py3-pathlib2
+  version: 2.3.7
+  epoch: 0
+  description: Object-oriented filesystem paths
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-six
+      - py3-scandir
+      - py3-typing
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 5b4b06be8c096b1070c812253f9072ad1430589a
+      repository: https://github.com/jazzband/pathlib2
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: jazzband/pathlib2
+    strip-suffix: -post1

--- a/py3-pymongo.yaml
+++ b/py3-pymongo.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/pymongo/
+package:
+  name: py3-pymongo
+  version: 4.5.0
+  epoch: 0
+  description: Python driver for MongoDB <http://www.mongodb.org>
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - py3-dnspython
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 3353b11cf236921426917b00f257e486d760e782
+      repository: https://github.com/mongodb/mongo-python-driver
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: mongodb/mongo-python-driver

--- a/py3-stack-data.yaml
+++ b/py3-stack-data.yaml
@@ -1,0 +1,44 @@
+# Generated from https://pypi.org/project/stack-data/
+package:
+  name: py3-stack-data
+  version: 0.6.2
+  epoch: 0
+  description: Extract data from python stack frames and tracebacks for informative displays
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-executing
+      - py3-asttokens
+      - py3-pure-eval
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 2b88dbed92fb37d9f1bca006bce3d881986945c5
+      repository: https://github.com/alexmojaki/stack_data
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: alexmojaki/stack_data
+    strip-prefix: v
+    use-tag: true

--- a/py3-typing-inspect.yaml
+++ b/py3-typing-inspect.yaml
@@ -1,0 +1,42 @@
+# Generated from https://pypi.org/project/typing-inspect/
+package:
+  name: py3-typing-inspect
+  version: 0.9.0
+  epoch: 0
+  description: Runtime inspection utilities for typing module.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-mypy-extensions
+      - py3-typing-extensions
+      - py3-typing
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: c014abf73c165dda826e4c25504f9250bbca9045
+      repository: https://github.com/ilevkivskyi/typing_inspect
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: ilevkivskyi/typing_inspect


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
