### PR TITLE
adds fluent-plugin-newrelic

### DIFF
--- a/fluent-plugin-newrelic.yaml
+++ b/fluent-plugin-newrelic.yaml
@@ -1,0 +1,46 @@
+package:
+  name: fluent-plugin-newrelic
+  version: "1.2.2_git20230928"
+  epoch: 0
+  description: Sends FluentD events to New Relic
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ruby3.2-fluentd
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+pipeline:
+  - uses: fetch
+    with:
+      # Hack until they cut a release
+      expected-sha256: 69f9b3e8ebbd65c42fca403fcbb45f94eab34ea461dc836014986158dd644dc0
+      uri: https://github.com/newrelic/newrelic-fluentd-output/archive/c08367bfae3b019a84d43a00a9db065d12033266.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      # Hard-coding because of difference in gemspec file name and gem name
+      gem: fluent-plugin-newrelic
+      # Hard-coding the version here to match with gemspec till they come with a release/tag
+      version: 1.2.2
+
+  - uses: ruby/clean
+
+vars:
+  gem: newrelic-fluentd-output
+
+update:
+  enabled: false

--- a/fluent-plugin-newrelic.yaml
+++ b/fluent-plugin-newrelic.yaml
@@ -1,3 +1,4 @@
+#nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: fluent-plugin-newrelic
   version: "1.2.2_git20230928"
@@ -20,15 +21,15 @@ environment:
       - git
 
 pipeline:
-  - uses: fetch
-    with:
-      # Hack until they cut a release
-      expected-sha256: 69f9b3e8ebbd65c42fca403fcbb45f94eab34ea461dc836014986158dd644dc0
-      uri: https://github.com/newrelic/newrelic-fluentd-output/archive/c08367bfae3b019a84d43a00a9db065d12033266.tar.gz
+  - runs: |
+      git clone https://github.com/newrelic/newrelic-fluentd-output
+      cd newrelic-fluentd-output
+      git checkout c08367bfae3b019a84d43a00a9db065d12033266
 
   - uses: ruby/build
     with:
       gem: ${{vars.gem}}
+      dir: newrelic-fluentd-output
 
   - uses: ruby/install
     with:
@@ -36,6 +37,7 @@ pipeline:
       gem: fluent-plugin-newrelic
       # Hard-coding the version here to match with gemspec till they come with a release/tag
       version: 1.2.2
+      dir: newrelic-fluentd-output
 
   - uses: ruby/clean
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
