### PR TITLE
rabbitmq-cluster-operator 2.5.0: new package

### DIFF
--- a/rabbitmq-cluster-operator.yaml
+++ b/rabbitmq-cluster-operator.yaml
@@ -1,0 +1,41 @@
+package:
+  name: rabbitmq-cluster-operator
+  version: 2.5.0
+  epoch: 0
+  description: Open source RabbitMQ cluster operator. Kubernetes operator to deploy and manage RabbitMQ clusters.
+  copyright:
+    - license: MPL-2.0
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+      - git
+      - go
+  environment:
+    CGO_ENABLED: 0
+    GO111MODULE: on
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rabbitmq/cluster-operator
+      tag: v${{package.version}}
+      expected-commit: 481710f801df2fb8e25d5b9dc370933d873ae04a
+
+  - uses: go/build
+    with:
+      packages: .
+      output: manager
+      tags: timetzdata
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      deps: golang.org/x/net@v0.17.0
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: rabbitmq/cluster-operator
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
