### PR TITLE
Refactor php-8.3 package to be more serviceable (add -config subpackages)

### DIFF
--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: 8.3_rc3
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -11,6 +11,7 @@ package:
     #  - php=${{package.full-version}}
     runtime:
       - libxml2
+      - ${{package.name}}-config
 
 environment:
   contents:
@@ -140,14 +141,9 @@ pipeline:
     runs: |
       cd $HOME/php-${{vars.mangled-package-version}}
       INSTALL_ROOT=${{targets.destdir}} DESTDIR=${{targets.destdir}} make install
+      mkdir -p "${{targets.destdir}}/bin" && ln -s /usr/bin/php "${{targets.destdir}}/bin/php"
 
   - uses: strip
-
-  - name: Copy configuration and set up alias on /bin
-    runs: |
-      mkdir -p "${{targets.destdir}}/etc/php/conf.d"
-      mv $HOME/php-${{vars.mangled-package-version}}/php.ini-production ${{targets.destdir}}/etc/php/php.ini
-      mkdir -p "${{targets.destdir}}/bin" && ln -s /usr/bin/php "${{targets.destdir}}/bin/php"
 
 data:
   - name: extensions
@@ -192,22 +188,44 @@ data:
       odbc: UnixODBC
 
 subpackages:
+  - name: ${{package.name}}-config
+    # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
+    # dependencies:
+    #   provides:
+    #     - php-${{range.key}}-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          mv $HOME/php-${{vars.mangled-package-version}}/php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
+
   - range: extensions
     name: "${{package.name}}-${{range.key}}"
     description: "The ${{range.value}} extension"
+    dependencies:
+      runtime:
+        - "${{package.name}}-${{range.key}}-config"
     # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
-    #dependencies:
     #  provides:
     #    - php-${{range.key}}=${{package.full-version}}
     pipeline:
       - runs: |
           export EXTENSIONS_DIR=usr/lib/php/modules
-          export CONF_DIR="${{targets.subpkgdir}}/etc/php/conf.d"
-          mkdir -p "${{targets.subpkgdir}}"/$EXTENSIONS_DIR $CONF_DIR
+          mkdir -p "${{targets.subpkgdir}}"/$EXTENSIONS_DIR
           mv "${{targets.destdir}}/$EXTENSIONS_DIR/${{range.key}}.so" \
             "${{targets.subpkgdir}}/$EXTENSIONS_DIR/${{range.key}}.so"
-          prefix=
-          [ "${{range.key}}" != "opcache" ] || prefix="zend_"
+
+  - range: extensions
+    name: "${{package.name}}-${{range.key}}-config"
+    description: "The ${{range.value}} extension configuration"
+    # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
+    #dependencies:
+    #  provides:
+    #    - php-${{range.key}}-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          export CONF_DIR="${{targets.subpkgdir}}/etc/php/conf.d"
+          mkdir -p $CONF_DIR
+          prefix=[ "${{range.key}}" != "opcache" ] || prefix="zend_"
           echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"${{range.key}}.ini"
 
   - name: ${{package.name}}-dev
@@ -223,7 +241,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/bin/phpize ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/lib ${{targets.subpkgdir}}/usr
 
-  - name: ${{package.name}}-cgi
+  - name: "${{package.name}}-cgi"
     description: PHP 8.3 CGI
     # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
     #dependencies:
@@ -234,7 +252,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/php-cgi ${{targets.subpkgdir}}/usr/bin/
 
-  - name: ${{package.name}}-dbg
+  - name: "${{package.name}}-dbg"
     description: Interactive PHP Debugger
     # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
     #dependencies:
@@ -245,16 +263,28 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/phpdbg ${{targets.subpkgdir}}/usr/bin/
 
-  - name: ${{package.name}}-fpm
+  - name: "${{package.name}}-fpm"
     description: PHP 8.3 FastCGI Process Manager (FPM)
-    # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
     dependencies:
+      runtime:
+        - "${{package.name}}-fpm-config"
+    # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
     #  provides:
     #    - php-fpm=${{package.full-version}}
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/sbin ${{targets.subpkgdir}}/etc/php/php-fpm.d
+          mkdir -p ${{targets.subpkgdir}}/usr/sbin
           mv ${{targets.destdir}}/usr/sbin/php-fpm ${{targets.subpkgdir}}/usr/sbin/
