### PR TITLE
fix: keda CVE-2023-39325 and CVE-2023-44487

### DIFF
--- a/keda-2.10.yaml
+++ b/keda-2.10.yaml
@@ -4,7 +4,7 @@ package:
   name: keda-2.10
   # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
   version: 2.10.1
-  epoch: 3
+  epoch: 4
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,19 @@ pipeline:
       expected-commit: 8adb70e97a08a4690613eef4c4f00391e44e1603
 
   - runs: |
+      # CVE-2023-45142
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.44.0
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.19.0
+      go get go.opentelemetry.io/otel/metric@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v0.42.0
+      # CVE-2023-39325
+      go mod edit -dropreplace=golang.org/x/net
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+      go mod vendor
+      go clean -cache -modcache
       ARCH=$(go env GOARCH) make build
       mkdir -p "${{targets.destdir}}/usr/bin"
       mv bin/keda "${{targets.destdir}}/usr/bin"

--- a/keda-2.11.yaml
+++ b/keda-2.11.yaml
@@ -4,7 +4,7 @@ package:
   name: keda-2.11
   # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
   version: 2.11.2
-  epoch: 6
+  epoch: 7
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -17,10 +17,10 @@ package:
 environment:
   contents:
     packages:
+      - build-base
+      - busybox
       - ca-certificates-bundle
       - go
-      - busybox
-      - build-base
       - protobuf-dev
       - protoc
 
@@ -32,6 +32,19 @@ pipeline:
       expected-commit: 517ed30cc311b0b81e39112cff0fa8e3251aed69
 
   - runs: |
+      # CVE-2023-45142
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.44.0
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.19.0
+      go get go.opentelemetry.io/otel/metric@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v0.42.0
+      # CVE-2023-39325
+      go mod edit -dropreplace=golang.org/x/net
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+      go mod vendor
+      go clean -cache -modcache
       ARCH=$(go env GOARCH) make build
       mkdir -p "${{targets.destdir}}/usr/bin"
       mv bin/keda "${{targets.destdir}}/usr/bin"

--- a/keda.yaml
+++ b/keda.yaml
@@ -2,7 +2,7 @@ package:
   name: keda
   # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
   version: 2.12.0
-  epoch: 2
+  epoch: 3
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,10 @@ pipeline:
       expected-commit: 9527a7f1f2797aa5662b2b45b1d26acf22a0cd09
 
   - runs: |
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+      go mod vendor
+      go clean -cache -modcache
       ARCH=$(go env GOARCH) make build
       mkdir -p "${{targets.destdir}}/usr/bin"
       mv bin/keda "${{targets.destdir}}/usr/bin"

--- a/keda.yaml
+++ b/keda.yaml
@@ -15,10 +15,10 @@ package:
 environment:
   contents:
     packages:
+      - build-base
+      - busybox
       - ca-certificates-bundle
       - go
-      - busybox
-      - build-base
       - protobuf-dev
       - protoc
 
@@ -30,6 +30,12 @@ pipeline:
       expected-commit: 9527a7f1f2797aa5662b2b45b1d26acf22a0cd09
 
   - runs: |
+      # CVE-2023-45142
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v0.42.0
+      # CVE-2023-39325
       go get golang.org/x/net@v0.17.0
       go mod tidy
       go mod vendor


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

```
➜  wolfictl scan  packages/aarch64/keda-2.12.0-r3.apk
Will process: keda-2.12.0-r10.apk
✅ No vulnerabilities found

➜   wolfictl scan  packages/aarch64/keda-2.12.0-r2.apk
Will process: keda-2.12.0-r2.apk
└── 📄 /usr/bin/keda
        📦 golang.org/x/net v0.15.0 (go-module)
            Medium CVE-2023-39325 GHSA-4374-p667-p6c8 fixed in 0.17.0
            Medium CVE-2023-44487 GHSA-qppj-fm5r-hxr3 fixed in 0.17.0
```

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
