### PR TITLE
bump py3 deps to rebuild with 3.12

### DIFF
--- a/aom.yaml
+++ b/aom.yaml
@@ -5,7 +5,7 @@
 package:
   name: aom
   version: 3.7.0
-  epoch: 0
+  epoch: 1
   description: Alliance for Open Media (AOM) AV1 codec SDK
   copyright:
     - license: BSD-2-Clause AND custom

--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.7
   version: 2.7.14
-  epoch: 1
+  epoch: 2
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0

--- a/argo-cd-2.8.yaml
+++ b/argo-cd-2.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.8
   version: 2.8.4
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0

--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-workflows
   version: 3.4.11
-  epoch: 0
+  epoch: 1
   description: Workflow engine for Kubernetes.
   copyright:
     - license: Apache-2.0

--- a/asciidoc.yaml
+++ b/asciidoc.yaml
@@ -1,7 +1,7 @@
 package:
   name: asciidoc
   version: 10.2.0
-  epoch: 0
+  epoch: 1
   description: "Text based documentation"
   copyright:
     - license: "GPL-2.0-or-later and GPL-1.0-or-later"

--- a/aws-c-common.yaml
+++ b/aws-c-common.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-common
   version: 0.9.4
-  epoch: 0
+  epoch: 1
   description: Core c99 package for AWS SDK for C including cross-platform primitives, configuration, data structures, and error handling
   copyright:
     - license: Apache-2.0

--- a/aws-cli.yaml
+++ b/aws-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-cli
   version: 1.27.165
-  epoch: 0
+  epoch: 1
   description: "Universal Command Line Interface for Amazon Web Services"
   copyright:
     - license: Apache-2.0

--- a/bazel-3.yaml
+++ b/bazel-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: bazel-3
   version: 3.7.2
-  epoch: 0
+  epoch: 1
   description: Bazel is an open-source build and test tool
   copyright:
     - license: Apache-2.0

--- a/bazel-5.yaml
+++ b/bazel-5.yaml
@@ -1,7 +1,7 @@
 package:
   name: bazel-5
   version: 5.4.1
-  epoch: 1
+  epoch: 2
   description: Bazel is an open-source build and test tool
   copyright:
     - license: Apache-2.0

--- a/bazel-6.yaml
+++ b/bazel-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: bazel-6
   version: 6.3.2
-  epoch: 0
+  epoch: 1
   description: Bazel is an open-source build and test tool
   copyright:
     - license: Apache-2.0

--- a/bluez.yaml
+++ b/bluez.yaml
@@ -2,7 +2,7 @@
 package:
   name: bluez
   version: "5.68"
-  epoch: 0
+  epoch: 1
   description: Tools for the Bluetooth protocol stack
   copyright:
     - license: GPL-2.0-or-later AND BSD-2-Clause AND MIT

--- a/boost.yaml
+++ b/boost.yaml
@@ -1,7 +1,7 @@
 package:
   name: boost
   version: 1.83.0
-  epoch: 0
+  epoch: 1
   description: "A library for interacting with the Linux kernel's Berkeley Packet Filter (BPF) facility from user space"
   copyright:
     - license: "BSL-1.0"

--- a/botan.yaml
+++ b/botan.yaml
@@ -1,7 +1,7 @@
 package:
   name: botan
   version: 3.1.1
-  epoch: 0
+  epoch: 1
   description: "Cryptography Toolkit"
   copyright:
     - license: BSD-2-Clause

--- a/btrfs-progs.yaml
+++ b/btrfs-progs.yaml
@@ -1,7 +1,7 @@
 package:
   name: btrfs-progs
   version: 6.5.1
-  epoch: 0
+  epoch: 1
   description: BTRFS filesystem utilities
   copyright:
     - license: GPL-2.0-or-later

--- a/cassandra.yaml
+++ b/cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra
   version: 4.1.3
-  epoch: 4
+  epoch: 5
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0

--- a/checkov.yaml
+++ b/checkov.yaml
@@ -1,7 +1,7 @@
 package:
   name: checkov
   version: 2.3.354
-  epoch: 0
+  epoch: 1
   description: "static code and composition analysis tool for IaC"
   copyright:
     - license: MIT

--- a/clamav.yaml
+++ b/clamav.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav
   version: 1.2.0
-  epoch: 1
+  epoch: 2
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only WITH OpenSSL-Exception

--- a/clang-15.yaml
+++ b/clang-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-15
   version: 15.0.7
-  epoch: 2
+  epoch: 3
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0

--- a/clang-16.yaml
+++ b/clang-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-16
   version: 16.0.6
-  epoch: 1
+  epoch: 2
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0

--- a/clickhouse.yaml
+++ b/clickhouse.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse
   version: 23.6.2.18
-  epoch: 0
+  epoch: 1
   description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
   copyright:
     - license: Apache-2.0

--- a/conda-build.yaml
+++ b/conda-build.yaml
@@ -2,7 +2,7 @@
 package:
   name: conda-build
   version: 3.27.0
-  epoch: 0
+  epoch: 1
   description: tools for building conda packages
   copyright:
     - license: BSD 3-clause

--- a/conda.yaml
+++ b/conda.yaml
@@ -1,7 +1,7 @@
 package:
   name: conda
   version: 23.7.4
-  epoch: 0
+  epoch: 1
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause

--- a/couchdb.yaml
+++ b/couchdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: couchdb
   version: 3.3.2
-  epoch: 0
+  epoch: 1
   description: Seamless multi-master syncing database with an intuitive HTTP/JSON API, designed for reliability
   copyright:
     - license: Apache-2.0

--- a/cqlsh.yaml
+++ b/cqlsh.yaml
@@ -1,7 +1,7 @@
 package:
   name: cqlsh
   version: 4.1.2
-  epoch: 0
+  epoch: 1
   description: CQL shell for apache cassandra
   copyright:
     - license: Apache-2.0

--- a/crun.yaml
+++ b/crun.yaml
@@ -1,7 +1,7 @@
 package:
   name: crun
   version: 1.9.2
-  epoch: 0
+  epoch: 1
   description: "Fast and lightweight fully featured OCI runtime and C library for running containers"
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/cyrus-sasl.yaml
+++ b/cyrus-sasl.yaml
@@ -1,7 +1,7 @@
 package:
   name: cyrus-sasl
   version: 2.1.28
-  epoch: 0
+  epoch: 1
   description: "Cyrus Simple Authentication Service Layer (SASL)"
   copyright:
     - license: BSD-3-Clause

--- a/cython-0.yaml
+++ b/cython-0.yaml
@@ -1,7 +1,7 @@
 package:
   name: cython-0
   version: 0.29.36
-  epoch: 0
+  epoch: 1
   description: Cython is an optimising static compiler for both the Python & the extended Cython programming languages.
   copyright:
     - license: Apache-2.0

--- a/cython.yaml
+++ b/cython.yaml
@@ -1,7 +1,7 @@
 package:
   name: cython
   version: 3.0.2
-  epoch: 1
+  epoch: 2
   description: Cython is an optimising static compiler for both the Python & the extended Cython programming languages.
   copyright:
     - license: Apache-2.0

--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-gateway
   version: 2023.9.0
-  epoch: 0
+  epoch: 1
   description: "A multi-tenant server for securely deploying and managing Dask clusters."
   copyright:
     - license: BSD-3-Clause

--- a/deno.yaml
+++ b/deno.yaml
@@ -1,7 +1,7 @@
 package:
   name: deno
   version: 1.37.1
-  epoch: 0
+  epoch: 1
   description: "A modern runtime for JavaScript and TypeScript."
   copyright:
     - license: MIT

--- a/diffoscope.yaml
+++ b/diffoscope.yaml
@@ -1,7 +1,7 @@
 package:
   name: diffoscope
   version: "249"
-  epoch: 0
+  epoch: 1
   description: "In-depth comparison of files, archives, and directories."
   copyright:
     - license: GPL-3.0-or-later

--- a/dnssec-root.yaml
+++ b/dnssec-root.yaml
@@ -1,7 +1,7 @@
 package:
   name: dnssec-root
   version: "20190225"
-  epoch: 0
+  epoch: 1
   description: The DNSSEC root key(s)
   copyright:
     - license: Public-Domain

--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-6
   version: 6.0.122
-  epoch: 0
+  epoch: 1
   description: ".NET SDK, version 6"
   target-architecture:
     - all

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-7
   version: 7.0.111
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   target-architecture:
     - all

--- a/doxygen.yaml
+++ b/doxygen.yaml
@@ -1,7 +1,7 @@
 package:
   name: doxygen
   version: 1.9.8
-  epoch: 1
+  epoch: 2
   description: A documentation system for C++, C, Java, IDL and PHP
   copyright:
     - license: GPL-2.0-or-later

--- a/dstat.yaml
+++ b/dstat.yaml
@@ -1,7 +1,7 @@
 package:
   name: dstat
   version: 0.7.4
-  epoch: 0
+  epoch: 1
   description: A versatile resource statistics tool
   copyright:
     - license: GPL-2.0-only

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -1,7 +1,7 @@
 package:
   name: envoy
   version: 1.27.0
-  epoch: 0
+  epoch: 1
   description: Cloud-native high-performance edge/middle/service proxy
   copyright:
     - license: Apache-2.0

--- a/fatrace.yaml
+++ b/fatrace.yaml
@@ -2,7 +2,7 @@
 package:
   name: fatrace
   version: 0.17.0
-  epoch: 0
+  epoch: 1
   description: Report system wide file access events
   copyright:
     - license: GPL-3.0-or-later

--- a/flatbuffers.yaml
+++ b/flatbuffers.yaml
@@ -2,7 +2,7 @@
 package:
   name: flatbuffers
   version: 23.5.26
-  epoch: 1
+  epoch: 2
   description: The FlatBuffers serialization format
   copyright:
     - license: Apache 2.0

--- a/fontconfig.yaml
+++ b/fontconfig.yaml
@@ -1,7 +1,7 @@
 package:
   name: fontconfig
   version: 2.14.2
-  epoch: 2
+  epoch: 3
   description: Library for configuring and customizing font access
   copyright:
     - license: MIT

--- a/gdb.yaml
+++ b/gdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdb
   version: "13.2"
-  epoch: 1
+  epoch: 2
   description: The GNU Debugger
   target-architecture:
     - all

--- a/gdk-pixbuf.yaml
+++ b/gdk-pixbuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdk-pixbuf
   version: 2.42.10
-  epoch: 4
+  epoch: 5
   description: GTK+ image loading library
   copyright:
     - license: LGPL-2.1-or-later

--- a/ggshield.yaml
+++ b/ggshield.yaml
@@ -1,7 +1,7 @@
 package:
   name: ggshield
   version: 1.19.1
-  epoch: 0
+  epoch: 1
   description: Find and fix 360+ types of hardcoded secrets and 70+ types of infrastructure-as-code misconfigurations.
   copyright:
     - license: MIT

--- a/glib.yaml
+++ b/glib.yaml
@@ -1,7 +1,7 @@
 package:
   name: glib
   version: 2.78.0
-  epoch: 0
+  epoch: 1
   description: Common C routines used by Gtk+ and other libs
   copyright:
     - license: LGPL-2.1-or-later

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.38
-  epoch: 4
+  epoch: 5
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later

--- a/glslang.yaml
+++ b/glslang.yaml
@@ -2,7 +2,7 @@
 package:
   name: glslang
   version: 1.3.261.1
-  epoch: 1
+  epoch: 2
   description: Khronos reference front-end for GLSL, ESSL, and sample SPIR-V generator
   copyright:
     - license: BSD-3-Clause

--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobject-introspection
   version: 1.78.1
-  epoch: 0
+  epoch: 1
   description: Introspection system for GObject-based libraries
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT

--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: google-cloud-sdk
   version: 427.0.0
-  epoch: 1
+  epoch: 2
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0

--- a/graphviz.yaml
+++ b/graphviz.yaml
@@ -1,7 +1,7 @@
 package:
   name: graphviz
   version: 9.0.0
-  epoch: 0
+  epoch: 1
   description: Graph Visualization Tools
   copyright:
     - license: EPL-1.0

--- a/grpc.yaml
+++ b/grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc
   version: 1.57.0
-  epoch: 1
+  epoch: 2
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/gtest.yaml
+++ b/gtest.yaml
@@ -1,7 +1,7 @@
 package:
   name: gtest
   version: 1.14.0
-  epoch: 0
+  epoch: 1
   description: Google Test - C++ testing utility based on the xUnit framework (like JUnit)
   copyright:
     - license: BSD-3-Clause

--- a/gtk-doc.yaml
+++ b/gtk-doc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gtk-doc
   version: 1.33.2
-  epoch: 0
+  epoch: 1
   description: Documentation tool for public library API
   copyright:
     - license: GPL-2.0-or-later AND GFDL-1.1-or-later

--- a/heimdal.yaml
+++ b/heimdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: heimdal
   version: 7.8.0
-  epoch: 2
+  epoch: 3
   description: "Implementation of Kerberos 5"
   copyright:
     - license: BSD-3-Clause

--- a/htop.yaml
+++ b/htop.yaml
@@ -1,7 +1,7 @@
 package:
   name: htop
   version: 3.2.2
-  epoch: 0
+  epoch: 1
   description: "A cross-platform interactive process viewer."
   copyright:
     - license: GPL-2.0-or-later

--- a/httpie.yaml
+++ b/httpie.yaml
@@ -1,7 +1,7 @@
 package:
   name: httpie
   version: 3.2.2
-  epoch: 0
+  epoch: 1
   description: "HTTPie for Terminal — modern, user-friendly command-line HTTP client for the API era. JSON support, colors, sessions, downloads, plugins & more."
   copyright:
     - license: BSD-3-Clause

--- a/ingress-nginx-controller.yaml
+++ b/ingress-nginx-controller.yaml
@@ -2,7 +2,7 @@
 package:
   name: ingress-nginx-controller
   version: 1.9.0
-  epoch: 0
+  epoch: 1
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0

--- a/iso-codes.yaml
+++ b/iso-codes.yaml
@@ -1,7 +1,7 @@
 package:
   name: iso-codes
   version: 4.15.0
-  epoch: 1
+  epoch: 2
   description: ISO codes and their translations
   copyright:
     - license: LGPL-2.1-or-later

