### PR TITLE
glibc: set provider-priority on libcrypt1 to steer apk-tools solving

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.38
-  epoch: 3
+  epoch: 4
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later
@@ -471,6 +471,8 @@ subpackages:
 
   - name: "libcrypt1"
     description: "Password hashing library included with glibc"
+    dependencies:
+      provider-priority: 10
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/lib


### PR DESCRIPTION
Set `provider-priority: 10` on `libcrypt1` to steer the apk-tools solver towards it for `so:libcrypt.so.1=1`.