### PR TITLE
ccache-4.8.3 new package & hiredis-1.2.0 new package

### DIFF
--- a/ccache.yaml
+++ b/ccache.yaml
@@ -46,3 +46,5 @@ update:
   enabled: true
   github:
     identifier: ccache/ccache
+    strip-prefix: v
+    use-tag: true

--- a/ccache.yaml
+++ b/ccache.yaml
@@ -1,0 +1,48 @@
+package:
+  name: ccache
+  version: 4.8.3
+  epoch: 0
+  description: Fast C/C++ compiler cache
+  copyright:
+    - license: GPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - asciidoctor
+      - cmake
+      - hiredis-dev
+      - linux-headers
+      - perl
+      - samurai
+      - xxhash-dev
+      - zstd-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ccache/ccache
+      tag: v${{package.version}}
+      expected-commit: 044558e647b49dbc8fc89b810a7d22f526101e6b
+
+  - runs: |
+      cmake -B build -G Ninja \
+        -DCCACHE_DEV_MODE=OFF \
+        -DCMAKE_BUILD_TYPE=MinSizeRel \
+        -DCMAKE_INSTALL_PREFIX=/usr
+      cmake --build build
+      DESTDIR="${{targets.destdir}}" cmake --install build
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/lib/ccache/bin
+      for link in cc gcc g++ cpp c++ clang clang++ c89 c99; do
+          ln -sf ${{targets.destdir}}/bin/ccache ${{targets.destdir}}/usr/lib/ccache/bin/${link}
+      done
+
+update:
+  enabled: true
+  github:
+    identifier: ccache/ccache

--- a/hiredis.yaml
+++ b/hiredis.yaml
@@ -36,3 +36,5 @@ update:
   enabled: true
   github:
     identifier: redis/hiredis
+    strip-prefix: v
+    use-tag: true

--- a/hiredis.yaml
+++ b/hiredis.yaml
@@ -22,9 +22,6 @@ pipeline:
       expected-commit: 60e5075d4ac77424809f855ba3e398df7aacefe8
 
   - runs: |
-      # make USE_SSL=1 PREFIX=/usr DEBUG="$CFLAGS" LDFLAGS="$LDFLAGS"
-
-  - runs: |
       make USE_SSL=1 PREFIX=${{targets.destdir}}/usr install
 
   - uses: strip

--- a/hiredis.yaml
+++ b/hiredis.yaml
@@ -1,0 +1,41 @@
+package:
+  name: hiredis
+  version: 1.2.0
+  epoch: 0
+  description: Minimalistic C client for Redis
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - openssl-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/redis/hiredis
+      tag: v${{package.version}}
+      expected-commit: 60e5075d4ac77424809f855ba3e398df7aacefe8
+
+  - runs: |
+      # make USE_SSL=1 PREFIX=/usr DEBUG="$CFLAGS" LDFLAGS="$LDFLAGS"
+
+  - runs: |
+      make USE_SSL=1 PREFIX=${{targets.destdir}}/usr install
+
+  - uses: strip
+
+subpackages:
+  - name: hiredis-dev
+    description: "hiredis dev headers"
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: redis/hiredis


### PR DESCRIPTION
Fixes: #6340 

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

Also added `hiredis` a minimalistic C client library for Redis.  
https://redis.com/lp/hiredis/

#### For new package PRs only
<!-- remove if unrelated -->
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
