### PR TITLE
Add py3-setuptools to gobject-introspection.

### DIFF
--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -1,10 +1,15 @@
 package:
   name: gobject-introspection
   version: 1.78.1
-  epoch: 0
+  epoch: 1
   description: Introspection system for GObject-based libraries
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT
+  # python 3.12 dropped support for distutils, and some things will fail to
+  # build it. This is a drop in replacement to make things work.
+  dependencies:
+    runtime:
+      - py3-setuptools
 
 # creates a new var that contains only the major and minor version to be used in the fetch URL
 # e.g. 1.74.0 will create a new var mangled-package-version=1.74
@@ -17,25 +22,26 @@ var-transforms:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - bash
+      - bison
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
-      - posix-libc-utils
-      - python3
       - cairo-dev
       - cairo-gobject
       - expat-dev
-      - libtool
+      - flex
+      - git
       - glib-dev
       - libffi-dev
-      - flex
-      - bison
-      - python3-dev
+      - libtool
       - meson
-      - bash
-      - git
+      - posix-libc-utils
+      - py3-setuptools
+      - python3
+      - python3-dev
 
 pipeline:
   - uses: fetch
@@ -64,11 +70,12 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
-        - gobject-introspection
-        - python3
         - cairo-dev
+        - gobject-introspection
         - libtool
         - posix-libc-utils
+        - py3-setuptools
+        - python3
     description: gobject-introspection dev
 
 update:


### PR DESCRIPTION
The changes are twofold:
 * Add build/runtime dep to py3-setuptools
 * sort the import lines (which makes it seem larger change).

With this change, if I build a local version of gobject-introspection, and then build gdb-pixbuf it works when it didn't work before. Not sure if there are better ways to test?


<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
