### PR TITLE
atlantis: add terraform as a runtime dep, CVE fixes

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,10 +1,13 @@
 package:
   name: atlantis
   version: 0.26.0
-  epoch: 2
+  epoch: 3
   description: Terraform Pull Request Automation
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - terraform
 
 environment:
   contents:
@@ -29,6 +32,8 @@ pipeline:
       packages: .
       output: atlantis
       ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      # CVE-2023-39325 and CVE-2023-44487
+      deps: golang.org/x/net@v0.17.0
 
   - uses: strip
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/chainguard-dev/image-requests/issues/481

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

https://github.com/wolfi-dev/advisories/pull/371