### PR TITLE
patch golang/x/net for minio|newrelic-infrastructure-agent|nodetaint|nri-prometheus|nvidia-device-plugin|oauth2-proxy|opentofu

### DIFF
--- a/minio.yaml
+++ b/minio.yaml
@@ -3,7 +3,7 @@ package:
   # minio uses strange versioning, the upstream version is RELEASE.2023-09-04T19-57-37Z
   # when bumping this, also bump the tag in git-checkout below
   version: 0.20230904.195737
-  epoch: 4
+  epoch: 5
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0
@@ -25,6 +25,10 @@ pipeline:
       expected-commit: 1c99fb106c3e1448ed92f8465d5695d055d432e7
 
   - runs: |
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make build
       mkdir -p ${{targets.destdir}}/usr/bin
       mv minio ${{targets.destdir}}/usr/bin

--- a/newrelic-infrastructure-agent.yaml
+++ b/newrelic-infrastructure-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-infrastructure-agent
   version: 1.47.2
-  epoch: 2
+  epoch: 3
   description: New Relic Infrastructure Agent
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,10 @@ pipeline:
   - runs: |
       # Our global LDFLAGS conflict with a Makefile parameter: https://github.com/newrelic/infrastructure-agent/blob/07ab68f181e25a1552588a3953167e0b15f52372/build/build.mk#L20-L22
       unset LDFLAGS
+
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
 
       GOOS=$(go env GOOS) GOARCH=$(go env GOARCH)
 

--- a/nodetaint.yaml
+++ b/nodetaint.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodetaint
   version: 0.0.4
-  epoch: 5
+  epoch: 6
   description: Controller to manage taints for nodes in a k8s cluster.
   copyright:
     - license: Apache-2.0
@@ -27,10 +27,12 @@ pipeline:
 
       # Mitigate GHSA-vvpx-j8f3-3w6h and GHSA-69ch-w2m2-3vjp
       go get golang.org/x/text@v0.3.8
-      go get golang.org/x/net@v0.7.0
 
       # GHSA-8cfg-vx93-jvxw
       go get k8s.io/client-go@v0.20.0-alpha.2
+
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
 
       go mod tidy -compat=1.17
 

--- a/nri-prometheus.yaml
+++ b/nri-prometheus.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-prometheus
   version: 2.18.7
-  epoch: 2
+  epoch: 3
   description: Fetch metrics in the Prometheus metrics inside or outside Kubernetes and send them to the New Relic Metrics platform.
   copyright:
     - license: Apache-2.0
@@ -24,8 +24,9 @@ pipeline:
     with:
       packages: ./cmd/nri-prometheus
       output: nri-prometheus
-      deps: google.golang.org/protobuf@v1.29.1
       ldflags: -s -w
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      deps: google.golang.org/protobuf@v1.29.1 golang.org/x/net@v0.17.0
 
   - uses: strip
 

--- a/nvidia-device-plugin.yaml
+++ b/nvidia-device-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: nvidia-device-plugin
   version: 0.14.1
-  epoch: 4
+  epoch: 5
   description: NVIDIA device plugin for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,11 @@ pipeline:
       expected-commit: 7086f91dfcd0cd7b06863be4a315ba873f0b81f9
 
   - runs: |
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+      go mod vendor
+
       make
       mkdir -p ${{targets.destdir}}/usr/bin
       mv config-manager ${{targets.destdir}}/usr/bin/

--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: oauth2-proxy
   version: 7.5.1
-  epoch: 2
+  epoch: 3
   description: Reverse proxy and static file server that provides authentication using various providers to validate accounts by email, domain or group.
   copyright:
     - license: MIT
@@ -28,7 +28,8 @@ pipeline:
       output: oauth2-proxy
       ldflags: -s -w -X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.Version=${{package.version}}
       # GHSA-vvpx-j8f3-3w6h
-      deps: golang.org/x/net@v0.7.0
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      deps: golang.org/x/net@v0.17.0
 
   - runs: |
       # Make sure there is at least an empty key file.

--- a/opentofu.yaml
+++ b/opentofu.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentofu
-  version: 1.6.0_alpha1
-  epoch: 2
+  version: 1.6.0_alpha2
+  epoch: 0
   copyright:
     - license: MPL-2.0
 
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: https://github.com/opentofu/opentofu
       tag: v${{vars.mangled-package-version}}
-      expected-commit: 98bd62453522350e31ee420ff50f76a2977f9647
+      expected-commit: 9e6bc7f86f1cbf36bc8dc079b97273fbd7909117
 
   - uses: go/build
     with:
@@ -28,6 +28,8 @@ pipeline:
       packages: ./cmd/tofu
       output: tofu
       ldflags: -s -w
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      deps: golang.org/x/net@v0.17.0
 
   - uses: strip
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
