### PR TITLE
try to fix pipenv/poetry conflicting on filelock

### DIFF
--- a/poetry.yaml
+++ b/poetry.yaml
@@ -1,13 +1,14 @@
 package:
   name: poetry
   version: 1.6.1
-  epoch: 1
+  epoch: 2
   description: "Python packaging and dependency management made easy"
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - python3
+      - py3-filelock
 
 environment:
   contents:
@@ -18,6 +19,7 @@ environment:
       - python3
       - py3-pip
       - py3-setuptools
+      - py3-filelock
 
 pipeline:
   - uses: fetch

--- a/py3-pipenv.yaml
+++ b/py3-pipenv.yaml
@@ -1,13 +1,14 @@
 package:
   name: py3-pipenv
   version: 2023.10.3
-  epoch: 0
+  epoch: 1
   description: "Pipenv is a Python virtualenv management tool that supports a multitude of systems and nicely bridges the gaps between pip, python (using system python, pyenv or asdf) and virtualenv."
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - python3
+      - py3-filelock
 
 environment:
   contents:
@@ -16,6 +17,7 @@ environment:
       - ca-certificates-bundle
       - build-base
       - py3-pip
+      - py3-filelock
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Both have pip dependencies on filelock, so both pull it in at `pip install` time and vendor it, at different versions.

This makes both packages depend on filelock at build time (so they don't try to install/vendor it) and at runtime (so they have it at runtime when they need it).

I'm a Python noob, I'd love someone who knows what they're talking about to tell me if this is wrong.