### PR TITLE
Add php-8.3-0RC3 release candidate.

### DIFF
--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,0 +1,279 @@
+package:
+  name: php-8.3
+  version: 8.3_rc3
+  epoch: 0
+  description: "the PHP programming language"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
+    #provides:
+    #  - php=${{package.full-version}}
+    runtime:
+      - libxml2
+
+environment:
+  contents:
+    packages:
+      - bison
+      - build-base
+      - busybox
+      - bzip2-dev
+      - ca-certificates-bundle
+      - curl-dev
+      - file
+      - freetds
+      - freetype-dev
+      - gmp-dev
+      - icu-dev
+      - libavif-dev
+      - libjpeg-turbo-dev
+      - libpng-dev
+      - libsodium-dev
+      - libtool
+      - libwebp-dev
+      - libx11-dev
+      - libxml2-dev
+      - libxpm-dev
+      - libxslt-dev
+      - libzip
+      - oniguruma-dev
+      - openldap-dev
+      - openssl-dev
+      - postgresql-15-dev
+      - readline-dev
+      - sqlite-dev
+      - unixodbc-dev
+
+# transform melange version to contain ".0" rather than "_" so we can use a
+# var in the fetch URL. Note that apparently you can't use upper case letters
+# in the version either, so just use lower case above, and then transform here.
+var-transforms:
+  - from: ${{package.version}}
+    match: \_rc
+    replace: '.0RC'
+    to: mangled-package-version
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://downloads.php.net/~jakub/php-${{vars.mangled-package-version}}.tar.gz
+      expected-sha512: 65646f32ede196a622372cc13cb548785613e4ac82d7e776a71ad316cef75b1ead36f75a3bca95c488b9dc85803c0ea77ded9c838dac8df15591482ea77e7296
+      extract: false
+
+  - name: Prepare Build Folder
+    runs: |
+      mv php-${{vars.mangled-package-version}}.tar.gz $HOME
+      tar zxf $HOME/php-${{vars.mangled-package-version}}.tar.gz
+
+  - name: Configure
+    runs: |
+      cd $HOME/php-${{vars.mangled-package-version}}
+      EXTENSION_DIR=/usr/lib/php/modules ./configure \
+        --prefix=/usr \
+        --libdir=/usr/lib/php \
+        --datadir=/usr/share/php \
+        --sysconfdir=/etc/php \
+        --localstatedir=/var \
+        --with-layout=GNU \
+        --with-pic \
+        --with-config-file-path=/etc/php \
+        --with-config-file-scan-dir=/etc/php/conf.d \
+        --enable-cli \
+        --enable-ctype=shared \
+        --enable-bcmath=shared \
+        --with-curl=shared \
+        --enable-dom=shared \
+        --enable-fileinfo=shared \
+        --with-iconv=shared \
+        --with-openssl=shared \
+        --with-readline \
+        --with-sodium=shared \
+        --enable-fpm \
+        --with-pear \
+        --enable-gd=shared \
+            --with-avif \
+            --with-freetype \
+            --with-jpeg \
+            --with-webp \
+            --with-xpm \
+            --disable-gd-jis-conv \
+        --with-libxml \
+        --enable-phar=shared \
+        --enable-mbstring=shared \
+      	--with-mysqli=shared \
+            --with-mysql-sock=/run/mysqld/mysqld.sock \
+        --enable-mysqlnd=shared \
+        --enable-pdo=shared \
+            --with-pdo-mysql=shared,mysqlnd \
+            --with-pdo-sqlite=shared \
+            --with-pdo-dblib=shared \
+            --with-pdo-pgsql=shared \
+        --with-unixODBC=shared,/usr \
+        --enable-pcntl=shared \
+        --enable-sockets=shared \
+        --with-bz2=shared \
+        --enable-calendar=shared \
+        --enable-exif=shared  \
+        --with-gettext=shared  \
+        --with-gmp=shared  \
+        --enable-intl=shared  \
+        --with-ldap=shared  \
+        --enable-opcache=shared  \
+        --enable-soap=shared  \
+        --with-xsl=shared \
+        --with-zlib \
+        --enable-xml=shared \
+        --enable-simplexml=shared \
+        --enable-xml=shared \
+        --enable-xmlreader=shared \
+        --enable-xmlwriter=shared \
+        --enable-posix=shared \
+        --with-pgsql=shared \
+        --with-zip=shared
+
+  - uses: autoconf/make
+    with:
+      dir: $HOME/php-${{vars.mangled-package-version}}
+
+  - name: Make Install
+    runs: |
+      cd $HOME/php-${{vars.mangled-package-version}}
+      INSTALL_ROOT=${{targets.destdir}} DESTDIR=${{targets.destdir}} make install
+
+  - uses: strip
+
+  - name: Copy configuration and set up alias on /bin
+    runs: |
+      mkdir -p "${{targets.destdir}}/etc/php/conf.d"
+      mv $HOME/php-${{vars.mangled-package-version}}/php.ini-production ${{targets.destdir}}/etc/php/php.ini
+      mkdir -p "${{targets.destdir}}/bin" && ln -s /usr/bin/php "${{targets.destdir}}/bin/php"
+
+data:
+  - name: extensions
+    items:
+      bz2: Bzip2
+      curl: cURL
+      gd: GD imaging
+      gmp: GNU GMP support
+      ldap: LDAP
+      mysqlnd: MySQLnd
+      openssl: OpenSSL
+      pdo_mysql: MySQL driver for PDO
+      pdo_sqlite: SQLite 3.x driver for PDO
+      pdo_dblib: PDO driver for Sybase / MS SQL databases
+      pdo_pgsql: PDO driver for pgsql
+      soap: SOAP
+      sodium: Sodium
+      calendar: Calendar
+      exif: EXIF
+      gettext: GetText
+      intl: Internationalization
+      mbstring: Multibyte String Functions
+      opcache: Opcache
+      pcntl: pcntl
+      pdo: PHP Data Objects
+      phar: PHP Archive
+      sockets: Sockets
+      xsl: XSL
+      bcmath: BC Math
+      ctype: ctype
+      iconv: Iconv
+      dom: DOM
+      pgsql: PostgreSQL
+      posix: Posix
+      simplexml: SimpleXML
+      mysqli: MySQLi
+      xml: XML
+      xmlreader: XMLReader
+      xmlwriter: XMLWriter
+      fileinfo: fileinfo
+      zip: Zip
+      odbc: UnixODBC
+
+subpackages:
+  - range: extensions
+    name: "${{package.name}}-${{range.key}}"
+    description: "The ${{range.value}} extension"
+    # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
+    #dependencies:
+    #  provides:
+    #    - php-${{range.key}}=${{package.full-version}}
+    pipeline:
+      - runs: |
+          export EXTENSIONS_DIR=usr/lib/php/modules
+          export CONF_DIR="${{targets.subpkgdir}}/etc/php/conf.d"
+          mkdir -p "${{targets.subpkgdir}}"/$EXTENSIONS_DIR $CONF_DIR
+          mv "${{targets.destdir}}/$EXTENSIONS_DIR/${{range.key}}.so" \
+            "${{targets.subpkgdir}}/$EXTENSIONS_DIR/${{range.key}}.so"
+          prefix=
+          [ "${{range.key}}" != "opcache" ] || prefix="zend_"
+          echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"${{range.key}}.ini"
+
+  - name: ${{package.name}}-dev
+    description: PHP 8.3 development headers
+    # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
+    #dependencies:
+    #  provides:
+    #    - php-dev=${{package.full-version}}
+    pipeline:
+      - uses: split/dev
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/phpize ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/lib ${{targets.subpkgdir}}/usr
+
+  - name: ${{package.name}}-cgi
+    description: PHP 8.3 CGI
+    # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
+    #dependencies:
+    #  provides:
+    #    - php-cgi=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/php-cgi ${{targets.subpkgdir}}/usr/bin/
+
+  - name: ${{package.name}}-dbg
+    description: Interactive PHP Debugger
+    # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
+    #dependencies:
+    #  provides:
+    #    - php-dbg=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/phpdbg ${{targets.subpkgdir}}/usr/bin/
+
+  - name: ${{package.name}}-fpm
+    description: PHP 8.3 FastCGI Process Manager (FPM)
+    # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
+    dependencies:
+    #  provides:
+    #    - php-fpm=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/sbin ${{targets.subpkgdir}}/etc/php/php-fpm.d
+          mv ${{targets.destdir}}/usr/sbin/php-fpm ${{targets.subpkgdir}}/usr/sbin/
+          mv ${{targets.destdir}}/etc/php/php-fpm.conf.default ${{targets.subpkgdir}}/etc/php/php-fpm.conf
+          mv ${{targets.destdir}}/etc/php/php-fpm.d/www.conf.default ${{targets.subpkgdir}}/etc/php/php-fpm.d/www.conf \
+          && { \
+            echo '[global]'; \
+            echo 'error_log = /proc/self/fd/2'; \
+            echo 'daemonize = no'; \
+            echo; \
+            echo '[www]'; \
+            echo 'listen = [::]:9000'; \
+            echo 'access.log = /proc/self/fd/2'; \
+            echo; \
+            echo 'clear_env = no'; \
+            echo; \
+            echo 'catch_workers_output = yes'; \
+            echo; \
+            echo 'decorate_workers_output = no'; \
+          } | tee ${{targets.subpkgdir}}/etc/php/php-fpm.d/zz-apko.conf
+
+# The release candidates are in a different location, so we can't really
+# monitor the github tags for these since they differ.
+update:
+  enabled: false


