### PR TITLE
Revert gcloud to python-3.11

### DIFF
--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,13 +1,13 @@
 package:
   name: google-cloud-sdk
   version: 427.0.0
-  epoch: 1
+  epoch: 2
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - python3
+      - python-3.11
       # Required for cyclic redunancy check (gsutil help crcmod)
       - py3-crcmod
 
@@ -18,8 +18,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - build-base
-      - python3
-      - python3-dev
+      - python-3.11
+      - python-3.11-dev
       - bash
 
 pipeline:


### PR DESCRIPTION
`gcloud` does not run on 3.12 https://issuetracker.google.com/issues/303737178