--- a/istio-envoy-1.18.yaml
+++ b/istio-envoy-1.18.yaml
@@ -2,7 +2,7 @@ package:
   name: istio-envoy-1.18
   # On the next version bump, please remove the make 4.4 patch.
   version: 1.18.3
-  epoch: 1
+  epoch: 2
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
   copyright:
     - license: Apache-2.0

--- a/istio-envoy-1.19.yaml
+++ b/istio-envoy-1.19.yaml
@@ -2,7 +2,7 @@ package:
   name: istio-envoy-1.19
   # On the next version bump, please remove the make 4.4 patch.
   version: 1.19.0
-  epoch: 1
+  epoch: 2
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
   copyright:
     - license: Apache-2.0

--- a/itstool.yaml
+++ b/itstool.yaml
@@ -1,7 +1,7 @@
 package:
   name: itstool
   version: 2.0.7
-  epoch: 0
+  epoch: 1
   description: ITS-based XML translation tool
   copyright:
     - license: GPL-3.0-or-later

--- a/jack.yaml
+++ b/jack.yaml
@@ -2,7 +2,7 @@
 package:
   name: jack
   version: 1.9.22
-  epoch: 0
+  epoch: 1
   description: The Jack Audio Connection Kit
   copyright:
     - license: GPL-2.0-or-later

--- a/jo.yaml
+++ b/jo.yaml
@@ -1,7 +1,7 @@
 package:
   name: jo
   version: 1.9
-  epoch: 0
+  epoch: 1
   description: "JSON output from a shell"
   copyright:
     - license: "GPL-2.0-or-later and GPL-1.0-or-later"

--- a/jwt-tool.yaml
+++ b/jwt-tool.yaml
@@ -1,7 +1,7 @@
 package:
   name: jwt-tool
   version: 2.2.6
-  epoch: 0
+  epoch: 1
   description: "toolkit for validating, forging, scanning and tampering JWTs"
   copyright:
     - license: GPL-3.0

--- a/k8s-sidecar.yaml
+++ b/k8s-sidecar.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8s-sidecar
   version: 1.25.1
-  epoch: 1
+  epoch: 2
   description: "container intended to run inside a kubernetes cluster to collect config maps with a specified label and store the included files in a local folder"
   copyright:
     - license: MIT

--- a/kdash.yaml
+++ b/kdash.yaml
@@ -1,7 +1,7 @@
 package:
   name: kdash
   version: 0.4.3
-  epoch: 0
+  epoch: 1
   description: "A simple and fast dashboard for Kubernetes"
   copyright:
     - license: MIT

--- a/kube-downscaler.yaml
+++ b/kube-downscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-downscaler
   version: 23.2.0
-  epoch: 5
+  epoch: 6
   description: Scale down Kubernetes deployments after work hours
   copyright:
     - license: GPL-3.0-or-later

--- a/kubeflow-jupyter-web-app.yaml
+++ b/kubeflow-jupyter-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-jupyter-web-app
   version: 1.7.0
-  epoch: 4
+  epoch: 5
   description: Kubeflow jupyter web app component
   copyright:
     - license: Apache-2.0

--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -1,6 +1,6 @@
 package:
   name: kubeflow-katib
-  epoch: 3
+  epoch: 4
   version: 0.15.0
   description: Kubeflow Katib services
   copyright:

--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: 2.1.3
-  epoch: 5
+  epoch: 6
   description: Machine Learning Pipelines for Kubeflow
   copyright:
     - license: Apache-2.0

--- a/kubeflow-volumes-web-app.yaml
+++ b/kubeflow-volumes-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-volumes-web-app
   version: 1.7.0
-  epoch: 5
+  epoch: 6
   description: Kubeflow volumes web app component
   copyright:
     - license: Apache-2.0

--- a/kubescape.yaml
+++ b/kubescape.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubescape
   version: 2.9.1
-  epoch: 1
+  epoch: 2
   description: "Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/libapr.yaml
+++ b/libapr.yaml
@@ -1,7 +1,7 @@
 package:
   name: libapr
   version: 1.7.4
-  epoch: 1
+  epoch: 2
   description: "Apache Portable Runtime Library (APR)"
   copyright:
     - license: Apache-2.0

--- a/libevent.yaml
+++ b/libevent.yaml
@@ -1,7 +1,7 @@
 package:
   name: libevent
   version: 2.1.12
-  epoch: 2
+  epoch: 3
   description: An event notification library
   copyright:
     - license: BSD-3-Clause

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpulsar
   version: 3.3.0
-  epoch: 0
+  epoch: 1
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0

--- a/libseccomp.yaml
+++ b/libseccomp.yaml
@@ -1,7 +1,7 @@
 package:
   name: libseccomp
   version: 2.5.4
-  epoch: 0
+  epoch: 1
   description: interface to the Linux Kernel's syscall filtering mechanism
   copyright:
     - license: LGPL-2.1-or-later

--- a/libsndfile.yaml
+++ b/libsndfile.yaml
@@ -2,7 +2,7 @@
 package:
   name: libsndfile
   version: 1.2.0
-  epoch: 0
+  epoch: 1
   description: C library for reading and writing files containing sampled sound
   copyright:
     - license: LGPL-2.1-or-later

--- a/libxcb.yaml
+++ b/libxcb.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcb
   version: "1.16"
-  epoch: 0
+  epoch: 1
   description: X11 client-side library
   copyright:
     - license: MIT

--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxml2
   version: 2.11.5
-  epoch: 0
+  epoch: 1
   description: XML parsing library, version 2
   copyright:
     - license: MIT

--- a/llvm-libcxx-16.yaml
+++ b/llvm-libcxx-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-libcxx-16
   version: 16.0.6
-  epoch: 1
+  epoch: 2
   description: The LLVM libc++ libraries
   copyright:
     - license: Apache-2.0

--- a/llvm15.yaml
+++ b/llvm15.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm15
   version: 15.0.7
-  epoch: 5
+  epoch: 6
   description: "low-level virtual machine - core frameworks"
   copyright:
     - license: Apache-2.0

--- a/llvm16.yaml
+++ b/llvm16.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm16
   version: 16.0.6
-  epoch: 1
+  epoch: 2
   description: "low-level virtual machine - core frameworks"
   copyright:
     - license: Apache-2.0

--- a/lttng-ust.yaml
+++ b/lttng-ust.yaml
@@ -1,7 +1,7 @@
 package:
   name: lttng-ust
   version: 2.13.6
-  epoch: 0
+  epoch: 1
   description: LTTng 2.0 Userspace Tracer
   copyright:
     - license: LGPL-2.1-or-later

--- a/mdbook.yaml
+++ b/mdbook.yaml
@@ -1,7 +1,7 @@
 package:
   name: mdbook
   version: 0.4.35
-  epoch: 0
+  epoch: 1
   description: "Create book from markdown files. Like Gitbook but implemented in Rust."
   copyright:
     - license: MPL-2.0

--- a/mercurial.yaml
+++ b/mercurial.yaml
@@ -1,7 +1,7 @@
 package:
   name: mercurial
   version: 6.5.2
-  epoch: 0
+  epoch: 1
   description: "Scalable distributed SCM tool"
   copyright:
     - license: GPL-2.0-or-later

--- a/mesa.yaml
+++ b/mesa.yaml
@@ -1,7 +1,7 @@
 package:
   name: mesa
   version: 23.1.4
-  epoch: 1
+  epoch: 2
   description: Mesa DRI OpenGL library
   copyright:
     - license: MIT AND SGI-B-2.0 AND BSL-1.0

--- a/meson.yaml
+++ b/meson.yaml
@@ -1,7 +1,7 @@
 package:
   name: meson
   version: 1.2.2
-  epoch: 0
+  epoch: 1
   description: Fast and user friendly build system
   copyright:
     - license: Apache-2.0

--- a/mitmproxy.yaml
+++ b/mitmproxy.yaml
@@ -2,7 +2,7 @@
 package:
   name: mitmproxy
   version: 9.0.1
-  epoch: 0
+  epoch: 1
   description: Interactive TLS-capable intercepting HTTP proxy
   copyright:
     - license: MIT

--- a/mozjs91.yaml
+++ b/mozjs91.yaml
@@ -1,7 +1,7 @@
 package:
   name: mozjs91
   version: 91.13.0
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: MPL-2.0

--- a/mycli.yaml
+++ b/mycli.yaml
@@ -1,7 +1,7 @@
 package:
   name: mycli
   version: 1.27.0
-  epoch: 0
+  epoch: 1
   description: "static code and composition analysis tool for IaC"
   copyright:
     - license: BSD-3-Clause

--- a/nfs-utils.yaml
+++ b/nfs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: nfs-utils
   version: 2.6.3
-  epoch: 0
+  epoch: 1
   description: kernel-mode NFS
   copyright:
     - license: GPL-2.0-only

--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-16
   version: 16.20.2
-  epoch: 1
+  epoch: 2
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     runtime:

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-18
   version: 18.18.0 # When bumping this, also bump the provides below!
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT

--- a/nodejs-19.yaml
+++ b/nodejs-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-19
   version: 19.9.0
-  epoch: 3
+  epoch: 4
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     runtime:

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-20
   version: 20.8.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     runtime:

--- a/numpy.yaml
+++ b/numpy.yaml
@@ -1,7 +1,7 @@
 package:
   name: numpy
   version: 1.26.0
-  epoch: 0
+  epoch: 1
   description: "The fundamental package for scientific computing with Python."
   copyright:
     - license: BSD-3-Clause

--- a/openmp-16.yaml
+++ b/openmp-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: openmp-16
   version: 16.0.6
-  epoch: 0
+  epoch: 1
   description: "LLVM OpenMP library"
   copyright:
     - license: Apache-2.0

--- a/openvpn.yaml
+++ b/openvpn.yaml
@@ -1,7 +1,7 @@
 package:
   name: openvpn
   version: 2.6.6
-  epoch: 0
+  epoch: 1
   description: Robust, and highly configurable VPN (Virtual Private Network)
   copyright:
     - license: GPL-2.0

--- a/pnpm.yaml
+++ b/pnpm.yaml
@@ -1,7 +1,7 @@
 package:
   name: pnpm
   version: 8.8.0
-  epoch: 0
+  epoch: 1
   description: "Fast, disk space efficient package manager"
   copyright:
     - license: MIT

--- a/poetry.yaml
+++ b/poetry.yaml
@@ -1,7 +1,7 @@
 package:
   name: poetry
   version: 1.6.1
-  epoch: 1
+  epoch: 2
   description: "Python packaging and dependency management made easy"
   copyright:
     - license: MIT

--- a/proxysql.yaml
+++ b/proxysql.yaml
@@ -1,7 +1,7 @@
 package:
   name: proxysql
   version: 2.5.5
-  epoch: 0
+  epoch: 1
   description: High-performance MySQL proxy with a GPL license
   copyright:
     - license: GPL-3.0

--- a/pstack.yaml
+++ b/pstack.yaml
@@ -1,7 +1,7 @@
 package:
   name: pstack
   version: 2.4.4
-  epoch: 0
+  epoch: 1
   description: "Print stack traces from running processes, or core files."
   copyright:
     - license: BSD-2-Clause

--- a/pulumi.yaml
+++ b/pulumi.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi
   version: 3.86.0
-  epoch: 0
+  epoch: 1
   description: Infrastructure as Code in any programming language
   copyright:
     - license: Apache-2.0

--- a/py3-Logbook.yaml
+++ b/py3-Logbook.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-Logbook
   version: 1.6.0
-  epoch: 0
+  epoch: 1
   description: A logging replacement for Python
   copyright:
     - license: BSD-3-Clause

--- a/py3-SecretStorage.yaml
+++ b/py3-SecretStorage.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-SecretStorage
   version: 3.3.3
-  epoch: 0
+  epoch: 1
   description: Python bindings to FreeDesktop.org Secret Service API
   copyright:
     - license: BSD 3-Clause License

--- a/py3-absl-py.yaml
+++ b/py3-absl-py.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-absl-py
   version: 2.0.0
-  epoch: 0
+  epoch: 1
   description: Abseil Python Common Libraries, see https://github.com/abseil/abseil-py.
   copyright:
     - license: Apache 2.0

--- a/py3-agate.yaml
+++ b/py3-agate.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-agate
   version: 1.7.1
-  epoch: 0
+  epoch: 1
   description: A data analysis library that is optimized for humans instead of machines.
   copyright:
     - license: MIT

--- a/py3-aiohttp.yaml
+++ b/py3-aiohttp.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-aiohttp
   version: 3.8.5
-  epoch: 0
+  epoch: 1
   description: Async http client/server framework (asyncio)
   copyright:
     - license: Apache 2

--- a/py3-aiosignal.yaml
+++ b/py3-aiosignal.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-aiosignal
   version: 1.3.1
-  epoch: 0
+  epoch: 1
   description: 'aiosignal: a list of registered asynchronous callbacks'
   copyright:
     - license: Apache 2.0

--- a/py3-alabaster.yaml
+++ b/py3-alabaster.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-alabaster
   version: 0.7.13
-  epoch: 0
+  epoch: 1
   description: A configurable sidebar-enabled Sphinx theme
   copyright:
     - license: BSD-3-Clause

--- a/py3-alembic.yaml
+++ b/py3-alembic.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-alembic
   version: 1.11.3
-  epoch: 1
+  epoch: 2
   description: A database migration tool for SQLAlchemy.
   copyright:
     - license: MIT License

--- a/py3-annotated-types.yaml
+++ b/py3-annotated-types.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-annotated-types
   version: 0.5.0
-  epoch: 1
+  epoch: 2
   description: Reusable constraint types to use with typing.Annotated
   copyright:
     - license: MIT

--- a/py3-anyio.yaml
+++ b/py3-anyio.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-anyio
   version: 4.0.0
-  epoch: 0
+  epoch: 1
   description: High level compatibility layer for multiple asynchronous event loop implementations
   copyright:
     - license: MIT

--- a/py3-appdirs.yaml
+++ b/py3-appdirs.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-appdirs
   version: 1.4.4
-  epoch: 3
+  epoch: 4
   description: "a small python module for appdir support"
   copyright:
     - license: MIT

--- a/py3-appnope.yaml
+++ b/py3-appnope.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-appnope
   version: 0.1.3
-  epoch: 0
+  epoch: 1
   description: Disable App Nap on macOS >= 10.9
   copyright:
     - license: BSD

