### PR TITLE
rootlesskit-config-nonuser: add /etc/subgid file

### DIFF
--- a/rootlesskit.yaml
+++ b/rootlesskit.yaml
@@ -1,7 +1,7 @@
 package:
   name: rootlesskit
   version: 1.1.1
-  epoch: 1
+  epoch: 2
   description: RootlessKit is a Linux-native implementation of "fake root" using user_namespaces(7).
   copyright:
     - license: Apache-2.0
@@ -45,6 +45,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.destdir}}/etc
           echo "nonroot:100000:65536" > ${{targets.destdir}}/etc/subuid
+          echo "nonroot:100000:65536" > ${{targets.destdir}}/etc/subgid
 
 update:
   enabled: true


### PR DESCRIPTION

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Adding /etc/subuid wasn't sufficient. Adding subgid as well.

```
│ [rootlesskit:parent] error: failed to setup UID/GID map: failed to compute uid/gid map: open /etc/subgid: no such file or directory
```

Related: #7047 

### Pre-review Checklist
