### PR TITLE
gitlab: install deps to run the images

### DIFF
--- a/gitlab-logger.yaml
+++ b/gitlab-logger.yaml
@@ -23,11 +23,18 @@ pipeline:
       output: gitlab-logger
       ldflags: -w
 
-  - runs: |
-      mkdir -p "${{targets.destdir}}"/usr/local/bin
-      cp ${{targets.destdir}}/usr/bin/gitlab-logger "${{targets.destdir}}"/usr/local/bin/gitlab-logger
-
   - uses: strip
+
+subpackages:
+  - name: gitlab-logger-compat
+    dependencies:
+      runtime:
+        - gitlab-logger
+    pipeline:
+      - runs: |
+          # GitLab helm chart mostly hardcodes multiple executables path to /usr/local/bin/*
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
+          ln -s /usr/bin/gitlab-logger "${{targets.subpkgdir}}"/usr/local/bin/gitlab-logger
 
 update:
   enabled: false

--- a/gitlab-logger.yaml
+++ b/gitlab-logger.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitlab-logger
   version: 3.0.0
-  epoch: 1
+  epoch: 2
   description: GitLab Logger provides a means of wrapping non-structured log files within structure JSON.
   copyright:
     - license: MIT
@@ -22,6 +22,10 @@ pipeline:
       packages: ./cmd/gitlab-logger
       output: gitlab-logger
       ldflags: -w
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/local/bin
+      cp ${{targets.destdir}}/usr/bin/gitlab-logger "${{targets.destdir}}"/usr/local/bin/gitlab-logger
 
   - uses: strip
 

--- a/gitlab-shell.yaml
+++ b/gitlab-shell.yaml
@@ -14,6 +14,7 @@ package:
       - gitlab-cng-base
       - gitlab-cng-shell-scripts
       - openssh
+      - gitlab-logger-compat
 
 environment:
   contents:

--- a/gitlab-shell.yaml
+++ b/gitlab-shell.yaml
@@ -5,7 +5,7 @@
 package:
   name: gitlab-shell
   version: 14.29.0
-  epoch: 2
+  epoch: 3
   description: SSH access for GitLab
   copyright:
     - license: MIT
@@ -13,12 +13,13 @@ package:
     runtime:
       - gitlab-cng-base
       - gitlab-cng-shell-scripts
+      - openssh
 
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
       # To be able to compile gssapi library
       - heimdal-dev


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

gitlab-logger is expected to be installed under `/usr/local/bin`

gitlab-shell missed some runtime dependencies to run the image such as openssl.

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->
