### PR TITLE
add cloud-sql-proxy to scaffolding as dep

### DIFF
--- a/sigstore-scaffolding.yaml
+++ b/sigstore-scaffolding.yaml
@@ -9,10 +9,6 @@ package:
     - license: Apache-2.0
       paths:
         - "*"
-  dependencies:
-    runtime:
-      - cloud-sql-proxy
-      - cloud-sql-proxy-compat
   checks:
     disabled:
       - empty
@@ -28,7 +24,6 @@ environment:
 data:
   - name: components
     items:
-      cloudsqlproxy: ./cmd/cloudsqlproxy
       ctlog-createctconfig: ./cmd/ctlog/createctconfig
       ctlog-managectroots: ./cmd/ctlog/managectroots
       ctlog-verifyfulcio: ./cmd/ctlog/verifyfulcio
@@ -59,6 +54,19 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{range.key}} ${{targets.subpkgdir}}/usr/bin/${{range.key}}
       - uses: strip
+
+  - name: "${{package.name}}-cloudsqlproxy"
+    pipeline:
+      - runs: |
+          CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o "cloudsqlproxy" ./cmd/cloudsqlproxy
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv cloudsqlproxy ${{targets.subpkgdir}}/usr/bin/cloudsqlproxy
+      - uses: strip
+    dependencies:
+      runtime:
+        - cloud-sql-proxy
+        - cloud-sql-proxy-compat
 
 update:
   enabled: true

--- a/sigstore-scaffolding.yaml
+++ b/sigstore-scaffolding.yaml
@@ -1,7 +1,7 @@
 package:
   name: sigstore-scaffolding
   version: 0.6.8
-  epoch: 1
+  epoch: 2
   description: Software Supply Chain Transparency Log
   target-architecture:
     - all
@@ -9,6 +9,10 @@ package:
     - license: Apache-2.0
       paths:
         - "*"
+  dependencies:
+    runtime:
+      - cloud-sql-proxy
+      - cloud-sql-proxy-compat
   checks:
     disabled:
       - empty


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
