### PR TITLE
patch golang.org/x/net@v0.17.0 for crossplane-provider-[aws|azure]|dex|dive

### DIFF
--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-aws
   version: 0.42.0
-  epoch: 0
+  epoch: 1
   description: Official AWS Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -40,6 +40,10 @@ pipeline:
       mkdir -p ./.cache/tools/linux_${hostarch}
 
       cp $(which up) ./.cache/tools/linux_${hostarch}/up-${UP_VERSION}
+
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
 
       make UP_VERSION=${UP_VERSION}
 

--- a/crossplane-provider-azure.yaml
+++ b/crossplane-provider-azure.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-azure
   version: 0.37.1
-  epoch: 3
+  epoch: 4
   description: Official Azure Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -40,6 +40,10 @@ pipeline:
       mkdir -p ./.cache/tools/linux_${hostarch}
 
       cp $(which up) ./.cache/tools/linux_${hostarch}/up-${UP_VERSION}
+
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
 
       make UP_VERSION=${UP_VERSION}
 

--- a/dex.yaml
+++ b/dex.yaml
@@ -2,7 +2,7 @@ package:
   name: dex
   # When bumping the version check if the GHSA mitigations below can be removed.
   version: 2.37.0
-  epoch: 6
+  epoch: 7
   description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors
   copyright:
     - license: Apache-2.0
@@ -35,6 +35,11 @@ pipeline:
       # These build commands are adapted from the upstream `make release-binary` target.
       export GOBIN="$GOPATH/bin"
       LD_FLAGS="-w -X main.version=v${{package.version}} -extldflags \"-static\""
+
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       go build -o "$GOBIN/dex" -v -ldflags "$LD_FLAGS" ./cmd/dex
       go build -o "$GOBIN/docker-entrypoint" -v -ldflags "$LD_FLAGS" ./cmd/docker-entrypoint
 

--- a/dive.yaml
+++ b/dive.yaml
@@ -1,7 +1,7 @@
 package:
   name: dive
   version: 0.11.0
-  epoch: 6
+  epoch: 7
   description: A tool for exploring each layer in a docker image
   copyright:
     - license: MIT
@@ -38,12 +38,6 @@ pipeline:
       # GHSA-p782-xgp4-8hr8
       go get -u golang.org/x/sys@v0.0.0-20220412211240-33da011f77ad
 
-      # GHSA-h86h-8ppg-mxmh
-      # GHSA-83g2-8m93-v3w7
-      # GHSA-69cg-p879-7622
-      # GHSA-vvpx-j8f3-3w6h
-      go get -u golang.org/x/net@v0.10.0
-
       # GHSA-77vh-xpmg-72qh
       go get -u github.com/opencontainers/image-spec@v1.0.2
 
@@ -52,6 +46,13 @@ pipeline:
 
       # GHSA-c3h9-896r-86jm
       go get -u github.com/gogo/protobuf@v1.3.2
+
+      # GHSA-h86h-8ppg-mxmh
+      # GHSA-83g2-8m93-v3w7
+      # GHSA-69cg-p879-7622
+      # GHSA-vvpx-j8f3-3w6h
+      # CVE-2023-39325 and CVE-2023-3978
+      go get -u golang.org/x/net@v0.17.0
 
       go mod tidy
       go mod vendor


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [X] Patch source is documented
