### PR TITLE
keda-2.11: new version stream

### DIFF
--- a/keda-2.11.yaml
+++ b/keda-2.11.yaml
@@ -3,7 +3,7 @@
 package:
   name: keda-2.11
   version: 2.11.2
-  epoch: 0
+  epoch: 4
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0

--- a/keda-2.11.yaml
+++ b/keda-2.11.yaml
@@ -72,4 +72,8 @@ subpackages:
       - uses: strip
 
 update:
-  enabled: false
+  enabled: true
+  github:
+    identifier: kedacore/keda
+    strip-prefix: v
+    tag-filter: v2.11.

--- a/keda-2.11.yaml
+++ b/keda-2.11.yaml
@@ -1,3 +1,5 @@
+# KEDA 2.11 version stream
+# Remove after 2.14 or 3.0
 package:
   name: keda-2.11
   version: 2.11.2
@@ -8,6 +10,8 @@ package:
   dependencies:
     runtime:
       - tzdata
+    provides:
+      - keda=${{package.full-version}}
 
 environment:
   contents:

--- a/keda-2.11.yaml
+++ b/keda-2.11.yaml
@@ -1,0 +1,71 @@
+package:
+  name: keda-2.11
+  version: 2.11.2
+  epoch: 0
+  description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - tzdata
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - go
+      - busybox
+      - build-base
+      - protobuf-dev
+      - protoc
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kedacore/keda
+      tag: v${{package.version}}
+      expected-commit: 517ed30cc311b0b81e39112cff0fa8e3251aed69
+
+  - runs: |
+      ARCH=$(go env GOARCH) make build
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      mv bin/keda "${{targets.destdir}}/usr/bin"
+
+  - uses: strip
+
+subpackages:
+  - name: "keda-adapter-2.11"
+    dependencies:
+      runtime:
+        - tzdata
+    description: "Metrics adapter for Keda"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/bin"
+          mv bin/keda-adapter "${{targets.subpkgdir}}/usr/bin"
+      - uses: strip
+
+  - name: "keda-admission-webhooks-2.11"
+    dependencies:
+      runtime:
+        - tzdata
+    description: "Webhooks for Keda"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/bin"
+          mv bin/keda-admission-webhooks "${{targets.subpkgdir}}/usr/bin"
+      - uses: strip
+
+  - name: "keda-compat-2.11"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          # The helm chart expects the keda binaries to be in / instead of /usr/bin
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/keda ${{targets.subpkgdir}}/keda
+          ln -sf /usr/bin/keda-admission-webhooks ${{targets.subpkgdir}}/keda-admission-webhooks
+          ln -sf /usr/bin/keda-adapter ${{targets.subpkgdir}}/keda-adapter
+      - uses: strip
+
+update:
+  enabled: false


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

KEDA Supports N-2 minor revisions (https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions) so this simply breaks out the N-1 version now that 2.12 is latest

Fixes:

Related:

https://github.com/wolfi-dev/os/pull/6024

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
