### PR TITLE
fix/nack some lint findings

### DIFF
--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.7
   version: 2.7.14
-  epoch: 1
+  epoch: 2
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -54,8 +54,6 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/bin
       mv dist/argocd* ${{targets.destdir}}/usr/bin/
 
-      # ArgoCD manifests and helm charts all hardcode the executables path to /usr/local/bin/*
-      mkdir -p ${{targets.destdir}}/usr/local/bin/
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-server
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-repo-server
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-cmp-server
@@ -93,6 +91,7 @@ subpackages:
     description: "Compatibility package for locating binaries according to upstream helm charts"
     pipeline:
       - runs: |
+          # ArgoCD manifests and helm charts all hardcode the executables path to /usr/local/bin/*
           mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
           # This must be copied and not symlinked due to how `argocd` copies executables between (init)containers
           # example: https://github.com/argoproj/argo-helm/blob/argo-cd-5.33.1/charts/argo-cd/templates/dex/deployment.yaml#L136-L143

--- a/argo-cd-2.8.yaml
+++ b/argo-cd-2.8.yaml
@@ -1,13 +1,13 @@
 package:
   name: argo-cd-2.8
   version: 2.8.4
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
-      - argo-cd=2.8.999
+      - argo-cd=2.8.999 # When updating to 2.9, use ${{package.version}} instead of 2.9.999
 
 environment:
   contents:
@@ -51,8 +51,6 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/bin
       mv dist/argocd* ${{targets.destdir}}/usr/bin/
 
-      # ArgoCD manifests and helm charts all hardcode the executables path to /usr/local/bin/*
-      mkdir -p ${{targets.destdir}}/usr/local/bin/
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-server
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-repo-server
       ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-cmp-server
@@ -90,6 +88,7 @@ subpackages:
     description: "Compatibility package for locating binaries according to upstream helm charts"
     pipeline:
       - runs: |
+          # ArgoCD manifests and helm charts all hardcode the executables path to /usr/local/bin/*
           mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
           # This must be copied and not symlinked due to how `argocd` copies executables between (init)containers
           # example: https://github.com/argoproj/argo-helm/blob/argo-cd-5.33.1/charts/argo-cd/templates/dex/deployment.yaml#L136-L143

--- a/dex.yaml
+++ b/dex.yaml
@@ -6,6 +6,9 @@ package:
   description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors
   copyright:
     - license: Apache-2.0
+  checks:
+    disabled:
+      - srv
 
 environment:
   contents:

--- a/haproxy-ingress.yaml
+++ b/haproxy-ingress.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-ingress
   version: 0.14.5
-  epoch: 1
+  epoch: 2
   description: HAProxy Ingress
   copyright:
     - license: Apache-2.0

--- a/haproxy-ingress.yaml
+++ b/haproxy-ingress.yaml
@@ -39,7 +39,7 @@ pipeline:
       # Move the startup scripts to /usr/bin
       mv ./rootfs/*.sh ${{targets.destdir}}/usr/bin/
 
-      mkdir -p ${{targets.destdir}}/var/empty  ${{targets.destdir}}/etc/lua ${{targets.destdir}}/etc/haproxy ${{targets.destdir}}/var/lib/haproxy ${{targets.destdir}}/var/run/haproxy
+      mkdir -p ${{targets.destdir}}/var/empty  ${{targets.destdir}}/etc/lua ${{targets.destdir}}/etc/haproxy ${{targets.destdir}}/var/lib/haproxy
       install -Dm755 ./rootfs/haproxy-ingress-controller ${{targets.destdir}}/usr/bin/haproxy-ingress-controller
 
   - uses: strip

--- a/heimdal.yaml
+++ b/heimdal.yaml
@@ -5,6 +5,9 @@ package:
   description: "Implementation of Kerberos 5"
   copyright:
     - license: BSD-3-Clause
+  checks:
+    disabled:
+      - setuidgid
 
 environment:
   contents:


### PR DESCRIPTION
- argo-cd-2.{7,8} shouldn't create an empty `/usr/local/bin` in the main package, only the `-compat` package
- heimdal is like su, and needs to setuid
- haproxy-ingress shouldn't create /var/run/haproxy
- dex writes to `/srv`