### PR TITLE
Refactor php-8.1,php-8.2 for serviceability, split docs.

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: 8.1.24
-  epoch: 2
+  epoch: 3
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -9,6 +9,7 @@ package:
     provides:
       - php=${{package.full-version}}
     runtime:
+      - ${{package.name}}-config
       - libxml2
 
 environment:
@@ -53,7 +54,7 @@ pipeline:
 
   - name: Prepare Build Folder
     runs: |
-      mv php-${{package.version}}.tar.gz $HOME/
+      mv php-${{package.version}}.tar.gz $HOME
       tar zxf $HOME/php-${{package.version}}.tar.gz
 
   - name: Configure
@@ -130,14 +131,9 @@ pipeline:
     runs: |
       cd $HOME/php-${{package.version}}
       INSTALL_ROOT=${{targets.destdir}} DESTDIR=${{targets.destdir}} make install
+      mkdir -p "${{targets.destdir}}/bin" && ln -s /usr/bin/php "${{targets.destdir}}/bin/php"
 
   - uses: strip
-
-  - name: Copy configuration and set up alias on /bin
-    runs: |
-      mkdir -p "${{targets.destdir}}/etc/php/conf.d"
-      mv $HOME/php-${{package.version}}/php.ini-production ${{targets.destdir}}/etc/php/php.ini
-      mkdir -p "${{targets.destdir}}/bin" && ln -s /usr/bin/php "${{targets.destdir}}/bin/php"
 
 data:
   - name: extensions
@@ -182,19 +178,40 @@ data:
       odbc: UnixODBC
 
 subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-${{range.key}}-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          mv $HOME/php-${{package.version}}/php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
+
   - range: extensions
     name: "${{package.name}}-${{range.key}}"
     description: "The ${{range.value}} extension"
     dependencies:
+      runtime:
+        - "${{package.name}}-${{range.key}}-config"
       provides:
         - php-${{range.key}}=${{package.full-version}}
     pipeline:
       - runs: |
           export EXTENSIONS_DIR=usr/lib/php/modules
-          export CONF_DIR="${{targets.subpkgdir}}/etc/php/conf.d"
-          mkdir -p "${{targets.subpkgdir}}"/$EXTENSIONS_DIR $CONF_DIR
+          mkdir -p "${{targets.subpkgdir}}"/$EXTENSIONS_DIR
           mv "${{targets.destdir}}/$EXTENSIONS_DIR/${{range.key}}.so" \
             "${{targets.subpkgdir}}/$EXTENSIONS_DIR/${{range.key}}.so"
+
+  - range: extensions
+    name: "${{package.name}}-${{range.key}}-config"
+    description: "The ${{range.value}} extension configuration"
+    dependencies:
+      provides:
+        - php-${{range.key}}-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          export CONF_DIR="${{targets.subpkgdir}}/etc/php/conf.d"
+          mkdir -p $CONF_DIR
           prefix=
           [ "${{range.key}}" != "opcache" ] || prefix="zend_"
           echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"${{range.key}}.ini"
@@ -211,7 +228,15 @@ subpackages:
           mv ${{targets.destdir}}/usr/bin/phpize ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/lib ${{targets.subpkgdir}}/usr
 
-  - name: ${{package.name}}-cgi
+  - name: ${{package.name}}-doc
+    description: PHP 8.1 documentation
+    dependencies:
+      provides:
+        - php-doc=${{package.full-version}}
+    pipeline:
+      - uses: split/manpages
+
+  - name: "${{package.name}}-cgi"
     description: PHP 8.1 CGI
     dependencies:
       provides:
@@ -221,7 +246,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/php-cgi ${{targets.subpkgdir}}/usr/bin/
 
-  - name: ${{package.name}}-dbg
+  - name: "${{package.name}}-dbg"
     description: Interactive PHP Debugger
     dependencies:
       provides:
@@ -231,31 +256,42 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/phpdbg ${{targets.subpkgdir}}/usr/bin/
 
