### PR TITLE
patch golang.org/x/net@v0.17.0 for prometheus[-*]

### DIFF
--- a/prometheus-adapter.yaml
+++ b/prometheus-adapter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-adapter
   version: 0.11.1
-  epoch: 2
+  epoch: 3
   description: Prometheus Adapter for Kubernetes Metrics APIs
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,10 @@ pipeline:
       tag: v${{package.version}}
 
   - runs: |
+      # Handle CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make prometheus-adapter
 
   - runs: |

--- a/prometheus-alertmanager.yaml
+++ b/prometheus-alertmanager.yaml
@@ -2,7 +2,7 @@ package:
   name: prometheus-alertmanager
   # When bumping this version you can remove the `go get` line in the build script
   version: 0.26.0
-  epoch: 3
+  epoch: 4
   description: Prometheus Alertmanager
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,10 @@ pipeline:
       expected-commit: d7b4f0c7322e7151d6e3b1e31cbc15361e295d8d
 
   - runs: |
+      # Handle CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make build
 
   - runs: |

--- a/prometheus-elasticsearch-exporter.yaml
+++ b/prometheus-elasticsearch-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-elasticsearch-exporter
   version: 1.6.0
-  epoch: 5
+  epoch: 6
   description: Elasticsearch stats exporter for Prometheus
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,9 @@ pipeline:
       expected-commit: a5f42797a10de8229eb5544c25c092f2fece5b63
 
   - runs: |
+      # Handle CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+
       go get golang.org/x/sys@v0.8.0
       go mod tidy
       make common-build

--- a/prometheus-mongodb-exporter.yaml
+++ b/prometheus-mongodb-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-mongodb-exporter
   version: 0.39.0
-  epoch: 3
+  epoch: 4
   description: A Prometheus exporter for MongoDB including sharding, replication and storage engines
   copyright:
     - license: MIT
@@ -21,6 +21,9 @@ pipeline:
       tag: v${{package.version}}
 
   - runs: |
+      # Handle CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+
       # Patch GHSA-7rg2-cxvp-9p7p
       go get github.com/prometheus/exporter-toolkit@v0.7.3
       go mod tidy

--- a/prometheus-mysqld-exporter.yaml
+++ b/prometheus-mysqld-exporter.yaml
@@ -2,7 +2,7 @@ package:
   name: prometheus-mysqld-exporter
   # When bumping this version you can remove the `go get` line in the build script
   version: 0.15.0
-  epoch: 5
+  epoch: 6
   description: Prometheus Exporter for MySQL server metrics
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,10 @@ pipeline:
       expected-commit: 6ca2a42f97f3403c7788ff4f374430aa267a6b6b
 
   - runs: |
+      # Handle CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make build
 
   - runs: |

--- a/prometheus-node-exporter.yaml
+++ b/prometheus-node-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-node-exporter
   version: 1.6.1
-  epoch: 5
+  epoch: 6
   description: Prometheus Exporter for machine metrics
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,10 @@ pipeline:
       expected-commit: 4a1b77600c1873a8233f3ffb55afcedbb63b8d84
 
   - runs: |
+      # Handle CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make build
 
   - runs: |

--- a/prometheus-operator.yaml
+++ b/prometheus-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-operator
   version: 0.68.0
-  epoch: 3
+  epoch: 4
   description: Prometheus Operator creates/configures/manages Prometheus clusters atop Kubernetes
   copyright:
     - license: Apache-2.0
@@ -24,9 +24,12 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 52526e3b0cfb5f3deaa967998ff88a5133f1ec0f
 
-  - uses: autoconf/make
-    with:
-      opts: operator
+  - runs: |
+      # Handle CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
+      make operator
 
   - runs: |
       mkdir -p "${{targets.contextdir}}/usr/bin"

--- a/prometheus-operator.yaml
+++ b/prometheus-operator.yaml
@@ -29,7 +29,9 @@ pipeline:
       go get golang.org/x/net@v0.17.0
       go mod tidy
 
-      make operator
+  - uses: autoconf/make
+    with:
+      opts: operator
 
   - runs: |
       mkdir -p "${{targets.contextdir}}/usr/bin"

--- a/prometheus-postgres-exporter.yaml
+++ b/prometheus-postgres-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-postgres-exporter
   version: 0.14.0
-  epoch: 2
+  epoch: 3
   description: Prometheus Exporter for Postgres server metrics
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,10 @@ pipeline:
       expected-commit: c06e57db4e502696ab4e8b8898bb2a59b7b33a59
 
   - runs: |
+      # Handle CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
       go mod tidy
+
       make build
 
   - runs: |

--- a/prometheus-pushgateway.yaml
+++ b/prometheus-pushgateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-pushgateway
   version: 1.6.2
-  epoch: 2
+  epoch: 3
   description: Push acceptor for ephemeral and batch jobs.
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,10 @@ pipeline:
       expected-commit: dd0ca68e2cf68ba061ed9e73b19e1928a4f6338f
 
   - runs: |
+      # Handle CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make build
 
   - runs: |

--- a/prometheus-statsd-exporter.yaml
+++ b/prometheus-statsd-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-statsd-exporter
   version: 0.24.0
-  epoch: 2
+  epoch: 3
   description: StatsD exporter for Prometheus
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,10 @@ pipeline:
       tag: v${{package.version}}
 
   - runs: |
+      # Handle CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make common-build
 
   - runs: |

--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus
   version: 2.47.1
-  epoch: 2
+  epoch: 3
   description: The Prometheus monitoring system and time series database.
   copyright:
     - license: Apache-2.0
@@ -33,6 +33,10 @@ pipeline:
         # LDFLAGS (and only LDFLAGS) should be passed to -extldflags.
         GOLDFLAGS="$GOLDFLAGS -extldflags '$LDFLAGS'"
       fi
+
+      # Handle CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
 
       # set -j1 to run things in the correct order in makefile
       # actual go building is still parallel


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
