### PR TITLE
ensure redis-bitnami compat packages have a default redis conf

### DIFF
--- a/redis-6.2.yaml
+++ b/redis-6.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis-6.2
   version: 6.2.14
-  epoch: 0
+  epoch: 1
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
@@ -83,6 +83,10 @@ subpackages:
           image: redis
           version-path: 6.2/debian-11
       - runs: |
+          # Bitnami startup scripts _require_ the redis-default.conf to exist
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc
+          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis/etc/redis-default.conf
+
           ln -s /opt/bitnami/scripts/redis/entrypoint.sh ${{targets.subpkgdir}}/entrypoint.sh
           ln -s /opt/bitnami/scripts/redis/run.sh ${{targets.subpkgdir}}/run.sh
 
@@ -105,6 +109,10 @@ subpackages:
         with:
           image: redis-sentinel
           version-path: 6.2/debian-11
+      - runs: |
+          # Bitnami startup scripts _require_ the redis-default.conf to exist
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis-sentinel/etc
+          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis-sentinel/etc/redis-default.conf
 
   # in bitnami, redis-cluster is redis-server paired with different startup to support cluster mode
   # keep this as a subpackage in redis to avoid confusion
@@ -125,6 +133,10 @@ subpackages:
         with:
           image: redis-cluster
           version-path: 6.2/debian-11
+      - runs: |
+          # Bitnami startup scripts _require_ the redis-default.conf to exist
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis-cluster/etc
+          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis-cluster/etc/redis-default.conf
 
 update:
   enabled: true

--- a/redis-7.0.yaml
+++ b/redis-7.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis-7.0
   version: 7.0.14
-  epoch: 0
+  epoch: 1
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
@@ -81,6 +81,10 @@ subpackages:
           image: redis
           version-path: 7.0/debian-11
       - runs: |
+          # Bitnami startup scripts _require_ the redis-default.conf to exist
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc
+          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis/etc/redis-default.conf
+
           ln -s /opt/bitnami/scripts/redis/entrypoint.sh ${{targets.subpkgdir}}/entrypoint.sh
           ln -s /opt/bitnami/scripts/redis/run.sh ${{targets.subpkgdir}}/run.sh
 
@@ -103,6 +107,10 @@ subpackages:
         with:
           image: redis-sentinel
           version-path: 7.0/debian-11
+      - runs: |
+          # Bitnami startup scripts _require_ the redis-default.conf to exist
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis-sentinel/etc
+          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis-sentinel/etc/redis-default.conf
 
   # in bitnami, redis-cluster is redis-server paired with different startup to support cluster mode
   # keep this as a subpackage in redis to avoid confusion
@@ -123,6 +131,10 @@ subpackages:
         with:
           image: redis-cluster
           version-path: 7.0/debian-11
+      - runs: |
+          # Bitnami startup scripts _require_ the redis-default.conf to exist
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis-cluster/etc
+          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis-cluster/etc/redis-default.conf
 
 update:
   enabled: true

--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis-7.2
   version: 7.2.2
-  epoch: 1
+  epoch: 2
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
@@ -21,6 +21,7 @@ environment:
       - ca-certificates-bundle
       - linux-headers
       - openssl-dev
+      - bash
 
 pipeline:
   - uses: fetch
@@ -83,6 +84,10 @@ subpackages:
           image: redis
           version-path: 7.2/debian-11
       - runs: |
+          # Bitnami startup scripts _require_ the redis-default.conf to exist
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc
+          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis/etc/redis-default.conf
+
           ln -s /opt/bitnami/scripts/redis/entrypoint.sh ${{targets.subpkgdir}}/entrypoint.sh
           ln -s /opt/bitnami/scripts/redis/run.sh ${{targets.subpkgdir}}/run.sh
 
@@ -106,6 +111,10 @@ subpackages:
         with:
           image: redis-sentinel
           version-path: 7.2/debian-11
+      - runs: |
+          # Bitnami startup scripts _require_ the redis-default.conf to exist
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis-sentinel/etc
+          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis-sentinel/etc/redis-default.conf
 
   # in bitnami, redis-cluster is redis-server paired with different startup to support cluster mode
   # keep this as a subpackage in redis to avoid confusion
@@ -128,6 +137,10 @@ subpackages:
         with:
           image: redis-cluster
           version-path: 7.2/debian-11
+      - runs: |
+          # Bitnami startup scripts _require_ the redis-default.conf to exist
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis-cluster/etc
+          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis-cluster/etc/redis-default.conf
 
 update:
   enabled: true


### PR DESCRIPTION
when starting up without the helm chart, the startup scripts require these to exist. in the helm deployment they are mounted in so we don't always notice this