### PR TITLE
typescript: Fix symlink (again)

### DIFF
--- a/typescript.yaml
+++ b/typescript.yaml
@@ -1,10 +1,13 @@
 package:
   name: typescript
   version: 5.2.2
-  epoch: 1
+  epoch: 2
   description: "TypeScript is a superset of JavaScript that compiles to clean JavaScript output."
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - nodejs
 
 environment:
   contents:
@@ -29,10 +32,13 @@ pipeline:
       npx hereby LKG
 
       mkdir -p "${{targets.destdir}}"/usr/lib/node_modules/typescript
+      mv lib "${{targets.destdir}}"/usr/lib/node_modules/typescript/lib
+      mv bin "${{targets.destdir}}"/usr/lib/node_modules/typescript/bin
+
       mkdir -p "${{targets.destdir}}"/usr/bin
-      mv lib/* "${{targets.destdir}}"/usr/lib/node_modules/typescript
-      mv bin/tsc "${{targets.destdir}}"/usr/bin/tsc
-      mv bin/tsserver "${{targets.destdir}}"/usr/bin/tsserver
+      for f in "${{targets.destdir}}"/usr/lib/node_modules/typescript/bin/*; do
+        ln -s "/usr/lib/node_modules/typescript/bin/$(basename $f)" "${{targets.destdir}}/usr/bin/$(basename $f)"
+      done
 
 update:
   enabled: true


### PR DESCRIPTION
Last change wasn't correct - the binaries are expected to be relative to the lib directory. This change moves the lib and bin folders to the ts dir first, then creates symlinks for all the bins separately with the correct install path.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: 