### PR TITLE
prometheus-pushgateway-compat: new package

### DIFF
--- a/prometheus-pushgateway-compat.yaml
+++ b/prometheus-pushgateway-compat.yaml
@@ -1,0 +1,41 @@
+#nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
+package:
+  name: prometheus-pushgateway-compat
+  version: 1.6.2
+  epoch: 0
+  description: "Pushgateway Bitnami compatible"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - bash
+
+pipeline:
+  - uses: git-checkout
+    with:
+      branch: main
+      repository: https://github.com/bitnami/containers
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/opt/bitnami
+      mkdir -p "${{targets.destdir}}"/opt/bitnami/licenses
+      mkdir -p "${{targets.destdir}}"/opt/bitnami/pushgateway/bin
+
+      cd bitnami/pushgateway/1/debian-11
+
+      cp -R ./prebuildfs/opt/bitnami/* ${{targets.destdir}}/opt/bitnami/
+      chmod g+rwX "${{targets.destdir}}"/opt/bitnami
+
+  - runs: |
+      ln -sf /usr/bin/pushgateway "${{targets.destdir}}"/opt/bitnami/pushgateway/bin/pushgateway
+
+  - uses: strip
+
+update:
+  enabled: false
+  manual: true # This requires manual updates because of the upstream repo does not release tags and branches.
+  github:
+    identifier: bitnami/containers


### PR DESCRIPTION
- prometheus-pushgateway-compat: new package

Fixes:

Related: https://github.com/chainguard-dev/enterprise-packages/pull/721

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)


#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

