### PR TITLE
cve fixes for metrics-server, metacontroller,memcached-exporter

### DIFF
--- a/memcached-exporter.yaml
+++ b/memcached-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached-exporter
   version: 0.13.0
-  epoch: 6
+  epoch: 7
   description: Exports metrics from memcached servers for consumption by Prometheus.
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,8 @@ pipeline:
       packages: ./cmd/memcached_exporter
       output: memcached_exporter
       ldflags: -s -w
+      # CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
 
   - uses: strip
 

--- a/metacontroller.yaml
+++ b/metacontroller.yaml
@@ -1,7 +1,7 @@
 package:
   name: metacontroller
   version: 4.11.0
-  epoch: 5
+  epoch: 6
   description: Writing kubernetes controllers can be simple
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,10 @@ pipeline:
 
   - runs: |
       export PATH=$(go env GOPATH)/bin:$PATH
+      # fix CVE-2023-39325 and CVE-2023-3978.
+      go mod edit -dropreplace=golang.org/x/net
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
       make build
       mkdir -p ${{targets.destdir}}/usr/bin
       mv /home/build/metacontroller ${{targets.destdir}}/usr/bin/metacontroller

--- a/metrics-server.yaml
+++ b/metrics-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: metrics-server
   version: 0.6.4
-  epoch: 3
+  epoch: 4
   description: Scalable and efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,9 @@ pipeline:
   - runs: |
       # The Makefile sets GOARCH from the ARCH env var which defaults to amd64
       set -x
+      # fix CVE-2023-39325 and CVE-2023-3978.
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
       make metrics-server ARCH="$(go env GOARCH)"
       mkdir -p ${{targets.destdir}}/usr/bin
       mv metrics-server ${{targets.destdir}}/usr/bin/


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
