### PR TITLE
apache-orc : new package

### DIFF
--- a/apache-orc.yaml
+++ b/apache-orc.yaml
@@ -1,0 +1,58 @@
+package:
+  name: apache-orc
+  version: 1.9.1
+  epoch: 0
+  description: "the smallest, fastest columnar storage for Hadoop workloads"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - build-base
+      - cmake
+      - samurai
+      - lz4-dev
+      - protobuf-dev
+      - snappy-dev
+      - zlib-dev
+      - zlib-static
+      - zstd-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/orc
+      tag: v${{package.version}}
+      expected-commit: 1ad46dd2fcad9759a4cfbed28a4d4c1b618466e0
+
+  - runs: |
+      cmake -B build -G Ninja \
+      -DCMAKE_INSTALL_PREFIX=/usr \
+      -DBUILD_SHARED_LIBS=True \
+      -DCMAKE_BUILD_TYPE=MinSizeRel \
+      -DBUILD_LIBHDFSPP=OFF \
+      -DBUILD_JAVA=OFF \
+      -DINSTALL_VENDORED_LIBS=OFF \
+      -DBUILD_POSITION_INDEPENDENT_LIB=ON \
+      -DSTOP_BUILD_ON_WARNING=OFF \
+      -DBUILD_CPP_TESTS=OFF
+      cmake --build build
+
+  - runs: |
+      DESTDIR="${{targets.destdir}}" cmake --install build
+
+  - uses: strip
+
+subpackages:
+  - name: "apache-orc-dev"
+    description: "the smallest, fastest columnar storage for Hadoop workloads (development files)"
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: apache/orc
+    strip-prefix: v


### PR DESCRIPTION
- apache-orc : new package

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
