### PR TITLE
nfs-subdir-external-provisioner

### DIFF
--- a/nfs-subdir-external-provisioner.yaml
+++ b/nfs-subdir-external-provisioner.yaml
@@ -1,0 +1,44 @@
+package:
+  name: nfs-subdir-external-provisioner
+  version: 4.0.18
+  epoch: 0
+  description: Dynamic sub-dir volume provisioner on a remote NFS server.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
+      tag: nfs-subdir-external-provisioner-${{package.version}}
+      expected-commit: c2a2d5d544781e3d3e4d7a7e2d21a8e64cf6d9d1
+
+  # I added `go mod edit -go=1.17` because when I do `go get golang.org/x/net@v0.7.0,`
+  # to fix a High CVE it gave me an error unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod.
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      GOOS=$(go env GOOS)
+      GOARCH=$(go env GOARCH)
+      go mod edit -go=1.17
+      go get github.com/prometheus/client_golang@v1.11.1
+      go get golang.org/x/text@v0.3.8
+      go get golang.org/x/net@v0.7.0
+      go get gopkg.in/yaml.v3@v3.0.0-20220521103104-8f96da9f5d5e
+      go mod tidy -compat=1.17
+      go mod vendor
+      make BUILD_PLATFORMS="${GOOS} ${GOARCH}" build
+      mv ./bin/nfs-subdir-external-provisioner ${{targets.destdir}}/usr/bin/
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/nfs-subdir-external-provisioner
+    strip-prefix: nfs-subdir-external-provisioner-


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

/work # wolfictl scan packages/aarch64/nfs-subdir-external-provisioner-4.0.18-r0.apk
Will process: nfs-subdir-external-provisioner-4.0.18-r0.apk
✅ No vulnerabilities found

🎉

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
