### PR TITLE
Change directory for extracted files to mirror original image

### DIFF
--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -45,10 +45,10 @@ pipeline:
       mv /opt/keycloak-* /opt/keycloak
 
       # We don't use these symlinks in our images, but leaving in place so not
-      to introduce a breaking change, package has existed for some time.
-      mkdir -p ${{targets.destdir}}/usr/bin
+      # to introduce a breaking change.
+      mkdir -p /usr/bin
       for i in kc.sh kcadm.sh kcreg.sh; do
-        ln -sf /opt/keycloak/bin/$i ${{targets.destdir}}/usr/bin/$i
+          ln -sf /opt/keycloak/bin/$i /usr/bin/$i
       done
 
 update:

--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -40,12 +40,15 @@ pipeline:
 
       ./mvnw clean install -DskipTests=true -Dnode.version=$(node --version) -Pdistribution -q
 
-      mkdir -p ${{targets.destdir}}/usr/share/java
-      unzip -d ${{targets.destdir}}/usr/share/java quarkus/dist/target/keycloak-*.zip
+      # Extracts the files to /opt/keycloak, which mirrors the original image.
+      unzip -d /opt quarkus/dist/target/keycloak-*.zip
+      mv /opt/keycloak-* /opt/keycloak
 
+      # We don't use these symlinks in our images, but leaving in place so not
+      to introduce a breaking change, package has existed for some time.
       mkdir -p ${{targets.destdir}}/usr/bin
       for i in kc.sh kcadm.sh kcreg.sh; do
-        ln -sf /usr/share/java/keycloak-${{package.version}}/bin/$i ${{targets.destdir}}/usr/bin/$i
+        ln -sf /opt/keycloak/bin/$i ${{targets.destdir}}/usr/bin/$i
       done
 
 update:


### PR DESCRIPTION
Extract keycloak files to `/opt/keycloak`, which mirrors the directory structure used by the original vendor image. It also makes it easier to reference files in this location from our images, as the folder name is not appended with the keycloak version.





