### PR TITLE
bump py3-jupyter-events to 0.8.0

### DIFF
--- a/py3-jupyter-events.yaml
+++ b/py3-jupyter-events.yaml
@@ -1,8 +1,8 @@
 # Generated from https://pypi.org/project/jupyter-events/
 package:
   name: py3-jupyter-events
-  version: 0.7.0
-  epoch: 1
+  version: 0.8.0
+  epoch: 0
   description: Jupyter Event System library
   copyright:
     - license: 'BSD 3-Clause License'
@@ -30,8 +30,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 7be27f54b8388c03eefea123a4f79247c5b9381c49fb1cd48615ee191eb12615
-      uri: https://files.pythonhosted.org/packages/3f/0a/1c839290324ab93dc79950eaf26e198578db8b27edb587082b6061f4f9f5/jupyter_events-${{package.version}}.tar.gz
+      expected-sha256: fda08f0defce5e16930542ce60634ba48e010830d50073c3dfd235759cee77bf
+      uri: https://files.pythonhosted.org/packages/bb/1c/4b886f1312ed13d248acbee26066db759473b3c3a24244bdc211914761eb/jupyter_events-${{package.version}}.tar.gz
 
   - name: Python Build
     uses: python/build-wheel


### PR DESCRIPTION
- bump py3-jupyter-events to 0.8.0

Fixes: https://github.com/wolfi-dev/os/issues/6847



### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->


#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0


