### PR TITLE
fluent-plugin-cloudwatch-logs package

### DIFF
--- a/fluent-plugin-cloudwatch-logs.yaml
+++ b/fluent-plugin-cloudwatch-logs.yaml
@@ -1,0 +1,49 @@
+package:
+  name: fluent-plugin-cloudwatch-logs
+  version: 0.14.3
+  epoch: 0
+  description: CloudWatch Logs Plugin for Fluentd
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby3.2-aws-sdk-cloudwatchlogs
+      - ruby3.2-fluentd
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 7287d1ae78b24e3fb74aee8d3830a65ecd89f65d
+      repository: https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs.git
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: fluent-plugin-cloudwatch-logs
+
+update:
+  enabled: true
+  github:
+    identifier: fluent-plugins-nursery/fluent-plugin-cloudwatch-logs
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-aws-eventstream.yaml
+++ b/ruby3.2-aws-eventstream.yaml
@@ -1,0 +1,47 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: ruby3.2-aws-eventstream
+  version: 1.2.0
+  epoch: 0
+  description: Amazon Web Services event stream library. Decodes and encodes binary stream under `vnd.amazon.event-stream` content-type
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 67bcc683df60c4fb5772305380cfc9a6584f2542
+      repository: https://github.com/aws/aws-sdk-ruby
+      branch: version-3
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+      dir: gems/${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+      dir: gems/${{vars.gem}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: aws-eventstream
+
+update:
+  enabled: false
+  manual: true # the library we fetch uses a different version then the package version
+  release-monitor:
+    identifier: 174496

--- a/ruby3.2-aws-partitions.yaml
+++ b/ruby3.2-aws-partitions.yaml
@@ -1,0 +1,47 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: ruby3.2-aws-partitions
+  version: 1.829.0
+  epoch: 0
+  description: Provides interfaces to enumerate AWS partitions, regions, and services.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 67bcc683df60c4fb5772305380cfc9a6584f2542
+      repository: https://github.com/aws/aws-sdk-ruby
+      branch: version-3
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+      dir: gems/${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+      dir: gems/${{vars.gem}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: aws-partitions
+
+update:
+  enabled: false
+  manual: true # the library we fetch uses a different version then the package version
+  release-monitor:
+    identifier: 174496

--- a/ruby3.2-aws-sdk-cloudwatchlogs.yaml
+++ b/ruby3.2-aws-sdk-cloudwatchlogs.yaml
@@ -1,0 +1,49 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: ruby3.2-aws-sdk-cloudwatchlogs
+  version: 1.71.0
+  epoch: 0
+  description: Official AWS Ruby gem for Amazon CloudWatch Logs. This gem is part of the AWS SDK for Ruby.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ruby3.2-aws-sdk-core
+      - ruby3.2-aws-sigv4
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 67bcc683df60c4fb5772305380cfc9a6584f2542
+      repository: https://github.com/aws/aws-sdk-ruby
+      branch: version-3
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+      dir: gems/${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+      dir: gems/${{vars.gem}}
+
+vars:
+  gem: aws-sdk-cloudwatchlogs
+
+update:
+  enabled: false
+  manual: true # the library we fetch uses a different version then the package version
+  release-monitor:
+    identifier: 174496

--- a/ruby3.2-aws-sdk-core.yaml
+++ b/ruby3.2-aws-sdk-core.yaml
@@ -1,0 +1,53 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: ruby3.2-aws-sdk-core
+  version: 3.184.0
+  epoch: 0
+  description: Provides API clients for AWS. This gem is part of the official AWS SDK for Ruby.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ruby3.2-aws-eventstream
+      - ruby3.2-aws-partitions
+      - ruby3.2-aws-sigv4
+      - ruby3.2-jmespath
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 67bcc683df60c4fb5772305380cfc9a6584f2542
+      repository: https://github.com/aws/aws-sdk-ruby
+      branch: version-3
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+      dir: gems/${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+      dir: gems/${{vars.gem}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: aws-sdk-core
+
+update:
+  enabled: false
+  manual: true # the library we fetch uses a different version then the package version
+  release-monitor:
+    identifier: 174496

--- a/ruby3.2-aws-sigv4.yaml
+++ b/ruby3.2-aws-sigv4.yaml
@@ -1,0 +1,50 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: ruby3.2-aws-sigv4
+  version: 1.6.0
+  epoch: 0
+  description: Amazon Web Services Signature Version 4 signing library. Generates sigv4 signature for HTTP requests.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ruby3.2-aws-eventstream
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 67bcc683df60c4fb5772305380cfc9a6584f2542
+      repository: https://github.com/aws/aws-sdk-ruby
+      branch: version-3
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+      dir: gems/${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+      dir: gems/${{vars.gem}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: aws-sigv4
+
+update:
+  enabled: false
+  manual: true # the library we fetch uses a different version then the package version
+  release-monitor:
+    identifier: 174496

--- a/ruby3.2-jmespath.yaml
+++ b/ruby3.2-jmespath.yaml
@@ -1,0 +1,44 @@
+package:
+  name: ruby3.2-jmespath
+  version: 1.6.2
+  epoch: 0
+  description: Implements JMESPath for Ruby
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 8336859844c3ebf053cf9498dcf5f494ee805750
+      repository: https://github.com/jmespath/jmespath.rb
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: jmespath
+
+update:
+  enabled: true
+  github:
+    identifier: jmespath/jmespath.rb
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
