### PR TITLE
caddy: CVE-2023-45142

### DIFF
--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: caddy
   version: 2.7.5
-  epoch: 0
+  epoch: 1
   description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
   copyright:
     - license: Apache-2.0
@@ -31,6 +31,7 @@ pipeline:
       packages: ./cmd/caddy
       output: caddy
       ldflags: -s -w
+      deps: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.19.0
 
   - uses: strip
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

```
 wolfictl scan packages/x86_64/caddy-2.7.5-r0.apk
Will process: caddy-2.7.5-r0.apk
└── 📄 /usr/bin/caddy
        📦 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0 (go-module)
            High CVE-2023-45142 GHSA-rcjv-mgp8-qvmr fixed in 0.44.0
            
  wolfictl scan packages/x86_64/caddy-2.7.5-r1.apk
Will process: caddy-2.7.5-r1.apk
✅ No vulnerabilities found
```
