### PR TITLE
cilium: update llvm deps + fix cni install script

### DIFF
--- a/cilium.yaml
+++ b/cilium.yaml
@@ -42,6 +42,7 @@ pipeline:
   - uses: patch
     with:
       patches: loopback-location.patch
+
   - runs: |
       # Remove groupadd from Makefile: it's not doing anything useful in
       # a package build anyway, and it's not available in busybox.

--- a/cilium.yaml
+++ b/cilium.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium
   version: 1.14.3
-  epoch: 1
+  epoch: 2
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -14,7 +14,8 @@ package:
       - kmod
       # cilium does compilations at runtime on the node.
       - clang
-      - llvm16
+      - llvm15
+      - llvm15-tools
       - cni-plugins
 
 environment:
@@ -27,7 +28,8 @@ environment:
       - coreutils # for GNU install
       - grep
       - clang
-      - llvm16
+      - llvm15
+      - llvm15-tools
       - iptables # for cilium-iptables
 
 pipeline:
@@ -37,6 +39,9 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 252a99efbc5def73405f9382b343846edc11d1ca
 
+  - uses: patch
+    with:
+      patches: loopback-location.patch
   - runs: |
       # Remove groupadd from Makefile: it's not doing anything useful in
       # a package build anyway, and it's not available in busybox.

--- a/cilium/loopback-location.patch
+++ b/cilium/loopback-location.patch
@@ -1,0 +1,15 @@
+Update the loopback binary location to be /usr/bin
+
+diff --git a/plugins/cilium-cni/install-plugin.sh b/plugins/cilium-cni/install-plugin.sh
+index 90d2a38184..683705d548 100755
+--- a/plugins/cilium-cni/install-plugin.sh
++++ b/plugins/cilium-cni/install-plugin.sh
+@@ -19,7 +19,7 @@ if [ ! -f "${CNI_DIR}/bin/loopback" ]; then
+ 	echo "Installing loopback driver..."
+ 
+ 	# Don't fail hard if this fails as it is usually not required
+-	cp /cni/loopback "${CNI_DIR}/bin/" || true
++	cp /usr/bin/loopback "${CNI_DIR}/bin/" || true
+ fi
+ 
+ echo "Installing ${BIN_NAME} to ${CNI_DIR}/bin/ ..."


### PR DESCRIPTION
Current script assumes the location of the `cni-plugins` package's `loopback` binary to be at `/cni/loopback`. Fixing to `/usr/bin/loopback` to match the Wolfi package expectation.

Also, fix the runtime LLVM dep to be LLVM 15 to avoid having 2 LLVM versions in the runtime dependencies (since clang packs its own LLVM dep).