### PR TITLE
add tigera-operator 1.30 version stream

### DIFF
--- a/tigera-operator-1.30.yaml
+++ b/tigera-operator-1.30.yaml
@@ -7,7 +7,7 @@ package:
     - license: Apache-2.0
   dependencies:
     provides:
-      - tigera-operator=1.30.99
+      - tigera-operator=${{package.full-version}}
 
 environment:
   contents:

--- a/tigera-operator-1.30.yaml
+++ b/tigera-operator-1.30.yaml
@@ -1,10 +1,13 @@
 package:
-  name: tigera-operator
-  version: 1.31.2
-  epoch: 1
+  name: tigera-operator-1.30
+  version: 1.30.7
+  epoch: 0
   description: Kubernetes operator for installing Calico and Calico Enterprise
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - tigera-operator=1.30.99
 
 environment:
   contents:
@@ -20,7 +23,7 @@ pipeline:
     with:
       repository: https://github.com/tigera/operator
       tag: v${{package.version}}
-      expected-commit: 4e45a51a6fecddd3badaf7383784b6e209cc5210
+      expected-commit: 8cbb161896a4ca641f885e668528cdb52de83f84
 
   - runs: |
       PACKAGE_NAME=github.com/tigera/operator
@@ -50,4 +53,4 @@ update:
     identifier: tigera/operator
     use-tag: true
     strip-prefix: v
-    tag-filter: v
+    tag-filter: v1.30

--- a/tigera-operator-1.31.yaml
+++ b/tigera-operator-1.31.yaml
@@ -1,0 +1,56 @@
+package:
+  name: tigera-operator-1.31
+  version: 1.31.2
+  epoch: 2
+  description: Kubernetes operator for installing Calico and Calico Enterprise
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - tigera-operator=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - go
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tigera/operator
+      tag: v${{package.version}}
+      expected-commit: 4e45a51a6fecddd3badaf7383784b6e209cc5210
+
+  - runs: |
+      PACKAGE_NAME=github.com/tigera/operator
+      ARCH=$(go env GOARCH)
+      BINDIR=build/_output/bin
+      GIT_VERSION=$(git describe --tags --dirty --always --abbrev=12)
+      if [ "${ARCH}" = "amd64" ]; then
+        CGO_ENABLED=1
+        GOEXPERIMENT=boringcrypto
+        TAGS="osusergo,netgo"
+      else
+        CGO_ENABLED=0
+      fi
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
+      echo "Building operator for ${ARCH} with CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=${GOEXPERIMENT} TAGS=${TAGS}"
+      GOEXPERIMENT=${GOEXPERIMENT} GO111MODULE=on CGO_ENABLED=${CGO_ENABLED} go build -buildvcs=false -v -o ${BINDIR}/operator-${ARCH} -tags "${TAGS}" -ldflags "-X ${PACKAGE_NAME}/version.VERSION=${GIT_VERSION} -w" ./main.go
+      install -Dm755 build/_output/bin/operator-$(go env GOARCH) "${{targets.destdir}}"/usr/bin/operator
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: tigera/operator
+    use-tag: true
+    strip-prefix: v
+    tag-filter: v1.31.


### PR DESCRIPTION
no official version compatibility matrix I can find, but upstream appears to be actively pushing to the 1.28, 1.29, 1.30, and 1.31 streams