### PR TITLE
fix py3-aiohttp for python 3.12

### DIFF
--- a/llhttp.yaml
+++ b/llhttp.yaml
@@ -1,0 +1,56 @@
+package:
+  name: llhttp
+  version: 8.1.1
+  epoch: 0
+  description: "HTTP parser written against llparse"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - build-base
+      - cmake
+      - clang-16
+      - nodejs-lts
+      - npm
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/nodejs/llhttp/archive/v${{package.version}}/llhttp-${{package.version}}.tar.gz
+      expected-sha512: 18530d1fcfde13ba634b367852e53bf7a2dc0eb130f07fbbb5b5e02b3d4ff0ab0cd7c5a0adef8a7a0e93a0104a2544ce11d3631792539c48e1a918c5d40f7f3c
+
+  - uses: patch
+    with:
+      patches: fix-sed.patch
+
+  - runs: |
+      npm ci
+
+  - runs: |
+      make release RELEASE="${{package.version}}"
+      cmake -S release -B releasebuild \
+        -DCMAKE_BUILD_TYPE=MinSizeRel \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DBUILD_SHARED_LIBS=ON
+      cmake --build releasebuild
+
+  - runs: |
+      DESTDIR="${{targets.destdir}}" cmake --install releasebuild
+
+  - uses: strip
+
+subpackages:
+  - name: "llhttp-dev"
+    description: "llhttp development headers"
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: nodejs/llhttp
+    strip-prefix: v

--- a/llhttp/fix-sed.patch
+++ b/llhttp/fix-sed.patch
@@ -1,0 +1,24 @@
+From 553ae7d1bda0b97a43af6b57ea2fd7ce04b6630d Mon Sep 17 00:00:00 2001
+From: "Benjamin A. Beasley" <code@musicinmybrain.net>
+Date: Tue, 27 Jun 2023 18:27:17 -0400
+Subject: [PATCH] Do not assume a particular sed implementation
+
+Make the release target in the Makefile more portable.
+---
+ Makefile | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 5b941b3..d9c6d35 100644
+--- a/Makefile
++++ b/Makefile
+@@ -52,8 +52,7 @@ release: clean generate
+ 	cp -rf src/native/*.c release/src/
+ 	cp -rf src/llhttp.gyp release/
+ 	cp -rf src/common.gypi release/
+-	cp -rf CMakeLists.txt release/
+-	sed -i '' s/_RELEASE_/$(RELEASE)/ release/CMakeLists.txt
++	sed s/_RELEASE_/$(RELEASE)/ CMakeLists.txt > release/CMakeLists.txt
+ 	cp -rf libllhttp.pc.in release/
+ 	cp -rf README.md release/
+ 	cp -rf LICENSE-MIT release/

--- a/py3-aiohttp.yaml
+++ b/py3-aiohttp.yaml
@@ -1,7 +1,7 @@
 # Generated from https://pypi.org/project/aiohttp/
 package:
   name: py3-aiohttp
-  version: 3.8.5
+  version: 3.8.6
   epoch: 0
   description: Async http client/server framework (asyncio)
   copyright:
@@ -29,18 +29,42 @@ environment:
       - build-base
       - python3-dev
       - py3-setuptools
+      - py3-attrs
+      - py3-charset-normalizer
+      - py3-multidict
+      - py3-async-timeout
+      - py3-yarl
+      - py3-frozenlist
+      - py3-aiosignal
+      - py3-idna-ssl
+      - py3-asynctest
+      - py3-typing-extensions
+      - llhttp-dev
+      - cython~0
 
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: b9552ec52cc147dbf1944ac7ac98af7602e51ea2dcd076ed194ca3c0d1c7d0bc
-      uri: https://files.pythonhosted.org/packages/d6/12/6fc7c7dcc84e263940e87cbafca17c1ef28f39dae6c0b10f51e4ccc764ee/aiohttp-${{package.version}}.tar.gz
+      expected-sha256: f437a7a676ee59f933a3592e3777690110bc570b38f702192bf349805382c22d
+      uri: https://github.com/aio-libs/aiohttp/archive/v${{package.version}}/aiohttp-${{package.version}}.tar.gz
+
+  - uses: patch
+    with:
+      patches: unbundle-llhttp.patch
+
+  - runs: |
+      mkdir -p .git
+      python tools/gen.py
+      python -m cython -3 aiohttp/*.pyx -I aiohttp
+      rm -rf .git
 
   - name: Python Build
-    runs: python setup.py build
+    runs: |
+      python setup.py build
 
   - name: Python Install
-    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+    runs: |
+      python setup.py install --prefix=/usr --root="${{targets.destdir}}"
 
   - uses: strip
 

--- a/py3-aiohttp/unbundle-llhttp.patch
+++ b/py3-aiohttp/unbundle-llhttp.patch
@@ -1,0 +1,43 @@
+From: Ariadne Conill <ariadne@ariadne.space>
+Date: Wed, 16 Feb 2022 13:57:57 +0100
+Subject: [PATCH] unbundle llhttp
+
+---
+ aiohttp/_cparser.pxd | 2 +-
+ setup.py             | 6 +-----
+ 2 files changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/aiohttp/_cparser.pxd b/aiohttp/_cparser.pxd
+index 165dd61d..49055d6a 100644
+--- a/aiohttp/_cparser.pxd
++++ b/aiohttp/_cparser.pxd
+@@ -10,7 +10,7 @@ from libc.stdint cimport (
+ )
+ 
+ 
+-cdef extern from "../vendor/llhttp/build/llhttp.h":
++cdef extern from "llhttp.h":
+ 
+     struct llhttp__internal_s:
+         int32_t _index
+diff --git a/setup.py b/setup.py
+index 38436806..bf4837a3 100644
+--- a/setup.py
++++ b/setup.py
+@@ -33,12 +33,8 @@ extensions = [
+         [
+             "aiohttp/_http_parser.c",
+             "aiohttp/_find_header.c",
+-            "vendor/llhttp/build/c/llhttp.c",
+-            "vendor/llhttp/src/native/api.c",
+-            "vendor/llhttp/src/native/http.c",
+         ],
+-        define_macros=[("LLHTTP_STRICT_MODE", 0)],
+-        include_dirs=["vendor/llhttp/build"],
++        libraries=["llhttp"],
+     ),
+     Extension("aiohttp._helpers", ["aiohttp/_helpers.c"]),
+     Extension("aiohttp._http_writer", ["aiohttp/_http_writer.c"]),
+-- 
+2.35.1
+


### PR DESCRIPTION
- Unbundle llhttp, allowing us to fix CVEs in it (node can use this llhttp too)
- Rebuild py3-aiohttp C sources with our own Cython, which is Python 3.12 compatible