### PR TITLE
zookeeper: fix cve CVE-2023-44487 CVE-2023-4586

### DIFF
--- a/zookeeper.yaml
+++ b/zookeeper.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper
   version: 3.9.1.0
-  epoch: 0
+  epoch: 1
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - paths:
@@ -43,8 +43,8 @@ pipeline:
   - runs: |
       export LANG=en_US.UTF-8
       export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
-
-      mvn install -DskipTests
+      # patch netty version for CVE-2023-4586 CVE-2023-44487
+      mvn install -DskipTests -Dnetty.version=4.1.100.Final
       tar -xf zookeeper-assembly/target/apache-zookeeper-${{vars.short-package-version}}-bin.tar.gz
 
       mkdir -p ${{targets.destdir}}/usr/share/java/zookeeper


### PR DESCRIPTION
https://github.com/wolfi-dev/advisories/pull/309
```
Will process: zookeeper-3.9.1.0-r0.apk
├── 📄 /usr/share/java/zookeeper/lib/jackson-databind-2.15.2.jar
│       📦 jackson-databind 2.15.2 (java-archive)
│           Medium CVE-2023-35116
│
└── 📄 /usr/share/java/zookeeper/lib/netty-handler-4.1.94.Final.jar
        📦 netty-handler 4.1.94.Final (java-archive)
            Medium CVE-2023-4586 GHSA-57m8-f3v5-hm5m


/work/work # wolfictl scan packages/x86_64/zookeeper-3.9.1.0-r1.apk
Will process: zookeeper-3.9.1.0-r1.apk
└── 📄 /usr/share/java/zookeeper/lib/jackson-databind-2.15.2.jar
        📦 jackson-databind 2.15.2 (java-archive)
            Medium CVE-2023-35116
 ```
 
 ```
work/work # /usr/share/java/zookeeper/bin/zkServer.sh  --config /usr/share/java/zookeeper/conf version
/usr/bin/java
ZooKeeper JMX enabled by default
Using config: /usr/share/java/zookeeper/conf/zoo.cfg
Apache ZooKeeper, version 3.9.1 2023-10-11 05:03 UT
```



