### PR TITLE
Add a package for `certificate-transparency-go`.

### DIFF
--- a/certificate-transparency.yaml
+++ b/certificate-transparency.yaml
@@ -1,0 +1,53 @@
+package:
+  name: certificate-transparency
+  version: 1.1.6
+  epoch: 0
+  description: Auditing for TLS certificates
+  target-architecture:
+    - all
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+  checks:
+    disabled:
+      - empty
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - git
+      - go
+
+data:
+  - name: components
+    items:
+      # There are a lot of binaries we may want to build out of this
+      # repo, but start with what we need for sigstore.
+      trillian-ctserver: ./trillian/ctfe/ct_server
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/google/certificate-transparency-go
+      tag: v${{package.version}}
+      expected-commit: 55b99fcbf9a9409ae11c1158fa6f0cb02d0290f5
+
+subpackages:
+  - range: components
+    name: "${{package.name}}-${{range.key}}"
+    pipeline:
+      - runs: |
+          CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o "${{range.key}}" ${{range.value}}
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{range.key}} ${{targets.subpkgdir}}/usr/bin/${{range.key}}
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: google/certificate-transparency-go
+    strip-prefix: v


### PR DESCRIPTION
This binary is used as part of the sigstore/scaffolding for standing up the ctlog.

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

