### PR TITLE
python 3.12 bump py3-scikit-learn + fix up dependencies that use py3-…

### DIFF
--- a/numpy.yaml
+++ b/numpy.yaml
@@ -1,7 +1,7 @@
 package:
   name: numpy
   version: 1.26.1
-  epoch: 0
+  epoch: 1
   description: "The fundamental package for scientific computing with Python."
   copyright:
     - license: BSD-3-Clause

--- a/py3-contourpy.yaml
+++ b/py3-contourpy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-contourpy
   version: 1.1.1
-  epoch: 0
+  epoch: 1
   description: Python library for calculating contours of 2D quadrilateral grids
   copyright:
     - license: BSD-3-Clause
@@ -22,7 +22,7 @@ environment:
       - py3-setuptools
       - py3-pip
       - py3-installer
-      - py3-pybind11
+      - py3-pybind11-dev
       - py3-build
 
 pipeline:

--- a/py3-matplotlib.yaml
+++ b/py3-matplotlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-matplotlib
   version: 3.8.0
-  epoch: 1
+  epoch: 2
   description: Python plotting package
   copyright:
     - license: PSF
@@ -32,7 +32,6 @@ environment:
       - py3-pillow
       - py3-tz
       - py3-tkinter
-      - py3-pybind11
       - py3-pybind11-dev
 
 pipeline:

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pulsar-client
   version: 3.3.0
-  epoch: 0
+  epoch: 1
   description: Apache Pulsar Python client library
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,7 @@ environment:
       - cmake
       - python3-dev
       - libpulsar-dev
-      - py3-pybind11
+      - py3-pybind11-dev
 
 pipeline:
   - uses: git-checkout

--- a/py3-pybind11.yaml
+++ b/py3-pybind11.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pybind11
   version: 2.11.1
-  epoch: 4
+  epoch: 5
   description: Seamless operability between C++11 and Python
   copyright:
     - license: BSD
@@ -55,6 +55,9 @@ pipeline:
 subpackages:
   - name: py3-pybind11-dev
     description: pybind11 development headers
+    dependencies:
+      runtime:
+        - py3-pybind11
     pipeline:
       - uses: split/dev
       - runs: |

--- a/py3-scikit-learn.yaml
+++ b/py3-scikit-learn.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scikit-learn
   version: 1.3.1
-  epoch: 0
+  epoch: 1
   description: A set of python modules for machine learning and data mining
   copyright:
     - license: BSD-3-Clause

--- a/py3-scipy.yaml
+++ b/py3-scipy.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-scipy
-  version: 1.11.2
+  version: 1.11.3
   epoch: 0
   description: Fundamental algorithms for scientific computing in Python
   copyright:
@@ -21,9 +21,9 @@ environment:
       - python3-dev
       - py3-setuptools
       - numpy
-      - py3-pybind11
+      - py3-pybind11-dev
       - py3-pip
-      - cython
+      - cython~0
       - openblas-dev
       - py3-pythran
       - gfortran
@@ -33,7 +33,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/scipy/scipy
-      expected-commit: 686422c4f0a71be1b4258309590fd3e9de102e18
+      expected-commit: f990b1d2471748c79bc4260baf8923db0a5248af
       tag: v${{package.version}}
 
   - runs: git submodule update --init


### PR DESCRIPTION
…pybind11 as it now has a dev subpackage

Also includes py3-scipy/1.11.3 and tensorflow-core/2.14.0 package updates now that their builds are fixed.