### PR TITLE
add bash as a calico-node runtime dep for logging

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.26.3
-  epoch: 1
+  epoch: 2
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64
@@ -131,6 +131,7 @@ subpackages:
     dependencies:
       runtime:
         - runit
+        - bash # required for logging functionality to work since `start_runit` logging script uses #!/bin/bash
         - iptables
         - ip6tables
         - ipset


### PR DESCRIPTION
while the image functioned fine without this, `calico-node` would spin up with the following:

```
runsv felix: fatal: unable to start log/./run: file does not exist
runsv allocate-tunnel-addrs: fatal: unable to start log/./run: file does not exist
runsv node-status-reporter: fatal: unable to start log/./run: file does not exist
```

this is because the services all include a ~independent [`run`](https://github.com/projectcalico/calico/blob/master/node/filesystem/etc/service/available/bird/log/run#L1) that uses `#!/bin/bash`.

adding `bash` as a runtime dependency fixes these start up errors, and fixes the logging

