### PR TITLE
Add crfsuite

### DIFF
--- a/crfsuite.yaml
+++ b/crfsuite.yaml
@@ -1,0 +1,51 @@
+package:
+  name: crfsuite
+  version: 0.12
+  epoch: 0
+  description: An implementation of Conditional Random Fields (CRFs) for labeling sequential data
+  copyright:
+    - license: BSD
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - libtool
+      - bash
+      - m4
+      - liblbfgs-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/chokkan/crfsuite/archive/${{package.version}}.tar.gz
+      expected-sha256: ab83084ed5d4532ec772d96c3e964104d689f2c295915e80299ea3c315335b00
+
+  - uses: patch
+    with:
+      patches: fix-autoconf-automake.patch
+
+  - runs: autoupdate
+
+  - runs: ./autogen.sh
+
+  - runs: autoreconf -vif
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --disable-sse2
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: false

--- a/crfsuite/fix-autoconf-automake.patch
+++ b/crfsuite/fix-autoconf-automake.patch
@@ -1,0 +1,92 @@
+# PR is merged and not merged in master branch: https://github.com/chokkan/crfsuite/pull/29
+From a6a4a38ccc4738deb0e90fc9ff2c11868922aa11 Mon Sep 17 00:00:00 2001
+From: Aleksey Cheusov <vle@gmx.net>
+Date: Thu, 30 Oct 2014 01:57:35 +0300
+Subject: [PATCH 1/2] Adapted for recent autoconf and automake
+
+---
+ configure.in         | 6 +++---
+ frontend/Makefile.am | 2 +-
+ lib/cqdb/Makefile.am | 2 +-
+ lib/crf/Makefile.am  | 2 +-
+ 4 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/configure.in b/configure.in
+index dafbcf65..33a0afdb 100644
+--- a/configure.in
++++ b/configure.in
+@@ -11,7 +11,7 @@ dnl ------------------------------------------------------------------
+ dnl Initialization for autoconf
+ dnl ------------------------------------------------------------------
+ AC_PREREQ(2.59)
+-AC_INIT
++AC_INIT(crfsuite, 0.12)
+ AC_CONFIG_SRCDIR([frontend/main.c])
+ AC_CONFIG_MACRO_DIR([m4])
+ 
+@@ -27,10 +27,10 @@ AC_ISC_POSIX
+ dnl ------------------------------------------------------------------
+ dnl Initialization for automake
+ dnl ------------------------------------------------------------------
+-AM_INIT_AUTOMAKE(crfsuite, 0.12)
++AM_INIT_AUTOMAKE
+ AC_CONFIG_HEADERS(config.h)
+ AM_MAINTAINER_MODE
+-AM_C_PROTOTYPES
++# AM_C_PROTOTYPES
+ 
+ 
+ dnl ------------------------------------------------------------------
+diff --git a/frontend/Makefile.am b/frontend/Makefile.am
+index d217a20e..415f36f9 100644
+--- a/frontend/Makefile.am
++++ b/frontend/Makefile.am
+@@ -22,7 +22,7 @@ crfsuite_SOURCES = \
+ #crfsuite_CPPFLAGS =
+ 
+ AM_CFLAGS = @CFLAGS@
+-INCLUDES = @INCLUDES@
++AM_CPPFLAGS = @INCLUDES@
+ AM_LDFLAGS = @LDFLAGS@
+ 
+ crfsuite_CFLAGS = -I$(top_builddir)/include
+diff --git a/lib/cqdb/Makefile.am b/lib/cqdb/Makefile.am
+index 5be12df1..5bc9966d 100644
+--- a/lib/cqdb/Makefile.am
++++ b/lib/cqdb/Makefile.am
+@@ -18,4 +18,4 @@ libcqdb_la_LDFLAGS = \
+ libcqdb_la_CFLAGS = -I./include
+ 
+ AM_CFLAGS = @CFLAGS@
+-INCLUDES = @INCLUDES@
++AM_CPPFLAGS = @INCLUDES@
+diff --git a/lib/crf/Makefile.am b/lib/crf/Makefile.am
+index 7367f4f4..7ab3ba95 100644
+--- a/lib/crf/Makefile.am
++++ b/lib/crf/Makefile.am
+@@ -43,4 +43,4 @@ libcrfsuite_la_LIBADD = \
+ 	$(top_builddir)/lib/cqdb/libcqdb.la
+ 
+ AM_CFLAGS = @CFLAGS@
+-INCLUDES = @INCLUDES@
++AM_CPPFLAGS = @INCLUDES@
+
+From 7b1359cd7f9b7c24ce47806fd44387cca1ba6914 Mon Sep 17 00:00:00 2001
+From: Aleksey Cheusov <vle@gmx.net>
+Date: Thu, 30 Oct 2014 17:35:44 +0300
+Subject: [PATCH 2/2] Shebang for crfutils.py
+
+---
+ example/crfutils.py | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/example/crfutils.py b/example/crfutils.py
+index b6fe26eb..2aae0015 100755
+--- a/example/crfutils.py
++++ b/example/crfutils.py
+@@ -1,3 +1,5 @@
++#!/usr/bin/env python
++
+ """
+ A miscellaneous utility for sequential labeling.
+ Copyright 2010,2011 Naoaki Okazaki.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
