### PR TITLE
cifs-utils and talloc

### DIFF
--- a/cifs-utils.yaml
+++ b/cifs-utils.yaml
@@ -1,0 +1,58 @@
+package:
+  name: cifs-utils
+  version: 7.0
+  epoch: 0
+  description: "CIFS filesystem user-space tools"
+  copyright:
+    - license: GPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - libcap-dev
+      - keyutils-dev
+      - krb5-dev
+      - autoconf
+      - automake
+      # - samba-dev
+      - talloc-dev
+      - py3-docutils
+      - pkgconf-dev
+      - libtool
+      - libcap-ng
+      - linux-pam-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://ftp.samba.org/pub/linux-cifs/cifs-utils/cifs-utils-${{package.version}}.tar.bz2
+      expected-sha256: 0defaab85bd3ea46ffc45ab41fb0d0ad54d05ae2cfaa7e503de86d4f12bc8161
+
+  - runs: |
+      autoreconf -i
+
+  - runs: |
+      ./configure \
+      --build=$CBUILD \
+      --host=$CHOST \
+      --prefix=/usr \
+      --disable-systemd \
+      --sbindir=/usr/bin
+      make
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/bin
+      make DESTDIR="${{targets.destdir}}" ROOTSBINDIR=/usr/bin install
+      # set mount.cifs uid, to enable none root mounting form fstab
+      chmod +s "${{targets.destdir}}"/usr/bin/mount.cifs
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 287

--- a/talloc.yaml
+++ b/talloc.yaml
@@ -1,0 +1,64 @@
+package:
+  name: talloc
+  version: 2.4.1
+  epoch: 0
+  description: "Memory pool management library"
+  copyright:
+    - license: LGPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - autoconf
+      - automake
+      - docbook-xml
+      - libxslt
+      - python3-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://samba.org/ftp/talloc/talloc-${{package.version}}.tar.gz
+      expected-sha256: 410a547f08557007be0e88194f218868358edc0ab98c98ba8c167930db3d33f9
+
+  - runs: |
+      ./configure \
+        --build=$CBUILD \
+        --host=$CHOST \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --infodir=/usr/share/info \
+        --localstatedir=/var \
+        --bundled-libraries=NONE \
+        --builtin-libraries=replace \
+        --disable-rpath \
+        --disable-rpath-install \
+        --without-gettext
+      make
+      ar qf libtalloc.a bin/default/talloc.c*.o
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/bin
+      make DESTDIR="${{targets.destdir}}" install
+      install -Dm644 libtalloc.a "${{targets.destdir}}"/usr/lib/libtalloc.a
+
+  - uses: strip
+
+subpackages:
+  - name: talloc-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - talloc
+    description: talloc dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1733


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
