### PR TITLE
add pushgateway-compat to add bitnami compatibility

### DIFF
--- a/prometheus-pushgateway.yaml
+++ b/prometheus-pushgateway.yaml
@@ -35,6 +35,26 @@ pipeline:
 
   - uses: strip
 
+subpackages:
+  - name: prometheus-pushgateway-bitnami-compat
+    dependencies:
+      provides:
+        - prometheus-pushgateway-bitnami-compat=${{package.full-version}}
+      runtime:
+        - prometheus-pushgateway
+        # Required by startup scripts
+        - busybox
+        - bash
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: pushgateway
+          version-path: 1/debian-11
+      - runs: |
+          mkdir -p  ${{targets.subpkgdir}}/opt/bitnami/pushgateway/bin/
+          chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami
+          ln -sf /usr/bin/pushgateway ${{targets.subpkgdir}}/opt/bitnami/pushgateway/bin/pushgateway
+
 update:
   enabled: true
   github:


### PR DESCRIPTION
add pushgateway-compat to add bitnami compatibility

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
