### PR TITLE
Bump envoy ratelimit and patch  CVE-2023-39325 and CVE-2023-3978

### DIFF
--- a/envoy-ratelimit.yaml
+++ b/envoy-ratelimit.yaml
@@ -1,20 +1,34 @@
 package:
   name: envoy-ratelimit
   # This project doesn't do releases and everything is commit based.
-  # This corresponds to commit e2a87f41d3a78d54eda197b3d49fcdcbca9a4f48
-  version: "0.0_git20230508"
-  epoch: 5
+  # This corresponds to commit b9796237b9cb028d90424fd0859e10133c510a29
+  version: "0.0_git20231014"
+  epoch: 0
   description: Go/gRPC service designed to enable generic rate limit scenarios from different types of applications.
   copyright:
     - license: Apache-2.0
 
+vars:
+  commit: b9796237b9cb028d90424fd0859e10133c510a29
+
 pipeline:
-  - uses: go/install
+  - uses: fetch
     with:
-      package: github.com/envoyproxy/ratelimit/src/service_cmd@e2a87f41d3a78d54eda197b3d49fcdcbca9a4f48
+      uri: https://github.com/envoyproxy/ratelimit/archive/${{vars.commit}}.zip
+      expected-sha256: eabb54820149c682351b0425d0a6ae1c62b044689de1ee0146f4230de2083c64
+      extract: false
 
   - runs: |
-      mv ${{targets.destdir}}/usr/bin/service_cmd ${{targets.destdir}}/usr/bin/ratelimit
+      unzip -q ${{vars.commit}}.zip
+      mv ratelimit-${{vars.commit}} ratelimit
+      rm *.zip
+
+  - uses: go/build
+    with:
+      packages: ./src/service_cmd
+      modroot: ratelimit
+      deps: golang.org/x/net@v0.17.0
+      output: service_cmd
 
 subpackages:
   - name: "envoy-ratelimit-compat"


### PR DESCRIPTION


Fixes:

Related:

### Pre-review Checklist
