### PR TITLE
osv-scanner: use git-checkout to get tag

### DIFF
--- a/osv-scanner.yaml
+++ b/osv-scanner.yaml
@@ -1,7 +1,7 @@
 package:
   name: osv-scanner
   version: 1.4.1
-  epoch: 0
+  epoch: 1
   description: Vulnerability scanner written in Go which uses the data provided by https://osv.dev
   copyright:
     - license: Apache-2.0
@@ -14,10 +14,11 @@ environment:
       - go
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: c54665916cbf23d545f0ea32ff1a68443a721f7fb21f16496a3615e7488c6477
-      uri: https://github.com/google/osv-scanner/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: c50977954ca3d2cc4cf37c52d2dec3e75a97b7a5
+      tag: v${{package.version}}
+      repository: https://github.com/google/osv-scanner
 
   - uses: go/build
     with:


### PR DESCRIPTION
osv-scanner seems to have a tag for 1.4.1 but not a release, so the `fetch` pipeline fails. Using `git-checkout` seems to work.