### PR DESCRIPTION
NOTE: This is fairly straight 1:1 mapping from 8.2. I will follow up with the changes to split out the -config subpackages so that it's easier to see what those changes look like in isolation.

Tested with:

935803af258d:/work/packages# apk add php-8.3
(1/7) Installing xz (5.4.4-r0)
(2/7) Installing libxml2 (2.11.5-r1)
(3/7) Installing ncurses-terminfo-base (6.4_p20230722-r1) (4/7) Installing ncurses (6.4_p20230722-r1)
(5/7) Installing readline (8.2-r2)
(6/7) Installing sqlite (3.40.0-r1)
(7/7) Installing php-8.3 (8.3.0RC3-r0)
OK: 33 MiB in 24 packages
935803af258d:/work/packages# php -version
PHP 8.3.0RC3 (cli) (built: Jan  1 1970 00:00:00) (NTS) Copyright (c) The PHP Group
Zend Engine v4.3.0RC3, Copyright (c) Zend Technologies 935803af258d:/work/packages# php -m
[PHP Modules]
Core
date
filter
hash
json
libxml
pcre
random
readline
Reflection
session
SPL
sqlite3
standard
tokenizer
zlib

[Zend Modules]

935803af258d:/work/packages# php -ini
phpinfo()
PHP Version => 8.3.0RC3

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist
#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
