### PR TITLE
gitlab: CVE-2023-44487 and CVE-2023-39325

### DIFF
--- a/gitlab-pages.yaml
+++ b/gitlab-pages.yaml
@@ -5,7 +5,7 @@ package:
   # The release-monitor identified is for the gitlab-runner,
   # but these seem to be co-versioned.
   version: 16.4.1
-  epoch: 0
+  epoch: 1
   description: GitLab Pages daemon used to serve static websites for GitLab users.
   copyright:
     - license: MIT
@@ -27,7 +27,10 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: a0250d92d0458183a53b7411653276cd0c09daf0
 
-  - runs: make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
+  - runs: |
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+      make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
 
   - runs: |
       mkdir -p ${{targets.destdir}}/bin

--- a/gitlab-shell.yaml
+++ b/gitlab-shell.yaml
@@ -5,7 +5,7 @@
 package:
   name: gitlab-shell
   version: 14.29.0
-  epoch: 1
+  epoch: 2
   description: SSH access for GitLab
   copyright:
     - license: MIT
@@ -30,7 +30,10 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: e75606d0bda76669ec310694643088527a97c1d5
 
-  - runs: make build
+  - runs: |
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+      make build
 
   - runs: |
       BINDIR=${{targets.destdir}}/srv/gitlab-shell/bin


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

```
➜  wolfictl scan packages/aarch64/gitlab-pages-16.4.1-r0.apk
Will process: gitlab-pages-16.4.1-r0.apk
└── 📄 /bin/gitlab-pages
        📦 golang.org/x/net v0.10.0 (go-module)
            Medium CVE-2023-39325 GHSA-4374-p667-p6c8 fixed in 0.17.0
            Medium CVE-2023-44487 GHSA-qppj-fm5r-hxr3 fixed in 0.17.0

➜ wolfictl scan packages/aarch64/gitlab-pages-16.4.1-r1.apk
Will process: gitlab-pages-16.4.1-r1.apk
✅ No vulnerabilities found
```
Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
