### PR TITLE
use persistent nodes for presubmit builds

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -55,7 +55,7 @@ jobs:
         arch: [ "x86_64", "aarch64" ]
       fail-fast: false
     runs-on:
-      group: wolfi-builder-spot-${{ matrix.arch }}
+      group: wolfi-builder-${{ matrix.arch }}
     needs: changes
     container:
       image: ghcr.io/wolfi-dev/sdk:latest@sha256:8edda3adc0b7a3beb6ecffb04d2ceb86e156c01ba56bc64fd450efc848b3f00d


### PR DESCRIPTION
adopt the existing `wolfi-builder` runner pool for presubmits to get rid of the spot eviction class of flakes