### PR TITLE
runc: fix GHSA-6xv5-86q9-7xr8

### DIFF
--- a/runc.yaml
+++ b/runc.yaml
@@ -1,7 +1,7 @@
 package:
   name: runc
   version: 1.1.9
-  epoch: 4
+  epoch: 5
   description: CLI tool for spawning and running containers according to the OCI specification
   copyright:
     - license: Apache-2.0
@@ -9,12 +9,12 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
-      - bash
       - go
       - go-md2man
       - libseccomp-dev
@@ -27,6 +27,14 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: ccaecfcbc907d70a7aa870a6650887b901b25b82
       destination: runc
+
+  - runs: |
+      cd runc
+
+      # GHSA-6xv5-86q9-7xr8
+      go get -u github.com/cyphar/filepath-securejoin@v0.2.4
+
+      go mod vendor
 
   - runs: |
       cd runc


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/advisories/GHSA-6xv5-86q9-7xr8

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

Notes: We've already [NACKed this](https://github.com/wolfi-dev/advisories/pull/232), but it's showing up in grype scans and it's easy to patch out 🤷 
