### PR TITLE
fix(kafka): CVE-2023-43642

### DIFF
--- a/kafka.yaml
+++ b/kafka.yaml
@@ -2,7 +2,7 @@ package:
   name: kafka
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.5.1
-  epoch: 2
+  epoch: 3
   description: Apache Kafka is a distributed event streaming platformm
   copyright:
     - paths:
@@ -34,6 +34,10 @@ pipeline:
   - uses: patch
     with:
       patches: bump-jetty-to-9.4.52.patch
+
+  - uses: patch
+    with:
+      patches: bump-snappy-java-to-1.1.10.4.patch
 
   - runs: |
       export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8

--- a/kafka/bump-snappy-java-to-1.1.10.4.patch
+++ b/kafka/bump-snappy-java-to-1.1.10.4.patch
@@ -1,0 +1,29 @@
+This patches CVE-2023-43642.
+
+---
+diff --git a/LICENSE-binary b/LICENSE-binary
+index 10ef6d7037..160e85cea9 100644
+--- a/LICENSE-binary
++++ b/LICENSE-binary
+@@ -252,7 +252,7 @@ scala-library-2.13.10
+ scala-logging_2.13-3.9.4
+ scala-reflect-2.13.10
+ scala-java8-compat_2.13-1.0.2
+-snappy-java-1.1.10.1
++snappy-java-1.1.10.4
+ swagger-annotations-2.2.8
+ zookeeper-3.6.4
+ zookeeper-jute-3.6.4
+diff --git a/gradle/dependencies.gradle b/gradle/dependencies.gradle
+index 1509065e22..f34f05d6c3 100644
+--- a/gradle/dependencies.gradle
++++ b/gradle/dependencies.gradle
+@@ -122,7 +122,7 @@ versions += [
+   scalaJava8Compat : "1.0.2",
+   scoverage: "1.9.3",
+   slf4j: "1.7.36",
+-  snappy: "1.1.10.1",
++  snappy: "1.1.10.4",
+   spotbugs: "4.7.3",
+   // New version of Swagger 2.2.14 requires minimum JDK 11.
+   swaggerAnnotations: "2.2.8",


### PR DESCRIPTION
via dependency bump patch: `snappy-java` to `1.1.10.4`

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

https://github.com/wolfi-dev/advisories/pull/272

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
