### PR TITLE
`cfssl`: new package

### DIFF
--- a/cfssl.yaml
+++ b/cfssl.yaml
@@ -1,0 +1,54 @@
+package:
+  name: cfssl
+  version: 1.6.4
+  epoch: 0
+  description: Cloudflare's PKI and TLS toolkit
+  copyright:
+    - license: BSD-2-Clause
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cloudflare/cfssl
+      tag: v${{package.version}}
+      expected-commit: b4d0d877cac528f63db39dfb62d5c96cd3a32a0b
+
+  - runs: make all
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/bin/
+      install -Dm755 bin/cfssl "${{targets.destdir}}"/usr/bin/
+
+  - uses: strip
+
+data:
+  - name: components
+    items:
+      bundle: cfssl-bundle
+      certinfo: cfssl-certinfo
+      newkey: cfssl-newkey
+      scan: cfssl-scan
+      json: cfssljson
+      mkbundle: mkbundle
+      multirootca: multirootca
+
+subpackages:
+  - range: components
+    name: "${{package.name}}-${{range.key}}"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin/
+          install -Dm755 bin/${{range.value}} "${{targets.subpkgdir}}"/usr/bin/
+
+update:
+  enabled: true
+  github:
+    identifier: cloudflare/cfssl
+    strip-prefix: v


### PR DESCRIPTION
This creates a new package for `cfssl` and subpackages for it's assorted peripherals.

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
