### PR TITLE
withdraw: py3-certifi-2023.5.7-r0.apk

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,3 +1,2 @@
-newrelic-nri-kube-events-2.3.0-r0.apk
 py3-certifi-2023.7.22-r0.apk
 py3-certifi-2023.5.7-r0.apk

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,5 +1,3 @@
-py3.11-installer-0.7.0-r1.apk
-cocoapods-1.13.0-r0.apk
-nodejs-21-21.0.0-r0.apk
 newrelic-nri-kube-events-2.3.0-r0.apk
 py3-certifi-2023.7.22-r0.apk
+py3-certifi-2023.5.7-r0.apk


### PR DESCRIPTION
we are still getting an older version of py3-certifi 
withdrawing the ` py3-certifi-2023.5.7-r0.apk` should be able to resolve to the latest version

```
/ # apk search py3-certifi 
py3-certifi-2023.5.7-r0
/ # apk search py3-certifi -a
py3-certifi-2023.07.22-r1
py3-certifi-2023.07.22-r2
py3-certifi-2023.07.22-r3
py3-certifi-2023.07.22-r4
py3-certifi-2023.5.7-r0
```