### PR TITLE
vault: fix lint errors

### DIFF
--- a/vault-1.13.yaml
+++ b/vault-1.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-1.13
   version: 1.13.7
-  epoch: 0
+  epoch: 1
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0
@@ -71,7 +71,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "${{package.name}}-entrypoint"
+  - name: "${{package.name}}-compat"
     description: "Container entrypoint script for vault and required dependencies"
     pipeline:
       - runs: |
@@ -84,6 +84,7 @@ subpackages:
     dependencies:
       provides:
         - vault-entrypoint=1.13.999 # This is because we had a 1.13.3 vault package, remove in 1.15+
+        - ${{package.name}}-entrypoint=1.13.999 # This was previously called vault-entrypoint, remove in 1.15+
       runtime:
         - dumb-init
         - busybox

--- a/vault-1.14.yaml
+++ b/vault-1.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-1.14
   version: 1.14.3
-  epoch: 0
+  epoch: 1
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0
@@ -71,7 +71,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "${{package.name}}-entrypoint"
+  - name: "${{package.name}}-compat"
     description: "Container entrypoint script for vault and required dependencies"
     pipeline:
       - runs: |
@@ -84,6 +84,7 @@ subpackages:
     dependencies:
       provides:
         - vault-entrypoint=1.14.999 # This is because we had a 1.14.1 vault package, remove in 1.15+
+        - ${{package.name}}-entrypoint=1.14.999 # This was previously called vault-entrypoint, remove in 1.15+
       runtime:
         - dumb-init
         - busybox


### PR DESCRIPTION
This package has an `-entrypoint` package for compatibility with the OCI image, which should be named `-compat`. We didn't have this idiom back when this subpackage was created.