### PR TITLE
Configure keda virtual packages

### DIFF
--- a/keda-2.10.yaml
+++ b/keda-2.10.yaml
@@ -1,10 +1,10 @@
-# KEDA 2.11 version stream
-# Remove after 2.14 or 3.0
+# KEDA 2.10 version stream
+# Remove after 2.13 or 3.0
 package:
-  name: keda-2.11
+  name: keda-2.10
   # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
-  version: 2.11.2
-  epoch: 5
+  version: 2.10.1
+  epoch: 2
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,10 @@ package:
 
 environment:
   contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - ca-certificates-bundle
       - go
@@ -29,7 +33,7 @@ pipeline:
     with:
       repository: https://github.com/kedacore/keda
       tag: v${{package.version}}
-      expected-commit: 517ed30cc311b0b81e39112cff0fa8e3251aed69
+      expected-commit: 8adb70e97a08a4690613eef4c4f00391e44e1603
 
   - runs: |
       ARCH=$(go env GOARCH) make build
@@ -84,4 +88,4 @@ update:
   github:
     identifier: kedacore/keda
     strip-prefix: v
-    tag-filter: v2.11.
+    tag-filter: v2.10.

--- a/keda-2.10.yaml
+++ b/keda-2.10.yaml
@@ -16,10 +16,6 @@ package:
 
 environment:
   contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - ca-certificates-bundle
       - go

--- a/keda-2.11.yaml
+++ b/keda-2.11.yaml
@@ -2,8 +2,9 @@
 # Remove after 2.14 or 3.0
 package:
   name: keda-2.11
+  # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
   version: 2.11.2
-  epoch: 4
+  epoch: 5
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -38,10 +39,12 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "keda-adapter-2.11"
+  - name: "${{package.name}}-adapter"
     dependencies:
       runtime:
         - tzdata
+      provides:
+        - keda-adapter=${{package.full-version}}
     description: "Metrics adapter for Keda"
     pipeline:
       - runs: |
@@ -49,10 +52,12 @@ subpackages:
           mv bin/keda-adapter "${{targets.subpkgdir}}/usr/bin"
       - uses: strip
 
-  - name: "keda-admission-webhooks-2.11"
+  - name: "${{package.name}}-admission-webhooks"
     dependencies:
       runtime:
         - tzdata
+      provides:
+        - keda-admission-webhooks=${{package.full-version}}
     description: "Webhooks for Keda"
     pipeline:
       - runs: |
@@ -60,7 +65,10 @@ subpackages:
           mv bin/keda-admission-webhooks "${{targets.subpkgdir}}/usr/bin"
       - uses: strip
 
-  - name: "keda-compat-2.11"
+  - name: "${{package.name}}-compat"
+    dependencies:
+      provides:
+        - keda-compat=${{package.full-version}}
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"
     pipeline:
       - runs: |

--- a/keda.yaml
+++ b/keda.yaml
@@ -38,12 +38,12 @@ pipeline:
 
 subpackages:
   - name: "${{package.name}}-adapter"
+    description: "Metrics adapter for Keda"
     dependencies:
       runtime:
         - tzdata
       provides:
         - keda-adapter=${{package.full-version}}
-    description: "Metrics adapter for Keda"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"
@@ -51,12 +51,12 @@ subpackages:
       - uses: strip
 
   - name: "${{package.name}}-admission-webhooks"
+    description: "Webhooks for Keda"
     dependencies:
       runtime:
         - tzdata
       provides:
         - keda-admission-webhooks=${{package.full-version}}
-    description: "Webhooks for Keda"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"
@@ -64,10 +64,10 @@ subpackages:
       - uses: strip
 
   - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
     dependencies:
       provides:
         - keda-compat=${{package.full-version}}
-    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
     pipeline:
       - runs: |
           # The helm chart expects the keda binaries to be in / instead of /usr/bin

--- a/keda.yaml
+++ b/keda.yaml
@@ -1,13 +1,16 @@
 package:
   name: keda
+  # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
   version: 2.12.0
-  epoch: 0
+  epoch: 1
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - tzdata
+    provides:
+      - keda=${{package.full-version}}
 
 environment:
   contents:
@@ -34,10 +37,12 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "keda-adapter"
+  - name: "${{package.name}}-adapter"
     dependencies:
       runtime:
         - tzdata
+      provides:
+        - keda-adapter=${{package.full-version}}
     description: "Metrics adapter for Keda"
     pipeline:
       - runs: |
@@ -45,10 +50,12 @@ subpackages:
           mv bin/keda-adapter "${{targets.subpkgdir}}/usr/bin"
       - uses: strip
 
-  - name: "keda-admission-webhooks"
+  - name: "${{package.name}}-admission-webhooks"
     dependencies:
       runtime:
         - tzdata
+      provides:
+        - keda-admission-webhooks=${{package.full-version}}
     description: "Webhooks for Keda"
     pipeline:
       - runs: |
@@ -56,7 +63,10 @@ subpackages:
           mv bin/keda-admission-webhooks "${{targets.subpkgdir}}/usr/bin"
       - uses: strip
 
-  - name: "keda-compat"
+  - name: "${{package.name}}-compat"
+    dependencies:
+      provides:
+        - keda-compat=${{package.full-version}}
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"
     pipeline:
       - runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Add support for KEDA version streams following upstream policy: https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

