### PR TITLE
Add Sigstore `timestamp-authority` package.

### DIFF
--- a/timestamp-authority.yaml
+++ b/timestamp-authority.yaml
@@ -1,0 +1,52 @@
+package:
+  name: timestamp-authority
+  version: 1.1.2
+  epoch: 0
+  description: RFC3161 Timestamp Authority
+  target-architecture:
+    - all
+  copyright:
+    - license: Apache-2.0
+      paths:
+        - "*"
+  checks:
+    disabled:
+      - empty
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - git
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/sigstore/timestamp-authority
+      tag: v${{package.version}}
+      expected-commit: 0fe7ba862a2edd29dabbaaf50ea3b339d9f08ff4
+
+  - runs: make timestamp-cli timestamp-server
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-server
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ./bin/timestamp-server ${{targets.subpkgdir}}/usr/bin/
+
+  - name: ${{package.name}}-cli
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ./bin/timestamp-cli ${{targets.subpkgdir}}/usr/bin/
+
+update:
+  enabled: true
+  github:
+    identifier: sigstore/timestamp-authority
+    strip-prefix: v


### PR DESCRIPTION
### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

