### PR TITLE
pnpm: track github releases rather than tags so we filter out pre-rel…

### DIFF
--- a/pnpm.yaml
+++ b/pnpm.yaml
@@ -48,4 +48,3 @@ update:
     identifier: pnpm/pnpm
     strip-prefix: v
     tag-filter: v
-    use-tag: true


### PR DESCRIPTION
…eases

This will prevent update bot PRs for pre-releases being created such as https://github.com/wolfi-dev/os/pull/6459