### PR TITLE
tomcat-native: fix packages

### DIFF
--- a/tomcat-native.yaml
+++ b/tomcat-native.yaml
@@ -1,7 +1,7 @@
 package:
   name: tomcat-native
   version: 2.0.5
-  epoch: 0
+  epoch: 1
   description: OpenSSL extension for Tomcat
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,7 @@ environment:
       - autoconf
       - automake
       - python3
+      - libtool
   environment:
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
@@ -32,22 +33,16 @@ pipeline:
       expected-commit: 7b3d702481bc9198e958b88a1f6028b9be5de4ff
 
   - runs: |
-      ant jar
-
-      mkdir -p ${{targets.destdir}}/usr/share/tomcat/lib
-      cp dist/tomcat-native-${{package.version}}.jar ${{targets.destdir}}/usr/share/tomcat/lib
-
-  - runs: |
       cd native
       ./buildconf --with-apr=/usr/share/apr-1
-      ./configure --prefix=/usr --with-java-home=$JAVA_HOME --with-ssl=/usr/include/openssl --with-apr=/usr/bin/apr-1-config
 
   - uses: autoconf/configure
     with:
       dir: native
       opts: |
-        --prefix=/usr \
+        --prefix=/usr/lib/tomcat-native \
         --with-java-home=$JAVA_HOME \
+        --libdir=/usr/lib/tomcat-native \
         --with-ssl=/usr/include/openssl \
         --with-apr=/usr/bin/apr-1-config
 
@@ -58,6 +53,9 @@ pipeline:
   - uses: autoconf/make-install
     with:
       dir: native
+
+  - name: remove
+    runs: rm -f ${{targets.destdir}}/usr/lib/tomcat-native/*.a
 
   - uses: strip
 


### PR DESCRIPTION
- this package was packaging the jni jar and there was a contention between the jni provided by the tomcat and tomcat native 
-  clean up 