### PR TITLE
Add support for pdo_pgsql for php 8.1, 8.2.

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: 8.1.24
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -98,6 +98,7 @@ pipeline:
             --with-pdo-mysql=shared,mysqlnd \
             --with-pdo-sqlite=shared \
             --with-pdo-dblib=shared \
+            --with-pdo-pgsql=shared \
         --with-unixODBC=shared,/usr \
         --enable-pcntl=shared \
         --enable-sockets=shared \
@@ -151,6 +152,7 @@ data:
       pdo_mysql: MySQL driver for PDO
       pdo_sqlite: SQLite 3.x driver for PDO
       pdo_dblib: PDO driver for Sybase / MS SQL databases
+      pdo_pgsql: PDO driver for pgsql
       soap: SOAP
       sodium: Sodium
       calendar: Calendar

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: 8.2.11
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -98,6 +98,7 @@ pipeline:
             --with-pdo-mysql=shared,mysqlnd \
             --with-pdo-sqlite=shared \
             --with-pdo-dblib=shared \
+            --with-pdo-pgsql=shared \
         --with-unixODBC=shared,/usr \
         --enable-pcntl=shared \
         --enable-sockets=shared \
@@ -151,6 +152,7 @@ data:
       pdo_mysql: MySQL driver for PDO
       pdo_sqlite: SQLite 3.x driver for PDO
       pdo_dblib: PDO driver for Sybase / MS SQL databases
+      pdo_pgsql: PDO driver for pgsql
       soap: SOAP
       sodium: Sodium
       calendar: Calendar


### PR DESCRIPTION
Add pdo_pgsql for php 8.1, and php 8.2.

Also tested by creating an image that includes these, and then making sure they are seen:
```
bash-5.2# php --ini | grep pgsql
/etc/php/conf.d/pdo_pgsql.ini,
/etc/php/conf.d/pgsql.ini,
bash-5.2# php -m | grep pgsql
pdo_pgsql
pgsql
```

Also:
```
vaikas@vaikas-MBP os % wolfictl scan packages/aarch64/php-pdo_pgsql-8.1.24-r1.apk
Will process: php-pdo_pgsql-8.1.24-r1.apk
✅ No vulnerabilities found
vaikas@vaikas-MBP os % wolfictl scan packages/aarch64/php-pdo_pgsql-8.2.11-r1.apk
Will process: php-pdo_pgsql-8.2.11-r1.apk
✅ No vulnerabilities found
```


Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
