### PR TITLE
Fix CVE-2023-43804 in urllib3 in several packages

### DIFF
--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-gateway
   version: 2023.9.0
-  epoch: 0
+  epoch: 1
   description: "A multi-tenant server for securely deploying and managing Dask clusters."
   copyright:
     - license: BSD-3-Clause

--- a/k8s-sidecar.yaml
+++ b/k8s-sidecar.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8s-sidecar
   version: 1.25.1
-  epoch: 1
+  epoch: 2
   description: "container intended to run inside a kubernetes cluster to collect config maps with a specified label and store the included files in a local folder"
   copyright:
     - license: MIT

--- a/kube-downscaler.yaml
+++ b/kube-downscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-downscaler
   version: 23.2.0
-  epoch: 5
+  epoch: 6
   description: Scale down Kubernetes deployments after work hours
   copyright:
     - license: GPL-3.0-or-later

--- a/kubeflow-jupyter-web-app.yaml
+++ b/kubeflow-jupyter-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-jupyter-web-app
   version: 1.7.0
-  epoch: 4
+  epoch: 5
   description: Kubeflow jupyter web app component
   copyright:
     - license: Apache-2.0

--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -3,6 +3,9 @@ package:
   version: 2.1.3
   epoch: 5
   description: Machine Learning Pipelines for Kubeflow
+  checks:
+    disabled:
+      - empty
   copyright:
     - license: Apache-2.0
 

--- a/kubeflow-volumes-web-app.yaml
+++ b/kubeflow-volumes-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-volumes-web-app
   version: 1.7.0
-  epoch: 5
+  epoch: 6
   description: Kubeflow volumes web app component
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bumping the epoch causes a rebuild which pulls in the latest (fixed) versions of `urllib3`.

I tried to fix this in `kubeflow-pipelines` too, but wasn't able to in the time I had allotted for today. 😞 

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

https://github.com/wolfi-dev/advisories/pull/296

---

Also fixes "empty linter" error in `kubeflow-pipelines`. cc: @imjasonh 