### PR TITLE
New package pyarrow 14.0.0

### DIFF
--- a/pyarrow.yaml
+++ b/pyarrow.yaml
@@ -1,0 +1,93 @@
+package:
+  name: pyarrow
+  version: 14.0.0
+  description: "Apache Arrow Python bindings"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - cython
+      - numpy
+      - py3-setuptools
+      - py3-pip
+      - python3-dev
+      - python3
+      - openssl-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/arrow.git
+      tag: apache-arrow-${{package.version}}
+      expected-commit: 7a814d1de2d8f81642a5e6a795e3d716ec4981b7
+
+  - name: Setup sub module
+    runs: |
+      git submodule update --init
+
+  - name: Setup py3 build env
+    runs: |
+      python3 -m venv pyarrow-dev
+      source ./pyarrow-dev/bin/activate
+      pip install -r python/requirements-build.txt
+
+  - name: Build
+    runs: |
+      export PARQUET_TEST_DATA="${PWD}/cpp/submodules/parquet-testing/data"
+      export ARROW_TEST_DATA="${PWD}/testing/data"
+      export ARROW_HOME=$(pwd)/dist
+      export LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH
+      export CMAKE_PREFIX_PATH=$ARROW_HOME:$CMAKE_PREFIX_PATH
+
+      mkdir cpp/build
+      cd cpp/build
+      cmake -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
+              -DCMAKE_INSTALL_LIBDIR=lib \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DARROW_BUILD_TESTS=ON \
+              -DARROW_COMPUTE=ON \
+              -DARROW_CSV=ON \
+              -DARROW_DATASET=ON \
+              -DARROW_FILESYSTEM=ON \
+              -DARROW_HDFS=ON \
+              -DARROW_JSON=ON \
+              -DARROW_PARQUET=ON \
+              -DARROW_WITH_BROTLI=ON \
+              -DARROW_WITH_BZ2=ON \
+              -DARROW_WITH_LZ4=ON \
+              -DARROW_WITH_SNAPPY=ON \
+              -DARROW_WITH_ZLIB=ON \
+              -DARROW_WITH_ZSTD=ON \
+              -DPARQUET_REQUIRE_ENCRYPTION=ON \
+              ..
+      make -j4
+      make install
+      cd ../../..
+
+  - name: Build python
+    runs: |
+      export PARQUET_TEST_DATA="${PWD}/cpp/submodules/parquet-testing/data"
+      export ARROW_TEST_DATA="${PWD}/testing/data"
+      export ARROW_HOME=$(pwd)/dist
+      export LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH
+      export CMAKE_PREFIX_PATH=$ARROW_HOME:$CMAKE_PREFIX_PATH
+
+      cd python
+      export PYARROW_WITH_PARQUET=1
+      export PYARROW_WITH_DATASET=1
+      export PYARROW_PARALLEL=4
+      python setup.py build_ext --inplace
+      cd ..
+      mkdir -p ${{targets.destdir}}/usr/lib/python3.12/site-packages
+      cp -R python/pyarrow ${{targets.destdir}}/usr/lib/python3.12/site-packages
+
+  - name: check
+    runs: |
+      cd python
+      find .

--- a/pyarrow.yaml
+++ b/pyarrow.yaml
@@ -1,9 +1,7 @@
 package:
   name: pyarrow
-  epoch: 1
-  # TODO(vaikas): Should this be 14.0.0?
+  epoch: 0
   version: 14.0.0
-  #version: 13.0.0
   description: "Apache Arrow Python bindings"
   copyright:
     - license: Apache-2.0
@@ -26,45 +24,21 @@ environment:
 
 pipeline:
   - uses: git-checkout
+    working-directory: /home/build/apache-arrow
     with:
       repository: https://github.com/apache/arrow.git
       tag: apache-arrow-${{package.version}}
-      # 14.0.0
-      expected-commit: 7a814d1de2d8f81642a5e6a795e3d716ec4981b7
-      # 13.0.0
-      #expected-commit: b7d2f7ffca66c868bd2fce5b3749c6caa002a7f0
-
-  - name: Setup sub module
-    runs: |
-      git submodule update --init
-
-  - name: Setup py3 build env
-    runs: |
-      python3 -m venv pyarrow-dev
-      source ./pyarrow-dev/bin/activate
-      pip install -r python/requirements-build.txt
+      expected-commit: 2dcee3f82c6cf54b53a64729fd81840efa583244
 
   - name: Build python
+    working-directory: /home/build/apache-arrow/python
     runs: |
-      export PARQUET_TEST_DATA="${PWD}/cpp/submodules/parquet-testing/data"
-      export ARROW_TEST_DATA="${PWD}/testing/data"
-      export ARROW_HOME=$(pwd)/dist
-      export LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH
-      export CMAKE_PREFIX_PATH=$ARROW_HOME:$CMAKE_PREFIX_PATH
-
-      cd python
-      export PYARROW_WITH_PARQUET=1
-      export PYARROW_WITH_DATASET=1
       export PYARROW_PARALLEL=4
-      python setup.py build_ext --inplace
-      cd ..
+      python setup.py build_ext --inplace \
+        --with-acero \
+        --with-parquet
       mkdir -p ${{targets.destdir}}/usr/lib/python3.12/site-packages
