### PR TITLE
fix no-op build again

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -153,11 +153,10 @@ jobs:
             # Sign the APK index
             melange sign-index -f --signing-key ./wolfi-signing.rsa packages/${arch}/APKINDEX.tar.gz
 
-            # Only attempt to sign when *.apk's exist
-            apks=$(ls ./packages/${arch}/*.apk 2>/dev/null)
-            if [ -n "$apks" ]; then
-              # Sign the apks built in the `build` step with the real key
-              melange sign --signing-key ./wolfi-signing.rsa ./packages/${arch}/*.apk
+            # Sign the apks built in the `build` step with the real key
+            for apk in ./packages/${arch}/*.apk; do
+              echo "Signing $apk"
+              melange sign --signing-key ./wolfi-signing.rsa $apk
             fi
           done
 


### PR DESCRIPTION
We had been trying to avoid signing apks if none existed (i.e., if no apks were build in this workflow)

Instead, just loop over changed apks (which might be empty) and sign each one individually. This should make it clearer that there's nothing to do when there's nothing to sign.