### PR TITLE
patch golang.org/x/net@v0.17.0 for vault-1.13|vault-1.14|vault-k8s|vertical-pod-autoscaler|weaviate|yq|zot

### DIFF
--- a/vault-1.13.yaml
+++ b/vault-1.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-1.13
   version: 1.13.8
-  epoch: 2
+  epoch: 3
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0
@@ -17,6 +17,7 @@ environment:
       - go
       - libcap-utils
       - nodejs-16
+      - py3-setuptools
       - python3
       - yarn
 
@@ -34,6 +35,8 @@ pipeline:
       go get github.com/cloudflare/circl@v1.3.3
       # Mitigate CVE-2023-34231
       go get github.com/snowflakedb/gosnowflake@v1.6.19
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
       go mod tidy
 
       go generate $(go list ./... | grep -v /vendor/)

--- a/vault-1.14.yaml
+++ b/vault-1.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-1.14
   version: 1.14.4
-  epoch: 2
+  epoch: 3
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0
@@ -34,6 +34,8 @@ pipeline:
       go get github.com/cloudflare/circl@v1.3.3
       # Mitigate CVE-2023-34231
       go get github.com/snowflakedb/gosnowflake@v1.6.19
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
       go mod tidy
 
       go generate $(go list ./... | grep -v /vendor/)

--- a/vault-k8s.yaml
+++ b/vault-k8s.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-k8s
   version: 1.2.1
-  epoch: 7
+  epoch: 8
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0
@@ -27,7 +27,8 @@ pipeline:
       unset LDFLAGS
 
       # Mitigate GHSA-vvpx-j8f3-3w6h
-      go get golang.org/x/net@v0.7.0
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
       go mod tidy
       make build GOARCH=$(go env GOARCH) VERSION=${{package.version}}
 

--- a/vertical-pod-autoscaler.yaml
+++ b/vertical-pod-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: vertical-pod-autoscaler
   version: 0.14.0
-  epoch: 4
+  epoch: 5
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,8 @@ pipeline:
       packages: ./pkg/admission-controller
       ldflags: -w
       output: admission-controller
-      deps: golang.org/x/net@v0.7.0
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
       vendor: "true"
 
   - uses: go/build
@@ -36,7 +37,8 @@ pipeline:
       packages: ./pkg/updater
       ldflags: -w
       output: updater
-      deps: golang.org/x/net@v0.7.0
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
       vendor: "true"
 
   - uses: go/build
@@ -45,7 +47,8 @@ pipeline:
       packages: ./pkg/recommender
       ldflags: -w
       output: recommender
-      deps: golang.org/x/net@v0.7.0
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
       vendor: "true"
 
   - uses: strip

--- a/weaviate.yaml
+++ b/weaviate.yaml
@@ -1,7 +1,7 @@
 package:
   name: weaviate
   version: 1.21.6
-  epoch: 0
+  epoch: 1
   description: Weaviate is an open source vector database that stores both objects and vectors, allowing for combining vector search with structured filtering with the fault-tolerance and scalability of a cloud-native database, all accessible through GraphQL, REST, and various language clients.
   copyright:
     - license: BSD-3-Clause
@@ -18,11 +18,14 @@ pipeline:
     with:
       repository: https://github.com/weaviate/weaviate
       tag: v${{package.version}}
-      expected-commit: f26b9119dd08a6559d345c4097f6184468e2f00b
+      expected-commit: 34e402da48a652e6ecc908765905dcaea121bcd0
 
   - runs: |
       mkdir -p ${{targets.destdir}}/bin
       GITHASH=$(git rev-parse --short HEAD)
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
       go build \
         -ldflags '-w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'' \
         -o ${{targets.destdir}}/bin/weaviate ./cmd/weaviate-server

--- a/yq.yaml
+++ b/yq.yaml
@@ -1,16 +1,24 @@
 package:
   name: yq
   version: 4.35.2
-  epoch: 2
+  epoch: 3
   description: "yq is a portable command-line YAML, JSON, XML, CSV and properties processor"
   copyright:
     - license: Apache License 2.0
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/mikefarah/yq/v4
-      version: v${{package.version}}
+      repository: https://github.com/mikefarah/yq
+      tag: v${{package.version}}
+      expected-commit: a198f72367ce9da70b564a2cc25399de8e27bf37
+
+  - uses: go/build
+    with:
+      packages: .
+      output: yq
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
 
   - runs: |
       ${{targets.destdir}}/usr/bin/yq --version | grep "version v${{package.version}}"

--- a/zot.yaml
+++ b/zot.yaml
@@ -1,7 +1,7 @@
 package:
   name: zot
   version: 1.4.3 # Check if the Go module patching can be removed in the next release.
-  epoch: 12
+  epoch: 13
   description: A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification)
   copyright:
     - license: Apache-2.0
@@ -41,6 +41,8 @@ pipeline:
       go get github.com/opencontainers/runc@v1.1.5
       go get github.com/sigstore/rekor@v1.2.2
       go get golang.org/x/net@v0.11.0
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
 
       go mod tidy
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
