### PR TITLE
Bump x/net for kube-* pkgs

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.17.6
-  epoch: 7
+  epoch: 8
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -86,6 +86,10 @@ pipeline:
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
       cd config-reloader
+
+      # CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+
       make build VERSION=${{package.version}}
       mv config-reloader ${{targets.destdir}}/usr/bin/
       mv ./templates ${{targets.destdir}}/etc/fluent/

--- a/kube-logging-operator.yaml
+++ b/kube-logging-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-logging-operator
   version: 4.2.2
-  epoch: 4
+  epoch: 5
   description: Logging operator for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,9 @@ pipeline:
       expected-commit: 469986c420204c2963a87df9a286c751ec6d77ec
 
   - runs: |
+      # CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+
       CGO_ENABLED=0 GO111MODULE=on go build -o bin/manager main.go
       mkdir -p ${{targets.destdir}}/usr/bin
       install -Dm755 ./bin/manager ${{targets.destdir}}/usr/bin/manager

--- a/kube-state-metrics.yaml
+++ b/kube-state-metrics.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-state-metrics
   version: 2.10.0
-  epoch: 3
+  epoch: 4
   description: Add-on agent to generate and expose cluster-level metrics.
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,9 @@ pipeline:
       expected-commit: 25fb4fa0767de7ee314500fcb7481ca7b3a55a35
 
   - runs: |
+      # CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+
       mkdir -p ${{targets.destdir}}/usr/bin
       make build-local
       cp kube-state-metrics ${{targets.destdir}}/usr/bin


### PR DESCRIPTION
kube-fluentd-operator needs some change to build script to upgrade to 1.8.0, which I will follow up, so ignore Wolfictl Check Updates for now.

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/330