### PR TITLE
fix: add WildFly OpenSSL runtime dependency

### DIFF
--- a/wildfly-openssl.yaml
+++ b/wildfly-openssl.yaml
@@ -1,10 +1,13 @@
 package:
   name: wildfly-openssl
   version: 2.2.5
-  epoch: 1
+  epoch: 2
   description: OpenSSL-based Java Secure Socket Extension implementation
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - libssl3
 
 environment:
   contents:


### PR DESCRIPTION
Fix WildFly OpenSSL Wolfi package to include the `so:libssl.so.3` runtime dependency required by WildFly OpenSSL.