### PR TITLE
Add Falco

### DIFF
--- a/falco-rules.yaml
+++ b/falco-rules.yaml
@@ -1,0 +1,41 @@
+package:
+  name: falco-rules
+  version: 2.0.0
+  epoch: 0
+  description: Falco rule repository
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/falcosecurity/rules
+      tag: falco-rules-${{package.version}}
+      expected-commit: 97308654f2e43baca516f61d5b43c5cfc7eb6e10
+
+  - uses: patch
+    with:
+      patches: remove-broken-rule.patch
+
+  - runs: |
+      install -Dm755 ./rules/falco_rules.yaml "${{targets.destdir}}"/etc/falco/falco_rules.yaml
+
+  - uses: strip
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - falco-sandbox-rules-*
+    - falco-incubating-rules-*
+    - falco-deprecated-rules-*
+    - application-rules-*
+  github:
+    identifier: falcosecurity/rules
+    strip-prefix: falco-rules-

--- a/falco-rules/remove-broken-rule.patch
+++ b/falco-rules/remove-broken-rule.patch
@@ -1,0 +1,33 @@
+# This is a patch to disable the rule "Contact K8S API Server From Container" in the falco_rules.yaml file.
+# Otherwise, we get: "LOAD_ERR_COMPILE_CONDITION (Error compiling condition): filter_check called with nonexistent field k8s.pod.name" error.
+# TODO(Dentrax): Ask to maintainers to fix this issue.
+diff --git a/rules/falco_rules.yaml b/rules/falco_rules.yaml
+index 12ee70d..af10bce 100644
+--- a/rules/falco_rules.yaml
++++ b/rules/falco_rules.yaml
+@@ -820,25 +820,6 @@
+ - macro: user_known_contact_k8s_api_server_activities
+   condition: (never_true)
+ 
+-- rule: Contact K8S API Server From Container
+-  desc: >
+-    Detect attempts to communicate with the K8S API Server from a container by non-profiled users. Kubernetes APIs play a 
+-    pivotal role in configuring the cluster management lifecycle. Detecting potential unauthorized access to the API server 
+-    is of utmost importance. Audit your complete infrastructure and pinpoint any potential machines from which the API server 
+-    might be accessible based on your network layout. If Falco can't operate on all these machines, consider analyzing the 
+-    Kubernetes audit logs (typically drained from control nodes, and Falco offers a k8saudit plugin) as an additional data 
+-    source for detections within the control plane.
+-  condition: >
+-    evt.type=connect and evt.dir=< 
+-    and (fd.typechar=4 or fd.typechar=6) 
+-    and container 
+-    and k8s_api_server 
+-    and not k8s_containers 
+-    and not user_known_contact_k8s_api_server_activities
+-  output: Unexpected connection to K8s API Server from container (connection=%fd.name lport=%fd.lport rport=%fd.rport fd_type=%fd.type fd_proto=fd.l4proto evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags %container.info)
+-  priority: NOTICE
+-  tags: [maturity_stable, container, network, k8s, mitre_discovery, T1565]
+-
+ - rule: Netcat Remote Code Execution in Container
+   desc: > 
+     Netcat Program runs inside container that allows remote code execution and may be utilized 

--- a/falco.yaml
+++ b/falco.yaml
@@ -1,0 +1,108 @@
+package:
+  name: falco
+  version: 0.36.1
+  epoch: 0
+  description: Cloud Native Runtime Security
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - falco-rules
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang-16
+      - gcc
+      - cmake
+      - make
+      - git
+      - bash
+      - perl
+      - linux-headers
+      - autoconf
+      - automake
+      - m4
+      - libtool
+      - elfutils-dev
+      - libelf
+      - libelf-static
+      - patch
+      - binutils
+      - libbpf
+      - openssl
+      - openssl-dev
+      - yaml-dev
+      - c-ares
+      - c-ares-dev
+      - protobuf
+      - protobuf-dev
+      - protobuf-c-dev
+      - re2
+      - re2-dev
+      - zlib-dev
+      - libcurl-openssl4
+      - llvm16
+      - abseil-cpp
+      - abseil-cpp-dev
+      - abseillib
+      - jq-dev
+      - curl-dev
+      - grpc
+      - grpc-dev
+      - icu
+      - icu-dev
+      - yaml-cpp
+      - yaml-cpp-dev
+      - systemd-dev
+      - libsystemd
+      - libzstd1
+      - zstd
+      - zstd-dev
+      - libtbb-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/falcosecurity/falco
+      tag: ${{package.version}}
+      expected-commit: 9eb611609a2876a5f5a5378e0613f0ff767f0d42
+      recurse-submodules: true
+
+  - runs: |
+      # Replace the find_dependency with find_package macro for newer cmake, otherwise it will fail.
+      sed -i 's/find_dependency(Protobuf CONFIG)/find_package(Protobuf CONFIG)/' /usr/lib64/cmake/grpc/gRPCConfig.cmake
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/etc/falco
+      install -Dm755 ./falco.yaml "${{targets.destdir}}"/etc/falco/falco.yaml
+      sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < "${{targets.destdir}}"/etc/falco/falco.yaml
+
+  - working-directory: build
+    pipeline:
+      - runs: |
+          cmake \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+            -DFALCO_ETC_DIR=/etc/falco \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DUSE_BUNDLED_DEPS=Off \
+            -DMINIMAL_BUILD=On \
+            -DBUILD_DRIVER=On \
+            -DBUILD_FALCO_MODERN_BPF=Off \
+            -DBUILD_BPF=Off \
+          ..
+      - runs: |
+          make falco
+          install -Dm755 ./userspace/falco/falco "${{targets.destdir}}"/usr/bin/falco
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: falcosecurity/falco
+    strip-prefix: v


### PR DESCRIPTION
> **Note**
> **Before:** `973MB, 366 vulnerability`
> **After:** `6.6MB, 0-CVE`

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #4342

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
