### PR TITLE
prometheus-mongodb-exporter: add bitnami-compat package

### DIFF
--- a/prometheus-mongodb-exporter.yaml
+++ b/prometheus-mongodb-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-mongodb-exporter
   version: 0.39.0
-  epoch: 2
+  epoch: 3
   description: A Prometheus exporter for MongoDB including sharding, replication and storage engines
   copyright:
     - license: MIT
@@ -30,6 +30,14 @@ pipeline:
       mv mongodb_exporter ${{targets.destdir}}/usr/bin/
 
   - uses: strip
+
+subpackages:
+  - name: prometheus-mongodb-exporter-bitnami-compat
+    description: "compat package with bitnami/mongodb helm chart"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/bin
+          ln -s /usr/bin/mongodb_exporter "${{targets.subpkgdir}}"/bin/mongodb_exporter
 
 update:
   enabled: true

--- a/py3-pendulum.yaml
+++ b/py3-pendulum.yaml
@@ -14,7 +14,6 @@ package:
 
 environment:
   contents:
-    repositories:
     packages:
       - ca-certificates-bundle
       - wolfi-base

--- a/py3-pendulum.yaml
+++ b/py3-pendulum.yaml
@@ -14,6 +14,7 @@ package:
 
 environment:
   contents:
+    repositories:
     packages:
       - ca-certificates-bundle
       - wolfi-base


### PR DESCRIPTION
This adds a -bitnami-compat package that symlinks the entrypoint to `/bin/mongodb_exporter` for compatibility with bitnami's mongodb helm chart.