### PR TITLE
bump epoch of zstd to build zstd-static

### DIFF
--- a/zstd.yaml
+++ b/zstd.yaml
@@ -1,7 +1,7 @@
 package:
   name: zstd
   version: 1.5.5
-  epoch: 0
+  epoch: 1
   description: "the Zstandard compression algorithm"
   copyright:
     - license: BSD-2-Clause AND GPL-2.0-only


### PR DESCRIPTION
`zstd-static` does not exist on APKINDEX, so bumping the epoch...