### PR TITLE
patch golang/x/net fuse-overlayfs-snapshotter|gatekeeper-3.12

### DIFF
--- a/fuse-overlayfs-snapshotter.yaml
+++ b/fuse-overlayfs-snapshotter.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs-snapshotter
   version: 1.0.7
-  epoch: 1
+  epoch: 2
   description: fuse-overlayfs plugin for rootless containerd
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,10 @@ pipeline:
       tag: v${{package.version}}
 
   - runs: |
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make bin/containerd-fuse-overlayfs-grpc
 
       make install BINDIR="${{targets.destdir}}"/usr/bin

--- a/gatekeeper-3.12.yaml
+++ b/gatekeeper-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gatekeeper-3.12
   version: 3.12.0
-  epoch: 5
+  epoch: 6
   description: Gatekeeper - Policy Controller for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,10 @@ pipeline:
 
   - runs: |
       cd gatekeeper
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+      go mod vendor
       FRAMEWORKS_VERSION=$(go list -f '{{ .Version }}' -m github.com/open-policy-agent/frameworks/constraint)
       OPA_VERSION=$(go list -f '{{ .Version }}' -m github.com/open-policy-agent/opa)
       CGO_ENABLED=0 GO111MODULE=on go build -mod vendor -a -ldflags "-w -X github.com/open-policy-agent/gatekeeper/pkg/version.Version=v${{package.version}} -X main.frameworksVersion=${FRAMEWORKS_VERSION} -X main.opaVersion=${OPA_VERSION}" -o manager


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
