### PR TITLE
re-enable wolfibot updates for vault-k8s

### DIFF
--- a/vault-k8s.yaml
+++ b/vault-k8s.yaml
@@ -1,6 +1,6 @@
 package:
   name: vault-k8s
-  version: 1.2.1
+  version: 1.2.1 # When updating, make sure to check that the license is still MPL!
   epoch: 8
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
@@ -39,4 +39,8 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false
+  enabled: true
+  github:
+    identifier: hashicorp/vault-k8s
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
Updates were disabled for this package in https://github.com/wolfi-dev/os/commit/afeab0d2f7e60781477361a29a2ec42888c5a578 ahead of Hashicorp moving repos to BUSL.

It looks like, for now at least, that the latest release v1.3.0 is still MPL: https://github.com/hashicorp/vault-k8s/blob/v1.3.0/LICENSE

