### PR TITLE
xmlstarlet package

### DIFF
--- a/xmlstarlet.yaml
+++ b/xmlstarlet.yaml
@@ -1,0 +1,44 @@
+package:
+  name: xmlstarlet
+  version: 1.6.1
+  epoch: 0
+  description: A set of tools to transform, query, validate, and edit XML documents
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - ghostscript
+      - libxml2-dev
+      - libxslt-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 4228df812caec7059d7a76986c4d9a4262bd861cc53dca05f341ae6c062be05f1c39fc637918ab00f60f40587c6c556e3c9bfaf8a18b149e3c321a92214dbe8b
+      uri: https://sourceforge.net/projects/xmlstar/files/xmlstarlet/${{package.version}}/xmlstarlet-${{package.version}}.tar.gz/download
+
+  - runs: |
+      LIBXSLT_PREFIX=/usr \
+      LIBXML_PREFIX=/usr \
+      ./configure \
+      		--prefix=/usr \
+      		--enable-build-docs
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/usr/share/licenses/xmlstarlet
+      make DESTDIR="${{targets.destdir}}" install
+      ln -s xml "${{targets.destdir}}"/usr/bin/xmlstarlet
+      install -Dm0644 Copyright "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/COPYING
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5201


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
