### PR TITLE
rebuild mercurial to compile with latest python version

### DIFF
--- a/mercurial.yaml
+++ b/mercurial.yaml
@@ -1,7 +1,7 @@
 package:
   name: mercurial
   version: 6.5.2
-  epoch: 0
+  epoch: 1
   description: "Scalable distributed SCM tool"
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
Fixes:

`mercurial` package depends on `python3` (now is *python-3.12*), but last build of mercurial was with *python-3.11*.

 ````console
536ecbe15883:/work# hg
abort: couldn't find mercurial libraries in [/usr/bin /usr/lib/python312.zip /usr/lib/python3.12 /usr/lib/python3.12/lib-dynload /usr/lib/python3.12/site-packages]
(check your install and PYTHONPATH)
````

`mercurial` libs are on `/usr/lib/python3.11/site-packages/mercurial`

- [x] This PR is marked as fixing a pre-existing package request bug