### PR TITLE
gitlab: add gitlab-pages

### DIFF
--- a/gitlab-pages.yaml
+++ b/gitlab-pages.yaml
@@ -1,0 +1,42 @@
+package:
+  name: gitlab-pages
+  # The release-monitor identified is for the gitlab-runner,
+  # but these seem to be co-versioned.
+  version: 16.4.1
+  epoch: 0
+  description: GitLab Pages daemon used to serve static websites for GitLab users.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-pages-scripts
+
+environment:
+  contents:
+    packages:
+      - go
+      - gitlab-cng-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/gitlab-pages.git
+      tag: v${{package.version}}
+      expected-commit: a0250d92d0458183a53b7411653276cd0c09daf0
+
+  - runs: make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
+
+      mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
+      mkdir -p ${{targets.destdir}}/var/log/gitlab
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 11337

--- a/gitlab-pages.yaml
+++ b/gitlab-pages.yaml
@@ -1,4 +1,5 @@
-package:
+# Source is on gitlab so we can't use github for updates
+#nolint:git-checkout-must-use-github-updates
   name: gitlab-pages
   # The release-monitor identified is for the gitlab-runner,
   # but these seem to be co-versioned.

--- a/gitlab-pages.yaml
+++ b/gitlab-pages.yaml
@@ -1,5 +1,6 @@
 # Source is on gitlab so we can't use github for updates
 #nolint:git-checkout-must-use-github-updates
+package:
   name: gitlab-pages
   # The release-monitor identified is for the gitlab-runner,
   # but these seem to be co-versioned.
@@ -16,8 +17,8 @@
 environment:
   contents:
     packages:
-      - go
       - gitlab-cng-base
+      - go
 
 pipeline:
   - uses: git-checkout
@@ -31,7 +32,6 @@ pipeline:
   - runs: |
       mkdir -p ${{targets.destdir}}/bin
       install -m +x ./bin/gitlab-pages ${{targets.destdir}}/bin/gitlab-pages
-
       mkdir -p ${{targets.destdir}}/srv/gitlab-pages/
       mkdir -p ${{targets.destdir}}/var/log/gitlab
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Adding support for gitlab-pages which uses gitlab-cng-base packages.

Related: 
https://gitlab.com/gitlab-org/gitlab-pages

https://github.com/chainguard-dev/image-requests/issues/462

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)



#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

