### PR TITLE
bump wolfictl to pick up: https://github.com/chainguard-dev/melange/pull/754

### DIFF
--- a/.github/workflows/wolfictl-check-update.yaml
+++ b/.github/workflows/wolfictl-check-update.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Check
       id: check
       if: ${{ steps.files.outputs.all_changed_files != '' }}
-      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:e367609d116f9bdc9f17f66c9d366cb0d19ad0d8d6701a8a875aa18d870a06b7
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:55b941de34632d049fb426b021dcf3280ac6b8c3c11ae58b5108667c1635aec2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/wolfictl-lint.yaml
+++ b/.github/workflows/wolfictl-lint.yaml
@@ -19,13 +19,13 @@ jobs:
     - uses: actions/checkout@v3
     - name: Lint
       id: lint
-      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:e367609d116f9bdc9f17f66c9d366cb0d19ad0d8d6701a8a875aa18d870a06b7
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:55b941de34632d049fb426b021dcf3280ac6b8c3c11ae58b5108667c1635aec2
       with:
         entrypoint: wolfictl
         args: lint --skip-rule no-makefile-entry-for-package
     - name: Enforce YAML formatting
       id: lint-yaml
-      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:e367609d116f9bdc9f17f66c9d366cb0d19ad0d8d6701a8a875aa18d870a06b7
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:55b941de34632d049fb426b021dcf3280ac6b8c3c11ae58b5108667c1635aec2
       with:
         entrypoint: wolfictl
         args: lint yam

--- a/.github/workflows/wolfictl-update-gh.yaml
+++ b/.github/workflows/wolfictl-update-gh.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:e367609d116f9bdc9f17f66c9d366cb0d19ad0d8d6701a8a875aa18d870a06b7
+    - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:55b941de34632d049fb426b021dcf3280ac6b8c3c11ae58b5108667c1635aec2
       with:
         entrypoint: wolfictl
         args: update https://github.com/${{github.repository}} --release-monitoring-query=false --github-labels request-version-update --github-labels "automated pr"

--- a/.github/workflows/wolfictl-update-rm.yaml
+++ b/.github/workflows/wolfictl-update-rm.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:e367609d116f9bdc9f17f66c9d366cb0d19ad0d8d6701a8a875aa18d870a06b7
+    - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:55b941de34632d049fb426b021dcf3280ac6b8c3c11ae58b5108667c1635aec2
       with:
         entrypoint: wolfictl
         args: update https://github.com/${{github.repository}} --github-release-query=false --github-labels request-version-update --github-labels "automated pr"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
