### PR TITLE
Remove some obsolete go module pinning

### DIFF
--- a/dive.yaml
+++ b/dive.yaml
@@ -1,7 +1,7 @@
 package:
   name: dive
   version: 0.11.0
-  epoch: 7
+  epoch: 8
   description: A tool for exploring each layer in a docker image
   copyright:
     - license: MIT
@@ -25,18 +25,6 @@ pipeline:
 
   - runs: |
       cd dive
-
-      # GHSA-r88r-gmrh-7j83
-      # GHSA-6q6q-88xp-6f2r
-      # GHSA-wxc4-f4m6-wwqv
-      go get -u gopkg.in/yaml.v2@v2.2.8
-
-      # GHSA-ppp9-7jff-5vj2
-      # GHSA-69ch-w2m2-3vjp
-      go get -u golang.org/x/text@v0.3.8
-
-      # GHSA-p782-xgp4-8hr8
-      go get -u golang.org/x/sys@v0.0.0-20220412211240-33da011f77ad
 
       # GHSA-77vh-xpmg-72qh
       go get -u github.com/opencontainers/image-spec@v1.0.2


### PR DESCRIPTION
This removes some obsolete patches, as @luhring [patched](https://github.com/wagoodman/dive/commit/6884c46d0fb89fc4cf07423c0743848ac13aa66f) upstream 