### PR TITLE
`gitlab-shell`: new package

### DIFF
--- a/gitlab-shell.yaml
+++ b/gitlab-shell.yaml
@@ -1,0 +1,54 @@
+# source is gitlab so we can't use github updates to get expected commit
+# let's still auto create the PR, it will fail as expected commit will be wrong
+# however it will be easy to fix
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-shell
+  version: 14.28.0
+  epoch: 0
+  description: SSH access for GitLab
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+      # To be able to compile gssapi library
+      - heimdal-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-shell
+      tag: v${{package.version}}
+      expected-commit: 787fc8db78dae329b722a90df4d29d99eda83b7f
+
+  - runs: make build
+
+  - runs: |
+      BINDIR=${{targets.destdir}}/srv/gitlab-shell/bin
+      mkdir -p "${BINDIR}"
+
+      install -m755 bin/check "${BINDIR}/check"
+      install -m755 bin/gitlab-shell "${BINDIR}/gitlab-shell"
+      install -m755 bin/gitlab-shell-authorized-keys-check "${BINDIR}/gitlab-shell-authorized-keys-check"
+      install -m755 bin/gitlab-shell-authorized-principals-check "${BINDIR}/gitlab-shell-authorized-principals-check"
+      install -m755 bin/gitlab-sshd "${BINDIR}/gitlab-sshd"
+
+      mkdir -p ${{targets.destdir}}/srv/gitlab-shell/
+      cp LICENSE VERSION ${{targets.destdir}}/srv/gitlab-shell/
+
+      install -d ${{targets.destdir}}/srv/sshd
+      install -d ${{targets.destdir}}/etc/ssh
+      install -d ${{targets.destdir}}/var/log/gitlab-shell
+      touch ${{targets.destdir}}/var/log/gitlab-shell/gitlab-shell.log
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11295


### PR DESCRIPTION
This change adds a new package for the `gitlab-shell` project.  The build process is loosely based on the upstream `Makefile` and the downstream CNG `Dockerfile`: https://gitlab.com/gitlab-org/build/CNG/-/blob/master/gitlab-shell/Dockerfile?ref_type=heads#L27-50

I checked all of the binaries we build in my local APK vs. the binaries in the latest docker image and they are all 5+MB smaller.

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
