### PR TITLE
Bump zeromq and change the license.

### DIFF
--- a/zeromq.yaml
+++ b/zeromq.yaml
@@ -1,11 +1,11 @@
 # Generated from https://git.alpinelinux.org/aports/plain/main/zeromq/APKBUILD
 package:
   name: zeromq
-  version: 4.3.4
+  version: 4.3.5
   epoch: 0
   description: The ZeroMQ messaging library and tools
   copyright:
-    - license: LGPL-3.0-or-later with exceptions
+    - license: MPL-2.0
 
 environment:
   contents:
@@ -22,7 +22,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
+      expected-sha256: 6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43
       uri: https://github.com/zeromq/libzmq/releases/download/v${{package.version}}/zeromq-${{package.version}}.tar.gz
 
   - runs: |


### PR DESCRIPTION
The license got switched upstream, see notes: https://github.com/zeromq/libzmq/releases/tag/v4.3.5


Fixes:

Related:
