### PR TITLE
add openssh (with the client) to argocd-repo-server runtime deps

### DIFF
--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.7
   version: 2.7.14
-  epoch: 5
+  epoch: 6
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -81,7 +81,7 @@ subpackages:
         - tzdata
         - helm
         - kustomize
-        - openssh-server
+        - openssh
       provides:
         - argo-cd-repo-server=2.7.999
     pipeline:

--- a/argo-cd-2.8.yaml
+++ b/argo-cd-2.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.8
   version: 2.8.4
-  epoch: 4
+  epoch: 5
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -78,7 +78,7 @@ subpackages:
         - tzdata
         - helm
         - kustomize
-        - openssh-server
+        - openssh
       provides:
         - argo-cd-repo-server=2.8.999
     pipeline:


### PR DESCRIPTION
argocd's host checking requires shelling out to `ssh` 