### PR TITLE
conftest: new package for atlantis image

### DIFF
--- a/conftest.yaml
+++ b/conftest.yaml
@@ -1,0 +1,34 @@
+package:
+  name: conftest
+  version: 0.46.0
+  epoch: 0
+  description: Write tests against structured configuration data using the Open Policy Agent Rego query language
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - cue
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/open-policy-agent/conftest
+      tag: v${{package.version}}
+      expected-commit: 79220b5b2de5fb851aaaacebb2568353251432cb
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: .
+      output: conftest
+      ldflags: -w -s -X github.com/open-policy-agent/conftest/internal/commands.version=${{package.version}}
+      # CVE-2023-39325 and CVE-2023-44487
+      deps: golang.org/x/net@v0.17.0
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: open-policy-agent/conftest
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/chainguard-dev/image-requests/issues/481

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

2 CVEs are fixed: CVE-2023-39325 and CVE-2023-44487

```
wolfictl scan packages/aarch64/conftest-0.46.0-r0.apk     
Will process: conftest-0.46.0-r0.apk
✅ No vulnerabilities found
```