### PR TITLE
rename npm-{async,lodash}-compat to drop -compat

### DIFF
--- a/npm-async.yaml
+++ b/npm-async.yaml
@@ -1,10 +1,13 @@
 package:
-  name: npm-async-compat
+  name: npm-async
   version: 3.2.4
   epoch: 0
   description: "Async is a utility module which provides straight-forward, powerful functions for working with asynchronous JavaScript"
   copyright:
     - license: MIT
+  checks:
+    disabled:
+      - usrlocal
 
 environment:
   contents:

--- a/npm-lodash.yaml
+++ b/npm-lodash.yaml
@@ -1,10 +1,13 @@
 package:
-  name: npm-lodash-compat
+  name: npm-lodash
   version: 4.17.21
   epoch: 0
   description: "A modern JavaScript utility library delivering modularity, performance & extras"
   copyright:
     - license: MIT
+  checks:
+    disabled:
+      - usrlocal
 
 environment:
   contents:


### PR DESCRIPTION
Added in https://github.com/wolfi-dev/os/pull/5888 and https://github.com/wolfi-dev/os/pull/5887

The packages were named `-compat` to get around linter errors. This PR disables those linters instead, so the package name is not misleadingly named.

I wasn't able to get these builds to pass locally, and `make dev-container` didn't have a new enough `melange` to understand the new `check` config directive, so I'm relying on CI to tell me if I broke something.