--- a/py3-asn1-modules.yaml
+++ b/py3-asn1-modules.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-asn1-modules
   version: 0.3.0
-  epoch: 0
+  epoch: 1
   description: A collection of ASN.1-based protocols modules
   copyright:
     - license: BSD

--- a/py3-asn1.yaml
+++ b/py3-asn1.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-asn1
   version: 0.4.8
-  epoch: 1
+  epoch: 2
   description: "Python3 ASN1 library"
   copyright:
     - license: BSD-2-Clause

--- a/py3-asttokens.yaml
+++ b/py3-asttokens.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-asttokens
   version: 2.4.0
-  epoch: 0
+  epoch: 1
   description: Annotate AST trees with source code positions
   copyright:
     - license: Apache 2.0

--- a/py3-astunparse.yaml
+++ b/py3-astunparse.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-astunparse
   version: 1.6.3
-  epoch: 0
+  epoch: 1
   description: An AST unparser for Python
   copyright:
     - license: BSD

--- a/py3-async-lru.yaml
+++ b/py3-async-lru.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-async-lru
   version: 2.0.4
-  epoch: 0
+  epoch: 1
   description: Simple LRU cache for asyncio
   copyright:
     - license: MIT License

--- a/py3-async-timeout.yaml
+++ b/py3-async-timeout.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-async-timeout
   version: 4.0.3
-  epoch: 0
+  epoch: 1
   description: Timeout context manager for asyncio programs
   copyright:
     - license: Apache 2

--- a/py3-asynctest.yaml
+++ b/py3-asynctest.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-asynctest
   version: 0.13.0
-  epoch: 0
+  epoch: 1
   description: Enhance the standard unittest package with features for testing asyncio libraries
   copyright:
     - license: Apache 2

--- a/py3-attrs.yaml
+++ b/py3-attrs.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-attrs
   version: 23.1.0
-  epoch: 0
+  epoch: 1
   description: Classes Without Boilerplate
   copyright:
     - license: MIT

--- a/py3-avro-python3.yaml
+++ b/py3-avro-python3.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-avro-python3
   version: 1.10.2
-  epoch: 0
+  epoch: 1
   description: Avro is a serialization and RPC framework.
   copyright:
     - license: Apache License 2.0

--- a/py3-awscrt.yaml
+++ b/py3-awscrt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-awscrt
   version: 0.19.2
-  epoch: 0
+  epoch: 1
   description: "Python bindings for the AWS Common Runtime"
   copyright:
     - license: Apache-2.0

--- a/py3-babel.yaml
+++ b/py3-babel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-babel
   version: 2.12.1
-  epoch: 0
+  epoch: 1
   description: Python3 i18n tool
   copyright:
     - license: "BSD-3-Clause"

--- a/py3-backcall.yaml
+++ b/py3-backcall.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-backcall
   version: 0.2.0
-  epoch: 0
+  epoch: 1
   description: Specifications for callback functions passed in to an API
   copyright:
     - license: "BSD 3-Clause"

--- a/py3-beautifulsoup4.yaml
+++ b/py3-beautifulsoup4.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-beautifulsoup4
   version: 4.12.2
-  epoch: 0
+  epoch: 1
   description: Screen-scraping library
   copyright:
     - license: "MIT License"

--- a/py3-beniget.yaml
+++ b/py3-beniget.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-beniget
   version: 0.4.1
-  epoch: 0
+  epoch: 1
   description: Extract semantic information about static Python code
   copyright:
     - license: BSD 3-Clause

--- a/py3-bleach.yaml
+++ b/py3-bleach.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-bleach
   version: 6.0.0
-  epoch: 0
+  epoch: 1
   description: An easy safelist-based HTML-sanitizing tool.
   copyright:
     - license: Apache Software License

--- a/py3-blinker.yaml
+++ b/py3-blinker.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-blinker
   version: 1.6.2
-  epoch: 0
+  epoch: 1
   description: Fast, simple object-to-object and broadcast signaling
   copyright:
     - license: MIT License

--- a/py3-bokeh.yaml
+++ b/py3-bokeh.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-bokeh
   version: 3.2.2
-  epoch: 0
+  epoch: 1
   description: Interactive plots and applications in the browser from Python
   copyright:
     - license: 'BSD 3-Clause License'

--- a/py3-boltons.yaml
+++ b/py3-boltons.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-boltons
   version: 23.0.0
-  epoch: 0
+  epoch: 1
   description: "When they're not builtins, they're boltons."
   copyright:
     - license: BSD-3-Clause

--- a/py3-botocore.yaml
+++ b/py3-botocore.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-botocore
   version: 1.31.57
-  epoch: 0
+  epoch: 1
   description: "The low-level, core functionality of Boto3"
   copyright:
     - license: Apache-2.0

--- a/py3-bracex.yaml
+++ b/py3-bracex.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-bracex
   version: "2.4"
-  epoch: 0
+  epoch: 1
   description: "Bash style brace expander."
   copyright:
     - license: MIT

--- a/py3-build.yaml
+++ b/py3-build.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-build
   version: 1.0.3
-  epoch: 0
+  epoch: 1
   description: A simple, correct Python build frontend
   copyright:
     - license: MIT

--- a/py3-cached-property.yaml
+++ b/py3-cached-property.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cached-property
   version: 1.5.2
-  epoch: 0
+  epoch: 1
   description: A decorator for caching properties in classes.
   copyright:
     - license: BSD

--- a/py3-cachetools.yaml
+++ b/py3-cachetools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cachetools
   version: 5.3.1
-  epoch: 0
+  epoch: 1
   description: Extensible memoizing collections and decorators
   copyright:
     - license: MIT

--- a/py3-cairo.yaml
+++ b/py3-cairo.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cairo
   version: 1.25.0
-  epoch: 0
+  epoch: 1
   description: Python3 bindings for the cairo graphics library
   copyright:
     - license: LGPL-2.0-or-later

--- a/py3-certifi.yaml
+++ b/py3-certifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-certifi
   version: 2023.07.22
-  epoch: 1
+  epoch: 2
   description: "Python3 package for providing Mozilla's CA Bundle"
   copyright:
     - license: MPL-2.0

--- a/py3-cffi.yaml
+++ b/py3-cffi.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cffi
   version: 1.15.1
-  epoch: 0
+  epoch: 1
   description: Foreign Function Interface for Python calling C code.
   copyright:
     - license: MIT

--- a/py3-charset-normalizer.yaml
+++ b/py3-charset-normalizer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-charset-normalizer
   version: 3.3.0
-  epoch: 0
+  epoch: 1
   description: "offers you an alternative to Universal Charset Encoding Detector, also known as Chardet"
   copyright:
     - license: Apache-2.0

--- a/py3-cli-helpers.yaml
+++ b/py3-cli-helpers.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cli-helpers
   version: 2.3.0
-  epoch: 0
+  epoch: 1
   description: Helpers for building command-line apps
   copyright:
     - license: BSD License

--- a/py3-click-option-group.yaml
+++ b/py3-click-option-group.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-click-option-group
   version: 0.5.6
-  epoch: 0
+  epoch: 1
   description: "Option groups missing in Click."
   copyright:
     - license: BSD-3-Clause

--- a/py3-click.yaml
+++ b/py3-click.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-click
   version: 8.1.7
-  epoch: 0
+  epoch: 1
   description: Composable command line interface toolkit
   copyright:
     - license: BSD-3-Clause

--- a/py3-cloudpickle.yaml
+++ b/py3-cloudpickle.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cloudpickle
   version: 2.2.1
-  epoch: 0
+  epoch: 1
   description: Extended pickling support for Python objects
   copyright:
     - license: BSD 3-Clause License

--- a/py3-cmaes.yaml
+++ b/py3-cmaes.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cmaes
   version: 0.10.0
-  epoch: 1
+  epoch: 2
   description: Lightweight Covariance Matrix Adaptation Evolution Strategy (CMA-ES) implementation for Python 3.
   copyright:
     - license: MIT License

--- a/py3-colorama.yaml
+++ b/py3-colorama.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-colorama
   version: 0.4.6
-  epoch: 1
+  epoch: 2
   description: "Simple cross-platform colored terminal text"
   copyright:
     - license: BSD-3-Clause

--- a/py3-colorlog.yaml
+++ b/py3-colorlog.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-colorlog
   version: 6.7.0
-  epoch: 1
+  epoch: 2
   description: Add colours to the output of Python's logging module.
   copyright:
     - license: MIT License

--- a/py3-comm.yaml
+++ b/py3-comm.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-comm
   version: 0.1.4
-  epoch: 0
+  epoch: 1
   description: Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc.
   copyright:
     - license: 'BSD 3-Clause'

--- a/py3-conda-package-handling.yaml
+++ b/py3-conda-package-handling.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-conda-package-handling
   version: 2.2.0
-  epoch: 1
+  epoch: 2
   description: Create and extract conda packages of various formats.
   copyright:
     - license: "BSD-3-Clause"

--- a/py3-conda-package-streaming.yaml
+++ b/py3-conda-package-streaming.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-conda-package-streaming
   version: 0.9.0
-  epoch: 1
+  epoch: 2
   description: An efficient library to read from new and old format .conda and .tar.bz2 conda packages.
   copyright:
     - license: "BSD-3-Clause"

--- a/py3-configobj.yaml
+++ b/py3-configobj.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-configobj
   version: 5.0.8
-  epoch: 0
+  epoch: 1
   description: Config file reading, writing and validation.
   copyright:
     - license: BSD (2 clause)

--- a/py3-contextlib2.yaml
+++ b/py3-contextlib2.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-contextlib2
   version: 21.6.0
-  epoch: 2
+  epoch: 3
   description: "backports of the contextlib module from newer versions of python"
   copyright:
     - license: PSF-2.0 AND Apache-2.0

--- a/py3-contourpy.yaml
+++ b/py3-contourpy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-contourpy
   version: 1.1.1
-  epoch: 0
+  epoch: 1
   description: Python library for calculating contours of 2D quadrilateral grids
   copyright:
     - license: BSD-3-Clause

--- a/py3-cppy.yaml
+++ b/py3-cppy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cppy
   version: 1.2.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-3-Clause
   dependencies:

--- a/py3-crcmod.yaml
+++ b/py3-crcmod.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-crcmod
   version: "1.7"
-  epoch: 0
+  epoch: 1
   description: Cyclic Redundancy Check (CRC) implementation in Python
   copyright:
     - license: 'MIT'

--- a/py3-cryptography.yaml
+++ b/py3-cryptography.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cryptography
   version: 41.0.4
-  epoch: 0
+  epoch: 1
   description: cryptography is a package which provides cryptographic recipes and primitives to Python developers.
   copyright:
     - license: Apache-2.0 OR BSD-3-Clause

--- a/py3-cycler.yaml
+++ b/py3-cycler.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cycler
   version: 0.12.0
-  epoch: 0
+  epoch: 1
   description: Composable style cycles
   copyright:
     - license: BSD-3-Clause

--- a/py3-dateutil.yaml
+++ b/py3-dateutil.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-dateutil
   version: 2.8.2
-  epoch: 3
+  epoch: 4
   description: "Python3 extensions for datetime module"
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause

--- a/py3-debugpy.yaml
+++ b/py3-debugpy.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-debugpy
   version: 1.8.0
-  epoch: 0
+  epoch: 1
   description: An implementation of the Debug Adapter Protocol for Python
   copyright:
     - license: MIT

--- a/py3-decorator.yaml
+++ b/py3-decorator.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-decorator
   version: 5.1.1
-  epoch: 0
+  epoch: 1
   description: Decorators for Humans
   copyright:
     - license: new BSD License

--- a/py3-defusedxml.yaml
+++ b/py3-defusedxml.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-defusedxml
   version: 0.7.1
-  epoch: 0
+  epoch: 1
   description: "XML bomb protection for Python stdlib modules"
   copyright:
     - license: PSF-2.0

--- a/py3-dill.yaml
+++ b/py3-dill.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-dill
   version: 0.3.7
-  epoch: 0
+  epoch: 1
   description: serialize all of Python
   copyright:
     - license: BSD-3-Clause

--- a/py3-distlib.yaml
+++ b/py3-distlib.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-distlib
   version: 0.3.7
-  epoch: 1
+  epoch: 2
   description: Distribution utilities
   copyright:
     - license: PSF-2.0

--- a/py3-distro.yaml
+++ b/py3-distro.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-distro
   version: 1.8.0
-  epoch: 0
+  epoch: 1
   description: "A Linux OS platform information API"
   copyright:
     - license: Apache-2.0

--- a/py3-dnspython.yaml
+++ b/py3-dnspython.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-dnspython
   version: 2.4.2
-  epoch: 0
+  epoch: 1
   description: DNS toolkit
   copyright:
     - license: ISC

--- a/py3-docopt.yaml
+++ b/py3-docopt.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-docopt
   version: 0.6.2
-  epoch: 0
+  epoch: 1
   description: Pythonic argument parser, that will make you smile
   copyright:
     - license: MIT

--- a/py3-docutils.yaml
+++ b/py3-docutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-docutils
   version: 0.20.1
-  epoch: 0
+  epoch: 1
   description: "Documentation Utilities for Python3"
   copyright:
     - license: BSD-2-Clause AND GPL-3.0-or-later AND Python-2.0

--- a/py3-editables.yaml
+++ b/py3-editables.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-editables
   version: "0.5"
-  epoch: 1
+  epoch: 2
   description: Editable installations
   copyright:
     - license: "MIT"

--- a/py3-entrypoints.yaml
+++ b/py3-entrypoints.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-entrypoints
   version: "0.4"
-  epoch: 0
+  epoch: 1
   description: Discover and load entry points from installed packages.
   copyright:
     - license: "MIT License"

--- a/py3-exceptiongroup.yaml
+++ b/py3-exceptiongroup.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-exceptiongroup
   version: 1.1.3
-  epoch: 1
+  epoch: 2
   description: Backport of PEP 654 (exception groups)
   copyright:
     - license: "MIT"

--- a/py3-executing.yaml
+++ b/py3-executing.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-executing
   version: 1.2.0
-  epoch: 0
+  epoch: 1
   description: Get the currently executing AST node of a frame, and other information
   copyright:
     - license: MIT

--- a/py3-face.yaml
+++ b/py3-face.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-face
   version: 22.0.0
