### PR TITLE
new package bmake

### DIFF
--- a/bmake.yaml
+++ b/bmake.yaml
@@ -1,0 +1,39 @@
+package:
+  name: bmake
+  version: "20230909"
+  epoch: 0
+  description: Portable version of the NetBSD make build tool
+  copyright:
+    - license: BSD-2-Clause
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - tzdata
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 1e5e6c76540dfe8104426cd7fd3f715cc6404f9039c9203447012b8f2f6b7b86
+      uri: http://www.crufty.net/ftp/pub/sjg/bmake-${{package.version}}.tar.gz
+      strip-components: 0
+
+  - runs: |
+      ./bmake/boot-strap \
+        --prefix=/usr \
+        --install-destdir=${{targets.destdir}} \
+        --install
+
+subpackages:
+  - name: bmake-doc
+    pipeline:
+      - uses: split/manpages
+    description: bmake manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 208


### PR DESCRIPTION
#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

