### PR TITLE
Bitnami compat package for prometheus-elasticsearch-exporter

### DIFF
--- a/prometheus-elasticsearch-exporter.yaml
+++ b/prometheus-elasticsearch-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-elasticsearch-exporter
   version: 1.6.0
-  epoch: 6
+  epoch: 7
   description: Elasticsearch stats exporter for Prometheus
   copyright:
     - license: Apache-2.0
@@ -26,15 +26,26 @@ pipeline:
   - runs: |
       # Handle CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
-
-      go get golang.org/x/sys@v0.8.0
       go mod tidy
+
       make common-build
 
   - runs: |
       install -Dm755 elasticsearch_exporter "${{targets.destdir}}"/usr/bin/elasticsearch_exporter
 
   - uses: strip
+
+subpackages:
+  - name: prometheus-elasticsearch-exporter-bitnami-compat
+    description: "compat package with bitnami/elasticsearch-exporter image"
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: elasticsearch-exporter
+          version-path: 1/debian-11
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/elasticsearch-exporter/bin
+          ln -s /usr/bin/elasticsearch_exporter ${{targets.contextdir}}/opt/bitnami/elasticsearch-exporter/bin/elasticsearch_exporter
 
 update:
   enabled: true


### PR DESCRIPTION
Adds the `bitnami-compat` package for elasticsearch-exporter. This change also fixes 3 CVEs. Before:

```
wolfictl scan =(curl -sL https://packages.wolfi.dev/os/x86_64/prometheus-elasticsearch-exporter-1.6.0-r6.apk)
Will process: zshlraGEN
└── 📄 /usr/bin/elasticsearch_exporter
        📦 golang.org/x/net v0.10.0 (go-module)
            Medium CVE-2023-3978 GHSA-2wrh-6pvc-2jm9 fixed in 0.13.0
            Medium CVE-2023-39325 GHSA-4374-p667-p6c8 fixed in 0.17.0
            Medium CVE-2023-44487 GHSA-qppj-fm5r-hxr3 fixed in 0.17.0
```

After:

```
wolfictl scan packages/aarch64/prometheus-elasticsearch-exporter-bitnami-compat-1.6.0-r7.apk
Will process: prometheus-elasticsearch-exporter-bitnami-compat-1.6.0-r7.apk
✅ No vulnerabilities found
```

Advisory PR:  https://github.com/wolfi-dev/advisories/pull/361