### PR TITLE
Add vexctl package

### DIFF
--- a/vexctl.yaml
+++ b/vexctl.yaml
@@ -1,0 +1,32 @@
+package:
+  name: vexctl
+  version: 0.2.3
+  epoch: 0
+  description: A tool to create, transform and attest VEX metadata
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - go
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: go/install
+    with:
+      package: github.com/openvex/vexctl
+      version: v${{package.version}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: openvex/vexctl
+    strip-prefix: v

--- a/vexctl.yaml
+++ b/vexctl.yaml
@@ -5,17 +5,6 @@ package:
   description: A tool to create, transform and attest VEX metadata
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - go
-
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - go
 
 pipeline:
   - uses: go/install


### PR DESCRIPTION
This PR packages `vexctl`, a Go tool for creating, transforming, and attesting VEX metadata. It is part of the OpenVEX project.

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`) (no support policy present)