### PR TITLE
adds kubebuilder package

### DIFF
--- a/kubebuilder.yaml
+++ b/kubebuilder.yaml
@@ -1,0 +1,49 @@
+package:
+  name: kubebuilder
+  version: 3.12.0
+  epoch: 0
+  description: SDK for building Kubernetes APIs using CRDs
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - go
+      - build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/kubebuilder
+      tag: v${{package.version}}
+      expected-commit: b48f95cd5384eadcdfd02a47a02910f72ddc7ea8
+
+  - uses: go/build
+    with:
+      packages: .
+      output: kubebuilder
+      ldflags: |
+        -s -w
+        -X main.kubeBuilderVersion=$(git describe --tags --dirty --broken)
+        -X main.goos=$(go env GOOS)
+        -X main.goarch=$(go env GOARCH)
+        -X main.gitCommit=$(git rev-parse HEAD)
+        -X main.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+  - uses: strip
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - tools-*
+    - release-*
+  github:
+    identifier: kubernetes-sigs/kubebuilder
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
