### PR TITLE
typescript: fix broken binary symlinks.

### DIFF
--- a/typescript.yaml
+++ b/typescript.yaml
@@ -31,8 +31,8 @@ pipeline:
       mkdir -p "${{targets.destdir}}"/usr/lib/node_modules/typescript
       mkdir -p "${{targets.destdir}}"/usr/bin
       mv lib/* "${{targets.destdir}}"/usr/lib/node_modules/typescript
-      ln -sf bin/tsc "${{targets.destdir}}"/usr/bin/tsc
-      ln -sf bin/tsserver "${{targets.destdir}}"/usr/bin/tsserver
+      mv bin/tsc "${{targets.destdir}}"/usr/bin/tsc
+      mv bin/tsserver "${{targets.destdir}}"/usr/bin/tsserver
 
 update:
   enabled: true


### PR DESCRIPTION

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Previously, this creates a broken symlink that looks like:

ℹ️  aarch64   | lrwxrwxrwx    1 root     root             7 Oct 20 18:29 /usr/bin/tsc -> bin/tsc

i.e. /usr/bin/tsc -> /usr/bin/bin/tsc, which doesn't exist.

This changes the symlink to a mv so we're properly moving the binary over to destdir.

Fixes:

Related:

### Pre-review Checklist