-      cp -R python/pyarrow ${{targets.destdir}}/usr/lib/python3.12/site-packages
-
-  - name: check
-    runs: |
-      cd python
-      find .
+      cp -R pyarrow ${{targets.destdir}}/usr/lib/python3.12/site-packages
 
 update:
   enabled: true

--- a/pyarrow.yaml
+++ b/pyarrow.yaml
@@ -42,8 +42,12 @@ pipeline:
 
 update:
   enabled: true
+  # There are some other things like js-* that break our update block.
+  ignore-regex-patterns:
+    - 'js-'
   github:
+    use-tag: true
     identifier: apache/arrow
     strip-prefix: apache-arrow-
-    use-tag: true
+    strip-suffix: .dev
     tag-filter: apache-arrow-

--- a/pyarrow.yaml
+++ b/pyarrow.yaml
@@ -1,6 +1,9 @@
 package:
   name: pyarrow
+  epoch: 1
+  # TODO(vaikas): Should this be 14.0.0?
   version: 14.0.0
+  #version: 13.0.0
   description: "Apache Arrow Python bindings"
   copyright:
     - license: Apache-2.0
@@ -8,24 +11,28 @@ package:
 environment:
   contents:
     packages:
+      - apache-arrow-dev
       - build-base
       - busybox
       - ca-certificates-bundle
       - cmake
       - cython
       - numpy
-      - py3-setuptools
-      - py3-pip
-      - python3-dev
-      - python3
       - openssl-dev
+      - py3-pip
+      - py3-setuptools
+      - python3
+      - python3-dev
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/apache/arrow.git
       tag: apache-arrow-${{package.version}}
+      # 14.0.0
       expected-commit: 7a814d1de2d8f81642a5e6a795e3d716ec4981b7
+      # 13.0.0
+      #expected-commit: b7d2f7ffca66c868bd2fce5b3749c6caa002a7f0
 
   - name: Setup sub module
     runs: |
@@ -36,39 +43,6 @@ pipeline:
       python3 -m venv pyarrow-dev
       source ./pyarrow-dev/bin/activate
       pip install -r python/requirements-build.txt
-
-  - name: Build
-    runs: |
-      export PARQUET_TEST_DATA="${PWD}/cpp/submodules/parquet-testing/data"
-      export ARROW_TEST_DATA="${PWD}/testing/data"
-      export ARROW_HOME=$(pwd)/dist
-      export LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH
-      export CMAKE_PREFIX_PATH=$ARROW_HOME:$CMAKE_PREFIX_PATH
-
-      mkdir cpp/build
-      cd cpp/build
-      cmake -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
-              -DCMAKE_INSTALL_LIBDIR=lib \
-              -DCMAKE_BUILD_TYPE=Debug \
-              -DARROW_BUILD_TESTS=ON \
-              -DARROW_COMPUTE=ON \
-              -DARROW_CSV=ON \
-              -DARROW_DATASET=ON \
-              -DARROW_FILESYSTEM=ON \
-              -DARROW_HDFS=ON \
-              -DARROW_JSON=ON \
-              -DARROW_PARQUET=ON \
-              -DARROW_WITH_BROTLI=ON \
-              -DARROW_WITH_BZ2=ON \
-              -DARROW_WITH_LZ4=ON \
-              -DARROW_WITH_SNAPPY=ON \
-              -DARROW_WITH_ZLIB=ON \
-              -DARROW_WITH_ZSTD=ON \
-              -DPARQUET_REQUIRE_ENCRYPTION=ON \
-              ..
-      make -j4
-      make install
-      cd ../../..
 
   - name: Build python
     runs: |
@@ -91,3 +65,11 @@ pipeline:
     runs: |
       cd python
       find .
+
+update:
+  enabled: true
+  github:
+    identifier: apache/arrow
+    strip-prefix: apache-arrow-
+    use-tag: true
+    tag-filter: apache-arrow-


### PR DESCRIPTION
This is blocked on better testing on #7089 and the subsequent withdrawals, but testing locally by explicitly adding 'thrift' and this:

```
apk add thrift
apk add python3-12
apk add pyarrow
```

```
7b7954b37baf:/work/packages# python3.12
Python 3.12.0 (main, Oct 12 2023, 17:58:08) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyarrow.parquet as pq
>>> pq.
pq.ColumnChunkMetaData(       pq.ParquetDataset(            pq.ParquetPartitions()        pq.RowGroupMetaData(          pq.read_pandas(               pq.write_to_dataset(
pq.ColumnSchema(              pq.ParquetDatasetPiece(       pq.ParquetReader(             pq.Statistics(                pq.read_schema(
pq.FileDecryptionProperties(  pq.ParquetFile(               pq.ParquetSchema(             pq.core                       pq.read_table(
pq.FileEncryptionProperties(  pq.ParquetLogicalType(        pq.ParquetWriter(             pq.filters_to_expression(     pq.write_metadata(
pq.FileMetaData(              pq.ParquetManifest(           pq.PartitionSet(              pq.read_metadata(             pq.write_table(
```

```
vaikas@vaikas-MBP os % wolfictl scan packages/aarch64/pyarrow-14.0.0-r5.apk
🔎 Scanning "packages/aarch64/pyarrow-14.0.0-r5.apk"
✅ No vulnerabilities found
```


Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
