### PR TITLE
keycloak: use maven wrapper for builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dag.svg
 .packagerules
 .melange.k8s.yaml
 .vscode/*
+
+# macOS
+.DS_Store

--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -38,7 +38,7 @@ pipeline:
       export LANG=en_US.UTF-8
       export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
-      mvn install -DskipTests=true -Dnode.version=$(node --version) -Pdistribution -q
+      ./mvnw clean install -DskipTests=true -Dnode.version=$(node --version) -Pdistribution -q
 
       mkdir -p ${{targets.destdir}}/usr/share/java
       unzip -d ${{targets.destdir}}/usr/share/java quarkus/dist/target/keycloak-*.zip


### PR DESCRIPTION
Switch to using the maven wrapper for initiating the package build. This ensures the correct version of maven is used, as intended by the upstream repository. Previously we'd be relying on the version available on the underlying host.

Recently we encountered some issues where the build would hang when compiling against later maven versions.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)


