### PR TITLE
Add sbomqs package

### DIFF
--- a/sbomqs.yaml
+++ b/sbomqs.yaml
@@ -1,0 +1,22 @@
+package:
+  name: sbomqs
+  version: 0.0.21
+  epoch: 0
+  description: SBOM quality score - Quality metrics for your sboms
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: go/install
+    with:
+      package: github.com/interlynk-io/sbomqs
+      version: v${{package.version}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: interlynk-io/sbomqs
+    tag-filter: v
+    strip-prefix: v


### PR DESCRIPTION
`sbomqs` is an SBOM quality scoring tool.

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`) (none found)