### PR TITLE
meson: rebuild against python 3.12

### DIFF
--- a/meson.yaml
+++ b/meson.yaml
@@ -1,13 +1,13 @@
 package:
   name: meson
   version: 1.2.2
-  epoch: 0
+  epoch: 1
   description: Fast and user friendly build system
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - python-3.11 # TODO: undo this
+      - python3
       - samurai
 
 environment:
@@ -15,8 +15,8 @@ environment:
     packages:
       - busybox
       - ca-certificates-bundle
-      - py3.11-setuptools # TODO: undo this
-      - python-3.11 # TODO: undo this
+      - py3-setuptools
+      - python3
       - samurai
 
 pipeline:


### PR DESCRIPTION
With `wolfictl dag` appeased, we can now rebuild meson.