### PR TITLE
New package: Python Canonical JSON

### DIFF
--- a/py3-canonicaljson.yaml
+++ b/py3-canonicaljson.yaml
@@ -1,0 +1,39 @@
+package:
+  name: py3-canonicaljson
+  version: 2.0.0
+  epoch: 0
+  description: Canonical JSON
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-setuptools
+      - python-3
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/matrix-org/python-canonicaljson
+      tag: v${{package.version}}
+      expected-commit: ebe1deeb8d24e44ae5f41156c6139febd807d17f
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: matrix-org/python-canonicaljson
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
py3-canonicaljson 

- Encodes objects and arrays as [RFC 7159](https://tools.ietf.org/html/rfc7159) JSON.
- Sorts object keys so that you get the same result each time.

### Pre-review Checklist

- [x] REQUIRED - The package is available under Apache 2.0
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] This PR links to the upstream project's support policy: https://github.com/matrix-org/python-canonicaljson/security/policy
