### PR TITLE
grpc-dev

### DIFF
--- a/grpc.yaml
+++ b/grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc
-  version: 1.59.1
-  epoch: 0
+  version: 1.57.0
+  epoch: 2
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -45,7 +45,7 @@ pipeline:
     with:
       repository: https://github.com/grpc/grpc
       tag: v${{package.version}}
-      expected-commit: 0df9accc5c3478d126742fb84dd7155786dc4f68
+      expected-commit: a61640173d00b63e0b55ad61915a9b1708e12d27
 
   - runs: |
       cd third_party

--- a/grpc.yaml
+++ b/grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc
-  version: 1.57.0
-  epoch: 1
+  version: 1.59.1
+  epoch: 0
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -45,7 +45,7 @@ pipeline:
     with:
       repository: https://github.com/grpc/grpc
       tag: v${{package.version}}
-      expected-commit: a61640173d00b63e0b55ad61915a9b1708e12d27
+      expected-commit: 0df9accc5c3478d126742fb84dd7155786dc4f68
 
   - runs: |
       cd third_party
@@ -102,6 +102,14 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv ${{targets.destdir}}/usr/lib/python3* ${{targets.subpkgdir}}/usr/lib/
+
+  - name: grpc-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - grpc
+    description: grpc dev
 
 update:
   enabled: true

--- a/grpc.yaml
+++ b/grpc.yaml
@@ -17,7 +17,7 @@ environment:
       - build-base
       - python3
       - py3-setuptools
-      - cython
+      - cython~0
       - c-ares-dev
       - autoconf
       - automake


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
