### PR TITLE
fix: cni-plugins compat packages runtimes deps

### DIFF
--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -100,7 +100,7 @@ subpackages:
     name: cni-plugins-${{range.key}}-compat
     dependencies:
       runtime:
-        - ${{range.key}}
+        - "cni-plugins-${{range.key}}"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/opt/cni/bin


### PR DESCRIPTION
https://github.com/wolfi-dev/os/commit/c8cbd39ed8410459d558476c5d908a3d069d07fb added compat packages with runtime dependencies on `${{range.key}}`, which don't exist -- the package it should depend on is `cni-plugins-${{range.key}}`. That commit also didn't bump the epoch, so the change wasn't actually rolled out.

Yesterday's Go epoch bump rebuilt the package and exposed the broken runtime dep: https://github.com/wolfi-dev/os/commit/46468f80ed4755766f8e35cffd1a527fa06225c9