### PR TITLE
CVE-2023-39325 and CVE-2023-3978 fixes for karpenter.

### DIFF
--- a/karpenter.yaml
+++ b/karpenter.yaml
@@ -1,7 +1,7 @@
 package:
   name: karpenter
   version: 0.31.1
-  epoch: 0
+  epoch: 1
   description: Karpenter is a Kubernetes Node Autoscaler built for flexibility, performance, and simplicity.
   copyright:
     - license: Apache-2.0
@@ -9,9 +9,18 @@ package:
         - "*"
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/aws/karpenter/cmd/controller@v${{package.version}}
+      repository: https://github.com/aws/karpenter
+      tag: v${{package.version}}
+      expected-commit: 61b3e1eca95b2ad702dee221f35041a494f1141f
+
+  - uses: go/build
+    with:
+      # CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
+      packages: ./cmd/controller
+      output: controller
 
   - uses: strip
 


### PR DESCRIPTION
Also split the go/install into github fetch / go build for better serviceability.

```
Will process: karpenter-0.31.1-r1.apk
✅ No vulnerabilities found
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
