### PR TITLE
Change extracted filepath to align with original image

### DIFF
--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -40,16 +40,13 @@ pipeline:
 
       ./mvnw clean install -DskipTests=true -Dnode.version=$(node --version) -Pdistribution -q
 
-      # Mirrors the original images file structure.
-      mkdir -p ${{targets.destdir}}/opt
-      unzip -d ${{targets.destdir}}/opt quarkus/dist/target/keycloak-*.zip
-      mv ${{targets.destdir}}/opt/keycloak-* ${{targets.destdir}}/opt/keycloak
+      mkdir -p ${{targets.destdir}}/usr/share/java
+      unzip -d ${{targets.destdir}}/usr/share/java quarkus/dist/target/keycloak-*.zip
+      mv ${{targets.destdir}}/usr/share/java/keycloak-* ${{targets.destdir}}/usr/share/java/keycloak
 
-      # We don't use these symlinks in our images, but leaving in place so not
-      # to introduce a breaking change.
       mkdir -p ${{targets.destdir}}/usr/bin
       for i in kc.sh kcadm.sh kcreg.sh; do
-        ln -sf /opt/keycloak/bin/$i ${{targets.destdir}}/usr/bin/$i
+        ln -sf /usr/share/java/keycloak/bin/$i ${{targets.destdir}}/usr/bin/$i
       done
 
 update:

--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -40,12 +40,16 @@ pipeline:
 
       ./mvnw clean install -DskipTests=true -Dnode.version=$(node --version) -Pdistribution -q
 
-      mkdir -p ${{targets.destdir}}/usr/share/java
-      unzip -d ${{targets.destdir}}/usr/share/java quarkus/dist/target/keycloak-*.zip
+      # Mirrors the original images file structure.
+      mkdir -p ${{targets.destdir}}/opt
+      unzip -d ${{targets.destdir}}/opt quarkus/dist/target/keycloak-*.zip
+      mv ${{targets.destdir}}/opt/keycloak-* ${{targets.destdir}}/opt/keycloak
 
+      # We don't use these symlinks in our images, but leaving in place so not
+      # to introduce a breaking change.
       mkdir -p ${{targets.destdir}}/usr/bin
       for i in kc.sh kcadm.sh kcreg.sh; do
-        ln -sf /usr/share/java/keycloak-${{package.version}}/bin/$i ${{targets.destdir}}/usr/bin/$i
+        ln -sf /opt/keycloak/bin/$i ${{targets.destdir}}/usr/bin/$i
       done
 
 update:


### PR DESCRIPTION
"Unpack the files into a consistently named 'keycloak' directory. This approach mirrors the structure of the original image. Additionally, it enables us to utilize the 'paths:' feature in apko for setting file permissions, which requires a static path to the directory.