### PR TITLE
update dependencies on py3.11 to use py3 instead

### DIFF
--- a/checkov.yaml
+++ b/checkov.yaml
@@ -16,7 +16,7 @@ environment:
       - ca-certificates-bundle
       - python3
       - py3-setuptools
-      - py3.11-installer
+      - py3-installer
       - py3-gpep517
       - py3-wheel
       - py3-yaml

--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -18,8 +18,8 @@ environment:
       - build-base
       - python3
       - python3-dev
-      - py3.11-pip
-      - py3.11-setuptools
+      - py3-pip
+      - py3-setuptools
       - py3-build
       - py3-installer
       - go

--- a/mitmproxy.yaml
+++ b/mitmproxy.yaml
@@ -14,7 +14,7 @@ environment:
       - ca-certificates-bundle
       - python3
       - py3-setuptools
-      - py3.11-installer
+      - py3-installer
       - py3-gpep517
       - py3-wheel
 

--- a/py3-influxdb-client.yaml
+++ b/py3-influxdb-client.yaml
@@ -19,7 +19,7 @@ environment:
       - py3-pip
       - py3-certifi
       - py3-dateutil
-      - py3.11-setuptools
+      - py3-setuptools
       - py3-urllib3
 
 pipeline:

--- a/py3-optuna.yaml
+++ b/py3-optuna.yaml
@@ -26,7 +26,7 @@ environment:
       - build-base
       - python3
       - py3-setuptools
-      - py3.11-installer
+      - py3-installer
       - py3-gpep517
       - py3-wheel
 


### PR DESCRIPTION
Python 3.12 is coming out soon, and these packages pin to 3.11 specifically, seemingly unintentionally (many depended on py3.* deps otherwise)

When 3.12 comes out it will provide a higher python3 (and py3-pip, py3-installer, etc.), so these will be rebuilt with the 3.12 versions.

Please review this with a skeptical eye befitting my standing as a Python moron.