### PR TITLE
patch kubescape 3.0.0

### DIFF
--- a/kubescape.yaml
+++ b/kubescape.yaml
@@ -9,13 +9,13 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - python3
-      - go
-      - git
       - cmake
+      - git
+      - go
+      - python3
 
 pipeline:
   - uses: git-checkout
@@ -28,7 +28,7 @@ pipeline:
   - runs: |
       cd kubescape
       export CGO_ENABLED=1
-     # Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978
+      # Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
       go mod tidy
 

--- a/kubescape.yaml
+++ b/kubescape.yaml
@@ -31,6 +31,10 @@ pipeline:
       # Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
       go mod tidy
+      pushd git2go
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+      go mod vendor
 
       make libgit2
       python3 --version && python3 build.py

--- a/kubescape.yaml
+++ b/kubescape.yaml
@@ -1,6 +1,6 @@
 package:
   name: kubescape
-  version: 2.9.2
+  version: 3.0.0
   epoch: 0
   description: "Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources."
   copyright:
@@ -22,7 +22,7 @@ pipeline:
     with:
       repository: https://github.com/kubescape/kubescape
       tag: v${{package.version}}
-      expected-commit: e4110837c70807de7c37cca69f422f5951249d64
+      expected-commit: 3e2314a269f650f89e9bbdae590f02ea361fee0c
       destination: kubescape
 
   - runs: |

--- a/kubescape.yaml
+++ b/kubescape.yaml
@@ -28,6 +28,10 @@ pipeline:
   - runs: |
       cd kubescape
       export CGO_ENABLED=1
+     # Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
       make libgit2
       python3 --version && python3 build.py
       install -Dm755  ./build/kubescape-ubuntu-latest ${{targets.destdir}}/usr/bin/kubescape


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

this is an odd one, 2.9.2 had golang.org/x/net@v0.17.0, but 3.0.0 did not.

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [X] Patch source is documented
