### PR TITLE
falco-libs: add package with `falco-libscap` and `falco-libscap-modern-ebpf`

### DIFF
--- a/falco-libs.yaml
+++ b/falco-libs.yaml
@@ -1,0 +1,110 @@
+package:
+  name: falco-libs
+  version: 0.13.2
+  epoch: 0
+  description: Foundational components necessary to build Falco
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gcc
+      - cmake
+      - make
+      - git
+      - bash
+      - perl
+      - linux-headers
+      - autoconf
+      - automake
+      - m4
+      - libtool
+      - elfutils-dev
+      - libelf
+      - libelf-static
+      - patch
+      - binutils
+      - c-ares-dev
+      - curl-dev
+      - grpc-dev
+      - jq-dev
+      - yaml-cpp-dev
+      - openssl-dev
+      - protobuf-dev
+      - zlib-dev
+      - clang-16-dev
+      - bpftool
+      - gtest-dev
+      - libtbb-dev
+      - json-c-dev
+      - luajit
+      - re2-dev
+      - libbpf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/falcosecurity/libs
+      tag: ${{package.version}}
+      expected-commit: 3977c2d638455cac5d978135bd883fa5c59ac8ed
+
+subpackages:
+#  - name: falco-libscap
+#    description: System capture library to manage the data capture process
+#    pipeline:
+#      - runs: |
+#          mkdir -p build
+#          cd build
+#          cmake \
+#            -DCMAKE_INSTALL_PREFIX=/usr \
+#            -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+#            -DFALCO_ETC_DIR=/etc/falco \
+#            -DCMAKE_BUILD_TYPE=Release \
+#            -DUSE_BUNDLED_DEPS=Off \
+#            -DUSE_BUNDLED_JSONCPP=On \
+#            -DUSE_BUNDLED_VALIJSON=On \
+#            -DMINIMAL_BUILD=On \
+#            -DBUILD_LIBSCAP_MODERN_BPF=Off \
+#          ..
+#      - runs: |
+#          cd build
+#          make scap
+#
+#      - uses: strip
+  - name: falco-libscap-modern-ebpf
+    description: System capture library to manage the data capture process with modern eBPF driver
+    pipeline:
+      - runs: |
+          mkdir -p build
+          cd build
+          cmake \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+            -DFALCO_ETC_DIR=/etc/falco \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DUSE_BUNDLED_DEPS=Off \
+            -DUSE_BUNDLED_JSONCPP=On \
+            -DUSE_BUNDLED_VALIJSON=On \
+            -DMINIMAL_BUILD=On \
+            -DBUILD_LIBSCAP_MODERN_BPF=On \
+          ..
+      - runs: |
+          cd build
+          make ProbeSkeleton
+          make scap
+          pwd
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/libscap
+          cp -R ./userspace/libscap/. "${{targets.subpkgdir}}"/usr/lib/libscap
+
+      - uses: strip
+
+
+update:
+  enabled: true
+  github:
+    identifier: falcosecurity/libs
+          

--- a/falco-libs.yaml
+++ b/falco-libs.yaml
@@ -52,11 +52,21 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 3977c2d638455cac5d978135bd883fa5c59ac8ed
 
+data:
+  - name: libs
+    items:
+      libscap: System capture library to manage the data capture process
+      libscap-modern-ebpf: System capture library to manage the data capture process with modern eBPF driver
+
 subpackages:
-  - name: falco-libscap
-    description: System capture library to manage the data capture process
+  - range: libs
+    name: falco-${{range.key}}
+    description: ${{range.value}}
     pipeline:
       - runs: |
+          export MODERN_BPF=Off
+          [ "${{range.key}}" == "libscap-modern-ebpf" ] && export MODERN_BPF=On
+
           mkdir -p build
           cd build
           cmake \
@@ -68,43 +78,17 @@ subpackages:
             -DUSE_BUNDLED_JSONCPP=On \
             -DUSE_BUNDLED_VALIJSON=On \
             -DMINIMAL_BUILD=On \
-            -DBUILD_LIBSCAP_MODERN_BPF=Off \
+            -DBUILD_LIBSCAP_MODERN_BPF=${MODERN_BPF} \
           ..
+
       - runs: |
           cd build
           make scap
-          
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/libscap
-          cp -R ../userspace/libscap/. "${{targets.subpkgdir}}"/usr/lib/libscap
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/${{range.key}}
+          cp -R ../userspace/libscap/. "${{targets.subpkgdir}}"/usr/lib/${{range.key}}
 
       - uses: strip
-
-  - name: falco-libscap-modern-ebpf
-    description: System capture library to manage the data capture process with modern eBPF driver
-    pipeline:
-      - runs: |
-          mkdir -p build
-          cd build
-          cmake \
-            -DCMAKE_INSTALL_PREFIX=/usr \
-            -DCMAKE_INSTALL_LIBDIR=/usr/lib \
-            -DFALCO_ETC_DIR=/etc/falco \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DUSE_BUNDLED_DEPS=Off \
-            -DUSE_BUNDLED_JSONCPP=On \
-            -DUSE_BUNDLED_VALIJSON=On \
-            -DMINIMAL_BUILD=On \
-            -DBUILD_LIBSCAP_MODERN_BPF=On \
-          ..
-      - runs: |
-          cd build
-          make scap
-          
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/libscap
-          cp -R ../userspace/libscap/. "${{targets.subpkgdir}}"/usr/lib/libscap
-
-      - uses: strip
-
 
 update:
   enabled: true

