### PR TITLE
update mozjs91 release monitor id

### DIFF
--- a/mozjs91.yaml
+++ b/mozjs91.yaml
@@ -87,4 +87,4 @@ subpackages:
 update:
   enabled: true
   release-monitor:
-    identifier: 235328
+    identifier: 369151

--- a/mozjs91.yaml
+++ b/mozjs91.yaml
@@ -1,7 +1,7 @@
 package:
   name: mozjs91
   version: 91.13.0
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: MPL-2.0
@@ -18,6 +18,7 @@ environment:
       - clang-15
       - llvm15
       - llvm-lld
+      - llvm15-tools
       - m4
       - erlang-dev
       - jemalloc-dev


### PR DESCRIPTION
- update mozjs91 release monitor id

looks like the release monitor id changed the new home is https://release-monitoring.org/project/369151/

Fixes: https://github.com/wolfi-dev/os/issues/5460
