### PR TITLE
Default make command `USE_CACHE` value to `no`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,14 +33,14 @@ Once you're done writing the new package configuration file, you can test it by 
 To build an individual package, you can use a `make` command like this:
 
 ```text
-make package/<your-new-package-name> USE_CACHE=no
+make package/<your-new-package-name>
 ```
 
-For example, if your package name is "foo", run `make package/foo USE_CACHE=no`.
+For example, if your package name is "foo", run `make package/foo`.
 
 This will build the package by invoking [melange](https://github.com/chainguard-dev/melange) in a particular way. This invocation is defined in the [Makefile](Makefile), if you're interested to see how this is wired up. Also, you can run Melange _directly_ without using `make` if you understand what you're doing.
 
-**Note:** The buildsystem has a cache of source files that may help reduce the time your build takes. Feel free to see if this cache helps you by removing `USE_CACHE=no` from the command above. If you encounter issues with this approach, the best advice is to restore the `USE_CACHE=no` to your command and carry on with your builds.
+**Note:** The buildsystem has a cache of source files that may help reduce the time your build takes. Feel free to see if this cache helps you by adding `USE_CACHE=yes` to the command above. If you encounter issues with this approach, the best advice is to remove the `USE_CACHE=no` from your command and carry on with your builds.
 
 When the build finishes, your package(s) should be found in the generated `./packages` directory.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-USE_CACHE ?= yes
+USE_CACHE ?= no
 ARCH ?= $(shell uname -m)
 ifeq (${ARCH}, arm64)
 	ARCH = aarch64


### PR DESCRIPTION
This reduces the amount of typing needed to ensure caching/auth issues don't unexpectedly prevent an otherwise successful build using the `make` command.