### PR TITLE
rootlesskit: new package

### DIFF
--- a/rootlesskit.yaml
+++ b/rootlesskit.yaml
@@ -1,0 +1,34 @@
+package:
+  name: rootlesskit
+  version: 1.1.1
+  epoch: 0
+  description: RootlessKit is a Linux-native implementation of "fake root" using user_namespaces(7).
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rootless-containers/rootlesskit
+      expected-commit: a2c596ff9b3fddc0c2becb38f2ef4004f15765b5
+      tag: v${{package.version}}
+
+  - runs: |
+      CGO_ENABLED=0 make all
+      DESTDIR=${{targets.destdir}} BINDIR="/usr/bin" make install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: rootless-containers/rootlesskit
+    strip-prefix: v


### PR DESCRIPTION
https://github.com/rootless-containers/rootlesskit

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/wolfi-dev/os/pull/1860 (rootlesskit required for rootless buildkit)

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
