### PR TITLE
Adding oj parser package

### DIFF
--- a/oj.yaml
+++ b/oj.yaml
@@ -1,0 +1,59 @@
+package:
+  name: oj
+  version: 3.16.1
+  epoch: 0
+  description: This is the oj JSON parser
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ruby3.2-fluentd
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - ruby-3.2
+      - ruby-3.2-dev
+      - build-base
+      - busybox
+      - git
+
+vars:
+  gem: oj
+
+pipeline:
+  # This package makes use of `git ls-files` in its gemspec so the git repo
+  # must be checked out in order for the gem to build with all files.
+  - uses: git-checkout
+    with:
+      destination: ${{vars.gem}}
+      expected-commit: 53632545c01d6beea86ed4ac2040448784f527c4
+      repository: https://github.com/ohler55/oj.git
+      tag: v${{package.version}}
+
+  - working-directory: ${{vars.gem}}
+    pipeline:
+      - uses: ruby/build
+        with:
+          gem: ${{vars.gem}}
+      - uses: ruby/install
+        with:
+          gem: ${{vars.gem}}
+          version: ${{package.version}}
+
+  - uses: ruby/clean
+
+  - runs: |-
+      GEM_DIR=${{targets.destdir}}$(ruby -e 'puts Gem.default_dir')/gems/${{vars.gem}}-${{package.version}}
+      rm -rf ${GEM_DIR}/test \
+             ${GEM_DIR}/docs \
+             ${GEM_DIR}/*.md \
+             ${GEM_DIR}/.github
+
+update:
+  enabled: true
+  github:
+    identifier: ohler55/oj
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
Used for fluentd and other services

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

Yes, MIT