### PR TITLE
Refactor openssh-server to openssh-server and openssh-server-config

### DIFF
--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssh
   version: 9.5_p1
-  epoch: 0
+  epoch: 1
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC
@@ -123,12 +123,17 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/sbin
           mv "${{targets.destdir}}"/usr/sbin/sshd "${{targets.subpkgdir}}"/usr/sbin/
-
-          mkdir -p "${{targets.subpkgdir}}"/etc
-          mv "${{targets.destdir}}"/etc/ssh "${{targets.subpkgdir}}"/etc/
     dependencies:
       runtime:
         - openssh-keygen
+        - openssh-server-config
+
+  - name: "openssh-server-config"
+    description: "OpenSSH server configuration"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/etc
+          mv "${{targets.destdir}}"/etc/ssh "${{targets.subpkgdir}}"/etc/
 
 update:
   manual: true # version in fetch url is different from package.version


### PR DESCRIPTION
This is to make the package more serviceable so it's easier to customize configuration.

```
22ea88231f3b:/work/packages# apk add openssh-server
(1/3) Installing openssh-keygen (9.5_p1-r1)
(2/3) Installing openssh-server-config (9.5_p1-r1)
(3/3) Installing openssh-server (9.5_p1-r1)
OK: 34 MiB in 30 packages

22ea88231f3b:/work/packages# apk info -L openssh-server
openssh-server-9.5_p1-r1 contains:
usr/sbin/sshd
var/lib/db/sbom/openssh-server-9.5_p1-r1.spdx.json

22ea88231f3b:/work/packages# apk info -L openssh-server-config
openssh-server-config-9.5_p1-r1 contains:
etc/ssh/sshd_config
var/lib/db/sbom/openssh-server-config-9.5_p1-r1.spdx.json
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
