### PR TITLE
Add py3-sacrebleu

### DIFF
--- a/py3-sacrebleu.yaml
+++ b/py3-sacrebleu.yaml
@@ -1,0 +1,49 @@
+package:
+  name: py3-sacrebleu
+  version: 2.3.0
+  epoch: 0
+  description: Reference BLEU implementation that auto-downloads test sets and reports a version string to facilitate cross-lab comparisons
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - py3-portalocker
+      - py3-regex
+      - py3-tabulate
+      - numpy
+      - py3-colorama
+      - py3-lxml
+      - python3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/mjpost/sacrebleu
+      expected-commit: 5166cf77b880ddd6d677f9243bcc4b4cb233cc90
+      tag: v${{package.version}}
+
+  - runs: |
+      # get_long_description() does not work as expected with 'python/build-wheel' since
+      # it couldn't find the `CHANGELOG.md` in the current directory. So disable this NIT func.
+      sed -i -e '/long_description=get_long_description(),/d' setup.py
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: mjpost/sacrebleu
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
