### PR TITLE
Break nginx into "main" and -config so we can customize easier.

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -1,35 +1,39 @@
 package:
   name: nginx-mainline
   version: 1.25.2
-  epoch: 2
+  epoch: 3
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause
   dependencies:
     provides:
-      - nginx=${{package.version}}-r${{package.epoch}}
+      - nginx=${{package.full-version}}
+    # Let's ensure that we have config. This gets the default, but can also
+    # be override by users.
+    runtime:
+      - nginx-config
 
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - brotli-dev
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
-      - brotli-dev
       - gd-dev
       - geoip-dev
       - libmaxminddb-dev
       - libxml2-dev
       - libxslt-dev
+      - luajit-dev
       - openssl-dev
       - pcre-dev
       - perl-dev
       - pkgconf
       - zeromq-dev
       - zlib-dev
-      - luajit-dev
 
 data:
   - name: modules
@@ -105,20 +109,42 @@ pipeline:
   - runs: |
       make -j$(nproc)
       make DESTDIR=${{targets.destdir}} install
-      # default error logs to standard error
-      sed -i 's/#error_log  logs\/error.log;$/error_log  stderr  notice;/' ${{targets.destdir}}/etc/nginx/nginx.conf
-      # and both access logs to stdout
-      sed -i 's/#access_log.*;$/access_log  \/dev\/stdout;/' ${{targets.destdir}}/etc/nginx/nginx.conf
+      # Stash the configuration into a separate directory so that it's not part
+      # of the main package and hence configurable by users of -config
+      # subpackage. We install it separately below in a subpackage.
+      #
+      # Unfortunately, there's no way to install configuration into a separate
+      # directory that I could find.
+      mkdir pkg-config
+      mv ${{targets.destdir}}/etc/nginx pkg-config/
   - uses: strip
 
 subpackages:
