### PR TITLE
Cargo-1.72.1 new package(sub package of rust)

### DIFF
--- a/rust.yaml
+++ b/rust.yaml
@@ -112,6 +112,19 @@ pipeline:
       ln -srft usr/lib   usr/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.so
       ln -srft usr/lib32 usr/lib/rustlib/i686-unknown-linux-gnu/lib/*.so
 
+subpackages:
+  - name: cargo
+    description: "Rust's package manager"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/cargo ${{targets.subpkgdir}}/usr/bin/cargo
+          mkdir -p ${{targets.subpkgdir}}/usr/libexec
+          mv ${{targets.destdir}}/usr/libexec/cargo-credential-1password ${{targets.subpkgdir}}/usr/libexec/cargo-credential-1password
+          # Move all the cargo docs 
+          mkdir -p ${{targets.subpkgdir}}/usr/share/man/man1
+          mv ${{targets.destdir}}/usr/share/man/man1/cargo* ${{targets.subpkgdir}}/usr/share/man/man1
+
 update:
   enabled: true
   github:

--- a/rust.yaml
+++ b/rust.yaml
@@ -121,7 +121,6 @@ subpackages:
           mv ${{targets.destdir}}/usr/bin/cargo ${{targets.subpkgdir}}/usr/bin/cargo
           mkdir -p ${{targets.subpkgdir}}/usr/libexec
           mv ${{targets.destdir}}/usr/libexec/cargo-credential-1password ${{targets.subpkgdir}}/usr/libexec/cargo-credential-1password
-          # Move all the cargo docs 
           mkdir -p ${{targets.subpkgdir}}/usr/share/man/man1
           mv ${{targets.destdir}}/usr/share/man/man1/cargo* ${{targets.subpkgdir}}/usr/share/man/man1
 


### PR DESCRIPTION

Related: #6203 

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] The PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)



