### PR TITLE
Add wait-for-port 1.0.7 package

### DIFF
--- a/wait-for-port.yaml
+++ b/wait-for-port.yaml
@@ -1,0 +1,35 @@
+package:
+  name: wait-for-port
+  version: 1.0.7
+  epoch: 0
+  description: CLI tool for waiting until a TCP port reaches the desired state
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/bitnami/wait-for-port
+      tag: v${{package.version}}
+      expected-commit: 51dc9ec7247d5431dc4888763bc11509abff2f21
+
+  - runs: |
+      CGO_ENABLED=1 go build -trimpath -ldflags '-linkmode external -extldflags "-static"' .
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv wait-for-port ${{targets.destdir}}/usr/bin
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: bitnami/wait-for-port
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
https://github.com/bitnami/wait-for-port

### Pre-review Checklist

#### For new package PRs only
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
