### PR TITLE
Revert "newrelic-nri-kube-events/2.3.0 package update"

### DIFF
--- a/newrelic-nri-kube-events.yaml
+++ b/newrelic-nri-kube-events.yaml
@@ -1,6 +1,6 @@
 package:
   name: newrelic-nri-kube-events
-  version: 2.3.0
+  version: 2.2.7
   epoch: 0
   description: New Relic integration that forwards Kubernetes events to New Relic
   copyright:
@@ -21,7 +21,7 @@ pipeline:
     with:
       repository: https://github.com/newrelic/nri-kube-events
       tag: v${{package.version}}
-      expected-commit: 00e115da58d204e782d98e996ba5c5e730a371f3
+      expected-commit: 75fcefe3e0a7971e8209378c15feb20e55b976fe
 
   - uses: go/build
     with:


### PR DESCRIPTION
Reverts wolfi-dev/os#6032

The upstream seems to have deleted the tag.

https://github.com/wolfi-dev/os/pull/6133#issuecomment-1742293926

I see https://github.com/newrelic/nri-kube-events/commit/00e115da58d204e782d98e996ba5c5e730a371f3 which looks like it was the 2.3.0 release commit, but now it's not on any branch.