### PR TITLE
volume-modifier-for-k8s by awslabs

### DIFF
--- a/volume-modifier-for-k8s.yaml
+++ b/volume-modifier-for-k8s.yaml
@@ -1,0 +1,38 @@
+package:
+  name: volume-modifier-for-k8s
+  version: 0.1.2
+  epoch: 0
+  description: volume-modifier-for-k8s is a sidecar deployed alongside CSI drivers to enable volume modification through annotations on the PVC.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/awslabs/volume-modifier-for-k8s
+      tag: v${{package.version}}
+      expected-commit: 69e91a9c0b982dcbc2a347767f49b1862c0dafb5
+
+  # TODO: Add support for plugins
+  - uses: go/build
+    with:
+      go-package: go-1.20 # pin to a specific version of Go as not working with go-1.21 yet
+      packages: ./cmd
+      output: volume-modifier-for-k8s
+      ldflags: "-X main.version=${{package.version}}"
+      modroot: .
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: awslabs/volume-modifier-for-k8s
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
