### PR TITLE
Python: Add py3-iniconfig package

### DIFF
--- a/py3-iniconfig.yaml
+++ b/py3-iniconfig.yaml
@@ -1,0 +1,39 @@
+package:
+  name: py3-iniconfig
+  version: 2.0.0
+  epoch: 0
+  description: brain-dead simple parsing of ini files
+  copyright:
+    - license: MIT License
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - ca-certificates-bundle
+      - py3-pip
+      - python3
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pytest-dev/iniconfig
+      expected-commit: 93f5930e668c0d1ddf4597e38dd0dea4e2665e7a
+      tag: v${{package.version}}
+
+  - name: Python build
+    runs: |
+      pip install . --prefix=/usr --root=${{targets.destdir}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pytest-dev/iniconfig
+    tag-filter: v
+    strip-prefix: v


### PR DESCRIPTION
`iniconfig` is a dependency of `pytest`, a Python testing framework that, to the best of my knowledge, is more widely used than the batteries-included test framework in Python's standard library. Adding `iniconfig` (and other packages) will eventually enable the addition of `pytest` to Wolfi.

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`) (I could not find such a policy)