### PR TITLE
bump py3-hdfs to 2.7.3

### DIFF
--- a/py3-hdfs.yaml
+++ b/py3-hdfs.yaml
@@ -1,8 +1,8 @@
 # Generated from https://pypi.org/project/hdfs/
 package:
   name: py3-hdfs
-  version: 2.7.2
-  epoch: 1
+  version: 2.7.3
+  epoch: 0
   description: 'HdfsCLI: API and command line interface for HDFS.'
   copyright:
     - license: MIT
@@ -23,8 +23,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 829b659f4ed8f114923690f5b1aa51d295e590bb25eb59ffee00acc1ce493a93
-      uri: https://files.pythonhosted.org/packages/a8/9f/723bf4d4c92e85562430b21b096fb8baa87ff39cd5d784ddd17df2b0146f/hdfs-${{package.version}}.tar.gz
+      expected-sha256: 752a21e43f82197dce43697c73f454ba490838108c73a57a9247efb66d1c0479
+      uri: https://files.pythonhosted.org/packages/29/c7/1be559eb10cb7cac0d26373f18656c8037553619ddd4098e50b04ea8b4ab/hdfs-${{package.version}}.tar.gz
 
   - name: Python Build
     uses: python/build-wheel


### PR DESCRIPTION
- bump py3-hdfs to 2.7.3

Fixes: https://github.com/wolfi-dev/os/issues/6732

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->


#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

