### PR TITLE
`gitlab-logger`: new package

### DIFF
--- a/gitlab-logger.yaml
+++ b/gitlab-logger.yaml
@@ -1,0 +1,29 @@
+package:
+  name: gitlab-logger
+  version: 3.0.0
+  epoch: 0
+  description: GitLab Logger provides a means of wrapping non-structured log files within structure JSON.
+  copyright:
+    - license: MIT
+
+environment:
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: fetch
+    with:
+      # https://gitlab.com/gitlab-org/cloud-native/gitlab-logger
+      uri: https://gitlab.com/gitlab-org/cloud-native/gitlab-logger/-/archive/v${{package.version}}/gitlab-logger-v${{package.version}}.tar.gz
+      expected-sha256: b6bca21e3eba525334f4b140d9d9405181a25821365ccd9065402fa050af78d5
+
+  - uses: go/build
+    with:
+      packages: ./cmd/gitlab-logger
+      output: gitlab-logger
+      ldflags: -w
+
+  - uses: strip
+
+update:
+  enabled: false


### PR DESCRIPTION
I went with `fetch` because that's what the upstream build process does, but if it makes adding automated updates easier we can switch this to use `git-checkout`: https://gitlab.com/gitlab-org/build/CNG/-/blob/master/gitlab-logger/Dockerfile#L10

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
