### PR TITLE
adds ruby-elastic search packages

### DIFF
--- a/ruby3.2-base64.yaml
+++ b/ruby3.2-base64.yaml
@@ -1,0 +1,45 @@
+package:
+  name: ruby3.2-base64
+  version: 0.1.1
+  epoch: 0
+  description: Support for encoding and decoding binary data using a Base64 representation.
+  copyright:
+    - license: Ruby
+    - license: BSD-2-Clause
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: a2fab48106ce23b900205818c47c97615af7f93bb5a2e5cec74df058da2c8e6e
+      uri: https://github.com/ruby/base64/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: base64
+
+update:
+  enabled: true
+  github:
+    identifier: ruby/base64
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-elastic-transport.yaml
+++ b/ruby3.2-elastic-transport.yaml
@@ -1,0 +1,49 @@
+package:
+  name: ruby3.2-elastic-transport
+  version: 8.3.0
+  epoch: 0
+  description: |
+    Low level Ruby client for Elastic. See the `elasticsearch` or `elastic-enterprise-search` gems for full integration.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ruby3.2-faraday
+      - ruby3.2-multi_json
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: b4a4fc085705c539d1a5008fd178ee1ca3e74a90b7977850dee59a5d31107888
+      uri: https://github.com/elastic/elastic-transport-ruby/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: elastic-transport
+
+update:
+  enabled: true
+  github:
+    identifier: elastic/elastic-transport-ruby
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-elasticsearch-api.yaml
+++ b/ruby3.2-elasticsearch-api.yaml
@@ -1,0 +1,49 @@
+package:
+  name: ruby3.2-elasticsearch-api
+  version: "8.10.0"
+  epoch: 0
+  description: |
+    Ruby API for Elasticsearch. See the `elasticsearch` gem for full integration.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ruby3.2-multi_json
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+vars:
+  gem: elasticsearch-api
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 9b3a4871c724d409ed6da3f2f1c7d4df442e821b88492129a782e7fa61a3dbbb
+      uri: https://github.com/elastic/elasticsearch-ruby/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - working-directory: ${{vars.gem}}
+    pipeline:
+      - uses: ruby/build
+        with:
+          gem: ${{vars.gem}}
+      - uses: ruby/install
+        with:
+          gem: ${{vars.gem}}
+          version: ${{package.version}}
+      - uses: ruby/clean
+
+update:
+  enabled: true
+  github:
+    identifier: elastic/elasticsearch-ruby
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v

--- a/ruby3.2-elasticsearch.yaml
+++ b/ruby3.2-elasticsearch.yaml
@@ -1,0 +1,49 @@
+package:
+  name: ruby3.2-elasticsearch
+  version: 8.10.0
+  epoch: 0
+  description: |
+    Ruby integrations for Elasticsearch (client, API, etc.)
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ruby3.2-elasticsearch-api
+      - ruby3.2-elastic-transport
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 9b3a4871c724d409ed6da3f2f1c7d4df442e821b88492129a782e7fa61a3dbbb
+      uri: https://github.com/elastic/elasticsearch-ruby/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - working-directory: ${{vars.gem}}
+    pipeline:
+      - uses: ruby/build
+        with:
+          gem: ${{vars.gem}}
+      - uses: ruby/install
+        with:
+          gem: ${{vars.gem}}
+          version: ${{package.version}}
+      - uses: ruby/clean
+
+vars:
+  gem: elasticsearch
+
+update:
+  enabled: true
+  github:
+    identifier: elastic/elasticsearch-ruby
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
