### PR TITLE
use wolfi based gcloud

### DIFF
--- a/.github/workflows/lint-world.yaml
+++ b/.github/workflows/lint-world.yaml
@@ -46,9 +46,11 @@ jobs:
           workload_identity_provider: ${{ env.EPHEMERAL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.EPHEMERAL_BUILD_SERVICE_ACCOUNT }}
 
+      - run: apk add google-cloud-sdk
       - uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ env.EPHEMERAL_BUILD_PROJECT_ID }}
+          skip_install: true
 
       - name: 'Setup workflow variables'
         run: |


### PR DESCRIPTION
the [runner](https://github.com/actions/runner) image doesn't include python, so use the wolfi created gcloud

https://github.com/wolfi-dev/os/actions/runs/6425979601/job/17449484324#step:6:23