--- a/falco-libs.yaml
+++ b/falco-libs.yaml
@@ -53,28 +53,32 @@ pipeline:
       expected-commit: 3977c2d638455cac5d978135bd883fa5c59ac8ed
 
 subpackages:
-#  - name: falco-libscap
-#    description: System capture library to manage the data capture process
-#    pipeline:
-#      - runs: |
-#          mkdir -p build
-#          cd build
-#          cmake \
-#            -DCMAKE_INSTALL_PREFIX=/usr \
-#            -DCMAKE_INSTALL_LIBDIR=/usr/lib \
-#            -DFALCO_ETC_DIR=/etc/falco \
-#            -DCMAKE_BUILD_TYPE=Release \
-#            -DUSE_BUNDLED_DEPS=Off \
-#            -DUSE_BUNDLED_JSONCPP=On \
-#            -DUSE_BUNDLED_VALIJSON=On \
-#            -DMINIMAL_BUILD=On \
-#            -DBUILD_LIBSCAP_MODERN_BPF=Off \
-#          ..
-#      - runs: |
-#          cd build
-#          make scap
-#
-#      - uses: strip
+  - name: falco-libscap
+    description: System capture library to manage the data capture process
+    pipeline:
+      - runs: |
+          mkdir -p build
+          cd build
+          cmake \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+            -DFALCO_ETC_DIR=/etc/falco \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DUSE_BUNDLED_DEPS=Off \
+            -DUSE_BUNDLED_JSONCPP=On \
+            -DUSE_BUNDLED_VALIJSON=On \
+            -DMINIMAL_BUILD=On \
+            -DBUILD_LIBSCAP_MODERN_BPF=Off \
+          ..
+      - runs: |
+          cd build
+          make scap
+          
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/libscap
+          cp -R ../userspace/libscap/. "${{targets.subpkgdir}}"/usr/lib/libscap
+
+      - uses: strip
+
   - name: falco-libscap-modern-ebpf
     description: System capture library to manage the data capture process with modern eBPF driver
     pipeline:
@@ -94,11 +98,10 @@ subpackages:
           ..
       - runs: |
           cd build
-          make ProbeSkeleton
           make scap
-          pwd
+          
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/libscap
-          cp -R ./userspace/libscap/. "${{targets.subpkgdir}}"/usr/lib/libscap
+          cp -R ../userspace/libscap/. "${{targets.subpkgdir}}"/usr/lib/libscap
 
       - uses: strip
 

--- a/falco-libs.yaml
+++ b/falco-libs.yaml
@@ -9,41 +9,41 @@ package:
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - gcc
-      - cmake
-      - make
-      - git
-      - bash
-      - perl
-      - linux-headers
       - autoconf
       - automake
-      - m4
-      - libtool
+      - bash
+      - binutils
+      - bpftool
+      - build-base
+      - busybox
+      - c-ares-dev
+      - ca-certificates-bundle
+      - clang-16-dev
+      - cmake
+      - curl-dev
       - elfutils-dev
+      - gcc
+      - git
+      - grpc-dev
+      - gtest-dev
+      - jq-dev
+      - json-c-dev
+      - libbpf-dev
       - libelf
       - libelf-static
-      - patch
-      - binutils
-      - c-ares-dev
-      - curl-dev
-      - grpc-dev
-      - jq-dev
-      - yaml-cpp-dev
-      - openssl-dev
-      - protobuf-dev
-      - zlib-dev
-      - clang-16-dev
-      - bpftool
-      - gtest-dev
       - libtbb-dev
-      - json-c-dev
+      - libtool
+      - linux-headers
       - luajit
+      - m4
+      - make
+      - openssl-dev
+      - patch
+      - perl
+      - protobuf-dev
       - re2-dev
-      - libbpf-dev
+      - yaml-cpp-dev
+      - zlib-dev
 
 pipeline:
   - uses: git-checkout
@@ -80,18 +80,17 @@ subpackages:
             -DMINIMAL_BUILD=On \
             -DBUILD_LIBSCAP_MODERN_BPF=${MODERN_BPF} \
           ..
-
       - runs: |
           cd build
           make scap
 
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/${{range.key}}
           cp -R ../userspace/libscap/. "${{targets.subpkgdir}}"/usr/lib/${{range.key}}
-
       - uses: strip
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - '.*\+driver'
   github:
     identifier: falcosecurity/libs
-          


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
Builds packages `falco-lipscap` and `falco-libscap-modern-ebpf` libraries to help with building `falco` with modern eBPF support. 

```
 $ wolfictl scan ./packages/aarch64/falco-libscap-modern-ebpf-0.13.2-r0.apk
Will process: falco-libscap-modern-ebpf-0.13.2-r0.apk
✅ No vulnerabilities found

 $ wolfictl scan ./packages/aarch64/falco-libscap-0.13.2-r0.apk
Will process: falco-libscap-0.13.2-r0.apk
✅ No vulnerabilities found
```

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
