### PR TITLE
Add visualization-server transitive deps vol4

### DIFF
--- a/py3-ipykernel.yaml
+++ b/py3-ipykernel.yaml
@@ -1,0 +1,50 @@
+# Generated from https://pypi.org/project/ipykernel/
+package:
+  name: py3-ipykernel
+  version: 6.25.2
+  epoch: 0
+  description: IPython Kernel for Jupyter
+  copyright:
+    - license: BSD 3-Clause License
+  dependencies:
+    runtime:
+      - py3-appnope
+      - py3-comm
+      - py3-debugpy
+      - py3-ipython
+      - py3-jupyter-client
+      - py3-jupyter-core
+      - py3-matplotlib-inline
+      - py3-nest-asyncio
+      - py3-packaging
+      - py3-psutil
+      - py3-pyzmq
+      - py3-tornado
+      - py3-traitlets
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: f468ddd1f17acb48c8ce67fcfa49ba6d46d4f9ac0438c1f441be7c3d1372230b
+      uri: https://files.pythonhosted.org/packages/8b/4a/3c1ba010e1517191eefb9f2fc556a3aed146b8c4e65708aed3ad17e803c5/ipykernel-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10514

--- a/py3-itables.yaml
+++ b/py3-itables.yaml
@@ -1,0 +1,43 @@
+# Generated from https://pypi.org/project/itables/
+package:
+  name: py3-itables
+  version: 1.6.1
+  epoch: 0
+  description: Interactive Tables in Jupyter
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-ipython
+      - py3-pandas
+      - numpy
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 92ca939215a3ca35d98bdf8d0013f9b91e228344
+      repository: https://github.com/mwouts/itables
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: mwouts/itables
+    strip-prefix: v

--- a/py3-jupyter-client.yaml
+++ b/py3-jupyter-client.yaml
@@ -1,0 +1,46 @@
+# Generated from https://pypi.org/project/jupyter-client/
+package:
+  name: py3-jupyter-client
+  version: 8.3.1
+  epoch: 0
+  description: Jupyter protocol implementation and client libraries
+  copyright:
+    - license: BSD 3-Clause
+  dependencies:
+    runtime:
+      - py3-importlib-metadata
+      - py3-jupyter-core
+      - py3-python-dateutil
+      - py3-pyzmq
+      - py3-tornado
+      - py3-traitlets
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: e240b71d96bae8186ebc40ac075b3d50df4c9edf
+      repository: https://github.com/jupyter/jupyter_client
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: jupyter/jupyter_client
+    strip-prefix: v

--- a/py3-jupyter-core.yaml
+++ b/py3-jupyter-core.yaml
@@ -1,0 +1,42 @@
+# Generated from https://pypi.org/project/jupyter-core/
+package:
+  name: py3-jupyter-core
+  version: 5.3.2
+  epoch: 0
+  description: Jupyter core package. A base package on which Jupyter projects rely.
+  copyright:
+    - license: BSD 3-Clause
+  dependencies:
+    runtime:
+      - py3-platformdirs
+      - py3-traitlets
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 269bb704f9cdcf4e161328912e9e67445d7aa34f
+      repository: https://github.com/jupyter/jupyter_core
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: jupyter/jupyter_core
+    strip-prefix: v

--- a/py3-jupyter-server-terminals.yaml
+++ b/py3-jupyter-server-terminals.yaml
@@ -1,0 +1,38 @@
+# Generated from https://pypi.org/project/jupyter-server-terminals/
+package:
+  name: py3-jupyter-server-terminals
+  version: 0.4.4
+  epoch: 0
+  description: A Jupyter Server Extension Providing Terminals.
+  copyright:
+    - license: '# Licensing terms  This project is licensed under the terms of the Modified BSD License (also known as New or Revised or 3-Clause BSD), as follows:  - Copyright (c) 2021-, Jupyter Development Team  All rights reserved.  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.  Neither the name of the Jupyter Development Team nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  ## About the Jupyter Development Team  The Jupyter Development Team is the set of all contributors to the Jupyter project. This includes all of the Jupyter subprojects.  The core team that coordinates development on GitHub can be found here: https://github.com/jupyter/.  ## Our Copyright Policy  Jupyter uses a shared copyright model. Each contributor maintains copyright over their contributions to Jupyter. But, it is important to note that these contributions are typically only changes to the repositories. Thus, the Jupyter source code, in its entirety is not the copyright of any single person or institution. Instead, it is the collective copyright of the entire Jupyter Development Team. If individual contributors want to maintain a record of what changes/contributions they have specific copyright on, they should indicate their copyright in the commit message of the change, when they commit the change to one of the Jupyter repositories.  With this in mind, the following banner should be used in any source code file to indicate the copyright and license terms:  # Copyright (c) Jupyter Development Team. # Distributed under the terms of the Modified BSD License.'
+  dependencies:
+    runtime:
+      - py3-terminado
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 57ab779797c25a7ba68e97bcfb5d7740f2b5e8a83b5e8102b10438041a7eac5d
+      uri: https://files.pythonhosted.org/packages/54/e1/6bc19392e6957356f085b8d7ec33d6d0d721e646b7576c1c6758dd264c64/jupyter_server_terminals-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 287756