-  - name: ${{package.name}}-fpm
+  - name: "${{package.name}}-fpm"
     description: PHP 8.1 FastCGI Process Manager (FPM)
     dependencies:
+      runtime:
+        - "${{package.name}}-fpm-config"
       provides:
         - php-fpm=${{package.full-version}}
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/sbin ${{targets.subpkgdir}}/etc/php/php-fpm.d
+          mkdir -p ${{targets.subpkgdir}}/usr/sbin
           mv ${{targets.destdir}}/usr/sbin/php-fpm ${{targets.subpkgdir}}/usr/sbin/
+
+  - name: ${{package.name}}-fpm-config
+    description: PHP 8.1 FastCGI Process Manager (FPM) configuration
+    dependencies:
+      provides:
+        - php-fpm-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc/php/php-fpm.d
           mv ${{targets.destdir}}/etc/php/php-fpm.conf.default ${{targets.subpkgdir}}/etc/php/php-fpm.conf
           mv ${{targets.destdir}}/etc/php/php-fpm.d/www.conf.default ${{targets.subpkgdir}}/etc/php/php-fpm.d/www.conf \
           && { \
-          	echo '[global]'; \
-          	echo 'error_log = /proc/self/fd/2'; \
+            echo '[global]'; \
+            echo 'error_log = /proc/self/fd/2'; \
             echo 'daemonize = no'; \
-          	echo; \
-          	echo '[www]'; \
+            echo; \
+            echo '[www]'; \
             echo 'listen = [::]:9000'; \
-          	echo 'access.log = /proc/self/fd/2'; \
+            echo 'access.log = /proc/self/fd/2'; \
             echo; \
-          	echo 'clear_env = no'; \
-          	echo; \
-          	echo 'catch_workers_output = yes'; \
+            echo 'clear_env = no'; \
             echo; \
-          	echo 'decorate_workers_output = no'; \
+            echo 'catch_workers_output = yes'; \
+            echo; \
+            echo 'decorate_workers_output = no'; \
           } | tee ${{targets.subpkgdir}}/etc/php/php-fpm.d/zz-apko.conf
 
 update:

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: 8.2.11
-  epoch: 2
+  epoch: 3
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -9,6 +9,7 @@ package:
     provides:
       - php=${{package.full-version}}
     runtime:
+      - ${{package.name}}-config
       - libxml2
 
 environment:
@@ -53,7 +54,7 @@ pipeline:
 
   - name: Prepare Build Folder
     runs: |
-      mv php-${{package.version}}.tar.gz $HOME/
+      mv php-${{package.version}}.tar.gz $HOME
       tar zxf $HOME/php-${{package.version}}.tar.gz
 
   - name: Configure
@@ -130,14 +131,9 @@ pipeline:
     runs: |
       cd $HOME/php-${{package.version}}
       INSTALL_ROOT=${{targets.destdir}} DESTDIR=${{targets.destdir}} make install
+      mkdir -p "${{targets.destdir}}/bin" && ln -s /usr/bin/php "${{targets.destdir}}/bin/php"
 
   - uses: strip
-
-  - name: Copy configuration and set up alias on /bin
-    runs: |
-      mkdir -p "${{targets.destdir}}/etc/php/conf.d"
-      mv $HOME/php-${{package.version}}/php.ini-production ${{targets.destdir}}/etc/php/php.ini
-      mkdir -p "${{targets.destdir}}/bin" && ln -s /usr/bin/php "${{targets.destdir}}/bin/php"
 
 data:
   - name: extensions
@@ -182,19 +178,40 @@ data:
       odbc: UnixODBC
 
 subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-${{range.key}}-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          mv $HOME/php-${{package.version}}/php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
+
   - range: extensions
     name: "${{package.name}}-${{range.key}}"
     description: "The ${{range.value}} extension"
     dependencies:
+      runtime:
+        - "${{package.name}}-${{range.key}}-config"
       provides:
         - php-${{range.key}}=${{package.full-version}}
     pipeline:
       - runs: |
           export EXTENSIONS_DIR=usr/lib/php/modules
