### PR TITLE
fix cross-compilation of argon2

### DIFF
--- a/argon2.yaml
+++ b/argon2.yaml
@@ -1,7 +1,7 @@
 package:
   name: argon2
   version: '20190702'
-  epoch: 0
+  epoch: 1
   description: The password hash Argon2, winner of PHC
   copyright:
     - license: Apache-2.0
@@ -19,6 +19,10 @@ pipeline:
       depth: 1
       tag: ${{package.version}}
       expected-commit: 62358ba2123abd17fccf2a108a301d4b52c01a7c
+
+  - uses: patch
+    with:
+      patches: fix-cross-compilation.patch
 
   - runs: |
       make -j$(nproc) OPTTARGET=none ARGON2_VERSION=${{package.version}}

--- a/argon2/fix-cross-compilation.patch
+++ b/argon2/fix-cross-compilation.patch
@@ -1,0 +1,35 @@
+# upstream patch merged but unreleased https://github.com/P-H-C/phc-winner-argon2/pull/277
+From cd1c1d8d204e4ec4557e358013567c097cb70562 Mon Sep 17 00:00:00 2001
+From: Vika <kisik21@fireburn.ru>
+Date: Mon, 26 Aug 2019 14:05:22 +0300
+Subject: [PATCH] Fix cross-compilation on some systems
+
+Some Linux distributions (e.g. NixOS, where this issue was spotted) don't provide an unprefixed ar when cross-compiling. This PR aims to fix this.
+
+See[NixOS/nixpkgs#67490](https://github.com/NixOS/nixpkgs/pull/67490) for information on where did it start.
+---
+ Makefile | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 837e7f7..38f16fc 100644
+--- a/Makefile
++++ b/Makefile
+@@ -123,6 +123,8 @@ ifdef LINKED_LIB_EXT
+ LINKED_LIB_SH := lib$(LIB_NAME).$(LINKED_LIB_EXT)
+ endif
+ 
++# Some systems don't provide an unprefixed ar when cross-compiling.
++AR=ar
+ 
+ LIBRARIES = $(LIB_SH) $(LIB_ST)
+ HEADERS = include/argon2.h
+@@ -182,7 +184,7 @@ $(LIB_SH): 	$(SRC)
+ 		$(CC) $(CFLAGS) $(LIB_CFLAGS) $(LDFLAGS) $(SO_LDFLAGS) $^ -o $@
+ 
+ $(LIB_ST): 	$(OBJ)
+-		ar rcs $@ $^
++		$(AR) rcs $@ $^
+ 
+ .PHONY: clean
+ clean:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