+  - name: nginx-mainline-config
+    description: Creates nginx config step that can then be overridden by users
+    dependencies:
+      runtime:
+        - nginx-mainline
+      provides:
+        - nginx-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          # This was moved into ./pkg-config/etc/nginx so put it into the
+          # subpackage directory here.
+          mkdir -p ${{targets.subpkgdir}}/etc/nginx
+          cp -R ./pkg-config/nginx/* ${{targets.subpkgdir}}/etc/nginx/
+          # default error logs to standard error
+          sed -i 's/#error_log  logs\/error.log;$/error_log  stderr  notice;/' ${{targets.subpkgdir}}/etc/nginx/nginx.conf
+          # and both access logs to stdout
+          sed -i 's/#access_log.*;$/access_log  \/dev\/stdout;/' ${{targets.subpkgdir}}/etc/nginx/nginx.conf
+
   - name: nginx-mainline-package-config
     description: Config supplied in packaged nginx.org bundles at https://hg.nginx.org/pkg-oss/
     dependencies:
       runtime:
         - nginx-mainline
       provides:
-        - nginx-package-config=${{package.version}}-r${{package.epoch}}
+        - nginx-package-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
@@ -140,7 +166,7 @@ subpackages:
     description: Nginx third-party module ${{range.key}}
     dependencies:
       provides:
-        - nginx-mod-${{range.key}}=${{package.version}}-r${{package.epoch}}
+        - nginx-mod-${{range.key}}=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib/nginx/modules

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -1,35 +1,39 @@
 package:
   name: nginx-stable
   version: 1.24.0
-  epoch: 1
+  epoch: 2
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause
   dependencies:
     provides:
-      - nginx=${{package.version}}-r${{package.epoch}}
+      - nginx=${{package.full-version}}
+    # Let's ensure that we have config. This gets the default, but can also
+    # be override by users.
+    runtime:
+      - nginx-config
 
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - brotli-dev
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
-      - brotli-dev
       - gd-dev
       - geoip-dev
       - libmaxminddb-dev
       - libxml2-dev
       - libxslt-dev
+      - luajit-dev
       - openssl-dev
       - pcre-dev
       - perl-dev
       - pkgconf
       - zeromq-dev
       - zlib-dev
-      - luajit-dev
 
 data:
   - name: modules
@@ -105,20 +109,42 @@ pipeline:
   - runs: |
       make -j$(nproc)
       make DESTDIR=${{targets.destdir}} install
-      # default error logs to standard error
-      sed -i 's/#error_log  logs\/error.log;$/error_log  stderr  notice;/' ${{targets.destdir}}/etc/nginx/nginx.conf
-      # and both access logs to stdout
-      sed -i 's/#access_log.*;$/access_log  \/dev\/stdout;/' ${{targets.destdir}}/etc/nginx/nginx.conf
+      # Stash the configuration into a separate directory so that it's not part
+      # of the main package and hence configurable by users of -config
+      # subpackage. We install it separately below in a subpackage.
+      #
+      # Unfortunately, there's no way to install configuration into a separate
+      # directory that I could find.
+      mkdir pkg-config
+      mv ${{targets.destdir}}/etc/nginx pkg-config/
   - uses: strip
 
 subpackages:
+  - name: nginx-stable-config
+    description: Creates nginx config step that can then be overridden by users
+    dependencies:
+      runtime:
+        - nginx-stable
+      provides:
+        - nginx-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          # This was moved into ./pkg-config/etc/nginx so put it into the
+          # subpackage directory here.
+          mkdir -p ${{targets.subpkgdir}}/etc/nginx
+          cp -R ./pkg-config/nginx/* ${{targets.subpkgdir}}/etc/nginx/
+          # default error logs to standard error
+          sed -i 's/#error_log  logs\/error.log;$/error_log  stderr  notice;/' ${{targets.subpkgdir}}/etc/nginx/nginx.conf
+          # and both access logs to stdout
+          sed -i 's/#access_log.*;$/access_log  \/dev\/stdout;/' ${{targets.subpkgdir}}/etc/nginx/nginx.conf
+
   - name: nginx-stable-package-config
     description: Config supplied in packaged nginx.org bundles at https://hg.nginx.org/pkg-oss/
     dependencies:
       runtime:
         - nginx-stable
       provides:
-        - nginx-package-config=${{package.version}}-r${{package.epoch}}
+        - nginx-package-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
@@ -140,7 +166,7 @@ subpackages:
     description: Nginx third-party module ${{range.key}}
     dependencies:
       provides:
-        - nginx-mod-${{range.key}}=${{package.version}}-r${{package.epoch}}
+        - nginx-mod-${{range.key}}=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib/nginx/modules


### PR DESCRIPTION
This refactors the main nginx package to have a `-config` subpackage making it easier to customize configurations:

```
a80315f20b16:/work/packages# apk add nginx
(1/5) Installing nginx-mainline-config (1.25.2-r3)
(2/5) Installing libgcc (13.2.0-r3)
(3/5) Installing libstdc++ (13.2.0-r3)
(4/5) Installing pcre (8.45-r0)
(5/5) Installing nginx-mainline (1.25.2-r3)
OK: 19 MiB in 19 packages
a80315f20b16:/work/packages# apk info -L nginx
nginx-mainline-1.25.2-r3 contains:
usr/sbin/nginx
var/lib/db/sbom/nginx-mainline-1.25.2-r3.spdx.json
var/lib/nginx/html/50x.html
var/lib/nginx/html/index.html

a80315f20b16:/work/packages# apk info -L nginx-config
nginx-mainline-config-1.25.2-r3 contains:
etc/nginx/fastcgi.conf
etc/nginx/fastcgi.conf.default
etc/nginx/fastcgi_params
etc/nginx/fastcgi_params.default
etc/nginx/koi-utf
etc/nginx/koi-win
etc/nginx/mime.types
etc/nginx/mime.types.default
etc/nginx/nginx.conf
etc/nginx/nginx.conf.default
etc/nginx/scgi_params
etc/nginx/scgi_params.default
etc/nginx/uwsgi_params
etc/nginx/uwsgi_params.default
etc/nginx/win-utf
var/lib/db/sbom/nginx-mainline-config-1.25.2-r3.spdx.json
```

This way you can create packages that either completely replace, or selectively replace the config.
