### PR TITLE
add temporalio/tctl package

### DIFF
--- a/tctl.yaml
+++ b/tctl.yaml
@@ -1,0 +1,37 @@
+package:
+  name: tctl
+  version: 1.18.0
+  epoch: 0
+  description: Temporal CLI
+  copyright:
+    - license: MIT License
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/temporalio/tctl
+      tag: v${{package.version}}
+      expected-commit: aed2d9e1cb8bba6f69d5463fa286eb0389149ee4
+      destination: tctl
+
+  - runs: |
+      cd tctl
+      make build
+      install -Dm755 tctl ${{targets.destdir}}/usr/bin/tctl
+      install -Dm755 tctl-authorization-plugin ${{targets.destdir}}/usr/bin/tctl-authorization-plugin
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: temporalio/tctl
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
tctl-1.18.0: new package
<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: https://github.com/chainguard-dev/image-requests/issues/484

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
