### PR TITLE
always upload APKs we were able to build (take 2)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -153,26 +153,26 @@ jobs:
             # Sign the APK index
             melange sign-index -f --signing-key ./wolfi-signing.rsa packages/${arch}/APKINDEX.tar.gz
 
-            # Only attempt to sign when *.apk's exist.
+            # Only attempt to sign and upload APKINDEX when *.apk's changed.
             apks=$(ls ./packages/${arch}/*.apk 2>/dev/null || true)
             if [ -n "$apks" ]; then
               melange sign --signing-key ./wolfi-signing.rsa ./packages/${arch}/*.apk
+
+              # Don't cache the APKINDEX.
+              gcloud --quiet storage cp \
+                  --cache-control=no-store \
+                  "./packages/${arch}/APKINDEX.tar.gz" "gs://wolfi-production-registry-destination/os/${arch}/"
+
+              gcloud --quiet storage cp \
+                  --cache-control=no-store \
+                  "./packages/${arch}/APKINDEX.json" "gs://wolfi-production-registry-destination/os/${arch}/"
             fi
           done
 
       - name: 'Upload the repository to the bucket'
         run: |
           for arch in "x86_64" "aarch64"; do
-            # Don't cache the APKINDEX.
-            gcloud --quiet storage cp \
-                --cache-control=no-store \
-                "./packages/${arch}/APKINDEX.tar.gz" "gs://wolfi-production-registry-destination/os/${arch}/"
-
-            gcloud --quiet storage cp \
-                --cache-control=no-store \
-                "./packages/${arch}/APKINDEX.json" "gs://wolfi-production-registry-destination/os/${arch}/"
-
-            # Only attempt to sign when *.apk's exist
+            # Only attempt to upload when *.apk's changed.
             apks=$(ls ./packages/${arch}/*.apk 2>/dev/null || true)
             if [ -n "$apks" ]; then
               # apks will be cached in CDN for an hour by default.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,12 +80,14 @@ jobs:
             MELANGE_EXTRA_OPTS="--keyring-append=/gcsfuse/wolfi-registry/wolfi-signing.rsa.pub" \
             all -j1
 
-      - run: |
+      - if: always()
+        run: |
           # Clean up the symlinks and create an archive for uploading
           find ./packages/${{ matrix.arch }} -type l -exec rm -f {} \;
           tar -cvzf /tmp/packages-${{ matrix.arch }}.tar.gz ./packages/${{ matrix.arch }}
 
       - name: 'Upload built packages archive to Github Artifacts'
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: packages-${{ matrix.arch }}
@@ -183,8 +185,72 @@ jobs:
             fi
           done
 
+  build-failure:
+    runs-on: ubuntu-latest
+    needs: build
+    if: failure()
+
+    permissions:
+      id-token: write
+      contents: read
+
+    container:
+      # NOTE: This step only signs and uploads, so it doesn't need any privileges
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:d00394feb1574663700eb9dc62da2d4dbe7a904430875c710d1fe051957bf932
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: 'Trust the github workspace'
+        run: |
+          # This is to avoid fatal errors about "dubious ownership" because we are
+          # running inside of a container action with the workspace mounted in.
+          git config --global --add safe.directory "$(pwd)"
+
+      - id: auth
+        name: 'Authenticate to Google Cloud'
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
+          service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
+
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: prod-images-c6e5
+
+      - name: 'Download x86_64 package archives'
+        uses: actions/download-artifact@v3
+        with:
+          path: /tmp/artifacts/
+          name: packages-x86_64
+
+      - name: 'Download aarch64 package archives'
+        uses: actions/download-artifact@v3
+        with:
+          path: /tmp/artifacts/
+          name: packages-aarch64
+
+      - run: echo "${{ secrets.MELANGE_RSA }}" > ./wolfi-signing.rsa
+      - run: |
+          mkdir -p /etc/apk/keys
+          cp ./wolfi-signing.rsa.pub /etc/apk/keys/wolfi-signing.rsa.pub
+
+      - name: 'Upload the repository to the bucket'
+        run: |
+          for arch in "x86_64" "aarch64"; do
+            # Only attempt to upload when *.apk's changed.
+            apks=$(ls ./packages/${arch}/*.apk 2>/dev/null || true)
+            if [ -n "$apks" ]; then
+              # apks will be cached in CDN for an hour by default.
+              # Don't upload the object if it already exists.
+              gcloud --quiet storage cp \
+                  --no-clobber \
+                  "./packages/${arch}/*.apk" "gs://wolfi-production-registry-destination/os/${arch}/"
+            fi
+          done
+
   postrun:
-    name: Build Wolfi OS
+    name: Notify Slack
     runs-on: ubuntu-latest
     if: failure()
     needs: [build, upload]


### PR DESCRIPTION
Starting https://github.com/wolfi-dev/os/pull/6454 from scratch

This splits apk and APKINDEX uploading into separate steps, and copies the `upload` workflow into a separate run-on-failure workflow that just uploads apks.