### PR TITLE
Fix atlantis/0.25.0 version and commit

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,7 +1,7 @@
 package:
   name: atlantis
   version: 0.25.0
-  epoch: 2
+  epoch: 3
   description: Terraform Pull Request Automation
   copyright:
     - license: Apache-2.0
@@ -25,8 +25,8 @@ pipeline:
 
   - runs: |
       CGO_ENABLED=0 go build -trimpath -ldflags \
-        "-s -w -X 'main.version=${ATLANTIS_VERSION}' \
-        -X 'main.commit=${ATLANTIS_COMMIT}' -X 'main.date=${ATLANTIS_DATE}'" \
+        "-s -w -X 'main.version=${{package.version}}' \
+        -X 'main.commit=$(git rev-parse HEAD)' -X 'main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")'" \
         -v -o atlantis .
       mkdir -p "${{targets.destdir}}"/usr/bin
       mv atlantis "${{targets.destdir}}"/usr/bin


### PR DESCRIPTION
Fixing variable values in the `runs` step for `atlantis`.

```
550fab1a74a6:/work/packages# atlantis version
atlantis 0.25.0 (commit: a12823e) (build date: 2023-10-04T19:26:49Z)
```