### PR TITLE
python: add seaborn package

### DIFF
--- a/py3-seaborn.yaml
+++ b/py3-seaborn.yaml
@@ -1,37 +1,39 @@
 # Generated from https://pypi.org/project/seaborn/
 package:
-    name: py3-seaborn
-    version: 0.13.0
-    epoch: 0
-    description: Statistical data visualization
-    copyright:
-        - license: BSD 3-Clause
-    dependencies:
-        runtime:
-            - py3-numpy
-            - py3-pandas
-            - py3-matplotlib
-            - python-3.11
+  name: py3-seaborn
+  version: 0.13.0
+  epoch: 0
+  description: Statistical data visualization
+  copyright:
+    - license: BSD 3-Clause
+  dependencies:
+    runtime:
+      - py3-numpy
+      - py3-pandas
+      - py3-matplotlib
+      - python3
+
 environment:
-    contents:
-        packages:
-            - ca-certificates-bundle
-            - wolfi-base
-            - build-base
-            - python-3.11
-            - py3.11-pip
+  contents:
+    packages:
+      - build-base
+      - ca-certificates-bundle
+      - py3-pip
+      - python3
+      - wolfi-base
+
 pipeline:
-    - uses: git-checkout
-      with:
-        repository: https://github.com/mwaskom/seaborn
-        expected-commit: c111a81dca54b208d53fa1f4bccb0cb83d2f2bbb
-        tag: v${{package.version}}
+  - uses: git-checkout
+    with:
+      repository: https://github.com/mwaskom/seaborn
+      expected-commit: c111a81dca54b208d53fa1f4bccb0cb83d2f2bbb
+      tag: v${{package.version}}
 
-    - name: Python build
-      runs: |
-        pip install . --prefix=/usr --root=${{targets.destdir}}
+  - name: Python build
+    runs: |
+      pip install . --prefix=/usr --root=${{targets.destdir}}
 
-    - uses: strip
+  - uses: strip
 
 update:
   enabled: true

--- a/py3-seaborn.yaml
+++ b/py3-seaborn.yaml
@@ -37,5 +37,6 @@ pipeline:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 7691
+  github:
+    identifier: mwaskom/seaborn
+    strip-prefix: v

--- a/py3-seaborn.yaml
+++ b/py3-seaborn.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/seaborn/
+package:
+    name: py3-seaborn
+    version: 0.13.0
+    epoch: 0
+    description: Statistical data visualization
+    copyright:
+        - license: BSD 3-Clause
+    dependencies:
+        runtime:
+            - py3-numpy
+            - py3-pandas
+            - py3-matplotlib
+            - python-3.11
+environment:
+    contents:
+        packages:
+            - ca-certificates-bundle
+            - wolfi-base
+            - build-base
+            - python-3.11
+            - py3.11-pip
+pipeline:
+    - uses: git-checkout
+      with:
+        repository: https://github.com/mwaskom/seaborn
+        expected-commit: c111a81dca54b208d53fa1f4bccb0cb83d2f2bbb
+        tag: v${{package.version}}
+
+    - name: Python build
+      runs: |
+        pip install . --prefix=/usr --root=${{targets.destdir}}
+
+    - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 7691

--- a/py3-seaborn.yaml
+++ b/py3-seaborn.yaml
@@ -8,7 +8,7 @@ package:
     - license: BSD 3-Clause
   dependencies:
     runtime:
-      - py3-numpy
+      - numpy
       - py3-pandas
       - py3-matplotlib
       - python3

--- a/py3-seaborn.yaml
+++ b/py3-seaborn.yaml
@@ -39,4 +39,5 @@ update:
   enabled: true
   github:
     identifier: mwaskom/seaborn
+    tag-filter: v
     strip-prefix: v


### PR DESCRIPTION
This PR adds the `seaborn` python package. This package is often used by data scientists and other data professionals. I think it could be useful for Wolfi users that want to build data science-related applications.

I should mention that this is my first time submitting a PR to Wolfi. So if it looks like I am confused, I am, or at least probably am. Helpful tips and constructive feedback encouraged. TY!

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates (I think so, at least. There are frequent updates.)
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`): I can't find one.