### PR TITLE
cilium, cilium-iptables, cilium-operator-generic, hubble-relay: new packages

### DIFF
--- a/cilium.yaml
+++ b/cilium.yaml
@@ -1,5 +1,7 @@
 package:
   name: cilium
+  # When updating this version, please check the dependencies patches below
+  # and remove if possible.
   version: 1.14.2
   epoch: 0
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
@@ -38,6 +40,11 @@ pipeline:
       expected-commit: a67489466c715854c4c472c939d32d35df3fe748
 
   - runs: |
+      # For CVE-2023-39325 ,CVE-2023-3978 and CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+      go mod vendor
+
       # Remove groupadd from Makefile: it's not doing anything useful in
       # a package build anyway, and it's not available in busybox.
       find . -name Makefile -exec sed -i '/groupadd/d' {} \;

--- a/cilium.yaml
+++ b/cilium.yaml
@@ -55,7 +55,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: cilium-iptables
+  - name: ${{package.name}}-iptables
     description: iptables compatibility package for cilium
     dependencies:
       runtime:
@@ -69,7 +69,7 @@ subpackages:
           mv /sbin/iptables-wrapper ${{targets.subpkgdir}}/sbin/iptables-wrapper
       - uses: strip
 
-  - name: cilium-operator-generic
+  - name: ${{package.name}}-operator-generic
     description: Generic operator for cilium
     dependencies:
       runtime:

--- a/cilium.yaml
+++ b/cilium.yaml
@@ -1,0 +1,90 @@
+package:
+  name: cilium
+  version: 1.14.2
+  epoch: 0
+  description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - iptables
+      - iproute2
+      - ipset
+      - bpftool
+      - kmod
+      # cilium does compilations at runtime on the node.
+      - clang
+      - llvm16
+      - cni-plugins
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - build-base
+      - go
+      - git
+      - coreutils # for GNU install
+      - grep
+      - clang
+      - llvm16
+      - iptables # for cilium-iptables
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cilium/cilium
+      tag: v${{package.version}}
+      expected-commit: a67489466c715854c4c472c939d32d35df3fe748
+
+  - runs: |
+      # Remove groupadd from Makefile: it's not doing anything useful in
+      # a package build anyway, and it's not available in busybox.
+      find . -name Makefile -exec sed -i '/groupadd/d' {} \;
+
+      DESTDIR=${{targets.destdir}} DISABLE_ENVOY_INSTALLATION=1 make build-container
+      DESTDIR=${{targets.destdir}} DISABLE_ENVOY_INSTALLATION=1 make install-container
+
+  - uses: strip
+
+subpackages:
+  - name: cilium-iptables
+    description: iptables compatibility package for cilium
+    dependencies:
+      runtime:
+        - iptables
+    pipeline:
+      - runs: |
+          # This script generates a wrapper based on the version
+          # of iptables provided by the build environment.
+          ./images/runtime/iptables-wrapper-installer.sh
+          mkdir -p ${{targets.subpkgdir}}/sbin
+          mv /sbin/iptables-wrapper ${{targets.subpkgdir}}/sbin/iptables-wrapper
+      - uses: strip
+
+  - name: cilium-operator-generic
+    description: Generic operator for cilium
+    dependencies:
+      runtime:
+        - gops
+    pipeline:
+      - runs: |
+          cd /home/build/operator
+          make cilium-operator-generic
+          DESTDIR=${{targets.subpkgdir}} make install-generic
+      - uses: strip
+
+  - name: hubble-relay
+    description: Hubble relay
+    pipeline:
+      - runs: |
+          cd /home/build/hubble-relay
+          make hubble-relay
+          DESTDIR=${{targets.subpkgdir}} make install
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: cilium/cilium
+    strip-prefix: v


### PR DESCRIPTION
cilium, cilium-iptables, cilium-operator-generic, hubble-relay: New packages

### Pre-review Checklist

<!-- remove if unrelated -->
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] This PR links to the upstream project's support policy (e.g. `endoflife.date`): https://github.com/cilium/cilium#stable-releases
