### PR TITLE
Update py3.12-installer.yaml

### DIFF
--- a/py3.12-installer.yaml
+++ b/py3.12-installer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.12-installer
   version: 0.7.0
-  epoch: 1
+  epoch: 3
   description: A library for installing Python wheels.
   copyright:
     - license: "MIT"


### PR DESCRIPTION
Bump epoch to make it win over 3.11-installer
