### PR TITLE
Bump epoch on gops.yaml

### DIFF
--- a/gops.yaml
+++ b/gops.yaml
@@ -1,7 +1,7 @@
 package:
   name: gops
   version: 0.3.28
-  epoch: 1
+  epoch: 3
   description: gops is a command to list and diagnose Go processes currently running on your system.
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
This conflicts with another package at epoch 2, and this one should win.