-  epoch: 0
+  epoch: 1
   description: "A command-line application framework (and CLI parser). Friendly for users, full-featured for developers."
   copyright:
     - license: BSD-3-Clause

--- a/py3-fastavro.yaml
+++ b/py3-fastavro.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-fastavro
   version: 1.8.3
-  epoch: 0
+  epoch: 1
   description: Fast read/write of AVRO files
   copyright:
     - license: MIT

--- a/py3-fasteners.yaml
+++ b/py3-fasteners.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-fasteners
   version: "0.19"
-  epoch: 0
+  epoch: 1
   description: A python package that provides useful locks
   copyright:
     - license: Apache-2.0

--- a/py3-fastjsonschema.yaml
+++ b/py3-fastjsonschema.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-fastjsonschema
   version: 2.18.1
-  epoch: 0
+  epoch: 1
   description: Fastest Python implementation of JSON schema
   copyright:
     - license: BSD

--- a/py3-filelock.yaml
+++ b/py3-filelock.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-filelock
   version: 3.12.4
-  epoch: 0
+  epoch: 1
   description: A platform independent file lock.
   copyright:
     - license: Unlicense

--- a/py3-flit-core.yaml
+++ b/py3-flit-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-flit-core
   version: 3.9.0
-  epoch: 0
+  epoch: 1
   description: "simple packaging tool for simple packages (core)"
   copyright:
     - license: BSD-3-Clause

--- a/py3-fonttools.yaml
+++ b/py3-fonttools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-fonttools
   version: 4.43.0
-  epoch: 0
+  epoch: 1
   description: Tools to manipulate font files
   copyright:
     - license: MIT

--- a/py3-forestci.yaml
+++ b/py3-forestci.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-forestci
   version: "0.6"
-  epoch: 1
+  epoch: 2
   description: 'forestci: confidence intervals for scikit-learn forest algorithms'
   copyright:
     - license: MIT

--- a/py3-frozenlist.yaml
+++ b/py3-frozenlist.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-frozenlist
   version: 1.4.0
-  epoch: 0
+  epoch: 1
   description: A list-like structure which implements collections.abc.MutableSequence
   copyright:
     - license: Apache 2

--- a/py3-fsspec.yaml
+++ b/py3-fsspec.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-fsspec
   version: 2023.9.1
-  epoch: 0
+  epoch: 1
   description: File-system specification
   copyright:
     - license: BSD

--- a/py3-future.yaml
+++ b/py3-future.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-future
   version: 0.18.3
-  epoch: 0
+  epoch: 1
   description: Clean single-source support for Python 3 and 2
   copyright:
     - license: MIT

--- a/py3-gast.yaml
+++ b/py3-gast.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-gast
   version: 0.5.4
-  epoch: 0
+  epoch: 1
   description: Python AST that abstracts the underlying Python version
   copyright:
     - license: BSD 3-Clause

--- a/py3-gcovr.yaml
+++ b/py3-gcovr.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-gcovr
   version: "6.0"
-  epoch: 0
+  epoch: 1
   description: Generate C/C++ code coverage reports with gcov
   copyright:
     - license: BSD-3-Clause # according to https://github.com/gcovr/gcovr/tree/master#license

--- a/py3-glom.yaml
+++ b/py3-glom.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-glom
   version: 23.3.0
-  epoch: 0
+  epoch: 1
   description: "Python's nested data operator (and CLI), for all your declarative restructuring needs. Got data? Glom it!"
   copyright:
     - license: BSD-3-Clause

--- a/py3-glpk.yaml
+++ b/py3-glpk.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-glpk
   version: 0.4.7
-  epoch: 0
+  epoch: 1
   description: PyGLPK, a Python module encapsulating GLPK.
   copyright:
     - license: GPL

--- a/py3-google-api-core.yaml
+++ b/py3-google-api-core.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-api-core
   version: 2.12.0
-  epoch: 0
+  epoch: 1
   description: Google API client core library
   copyright:
     - license: Apache 2.0

--- a/py3-google-auth-httplib2.yaml
+++ b/py3-google-auth-httplib2.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-auth-httplib2
   version: 0.1.1
-  epoch: 0
+  epoch: 1
   description: 'Google Authentication Library: httplib2 transport'
   copyright:
     - license: Apache 2.0

--- a/py3-google-auth-oauthlib.yaml
+++ b/py3-google-auth-oauthlib.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-auth-oauthlib
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: Google Authentication Library
   copyright:
     - license: Apache 2.0

--- a/py3-google-auth.yaml
+++ b/py3-google-auth.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-auth
   version: 2.23.2
-  epoch: 0
+  epoch: 1
   description: Google Authentication Library
   copyright:
     - license: Apache 2.0

--- a/py3-google-cloud-bigquery-storage.yaml
+++ b/py3-google-cloud-bigquery-storage.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-cloud-bigquery-storage
   version: 2.22.0
-  epoch: 0
+  epoch: 1
   description: Google Cloud Bigquery Storage API client library
   copyright:
     - license: Apache 2.0

--- a/py3-google-cloud-core.yaml
+++ b/py3-google-cloud-core.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-cloud-core
   version: 2.3.3
-  epoch: 0
+  epoch: 1
   description: Google Cloud API client core library
   copyright:
     - license: Apache 2.0

--- a/py3-google-cloud-dlp.yaml
+++ b/py3-google-cloud-dlp.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-cloud-dlp
   version: 3.12.3
-  epoch: 0
+  epoch: 1
   description: Google Cloud Dlp API client library
   copyright:
     - license: Apache 2.0

--- a/py3-google-cloud-language.yaml
+++ b/py3-google-cloud-language.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-cloud-language
   version: 2.11.1
-  epoch: 0
+  epoch: 1
   description: Google Cloud Language API client library
   copyright:
     - license: Apache 2.0

--- a/py3-google-cloud-pubsub.yaml
+++ b/py3-google-cloud-pubsub.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-cloud-pubsub
   version: 2.18.4
-  epoch: 0
+  epoch: 1
   description: Google Cloud Pub/Sub API client library
   copyright:
     - license: Apache 2.0

--- a/py3-google-cloud-recommendations-ai.yaml
+++ b/py3-google-cloud-recommendations-ai.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-cloud-recommendations-ai
   version: 0.10.5
-  epoch: 0
+  epoch: 1
   description: Google Cloud Recommendations Ai API client library
   copyright:
     - license: Apache 2.0

--- a/py3-google-cloud-videointelligence.yaml
+++ b/py3-google-cloud-videointelligence.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-cloud-videointelligence
   version: 2.11.4
-  epoch: 0
+  epoch: 1
   description: Google Cloud Videointelligence API client library
   copyright:
     - license: Apache 2.0

--- a/py3-google-cloud-vision.yaml
+++ b/py3-google-cloud-vision.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-cloud-vision
   version: 3.4.4
-  epoch: 0
+  epoch: 1
   description: Google Cloud Vision API client library
   copyright:
     - license: Apache 2.0

--- a/py3-google-crc32c.yaml
+++ b/py3-google-crc32c.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-crc32c
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: A python wrapper of the C library 'Google CRC32C'
   copyright:
     - license: Apache 2.0

--- a/py3-google-pasta.yaml
+++ b/py3-google-pasta.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-pasta
   version: 0.2.0
-  epoch: 0
+  epoch: 1
   description: pasta is an AST-based Python refactoring library
   copyright:
     - license: Apache 2.0

--- a/py3-google-resumable-media.yaml
+++ b/py3-google-resumable-media.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-google-resumable-media
   version: 2.6.0
-  epoch: 0
+  epoch: 1
   description: Utilities for Google Media Downloads and Resumable Uploads
   copyright:
     - license: Apache 2.0

--- a/py3-googleapis-common-protos.yaml
+++ b/py3-googleapis-common-protos.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-googleapis-common-protos
   version: 1.60.0
-  epoch: 0
+  epoch: 1
   description: Common protobufs used in Google APIs
   copyright:
     - license: Apache-2.0

--- a/py3-gpep517.yaml
+++ b/py3-gpep517.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-gpep517
   version: "15"
-  epoch: 1
+  epoch: 2
   description: "PEP517 build system support for distros"
   copyright:
     - license: MIT

--- a/py3-grpc-google-iam-v1.yaml
+++ b/py3-grpc-google-iam-v1.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-grpc-google-iam-v1
   version: 0.12.6
-  epoch: 0
+  epoch: 1
   description: IAM API client library
   copyright:
     - license: Apache 2.0

--- a/py3-grpcio-gcp.yaml
+++ b/py3-grpcio-gcp.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-grpcio-gcp
   version: 0.2.2
-  epoch: 0
+  epoch: 1
   description: gRPC extensions for Google Cloud Platform
   copyright:
     - license: Apache License 2.0

--- a/py3-grpcio-status.yaml
+++ b/py3-grpcio-status.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-grpcio-status
   version: 1.58.0
-  epoch: 0
+  epoch: 1
   description: Status proto mapping for gRPC
   copyright:
     - license: Apache License 2.0

--- a/py3-gunicorn.yaml
+++ b/py3-gunicorn.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-gunicorn
   version: 21.2.0
-  epoch: 0
+  epoch: 1
   description: WSGI HTTP Server for UNIX
   copyright:
     - license: MIT

--- a/py3-h11.yaml
+++ b/py3-h11.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-h11
   version: 0.14.0
-  epoch: 1
+  epoch: 2
   description: A pure-Python, bring-your-own-I/O implementation of HTTP/1.1
   copyright:
     - license: MIT

--- a/py3-h5py.yaml
+++ b/py3-h5py.yaml
@@ -3,7 +3,7 @@ package:
   description: 'Read and write HDF5 files from Python'
   url: 'https://www.h5py.org'
   version: 3.9.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-3-Clause
 

--- a/py3-hatch.yaml
+++ b/py3-hatch.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-hatch
   version: 1.7.0
-  epoch: 0
+  epoch: 1
   description: Modern, extensible Python project management
   copyright:
     - license: "MIT"

--- a/py3-hatchling.yaml
+++ b/py3-hatchling.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-hatchling
   version: 1.18.0
-  epoch: 1
+  epoch: 2
   description: "Modern, extensible Python build backend"
   copyright:
     - license: BSD-3-Clause

--- a/py3-hdfs.yaml
+++ b/py3-hdfs.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-hdfs
   version: 2.7.2
-  epoch: 0
+  epoch: 1
   description: 'HdfsCLI: API and command line interface for HDFS.'
   copyright:
     - license: MIT

--- a/py3-hologram.yaml
+++ b/py3-hologram.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-hologram
   version: 0.0.16
-  epoch: 0
+  epoch: 1
   description: JSON schema generation from dataclasses
   copyright:
     - license: MIT

--- a/py3-html5lib.yaml
+++ b/py3-html5lib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-html5lib
   version: "1.1"
-  epoch: 0
+  epoch: 1
   description: HTML parser based on the WHATWG HTML specification
   copyright:
     - license: MIT License

--- a/py3-httpcore.yaml
+++ b/py3-httpcore.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-httpcore
   version: 0.18.0
-  epoch: 0
+  epoch: 1
   description: A minimal low-level HTTP client.
   copyright:
     - license: BSD

--- a/py3-httplib2.yaml
+++ b/py3-httplib2.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-httplib2
   version: 0.22.0
-  epoch: 0
+  epoch: 1
   description: A comprehensive HTTP client library.
   copyright:
     - license: MIT

--- a/py3-httpx.yaml
+++ b/py3-httpx.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-httpx
   version: 0.25.0
-  epoch: 0
+  epoch: 1
   description: The next generation HTTP client.
   copyright:
     - license: "BSD-3-Clause"

--- a/py3-humanfriendly.yaml
+++ b/py3-humanfriendly.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-humanfriendly
   version: "10.0"
-  epoch: 1
+  epoch: 2
   description: Human friendly output for text interfaces using Python
   copyright:
     - license: MIT

--- a/py3-hyperlink.yaml
+++ b/py3-hyperlink.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-hyperlink
   version: 21.0.0
-  epoch: 1
+  epoch: 2
   description: A featureful, immutable, and correct URL for Python.
   copyright:
     - license: MIT

--- a/py3-hyperopt.yaml
+++ b/py3-hyperopt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-hyperopt
   version: 0.2.7
-  epoch: 0
+  epoch: 1
   description: Distributed Asynchronous Hyperparameter Optimization
   copyright:
     - license: BSD

--- a/py3-idna-ssl.yaml
+++ b/py3-idna-ssl.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-idna-ssl
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: Patch ssl.match_hostname for Unicode(idna) domains support
   copyright:
     - license: MIT

--- a/py3-idna.yaml
+++ b/py3-idna.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-idna
   version: "3.4"
-  epoch: 0
+  epoch: 1
   description: Internationalized Domain Names in Applications (IDNA)
   copyright:
     - license: BSD-3-Clause

--- a/py3-imagesize.yaml
+++ b/py3-imagesize.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-imagesize
   version: 1.4.1
-  epoch: 0
+  epoch: 1
   description: Getting image size from png/jpeg/jpeg2000/gif file
   copyright:
     - license: MIT

--- a/py3-importlib-metadata.yaml
+++ b/py3-importlib-metadata.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-importlib-metadata
   version: 6.8.0
-  epoch: 0
+  epoch: 1
   description: Read metadata from Python packages
   copyright:
     - license: Apache-2.0

--- a/py3-importlib-resources.yaml
+++ b/py3-importlib-resources.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-importlib-resources
   version: 6.1.0
-  epoch: 0
+  epoch: 1
   description: Read resources from Python packages
   copyright:
     - license: MIT

--- a/py3-influxdb-client.yaml
+++ b/py3-influxdb-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-influxdb-client
   version: 1.37.0
-  epoch: 0
+  epoch: 1
   description: "InfluxDB 2.0 python client"
   copyright:
     - license: MIT

--- a/py3-invoke.yaml
+++ b/py3-invoke.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-invoke
   version: 2.2.0
-  epoch: 0
+  epoch: 1
   description: Pythonic task management & command execution.
   copyright:
     - license: BSD-2-Clause

--- a/py3-ipaddress.yaml
+++ b/py3-ipaddress.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ipaddress
   version: 1.0.23
-  epoch: 0
+  epoch: 1
   description: IPv4/IPv6 manipulation library
   copyright:
     - license: Python Software Foundation License

