### PR TITLE
patch golang/x/net for kpt|kots

### DIFF
--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
   version: 1.103.2
-  epoch: 1
+  epoch: 2
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0
@@ -45,6 +45,10 @@ pipeline:
 
       # Configure Yarn
       yarn install --pure-lockfile --network-concurrency 1
+
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
 
       # removing tests for now to see if this builds
       make -C web deps lint build-kotsadm

--- a/kpt.yaml
+++ b/kpt.yaml
@@ -1,7 +1,7 @@
 package:
   name: kpt
   version: 1.0.0_beta46
-  epoch: 9
+  epoch: 0
   description: Automate Kubernetes Configuration Editing
   copyright:
     - license: Apache-2.0

--- a/kpt.yaml
+++ b/kpt.yaml
@@ -1,6 +1,6 @@
 package:
   name: kpt
-  version: 1.0.0_beta31
+  version: 1.0.0_beta46
   epoch: 9
   description: Automate Kubernetes Configuration Editing
   copyright:
@@ -19,12 +19,14 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/GoogleContainerTools/kpt
-      tag: v1.0.0-beta.31
-      expected-commit: 8e101e6fe15d0e5868ddec24325da61809c2bae5
+      tag: v1.0.0-beta.46
+      expected-commit: 8b5e2f5450de1d468307d8026790914c92a25c1f
 
   - runs: |
       # Mitigate GHSA-hqxw-f8mx-cpmw
       go get github.com/docker/distribution@v2.8.2
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
 
       go mod tidy
       go mod vendor


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