--- a/py3-libcst.yaml
+++ b/py3-libcst.yaml
@@ -1,0 +1,46 @@
+# Generated from https://pypi.org/project/libcst/
+package:
+  name: py3-libcst
+  version: 1.0.1
+  epoch: 0
+  description: A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7, 3.8, 3.9, and 3.10 programs.
+  copyright:
+    - license: MIT and PSF
+  dependencies:
+    runtime:
+      - py3-typing-extensions
+      - py3-typing-inspect
+      - py3-pyyaml
+      - python-3
+      - glibc
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+      - py3-setuptools-rust
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 3cacca1a1029f05707e50703b49fe3dd860aa839
+      repository: https://github.com/Instagram/LibCST
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: Instagram/LibCST
+    strip-prefix: v

--- a/py3-nbclient.yaml
+++ b/py3-nbclient.yaml
@@ -1,0 +1,44 @@
+# Generated from https://pypi.org/project/nbclient/
+package:
+  name: py3-nbclient
+  version: 0.8.0
+  epoch: 0
+  description: A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor.
+  copyright:
+    - license: BSD 3-Clause
+  dependencies:
+    runtime:
+      - py3-jupyter-client
+      - py3-jupyter-core
+      - py3-nbformat
+      - py3-traitlets
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: fea86d646d955ec1595826e961d593611071447a
+      repository: https://github.com/jupyter/nbclient
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: jupyter/nbclient
+    strip-prefix: v

--- a/py3-nbconvert.yaml
+++ b/py3-nbconvert.yaml
@@ -1,0 +1,53 @@
+# Generated from https://pypi.org/project/nbconvert/
+package:
+  name: py3-nbconvert
+  version: 7.9.2
+  epoch: 0
+  description: Converting Jupyter Notebooks
+  copyright:
+    - license: BSD 3-Clause
+  dependencies:
+    runtime:
+      - py3-beautifulsoup4
+      - py3-bleach
+      - py3-defusedxml
+      - py3-importlib-metadata
+      - py3-jinja2
+      - py3-jupyter-core
+      - py3-jupyterlab-pygments
+      - py3-markupsafe
+      - py3-mistune
+      - py3-nbclient
+      - py3-nbformat
+      - py3-packaging
+      - py3-pandocfilters
+      - py3-pygments
+      - py3-tinycss2
+      - py3-traitlets
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: e56cc7588acc4f93e2bb5a34ec69028e4941797b2bfaf6462f18a41d1cc258c9
+      uri: https://files.pythonhosted.org/packages/e7/30/b73c286d496a280dfdff4fa8160587b12270591c895d34d8e4a33bc8fc1c/nbconvert-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10522

--- a/py3-nbformat.yaml
+++ b/py3-nbformat.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/nbformat/
+package:
+  name: py3-nbformat
+  version: 5.9.2
+  epoch: 0
+  description: The Jupyter Notebook format
+  copyright:
+    - license: BSD 3-Clause
+  dependencies:
+    runtime:
+      - py3-fastjsonschema
+      - py3-jsonschema
+      - py3-jupyter-core
+      - py3-traitlets
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 5f98b5ba1997dff175e77e0c17d5c10a96eaed2cbd1de3533d1fc35d5e111192
+      uri: https://files.pythonhosted.org/packages/54/d8/31dceef56952da6ea2c43405a83c9759a22a86cb530197988cfa8599b178/nbformat-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10523

--- a/py3-terminado.yaml
+++ b/py3-terminado.yaml
@@ -1,0 +1,42 @@
+# Generated from https://pypi.org/project/terminado/
+package:
+  name: py3-terminado
+  version: 0.17.1
+  epoch: 0
+  description: Tornado websocket backend for the Xterm.js Javascript terminal emulator library.
+  copyright:
+    - license: BSD 3-Clause
+  dependencies:
+    runtime:
+      - py3-ptyprocess
+      - py3-tornado
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: bc159f02a35b117fa633d77fdb445b36dc2c1992
+      repository: https://github.com/jupyter/terminado
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: jupyter/terminado
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
