### PR TITLE
ci: add check for vulnerability scanning

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -125,3 +125,58 @@ jobs:
         with:
           filePath: diff.log
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Upload built packages to GitHub artifacts'
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            ./packages/${{ matrix.arch }}
+            ./packages.log
+          name: packages-${{ matrix.arch }}
+          retention-days: 1
+          if-no-files-found: warn
+
+  scan:
+    name: "Scan packages for CVEs"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:24f764649829f811cde1fe914431a2b949a0a9a69a317fb7eb31ca165df914fa
+    needs: build
+    steps:
+
+      - name: 'Retrieve x86_64 packages'
+        uses: actions/download-artifact@v3
+        with:
+          name: packages-x86_64
+          path: /tmp/artifacts-1/
+
+      - name: 'Retrieve aarch64 packages'
+        uses: actions/download-artifact@v3
+        with:
+          name: packages-aarch64
+          path: /tmp/artifacts-2/
+
+      - name: 'Collect packages from all architectures into one place'
+        run: |
+          cd /tmp/artifacts-1
+
+          # Put the packages into one place
+          mv /tmp/artifacts-2/packages/* ./packages/
+
+          # Merge the build log ("packages.log") files
+          cat /tmp/artifacts-2/packages.log >> ./packages.log
+
+      - name: 'Retrieve Wolfi advisory data'
+        uses: actions/checkout@v4
+        with:
+          repository: 'wolfi-dev/advisories'
+          path: 'data/wolfi-advisories'
+
+      - name: Scan for CVEs
+        run: |
+          wolfictl scan \
+            --build-log \
+            --advisories-repo-dir 'data/wolfi-advisories' \
+            --advisory-filter 'all' \
+            --require-zero \
+            /tmp/artifacts-1

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -142,8 +142,9 @@ jobs:
     container:
       image: ghcr.io/wolfi-dev/sdk:latest@sha256:24f764649829f811cde1fe914431a2b949a0a9a69a317fb7eb31ca165df914fa
     needs: build
-    steps:
+    if: needs.build.outputs.exists == 'true'
 
+    steps:
       - name: 'Retrieve x86_64 packages'
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This PR adds a new CI check — intended to be non-blocking for now, and required later — to scan packages we build in CI for vulnerabilities.

The new check uses `wolfictl scan` to scan packages listed in the build logs from both our aarch64 and x84_64 builds.

Vulnerabilities that have **any kind of representation in the Wolfi advisory data** are filtered out from the scan results, and thus don't impact the pass/failure result on the CI check. The advisory data is cloned on each run from https://github.com/wolfi-dev/advisories (`main` branch).

🔮  More docs to follow on how to get this check to pass! For now, it's a simple early warning light. It gives a heads up to folks creating/updating packages that you may want to scan the package you're working on before more CVEs crop up downstream.

Example failed run in CI:

<img width="1294" alt="image" src="https://github.com/wolfi-dev/os/assets/5199289/1a5c46f1-78ff-401c-b11d-3544806f52a2">
