### PR TITLE
update py3-pandas => python-3.12

### DIFF
--- a/py3-pandas.yaml
+++ b/py3-pandas.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pandas
   version: 2.0.3
-  epoch: 0
+  epoch: 1
   description: Powerful data structures for data analysis, time series, and statistics
   copyright:
     - license: 'BSD-3-Clause'
@@ -16,22 +16,23 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - wolfi-base
-      - busybox
       - build-base
-      - python-3
-      - python-3-dev
+      - busybox
+      - ca-certificates-bundle
+      - cython
+      - meson
       - numpy
       - py3-dateutil
+      - py3-gpep517
+      - py3-meson-python
+      - py3-setuptools
       - py3-tz
       - py3-tzdata
-      - py3-wheel
-      - py3-gpep517
-      - py3-setuptools
-      - py3-meson-python
       - py3-versioneer
-      - cython
+      - py3-wheel
+      - python-3
+      - python-3-dev
+      - wolfi-base
 
 pipeline:
   - uses: fetch
@@ -46,7 +47,10 @@ pipeline:
   - uses: strip
 
 update:
-  # Pandas 2.1.0 fails to build from source, so skip updates for now.
+  # Pandas 2.1.1 fails to build from source, so skip updates for now.
+  # Fails with:
+  # ℹ️  aarch64   | /home/build/pandas/_libs/khash.pxd:129:0: 'khash_for_primitive_helper.pxi' not found
+  # Maybe related to: https://github.com/pandas-dev/pandas/issues/51875
   enabled: false
   release-monitor:
     identifier: 7578


### PR DESCRIPTION
Rebuild to run on python-3.12

```
89faa954393f:/work/packages# apk add py3-pandas
(1/8) Installing libgfortran (13.2.0-r3)
(2/8) Installing openblas (0.3.23-r0)
(3/8) Installing numpy (1.26.1-r1)
(4/8) Installing py3-six (1.16.0-r5)
(5/8) Installing py3-dateutil (2.8.2-r5)
(6/8) Installing py3-tz (2023.3-r2)
(7/8) Installing py3-tzdata (2023.3-r1)
(8/8) Installing py3-pandas (2.0.3-r1)
OK: 200 MiB in 36 packages
89faa954393f:/work/packages# ls -l /usr/lib/python3.12/site-packages/pandas
total 140
-rw-r--r--    1 root     root          8025 Jan  1  1970 __init__.py
drwxr-xr-x    2 root     root          4096 Oct 20 21:12 __pycache__
drwxr-xr-x    3 root     root          4096 Oct 20 21:12 _config
drwxr-xr-x    5 root     root         12288 Oct 20 21:12 _libs
<SNIP>
```

Scan:
```
vaikas@vaikas-MBP os % wolfictl scan packages/aarch64/py3-pandas-2.0.3-r1.apk
🔎 Scanning "packages/aarch64/py3-pandas-2.0.3-r1.apk"
✅ No vulnerabilities found
```



<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