-          export CONF_DIR="${{targets.subpkgdir}}/etc/php/conf.d"
-          mkdir -p "${{targets.subpkgdir}}"/$EXTENSIONS_DIR $CONF_DIR
+          mkdir -p "${{targets.subpkgdir}}"/$EXTENSIONS_DIR
           mv "${{targets.destdir}}/$EXTENSIONS_DIR/${{range.key}}.so" \
             "${{targets.subpkgdir}}/$EXTENSIONS_DIR/${{range.key}}.so"
+
+  - range: extensions
+    name: "${{package.name}}-${{range.key}}-config"
+    description: "The ${{range.value}} extension configuration"
+    dependencies:
+      provides:
+        - php-${{range.key}}-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          export CONF_DIR="${{targets.subpkgdir}}/etc/php/conf.d"
+          mkdir -p $CONF_DIR
           prefix=
           [ "${{range.key}}" != "opcache" ] || prefix="zend_"
           echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"${{range.key}}.ini"
@@ -211,7 +228,15 @@ subpackages:
           mv ${{targets.destdir}}/usr/bin/phpize ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/lib ${{targets.subpkgdir}}/usr
 
-  - name: ${{package.name}}-cgi
+  - name: ${{package.name}}-doc
+    description: PHP 8.2 documentation
+    dependencies:
+      provides:
+        - php-doc=${{package.full-version}}
+    pipeline:
+      - uses: split/manpages
+
+  - name: "${{package.name}}-cgi"
     description: PHP 8.2 CGI
     dependencies:
       provides:
@@ -221,7 +246,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/php-cgi ${{targets.subpkgdir}}/usr/bin/
 
-  - name: ${{package.name}}-dbg
+  - name: "${{package.name}}-dbg"
     description: Interactive PHP Debugger
     dependencies:
       provides:
@@ -231,31 +256,42 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/phpdbg ${{targets.subpkgdir}}/usr/bin/
 
-  - name: ${{package.name}}-fpm
+  - name: "${{package.name}}-fpm"
     description: PHP 8.2 FastCGI Process Manager (FPM)
     dependencies:
+      runtime:
+        - "${{package.name}}-fpm-config"
       provides:
         - php-fpm=${{package.full-version}}
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/sbin ${{targets.subpkgdir}}/etc/php/php-fpm.d
+          mkdir -p ${{targets.subpkgdir}}/usr/sbin
           mv ${{targets.destdir}}/usr/sbin/php-fpm ${{targets.subpkgdir}}/usr/sbin/
+
+  - name: ${{package.name}}-fpm-config
+    description: PHP 8.2 FastCGI Process Manager (FPM) configuration
+    dependencies:
+      provides:
+        - php-fpm-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc/php/php-fpm.d
           mv ${{targets.destdir}}/etc/php/php-fpm.conf.default ${{targets.subpkgdir}}/etc/php/php-fpm.conf
           mv ${{targets.destdir}}/etc/php/php-fpm.d/www.conf.default ${{targets.subpkgdir}}/etc/php/php-fpm.d/www.conf \
           && { \
-          	echo '[global]'; \
-          	echo 'error_log = /proc/self/fd/2'; \
+            echo '[global]'; \
+            echo 'error_log = /proc/self/fd/2'; \
             echo 'daemonize = no'; \
-          	echo; \
-          	echo '[www]'; \
+            echo; \
+            echo '[www]'; \
             echo 'listen = [::]:9000'; \
-          	echo 'access.log = /proc/self/fd/2'; \
+            echo 'access.log = /proc/self/fd/2'; \
             echo; \
-          	echo 'clear_env = no'; \
-          	echo; \
-          	echo 'catch_workers_output = yes'; \
+            echo 'clear_env = no'; \
             echo; \
-          	echo 'decorate_workers_output = no'; \
+            echo 'catch_workers_output = yes'; \
+            echo; \
+            echo 'decorate_workers_output = no'; \
           } | tee ${{targets.subpkgdir}}/etc/php/php-fpm.d/zz-apko.conf
 
 update:


### PR DESCRIPTION
Similar to: #6705 refactor the existing php to be more serviceable, and split the docs into their own sub package.

