### PR TITLE
Add falco v0.36.1 supporting --no-driver and modern-bpf

### DIFF
--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -1,0 +1,111 @@
+package:
+  name: falco-no-driver
+  version: 0.36.1
+  epoch: 0
+  description: Cloud Native Runtime Security
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - falco-rules
+
+environment:
+  contents:
+    packages:
+      - abseil-cpp
+      - abseil-cpp-dev
+      - abseillib
+      - autoconf
+      - automake
+      - bash
+      - binutils
+      - bpftool
+      - build-base
+      - busybox
+      - c-ares
+      - c-ares-dev
+      - ca-certificates-bundle
+      - clang-16
+      - clang-16-dev
+      - cmake
+      - curl-dev
+      - elfutils-dev
+      - gcc
+      - git
+      - grpc
+      - grpc-dev
+      - icu
+      - icu-dev
+      - jq-dev
+      - libbpf
+      - libbpf-dev
+      - libcurl-openssl4
+      - libelf
+      - libelf-static
+      - libsystemd
+      - libtbb-dev
+      - libtool
+      - libzstd1
+      - linux-headers
+      - llvm16
+      - m4
+      - make
+      - openssl
+      - openssl-dev
+      - patch
+      - perl
+      - protobuf
+      - protobuf-c-dev
+      - protobuf-dev
+      - re2
+      - re2-dev
+      - systemd-dev
+      - yaml-cpp
+      - yaml-cpp-dev
+      - yaml-dev
+      - zlib-dev
+      - zstd
+      - zstd-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/falcosecurity/falco
+      tag: ${{package.version}}
+      expected-commit: 9eb611609a2876a5f5a5378e0613f0ff767f0d42
+      recurse-submodules: true
+
+  - runs: |
+      # Replace the find_dependency with find_package macro for newer cmake, otherwise it will fail.
+      sed -i 's/find_dependency(Protobuf CONFIG)/find_package(Protobuf CONFIG)/' /usr/lib64/cmake/grpc/gRPCConfig.cmake
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/etc/falco
+      install -Dm755 ./falco.yaml "${{targets.destdir}}"/etc/falco/falco.yaml
+      sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < "${{targets.destdir}}"/etc/falco/falco.yaml
+
+  - working-directory: build
+    pipeline:
+      - runs: |
+          cmake \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+            -DFALCO_ETC_DIR=/etc/falco \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DUSE_BUNDLED_DEPS=Off \
+            -DMINIMAL_BUILD=On \
+            -DBUILD_DRIVER=On \
+            -DBUILD_LIBSCAP_MODERN_BPF=Off \
+            -DBUILD_BPF=Off \
+          ..
+      - runs: |
+          make falco
+          install -Dm755 ./userspace/falco/falco "${{targets.destdir}}"/usr/bin/falco
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: falcosecurity/falco
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
