### PR TITLE
build caddy with `CGO_ENABLED: 0`

### DIFF
--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: caddy
   version: 2.7.4
-  epoch: 2
+  epoch: 3
   description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
   copyright:
     - license: Apache-2.0
@@ -11,6 +11,8 @@ environment:
     packages:
       - busybox
       - ca-certificates-bundle
+  environment:
+    CGO_ENABLED: 0
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Caddy can be built without CGO. I noticed the caddy.yaml did not set the CGO_ENABLED variable, which leaves uncertainty on the table. Explicitly setting CGO_ENABLED to 0 to ensure Caddy build are static and CGO-free.