### PR TITLE
add coreutils dependencies for redis-{7.0,6.2}

### DIFF
--- a/redis-6.2.yaml
+++ b/redis-6.2.yaml
@@ -73,6 +73,7 @@ subpackages:
         # Required by startup scripts
         - busybox
         - bash
+        - coreutils
         - openssl
         - redis-cli-6.2
       provides:
@@ -100,6 +101,7 @@ subpackages:
         # Required by startup scripts
         - busybox
         - bash
+        - coreutils
         - openssl
         - redis-cli-6.2
       provides:
@@ -124,6 +126,7 @@ subpackages:
         # Required by startup scripts
         - busybox
         - bash
+        - coreutils
         - openssl
         - redis-cli-6.2
       provides:

--- a/redis-7.0.yaml
+++ b/redis-7.0.yaml
@@ -71,6 +71,7 @@ subpackages:
         # Required by startup scripts
         - busybox
         - bash
+        - coreutils
         - openssl
         - redis-cli-7.0
       provides:
@@ -98,6 +99,7 @@ subpackages:
         # Required by startup scripts
         - busybox
         - bash
+        - coreutils
         - openssl
         - redis-cli-7.0
       provides:
@@ -122,6 +124,7 @@ subpackages:
         # Required by startup scripts
         - busybox
         - bash
+        - coreutils
         - openssl
         - redis-cli-7.0
       provides:


### PR DESCRIPTION
Missed these from #7079 