--- a/py3-ipython-genutils.yaml
+++ b/py3-ipython-genutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-ipython-genutils
   version: 0.2.0
-  epoch: 0
+  epoch: 1
   description: Vestigial utilities from IPython
   copyright:
     - license: BSD

--- a/py3-isodate.yaml
+++ b/py3-isodate.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-isodate
   version: 0.6.1
-  epoch: 0
+  epoch: 1
   description: An ISO 8601 date/time/duration parser and formatter
   copyright:
     - license: BSD

--- a/py3-jaraco.classes.yaml
+++ b/py3-jaraco.classes.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-jaraco.classes
   version: 3.3.0
-  epoch: 0
+  epoch: 1
   description: Utility functions for Python class constructs
   copyright:
     - license: "MIT"

--- a/py3-jedi.yaml
+++ b/py3-jedi.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-jedi
   version: 0.19.0
-  epoch: 0
+  epoch: 1
   description: An autocompletion tool for Python that can be used for text editors.
   copyright:
     - license: MIT

--- a/py3-jeepney.yaml
+++ b/py3-jeepney.yaml
@@ -7,7 +7,7 @@ package:
   # Other tags do have all three numbers, so I've skipped the var-transform since this appears to
   # be an exception.
   version: 0.8.0
-  epoch: 1
+  epoch: 2
   description: Low-level, pure Python DBus protocol wrapper.
   copyright:
     - license: MIT

--- a/py3-jinja2.yaml
+++ b/py3-jinja2.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jinja2
   version: 3.1.2
-  epoch: 2
+  epoch: 3
   description: "A small but fast and easy to use stand-alone python template engine"
   copyright:
     - license: BSD-3-Clause

--- a/py3-jmespath.yaml
+++ b/py3-jmespath.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jmespath
   version: 1.0.1
-  epoch: 0
+  epoch: 1
   description: "JMESPath is a query language for JSON"
   copyright:
     - license: MIT

--- a/py3-joblib.yaml
+++ b/py3-joblib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-joblib
   version: 1.3.2
-  epoch: 0
+  epoch: 1
   description: Lightweight pipelining with Python functions
   copyright:
     - license: BSD 3-Clause

--- a/py3-json5.yaml
+++ b/py3-json5.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-json5
   version: 0.9.14
-  epoch: 0
+  epoch: 1
   description: A Python implementation of the JSON5 data format.
   copyright:
     - license: Apache

--- a/py3-jsonschema-specifications.yaml
+++ b/py3-jsonschema-specifications.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jsonschema-specifications
   version: 2023.07.1
-  epoch: 0
+  epoch: 1
   description: "Cross-specification JSON referencing (JSON Schema, OpenAPI, and the one you just made up!)."
   copyright:
     - license: MIT

--- a/py3-jsonschema.yaml
+++ b/py3-jsonschema.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jsonschema
   version: 4.19.1
-  epoch: 0
+  epoch: 1
   description: "Python Classes Without Boilerplate."
   copyright:
     - license: MIT

--- a/py3-jupyter-events.yaml
+++ b/py3-jupyter-events.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-jupyter-events
   version: 0.7.0
-  epoch: 0
+  epoch: 1
   description: Jupyter Event System library
   copyright:
     - license: 'BSD 3-Clause License'

--- a/py3-jupyterlab-pygments.yaml
+++ b/py3-jupyterlab-pygments.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-jupyterlab-pygments
   version: 0.2.2
-  epoch: 0
+  epoch: 1
   description: Pygments theme using JupyterLab CSS variables
   copyright:
     - license: BSD

--- a/py3-keras-applications.yaml
+++ b/py3-keras-applications.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-keras-applications
   version: 1.0.8
-  epoch: 0
+  epoch: 1
   description: Reference implementations of popular deep learning models
   copyright:
     - license: MIT

--- a/py3-keras-preprocessing.yaml
+++ b/py3-keras-preprocessing.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-keras-preprocessing
   version: 1.1.2
-  epoch: 0
+  epoch: 1
   description: Easy data preprocessing and data augmentation for deep learning models
   copyright:
     - license: MIT

--- a/py3-keras.yaml
+++ b/py3-keras.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-keras
   version: 2.14.0
-  epoch: 0
+  epoch: 1
   description: Deep learning for humans.
   copyright:
     - license: Apache 2.0

--- a/py3-keyring.yaml
+++ b/py3-keyring.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-keyring
   version: 24.2.0
-  epoch: 0
+  epoch: 1
   description: Store and access your passwords safely.
   copyright:
     - license: "MIT"

--- a/py3-kiwisolver.yaml
+++ b/py3-kiwisolver.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-kiwisolver
   version: 1.4.5
-  epoch: 2
+  epoch: 3
   description: A fast implementation of the Cassowary constraint solver
   copyright:
     - license: BSD-3-Clause-Attribution

--- a/py3-kubernetes-asyncio.yaml
+++ b/py3-kubernetes-asyncio.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-kubernetes-asyncio
   version: 26.9.0
-  epoch: 0
+  epoch: 1
   description: Kubernetes asynchronous python client
   copyright:
     - license: Apache License Version 2.0

--- a/py3-kubernetes.yaml
+++ b/py3-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-kubernetes
   version: 28.1.0
-  epoch: 0
+  epoch: 1
   description: Kubernetes python client
   copyright:
     - license: Apache-2.0

--- a/py3-leather.yaml
+++ b/py3-leather.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-leather
   version: 0.3.4
-  epoch: 0
+  epoch: 1
   description: Python charting for 80% of humans.
   copyright:
     - license: MIT

--- a/py3-libarchive-c.yaml
+++ b/py3-libarchive-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-libarchive-c
   version: 5.0
-  epoch: 0
+  epoch: 1
   description: "Python interface to libarchive."
   copyright:
     - license: CC0-1.0

--- a/py3-libclang.yaml
+++ b/py3-libclang.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-libclang
   version: 16.0.6
-  epoch: 0
+  epoch: 1
   description: 'Clang Python Bindings, mirrored from the official LLVM repo: https://github.com/llvm/llvm-project/tree/main/clang/bindings/python, to make the installation process easier.'
   copyright:
     - license: Apache License 2.0

--- a/py3-llhttp.yaml
+++ b/py3-llhttp.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-llhttp
   version: 6.0.9.0
-  epoch: 0
+  epoch: 1
   description: llhttp in python
   copyright:
     - license: MIT

--- a/py3-lru-dict.yaml
+++ b/py3-lru-dict.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-lru-dict
   version: 1.2.0
-  epoch: 0
+  epoch: 1
   description: An Dict like LRU container.
   copyright:
     - license: MIT

--- a/py3-lxml.yaml
+++ b/py3-lxml.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-lxml
   version: 4.9.3
-  epoch: 0
+  epoch: 1
   description: Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.
   copyright:
     - license: BSD-3-Clause

--- a/py3-magic.yaml
+++ b/py3-magic.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-magic
   version: 0.4.27
-  epoch: 2
+  epoch: 3
   description: "Python3 wrapper for libmagic"
   copyright:
     - license: MIT

--- a/py3-mako.yaml
+++ b/py3-mako.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-mako
   version: 1.2.4
-  epoch: 0
+  epoch: 1
   description: Python3 fast templating language
   copyright:
     - license: MIT

--- a/py3-markdown-it-py.yaml
+++ b/py3-markdown-it-py.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-markdown-it-py
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: "Python port of markdown-it. Markdown parsing, done right!"
   copyright:
     - license: MIT

--- a/py3-markdown.yaml
+++ b/py3-markdown.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-markdown
   version: 3.4.4
-  epoch: 0
+  epoch: 1
   description: Python implementation of John Gruber's Markdown.
   copyright:
     - license: BSD-3-Clause

--- a/py3-markupsafe.yaml
+++ b/py3-markupsafe.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-markupsafe
   version: 2.1.3
-  epoch: 0
+  epoch: 1
   description: "Implements a XML/HTML/XHTML Markup safe string"
   copyright:
     - license: BSD-3-Clause

--- a/py3-mashumaro.yaml
+++ b/py3-mashumaro.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-mashumaro
   version: "3.10"
-  epoch: 0
+  epoch: 1
   description: Fast serialization library on top of dataclasses
   copyright:
     - license: Apache-2.0

--- a/py3-matplotlib-inline.yaml
+++ b/py3-matplotlib-inline.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-matplotlib-inline
   version: 0.1.6
-  epoch: 0
+  epoch: 1
   description: Inline Matplotlib backend for Jupyter
   copyright:
     - license: BSD 3-Clause

--- a/py3-matplotlib.yaml
+++ b/py3-matplotlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-matplotlib
   version: 3.8.0
-  epoch: 0
+  epoch: 1
   description: Python plotting package
   copyright:
     - license: PSF

--- a/py3-mdurl.yaml
+++ b/py3-mdurl.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-mdurl
   version: 0.1.2
-  epoch: 0
+  epoch: 1
   description: "Markdown URL utilities"
   copyright:
     - license: MIT

--- a/py3-meson-python.yaml
+++ b/py3-meson-python.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-meson-python
   version: 0.14.0
-  epoch: 0
+  epoch: 1
   description: Meson Python build backend (PEP 517)
   copyright:
     - license: MIT

--- a/py3-minimal-snowplow-tracker.yaml
+++ b/py3-minimal-snowplow-tracker.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-minimal-snowplow-tracker
   version: 1.0.1
-  epoch: 0
+  epoch: 1
   description: A minimal snowplow event tracker for Python. Add analytics to your Python and Django apps, webapps and games
   copyright:
     - license: Apache-2.0

--- a/py3-mistune.yaml
+++ b/py3-mistune.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-mistune
   version: 3.0.2
-  epoch: 0
+  epoch: 1
   description: A sane and fast Markdown parser with useful plugins and renderers
   copyright:
     - license: BSD-3-Clause

--- a/py3-ml-metadata.yaml
+++ b/py3-ml-metadata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ml-metadata
   version: 1.14.0
-  epoch: 0
+  epoch: 1
   description: For recording and retrieving metadata associated with ML developer and data scientist workflows.
   copyright:
     - license: MIT

--- a/py3-more-itertools.yaml
+++ b/py3-more-itertools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-more-itertools
   version: 10.1.0
-  epoch: 0
+  epoch: 1
   description: "more routines for operating on iterables, beyond itertools"
   copyright:
     - license: MIT

--- a/py3-multidict.yaml
+++ b/py3-multidict.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-multidict
   version: 6.0.4
-  epoch: 0
+  epoch: 1
   description: multidict implementation
   copyright:
     - license: Apache 2

--- a/py3-mypy-extensions.yaml
+++ b/py3-mypy-extensions.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-mypy-extensions
   version: 1.0.0
-  epoch: 0
+  epoch: 1
   description: Type system extensions for programs checked with the mypy type checker.
   copyright:
     - license: MIT License

--- a/py3-nest-asyncio.yaml
+++ b/py3-nest-asyncio.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-nest-asyncio
   version: 1.5.8
-  epoch: 0
+  epoch: 1
   description: Patch asyncio to allow nested event loops
   copyright:
     - license: BSD

--- a/py3-networkx.yaml
+++ b/py3-networkx.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-networkx
   version: "3.1"
-  epoch: 0
+  epoch: 1
   description: Python package for creating and manipulating graphs and networks
   copyright:
     - license: BSD-3-Clause

--- a/py3-oauth2client.yaml
+++ b/py3-oauth2client.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-oauth2client
   version: 4.1.3
-  epoch: 0
+  epoch: 1
   description: OAuth 2.0 client library
   copyright:
     - license: Apache 2.0

--- a/py3-oauthlib.yaml
+++ b/py3-oauthlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-oauthlib
   version: 3.2.2
-  epoch: 0
+  epoch: 1
   description: A generic, spec-compliant, thorough implementation of the OAuth request-signing logic
   copyright:
     - license: BSD

--- a/py3-objsize.yaml
+++ b/py3-objsize.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-objsize
   version: 0.7.0
-  epoch: 0
+  epoch: 1
   description: Traversal over Python's objects subtree and calculate the total size of the subtree in bytes (deep size).
   copyright:
     - license: BSD-3-Clause

--- a/py3-openai.yaml
+++ b/py3-openai.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-openai
   version: 0.28.1
-  epoch: 0
+  epoch: 1
   description: Python client library for the OpenAI API
   copyright:
     - license: MIT

--- a/py3-opt-einsum.yaml
+++ b/py3-opt-einsum.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-opt-einsum
   version: 3.3.0
-  epoch: 0
+  epoch: 1
   description: Optimizing numpys einsum function
   copyright:
     - license: MIT

--- a/py3-optuna.yaml
+++ b/py3-optuna.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-optuna
   version: 3.3.0
-  epoch: 1
+  epoch: 2
   description: A hyperparameter optimization framework
   copyright:
     - license: MIT License

--- a/py3-ordered-set.yaml
+++ b/py3-ordered-set.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ordered-set
   version: 4.1.0
-  epoch: 0
+  epoch: 1
   description: "mutableset which remembers its order"
   copyright:
     - license: MIT

--- a/py3-orjson.yaml
+++ b/py3-orjson.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-orjson
   version: 3.9.7
-  epoch: 0
+  epoch: 1
   description: Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy
   copyright:
     - license: Apache-2.0 OR MIT

--- a/py3-overrides.yaml
+++ b/py3-overrides.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-overrides
   version: 7.4.0
-  epoch: 0
+  epoch: 1
   description: A decorator to automatically detect mismatch when overriding a method.
   copyright:
     - license: Apache License, Version 2.0

--- a/py3-packaging.yaml
+++ b/py3-packaging.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-packaging
   version: "23.2"
-  epoch: 0
+  epoch: 1
   description: "core utilities for python3 packaging"
   copyright:
     - license: Apache-2.0 AND BSD-2-Clause

--- a/py3-pandas.yaml
+++ b/py3-pandas.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pandas
   version: 2.0.3
-  epoch: 0
+  epoch: 1
   description: Powerful data structures for data analysis, time series, and statistics
   copyright:
     - license: 'BSD-3-Clause'

--- a/py3-pandocfilters.yaml
+++ b/py3-pandocfilters.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pandocfilters
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: Utilities for writing pandoc filters in python
   copyright:
     - license: BSD-3-Clause

--- a/py3-parsedatetime.yaml
+++ b/py3-parsedatetime.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-parsedatetime
   version: "2.6"
