### PR TITLE
Withdraw newrelic-nri-kube-events-2.3.0-r0

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -15,3 +15,4 @@ py3.11-installer-0.7.0-r0.apk
 py3.11-installer-0.7.0-r1.apk
 cocoapods-1.13.0-r0.apk
 nodejs-21-21.0.0-r0.apk
+newrelic-nri-kube-events-2.3.0-r0.apk


### PR DESCRIPTION
Per #6149, the upstream tag has been removed, and the latest version is now `2.2.12-r1`

We must withdraw this package to prevent the stale `2.3.0-r0` from being selected as `latest`. Once the withdrawal is complete, we'll have to remove it from the list to allow a future upgrade path to `2.3.0`