### PR TITLE
wavefront-proxy: update and fix package

### DIFF
--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -62,7 +62,7 @@ subpackages:
       runtime:
         - wavefront-proxy
 
-  - name: wavefront-proxy-oci-entrypoint
+  - name: wavefront-proxy-compat
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin/

--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -1,7 +1,6 @@
 package:
   name: wavefront-proxy
-  # When version is bumped, check if patches are still needed to address CVE-2023-34462
-  version: "13.2"
+  version: "13.3" # When version is bumped, check if patches are still needed to address CVE-2023-34462
   epoch: 0
   description: Wavefront Proxy Project
   copyright:
@@ -26,7 +25,7 @@ pipeline:
     with:
       repository: https://github.com/wavefronthq/wavefront-proxy
       tag: proxy-${{package.version}}
-      expected-commit: 3574d081d6e9351f45551afb5b837f4ac2a7a826
+      expected-commit: 35604d4a5b2f2d78dbc7cf5a760a11a5cceee909
 
   - uses: patch
     with:

--- a/wavefront-proxy/0001-PATCH-netty-version.patch
+++ b/wavefront-proxy/0001-PATCH-netty-version.patch
@@ -6,7 +6,7 @@ index 69cdfc50..07c9218c 100644
        <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-bom</artifactId>
--        <version>4.1.89.Final</version>
+-        <version>4.1.92.Final</version>
 +        <version>4.1.94.Final</version>
          <type>pom</type>
          <scope>import</scope>


### PR DESCRIPTION
I was hoping the latest version resolved a few CVEs, but it doesn't. 😢 

Meanwhile, we still needed to do some things to fix this package in other ways, so I went ahead and did them:

1. Fix (still needed) dependency patch so it applies cleanly.
2. Fix linter error by renaming `-oci-entrypoint` subpackage to `-compat`. This will necessitate a follow-up PR for the image: https://github.com/chainguard-images/images/pull/1507

This PR also obviates https://github.com/wolfi-dev/os/pull/6043.

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
