### PR TITLE
fix py3-tqdm as the previous packages were empty

### DIFF
--- a/py3-tqdm.yaml
+++ b/py3-tqdm.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tqdm
   version: 4.66.1
-  epoch: 1
+  epoch: 2
   description: Fast, Extensible Progress Meter
   copyright:
     - license: MPL-2.0 AND MIT
@@ -13,31 +13,26 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - wolfi-base
-      - busybox
       - build-base
-      - python3
+      - busybox
+      - ca-certificates-bundle
       - py3-setuptools
-      - py3-pip
+      - python3
+      - wolfi-base
 
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://github.com/tqdm/tqdm
-      tag: v${{package.version}}
-      expected-commit: 4c956c20b83be4312460fc0c4812eeb3fef5e7df
+      README: 'CONFIRM WITH: curl -L https://files.pythonhosted.org/packages/source/t/tqdm/tqdm-4.66.1.tar.gz | sha256sum'
+      expected-sha256: d88e651f9db8d8551a62556d3cff9e3034274ca5d66e93197cf2490e2dcb69c7
+      uri: https://files.pythonhosted.org/packages/source/t/tqdm/tqdm-${{package.version}}.tar.gz
 
-  - runs: python3 -m pip install --upgrade build
+  - name: Python Build
+    uses: python/build-wheel
 
-  - runs: python3 -m pip install --upgrade twine
-
-  - runs: python3 -m build
-
-  - runs: python3 -m twine check dist/*
+  - uses: strip
 
 update:
   enabled: true
-  github:
-    identifier: tqdm/tqdm
-    strip-prefix: v
+  release-monitor:
+    identifier: 36051


### PR DESCRIPTION
py3-tqdm packages are empty causing issues on conda
```/ # apk update 
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
 [https://packages.wolfi.dev/os]
OK: 24087 distinct packages available
/ # apk fetch py3-tqdm
Downloading py3-tqdm-4.66.1-r1
/ # ls
bin                     home                    opt                     root                    sys                     var
dev                     lib                     proc                    run                     tmp
etc                     lib64                   py3-tqdm-4.66.1-r1.apk  sbin                    usr
/ # tar tvf py3-tqdm-4.66.1-r1.apk
-rwxrwxrwx root/root       512 2023-10-14 13:37:30 .SIGN.RSA.wolfi-signing.rsa.pub
-rw-r--r-- root/root       371 2023-10-14 12:49:29 .PKGINFO
drwxr-xr-x root/root         0 2023-10-14 12:49:29 var
drwxr-xr-x root/root         0 2023-10-14 12:49:29 var/lib
drwxr-xr-x root/root         0 2023-10-14 12:49:29 var/lib/db
drwxr-xr-x root/root         0 2023-10-14 12:49:29 var/lib/db/sbom
-rw-r--r-- root/root      1195 2023-10-14 12:49:29 var/lib/db/sbom/py3-tqdm-4.66.1-r1.spdx.json

```