### PR TITLE
Add sops package.

### DIFF
--- a/sops.yaml
+++ b/sops.yaml
@@ -1,0 +1,35 @@
+package:
+  name: sops
+  version: 3.8.1
+  epoch: 0
+  description: Simple and flexible tool for managing secrets
+  copyright:
+    - license: MPL-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/getsops/sops
+      tag: v${{package.version}}
+      expected-commit: b6d3c9700d88e0c9348f3ec7cd2f10ce4a4b3ee1
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/sops
+      output: sops
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: getsops/sops
+    strip-prefix: v


### PR DESCRIPTION

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
