### PR TITLE
gitlab-shell: add missing runtime deps

### DIFF
--- a/gitlab-shell.yaml
+++ b/gitlab-shell.yaml
@@ -5,10 +5,14 @@
 package:
   name: gitlab-shell
   version: 14.29.0
-  epoch: 0
+  epoch: 1
   description: SSH access for GitLab
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      - gitlab-cng-base
+      - gitlab-cng-shell-scripts
 
 environment:
   contents:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: 

When deploying a gitlab-shell image using the gitlab helm chart and re-using our shell package, I saw that we had some missing runtime dependencies. 
Generally the gitlab-shell image runs reusing the gitlab-base scripts + the gitlab-shell specific scripts that we already generate as an independent package.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->


