### PR TITLE
Build pulumi with Python 3.11

### DIFF
--- a/pulumi.yaml
+++ b/pulumi.yaml
@@ -3,7 +3,7 @@ package:
   # When this version is bumped, please check the dependency version
   # patches below and remove if possible.
   version: 3.88.1
-  epoch: 1
+  epoch: 2
   description: Infrastructure as Code in any programming language
   copyright:
     - license: Apache-2.0
@@ -17,8 +17,8 @@ environment:
       - go
       - nodejs
       - patch
-      - python3
-      - python3-dev
+      - python-3.11
+      - python-3.11-dev
       - yarn
   environment:
     CGO_ENABLED: "0"
@@ -44,9 +44,7 @@ pipeline:
               go mod tidy
             )
           done
-          # Upgrade grpcio to work with Python 3.12
-          sed -i "s/^grpcio==.*/grpcio==1.59.0/g" sdk/python/requirements.txt
-          sed -i "s/'grpcio==.*'/'grpcio==1.59.0'/g" sdk/python/lib/setup.py
+
       - runs: |
           set -x
 

--- a/pulumi.yaml
+++ b/pulumi.yaml
@@ -44,7 +44,6 @@ pipeline:
               go mod tidy
             )
           done
-
       - runs: |
           set -x
 


### PR DESCRIPTION
Patching the grpcio didn't work, as the python SDK still fails at runtime.