### PR TITLE
patch golang.org/x/net@v0.17.0 for pulumi*

### DIFF
--- a/pulumi-kubernetes-operator.yaml
+++ b/pulumi-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-kubernetes-operator
   version: 1.13.0
-  epoch: 3
+  epoch: 4
   description: A Kubernetes Operator that automates the deployment of Pulumi Stacks
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,10 @@ pipeline:
   - working-directory: ${{package.name}}
     pipeline:
       - runs: |
+          # Mitigate CVE-2023-39325 and CVE-2023-3978
+          go get golang.org/x/net@v0.17.0
+          go mod tidy
+
           # Original Go build args found in ./scripts/build.sh
           CGO_ENABLED=0 go build -o "${{targets.destdir}}/usr/bin/${{package.name}}" \
             -ldflags "-s -w -X github.com/pulumi/pulumi-kubernetes-operator/version.Version=v${{package.version}} -extldflags \"-static\"" \

--- a/pulumi-language-dotnet.yaml
+++ b/pulumi-language-dotnet.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-dotnet
   version: 3.57.0
-  epoch: 2
+  epoch: 3
   description: Pulumi Language SDK for Dotnet
   copyright:
     - license: Apache-2.0
@@ -21,19 +21,15 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 16e97ffc0326b91c44ca90869b13f096ea5ec2db
 
-  - working-directory: pulumi-language-dotnet
-    runs: |
-      # Fix CVE-2023-32731 / GHSA-cfgp-2977-2fmm
-      go get google.golang.org/grpc@v1.53.0
-
-      go mod tidy
-
   - uses: go/build
     with:
       packages: .
       output: pulumi-language-dotnet
       ldflags: -s -w -X github.com/pulumi/pulumi-language-dotnet/pkg/version.Version=v${{package.version}}
       modroot: pulumi-language-dotnet
+      # Fix CVE-2023-32731 / GHSA-cfgp-2977-2fmm
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      deps: google.golang.org/grpc@v1.53.0 golang.org/x/net@v0.17.0
 
   - uses: strip
 

--- a/pulumi-language-java.yaml
+++ b/pulumi-language-java.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-java
   version: 0.9.8
-  epoch: 1
+  epoch: 2
   description: Pulumi Language SDK for Java
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,8 @@ pipeline:
       packages: ./cmd/pulumi-language-java
       output: pulumi-language-java
       ldflags: -s -w -X github.com/pulumi/pulumi-java/pkg/version.Version=v${{package.version}}
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
 
   - uses: strip
 

--- a/pulumi-language-yaml.yaml
+++ b/pulumi-language-yaml.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-yaml
   version: 1.3.0
-  epoch: 4
+  epoch: 5
   description: Pulumi Language SDK for YAML
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,10 @@ pipeline:
     pipeline:
       - runs: |
           set -x
+          # Mitigate CVE-2023-39325 and CVE-2023-3978
+          go get golang.org/x/net@v0.17.0
+          go mod tidy
+
           export CGO_ENABLED=0 GO111MODULE=on
           go build \
             -o "${{targets.destdir}}/usr/bin/pulumi-language-yaml" \


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
