### PR TITLE
Add python 3.12 release package.

### DIFF
--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,6 @@
 package:
   name: python-3.12
-  # When bumping to a real non-prerelease you'll have to change the URL pattern on line 45
-  version: 3.12.0_rc3
+  version: 3.12.0
   epoch: 0
   description: "the Python programming language"
   copyright:
@@ -29,8 +28,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://www.python.org/ftp/python/3.12.0/Python-3.12.0rc3.tar.xz
-      expected-sha256: 96397e891e98802b1d399dee3ceaeb9bcf0aa2566c8a7b1cce4d0196c277506a
+      uri: https://www.python.org/ftp/python/${{package.version}}/Python-${{package.version}}.tar.xz
+      expected-sha256: 795c34f44df45a0e9b9710c8c71c15c671871524cd412ca14def212e8ccb155d
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
They haven't published the tag yet so we'll need to keep updates manual.

Fixes:

Related:

### Pre-review Checklist
