### PR TITLE
gitlab: add gitlab-cng-base as subpackage of gitlab-cng

### DIFF
--- a/gitlab-cng.yaml
+++ b/gitlab-cng.yaml
@@ -7,7 +7,7 @@ package:
   # The release-monitor identified is for the gitlab-runner,
   # but these seem to be co-versioned.
   version: 16.4.1
-  epoch: 0
+  epoch: 1
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -28,7 +28,6 @@ data:
   # Used to create all of the *-scripts subpackages from the CNG repo.
   - name: scripts
     items:
-      base: ./gitlab-base
       cfssl-self-sign: ./cfssl-self-sign
       container-registry: ./gitlab-container-registry
       exporter: ./gitlab-exporter
@@ -53,6 +52,25 @@ subpackages:
             mkdir -p ${{targets.subpkgdir}}/$(dirname $x)
             cp -r $x ${{targets.subpkgdir}}/$x
           done
+
+  - name: "${{package.name}}-base"
+    pipeline:
+      - runs: |
+          cd ./gitlab-base
+          for x in $(find scripts/ -type f); do
+            mkdir -p ${{targets.subpkgdir}}/$(dirname $x)
+            cp -r $x ${{targets.subpkgdir}}/$x
+          done
+    dependencies:
+      runtime:
+        - bash
+        - busybox
+        - ca-certificates-bundle
+        - curl
+        - gitlab-logger
+        - gomplate
+        - procps
+        - xtail
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

We need to create a gitlab-base subpackage that contains few dependencies and some scripts from the original git checkout from cng.

Related: 
 https://github.com/chainguard-dev/image-requests/issues/457

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new version streams
<!-- remove if unrelated -->
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)

