### PR TITLE
new package: python 3.12

### DIFF
--- a/py3.12-installer.yaml
+++ b/py3.12-installer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.12-installer
-  version: TODO
-  epoch: 1
+  version: 0.7.0
+  epoch: 0
   description: A library for installing Python wheels.
   copyright:
     - license: "MIT"
@@ -25,7 +25,7 @@ pipeline:
     with:
       repository: https://github.com/pypa/installer.git
       tag: ${{package.version}}
-      expected-commit: TODO
+      expected-commit: b1d39180f8548820d09ce992dfadff0a42242c48
 
   - name: Python Install
     runs: pip install . --prefix=/usr --root=${{targets.destdir}}

--- a/py3.12-installer.yaml
+++ b/py3.12-installer.yaml
@@ -6,8 +6,9 @@ package:
   copyright:
     - license: "MIT"
   dependencies:
-    provides:
-      - py3-installer=${{package.version}}
+    # TODO(jason): Uncomment when py-3.12 is default everywhere.
+    #provides:
+    #  - py3-installer=${{package.version}}
     runtime:
       - python-3.12
 

--- a/py3.12-installer.yaml
+++ b/py3.12-installer.yaml
@@ -1,0 +1,39 @@
+package:
+  name: py3.12-installer
+  version: TODO
+  epoch: 1
+  description: A library for installing Python wheels.
+  copyright:
+    - license: "MIT"
+  dependencies:
+    provides:
+      - py3-installer=${{package.version}}
+    runtime:
+      - python-3.12
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - py3.12-pip
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pypa/installer.git
+      tag: ${{package.version}}
+      expected-commit: TODO
+
+  - name: Python Install
+    runs: pip install . --prefix=/usr --root=${{targets.destdir}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pypa/installer
+    use-tag: true

--- a/py3.12-pip.yaml
+++ b/py3.12-pip.yaml
@@ -1,0 +1,45 @@
+package:
+  name: py3.12-pip
+  version: TODO
+  epoch: 0
+  description: The PyPA recommended tool for installing Python packages.
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - py3-pip=${{package.version}}
+    runtime:
+      - python-3.12
+      - py3.12-setuptools
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3.12
+      - py3.12-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pypa/pip
+      expected-commit: TODO
+      tag: ${{package.version}}
+
+  - name: Python Build
+    runs: python setup.py build
+
+  - name: Python Install
+    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+
+  - uses: strip
+
+update:
+  enabled: true
+  shared: true
+  github:
+    identifier: pypa/pip
+    use-tag: true

--- a/py3.12-pip.yaml
+++ b/py3.12-pip.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3.12-pip
-  version: TODO
+  version: 23.2.1
   epoch: 0
   description: The PyPA recommended tool for installing Python packages.
   copyright:
@@ -26,7 +26,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/pypa/pip
-      expected-commit: TODO
+      expected-commit: 4a79e65cb6aac84505ad92d272a29f0c3c1aedce
       tag: ${{package.version}}
 
   - name: Python Build

--- a/py3.12-pip.yaml
+++ b/py3.12-pip.yaml
@@ -6,8 +6,9 @@ package:
   copyright:
     - license: MIT
   dependencies:
-    provides:
-      - py3-pip=${{package.version}}
+    # TODO(jason): Uncomment when py-3.12 is default everywhere.
+    #provides:
+    #  - py3-pip=${{package.version}}
     runtime:
       - python-3.12
       - py3.12-setuptools

--- a/py3.12-setuptools.yaml
+++ b/py3.12-setuptools.yaml
@@ -6,8 +6,9 @@ package:
   copyright:
     - license: "MIT"
   dependencies:
-    provides:
-      - py3-setuptools=${{package.version}}
+    # TODO(jason): Uncomment when py-3.12 is default everywhere.
+    #provides:
+    #  - py3-setuptools=${{package.version}}
     runtime:
       - python-3.12
 

--- a/py3.12-setuptools.yaml
+++ b/py3.12-setuptools.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3.12-setuptools
-  version: TODO
+  version: 68.2.2
   epoch: 0
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: TODO
+      expected-sha256: 4ac1475276d2f1c48684874089fefcd83bd7162ddaafb81fac866ba0db282a87
       uri: https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-${{package.version}}.tar.gz
 
   - name: Python Build

--- a/py3.12-setuptools.yaml
+++ b/py3.12-setuptools.yaml
@@ -1,0 +1,39 @@
+package:
+  name: py3.12-setuptools
+  version: TODO
+  epoch: 0
+  description: Easily download, build, install, upgrade, and uninstall Python packages
+  copyright:
+    - license: "MIT"
+  dependencies:
+    provides:
+      - py3-setuptools=${{package.version}}
+    runtime:
+      - python-3.12
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3.12
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: TODO
+      uri: https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-${{package.version}}.tar.gz
+
+  - name: Python Build
+    runs: python setup.py build
+
+  - name: Python Install
+    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+
+update:
+  enabled: true
+  shared: true
+  release-monitor:
+    identifier: 4021

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -5,12 +5,12 @@ package:
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
-  # TODO(jason): Uncomment when we're ready for py-3.12 to be default everywhere.
-  #dependencies:
-  #  provides:
-  #    - python3=${{package.version}}
-  #    - python-3=${{package.version}}
 
+# TODO(jason): Uncomment when we're ready for py-3.12 to be default everywhere.
+#dependencies:
+#  provides:
+#    - python3=${{package.version}}
+#    - python-3=${{package.version}}
 environment:
   contents:
     packages:

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -100,7 +100,6 @@ subpackages:
 #  provides:
 #    - python3-dev=${{package.version}}
 #    - python-3-dev=${{package.version}}
-
 update:
   enabled: true
   shared: true

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,11 +1,14 @@
 package:
   name: python-3.12
-  # When bumping to a real non-prerelease you'll have to change the URL pattern on line 45
-  version: 3.12.0_rc3
+  version: 3.12.0
   epoch: 0
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
+  dependencies:
+    provides:
+      - python3=${{package.version}}
+      - python-3=${{package.version}}
 
 environment:
   contents:
@@ -29,8 +32,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://www.python.org/ftp/python/3.12.0/Python-3.12.0rc3.tar.xz
-      expected-sha256: 96397e891e98802b1d399dee3ceaeb9bcf0aa2566c8a7b1cce4d0196c277506a
+      uri: https://www.python.org/ftp/python/${{package.version}}/Python-${{package.version}}.tar.xz
+      expected-sha256: TODO
 
   - name: Force use of system libraries
     runs: |
@@ -90,10 +93,13 @@ subpackages:
           # pyconfig.h is needed at runtime... ugh.
           mkdir -p "${{targets.destdir}}"/usr/include/python3.12
           mv "${{targets.subpkgdir}}"/usr/include/python3.12/pyconfig.h "${{targets.destdir}}"/usr/include/python3.12
+    dependencies:
+      provides:
+        - python3-dev=${{package.version}}
+        - python-3-dev=${{package.version}}
 
 update:
   enabled: true
-  manual: true # auto update on pre release packages is not supported
   shared: true
   github:
     identifier: python/cpython

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -5,10 +5,11 @@ package:
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
-  dependencies:
-    provides:
-      - python3=${{package.version}}
-      - python-3=${{package.version}}
+  # TODO(jason): Uncomment when we're ready for py-3.12 to be default everywhere.
+  #dependencies:
+  #  provides:
+  #    - python3=${{package.version}}
+  #    - python-3=${{package.version}}
 
 environment:
   contents:

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -94,10 +94,12 @@ subpackages:
           # pyconfig.h is needed at runtime... ugh.
           mkdir -p "${{targets.destdir}}"/usr/include/python3.12
           mv "${{targets.subpkgdir}}"/usr/include/python3.12/pyconfig.h "${{targets.destdir}}"/usr/include/python3.12
-    dependencies:
-      provides:
-        - python3-dev=${{package.version}}
-        - python-3-dev=${{package.version}}
+
+# TODO(jason): Uncomment when we're ready for py-3.12 to be default everywhere.
+#dependencies:
+#  provides:
+#    - python3-dev=${{package.version}}
+#    - python-3-dev=${{package.version}}
 
 update:
   enabled: true

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -33,7 +33,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://www.python.org/ftp/python/${{package.version}}/Python-${{package.version}}.tar.xz
-      expected-sha256: TODO
+      expected-sha256: 795c34f44df45a0e9b9710c8c71c15c671871524cd412ca14def212e8ccb155d
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
Also updating pip, setuptools and installer to be built with 3.12.

This doesn't make these `provide` python-3 yet, since that will make it the default python version for future packages, and will need to be coordinated with python package rebuilds.