### PR TITLE
dask-gateway: fix broken build, avoid using requirements.txt and bump…

### DIFF
--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-gateway
   version: 2023.9.0
-  epoch: 2
+  epoch: 3
   description: "A multi-tenant server for securely deploying and managing Dask clusters."
   copyright:
     - license: BSD-3-Clause
@@ -27,6 +27,8 @@ environment:
       - py3-cryptography
       - py3-colorlog
       - py3-aiohttp
+      - py3-gpep517
+      - py3-wheel
 
 pipeline:
   - uses: git-checkout
@@ -36,13 +38,10 @@ pipeline:
       expected-commit: b3f56da3579da731a1a05088cc2e3509c962592c
 
   - runs: |
-      pip wheel \
-        --wheel-dir=/tmp/wheels/ \
-        -r dask-gateway/requirements.txt
-      pip install \
-        --find-links=/tmp/wheels/ \
-        -r dask-gateway/requirements.txt \
-        --prefix=/usr --root=${{targets.destdir}}
+      cd dask-gateway
+      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 1
+
+      python3 -m installer -d "${{targets.destdir}}" dist/dask_gateway*.whl
 
 subpackages:
   - name: dask-gateway-server
@@ -51,7 +50,7 @@ subpackages:
       - name: Python Build
         runs: |
           cd dask-gateway-server
-          python -m build --sdist --wheel .
+          python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 1
           mkdir -p "${{targets.subpkgdir}}/usr/bin"
           install -Dm755 ./dask_gateway_server/proxy/dask-gateway-proxy "${{targets.subpkgdir}}/usr/bin/"
           python -m installer -d "${{targets.subpkgdir}}/" dist/dask_gateway_server*.whl


### PR DESCRIPTION
… for python 3.12 rebuild

