### PR TITLE
patch golang.org/x/net@v0.17.0 for thanos|thanos-operator|tigera-operator|tkn|trillian|trust-manager

### DIFF
--- a/thanos-0.31.yaml
+++ b/thanos-0.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-0.31
   version: 0.31.0
-  epoch: 4
+  epoch: 5
   description: Highly available Prometheus setup with long term storage capabilities.
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,8 @@ pipeline:
       # Fails to build on go1.21 without this. Remove in next release.
       # See https://github.com/thanos-io/thanos/pull/6609
       go get -u go4.org/intern@6c62f75575cbbc91d0d439652bef2613e7889238
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
 
       go mod tidy
       make build

--- a/thanos-0.32.yaml
+++ b/thanos-0.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-0.32
   version: 0.32.4
-  epoch: 2
+  epoch: 3
   description: Highly available Prometheus setup with long term storage capabilities.
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,10 @@ pipeline:
       expected-commit: fcd5683e3049924ae26a680e166ae6f27a344896
 
   - runs: |
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make build
 
   - runs: |

--- a/thanos-operator.yaml
+++ b/thanos-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-operator
   version: 0.3.7
-  epoch: 7
+  epoch: 8
   description: Kubernetes operator for deploying Thanos
   copyright:
     - license: Apache-2.0
@@ -24,10 +24,11 @@ pipeline:
       # Address  CVE-2022-21698  GHSA-69ch-w2m2-3vjp  GHSA-69cg-p879-7622
       go get github.com/prometheus/client_golang@v1.11.1
       go get golang.org/x/text@v0.3.8
-      go get golang.org/x/net@v0.7.0
 
       # Mitigate CVE-2022-28948
       go get gopkg.in/yaml.v3@v3.0.0-20220521103104-8f96da9f5d5e
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
 
       go mod tidy
 

--- a/tigera-operator.yaml
+++ b/tigera-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: tigera-operator
   version: 1.31.2
-  epoch: 0
+  epoch: 1
   description: Kubernetes operator for installing Calico and Calico Enterprise
   copyright:
     - license: Apache-2.0
@@ -34,6 +34,10 @@ pipeline:
       else
         CGO_ENABLED=0
       fi
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       echo "Building operator for ${ARCH} with CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=${GOEXPERIMENT} TAGS=${TAGS}"
       GOEXPERIMENT=${GOEXPERIMENT} GO111MODULE=on CGO_ENABLED=${CGO_ENABLED} go build -buildvcs=false -v -o ${BINDIR}/operator-${ARCH} -tags "${TAGS}" -ldflags "-X ${PACKAGE_NAME}/version.VERSION=${GIT_VERSION} -w" ./main.go
       install -Dm755 build/_output/bin/operator-$(go env GOARCH) "${{targets.destdir}}"/usr/bin/operator

--- a/timoni.yaml
+++ b/timoni.yaml
@@ -1,7 +1,7 @@
 package:
   name: timoni
   version: 0.14.2
-  epoch: 1
+  epoch: 2
   description: Timoni is a package manager for Kubernetes, powered by CUE and inspired by Helm.
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,8 @@ pipeline:
       packages: ./cmd/timoni
       output: timoni
       ldflags: -s -w -X main.VERSION=${{package.version}}
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
 
   - uses: strip
 

--- a/tkn.yaml
+++ b/tkn.yaml
@@ -24,6 +24,7 @@ pipeline:
       # Mitigate CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
       go mod tidy
+      go mod vendor
 
       make bin/tkn
       install -Dm755 ./bin/tkn ${{targets.destdir}}/usr/bin/tkn

--- a/tkn.yaml
+++ b/tkn.yaml
@@ -1,7 +1,7 @@
 package:
   name: tkn
   version: 0.32.0
-  epoch: 3
+  epoch: 4
   description: A CLI for interacting with Tekton!
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,10 @@ pipeline:
       expected-sha256: 18e49e09b1fbc9fbfd91dbf2a26d22a4e55ea9afcc526924b79a9d6464c13443
 
   - runs: |
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make bin/tkn
       install -Dm755 ./bin/tkn ${{targets.destdir}}/usr/bin/tkn
 

--- a/trillian.yaml
+++ b/trillian.yaml
@@ -1,7 +1,7 @@
 package:
   name: trillian
   version: 1.5.2
-  epoch: 3
+  epoch: 4
   description: Merkle tree implementation used in Sigstore
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,10 @@ pipeline:
       rm .gitconfig
       export GOCACHE=$(mktemp -d)/.cache
       export GOMODCACHE=$(mktemp -d)/mod
+
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
 
       go build -o trillian_log_server -trimpath -ldflags "-s -w" ./cmd/trillian_log_server
       go build -o trillian_log_signer -trimpath -ldflags "-s -w" ./cmd/trillian_log_signer

--- a/trust-manager.yaml
+++ b/trust-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: trust-manager
   version: 0.6.0
-  epoch: 4
+  epoch: 5
   description: trust-manager is an operator for distributing trust bundles across a Kubernetes cluster.
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,11 @@ pipeline:
 
   - runs: |
       cd trust-manager
+
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make build
       mkdir -p ${{targets.destdir}}/usr/bin
       install -Dm755 ./bin/trust-manager ${{targets.destdir}}/usr/bin/trust-manager


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
