### PR TITLE
Add py3-setuptools as dep so works with python 3.12.

### DIFF
--- a/gdk-pixbuf.yaml
+++ b/gdk-pixbuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdk-pixbuf
   version: 2.42.10
-  epoch: 4
+  epoch: 5
   description: GTK+ image loading library
   copyright:
     - license: LGPL-2.1-or-later
@@ -12,19 +12,20 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
       - glib-dev
       - gobject-introspection-dev
       - libjpeg-turbo-dev
       - libpng-dev
       - meson
       - py3-docutils
-      - tiff-dev
+      - py3-setuptools
       - shared-mime-info
+      - tiff-dev
 
 pipeline:
   - uses: fetch


### PR DESCRIPTION
Fix the build to work with python 3.12. Without this the build would fail with:

```
ℹ️  aarch64   | Traceback (most recent call last):
ℹ️  aarch64   |   File "/usr/bin/g-ir-scanner", line 99, in <module>
ℹ️  aarch64   |     from giscanner.utils import dll_dirs
ℹ️  aarch64   |   File "/usr/lib/gobject-introspection/giscanner/utils.py", line 385, in <module>
ℹ️  aarch64   |     import distutils.cygwinccompiler
ℹ️  aarch64   | ModuleNotFoundError: No module named 'distutils'
```

And now it works.

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
