### PR TITLE
bump conntrack-tools to 1.4.8

### DIFF
--- a/conntrack-tools.yaml
+++ b/conntrack-tools.yaml
@@ -1,6 +1,6 @@
 package:
   name: conntrack-tools
-  version: "1.4.7"
+  version: "1.4.8"
   epoch: 0
   description: Connection tracking userspace tools
   copyright:
@@ -25,8 +25,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://www.netfilter.org/projects/conntrack-tools/files/conntrack-tools-${{package.version}}.tar.bz2
-      expected-sha256: 099debcf57e81690ced57f516b493588a73518f48c14d656f823b29b4fc24b5d
+      uri: https://www.netfilter.org/projects/conntrack-tools/files/conntrack-tools-${{package.version}}.tar.xz
+      expected-sha256: 067677f4c5f6564819e78ed3a9d4a8980935ea9273f3abb22a420ea30ab5ded6
 
   - runs: |
       export CFLAGS="$CFLAGS -D_GNU_SOURCE $(pkgconf --cflags libtirpc)"


### PR DESCRIPTION
bump conntrack-tools to 1.4.8

Fixes: https://github.com/wolfi-dev/os/issues/6076

Related:

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

