### PR TITLE
cleanup: remove attestation:TODO and license paths

### DIFF
--- a/ctop.yaml
+++ b/ctop.yaml
@@ -3,13 +3,8 @@ package:
   version: 0.7.7
   epoch: 9
   description: Top-like interface for container metrics
-  target-architecture:
-    - all
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: MIT
+    - license: MIT
 
 environment:
   contents:

--- a/dhcping.yaml
+++ b/dhcping.yaml
@@ -4,10 +4,7 @@ package:
   epoch: 0
   description: dhcp daemon ping program
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: BSD-2-Clause
+    - license: BSD-2-Clause
 
 environment:
   contents:

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -3,13 +3,8 @@ package:
   version: 7.0.111
   epoch: 0
   description: ".NET SDK"
-  target-architecture:
-    - all
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: MIT
+    - license: MIT
   dependencies:
     runtime:
       - icu

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -3,8 +3,13 @@ package:
   version: 7.0.111
   epoch: 0
   description: ".NET SDK"
+  target-architecture:
+    - all
   copyright:
-    - license: MIT
+    - paths:
+        - "*"
+      attestation: TODO
+      license: MIT
   dependencies:
     runtime:
       - icu

--- a/gdb.yaml
+++ b/gdb.yaml
@@ -3,13 +3,8 @@ package:
   version: "13.2"
   epoch: 1
   description: The GNU Debugger
-  target-architecture:
-    - all
   copyright:
-    - paths:
-        - '*'
-      attestation: TODO
-      license: GPL-3.0-or-later AND LGPL-3.0-or-later
+    - license: GPL-3.0-or-later AND LGPL-3.0-or-later
 
 environment:
   contents:

--- a/iperf.yaml
+++ b/iperf.yaml
@@ -4,10 +4,7 @@ package:
   epoch: 0
   description: A tool to measure IP bandwidth using UDP or TCP
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: NCSA
+    - license: NCSA
 
 environment:
   contents:

--- a/iperf3.yaml
+++ b/iperf3.yaml
@@ -4,10 +4,7 @@ package:
   epoch: 0
   description: A tool to measure IP bandwidth using UDP or TCP
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: BSD-3-Clause-LBNL
+    - license: BSD-3-Clause-LBNL
 
 environment:
   contents:

--- a/libmnl.yaml
+++ b/libmnl.yaml
@@ -3,13 +3,8 @@ package:
   version: 1.0.5
   epoch: 0
   description: Library for minimalistic netlink
-  target-architecture:
-    - all
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: LGPL-2.1-or-later
+    - license: LGPL-2.1-or-later
 
 environment:
   contents:

--- a/libnet.yaml
+++ b/libnet.yaml
@@ -3,13 +3,8 @@ package:
   version: "1.3"
   epoch: 0
   description: A generic networking API that provides access to several protocols
-  target-architecture:
-    - all
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: BSD-2-Clause
+    - license: BSD-2-Clause
 
 environment:
   contents:

--- a/libpcap.yaml
+++ b/libpcap.yaml
@@ -3,13 +3,8 @@ package:
   version: 1.10.4
   epoch: 0
   description: A system-independent interface for user-level packet capture
-  target-architecture:
-    - all
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: BSD-3-Clause
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/libssh.yaml
+++ b/libssh.yaml
@@ -3,13 +3,8 @@ package:
   version: 0.10.5
   epoch: 0
   description: Library for accessing ssh client services through C libraries
-  target-architecture:
-    - all
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: LGPL-2.1-or-later BSD-2-Clause
+    - license: LGPL-2.1-or-later BSD-2-Clause
 
 environment:
   contents:

--- a/metacontroller.yaml
+++ b/metacontroller.yaml
@@ -4,10 +4,7 @@ package:
   epoch: 5
   description: Writing kubernetes controllers can be simple
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: Apache-2.0
+    - license: Apache-2.0
 
 environment:
   contents:

--- a/sbt-stage0.yaml
+++ b/sbt-stage0.yaml
@@ -3,13 +3,8 @@ package:
   version: 1.8.2
   epoch: 0
   description: A scala build tool
-  target-architecture:
-    - all
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: Apache-2.0
+    - license: Apache-2.0
   dependencies:
     runtime:
       - openjdk-11-jre

--- a/sbt.yaml
+++ b/sbt.yaml
@@ -3,13 +3,8 @@ package:
   version: 1.9.6
   epoch: 0
   description: A scala build tool
-  target-architecture:
-    - all
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: Apache-2.0
+    - license: Apache-2.0
   dependencies:
     runtime:
       - openjdk-11-jre

--- a/socat.yaml
+++ b/socat.yaml
@@ -3,13 +3,8 @@ package:
   version: 1.7.4.4
   epoch: 0
   description: Multipurpose relay for binary protocols
-  target-architecture:
-    - all
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: GPL-2.0-only WITH OpenSSL-Exception
+    - license: GPL-2.0-only WITH OpenSSL-Exception
 
 environment:
   contents:

--- a/spark-operator.yaml
+++ b/spark-operator.yaml
@@ -4,10 +4,7 @@ package:
   epoch: 11
   description: Kubernetes operator for managing the lifecycle of Apache Spark applications on Kubernetes.
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: Apache-2.0
+    - license: Apache-2.0
 
 environment:
   contents:

--- a/wasmedge.yaml
+++ b/wasmedge.yaml
@@ -3,13 +3,8 @@ package:
   version: 0.13.4
   epoch: 0
   description: WasmEdge is a lightweight, high-performance, and extensible WebAssembly runtime for cloud native, edge, and decentralized applications.
-  target-architecture:
-    - all
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: Apache-2.0
+    - license: Apache-2.0
   dependencies:
     runtime:
       - libLLVM-15 # This isn't detected by melange for some reason.

--- a/x264.yaml
+++ b/x264.yaml
@@ -5,13 +5,8 @@ package:
   version: 0_git20191217
   epoch: 0
   description: Free library for encoding H264/AVC video streams
-  target-architecture:
-    - all
   copyright:
-    - paths:
-        - '*'
-      attestation: TODO
-      license: GPL-2.0-or-later
+    - license: GPL-2.0-or-later
 
 environment:
   contents:


### PR DESCRIPTION
This doesn't bump epochs, because it's not expected to have any functional changes.

These fields don't do anything useful, and just get copypasted around to new packages. Let's just remove them.