### PR TITLE
py3-zipp: switch updates to track GH releases as non release tags are…

### DIFF
--- a/py3-zipp.yaml
+++ b/py3-zipp.yaml
@@ -13,14 +13,14 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - wolfi-base
-      - busybox
       - build-base
-      - python3
-      - py3-wheel
+      - busybox
+      - ca-certificates-bundle
       - py3-gpep517
       - py3-setuptools
+      - py3-wheel
+      - python3
+      - wolfi-base
 
 pipeline:
   - uses: git-checkout
@@ -43,9 +43,6 @@ pipeline:
 
 update:
   enabled: true
-  ignore-regex-patterns:
-    - "bpo-.*"
   github:
     identifier: jaraco/zipp
     strip-prefix: v
-    use-tag: true

--- a/py3-zipp.yaml
+++ b/py3-zipp.yaml
@@ -27,7 +27,7 @@ pipeline:
     with:
       repository: https://github.com/jaraco/zipp
       tag: v${{package.version}}
-      expected-commit: 488dd04fa4b0a2ed146bc08a2847e590e14840d5
+      expected-commit: 5c59b561f5b79631a846b8823d5033cc1407b511
 
   - name: Python Build
     runs: |


### PR DESCRIPTION
… being published upstream

This will avoid updates like this https://github.com/wolfi-dev/os/pull/6503