https://wiki.inky.wtf/docs/teams/engineering/images/package-and-image-guides/serviceable-packages/

Each subpackage extension that was for example php-8.1 is now split into php-8.1 and php-8.1-config.


```
34c74983078b:/work/packages# apk add php-8.1
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/8) Installing xz (5.4.4-r0)
(2/8) Installing libxml2 (2.11.5-r1)
(3/8) Installing php-8.1-config (8.1.24-r3)
(4/8) Installing ncurses-terminfo-base (6.4_p20230722-r1)
(5/8) Installing ncurses (6.4_p20230722-r1)
(6/8) Installing readline (8.2-r2)
(7/8) Installing sqlite (3.40.0-r1)
(8/8) Installing php-8.1 (8.1.24-r3)
OK: 31 MiB in 22 packages
34c74983078b:/work/packages# apk info -L php-8.1 php-8.1-config
php-8.1-8.1.24-r3 contains:
bin/php
usr/bin/phar
usr/bin/phar.phar
usr/bin/php
usr/share/php/fpm/status.html
var/lib/db/sbom/php-8.1-8.1.24-r3.spdx.json

php-8.1-config-8.1.24-r3 contains:
etc/php/php.ini
var/lib/db/sbom/php-8.1-config-8.1.24-r3.spdx.json

34c74983078b:/work/packages# apk add php-8.1-soap
(1/2) Installing php-8.1-soap-config (8.1.24-r3)
(2/2) Installing php-8.1-soap (8.1.24-r3)
OK: 32 MiB in 24 packages
34c74983078b:/work/packages# apk info -L php-8.1-soap php-8.1-config
php-8.1-config-8.1.24-r3 contains:
etc/php/php.ini
var/lib/db/sbom/php-8.1-config-8.1.24-r3.spdx.json

php-8.1-soap-8.1.24-r3 contains:
usr/lib/php/modules/soap.so
var/lib/db/sbom/php-8.1-soap-8.1.24-r3.spdx.json

```

```
f56e9d6b1bbf:/work/packages# apk add php-8.2
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/8) Installing xz (5.4.4-r0)
(2/8) Installing libxml2 (2.11.5-r1)
(3/8) Installing php-8.2-config (8.2.11-r3)
(4/8) Installing ncurses-terminfo-base (6.4_p20230722-r1)
(5/8) Installing ncurses (6.4_p20230722-r1)
(6/8) Installing readline (8.2-r2)
(7/8) Installing sqlite (3.40.0-r1)
(8/8) Installing php-8.2 (8.2.11-r3)
OK: 32 MiB in 22 packages
f56e9d6b1bbf:/work/packages# apk info -L php-8.2 php-8.2-config
php-8.2-8.2.11-r3 contains:
bin/php
usr/bin/phar
usr/bin/phar.phar
usr/bin/php
usr/share/php/fpm/status.html
var/lib/db/sbom/php-8.2-8.2.11-r3.spdx.json

php-8.2-config-8.2.11-r3 contains:
etc/php/php.ini
var/lib/db/sbom/php-8.2-config-8.2.11-r3.spdx.json

f56e9d6b1bbf:/work/packages# apk add php-8.2-soap
(1/2) Installing php-8.2-soap-config (8.2.11-r3)
(2/2) Installing php-8.2-soap (8.2.11-r3)
OK: 32 MiB in 24 packages
f56e9d6b1bbf:/work/packages# apk info -L php-8.2-soap php-8.2-soap-config
php-8.2-soap-8.2.11-r3 contains:
usr/lib/php/modules/soap.so
var/lib/db/sbom/php-8.2-soap-8.2.11-r3.spdx.json

php-8.2-soap-config-8.2.11-r3 contains:
etc/php/conf.d/soap.ini
var/lib/db/sbom/php-8.2-soap-config-8.2.11-r3.spdx.json
```

I also loaded some other modules, including zend_ modules to ensure, and then ran `php -m` and `php -ini` to make sure the modules / zend_modules are sorted correctly.