### PR TITLE
buildkitd: Add buildctl-daemonless.sh

### DIFF
--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -2,7 +2,7 @@ package:
   name: buildkitd
   version: 0.12.2
   description: "concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
-  epoch: 3
+  epoch: 4
   copyright:
     - license: Apache-2.0
 
@@ -36,6 +36,9 @@ pipeline:
       go build \
         -ldflags "-s -w -X ${PKG}/version.Version=${VERSION} -X ${PKG}/version.Revision=${REVISION} -X ${PKG}/version.Package=${PKG} -extldflags '-static'" \
         -o ${{targets.destdir}}/usr/bin/buildctl ./cmd/buildctl
+
+      # https://github.com/moby/buildkit/blob/4c93208b9db9f8936b17c33bc93d19fc1bbf5266/Dockerfile#L152
+      cp ./examples/buildctl-daemonless/buildctl-daemonless.sh /usr/bin/
 
   - uses: strip
 

--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -38,7 +38,7 @@ pipeline:
         -o ${{targets.destdir}}/usr/bin/buildctl ./cmd/buildctl
 
       # https://github.com/moby/buildkit/blob/4c93208b9db9f8936b17c33bc93d19fc1bbf5266/Dockerfile#L152
-      cp ./examples/buildctl-daemonless/buildctl-daemonless.sh /usr/bin/
+      cp ./examples/buildctl-daemonless/buildctl-daemonless.sh ${{targets.destdir}}/usr/bin/
 
   - uses: strip
 


### PR DESCRIPTION
This is a helper script included in the upstream image to aid running buildkit in daemonless mode: See https://github.com/moby/buildkit#daemonless

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: n/a

Related: https://github.com/chainguard-images/images/pull/1599 (needed to run buildkit test in self-contained docker run)

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

