### PR TITLE
patch golang/x/net for kubevela|kubewatch|kyverno|node-problem-detector-0.8

### DIFF
--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubevela
   version: 1.9.6
-  epoch: 3
+  epoch: 4
   description: KubeVela is a modern application delivery platform that makes deploying and operating applications across today's hybrid, multi-cloud environments easier, faster and more reliable
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,8 @@ pipeline:
       packages: ./cmd/core/main.go
       ldflags: -s -w -X github.com/oam-dev/kubevela/version.VelaVersion=${{package.version}}
       output: manager
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      deps: golang.org/x/net@v0.17.0
 
   - uses: go/build
     with:

--- a/kubewatch.yaml
+++ b/kubewatch.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubewatch
   version: 2.5.0
-  epoch: 6
+  epoch: 7
   description: Watch k8s events and trigger Handlers
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,8 @@ pipeline:
   - runs: |
       go get golang.org/x/crypto@v0.8.0
       go get gopkg.in/yaml.v3@v3.0.1
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
       go mod tidy
 
   - runs: |

--- a/kyverno.yaml
+++ b/kyverno.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno
   version: 1.10.3
-  epoch: 5
+  epoch: 6
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,9 @@ pipeline:
       expected-commit: 8137b4b8afd7ab1464a42e717dc83f1cc471a4a1
 
   - runs: |
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
       make build-all
       mkdir -p ${{targets.destdir}}/usr/bin
       install -Dm755 cmd/kyverno/kyverno ${{targets.destdir}}/usr/bin/kyverno

--- a/node-problem-detector-0.8.yaml
+++ b/node-problem-detector-0.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: node-problem-detector-0.8
   version: 0.8.14
-  epoch: 4
+  epoch: 5
   description: node-problem-detector aims to make various node problems visible to the upstream layers in the cluster management stack.
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,12 @@ pipeline:
   - uses: patch
     with:
       patches: fix-archs.patch
+
+  - runs: |
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+      go mod vendor
 
   - if: ${{build.arch}} == 'x86_64'
     runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
