### PR TITLE
adds ruby3.2-excon and faraday-excon

### DIFF
--- a/ruby3.2-excon.yaml
+++ b/ruby3.2-excon.yaml
@@ -1,0 +1,44 @@
+# Generated from https://github.com/excon/excon
+package:
+  name: ruby3.2-excon
+  version: 0.103.0
+  epoch: 0
+  description: EXtended http(s) CONnections
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: d8078a623a5652e9e6e70b669146955ffcc05d272c745c4b09ecd68aa6a037ba
+      uri: https://github.com/excon/excon/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: excon
+
+update:
+  enabled: true
+  github:
+    identifier: excon/excon
+    strip-prefix: v

--- a/ruby3.2-faraday-excon.yaml
+++ b/ruby3.2-faraday-excon.yaml
@@ -1,0 +1,48 @@
+# Generated from https://github.com/lostisland/faraday-excon
+package:
+  name: ruby3.2-faraday-excon
+  version: 2.1.0
+  epoch: 0
+  description: Faraday adapter for Excon
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby3.2-excon
+      - ruby3.2-faraday
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: fd890fbfc90301194e884f381ecffcf7cc8516706aeb486a3a6c90f1e5925973
+      uri: https://github.com/lostisland/faraday-excon/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: faraday-excon
+
+update:
+  enabled: true
+  github:
+    identifier: lostisland/faraday-excon
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
