### PR TITLE
patch golang.org/x/net@v0.17.0 for git-lfs|gitness|gomplate|grpcurl|haproxy-ingress|helm|hugo|influxd

### DIFF
--- a/git-lfs.yaml
+++ b/git-lfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-lfs
   version: 3.4.0
-  epoch: 3
+  epoch: 4
   description: "large file support for git"
   copyright:
     - license: MIT
@@ -28,14 +28,9 @@ pipeline:
 
   - runs: |
       cd git-lfs
-      # mitigate CVE-2021-38561
-      go get golang.org/x/text
-
-      # mitigate CVE-2022-27191
-      go get golang.org/x/crypto/ssh
-
-      # mitigate GHSA-vvpx-j8f3-3w6h
-      go get golang.org/x/net@v0.7.0
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
 
   - runs: |
       cd git-lfs

--- a/gitness.yaml
+++ b/gitness.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitness
-  version: 3.0.0_beta1
-  epoch: 2
+  version: 3.0.0_beta2
+  epoch: 0
   description: Gitness is an Open Source developer platform with Source Control management, Continuous Integration and Continuous Delivery.
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,7 @@ pipeline:
     with:
       # Hack until they cut a release
       repository: https://github.com/harness/gitness/
-      expected-commit: 8872d04dec89aad48492fc98e3c141f5cec142f1
+      expected-commit: 1c762c6802b391ef2f3346886629bb0c1d514e24
       tag: v${{vars.mangled-package-version}}
 
   - runs: |
@@ -39,14 +39,8 @@ pipeline:
       yarn && yarn build && yarn cache clean
       cd ..
 
-      # GHSA-hmfx-3pcx-653p
-      go get github.com/containerd/containerd@v1.5.18
-
-      # CVE-2023-2253
-      go get github.com/docker/distribution@v2.8.2
-
-      # GHSA-77vh-xpmg-72qh
-      go get github.com/opencontainers/image-spec@v1.0.2
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
 
       go mod tidy
 

--- a/gomplate.yaml
+++ b/gomplate.yaml
@@ -1,7 +1,7 @@
 package:
   name: gomplate
   version: 3.11.5
-  epoch: 5
+  epoch: 6
   description: A go templating utility.
   copyright:
     - license: MIT
@@ -26,6 +26,10 @@ pipeline:
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
+
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
 
       go build -o ${{targets.destdir}}/usr/bin \
         -ldflags "-w -s -X github.com/hairyhenderson/gomplate/v3/version.Version=${{package.version}} \

--- a/grpcurl.yaml
+++ b/grpcurl.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpcurl
   version: 1.8.8
-  epoch: 2
+  epoch: 3
   description: CLI tool to interact with gRPC servers
   copyright:
     - license: MIT
@@ -30,6 +30,8 @@ pipeline:
       packages: ./cmd/grpcurl
       output: grpcurl
       ldflags: -s -w -X main.version=v${{package.version}}
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
 
   - uses: strip
 

--- a/haproxy-ingress.yaml
+++ b/haproxy-ingress.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-ingress
   version: 0.14.5
-  epoch: 4
+  epoch: 5
   description: HAProxy Ingress
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,10 @@ pipeline:
       expected-commit: 7e2c5786279d2b3b7f38c3585e4a82af818aa70d
 
   - runs: |
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) linux-build
       mkdir -p ${{targets.destdir}}/usr/bin
       mkdir -p ${{targets.destdir}}/haproxy-ingress

--- a/helm.yaml
+++ b/helm.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm
   version: 3.13.1
-  epoch: 0
+  epoch: 1
   description: The Kubernetes Package Manager
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,10 @@ pipeline:
 
   - runs: |
       cd helm
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make build
       install -Dm755 ./bin/helm "${{targets.destdir}}/usr/bin/helm"
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,7 +1,7 @@
 package:
   name: hugo
   version: 0.119.0
-  epoch: 3
+  epoch: 4
   description: The world's fastest framework for building websites.
   copyright:
     - license: Apache-2.0
@@ -14,10 +14,18 @@ environment:
       - git
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/gohugoio/hugo
-      version: v${{package.version}}
+      repository: https://github.com/gohugoio/hugo
+      tag: v${{package.version}}
+      expected-commit: b84644c008e0dc2c4b67bd69cccf87a41a03937e
+
+  - uses: go/build
+    with:
+      packages: .
+      output: hugo
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
 
   - uses: strip
 

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -1,7 +1,7 @@
 package:
   name: influxd
   version: 2.7.1
-  epoch: 7
+  epoch: 8
   description: Scalable datastore for metrics, events, and real-time analytics
   copyright:
     - license: MIT
@@ -29,6 +29,10 @@ pipeline:
   - runs: |
       cd influxdb
       unset LDFLAGS
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make generate-web-assets
 
       # There's currently a #![deny(warnings)] section in a crate that fails to build with Rust 1.72


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
