### PR TITLE
fix: php version streams

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: 8.1.24
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -183,11 +183,11 @@ data:
 
 subpackages:
   - range: extensions
-    name: "php-${{range.key}}"
+    name: "${{package.name}}-${{range.key}}"
     description: "The ${{range.value}} extension"
     dependencies:
       provides:
-        - php-8.1-${{range.key}}=${{package.version}}-r${{package.epoch}}
+        - php-${{range.key}}=${{package.full-version}}
     pipeline:
       - runs: |
           export EXTENSIONS_DIR=usr/lib/php/modules
@@ -199,11 +199,11 @@ subpackages:
           [ "${{range.key}}" != "opcache" ] || prefix="zend_"
           echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"${{range.key}}.ini"
 
-  - name: php-dev
+  - name: ${{package.name}}-dev
     description: PHP 8.1 development headers
     dependencies:
       provides:
-        - ${{package.name}}-dev=${{package.version}}-r${{package.epoch}}
+        - php-dev=${{package.full-version}}
     pipeline:
       - uses: split/dev
       - runs: |
@@ -211,31 +211,31 @@ subpackages:
           mv ${{targets.destdir}}/usr/bin/phpize ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/lib ${{targets.subpkgdir}}/usr
 
-  - name: php-cgi
+  - name: ${{package.name}}-cgi
     description: PHP 8.1 CGI
     dependencies:
       provides:
-        - ${{package.name}}-cgi=${{package.version}}-r${{package.epoch}}
+        - php-cgi=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/php-cgi ${{targets.subpkgdir}}/usr/bin/
 
-  - name: php-dbg
+  - name: ${{package.name}}-dbg
     description: Interactive PHP Debugger
     dependencies:
       provides:
-        - ${{package.name}}-dbg=${{package.version}}-r${{package.epoch}}
+        - php-dbg=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/phpdbg ${{targets.subpkgdir}}/usr/bin/
 
-  - name: php-fpm
+  - name: ${{package.name}}-fpm
     description: PHP 8.1 FastCGI Process Manager (FPM)
     dependencies:
       provides:
-        - ${{package.name}}-fpm=${{package.version}}-r${{package.epoch}}
+        - php-fpm=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/sbin ${{targets.subpkgdir}}/etc/php/php-fpm.d

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,13 +1,13 @@
 package:
   name: php-8.2
   version: 8.2.11
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
   dependencies:
     provides:
-      - php=${{ package.full-version }}
+      - php=${{package.full-version}}
     runtime:
       - libxml2
 
@@ -183,11 +183,11 @@ data:
 
 subpackages:
   - range: extensions
-    name: "php-${{range.key}}"
+    name: "${{package.name}}-${{range.key}}"
     description: "The ${{range.value}} extension"
     dependencies:
       provides:
-        - php-8.2-${{range.key}}=${{package.version}}-r${{package.epoch}}
+        - php-${{range.key}}=${{package.full-version}}
     pipeline:
       - runs: |
           export EXTENSIONS_DIR=usr/lib/php/modules
@@ -199,11 +199,11 @@ subpackages:
           [ "${{range.key}}" != "opcache" ] || prefix="zend_"
           echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"${{range.key}}.ini"
 
-  - name: php-dev
+  - name: ${{package.name}}-dev
     description: PHP 8.2 development headers
     dependencies:
       provides:
-        - ${{package.name}}-dev=${{package.version}}-r${{package.epoch}}
+        - php-dev=${{package.full-version}}
     pipeline:
       - uses: split/dev
       - runs: |
@@ -211,31 +211,31 @@ subpackages:
           mv ${{targets.destdir}}/usr/bin/phpize ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/lib ${{targets.subpkgdir}}/usr
 
-  - name: php-cgi
+  - name: ${{package.name}}-cgi
     description: PHP 8.2 CGI
     dependencies:
       provides:
-        - ${{package.name}}-cgi=${{package.version}}-r${{package.epoch}}
+        - php-cgi=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/php-cgi ${{targets.subpkgdir}}/usr/bin/
 
-  - name: php-dbg
+  - name: ${{package.name}}-dbg
     description: Interactive PHP Debugger
     dependencies:
       provides:
-        - ${{package.name}}-dbg=${{package.version}}-r${{package.epoch}}
+        - php-dbg=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/phpdbg ${{targets.subpkgdir}}/usr/bin/
 
-  - name: php-fpm
+  - name: ${{package.name}}-fpm
     description: PHP 8.2 FastCGI Process Manager (FPM)
     dependencies:
       provides:
-        - ${{package.name}}-fpm=${{package.version}}-r${{package.epoch}}
+        - php-fpm=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/sbin ${{targets.subpkgdir}}/etc/php/php-fpm.d


### PR DESCRIPTION
This adjusts the names of subpackages for `php-8.1` and `php-8.2`, so that the subpackage names use the version stream name, and the `provides` is just `php-whatever`. This also takes advantage of the new `${{package.full-version}}` variable.

cc: @vaikas @mattmoor 