### PR TITLE
Fix broken ruby gems using git ls-files

### DIFF
--- a/fluent-plugin-label-router.yaml
+++ b/fluent-plugin-label-router.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-label-router
   version: "0.2.10_git20230928"
-  epoch: 0
+  epoch: 1
   description: Label-Router helps routing log messages based on their labels and namespace tag in a Kubernetes environment.
   copyright:
     - license: Apache-2.0
@@ -21,23 +21,23 @@ environment:
       - git
 
 pipeline:
-  - uses: fetch
-    with:
-      # Hack until they cut a release
-      uri: https://github.com/kube-logging/fluent-plugin-label-router/archive/695d289f3b170d4739e79b21ce062700b10acf16.tar.gz
-      expected-sha256: 5323ee3eef3b39c3834a527dedf01077d13c269838ad994f790a5fbd8e1486cf
+  # Hack until they cut a release
+  - runs: |
+      git clone https://github.com/kube-logging/fluent-plugin-label-router
+      cd fluent-plugin-label-router
+      git checkout 695d289f3b170d4739e79b21ce062700b10acf16
 
-  - uses: ruby/build
-    with:
-      gem: ${{vars.gem}}
-
-  - uses: ruby/install
-    with:
-      gem: ${{vars.gem}}
-      # Hard-coding the version here to match with gemspec till they come with a release/tag
-      version: 0.2.10
-
-  - uses: ruby/clean
+  - working-directory: fluent-plugin-label-router
+    pipeline:
+    - uses: ruby/build
+      with:
+        gem: ${{vars.gem}}
+    - uses: ruby/install
+      with:
+        gem: ${{vars.gem}}
+        # Hard-coding the version here to match with gemspec till they come with a release/tag
+        version: 0.2.10
+    - uses: ruby/clean
 
 vars:
   gem: fluent-plugin-label-router

--- a/fluent-plugin-label-router.yaml
+++ b/fluent-plugin-label-router.yaml
@@ -13,12 +13,12 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - ruby-3.2
-      - ruby-3.2-dev
       - build-base
       - busybox
+      - ca-certificates-bundle
       - git
+      - ruby-3.2
+      - ruby-3.2-dev
 
 pipeline:
   # Hack until they cut a release
@@ -29,15 +29,15 @@ pipeline:
 
   - working-directory: fluent-plugin-label-router
     pipeline:
-    - uses: ruby/build
-      with:
-        gem: ${{vars.gem}}
-    - uses: ruby/install
-      with:
-        gem: ${{vars.gem}}
-        # Hard-coding the version here to match with gemspec till they come with a release/tag
-        version: 0.2.10
-    - uses: ruby/clean
+      - uses: ruby/build
+        with:
+          gem: ${{vars.gem}}
+      - uses: ruby/install
+        with:
+          gem: ${{vars.gem}}
+          # Hard-coding the version here to match with gemspec till they come with a release/tag
+          version: 0.2.10
+      - uses: ruby/clean
 
 vars:
   gem: fluent-plugin-label-router

--- a/ruby3.2-excon.yaml
+++ b/ruby3.2-excon.yaml
@@ -43,3 +43,4 @@ update:
   github:
     identifier: excon/excon
     strip-prefix: v
+    use-tag: true

--- a/ruby3.2-excon.yaml
+++ b/ruby3.2-excon.yaml
@@ -1,7 +1,7 @@
 # Generated from https://github.com/excon/excon
 package:
   name: ruby3.2-excon
-  version: 0.103.0
+  version: 0.104.0
   epoch: 0
   description: EXtended http(s) CONnections
   copyright:
@@ -18,10 +18,11 @@ environment:
       - git
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: d8078a623a5652e9e6e70b669146955ffcc05d272c745c4b09ecd68aa6a037ba
-      uri: https://github.com/excon/excon/archive/refs/tags/v${{package.version}}.tar.gz
+      repository: https://github.com/excon/excon
+      expected-commit: 5332be21be81ff30c23a0c768ff7b742312e4cba
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
These gems were missing files due to missing git metadata when the gem was built