### PR TITLE
ingress-nginx-controller: patch CVE 2023-44487

### DIFF
--- a/ingress-nginx-controller.yaml
+++ b/ingress-nginx-controller.yaml
@@ -2,7 +2,7 @@
 package:
   name: ingress-nginx-controller
   version: 1.9.3
-  epoch: 0
+  epoch: 1
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0

--- a/ingress-nginx-controller.yaml
+++ b/ingress-nginx-controller.yaml
@@ -333,6 +333,12 @@ pipeline:
 
       cd "$BUILD_PATH/nginx-${{vars.NGINX_VERSION}}"
 
+      # CVE 2023-44487
+      #
+      # The filename is confusing because upstream uses nginx-1.21.4 while
+      # Wolfi uses 1.25.2 but it is the same patch.
+      patch -p1 $BUILD_PATH/images/nginx/rootfs/patches/nginx-1.21.4-http2.patch
+
       WITH_FLAGS="--with-debug \
       --with-compat \
       --with-pcre-jit \


### PR DESCRIPTION
* ingress-nginx-controller: CVE 2023-44487

### Pre-review Checklist

#### For new package PRs only

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented: patch is included in upstream ingress-nginx-controller code https://github.com/kubernetes/ingress-nginx/commit/86f1cedcadd8bb86585f4ef8ee89e6645cbb325e