-  epoch: 0
+  epoch: 1
   description: Parse human-readable date/time text.
   copyright:
     - license: Apache License 2.0

--- a/py3-parsing.yaml
+++ b/py3-parsing.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-parsing
   version: 3.1.1
-  epoch: 0
+  epoch: 1
   description: "simple packaging tool for simple packages (core)"
   copyright:
     - license: MIT

--- a/py3-parso.yaml
+++ b/py3-parso.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-parso
   version: 0.8.3
-  epoch: 0
+  epoch: 1
   description: A Python Parser
   copyright:
     - license: MIT

--- a/py3-pathlib2.yaml
+++ b/py3-pathlib2.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pathlib2
   version: 2.3.7
-  epoch: 0
+  epoch: 1
   description: Object-oriented filesystem paths
   copyright:
     - license: MIT

--- a/py3-pathspec.yaml
+++ b/py3-pathspec.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pathspec
   version: 0.11.2
-  epoch: 0
+  epoch: 1
   description: "Utility library for gitignore style pattern matching of file paths"
   copyright:
     - license: MPL-2.0

--- a/py3-peewee.yaml
+++ b/py3-peewee.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-peewee
   version: 3.16.3
-  epoch: 0
+  epoch: 1
   description: "a little orm"
   copyright:
     - license: MIT

--- a/py3-pendulum.yaml
+++ b/py3-pendulum.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pendulum
   version: 2.1.2
-  epoch: 0
+  epoch: 1
   description: Python datetimes made easy
   copyright:
     - license: MIT

--- a/py3-pep517.yaml
+++ b/py3-pep517.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pep517
   version: 0.13.0
-  epoch: 2
+  epoch: 3
   description: "wrappers to build python3 packages with PEP 517 hooks"
   copyright:
     - license: MIT

--- a/py3-pexpect.yaml
+++ b/py3-pexpect.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pexpect
   version: 4.8.0
-  epoch: 0
+  epoch: 1
   description: Pexpect allows easy control of interactive console applications.
   copyright:
     - license: ISC license

--- a/py3-pgcli.yaml
+++ b/py3-pgcli.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pgcli
   version: 3.5.0
-  epoch: 0
+  epoch: 1
   description: CLI for Postgres Database. With auto-completion and syntax highlighting.
   copyright:
     - license: BSD

--- a/py3-pgspecial.yaml
+++ b/py3-pgspecial.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pgspecial
   version: 2.1.0
-  epoch: 0
+  epoch: 1
   description: Meta-commands handler for Postgres Database.
   copyright:
     - license: LICENSE.txt

--- a/py3-pillow.yaml
+++ b/py3-pillow.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pillow
   version: 10.0.1
-  epoch: 0
+  epoch: 1
   description: Python Imaging Library (Fork)
   copyright:
     - license: HPND

--- a/py3-pkgconfig.yaml
+++ b/py3-pkgconfig.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pkgconfig
   version: 1.5.5
-  epoch: 0
+  epoch: 1
   description: Interface Python with pkg-config
   copyright:
     - license: MIT

--- a/py3-platformdirs.yaml
+++ b/py3-platformdirs.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-platformdirs
   version: 3.10.0
-  epoch: 0
+  epoch: 1
   description: A small Python package for determining appropriate platform-specific dirs, e.g. a "user data dir".
   copyright:
     - license: "MIT"

--- a/py3-pluggy.yaml
+++ b/py3-pluggy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pluggy
   version: 1.3.0
-  epoch: 1
+  epoch: 2
   description: "Plugin management and hook calling for Python"
   copyright:
     - license: MIT

--- a/py3-ply.yaml
+++ b/py3-ply.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ply
   version: 3.11_git20180215
-  epoch: 0
+  epoch: 1
   description: Python Lex & Yacc
   copyright:
     - license: BSD

--- a/py3-prometheus-client.yaml
+++ b/py3-prometheus-client.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-prometheus-client
   version: 0.17.1
-  epoch: 0
+  epoch: 1
   description: Python client for the Prometheus monitoring system.
   copyright:
     - license: Apache Software License 2.0

--- a/py3-prompt-toolkit.yaml
+++ b/py3-prompt-toolkit.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-prompt-toolkit
   version: 3.0.39
-  epoch: 0
+  epoch: 1
   description: Library for building powerful interactive command lines in Python
   copyright:
     - license: BSD License

--- a/py3-proto-plus.yaml
+++ b/py3-proto-plus.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-proto-plus
   version: 1.22.3
-  epoch: 0
+  epoch: 1
   description: Beautiful, Pythonic protocol buffers.
   copyright:
     - license: Apache 2.0

--- a/py3-protobuf.yaml
+++ b/py3-protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-protobuf
   version: 4.24.3
-  epoch: 0
+  epoch: 1
   copyright:
     - license: 3-Clause BSD License
   dependencies:

--- a/py3-psutil.yaml
+++ b/py3-psutil.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-psutil
   version: 5.9.5
-  epoch: 1
+  epoch: 2
   description: Cross-platform lib for process and system monitoring in Python.
   copyright:
     - license: BSD-3-Clause

--- a/py3-psycopg.yaml
+++ b/py3-psycopg.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-psycopg
   version: 3.1.10
-  epoch: 0
+  epoch: 1
   description: PostgreSQL database adapter for Python
   copyright:
     - license: GNU Lesser General Public License v3 (LGPLv3)

--- a/py3-psycopg2.yaml
+++ b/py3-psycopg2.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-psycopg2
   version: 2.9.7
-  epoch: 0
+  epoch: 1
   description: psycopg2 - Python-PostgreSQL Database Adapter
   copyright:
     - license: LGPL with exceptions

--- a/py3-ptyprocess.yaml
+++ b/py3-ptyprocess.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-ptyprocess
   version: 0.7.0
-  epoch: 0
+  epoch: 1
   description: Run a subprocess in a pseudo terminal
   copyright:
     - license: ISC

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pulsar-client
   version: 3.3.0
-  epoch: 0
+  epoch: 1
   description: Apache Pulsar Python client library
   copyright:
     - license: Apache-2.0

--- a/py3-pure-eval.yaml
+++ b/py3-pure-eval.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pure-eval
   version: 0.2.2
-  epoch: 0
+  epoch: 1
   description: Safely evaluate AST nodes without side effects
   copyright:
     - license: MIT

--- a/py3-py4j.yaml
+++ b/py3-py4j.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-py4j
   version: 0.10.9.7
-  epoch: 0
+  epoch: 1
   description: Enables Python programs to dynamically access arbitrary Java objects
   copyright:
     - license: BSD License

--- a/py3-pyaes.yaml
+++ b/py3-pyaes.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pyaes
   version: 1.6.1
-  epoch: 0
+  epoch: 1
   description: Pure-Python Implementation of the AES block-cipher and common modes of operation
   copyright:
     - license: 'License :: OSI Approved :: MIT License'

--- a/py3-pybind11.yaml
+++ b/py3-pybind11.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pybind11
   version: 2.11.1
-  epoch: 1
+  epoch: 2
   description: Seamless operability between C++11 and Python
   copyright:
     - license: BSD

--- a/py3-pycparser.yaml
+++ b/py3-pycparser.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pycparser
   version: 2.21
-  epoch: 0
+  epoch: 1
   description: C parser in Python
   copyright:
     - license: BSD

--- a/py3-pydantic-core.yaml
+++ b/py3-pydantic-core.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pydantic-core
   version: 2.10.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-pydantic.yaml
+++ b/py3-pydantic.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pydantic
   version: 2.4.2
-  epoch: 0
+  epoch: 1
   description: Data validation using Python type hints
   copyright:
     - license: "MIT"

--- a/py3-pydot.yaml
+++ b/py3-pydot.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pydot
   version: 1.4.2
-  epoch: 0
+  epoch: 1
   description: Python interface to Graphviz's Dot
   copyright:
     - license: MIT

--- a/py3-pyfarmhash.yaml
+++ b/py3-pyfarmhash.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pyfarmhash
   version: 0.3.2
-  epoch: 0
+  epoch: 1
   description: Google FarmHash Bindings for Python
   copyright:
     - license: "MIT License"

--- a/py3-pygments.yaml
+++ b/py3-pygments.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pygments
   version: 2.16.1
-  epoch: 0
+  epoch: 1
   description: Syntax highlighting package written in Python
   copyright:
     - license: BSD-2-Clause

--- a/py3-pyjwt.yaml
+++ b/py3-pyjwt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyjwt
   version: 2.8.0
-  epoch: 0
+  epoch: 1
   description: JSON Web Token implementation in Python
   copyright:
     - license: MIT

--- a/py3-pymongo.yaml
+++ b/py3-pymongo.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pymongo
   version: 4.5.0
-  epoch: 0
+  epoch: 1
   description: Python driver for MongoDB <http://www.mongodb.org>
   copyright:
     - license: Apache-2.0

--- a/py3-pymysql.yaml
+++ b/py3-pymysql.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pymysql
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: Pure Python MySQL Driver
   copyright:
     - license: MIT License

--- a/py3-pyperclip.yaml
+++ b/py3-pyperclip.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pyperclip
   version: 1.8.2
-  epoch: 0
+  epoch: 1
   description: A cross-platform clipboard module for Python. (Only handles plain text for now.)
   copyright:
     - license: BSD

--- a/py3-pyproject-hooks.yaml
+++ b/py3-pyproject-hooks.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyproject-hooks
   version: 1.0.0
-  epoch: 1
+  epoch: 2
   description: A low-level library for calling build-backends in `pyproject.toml`-based project
   copyright:
     - license: MIT

--- a/py3-pyproject-metadata.yaml
+++ b/py3-pyproject-metadata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyproject-metadata
   version: 0.7.1
-  epoch: 0
+  epoch: 1
   description: PEP 621 metadata parsing
   copyright:
     - license: MIT

--- a/py3-pyrsistent.yaml
+++ b/py3-pyrsistent.yaml
@@ -5,7 +5,7 @@
 package:
   name: py3-pyrsistent
   version: 0.19.3
-  epoch: 0
+  epoch: 1
   description: Persistent/Functional/Immutable data structures
   copyright:
     - license: MIT

--- a/py3-python-dateutil.yaml
+++ b/py3-python-dateutil.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-python-dateutil
   version: 2.8.2
-  epoch: 0
+  epoch: 1
   description: Extensions to the standard Python datetime module
   copyright:
     - license: Apache-2.0

--- a/py3-python-editor.yaml
+++ b/py3-python-editor.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-editor
   version: 1.0.4
-  epoch: 1
+  epoch: 2
   description: Programmatically open an editor, capture the result.
   copyright:
     - license: Apache-2.0

--- a/py3-python-json-logger.yaml
+++ b/py3-python-json-logger.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-python-json-logger
   version: 2.0.7
-  epoch: 0
+  epoch: 1
   description: A python library adding a json log formatter
   copyright:
     - license: BSD

--- a/py3-python-lsp-jsonrpc.yaml
+++ b/py3-python-lsp-jsonrpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-lsp-jsonrpc
   version: 1.1.2
-  epoch: 0
+  epoch: 1
   description: "JSON RPC 2.0 server library"
   copyright:
     - license: MIT

--- a/py3-python-slugify.yaml
+++ b/py3-python-slugify.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-python-slugify
   version: 8.0.1
-  epoch: 0
+  epoch: 1
   description: A Python slugify application that also handles Unicode
   copyright:
     - license: MIT

--- a/py3-pythran.yaml
+++ b/py3-pythran.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pythran
   version: 0.14.0
-  epoch: 0
+  epoch: 1
   description: Ahead of Time compiler for numeric kernels
   copyright:
     - license: BSD 3-Clause

--- a/py3-pytimeparse.yaml
+++ b/py3-pytimeparse.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pytimeparse
   version: 1.1.8
-  epoch: 0
+  epoch: 1
   description: Time expression parser
   copyright:
     - license: 'MIT'

--- a/py3-pytz.yaml
+++ b/py3-pytz.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pytz
   version: 2023.3_p1
-  epoch: 0
+  epoch: 1
   description: World timezone definitions, modern and historical
   copyright:
     - license: MIT

--- a/py3-pytzdata.yaml
+++ b/py3-pytzdata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pytzdata
   version: "2020.1"
-  epoch: 0
+  epoch: 1
   description: The Olson timezone database for Python.
   copyright:
     - license: MIT

--- a/py3-pywin32-ctypes.yaml
+++ b/py3-pywin32-ctypes.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pywin32-ctypes
   version: 0.2.2
-  epoch: 0
+  epoch: 1
   description: A (partial) reimplementation of pywin32 using ctypes/cffi
   copyright:
     - license: BSD-3-Clause

--- a/py3-pyyaml.yaml
+++ b/py3-pyyaml.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyyaml
   version: 6.0.1
-  epoch: 0
+  epoch: 1
   description: YAML parser and emitter for Python
   copyright:
     - license: MIT

--- a/py3-pyzmq.yaml
+++ b/py3-pyzmq.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pyzmq
   version: 25.1.1
-  epoch: 0
+  epoch: 1
   description: Python bindings for 0MQ
   copyright:
     - license: LGPL+BSD

--- a/py3-referencing.yaml
+++ b/py3-referencing.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-referencing
   version: 0.30.2
-  epoch: 0
+  epoch: 1
   description: "Cross-specification JSON referencing (JSON Schema, OpenAPI, and the one you just made up!)."
   copyright:
     - license: MIT

--- a/py3-regex.yaml
+++ b/py3-regex.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-regex
   version: 2023.8.8
-  epoch: 0
+  epoch: 1
   description: Alternative regular expression module, to replace re.
   copyright:
     - license: Apache Software License

--- a/py3-requests-oauthlib.yaml
+++ b/py3-requests-oauthlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-requests-oauthlib
   version: 1.3.1
-  epoch: 0
+  epoch: 1
   description: OAuthlib authentication support for Requests.
   copyright:
     - license: ISC

--- a/py3-requests.yaml
+++ b/py3-requests.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-requests
   version: 2.31.0
-  epoch: 0
+  epoch: 1
   description: Python HTTP for Humans.
   copyright:
     - license: Apache 2.0

--- a/py3-retrying.yaml
+++ b/py3-retrying.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-retrying
   version: 1.3.4
-  epoch: 2
+  epoch: 3
   description: "python 2 and 3 compatibility library"
   copyright:
     - license: Apache-2.0

