### PR TITLE
keda: bump x/net for rapid reset CVEs

### DIFF
--- a/keda-2.10.yaml
+++ b/keda-2.10.yaml
@@ -3,8 +3,11 @@
 package:
   name: keda-2.10
   # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
+  #
+  # When updating this version, please check the dependencies version patching
+  # below and remove if possible.
   version: 2.10.1
-  epoch: 3
+  epoch: 4
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -32,6 +35,10 @@ pipeline:
       expected-commit: 8adb70e97a08a4690613eef4c4f00391e44e1603
 
   - runs: |
+      # CVE-2023-{44487,39325,3978}
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       ARCH=$(go env GOARCH) make build
       mkdir -p "${{targets.destdir}}/usr/bin"
       mv bin/keda "${{targets.destdir}}/usr/bin"

--- a/keda-2.10.yaml
+++ b/keda-2.10.yaml
@@ -38,6 +38,7 @@ pipeline:
       # CVE-2023-{44487,39325,3978}
       go get golang.org/x/net@v0.17.0
       go mod tidy
+      go mod vendor
 
       ARCH=$(go env GOARCH) make build
       mkdir -p "${{targets.destdir}}/usr/bin"

--- a/keda-2.11.yaml
+++ b/keda-2.11.yaml
@@ -3,8 +3,11 @@
 package:
   name: keda-2.11
   # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
+  #
+  # When updating this version, please check the dependencies version patching
+  # below and remove if possible.
   version: 2.11.2
-  epoch: 6
+  epoch: 7
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -32,6 +35,10 @@ pipeline:
       expected-commit: 517ed30cc311b0b81e39112cff0fa8e3251aed69
 
   - runs: |
+      # CVE-2023-{44487,39325,3978}
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       ARCH=$(go env GOARCH) make build
       mkdir -p "${{targets.destdir}}/usr/bin"
       mv bin/keda "${{targets.destdir}}/usr/bin"

--- a/keda-2.11.yaml
+++ b/keda-2.11.yaml
@@ -38,6 +38,7 @@ pipeline:
       # CVE-2023-{44487,39325,3978}
       go get golang.org/x/net@v0.17.0
       go mod tidy
+      go mod vendor
 
       ARCH=$(go env GOARCH) make build
       mkdir -p "${{targets.destdir}}/usr/bin"

--- a/keda.yaml
+++ b/keda.yaml
@@ -1,8 +1,11 @@
 package:
   name: keda
   # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
+  #
+  # When updating this version, please check the dependencies version patching
+  # below and remove if possible.
   version: 2.12.0
-  epoch: 2
+  epoch: 3
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -30,6 +33,10 @@ pipeline:
       expected-commit: 9527a7f1f2797aa5662b2b45b1d26acf22a0cd09
 
   - runs: |
+      # CVE-2023-{44487,39325,3978}
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       ARCH=$(go env GOARCH) make build
       mkdir -p "${{targets.destdir}}/usr/bin"
       mv bin/keda "${{targets.destdir}}/usr/bin"

--- a/keda.yaml
+++ b/keda.yaml
@@ -36,6 +36,7 @@ pipeline:
       # CVE-2023-{44487,39325,3978}
       go get golang.org/x/net@v0.17.0
       go mod tidy
+      go mod vendor
 
       ARCH=$(go env GOARCH) make build
       mkdir -p "${{targets.destdir}}/usr/bin"


### PR DESCRIPTION
#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/347