### PR TITLE
cni-plugins: bump epoch

### DIFF
--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -1,7 +1,7 @@
 package:
   name: cni-plugins
   version: 1.3.0
-  epoch: 7
+  epoch: 8
   description: Some reference and example networking plugins, maintained by the CNI team.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Ironically, I forgot to bump the epoch in https://github.com/wolfi-dev/os/pull/6407/