### PR TITLE
bump 16 python3 packages

### DIFF
--- a/py3-docutils.yaml
+++ b/py3-docutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-docutils
   version: 0.20.1
-  epoch: 0
+  epoch: 1
   description: "Documentation Utilities for Python3"
   copyright:
     - license: BSD-2-Clause AND GPL-3.0-or-later AND Python-2.0

--- a/py3-flit-core.yaml
+++ b/py3-flit-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-flit-core
   version: 3.9.0
-  epoch: 0
+  epoch: 1
   description: "simple packaging tool for simple packages (core)"
   copyright:
     - license: BSD-3-Clause

--- a/py3-gpep517.yaml
+++ b/py3-gpep517.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-gpep517
   version: "15"
-  epoch: 1
+  epoch: 2
   description: "PEP517 build system support for distros"
   copyright:
     - license: MIT

--- a/py3-hatchling.yaml
+++ b/py3-hatchling.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-hatchling
   version: 1.18.0
-  epoch: 1
+  epoch: 2
   description: "Modern, extensible Python build backend"
   copyright:
     - license: BSD-3-Clause

--- a/py3-importlib-metadata.yaml
+++ b/py3-importlib-metadata.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-importlib-metadata
   version: 6.8.0
-  epoch: 0
+  epoch: 1
   description: Read metadata from Python packages
   copyright:
     - license: Apache-2.0

--- a/py3-mako.yaml
+++ b/py3-mako.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-mako
   version: 1.2.4
-  epoch: 0
+  epoch: 1
   description: Python3 fast templating language
   copyright:
     - license: MIT

--- a/py3-markupsafe.yaml
+++ b/py3-markupsafe.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-markupsafe
   version: 2.1.3
-  epoch: 0
+  epoch: 1
   description: "Implements a XML/HTML/XHTML Markup safe string"
   copyright:
     - license: BSD-3-Clause

--- a/py3-packaging.yaml
+++ b/py3-packaging.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-packaging
   version: "23.2"
-  epoch: 0
+  epoch: 1
   description: "core utilities for python3 packaging"
   copyright:
     - license: Apache-2.0 AND BSD-2-Clause

--- a/py3-parsing.yaml
+++ b/py3-parsing.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-parsing
   version: 3.1.1
-  epoch: 0
+  epoch: 1
   description: "simple packaging tool for simple packages (core)"
   copyright:
     - license: MIT

--- a/py3-pathspec.yaml
+++ b/py3-pathspec.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pathspec
   version: 0.11.2
-  epoch: 0
+  epoch: 1
   description: "Utility library for gitignore style pattern matching of file paths"
   copyright:
     - license: MPL-2.0

--- a/py3-pluggy.yaml
+++ b/py3-pluggy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pluggy
   version: 1.3.0
-  epoch: 1
+  epoch: 2
   description: "Plugin management and hook calling for Python"
   copyright:
     - license: MIT

--- a/py3-pygments.yaml
+++ b/py3-pygments.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pygments
   version: 2.16.1
-  epoch: 0
+  epoch: 1
   description: Syntax highlighting package written in Python
   copyright:
     - license: BSD-2-Clause

--- a/py3-sphinx.yaml
+++ b/py3-sphinx.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinx
   version: 7.2.6
-  epoch: 0
+  epoch: 1
   description: "Python Documentation Generator"
   copyright:
     - license: MIT

--- a/py3-tomli.yaml
+++ b/py3-tomli.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tomli
   version: 2.0.1
-  epoch: 2
+  epoch: 3
   description: "TOML parser"
   copyright:
     - license: MIT

--- a/py3-typing-extensions.yaml
+++ b/py3-typing-extensions.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-typing-extensions
   version: 4.8.0
-  epoch: 0
+  epoch: 1
   description: Backported and Experimental Type Hints for Python 3.7+
   copyright:
     - license: Python Software Foundation

--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wheel
   version: 0.41.2
-  epoch: 0
+  epoch: 1
   description: "built-package format for Python"
   copyright:
     - license: MIT

--- a/py3-zipp.yaml
+++ b/py3-zipp.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-zipp
   version: 3.17.0
-  epoch: 0
+  epoch: 1
   description: Backport of pathlib-compatible object wrapper for zip files
   copyright:
     - license: MIT License


### PR DESCRIPTION
First 16 from `wolfictl text -t name | grep py3-`, manually verified that the build order and dependency tree are correct.