+
+  - name: ${{package.name}}-fpm-config
+    description: PHP 8.3 FastCGI Process Manager (FPM) configuration
+    # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
+    # dependencies:
+    #  provides:
+    #    - php-fpm-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc/php/php-fpm.d
           mv ${{targets.destdir}}/etc/php/php-fpm.conf.default ${{targets.subpkgdir}}/etc/php/php-fpm.conf
           mv ${{targets.destdir}}/etc/php/php-fpm.d/www.conf.default ${{targets.subpkgdir}}/etc/php/php-fpm.d/www.conf \
           && { \

--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -41,7 +41,7 @@ environment:
       - oniguruma-dev
       - openldap-dev
       - openssl-dev
-      - postgresql-15-dev
+      - postgresql-16-dev
       - readline-dev
       - sqlite-dev
       - unixodbc-dev
@@ -225,7 +225,8 @@ subpackages:
       - runs: |
           export CONF_DIR="${{targets.subpkgdir}}/etc/php/conf.d"
           mkdir -p $CONF_DIR
-          prefix=[ "${{range.key}}" != "opcache" ] || prefix="zend_"
+          prefix=
+          [ "${{range.key}}" != "opcache" ] || prefix="zend_"
           echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"${{range.key}}.ini"
 
   - name: ${{package.name}}-dev
@@ -240,6 +241,15 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/phpize ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/lib ${{targets.subpkgdir}}/usr
+
+  - name: ${{package.name}}-doc
+    description: PHP 8.3 documentation
+    # DO NOT USE PROVIDES UNTIL A RELEASE HAS BEEN MADE (not a release candidate)
+    #dependencies:
+    #  provides:
+    #    - php-doc=${{package.full-version}}
+    pipeline:
+      - uses: split/manpages
 
   - name: "${{package.name}}-cgi"
     description: PHP 8.3 CGI


### PR DESCRIPTION
After installing with apk add php-8.3 also installs the php-8.3-config

```
a222f2705f2c:/work/packages# apk add php-8.3
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/8) Installing xz (5.4.4-r0)
(2/8) Installing libxml2 (2.11.5-r1)
(3/8) Installing php-8.3-config (8.3_rc3-r2)
(4/8) Installing ncurses-terminfo-base (6.4_p20230722-r1)
(5/8) Installing ncurses (6.4_p20230722-r1)
(6/8) Installing readline (8.2-r2)
(7/8) Installing sqlite (3.40.0-r1)
(8/8) Installing php-8.3 (8.3_rc3-r2)
OK: 32 MiB in 22 packages
a222f2705f2c:/work/packages# apk info -L php-8.3
php-8.3-8.3_rc3-r2 contains:
bin/php
usr/bin/phar
usr/bin/phar.phar
usr/bin/php
usr/share/php/fpm/status.html
var/lib/db/sbom/php-8.3-8.3_rc3-r2.spdx.json
a222f2705f2c:/work/packages# apk apk info -L php-8.3-config
php-8.3-config-8.3_rc3-r2 contains:
etc/php/php.ini
```

Spot checking an extension:
```
a222f2705f2c:/work/packages# apk add php-8.3-gettext
(1/2) Installing php-8.3-gettext-config (8.3_rc3-r2)
(2/2) Installing php-8.3-gettext (8.3_rc3-r2)
OK: 32 MiB in 24 packages
a222f2705f2c:/work/packages# apk info -L php-8.3-gettext
php-8.3-gettext-8.3_rc3-r2 contains:
usr/lib/php/modules/gettext.so
var/lib/db/sbom/php-8.3-gettext-8.3_rc3-r2.spdx.json

a222f2705f2c:/work/packages# apk info -L php-8.3-gettext-config
php-8.3-gettext-config-8.3_rc3-r2 contains:
etc/php/conf.d/gettext.ini
var/lib/db/sbom/php-8.3-gettext-config-8.3_rc3-r2.spdx.json
```

Has all the same stuff as php-8.1, php-8.2, I'll add advisories for them in a follow on PR.

https://github.com/wolfi-dev/advisories/pull/358

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
