### PR TITLE
fluent-plugin-tag-normaliser package

### DIFF
--- a/fluent-plugin-tag-normaliser.yaml
+++ b/fluent-plugin-tag-normaliser.yaml
@@ -33,7 +33,7 @@ pipeline:
   - uses: ruby/install
     with:
       gem: ${{vars.gem}}
-      version: ${{package.version}}
+      version: 0.1.2 # hard coded as no tags or releases
 
   - uses: ruby/clean
 

--- a/fluent-plugin-tag-normaliser.yaml
+++ b/fluent-plugin-tag-normaliser.yaml
@@ -29,6 +29,7 @@ pipeline:
   - uses: ruby/build
     with:
       gem: ${{vars.gem}}
+      dir: fluent-plugin-tag-normaliser
 
   - uses: ruby/install
     with:

--- a/fluent-plugin-tag-normaliser.yaml
+++ b/fluent-plugin-tag-normaliser.yaml
@@ -34,6 +34,7 @@ pipeline:
   - uses: ruby/install
     with:
       gem: ${{vars.gem}}
+      dir: fluent-plugin-tag-normaliser
       version: 0.1.2 # hard coded as no tags or releases
 
   - uses: ruby/clean

--- a/fluent-plugin-tag-normaliser.yaml
+++ b/fluent-plugin-tag-normaliser.yaml
@@ -1,0 +1,44 @@
+#nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
+package:
+  name: fluent-plugin-tag-normaliser
+  version: 0.0_git20230928
+  epoch: 0
+  description: Tag-normaliser is a `fluentd` plugin to help re-tag logs with Kubernetes metadata. It uses special placeholders to change tag.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ruby3.2-fluentd
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - runs: |
+      git clone https://github.com/kube-logging/fluent-plugin-tag-normaliser
+      cd fluent-plugin-tag-normaliser
+      git checkout 977a7a0de97db777d83f0db660a3789dcd83a5d4
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: fluent-plugin-tag-normaliser
+
+update:
+  enabled: false

--- a/fluent-plugin-tag-normaliser.yaml
+++ b/fluent-plugin-tag-normaliser.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: fluent-plugin-tag-normaliser
-  version: 0.0_git20230928
+  version: 0.1.2_git20230928
   epoch: 0
   description: Tag-normaliser is a `fluentd` plugin to help re-tag logs with Kubernetes metadata. It uses special placeholders to change tag.
   copyright:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
