### PR TITLE
Revert "gitlab-runner/16.4.1 package update"

### DIFF
--- a/gitlab-runner.yaml
+++ b/gitlab-runner.yaml
@@ -4,7 +4,7 @@
 #nolint:git-checkout-must-use-github-updates
 package:
   name: gitlab-runner
-  version: 16.4.1
+  version: 16.4.0
   epoch: 0
   description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
   copyright:
@@ -21,7 +21,7 @@ pipeline:
     with:
       repository: https://gitlab.com/gitlab-org/gitlab-runner
       tag: v${{package.version}}
-      expected-commit: d89a789a8800a94f7c2d98f0b9d85b79736b4f4a
+      expected-commit: 6e766faf8f13dff6d05d0b4617fb4744a2149b52
 
   - uses: go/build
     with:

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -8,3 +8,5 @@ libucontext-1.2-r1.apk
 libucontext-dev-1.2-r1.apk
 go-fips-1.21-1.21.1-r0.apk
 go-fips-1.21-1.21.1-r1.apk
+gitlab-runner-16.4.1-r0.apk
+gitlab-runner-helper-16.4.1-r0.apk


### PR DESCRIPTION
They seem to have retracted this tag.