### PR TITLE
py3-versioneer for python 3.12

### DIFF
--- a/py3-versioneer.yaml
+++ b/py3-versioneer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-versioneer
   version: "0.29"
-  epoch: 0
+  epoch: 1
   description: Easy VCS-based management of project version strings
   copyright:
     - license: 'Unlicense'
@@ -12,14 +12,14 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - wolfi-base
-      - busybox
       - build-base
-      - python-3
-      - py3-wheel
+      - busybox
+      - ca-certificates-bundle
       - py3-gpep517
       - py3-setuptools
+      - py3-wheel
+      - python-3
+      - wolfi-base
 
 pipeline:
   - uses: fetch


### PR DESCRIPTION
```
89faa954393f:/work/packages# apk info -L py3-versioneer
py3-versioneer-0.29-r1 contains:
usr/bin/versioneer
usr/lib/python3.12/site-packages/versioneer.py
usr/lib/python3.12/site-packages/__pycache__/versioneer.cpython-312.opt-1.pyc
usr/lib/python3.12/site-packages/__pycache__/versioneer.cpython-312.pyc
usr/lib/python3.12/site-packages/versioneer-0.29.dist-info/LICENSE
usr/lib/python3.12/site-packages/versioneer-0.29.dist-info/METADATA
usr/lib/python3.12/site-packages/versioneer-0.29.dist-info/RECORD
usr/lib/python3.12/site-packages/versioneer-0.29.dist-info/WHEEL
usr/lib/python3.12/site-packages/versioneer-0.29.dist-info/entry_points.txt
usr/lib/python3.12/site-packages/versioneer-0.29.dist-info/top_level.txt
var/lib/db/sbom/py3-versioneer-0.29-r1.spdx.json
```

scan:
```
vaikas@vaikas-MBP os % wolfictl scan packages/aarch64/py3-versioneer-0.29-r1.apk
🔎 Scanning "packages/aarch64/py3-versioneer-0.29-r1.apk"
✅ No vulnerabilities found
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
