### PR TITLE
patch golang.org/x/net@v0.17.0 for chartmuseum|cloud-sql-proxy|cluster-autoscaler|consul|containerd|coredns|cosign

### DIFF
--- a/chartmuseum.yaml
+++ b/chartmuseum.yaml
@@ -1,7 +1,7 @@
 package:
   name: chartmuseum
   version: 0.16.0
-  epoch: 5
+  epoch: 6
   description: helm chart repository server
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,10 @@ pipeline:
 
   - runs: |
       cd chartmuseum
+      # Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       CGO_ENABLED=0 go build --ldflags="-s -w -X main.Version=${{package.version}} \
         -X main.Revision=$(git rev-parse --short HEAD)" \
         -o "${{targets.destdir}}/usr/bin/chartmuseum" \

--- a/cloud-sql-proxy.yaml
+++ b/cloud-sql-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloud-sql-proxy
   version: 2.7.0
-  epoch: 0
+  epoch: 1
   description: The Cloud SQL Auth Proxy is a utility for ensuring secure connections to your Cloud SQL instances
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,8 @@ pipeline:
       packages: .
       output: cloud-sql-proxy
       ldflags: -w -X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container
+      # CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
 
   - uses: strip
 

--- a/cluster-autoscaler-1.28.yaml
+++ b/cluster-autoscaler-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.28
   version: 1.28.0
-  epoch: 4
+  epoch: 5
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -32,7 +32,8 @@ pipeline:
       packages: .
       output: cluster-autoscaler
       ldflags: -s -w
-      deps: github.com/docker/distribution@v2.8.2
+      # CVE-2023-39325 and CVE-2023-3978
+      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0
       vendor: true
 
   - uses: strip

--- a/consul-1.15.yaml
+++ b/consul-1.15.yaml
@@ -2,7 +2,7 @@ package:
   name: consul-1.15
   version: 1.15.6
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
-  epoch: 2
+  epoch: 3
   description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
   copyright:
     - license: MPL-2.0
@@ -28,6 +28,10 @@ pipeline:
   - working-directory: ${{package.name}}
     pipeline:
       - runs: |
+          # Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978
+          go get golang.org/x/net@v0.17.0
+          go mod tidy
+
           make linux
       - runs: |
           mkdir -p ${{targets.destdir}}/bin

--- a/consul-1.16.yaml
+++ b/consul-1.16.yaml
@@ -2,7 +2,7 @@ package:
   name: consul-1.16
   version: 1.16.2
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
-  epoch: 2
+  epoch: 3
   description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
   copyright:
     - license: MPL-2.0
@@ -28,6 +28,10 @@ pipeline:
   - working-directory: ${{package.name}}
     pipeline:
       - runs: |
+          # Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978
+          go get golang.org/x/net@v0.17.0
+          go mod tidy
+
           make linux
       - runs: |
           mkdir -p ${{targets.destdir}}/bin

--- a/containerd.yaml
+++ b/containerd.yaml
@@ -1,7 +1,7 @@
 package:
   name: containerd
   version: 1.7.7
-  epoch: 1
+  epoch: 2
   description: An open and reliable container runtime
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,10 @@ pipeline:
       expected-commit: 8c087663b0233f6e6e2f4515cee61d49f14746a8
 
   - runs: |
+      # Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make VERSION="v${{package.version}}"
 
   # Set up default config

--- a/containerd.yaml
+++ b/containerd.yaml
@@ -29,6 +29,7 @@ pipeline:
       # Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
       go mod tidy
+      go mod vendor
 
       make VERSION="v${{package.version}}"
 

--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: 1.11.1
-  epoch: 4
+  epoch: 5
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,10 @@ pipeline:
       expected-commit: ae2bbc29be1aaae0b3ded5d188968a6c97bb3144
 
   - runs: |
+      # Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       # Ensures plugins get included
       make check
 

--- a/cosign.yaml
+++ b/cosign.yaml
@@ -1,7 +1,7 @@
 package:
   name: cosign
   version: 2.2.0
-  epoch: 4
+  epoch: 5
   description: Container Signing
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,8 @@ pipeline:
       packages: ./cmd/cosign
       output: cosign
       ldflags: -s -w -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}}
+      # CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
 
   - uses: strip
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [X] Patch source is documented
