### PR TITLE
CVE-2023-39325 and CVE-2023-3978 kubeflow-katib

### DIFF
--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -1,6 +1,6 @@
 package:
   name: kubeflow-katib
-  epoch: 6
+  epoch: 7
   version: 0.15.0
   description: Kubeflow Katib services
   copyright:
@@ -49,7 +49,7 @@ subpackages:
           output: katib-${{range.key}}
           ldflags: -w -X main.version=${{package.version}}
           subpackage: true
-          deps: golang.org/x/net@v0.7.0 github.com/docker/distribution@v2.8.2 github.com/docker/docker@v20.10.24
+          deps: golang.org/x/net@v0.17.0 github.com/docker/distribution@v2.8.2 github.com/docker/docker@v20.10.24
       - uses: strip
 
   - range: go-builds


### PR DESCRIPTION
```
vaikas@vaikas-MBP os % wolfictl scan packages/aarch64/katib-controller-0.15.0-r6.apk
Will process: katib-controller-0.15.0-r6.apk
└── 📄 /usr/bin/katib-controller
        📦 golang.org/x/net v0.7.0 (go-module)
            Medium CVE-2023-3978 GHSA-2wrh-6pvc-2jm9 fixed in 0.13.0
            Medium CVE-2023-39325 GHSA-4374-p667-p6c8 fixed in 0.17.0

vaikas@vaikas-MBP os % wolfictl scan packages/aarch64/katib-controller-0.15.0-r7.apk
Will process: katib-controller-0.15.0-r7.apk
✅ No vulnerabilities found
```


Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
