### PR TITLE
Remove unnecessary runtime dependencies from bitnami subpackage

### DIFF
--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus
   version: 2.47.2
-  epoch: 1
+  epoch: 2
   description: The Prometheus monitoring system and time series database.
   copyright:
     - license: Apache-2.0
@@ -83,9 +83,6 @@ pipeline:
 subpackages:
   - name: ${{package.name}}-bitnami-compat
     description: "compat package with bitnami/prometheus image"
-    dependencies:
-      runtime:
-        - prometheus
     pipeline:
       - uses: bitnami/compat
         with:


### PR DESCRIPTION
I think this is making the image larger than it needs to be.