--- a/py3-rfc3339-validator.yaml
+++ b/py3-rfc3339-validator.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-rfc3339-validator
   version: 0.1.4
-  epoch: 0
+  epoch: 1
   description: A pure python RFC3339 validator
   copyright:
     - license: MIT license

--- a/py3-rfc3339.yaml
+++ b/py3-rfc3339.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rfc3339
   version: 1.1
-  epoch: 1
+  epoch: 2
   description: Generate and parse RFC 3339 timestamps
   copyright:
     - license: MIT

--- a/py3-rfc3986-validator.yaml
+++ b/py3-rfc3986-validator.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-rfc3986-validator
   version: 0.1.1
-  epoch: 0
+  epoch: 1
   description: Pure python rfc3986 validator
   copyright:
     - license: MIT license

--- a/py3-rich.yaml
+++ b/py3-rich.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rich
   version: 13.6.0
-  epoch: 0
+  epoch: 1
   description: "Rich is a Python library for rich text and beautiful formatting in the terminal."
   copyright:
     - license: LGPL-2.1

--- a/py3-rpds-py.yaml
+++ b/py3-rpds-py.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rpds-py
   version: 0.10.3
-  epoch: 0
+  epoch: 1
   description: "Python bindings to Rust's persistent data structures (rpds)."
   copyright:
     - license: MIT

--- a/py3-rsa.yaml
+++ b/py3-rsa.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rsa
   version: 4.9
-  epoch: 0
+  epoch: 1
   description: "Pure-Python3 RSA implementation"
   copyright:
     - license: Apache-2.0

--- a/py3-ruamel-yaml-clib.yaml
+++ b/py3-ruamel-yaml-clib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ruamel-yaml-clib
   version: 0.2.7
-  epoch: 0
+  epoch: 1
   description: "C version of reader, parser and emitter for ruamel.yaml derived from libyaml."
   copyright:
     - license: MIT

--- a/py3-ruamel-yaml.yaml
+++ b/py3-ruamel-yaml.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-ruamel-yaml
   version: 0.17.32
-  epoch: 0
+  epoch: 1
   description: ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order
   copyright:
     - license: MIT license

--- a/py3-s3transfer.yaml
+++ b/py3-s3transfer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-s3transfer
   version: 0.7.0
-  epoch: 0
+  epoch: 1
   description: "Amazon S3 Transfer Manager for Python"
   copyright:
     - license: Apache-2.0

--- a/py3-scandir.yaml
+++ b/py3-scandir.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-scandir
   version: 1.10.0
-  epoch: 0
+  epoch: 1
   description: scandir, a better directory iterator and faster os.walk()
   copyright:
     - license: New BSD License

--- a/py3-scikit-learn.yaml
+++ b/py3-scikit-learn.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scikit-learn
   version: 1.3.1
-  epoch: 0
+  epoch: 1
   description: A set of python modules for machine learning and data mining
   copyright:
     - license: BSD-3-Clause

--- a/py3-scikit-optimize.yaml
+++ b/py3-scikit-optimize.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scikit-optimize
   version: 0.9.0
-  epoch: 0
+  epoch: 1
   description: Sequential model-based optimization toolbox.
   copyright:
     - license: BSD-3-Clause

--- a/py3-scipy.yaml
+++ b/py3-scipy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scipy
   version: 1.11.2
-  epoch: 0
+  epoch: 1
   description: Fundamental algorithms for scientific computing in Python
   copyright:
     - license: BSD-3-Clause

--- a/py3-semantic-version.yaml
+++ b/py3-semantic-version.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-semantic-version
   version: 2.10.0
-  epoch: 0
+  epoch: 1
   description: A library implementing the 'SemVer' scheme.
   copyright:
     - license: BSD

--- a/py3-send2trash.yaml
+++ b/py3-send2trash.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-send2trash
   version: 1.8.2
-  epoch: 0
+  epoch: 1
   description: Send file to trash natively under Mac OS X, Windows and Linux
   copyright:
     - license: BSD License

--- a/py3-setproctitle.yaml
+++ b/py3-setproctitle.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-setproctitle
   version: 1.3.2
-  epoch: 0
+  epoch: 1
   description: A Python module to customize the process title
   copyright:
     - license: BSD

--- a/py3-setuptools-rust.yaml
+++ b/py3-setuptools-rust.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-setuptools-rust
   version: 1.7.0
-  epoch: 1
+  epoch: 2
   description: Setuptools Rust extension plugin
   copyright:
     - license: MIT

--- a/py3-setuptools-scm.yaml
+++ b/py3-setuptools-scm.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-setuptools-scm
   version: 7.1.0
-  epoch: 0
+  epoch: 1
   description: the blessed package to manage your versions by scm tags
   copyright:
     - license: MIT

--- a/py3-shellingham.yaml
+++ b/py3-shellingham.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-shellingham
   version: 1.5.3
-  epoch: 0
+  epoch: 1
   description: Tool to Detect Surrounding Shell
   copyright:
     - license: ISC License

--- a/py3-six.yaml
+++ b/py3-six.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-six
   version: 1.16.0
-  epoch: 3
+  epoch: 4
   description: "python 2 and 3 compatibility library"
   copyright:
     - license: MIT

--- a/py3-sniffio.yaml
+++ b/py3-sniffio.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-sniffio
   version: 1.3.0
-  epoch: 0
+  epoch: 1
   description: Sniff out which async library your code is running under
   copyright:
     - license: MIT OR Apache-2.0

--- a/py3-snowballstemmer.yaml
+++ b/py3-snowballstemmer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-snowballstemmer
   version: 2.2.0
-  epoch: 0
+  epoch: 1
   description: This package provides 29 stemmers for 28 languages generated from Snowball algorithms.
   copyright:
     - license: BSD-3-Clause

--- a/py3-soupsieve.yaml
+++ b/py3-soupsieve.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-soupsieve
   version: 2.5
-  epoch: 0
+  epoch: 1
   description: A modern CSS selector implementation for Beautiful Soup.
   copyright:
     - license: "MIT License"

--- a/py3-sphinx.yaml
+++ b/py3-sphinx.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinx
   version: 7.2.6
-  epoch: 0
+  epoch: 1
   description: "Python Documentation Generator"
   copyright:
     - license: MIT

--- a/py3-sphinxcontrib-applehelp.yaml
+++ b/py3-sphinxcontrib-applehelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-applehelp
   version: 1.0.7
-  epoch: 2
+  epoch: 3
   description: sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books
   copyright:
     - license: BSD-2-Clause

--- a/py3-sphinxcontrib-devhelp.yaml
+++ b/py3-sphinxcontrib-devhelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-devhelp
   version: 1.0.5
-  epoch: 2
+  epoch: 3
   description: sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp documents
   copyright:
     - license: BSD-2-Clause

--- a/py3-sphinxcontrib-htmlhelp.yaml
+++ b/py3-sphinxcontrib-htmlhelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-htmlhelp
   version: 2.0.4
-  epoch: 2
+  epoch: 3
   description: sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files
   copyright:
     - license: BSD-2-Clause

--- a/py3-sphinxcontrib-jsmath.yaml
+++ b/py3-sphinxcontrib-jsmath.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-jsmath
   version: 1.0.1
-  epoch: 2
+  epoch: 3
   description: A sphinx extension which renders display math in HTML via JavaScript
   copyright:
     - license: BSD

--- a/py3-sphinxcontrib-packages.yaml
+++ b/py3-sphinxcontrib-packages.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-packages
   version: 1.1.2
-  epoch: 2
+  epoch: 3
   description: This packages contains the Packages sphinx extension, which provides directives to display packages installed on the host machine
   copyright:
     - license: AGPLv3 or any later version

--- a/py3-sphinxcontrib-qthelp.yaml
+++ b/py3-sphinxcontrib-qthelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-qthelp
   version: 1.0.6
-  epoch: 0
+  epoch: 1
   description: sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp documents
   copyright:
     - license: BSD-2-Clause

--- a/py3-sphinxcontrib-serializinghtml.yaml
+++ b/py3-sphinxcontrib-serializinghtml.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-serializinghtml
   version: 1.1.9
-  epoch: 0
+  epoch: 1
   description: sphinxcontrib-serializinghtml is a sphinx extension which outputs "serialized" HTML files (json and pickle)
   copyright:
     - license: BSD-2-Clause

--- a/py3-sqlalchemy.yaml
+++ b/py3-sqlalchemy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sqlalchemy
   version: 2.0.20
-  epoch: 1
+  epoch: 2
   description: Database Abstraction Library
   copyright:
     - license: MIT

--- a/py3-sqlglot.yaml
+++ b/py3-sqlglot.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-sqlglot
   version: 18.10.1
-  epoch: 0
+  epoch: 1
   description: An easily customizable SQL parser and transpiler
   copyright:
     - license: MIT

--- a/py3-sqlparse.yaml
+++ b/py3-sqlparse.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-sqlparse
   version: 0.4.4
-  epoch: 0
+  epoch: 1
   description: A non-validating SQL parser.
   copyright:
     - license: BSD License

--- a/py3-stack-data.yaml
+++ b/py3-stack-data.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-stack-data
   version: 0.6.3
-  epoch: 0
+  epoch: 1
   description: Extract data from python stack frames and tracebacks for informative displays
   copyright:
     - license: MIT

--- a/py3-tabulate.yaml
+++ b/py3-tabulate.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-tabulate
   version: 0.9.0
-  epoch: 0
+  epoch: 1
   description: Pretty-print tabular data
   copyright:
     - license: MIT

--- a/py3-tensorflow-io-gcs-filesystem.yaml
+++ b/py3-tensorflow-io-gcs-filesystem.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-tensorflow-io-gcs-filesystem
   version: 0.34.0
-  epoch: 0
+  epoch: 1
   description: TensorFlow IO
   copyright:
     - license: "Apache License 2.0"

--- a/py3-termcolor.yaml
+++ b/py3-termcolor.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-termcolor
   version: 2.3.0
-  epoch: 0
+  epoch: 1
   description: ANSI color formatting for output in terminal
   copyright:
     - license: MIT

--- a/py3-testpath.yaml
+++ b/py3-testpath.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-testpath
   version: 0.6.0
-  epoch: 0
+  epoch: 1
   description: Test utilities for code working with files and commands
   copyright:
     - license: "BSD 3-Clause"

--- a/py3-text-unidecode.yaml
+++ b/py3-text-unidecode.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-text-unidecode
   version: "1.3"
-  epoch: 0
+  epoch: 1
   description: The most basic Text::Unidecode port
   copyright:
     - license: GPL-2.0-or-later

--- a/py3-threadpoolctl.yaml
+++ b/py3-threadpoolctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-threadpoolctl
   version: 3.2.0
-  epoch: 0
+  epoch: 1
   description: Python helpers to limit the number of threads used in native libraries
   copyright:
     - license: BSD-3-Clause

--- a/py3-tinycss2.yaml
+++ b/py3-tinycss2.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-tinycss2
   version: 1.2.1
-  epoch: 0
+  epoch: 1
   description: A tiny CSS parser
   copyright:
     - license: "BSD 3-Clause"

--- a/py3-tkinter.yaml
+++ b/py3-tkinter.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tkinter
   version: 3.11.5
-  epoch: 0
+  epoch: 1
   description: A graphical user interface for the Python programming language
   copyright:
     - license: SF-2.0

--- a/py3-tomli-w.yaml
+++ b/py3-tomli-w.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-tomli-w
   version: 1.0.0
-  epoch: 0
+  epoch: 1
   description: A lil' TOML writer
   copyright:
     - license: "MIT"

--- a/py3-tomli.yaml
+++ b/py3-tomli.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tomli
   version: 2.0.1
-  epoch: 2
+  epoch: 3
   description: "TOML parser"
   copyright:
     - license: MIT

--- a/py3-tomlkit.yaml
+++ b/py3-tomlkit.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-tomlkit
   version: 0.12.2
-  epoch: 0
+  epoch: 1
   description: Style preserving TOML library
   copyright:
     - license: MIT

--- a/py3-tornado.yaml
+++ b/py3-tornado.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-tornado
   version: 6.3.3
-  epoch: 0
+  epoch: 1
   description: Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed.
   copyright:
     - license: Apache-2.0

--- a/py3-tqdm.yaml
+++ b/py3-tqdm.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tqdm
   version: 4.66.1
-  epoch: 0
+  epoch: 1
   description: Fast, Extensible Progress Meter
   copyright:
     - license: MPL-2.0 AND MIT

--- a/py3-traitlets.yaml
+++ b/py3-traitlets.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-traitlets
   version: 5.10.1
-  epoch: 0
+  epoch: 1
   description: Traitlets Python configuration system
   copyright:
     - license: BSD-3-Clause

--- a/py3-trove-classifiers.yaml
+++ b/py3-trove-classifiers.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-trove-classifiers
   version: 2023.9.19
-  epoch: 0
+  epoch: 1
   description: Canonical source for classifiers on PyPI (pypi.org).
   copyright:
     - license: Apache-2.0

--- a/py3-typing-extensions.yaml
+++ b/py3-typing-extensions.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-typing-extensions
   version: 4.8.0
-  epoch: 0
+  epoch: 1
   description: Backported and Experimental Type Hints for Python 3.7+
   copyright:
     - license: Python Software Foundation

--- a/py3-typing-inspect.yaml
+++ b/py3-typing-inspect.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-typing-inspect
   version: 0.9.0
-  epoch: 0
+  epoch: 1
   description: Runtime inspection utilities for typing module.
   copyright:
     - license: MIT

--- a/py3-typing.yaml
+++ b/py3-typing.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-typing
   version: 3.10.0.0
-  epoch: 0
+  epoch: 1
   description: Type Hints for Python
   copyright:
     - license: PSF

--- a/py3-tz.yaml
+++ b/py3-tz.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tz
   version: 2023.3
-  epoch: 1
+  epoch: 2
   description: Python3 definitions of world timezone
   copyright:
     - license: MIT

--- a/py3-tzdata.yaml
+++ b/py3-tzdata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tzdata
   version: "2023.3"
-  epoch: 0
+  epoch: 1
   description: Provider of IANA time zone data
   copyright:
     - license: Apache-2.0

--- a/py3-ujson.yaml
+++ b/py3-ujson.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ujson
   version: 5.8.0
