### PR TITLE
Bump cilium-envoy epoch to build CVE fixes

### DIFF
--- a/cilium-envoy.yaml
+++ b/cilium-envoy.yaml
@@ -3,7 +3,7 @@ package:
   # cilium/proxy is refered by the build in cilium/cilium using
   # digest. the project itself does not have any tag nor release.
   version: "1.25_git20230823"
-  epoch: 0
+  epoch: 1
   description: Envoy proxy for Cilium with minimal Envoy extensions and Cilium policy enforcement filters.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Missed in https://github.com/wolfi-dev/os/pull/6922 