### PR TITLE
librdkafka: Update GitHub organization

### DIFF
--- a/librdkafka.yaml
+++ b/librdkafka.yaml
@@ -1,7 +1,7 @@
 package:
   name: librdkafka
   version: 2.2.0
-  epoch: 2
+  epoch: 3
   description: "The Apache Kafka C/C++ library"
   copyright:
     - license: BSD-2-Clause
@@ -26,7 +26,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha512: 1a85b5864efdeece1327e461b62a378f24b73eb7174168f630aeff01d4a5074d6b2f15744bc267665fcfc6384e804df00c20b7271ecd85a98dca84746b86b4d9
-      uri: https://github.com/edenhill/librdkafka/archive/refs/tags/v${{package.version}}.tar.gz
+      uri: https://github.com/confluentinc/librdkafka/archive/refs/tags/v${{package.version}}.tar.gz
 
   - runs: |
       CFLAGS="$CFLAGS -flto=auto" \
@@ -55,6 +55,6 @@ update:
   ignore-regex-patterns:
     - full-integration-tests
   github:
-    identifier: edenhill/librdkafka
+    identifier: confluentinc/librdkafka
     strip-prefix: v
     use-tag: true


### PR DESCRIPTION
The `librdkafka` repository has been moved from https://github.com/edenhill/librdkafka to https://github.com/confluentinc/librdkafka, all of the tags/releases are still present and redirect from the old URL so this PR is a no-op but will ensure future releases are detected and downloaded from the correct URL.

I wasn't sure if I should bump `epoch` given this context or leave it the same.