### PR TITLE
fix(ghostscript): CVE-2023-43115

### DIFF
--- a/ghostscript.yaml
+++ b/ghostscript.yaml
@@ -1,6 +1,6 @@
 package:
   name: ghostscript
-  version: 10.01.2
+  version: 10.02.0
   epoch: 0
   description: Interpreter for the PostScript language and for PDF
   copyright:
@@ -36,7 +36,7 @@ var-transforms:
 pipeline:
   - uses: fetch
     with:
-      expected-sha512: 11887850d440b8bbd8b83b8b58df8c743cf94be8fdbcfbda1a5fce55ce7c6a963d94b41a4ebcf1ba48f64f8af01e76dec789e2711212b1f7a32f98c42d75e0ff
+      expected-sha512: a854692887477455f967f95a3f7744fecffa075a6b58d72049ef7be02d3f0e5ee57fbb8420c2c16ec0b4b22e439f29103729f306e9d1fba86b407eb1de2c9aef
       uri: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs${{vars.mangled-package-version}}/ghostscript-${{package.version}}.tar.gz
 
   - uses: patch


### PR DESCRIPTION
Via just a package update. (TBD why this wasn't handled automatically.)

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

https://github.com/wolfi-dev/advisories/pull/280

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
