### PR TITLE
`gitlab-cng`: new package

### DIFF
--- a/gitlab-cng.yaml
+++ b/gitlab-cng.yaml
@@ -1,0 +1,60 @@
+# source is gitlab so we can't use github updates to get expected commit
+# let's still auto create the PR, it will fail as expected commit will be wrong
+# however it will be easy to fix
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-cng
+  # The release-monitor identified is for the gitlab-runner,
+  # but these seem to be co-versioned.
+  version: 16.4.1
+  epoch: 0
+  description: Cloud Native container images per component of GitLab
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/build/CNG.git
+      tag: v${{package.version}}
+      expected-commit: ace03b95e063fc9be782f49c49f20e735ee876de
+
+data:
+  # Used to create all of the *-scripts subpackages from the CNG repo.
+  - name: scripts
+    items:
+      base: ./gitlab-base
+      cfssl-self-sign: ./cfssl-self-sign
+      container-registry: ./gitlab-container-registry
+      exporter: ./gitlab-exporter
+      geo-logcursor: ./gitlab-geo-logcursor
+      gitaly: ./gitaly
+      mailroom: ./gitlab-mailroom
+      pages: ./gitlab-pages
+      rails: ./gitlab-rails
+      shell: ./gitlab-shell
+      sidekiq: ./gitlab-sidekiq
+      toolbox: ./gitlab-toolbox
+      webservice: ./gitlab-webservice
+      workhorse: ./gitlab-workhorse
+
+subpackages:
+  - range: scripts
+    name: "${{package.name}}-${{range.key}}-scripts"
+    pipeline:
+      - runs: |
+          cd ${{range.value}}
+          for x in $(find scripts/ -type f); do
+            mkdir -p ${{targets.subpkgdir}}/$(dirname $x)
+            cp -r $x ${{targets.subpkgdir}}/$x
+          done
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11337


### PR DESCRIPTION
This packages up `*-script` package for the Gitlab CNG repository.

These packages will compose with other binary packages to build images.

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
