### PR TITLE
secrets-store-csi-driver-provider-gcp: remove obsolete go mod

### DIFF
--- a/secrets-store-csi-driver-provider-gcp.yaml
+++ b/secrets-store-csi-driver-provider-gcp.yaml
@@ -25,13 +25,6 @@ pipeline:
       expected-commit: 7eb0775d3e47d4c81e9c2a4b324cab9e80826fa0
 
   - runs: |
-      # Mitigate GHSA-vvpx-j8f3-3w6h
-      go get golang.org/x/net@v0.7.0
-
-      # GHSA-g82w-58jf-gcxx
-      go get sigs.k8s.io/secrets-store-csi-driver@v1.3.3
-      go mod tidy
-
       mkdir -p ${{targets.destdir}}/usr/bin/
       go build \
         -ldflags "-w -extldflags '-static' -X 'main.version=${{package.version}}'" \


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/blob/v1.3.0/go.mod

