### PR TITLE
k3s: fix CVE-2023-45142

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.28.2
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: Apache-2.0
@@ -69,6 +69,26 @@ pipeline:
       # note dropreplace is safe to whether it's there or not.
       go mod edit -dropreplace=golang.org/x/net
       go get golang.org/x/net@v0.17.0
+
+      # CVE-2023-45142
+      go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/otlpmetric
+      go mod edit -dropreplace=go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
+      go mod edit -dropreplace=go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful
+      go mod edit -dropreplace=go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
+      go mod edit -dropreplace=go.opentelemetry.io/otel
+      go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
+      go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/otlptrace
+      go mod edit -dropreplace=go.opentelemetry.io/otel/metric
+      go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/internal/retry
+
+      go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric@v0.42.0
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.44.0
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
+      go get go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful@v0.44.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.19.0
+      go get go.opentelemetry.io/otel/metric@v1.19.0
+
       go mod tidy
 
       ./scripts/build


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

```
Will process: k3s-1.28.2-r2.apk
├── 📄 /bin/_k3s-inner
│       📦 github.com/cyphar/filepath-securejoin v0.2.3 (go-module)
│           Medium GHSA-6xv5-86q9-7xr8 fixed in 0.2.4
│       📦 go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.35.0 (go-module)
│           High CVE-2023-45142 GHSA-rcjv-mgp8-qvmr fixed in 0.44.0
│       📦 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.35.1 (go-module)
│           High CVE-2023-45142 GHSA-rcjv-mgp8-qvmr fixed in 0.44.0
│
└── 📄 /bin/k3s
        📦 github.com/k3s-io/k3s (devel) (go-module)
            High CVE-2023-32187 GHSA-m4hf-6vgr-75r2 fixed in 1.24.17
            
            
 Will process: k3s-1.28.2-r4.apk
├── 📄 /bin/_k3s-inner
│       📦 github.com/cyphar/filepath-securejoin v0.2.3 (go-module)
│           Medium GHSA-6xv5-86q9-7xr8 fixed in 0.2.4
│
└── 📄 /bin/k3s
        📦 github.com/k3s-io/k3s (devel) (go-module)
            High CVE-2023-32187 GHSA-m4hf-6vgr-75r2 fixed in 1.24.17
```

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
