### PR TITLE
patch golang.org/x/net@v0.17.0 for etcd|external-dns|external-secrets-operator|falcoctl

### DIFF
--- a/etcd.yaml
+++ b/etcd.yaml
@@ -2,7 +2,7 @@ package:
   name: etcd
   version: 3.5.9
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
-  epoch: 6
+  epoch: 7
   description: A highly-available key value store for shared configuration and service discovery.
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,10 @@ pipeline:
       expected-sha256: ab24d74b66ba1ed7d2bc391839d961e7215f0f3d674c3a9592dad6dc67a7b223
 
   - runs: |
-      go get golang.org/x/net@v0.7.0
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       bash -x ./build.sh
       mkdir -p "${{targets.destdir}}"/var/lib/${{package.name}}
       chmod 700 "${{targets.destdir}}"/var/lib/${{package.name}}

--- a/external-dns.yaml
+++ b/external-dns.yaml
@@ -1,7 +1,7 @@
 package:
   name: external-dns
   version: 0.13.6
-  epoch: 4
+  epoch: 5
   description: Configure external DNS servers (AWS Route53, Google CloudDNS and others) for Kubernetes Ingresses and Services.
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,10 @@ pipeline:
       expected-commit: 0483ffde22e60436f16be154b9fe1a388a1400d0
 
   - runs: |
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       # Our global LDFLAGS conflict with a Makefile parameter
       unset LDFLAGS
       make build

--- a/external-secrets-operator.yaml
+++ b/external-secrets-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: external-secrets-operator
   version: 0.9.5
-  epoch: 2
+  epoch: 3
   description: Integrate external secret management systems with Kubernetes
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,10 @@ pipeline:
       expected-commit: b9f8ddad2098ef8dcecb48718fd6bcb3577a0b56
 
   - runs: |
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make build-$(go env GOARCH)
       mkdir -p ${{targets.destdir}}/usr/bin
       install -m755 -D bin/external-secrets-$(go env GOOS)-$(go env GOARCH) "${{targets.destdir}}"/usr/bin/external-secrets

--- a/falcoctl.yaml
+++ b/falcoctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: falcoctl
   version: 0.6.2
-  epoch: 2
+  epoch: 3
   description: Administrative tooling for Falco
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,10 @@ pipeline:
       expected-commit: 9fa598a6bb6b5ba824f70e4d478e1be9533bacd4
 
   - runs: |
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make falcoctl RELEASE=${{package.version}}
       mkdir -p ${{targets.destdir}}/usr/bin
       mv falcoctl ${{targets.destdir}}/usr/bin/


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [X] Patch source is documented
