### PR TITLE
curl-rustls: disable empty linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ ifeq (${USE_CACHE}, yes)
 	MELANGE_OPTS += --cache-source ${CACHE_DIR}
 endif
 
+ifeq (${LINT}, yes)
+	MELANGE_OPTS += --fail-on-lint-warning
+endif
+
 # The list of packages to be built. The order matters.
 # wolfictl determines the list and order
 # set only to be called when needed, so make can be instant to run

--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -1,13 +1,16 @@
 package:
   name: curl-rustls
   version: 8.3.0
-  epoch: 1
+  epoch: 2
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - libcurl-rustls4
+  checks:
+    disabled:
+      - empty # curl-rustls is expected to be empty, it brings in a runtime dep on libcurl-rustls4
 
 environment:
   contents:


### PR DESCRIPTION
The curl-rustls package is expected to be empty, it brings in a runtime dep on its subpackage, `libcurl-rustls4`.

This PR also adds a flag to `make` to re-enable lint checks, which were disabled by default before.