### PR TITLE
poetry: fix CVE-2023-43804 and GHSA-v8gr-m533-ghj9

### DIFF
--- a/poetry.yaml
+++ b/poetry.yaml
@@ -1,7 +1,7 @@
 package:
   name: poetry
   version: 1.6.1
-  epoch: 1
+  epoch: 2
   description: "Python packaging and dependency management made easy"
   copyright:
     - license: MIT


### PR DESCRIPTION
This fixes outdated depedencies for poetry, to be properly fixed in the future with explicit build/runtime dependencies.

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [X] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
https://github.com/wolfi-dev/advisories/pull/314