### PR TITLE
frp: bump to 0.52.2 and fix CVE-2023-39325, CVE-2023-3978 and CVE-2023-44487

### DIFF
--- a/frp.yaml
+++ b/frp.yaml
@@ -22,6 +22,9 @@ pipeline:
       tag: v${{package.version}}
 
   - runs: |
+      # CVE-2023-39325, CVE-2023-3978 and CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
+
       make
       mkdir -p ${{targets.destdir}}/usr/bin
       mv bin/frp* ${{targets.destdir}}/usr/bin

--- a/frp.yaml
+++ b/frp.yaml
@@ -1,6 +1,6 @@
 package:
   name: frp
-  version: 0.52.1
+  version: 0.52.2
   epoch: 0
   description: A fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet.
   copyright:
@@ -18,7 +18,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/fatedier/frp
-      expected-commit: 31fa3f021ad290df8b2ef4e3f6eecfc49b3cc69f
+      expected-commit: c9ca9353cfbb377e128af6af725ab24167dfae5c
       tag: v${{package.version}}
 
   - runs: |


### PR DESCRIPTION
- frp: bump to 0.52.2 and fix CVE-2023-39325, CVE-2023-3978 and CVE-2023-44487

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
