### PR TITLE
adds spark package

### DIFF
--- a/spark.yaml
+++ b/spark.yaml
@@ -1,0 +1,46 @@
+package:
+  name: spark
+  version: 3.5.0
+  epoch: 0
+  description:
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - openjdk-17-jre
+      - bash
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - maven
+      - openjdk-17
+      - openjdk-17-default-jvm
+      - bash
+      - wolfi-base
+      - wolfi-baselayout
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/spark
+      tag: v${{package.version}}
+      expected-commit: ce5ddad990373636e94071e7cef2f31021add07b
+
+  - runs: |
+      export LANG=en_US.UTF-8
+      export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+
+      ./build/mvn -DskipTests clean package
+      mkdir -p ${{targets.destdir}}/usr/share/java/spark
+
+      # TO-DO move the jars to destdir
+
+update:
+  enabled: true
+  github:
+    identifier: apache/spark
+    use-tag: true

--- a/spark.yaml
+++ b/spark.yaml
@@ -34,10 +34,9 @@ pipeline:
       export LANG=en_US.UTF-8
       export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
-      ./build/mvn -DskipTests clean package
+      ./build/mvn -DskipTests clean install
       mkdir -p ${{targets.destdir}}/usr/share/java/spark
-
-      # TO-DO move the jars to destdir
+      mv /root/.m2/repository/org/apache/spark/* ${{targets.destdir}}/usr/share/java/spark
 
 update:
   enabled: true

--- a/spark.yaml
+++ b/spark.yaml
@@ -43,3 +43,4 @@ update:
   github:
     identifier: apache/spark
     use-tag: true
+    strip-prefix: v

--- a/spark.yaml
+++ b/spark.yaml
@@ -36,7 +36,7 @@ pipeline:
 
       ./build/mvn -DskipTests clean install
       mkdir -p ${{targets.destdir}}/usr/share/java/spark
-      mv /root/.m2/repository/org/apache/spark/* ${{targets.destdir}}/usr/share/java/spark
+      find /root/.m2/repository/org/apache/spark -name "*.jar" |egrep -v "test|source|javadoc" |xargs mv -t ${{targets.destdir}}/usr/share/java/spark
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
