### PR TITLE
ensure bitnami redis compat has coreutils for liveness checks

### DIFF
--- a/pipelines/bitnami/compat.yaml
+++ b/pipelines/bitnami/compat.yaml
@@ -23,6 +23,8 @@ pipeline:
       destination: bitnami
   - runs: |
       mkdir -p ${{targets.contextdir}}
+      mkdir -p "${{targets.contextdir}}"/opt/bitnami
+      mkdir -p "${{targets.contextdir}}"/bitnami/${{inputs.image}}
 
       if [ -d "./bitnami/bitnami/${{inputs.image}}/${{inputs.version-path}}/prebuildfs" ]; then
         cp -rf ./bitnami/bitnami/${{inputs.image}}/${{inputs.version-path}}/prebuildfs/* ${{targets.contextdir}}/
@@ -31,3 +33,5 @@ pipeline:
       if [ -d "./bitnami/bitnami/${{inputs.image}}/${{inputs.version-path}}/rootfs" ]; then
         cp -rf ./bitnami/bitnami/${{inputs.image}}/${{inputs.version-path}}/rootfs/* ${{targets.contextdir}}/
       fi
+
+      chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami

--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis-7.2
   version: 7.2.2
-  epoch: 0
+  epoch: 1
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
@@ -73,8 +73,10 @@ subpackages:
         # Required by startup scripts
         - busybox
         - bash
+        - coreutils
         - openssl
         - redis-cli
+        - wait-for-port
     pipeline:
       - uses: bitnami/compat
         with:
@@ -95,8 +97,10 @@ subpackages:
         # Required by startup scripts
         - busybox
         - bash
+        - coreutils
         - openssl
         - redis-cli
+        - wait-for-port
     pipeline:
       - uses: bitnami/compat
         with:
@@ -115,8 +119,10 @@ subpackages:
         # Required by startup scripts
         - busybox
         - bash
+        - coreutils
         - openssl
         - redis-cli
+        - wait-for-port
     pipeline:
       - uses: bitnami/compat
         with:


### PR DESCRIPTION
the debian flavor of `timeout` used by the redis-bitnami liveness checks requires `coreutils` instead of our default `busybox`

also adding some niceties to the `bitnami/compat` subpipeline to ensure common directories are created

cc @jamonation 🙏 