### PR TITLE
zookeper-3.8 and 3.9 with bitnami compliant subpackages

### DIFF
--- a/zookeeper-3.8.yaml
+++ b/zookeeper-3.8.yaml
@@ -1,17 +1,16 @@
 package:
-  name: zookeeper
-  version: 3.9.1.0
-  epoch: 1
+  name: zookeeper-3.8
+  version: 3.8.3.0
+  epoch: 0
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
-    - paths:
-        - "*"
-      attestation:
-      license: Apache-2.0
+    - license: Apache-2.0
   dependencies:
     runtime:
       - bash # some helper scripts use bash
       - openjdk-17-default-jvm
+    provides:
+      - zookeeper=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.version}}
@@ -38,7 +37,7 @@ pipeline:
     with:
       repository: https://github.com/apache/zookeeper
       tag: release-${{vars.mangled-package-version}}
-      expected-commit: 1398af177833412e9ead6b9bb737dc9fd7418a45
+      expected-commit: 6ad6d364c7c0bcf0de452d54ebefa3058098ab56
 
   - runs: |
       export LANG=en_US.UTF-8
@@ -61,11 +60,20 @@ pipeline:
       # Setup a sample conf
       cp ${{targets.destdir}}/usr/share/java/zookeeper/conf/zoo_sample.cfg ${{targets.destdir}}/usr/share/java/zookeeper/conf/zoo.cfg
 
+subpackages:
+  - name: zookeeper-bitnami-3.8-compat
+    description: "compat package with bitnami/zookeeper image"
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: zookeeper
+          version-path: 3.8/debian-11
+
 update:
   enabled: true
   version-separator: "-"
   github:
-    tag-filter: release-
+    tag-filter: release-3.8
     identifier: apache/zookeeper
     strip-prefix: release-
     use-tag: true

--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,0 +1,79 @@
+package:
+  name: zookeeper-3.9
+  version: 3.9.1.0
+  epoch: 0
+  description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - bash # some helper scripts use bash
+      - openjdk-17-default-jvm
+    provides:
+      - zookeeper=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.version}}
+    match: \.(\d+)$
+    replace: "-$1"
+    to: mangled-package-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: short-package-version
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - maven
+      - openjdk-17
+      - openjdk-17-default-jvm
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/zookeeper
+      tag: release-${{vars.mangled-package-version}}
+      expected-commit: 1398af177833412e9ead6b9bb737dc9fd7418a45
+
+  - runs: |
+      export LANG=en_US.UTF-8
+      export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+      # patch netty version for CVE-2023-4586 CVE-2023-44487
+      mvn install -DskipTests -Dnetty.version=4.1.100.Final
+      tar -xf zookeeper-assembly/target/apache-zookeeper-${{vars.short-package-version}}-bin.tar.gz
+
+      mkdir -p ${{targets.destdir}}/usr/share/java/zookeeper
+      mkdir -p ${{targets.destdir}}/usr/share/java/zookeeper/bin
+      mkdir -p ${{targets.destdir}}/usr/share/java/zookeeper/lib
+      mkdir -p ${{targets.destdir}}/usr/share/java/zookeeper/conf
+
+      # Clean up windows files
+      rm -rf apache-zookeeper-${{vars.short-package-version}}-bin/bin/*.cmd
+      mv apache-zookeeper-${{vars.short-package-version}}-bin/lib/* ${{targets.destdir}}/usr/share/java/zookeeper/lib
+      mv apache-zookeeper-${{vars.short-package-version}}-bin/bin/* ${{targets.destdir}}/usr/share/java/zookeeper/bin
+      mv apache-zookeeper-${{vars.short-package-version}}-bin/conf/* ${{targets.destdir}}/usr/share/java/zookeeper/conf
+
+      # Setup a sample conf
+      cp ${{targets.destdir}}/usr/share/java/zookeeper/conf/zoo_sample.cfg ${{targets.destdir}}/usr/share/java/zookeeper/conf/zoo.cfg
+
+subpackages:
+  - name: zookeeper-bitnami-3.9-compat
+    description: "compat package with bitnami/zookeper image"
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: zookeeper
+          version-path: 3.9/debian-11
+
+update:
+  enabled: true
+  version-separator: "-"
+  github:
+    tag-filter: release-3.9
+    identifier: apache/zookeeper
+    strip-prefix: release-
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
