### PR TITLE
gatekeeper: CVE-2023-45142

### DIFF
--- a/gatekeeper-3.12.yaml
+++ b/gatekeeper-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gatekeeper-3.12
   version: 3.12.0
-  epoch: 6
+  epoch: 7
   description: Gatekeeper - Policy Controller for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -31,6 +31,10 @@ pipeline:
       cd gatekeeper
       # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
       go get golang.org/x/net@v0.17.0
+      # CVE-2023-45142
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.19.0
       go mod tidy
       go mod vendor
       FRAMEWORKS_VERSION=$(go list -f '{{ .Version }}' -m github.com/open-policy-agent/frameworks/constraint)

--- a/gatekeeper-3.13.yaml
+++ b/gatekeeper-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: gatekeeper-3.13
   version: 3.13.3
-  epoch: 0
+  epoch: 1
   description: Gatekeeper - Policy Controller for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -31,6 +31,12 @@ pipeline:
       cd gatekeeper
       FRAMEWORKS_VERSION=$(go list -f '{{ .Version }}' -m github.com/open-policy-agent/frameworks/constraint)
       OPA_VERSION=$(go list -f '{{ .Version }}' -m github.com/open-policy-agent/opa)
+      # CVE-2023-45142
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.19.0
+      go mod tidy
+      go mod vendor
       CGO_ENABLED=0 GO111MODULE=on go build -mod vendor -a -ldflags "-w -X github.com/open-policy-agent/gatekeeper/pkg/version.Version=v${{package.version}} -X main.frameworksVersion=${FRAMEWORKS_VERSION} -X main.opaVersion=${OPA_VERSION}" -o manager
       mkdir -p ${{targets.destdir}}/usr/bin
       install -Dm755 ./manager ${{targets.destdir}}/usr/bin/manager


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

```
Will process: gatekeeper-3.12-3.12.0-r6.apk
└── 📄 /usr/bin/manager
        📦 github.com/prometheus/prometheus v0.35.0 (go-module)
            Medium CVE-2019-3826
        📦 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.35.0 (go-module)
            High CVE-2023-45142 GHSA-rcjv-mgp8-qvmr fixed in 0.44.0


Will process: gatekeeper-3.12-3.12.0-r7.apk
└── 📄 /usr/bin/manager
        📦 github.com/prometheus/prometheus v0.35.0 (go-module)
            Medium CVE-2019-3826
```

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
