### PR TITLE
cilium: add compat package (symlinks to startup scripts)

### DIFF
--- a/cilium.yaml
+++ b/cilium.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium
   version: 1.14.3
-  epoch: 0
+  epoch: 1
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -48,6 +48,28 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: ${{package.name}}-container-init
+    description: init scripts for cilium
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          cp images/cilium/init-container.sh \
+             plugins/cilium-cni/install-plugin.sh \
+             plugins/cilium-cni/cni-uninstall.sh \
+            ${{targets.subpkgdir}}/usr/bin
+
+  - name: ${{package.name}}-container-init-compat
+    description: init scripts for cilium
+    dependencies:
+      runtime:
+        - ${{package.name}}-container-init
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}
+          ln -sf /usr/bin/init-container.sh ${{targets.subpkgdir}}/init-container.sh
+          ln -sf /usr/bin/install-plugin.sh ${{targets.subpkgdir}}/install-plugin.sh
+          ln -sf /usr/bin/cni-uninstall.sh ${{targets.subpkgdir}}/cni-uninstall.sh
+
   - name: ${{package.name}}-iptables
     description: iptables compatibility package for cilium
     dependencies:


### PR DESCRIPTION
* "cilium: add compat package with symlink to startup scripts"

(both the Helm chart and the operator expect these to be in the root directory)