### PR TITLE
Drop `kube-logging-operator` `tag-prefix`.

### DIFF
--- a/kube-logging-operator.yaml
+++ b/kube-logging-operator.yaml
@@ -44,5 +44,3 @@ update:
   enabled: true
   github:
     identifier: kube-logging/logging-operator
-    tag-filter: 4.2
-    use-tag: true


### PR DESCRIPTION
This is up to `4.4.0` and we've been missing updated because of the tag-prefix.

This doesn't do the bump, it JUST allows the automation to bump things, so I expect wolfictl lint to fail.