### PR TITLE
Add kor golang package

### DIFF
--- a/kor.yaml
+++ b/kor.yaml
@@ -17,6 +17,7 @@ pipeline:
     with:
       modroot: .
       packages: .
+      ldflags: -w
       output: kor
       deps: golang.org/x/net@v0.17.0
 

--- a/kor.yaml
+++ b/kor.yaml
@@ -1,0 +1,29 @@
+package:
+  name: kor
+  version: 0.2.4
+  epoch: 0
+  description: A Golang Tool to discover unused Kubernetes Resources
+  copyright:
+    - license: MIT License
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/yonahd/kor
+      tag: v${{package.version}}
+      expected-commit: ec0b8fab7731e65decdf838019e9ec0834bac5ec
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: .
+      output: kor
+      deps: golang.org/x/net@v0.17.0
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: yonahd/kor
+    strip-prefix: v


### PR DESCRIPTION
Kor is a Golang Tool to discover unused Kubernetes Resources.  I could not find a version support policy or anything published on endoflife.  

### Pre-review Checklist

## For new package PRs only
- [x] REQUIRED - The package is available under MIT License
- [x] REQUIRED - It's assumed that this version of the package is still receiving security updates

## Note:

Package builds successfully and I was able to add it to a local-wolfi container and mess around.

