### PR TITLE
hubble: new package

### DIFF
--- a/hubble.yaml
+++ b/hubble.yaml
@@ -1,0 +1,48 @@
+package:
+  name: hubble
+  version: 0.12.0
+  epoch: 0
+  description: hubble is a command to list and diagnose Go processes currently running on your system.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - go
+      - git
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cilium/hubble
+      tag: v${{package.version}}
+      expected-commit: 1bb77ce6c27c0a155a245a8109d35ac2d8121065
+
+  - runs: |
+      # For critical CVE-2023-39347
+      go get github.com/cilium/cilium@v1.14.2
+
+      # Resyncing the vendor dir
+      go mod vendor
+
+      DESTDIR=${{targets.destdir}} BINDIR=/usr/bin make install
+
+  - uses: strip
+
+subpackages:
+  - name: hubble-compat
+    description: Compatibility package for hubble
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          ln -sf /usr/bin/hubble ${{targets.subpkgdir}}/usr/local/bin/hubble
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: cilium/hubble
+    strip-prefix: v


### PR DESCRIPTION
* "hubble-0.12: new package"

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] This PR links to the upstream project's support policy: https://github.com/cilium/hubble#releases

| Version                                              | Release Date         | Maintained | Supported Cilium Version | Artifacts                                                               |
|------------------------------------------------------|----------------------|------------|--------------------------|-------------------------------------------------------------------------|
| [v0.12](https://github.com/cilium/hubble/tree/v0.12) | 2023-07-10 (v0.12.0) | Yes        | Cilium 1.14 and older    | [GitHub Release](https://github.com/cilium/hubble/releases/tag/v0.12.0) |