### PR TITLE
CVE-2023-39325 and CVE-2023-3978 fix for k3s, k8sgpt, k8sgpt-operator.

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.28.2
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -64,6 +64,11 @@ pipeline:
       # Patch things that need patching
       go mod edit -dropreplace=github.com/docker/distribution # CVE-2023-2253 GHSA-hqxw-f8mx-cpmw
       go get github.com/docker/distribution@v2.8.2
+
+      # CVE-2023-39325 and CVE-2023-3978
+      # note dropreplace is safe to whether it's there or not.
+      go mod edit -dropreplace=golang.org/x/net
+      go get golang.org/x/net@v0.17.0
       go mod tidy
 
       ./scripts/build

--- a/k8sgpt-operator.yaml
+++ b/k8sgpt-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8sgpt-operator
   version: 0.0.21
-  epoch: 5
+  epoch: 6
   description: Automatic SRE Superpowers within your Kubernetes cluster
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,8 @@ pipeline:
       packages: .
       output: manager
       ldflags: -w
+      # CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
 
   - uses: strip
 

--- a/k8sgpt.yaml
+++ b/k8sgpt.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8sgpt
   version: 0.3.18
-  epoch: 0
+  epoch: 1
   description: Giving Kubernetes Superpowers to everyone
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,11 @@ pipeline:
 
   - runs: |
       cd k8sgpt
+      # CVE-2023-39325 and CVE-2023-3978
+      # note dropreplace is safe to whether it's there or not.
+      go mod edit -dropreplace=golang.org/x/net
+      go get golang.org/x/net@v0.17.0
+
       make build
       install -Dm755 ./bin/k8sgpt "${{targets.destdir}}/usr/bin/k8sgpt"
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
