### PR TITLE
pipenv: try to avoid vendoring certifi

### DIFF
--- a/py3-pipenv.yaml
+++ b/py3-pipenv.yaml
@@ -1,21 +1,30 @@
+# Generated from https://pypi.org/project/pipenv/
 package:
   name: py3-pipenv
   version: 2023.10.3
-  epoch: 1
-  description: "Pipenv is a Python virtualenv management tool that supports a multitude of systems and nicely bridges the gaps between pip, python (using system python, pyenv or asdf) and virtualenv."
+  epoch: 2
+  description: Python Development Workflow for Humans.
   copyright:
-    - license: MIT
+    - license: 'The MIT License (MIT)  Copyright 2020-2022 Python Packaging Authority  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. '
   dependencies:
     runtime:
-      - python3
+      - py3-certifi
+      - py3-setuptools
+      - py3-virtualenv
+      - python-3
 
 environment:
   contents:
     packages:
-      - busybox
       - ca-certificates-bundle
+      - wolfi-base
+      - busybox
       - build-base
+      - python-3
+      - py3-setuptools
       - py3-pip
+      - py3-certifi
+      - py3-virtualenv
 
 pipeline:
   - uses: git-checkout

--- a/py3-pipenv.yaml
+++ b/py3-pipenv.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 2
   description: Python Development Workflow for Humans.
   copyright:
-    - license: 'The MIT License (MIT)  Copyright 2020-2022 Python Packaging Authority  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. '
+    - license: MIT
   dependencies:
     runtime:
       - py3-certifi


### PR DESCRIPTION
However I'm not sure this works:

```
$ cat packages/aarch64/py3-pipenv-2023.10.3-r2.apk| tar -tvf - | grep certifi
drwxr-xr-x  0 root   root        0 Oct 14 17:26 usr/lib/python3.12/site-packages/pipenv/patched/pip/_vendor/certifi
-rw-r--r--  0 root   root     1052 Oct 14 17:26 usr/lib/python3.12/site-packages/pipenv/patched/pip/_vendor/certifi/LICENSE
-rw-r--r--  0 root   root       94 Oct 14 17:26 usr/lib/python3.12/site-packages/pipenv/patched/pip/_vendor/certifi/__init__.py
-rw-r--r--  0 root   root      270 Oct 14 17:26 usr/lib/python3.12/site-packages/pipenv/patched/pip/_vendor/certifi/__main__.py
drwxr-xr-x  0 root   root        0 Oct 14 17:26 usr/lib/python3.12/site-packages/pipenv/patched/pip/_vendor/certifi/__pycache__
-rw-r--r--  0 root   root      338 Oct 14 17:26 usr/lib/python3.12/site-packages/pipenv/patched/pip/_vendor/certifi/__pycache__/__init__.cpython-312.pyc
-rw-r--r--  0 root   root      680 Oct 14 17:26 usr/lib/python3.12/site-packages/pipenv/patched/pip/_vendor/certifi/__pycache__/__main__.cpython-312.pyc
-rw-r--r--  0 root   root     2886 Oct 14 17:26 usr/lib/python3.12/site-packages/pipenv/patched/pip/_vendor/certifi/__pycache__/core.cpython-312.pyc
-rw-r--r--  0 root   root   271898 Oct 14 17:26 usr/lib/python3.12/site-packages/pipenv/patched/pip/_vendor/certifi/cacert.pem
-rw-r--r--  0 root   root     4354 Oct 14 17:26 usr/lib/python3.12/site-packages/pipenv/patched/pip/_vendor/certifi/core.py
```