-  epoch: 0
+  epoch: 1
   description: "Ultra fast JSON decoder and encoder written in C with Python bindings."
   copyright:
     - license: BSD-3-Clause

--- a/py3-uritemplate.yaml
+++ b/py3-uritemplate.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-uritemplate
   version: 4.1.1
-  epoch: 0
+  epoch: 1
   description: Implementation of RFC 6570 URI Templates
   copyright:
     - license: BSD 3-Clause License or Apache License, Version 2.0

--- a/py3-urllib3-1.yaml
+++ b/py3-urllib3-1.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-urllib3-1
   version: 1.26.16
-  epoch: 0
+  epoch: 1
   description: "HTTP library with thread-safe connection pooling, file post, and more"
   copyright:
     - license: MIT

--- a/py3-urllib3.yaml
+++ b/py3-urllib3.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-urllib3
   version: 2.0.5
-  epoch: 0
+  epoch: 1
   description: "HTTP library with thread-safe connection pooling, file post, and more"
   copyright:
     - license: MIT

--- a/py3-userpath.yaml
+++ b/py3-userpath.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-userpath
   version: 1.9.1
-  epoch: 0
+  epoch: 1
   description: Cross-platform tool for adding locations to the user PATH
   copyright:
     - license: "MIT"

--- a/py3-versioneer.yaml
+++ b/py3-versioneer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-versioneer
   version: "0.29"
-  epoch: 0
+  epoch: 1
   description: Easy VCS-based management of project version strings
   copyright:
     - license: 'Unlicense'

--- a/py3-virtualenv.yaml
+++ b/py3-virtualenv.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-virtualenv
   version: 20.24.5
-  epoch: 0
+  epoch: 1
   description: Virtual Python Environment builder
   copyright:
     - license: "MIT"

--- a/py3-wcmatch.yaml
+++ b/py3-wcmatch.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wcmatch
   version: "8.5"
-  epoch: 0
+  epoch: 1
   description: "Wilcard File Name matching library."
   copyright:
     - license: MIT

--- a/py3-wcwidth.yaml
+++ b/py3-wcwidth.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-wcwidth
   version: 0.2.8
-  epoch: 0
+  epoch: 1
   description: Measures the displayed width of unicode strings in a terminal
   copyright:
     - license: MIT

--- a/py3-webencodings.yaml
+++ b/py3-webencodings.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-webencodings
   version: 0.5.1
-  epoch: 0
+  epoch: 1
   description: Character encoding aliases for legacy web content
   copyright:
     - license: BSD

--- a/py3-websocket-client.yaml
+++ b/py3-websocket-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-websocket-client
   version: 1.6.3
-  epoch: 0
+  epoch: 1
   description: WebSocket client for Python with low level API options
   copyright:
     - license: Apache-2.0

--- a/py3-werkzeug.yaml
+++ b/py3-werkzeug.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-werkzeug
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: The comprehensive WSGI web application library.
   copyright:
     - license: BSD-3-Clause

--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wheel
   version: 0.41.2
-  epoch: 0
+  epoch: 1
   description: "built-package format for Python"
   copyright:
     - license: MIT

--- a/py3-widgetsnbextension.yaml
+++ b/py3-widgetsnbextension.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-widgetsnbextension
   version: 4.0.9
-  epoch: 0
+  epoch: 1
   description: Jupyter interactive widgets for Jupyter Notebook
   copyright:
     - license: BSD 3-Clause License

--- a/py3-wrapt.yaml
+++ b/py3-wrapt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wrapt
   version: 1.15.0
-  epoch: 0
+  epoch: 1
   description: Module for decorators, wrappers and monkey patching.
   copyright:
     - license: BSD

--- a/py3-xmlsec.yaml
+++ b/py3-xmlsec.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-xmlsec
   version: 1.3.13
-  epoch: 0
+  epoch: 1
   description: About Python bindings for the XML Security Library
   copyright:
     - license: MIT

--- a/py3-xyzservices.yaml
+++ b/py3-xyzservices.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-xyzservices
   version: 2023.7.0
-  epoch: 0
+  epoch: 1
   description: Source of XYZ tiles providers
   copyright:
     - license: 3-Clause BSD

--- a/py3-yaml.yaml
+++ b/py3-yaml.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-yaml
   version: 6.0.1
-  epoch: 0
+  epoch: 1
   description: "Python3 bindings for YAML"
   copyright:
     - license: MIT

--- a/py3-yarl.yaml
+++ b/py3-yarl.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-yarl
   version: 1.9.2
-  epoch: 0
+  epoch: 1
   description: Yet another URL library
   copyright:
     - license: Apache-2.0

--- a/py3-zipp.yaml
+++ b/py3-zipp.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-zipp
   version: 3.17.0
-  epoch: 0
+  epoch: 1
   description: Backport of pathlib-compatible object wrapper for zip files
   copyright:
     - license: MIT License

--- a/py3-zstandard.yaml
+++ b/py3-zstandard.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-zstandard
   version: 0.21.0
-  epoch: 1
+  epoch: 2
   description: Zstandard bindings for Python
   copyright:
     - license: BSD

--- a/py3.10-installer.yaml
+++ b/py3.10-installer.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3.10-installer
   version: 0.7.0 # When bumping this, also bump the provides below!
-  epoch: 2
+  epoch: 3
   description: A library for installing Python wheels.
   copyright:
     - license: "MIT"

--- a/py3.10-pip.yaml
+++ b/py3.10-pip.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3.10-pip
   version: 23.2.1
-  epoch: 0
+  epoch: 1
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT

--- a/py3.10-setuptools.yaml
+++ b/py3.10-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.10-setuptools
   version: 68.2.2
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"

--- a/py3.11-installer.yaml
+++ b/py3.11-installer.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3.11-installer
   version: 0.7.0 # When bumping this, also bump the provides below!
-  epoch: 1
+  epoch: 2
   description: A library for installing Python wheels.
   copyright:
     - license: "MIT"

--- a/py3.11-pip.yaml
+++ b/py3.11-pip.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3.11-pip
   version: 23.2.1
-  epoch: 0
+  epoch: 1
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT

--- a/py3.11-setuptools.yaml
+++ b/py3.11-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.11-setuptools
   version: 68.2.2 # When bumping this, also bump the provides below!
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"

--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: 3.10.13
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: 3.11.5
-  epoch: 2
+  epoch: 3
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/rabbitmq-server.yaml
+++ b/rabbitmq-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-server
   version: 3.12.6
-  epoch: 0
+  epoch: 1
   description: Open source RabbitMQ. core server and tier 1 (built-in) plugins
   copyright:
     - license: MPL-2.0

--- a/reflex.yaml
+++ b/reflex.yaml
@@ -1,7 +1,7 @@
 package:
   name: reflex
   version: 0.2.8
-  epoch: 0
+  epoch: 1
   description: "Web apps in pure Python"
   copyright:
     - license: Apache-2.0

--- a/rethinkdb.yaml
+++ b/rethinkdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: rethinkdb
   version: 2.4.3
-  epoch: 0
+  epoch: 1
   description: The open-source database for the realtime web.
   copyright:
     - license: Apache-2.0

--- a/rust.yaml
+++ b/rust.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust
   version: 1.72.1
-  epoch: 0
+  epoch: 1
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rustup.yaml
+++ b/rustup.yaml
@@ -1,7 +1,7 @@
 package:
   name: rustup
   version: 1.26.0
-  epoch: 0
+  epoch: 1
   description: "rustup is an installer for the systems programming language Rust"
   copyright:
     - license: MIT

--- a/s3cmd.yaml
+++ b/s3cmd.yaml
@@ -1,7 +1,7 @@
 package:
   name: s3cmd
   version: 2.3.0
-  epoch: 0
+  epoch: 1
   description: Command-line tool for managing Amazon S3 and CloudFront services
   copyright:
     - license: GPL-2.0-or-later

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1,7 +1,7 @@
 package:
   name: semgrep
   version: 1.42.0
-  epoch: 0
+  epoch: 1
   description: "Lightweight static analysis for many languages. Find bug variants with patterns that look like source code."
   copyright:
     - license: LGPL-2.1

--- a/souffle.yaml
+++ b/souffle.yaml
@@ -1,7 +1,7 @@
 package:
   name: souffle
   version: 2.4
-  epoch: 0
+  epoch: 1
   description: Soufflé is a variant of Datalog for tool designers crafting analyses in Horn clauses. Soufflé synthesizes a native parallel C++ program from a logic specification.
   copyright:
     - license: UPL-1.0

--- a/spirv-tools.yaml
+++ b/spirv-tools.yaml
@@ -2,7 +2,7 @@
 package:
   name: spirv-tools
   version: 1.3.261.1
-  epoch: 0
+  epoch: 1
   description: API and commands for processing SPIR-V modules
   copyright:
     - license: Apache-2.0

--- a/sqlmap.yaml
+++ b/sqlmap.yaml
@@ -1,7 +1,7 @@
 package:
   name: sqlmap
   version: 1.7.6
-  epoch: 0
+  epoch: 1
   description: "a tool that automates the process of detecting and exploiting SQL injection flaws"
   copyright:
     - license: GPL-2.0

--- a/stunnel.yaml
+++ b/stunnel.yaml
@@ -1,7 +1,7 @@
 package:
   name: stunnel
   version: "5.71"
-  epoch: 0
+  epoch: 1
   description: SSL encryption wrapper between network client and server
   copyright:
     - license: GPL-2.0-or-later with OpenSSL exception

--- a/supervisor.yaml
+++ b/supervisor.yaml
@@ -1,7 +1,7 @@
 package:
   name: supervisor
   version: 4.2.5
-  epoch: 0
+  epoch: 1
   description: Supervisor process control system for Unix (supervisord)
   copyright:
     - license: BSD

--- a/suricata-update.yaml
+++ b/suricata-update.yaml
@@ -1,7 +1,7 @@
 package:
   name: suricata-update
   version: 1.2.7
-  epoch: 1
+  epoch: 2
   description: "The tool for updating your Suricata rules"
   copyright:
     - license: GPL-2.0-only

--- a/suricata.yaml
+++ b/suricata.yaml
@@ -1,7 +1,7 @@
 package:
   name: suricata
   version: 7.0.1
-  epoch: 0
+  epoch: 1
   description: "Suricata is a network Intrusion Detection System, Intrusion Prevention System and Network Security Monitoring engine"
   copyright:
     - license: GPL-2.0-only

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "254"
-  epoch: 1
+  epoch: 2
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later

--- a/tdb.yaml
+++ b/tdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: tdb
   version: 1.4.9
-  epoch: 0
+  epoch: 1
   description: The tdb library
   copyright:
     - license: LGPL-3.0-or-later

--- a/tensorflow-core.yaml
+++ b/tensorflow-core.yaml
@@ -2,7 +2,7 @@ package:
   name: tensorflow-core
   description: Framework for data-graph oriented computing (core libraries, oneDNN build)
   version: 2.13.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
 

--- a/tiff.yaml
+++ b/tiff.yaml
@@ -1,7 +1,7 @@
 package:
   name: tiff
   version: 4.6.0
-  epoch: 0
+  epoch: 1
   description: Provides support for the Tag Image File Format or TIFF
   copyright:
     - license: libtiff

--- a/tomcat-native.yaml
+++ b/tomcat-native.yaml
@@ -1,7 +1,7 @@
 package:
   name: tomcat-native
   version: 2.0.5
-  epoch: 1
+  epoch: 2
   description: OpenSSL extension for Tomcat
   copyright:
     - license: Apache-2.0

--- a/valgrind.yaml
+++ b/valgrind.yaml
@@ -1,7 +1,7 @@
 package:
   name: valgrind
   version: "3.21.0"
-  epoch: 0
+  epoch: 1
   description: "Tool to help find memory-management problems in programs"
   copyright:
     - license: GPL-2.0-or-later

--- a/vault-1.13.yaml
+++ b/vault-1.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-1.13
   version: 1.13.7
-  epoch: 0
+  epoch: 1
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0

--- a/vault-1.14.yaml
+++ b/vault-1.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-1.14
   version: 1.14.3
-  epoch: 0
+  epoch: 1
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0

--- a/vim.yaml
+++ b/vim.yaml
@@ -1,7 +1,7 @@
 package:
   name: vim
   version: 9.0.1963
-  epoch: 0
+  epoch: 1
   description: "Improved vi-style text editor"
   copyright:
     - license: Vim

--- a/wabt.yaml
+++ b/wabt.yaml
@@ -1,7 +1,7 @@
 package:
   name: wabt
   version: 1.0.33
-  epoch: 0
+  epoch: 1
   description: The WebAssembly Binary Toolkit
   copyright:
     - license: Apache-2.0

--- a/wasmedge.yaml
+++ b/wasmedge.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasmedge
   version: 0.13.4
-  epoch: 0
+  epoch: 1
   description: WasmEdge is a lightweight, high-performance, and extensible WebAssembly runtime for cloud native, edge, and decentralized applications.
   target-architecture:
     - all

--- a/xcb-proto.yaml
+++ b/xcb-proto.yaml
@@ -1,7 +1,7 @@
 package:
   name: xcb-proto
   version: 1.16.0
-  epoch: 0
+  epoch: 1
   description: XML-XCB protocol descriptions
   copyright:
     - license: MIT

--- a/xfsprogs.yaml
+++ b/xfsprogs.yaml
@@ -1,7 +1,7 @@
 package:
   name: xfsprogs
   version: 6.4.0
-  epoch: 1
+  epoch: 2
   description: XFS filesystem utilities
   copyright:
     - license: LGPL-2.1-or-later

--- a/xmlsec.yaml
+++ b/xmlsec.yaml
@@ -1,7 +1,7 @@
 package:
   name: xmlsec
   version: 1.3.1
-  epoch: 0
+  epoch: 1
   description: C based implementation for XML Signature Syntax and Processing and XML Encryption Syntax and Processing
   copyright:
     - license: MIT


### PR DESCRIPTION
After https://github.com/wolfi-dev/os/pull/6123 we'll need to rebuild everything that's built with python3 to be built with 3.12. This is an attempt to collect those bumps and get feedback about what else I've missed.

I did this pretty naively, with `git grep -l -- "- py.*3" | xargs wolfictl bump`, then eyeballed probably 20 or so packages that weren't named `py3-*`, I only found one that wasn't a genuine build-time dep (AFAIK)