### PR TITLE
ignore tags starting with v for py3-flask-cors package

### DIFF
--- a/py3-flask-cors.yaml
+++ b/py3-flask-cors.yaml
@@ -38,5 +38,7 @@ pipeline:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - "v.*"
   github:
     identifier: corydolphin/flask-cors


### PR DESCRIPTION
xref: https://github.com/wolfi-dev/os/pull/6344

The project https://github.com/corydolphin/flask-cors looks like it has some mixed tags with `v` and without, but the past releases were without the `v`, so lets ignore the tags starting with `v` to avoid prs being opened for that like #6344


also opened an upstream issue to ask for clarification: https://github.com/corydolphin/flask-cors/issues/336