### PR TITLE
Add visualization-server transitive deps vol5

### DIFF
--- a/py3-hatch-jupyter-builder.yaml
+++ b/py3-hatch-jupyter-builder.yaml
@@ -1,0 +1,44 @@
+# Generated from https://pypi.org/project/hatch-jupyter-builder/
+package:
+  name: py3-hatch-jupyter-builder
+  version: 0.8.3
+  epoch: 0
+  description: A hatch plugin to help build Jupyter packages
+  copyright:
+    - license: BSD 3-Clause
+  dependencies:
+    runtime:
+      - py3-hatchling
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+  environment:
+    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
+    SOURCE_DATE_EPOCH: 315532800
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/jupyterlab/hatch-jupyter-builder
+      tag: v${{package.version}}
+      expected-commit: bcb4ea9076b20375198aeee1be2ed3d2c0dfd6f5
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: jupyterlab/hatch-jupyter-builder
+    use-tag: true
+    strip-prefix: v

--- a/py3-jupyter-lsp.yaml
+++ b/py3-jupyter-lsp.yaml
@@ -1,0 +1,39 @@
+# Generated from https://pypi.org/project/jupyter-lsp/
+package:
+  name: py3-jupyter-lsp
+  version: 2.2.0
+  epoch: 0
+  description: Multi-Language Server WebSocket proxy for Jupyter Notebook/Lab server
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - py3-jupyter-server
+      - py3-importlib-metadata
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 8ebbcb533adb41e5d635eb8fe82956b0aafbf0fd443b6c4bfa906edeeb8635a1
+      uri: https://files.pythonhosted.org/packages/01/f9/85c8361175208e279f63c3896db14b547d821c9cb8a52675e51a7bdb336f/jupyter-lsp-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 33411

--- a/py3-jupyter-server.yaml
+++ b/py3-jupyter-server.yaml
@@ -1,0 +1,60 @@
+# Generated from https://pypi.org/project/jupyter-server/
+package:
+  name: py3-jupyter-server
+  version: 2.7.3
+  epoch: 0
+  description: The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications.
+  copyright:
+    - license: BSD 3-Clause
+  dependencies:
+    runtime:
+      - py3-anyio
+      - py3-argon2-cffi
+      - py3-jinja2
+      - py3-jupyter-client
+      - py3-jupyter-core
+      - py3-jupyter-events
+      - py3-jupyter-server-terminals
+      - py3-nbconvert
+      - py3-nbformat
+      - py3-overrides
+      - py3-packaging
+      - py3-prometheus-client
+      - py3-pywinpty
+      - py3-pyzmq
+      - py3-send2trash
+      - py3-terminado
+      - py3-tornado
+      - py3-traitlets
+      - py3-websocket-client
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+      - nodejs
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: cf8df8a6b26455977f1eb946dc3dead069981ea4
+      repository: https://github.com/jupyter-server/jupyter_server
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: jupyter-server/jupyter_server
+    strip-prefix: v

--- a/py3-jupyterlab-server.yaml
+++ b/py3-jupyterlab-server.yaml
@@ -1,0 +1,48 @@
+# Generated from https://pypi.org/project/jupyterlab-server/
+package:
+  name: py3-jupyterlab-server
+  version: 2.25.0
+  epoch: 0
+  description: A set of server components for JupyterLab and JupyterLab like applications.
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - py3-babel
+      - py3-importlib-metadata
+      - py3-jinja2
+      - py3-json5
+      - py3-jsonschema
+      - py3-jupyter-server
+      - py3-packaging
+      - py3-requests
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 93ea53973d6d7be9ed811b3a7a14ad4fffe65b83
+      repository: https://github.com/jupyterlab/jupyterlab_server
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: jupyterlab/jupyterlab_server
+    strip-prefix: v

--- a/py3-notebook-shim.yaml
+++ b/py3-notebook-shim.yaml
@@ -1,0 +1,38 @@
+# Generated from https://pypi.org/project/notebook-shim/
+package:
+  name: py3-notebook-shim
+  version: 0.2.3
+  epoch: 0
+  description: A shim layer for notebook traits and config
+  copyright:
+    - license: BSD 3-Clause
+  dependencies:
+    runtime:
+      - py3-jupyter-server
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: f69388ac283ae008cd506dda10d0288b09a017d822d5e8c7129a152cbd3ce7e9
+      uri: https://files.pythonhosted.org/packages/ea/10/6c6c7adc0d61e72cfc4055d0671bbd12bdc6ffea86892e903bd2398b9019/notebook_shim-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 31429


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