```
/work/work # /usr/share/java/zookeeper/bin/zkServer.sh  --config /usr/share/java/zookeeper/conf start-foreground
/usr/bin/java
ZooKeeper JMX enabled by default
Using config: /usr/share/java/zookeeper/conf/zoo.cfg
2023-10-11 05:19:51,719 [myid:] - INFO  [main:o.a.z.s.q.QuorumPeerConfig@177] - Reading configuration from: /usr/share/java/zookeeper/conf/zoo.cfg
2023-10-11 05:19:51,722 [myid:] - INFO  [main:o.a.z.s.q.QuorumPeerConfig@440] - clientPortAddress is 0.0.0.0:2181
2023-10-11 05:19:51,723 [myid:] - INFO  [main:o.a.z.s.q.QuorumPeerConfig@444] - secureClientPort is not set
2023-10-11 05:19:51,723 [myid:] - INFO  [main:o.a.z.s.q.QuorumPeerConfig@460] - observerMasterPort is not set
2023-10-11 05:19:51,723 [myid:] - INFO  [main:o.a.z.s.q.QuorumPeerConfig@477] - metricsProvider.className is org.apache.zookeeper.metrics.impl.DefaultMetricsProvider
2023-10-11 05:19:51,724 [myid:] - INFO  [main:o.a.z.s.DatadirCleanupManager@78] - autopurge.snapRetainCount set to 3
2023-10-11 05:19:51,725 [myid:] - INFO  [main:o.a.z.s.DatadirCleanupManager@79] - autopurge.purgeInterval set to 0
2023-10-11 05:19:51,725 [myid:] - INFO  [main:o.a.z.s.DatadirCleanupManager@101] - Purge task is not scheduled.
2023-10-11 05:19:51,725 [myid:] - WARN  [main:o.a.z.s.q.QuorumPeerMain@139] - Either no config or no quorum defined in config, running in standalone mode
2023-10-11 05:19:51,726 [myid:] - INFO  [main:o.a.z.j.ManagedUtil@46] - Log4j 1.2 jmx support not found; jmx disabled.
2023-10-11 05:19:51,726 [myid:] - INFO  [main:o.a.z.s.q.QuorumPeerConfig@177] - Reading configuration from: /usr/share/java/zookeeper/conf/zoo.cfg
2023-10-11 05:19:51,727 [myid:] - INFO  [main:o.a.z.s.q.QuorumPeerConfig@440] - clientPortAddress is 0.0.0.0:2181
2023-10-11 05:19:51,727 [myid:] - INFO  [main:o.a.z.s.q.QuorumPeerConfig@444] - secureClientPort is not set
2023-10-11 05:19:51,727 [myid:] - INFO  [main:o.a.z.s.q.QuorumPeerConfig@460] - observerMasterPort is not set
2023-10-11 05:19:51,727 [myid:] - INFO  [main:o.a.z.s.q.QuorumPeerConfig@477] - metricsProvider.className is org.apache.zookeeper.metrics.impl.DefaultMetricsProvider
2023-10-11 05:19:51,727 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServerMain@123] - Starting server
2023-10-11 05:19:51,735 [myid:] - INFO  [main:o.a.z.s.ServerMetrics@64] - ServerMetrics initialized with provider org.apache.zookeeper.metrics.impl.DefaultMetricsProvider@223191a6
2023-10-11 05:19:51,737 [myid:] - INFO  [main:o.a.z.s.a.DigestAuthenticationProvider@51] - ACL digest algorithm is: SHA1
2023-10-11 05:19:51,737 [myid:] - INFO  [main:o.a.z.s.a.DigestAuthenticationProvider@65] - zookeeper.DigestAuthenticationProvider.enabled = true
2023-10-11 05:19:51,739 [myid:] - INFO  [main:o.a.z.s.p.FileTxnSnapLog@124] - zookeeper.snapshot.trust.empty : false
2023-10-11 05:19:51,745 [myid:] - INFO  [main:o.a.z.ZookeeperBanner@42] - 
2023-10-11 05:19:51,745 [myid:] - INFO  [main:o.a.z.ZookeeperBanner@42] -   ______                  _                                          
2023-10-11 05:19:51,745 [myid:] - INFO  [main:o.a.z.ZookeeperBanner@42] -  |___  /                 | |                                         
2023-10-11 05:19:51,745 [myid:] - INFO  [main:o.a.z.ZookeeperBanner@42] -     / /    ___     ___   | | __   ___    ___   _ __     ___   _ __   
2023-10-11 05:19:51,745 [myid:] - INFO  [main:o.a.z.ZookeeperBanner@42] -    / /    / _ \   / _ \  | |/ /  / _ \  / _ \ | '_ \   / _ \ | '__|
2023-10-11 05:19:51,746 [myid:] - INFO  [main:o.a.z.ZookeeperBanner@42] -   / /__  | (_) | | (_) | |   <  |  __/ |  __/ | |_) | |  __/ | |    
2023-10-11 05:19:51,746 [myid:] - INFO  [main:o.a.z.ZookeeperBanner@42] -  /_____|  \___/   \___/  |_|\_\  \___|  \___| | .__/   \___| |_|
2023-10-11 05:19:51,746 [myid:] - INFO  [main:o.a.z.ZookeeperBanner@42] -                                               | |                     
2023-10-11 05:19:51,746 [myid:] - INFO  [main:o.a.z.ZookeeperBanner@42] -                                               |_|                     
2023-10-11 05:19:51,746 [myid:] - INFO  [main:o.a.z.ZookeeperBanner@42] - 
2023-10-11 05:19:51,747 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:zookeeper.version=3.9.1-1398af177833412e9ead6b9bb737dc9fd7418a45-dirty, built on 2023-10-11 05:03 UTC
2023-10-11 05:19:51,747 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:host.name=10dffb66582b
2023-10-11 05:19:51,747 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:java.version=17.0.9
2023-10-11 05:19:51,747 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:java.vendor=wolfi
2023-10-11 05:19:51,747 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:java.home=/usr/lib/jvm/java-17-openjdk
2023-10-11 05:19:51,747 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:java.class.path=/usr/share/java/zookeeper/bin/../zookeeper-metrics-providers/zookeeper-prometheus-metrics/target/classes:/usr/share/java/zookeeper/bin/../zookeeper-server/target/classes:/usr/share/java/zookeeper/bin/../build/classes:/usr/share/java/zookeeper/bin/../zookeeper-metrics-providers/zookeeper-prometheus-metrics/target/lib/*.jar:/usr/share/java/zookeeper/bin/../zookeeper-server/target/lib/*.jar:/usr/share/java/zookeeper/bin/../build/lib/*.jar:/usr/share/java/zookeeper/bin/../lib/zookeeper-prometheus-metrics-3.9.1.jar:/usr/share/java/zookeeper/bin/../lib/zookeeper-jute-3.9.1.jar:/usr/share/java/zookeeper/bin/../lib/zookeeper-3.9.1.jar:/usr/share/java/zookeeper/bin/../lib/snappy-java-1.1.10.5.jar:/usr/share/java/zookeeper/bin/../lib/slf4j-api-1.7.30.jar:/usr/share/java/zookeeper/bin/../lib/simpleclient_servlet-0.9.0.jar:/usr/share/java/zookeeper/bin/../lib/simpleclient_hotspot-0.9.0.jar:/usr/share/java/zookeeper/bin/../lib/simpleclient_common-0.9.0.jar:/usr/share/java/zookeeper/bin/../lib/simpleclient-0.9.0.jar:/usr/share/java/zookeeper/bin/../lib/netty-transport-native-unix-common-4.1.100.Final.jar:/usr/share/java/zookeeper/bin/../lib/netty-transport-native-epoll-4.1.100.Final-linux-x86_64.jar:/usr/share/java/zookeeper/bin/../lib/netty-transport-classes-epoll-4.1.100.Final.jar:/usr/share/java/zookeeper/bin/../lib/netty-transport-4.1.100.Final.jar:/usr/share/java/zookeeper/bin/../lib/netty-tcnative-classes-2.0.61.Final.jar:/usr/share/java/zookeeper/bin/../lib/netty-tcnative-boringssl-static-2.0.61.Final.jar:/usr/share/java/zookeeper/bin/../lib/netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar:/usr/share/java/zookeeper/bin/../lib/netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar:/usr/share/java/zookeeper/bin/../lib/netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar:/usr/share/java/zookeeper/bin/../lib/netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar:/usr/share/java/zookeeper/bin/../lib/netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar:/usr/share/java/zookeeper/bin/../lib/netty-resolver-4.1.100.Final.jar:/usr/share/java/zookeeper/bin/../lib/netty-handler-4.1.100.Final.jar:/usr/share/java/zookeeper/bin/../lib/netty-common-4.1.100.Final.jar:/usr/share/java/zookeeper/bin/../lib/netty-codec-4.1.100.Final.jar:/usr/share/java/zookeeper/bin/../lib/netty-buffer-4.1.100.Final.jar:/usr/share/java/zookeeper/bin/../lib/metrics-core-4.1.12.1.jar:/usr/share/java/zookeeper/bin/../lib/logback-core-1.2.10.jar:/usr/share/java/zookeeper/bin/../lib/logback-classic-1.2.10.jar:/usr/share/java/zookeeper/bin/../lib/jline-2.14.6.jar:/usr/share/java/zookeeper/bin/../lib/jetty-util-ajax-9.4.52.v20230823.jar:/usr/share/java/zookeeper/bin/../lib/jetty-util-9.4.52.v20230823.jar:/usr/share/java/zookeeper/bin/../lib/jetty-servlet-9.4.52.v20230823.jar:/usr/share/java/zookeeper/bin/../lib/jetty-server-9.4.52.v20230823.jar:/usr/share/java/zookeeper/bin/../lib/jetty-security-9.4.52.v20230823.jar:/usr/share/java/zookeeper/bin/../lib/jetty-io-9.4.52.v20230823.jar:/usr/share/java/zookeeper/bin/../lib/jetty-http-9.4.52.v20230823.jar:/usr/share/java/zookeeper/bin/../lib/javax.servlet-api-3.1.0.jar:/usr/share/java/zookeeper/bin/../lib/jackson-databind-2.15.2.jar:/usr/share/java/zookeeper/bin/../lib/jackson-core-2.15.2.jar:/usr/share/java/zookeeper/bin/../lib/jackson-annotations-2.15.2.jar:/usr/share/java/zookeeper/bin/../lib/commons-io-2.11.0.jar:/usr/share/java/zookeeper/bin/../lib/commons-cli-1.5.0.jar:/usr/share/java/zookeeper/bin/../lib/audience-annotations-0.12.0.jar:/usr/share/java/zookeeper/bin/../zookeeper-*.jar:/usr/share/java/zookeeper/bin/../zookeeper-server/src/main/resources/lib/*.jar:/usr/share/java/zookeeper/conf:
2023-10-11 05:19:51,747 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:java.library.path=/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
2023-10-11 05:19:51,747 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:java.io.tmpdir=/tmp
2023-10-11 05:19:51,747 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:java.compiler=<NA>
2023-10-11 05:19:51,747 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:os.name=Linux
2023-10-11 05:19:51,747 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:os.arch=amd64
2023-10-11 05:19:51,747 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:os.version=5.15.120+
2023-10-11 05:19:51,747 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:user.name=root
2023-10-11 05:19:51,748 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:user.home=/root
2023-10-11 05:19:51,748 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:user.dir=/work/work
2023-10-11 05:19:51,748 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:os.memory.free=983MB
2023-10-11 05:19:51,748 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:os.memory.max=1000MB
2023-10-11 05:19:51,748 [myid:] - INFO  [main:o.a.z.Environment@98] - Server environment:os.memory.total=1000MB
2023-10-11 05:19:51,748 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@149] - zookeeper.enableEagerACLCheck = false
2023-10-11 05:19:51,748 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@162] - zookeeper.digest.enabled = true
2023-10-11 05:19:51,748 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@166] - zookeeper.closeSessionTxn.enabled = true
2023-10-11 05:19:51,748 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@2251] - zookeeper.serializeLastProcessedZxid.enabled = true
2023-10-11 05:19:51,748 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@1594] - zookeeper.flushDelay = 0 ms
2023-10-11 05:19:51,748 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@1603] - zookeeper.maxWriteQueuePollTime = 0 ms
2023-10-11 05:19:51,748 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@1612] - zookeeper.maxBatchSize=1000
2023-10-11 05:19:51,748 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@287] - zookeeper.intBufferStartingSizeBytes = 1024
2023-10-11 05:19:51,749 [myid:] - INFO  [main:o.a.z.s.BlueThrottle@141] - Weighed connection throttling is disabled
2023-10-11 05:19:51,750 [myid:] - INFO  [main:o.a.z.s.AuthenticationHelper@66] - zookeeper.enforce.auth.enabled = false
2023-10-11 05:19:51,750 [myid:] - INFO  [main:o.a.z.s.AuthenticationHelper@67] - zookeeper.enforce.auth.schemes = []
2023-10-11 05:19:51,751 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@1406] - minSessionTimeout set to 4000 ms
2023-10-11 05:19:51,751 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@1415] - maxSessionTimeout set to 40000 ms
2023-10-11 05:19:51,752 [myid:] - INFO  [main:o.a.z.s.ResponseCache@45] - getData response cache size is initialized with value 400.
2023-10-11 05:19:51,752 [myid:] - INFO  [main:o.a.z.s.ResponseCache@45] - getChildren response cache size is initialized with value 400.
2023-10-11 05:19:51,752 [myid:] - INFO  [main:o.a.z.s.u.RequestPathMetricsCollector@109] - zookeeper.pathStats.slotCapacity = 60
2023-10-11 05:19:51,753 [myid:] - INFO  [main:o.a.z.s.u.RequestPathMetricsCollector@110] - zookeeper.pathStats.slotDuration = 15
2023-10-11 05:19:51,753 [myid:] - INFO  [main:o.a.z.s.u.RequestPathMetricsCollector@111] - zookeeper.pathStats.maxDepth = 6
2023-10-11 05:19:51,753 [myid:] - INFO  [main:o.a.z.s.u.RequestPathMetricsCollector@112] - zookeeper.pathStats.initialDelay = 5
2023-10-11 05:19:51,753 [myid:] - INFO  [main:o.a.z.s.u.RequestPathMetricsCollector@113] - zookeeper.pathStats.delay = 5
2023-10-11 05:19:51,753 [myid:] - INFO  [main:o.a.z.s.u.RequestPathMetricsCollector@114] - zookeeper.pathStats.enabled = false
2023-10-11 05:19:51,755 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@1631] - The max bytes for all large requests are set to 104857600
2023-10-11 05:19:51,755 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@1645] - The large request threshold is set to -1
2023-10-11 05:19:51,755 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@385] - Created server with tickTime 2000 ms minSessionTimeout 4000 ms maxSessionTimeout 40000 ms clientPortListenBacklog -1 datadir /tmp/zookeeper/version-2 snapdir /tmp/zookeeper/version-2
2023-10-11 05:19:51,770 [myid:] - INFO  [main:o.e.j.u.l.Log@170] - Logging initialized @355ms to org.eclipse.jetty.util.log.Slf4jLog
2023-10-11 05:19:51,817 [myid:] - WARN  [main:o.e.j.s.h.ContextHandler@1662] - o.e.j.s.ServletContextHandler@306e95ec{/,null,STOPPED} contextPath ends with /*
2023-10-11 05:19:51,817 [myid:] - WARN  [main:o.e.j.s.h.ContextHandler@1673] - Empty contextPath
2023-10-11 05:19:51,832 [myid:] - INFO  [main:o.e.j.s.Server@375] - jetty-9.4.52.v20230823; built: 2023-08-23T19:29:37.669Z; git: abdcda73818a1a2c705da276edb0bf6581e7997e; jvm 17.0.9+7-wolfi-r0
2023-10-11 05:19:51,851 [myid:] - INFO  [main:o.e.j.s.s.DefaultSessionIdManager@334] - DefaultSessionIdManager workerName=node0
2023-10-11 05:19:51,851 [myid:] - INFO  [main:o.e.j.s.s.DefaultSessionIdManager@339] - No SessionScavenger set, using defaults
2023-10-11 05:19:51,852 [myid:] - INFO  [main:o.e.j.s.s.HouseKeeper@132] - node0 Scavenging every 660000ms
2023-10-11 05:19:51,855 [myid:] - WARN  [main:o.e.j.s.ConstraintSecurityHandler@759] - ServletContext@o.e.j.s.ServletContextHandler@306e95ec{/,null,STARTING} has uncovered http methods for path: /*
2023-10-11 05:19:51,863 [myid:] - INFO  [main:o.e.j.s.h.ContextHandler@921] - Started o.e.j.s.ServletContextHandler@306e95ec{/,null,AVAILABLE}
2023-10-11 05:19:51,872 [myid:] - INFO  [main:o.e.j.s.AbstractConnector@333] - Started ServerConnector@1eb5174b{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
2023-10-11 05:19:51,872 [myid:] - INFO  [main:o.e.j.s.Server@415] - Started @457ms
2023-10-11 05:19:51,872 [myid:] - INFO  [main:o.a.z.s.a.JettyAdminServer@201] - Started AdminServer on address 0.0.0.0, port 8080 and command URL /commands
2023-10-11 05:19:51,876 [myid:] - INFO  [main:o.a.z.s.ServerCnxnFactory@169] - Using org.apache.zookeeper.server.NIOServerCnxnFactory as server connection factory
2023-10-11 05:19:51,876 [myid:] - WARN  [main:o.a.z.s.ServerCnxnFactory@309] - maxCnxns is not configured, using default value 0.
2023-10-11 05:19:51,877 [myid:] - INFO  [main:o.a.z.s.NIOServerCnxnFactory@652] - Configuring NIO connection handler with 10s sessionless connection timeout, 2 selector thread(s), 32 worker threads, and 64 kB direct buffers.
2023-10-11 05:19:51,878 [myid:] - INFO  [main:o.a.z.s.NIOServerCnxnFactory@660] - binding to port 0.0.0.0/0.0.0.0:2181
2023-10-11 05:19:51,887 [myid:] - INFO  [main:o.a.z.s.w.WatchManagerFactory@42] - Using org.apache.zookeeper.server.watch.WatchManager as watch manager
2023-10-11 05:19:51,888 [myid:] - INFO  [main:o.a.z.s.w.WatchManagerFactory@42] - Using org.apache.zookeeper.server.watch.WatchManager as watch manager
2023-10-11 05:19:51,888 [myid:] - INFO  [main:o.a.z.s.ZKDatabase@135] - zookeeper.snapshotSizeFactor = 0.33
2023-10-11 05:19:51,888 [myid:] - INFO  [main:o.a.z.s.ZKDatabase@155] - zookeeper.commitLogCount=500
2023-10-11 05:19:51,890 [myid:] - INFO  [main:o.a.z.s.p.SnapStream@61] - zookeeper.snapshot.compression.method = CHECKED
2023-10-11 05:19:51,891 [myid:] - INFO  [main:o.a.z.s.p.FileSnap@86] - Reading snapshot /tmp/zookeeper/version-2/snapshot.0
2023-10-11 05:19:51,893 [myid:] - INFO  [main:o.a.z.s.DataTree@1701] - The digest value is empty in snapshot
2023-10-11 05:19:51,895 [myid:] - INFO  [main:o.a.z.s.ZKDatabase@292] - Snapshot loaded in 7 ms, highest zxid is 0x0, digest is 1371985504
2023-10-11 05:19:51,896 [myid:] - INFO  [main:o.a.z.s.p.FileTxnSnapLog@480] - Snapshotting: 0x0 to /tmp/zookeeper/version-2/snapshot.0
2023-10-11 05:19:51,897 [myid:] - INFO  [main:o.a.z.s.ZooKeeperServer@589] - Snapshot taken in 1 ms
2023-10-11 05:19:51,903 [myid:] - INFO  [ProcessThread(sid:0 cport:2181)::o.a.z.s.PrepRequestProcessor@138] - PrepRequestProcessor (sid:0) started, reconfigEnabled=false
2023-10-11 05:19:51,903 [myid:] - INFO  [main:o.a.z.s.RequestThrottler@75] - zookeeper.request_throttler.shutdownTimeout = 10000 ms
2023-10-11 05:19:51,915 [myid:] - INFO  [main:o.a.z.s.ContainerManager@83] - Using checkIntervalMs=60000 maxPerMinute=10000 maxNeverUsedIntervalMs=0
2023-10-11 05:19:51,916 [myid:] - INFO  [main:o.a.z.a.ZKAuditProvider@42] - ZooKeeper audit is disabled.

```