### PR TITLE
Re-package `trino`, making sure to build every package

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -1,8 +1,8 @@
 package:
   name: trino
   version: "430"
-  epoch: 0
-  description: Official repository of Trino, the distributed SQL query engine for big data, formerly known as PrestoSQL
+  epoch: 1
+  description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0
   dependencies:
@@ -22,7 +22,7 @@ environment:
       - build-base
       - openjdk-17
       - git
-      - rsync
+      - diffutils
       - jvmkill
 
 pipeline:
@@ -32,49 +32,36 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 15024442d61e68bc1bb91fa472fc491dadd9d042
 
+  - uses: patch
+    with:
+      patches: CVE-2023-36478.patch CVE-2023-5072.patch
+
   - runs: |
+      set -x
+
       export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
-      export LANG=en_US.UTF-8
-      export INCLUDE="-I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux"
-      export CFLAGS="-Wall -Werror -fPIC -shared ${INCLUDE}"
 
-      mkdir -p ${{targets.destdir}}/data/trino
-      mkdir -p ${{targets.destdir}}/etc/trino/catalog
+      ./mvnw package -q -DskipTests -T 8  -pl '!:trino-docs,!:trino-server-rpm'
+
+      mkdir -p ${{targets.destdir}}/usr/lib/trino
+      cp ./core/trino-server/target/trino-server-${{package.version}}/NOTICE ${{targets.destdir}}/usr/lib/trino/
+      cp ./core/trino-server/target/trino-server-${{package.version}}/README.txt ${{targets.destdir}}/usr/lib/trino/
+      cp -r ./core/trino-server/target/trino-server-${{package.version}}/bin ${{targets.destdir}}/usr/lib/trino/bin/
+      cp -r ./core/trino-server/target/trino-server-${{package.version}}/lib ${{targets.destdir}}/usr/lib/trino/lib/
+
+      # Copy default configurations.
+      mkdir -p ${{targets.destdir}}/etc
+      cp -r core/docker/default/etc ${{targets.destdir}}/etc/trino
+
+      # Copy docker helper scripts.
+      cp core/docker/bin/* ${{targets.destdir}}/usr/lib/trino/bin/
+      cp /usr/lib/libjvmkill.so ${{targets.destdir}}/usr/lib/trino/bin/
+
+      # Link launcher script.
       mkdir -p ${{targets.destdir}}/usr/bin
-      mkdir -p ${{targets.destdir}}/usr/lib/trino/bin
-      mkdir -p ${{targets.destdir}}/usr/lib/trino/lib
-      mkdir -p ${{targets.destdir}}/usr/lib/trino/plugin
-      mkdir -p ${{targets.destdir}}/var/lib/trino
+      ln -s /usr/lib/trino/bin/run-trino ${{targets.destdir}}/usr/bin/
+
       mkdir -p ${{targets.destdir}}/etc/security/
-      mkdir -p /home/build/trino-all
-      mkdir -p /home/build/plugins/default/
-      mkdir -p /home/build/plugins/optional/
-
-      cd /home/build/
-      mvn package -q -DskipTests -T $(nproc) -pl ':trino-server'
-      tar -C /home/build/trino-all/ --strip-components 1 -xf core/trino-server/target/trino-server-${{package.version}}.tar.gz
-
-      mvn package -q -DskipTests -T $(nproc) -pl ':trino-cli'
-      chmod +x client/trino-cli/target/trino-cli-${{package.version}}-executable.jar
-
-      rsync -av /home/build/trino-all/plugin/* /home/build/plugins/optional/
-      rm -rf /home/build/trino-all/plugin/*
-      rsync -av --ignore-existing /home/build/trino-all/* ${{targets.destdir}}/usr/lib/trino/
-      # rsync -av --ignore-existing /home/build/plugins/default/* ${{targets.destdir}}/usr/lib/trino/plugin/
-
-      rsync -av --ignore-existing core/docker/default/etc/* ${{targets.destdir}}/etc/trino/
-      rsync -av --force core/docker/bin/* ${{targets.destdir}}/usr/lib/trino/bin/
-      rsync -av --ignore-existing client/trino-cli/target/trino-cli-${{package.version}}-executable.jar ${{targets.destdir}}/usr/bin/
-      rsync -av --ignore-existing /usr/lib/libjvmkill.so ${{targets.destdir}}/usr/lib/trino/bin/
-
-      cd ${{targets.destdir}}/usr/lib/trino/bin
-      for file in *; do
-        if [[ -f $file ]]; then
-          ln -sf ../lib/trino/bin/$file ${{targets.destdir}}/usr/bin/$file
-        fi
-      done
-      cd /home/build/
-
       touch ${{targets.destdir}}/etc/security/limits.conf
       cat << EOF >> ${{targets.destdir}}/etc/security/limits.conf
       trino soft nofile 131072
@@ -144,8 +131,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib/trino/plugin/${{range.value}}
-          cd /home/build/plugins/optional/
-          cp -R ./${{range.value}}/* ${{targets.subpkgdir}}/usr/lib/trino/plugin/${{range.value}}/
+          cp -r ./core/trino-server/target/trino-server-${{package.version}}/plugin/${{range.value}} ${{targets.subpkgdir}}/usr/lib/trino/plugin/
 
 update:
   enabled: true

--- a/trino.yaml
+++ b/trino.yaml
@@ -7,9 +7,9 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - bash # some helper scripts use bash
       - openjdk-17-default-jvm
       - python3 # required by trino launcher script
+      - trino-config
 
 environment:
   contents:
@@ -49,26 +49,9 @@ pipeline:
       cp -r ./core/trino-server/target/trino-server-${{package.version}}/bin ${{targets.destdir}}/usr/lib/trino/bin/
       cp -r ./core/trino-server/target/trino-server-${{package.version}}/lib ${{targets.destdir}}/usr/lib/trino/lib/
 
-      # Copy default configurations.
-      mkdir -p ${{targets.destdir}}/etc
-      cp -r core/docker/default/etc ${{targets.destdir}}/etc/trino
-
-      # Copy docker helper scripts.
-      cp core/docker/bin/* ${{targets.destdir}}/usr/lib/trino/bin/
-      cp /usr/lib/libjvmkill.so ${{targets.destdir}}/usr/lib/trino/bin/
-
-      # Link launcher script.
-      mkdir -p ${{targets.destdir}}/usr/bin
-      ln -s /usr/lib/trino/bin/run-trino ${{targets.destdir}}/usr/bin/
-
-      mkdir -p ${{targets.destdir}}/etc/security/
-      touch ${{targets.destdir}}/etc/security/limits.conf
-      cat << EOF >> ${{targets.destdir}}/etc/security/limits.conf
-      trino soft nofile 131072
-      trino hard nofile 131072
-      trino soft nproc 128000
-      trino hard nproc 128000
-      EOF
+      mkdir -p ${{targets.destdir}}/usr/bin/
+      cp ./client/trino-cli/target/trino-cli-430-executable.jar ${{targets.destdir}}/usr/bin/trino
+      chmod 0755 ${{targets.destdir}}/usr/bin/trino
 
 data:
   - name: plugins
@@ -122,6 +105,39 @@ data:
       tpch: tpch
 
 subpackages:
+  - name: ${{package.name}}-config
+    description: Creates trino config step that can then be overridden.
+    dependencies:
+      runtime:
+        - trino
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc
+          cp -r core/docker/default/etc ${{targets.subpkgdir}}/etc/trino
+
+  - name: ${{package.name}}-oci-entrypoint
+    dependencies:
+      runtime:
+        - trino
+        - bash # run-trino script needs bash
+        - curl # health-check needs curl
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/trino/bin
+          cp ./core/docker/bin/* ${{targets.subpkgdir}}/usr/lib/trino/bin/
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          ln -s /usr/lib/trino/bin/run-trino ${{targets.subpkgdir}}/usr/bin/
+          cp /usr/lib/libjvmkill.so ${{targets.subpkgdir}}/usr/lib/trino/bin/
+
+          mkdir -p ${{targets.subpkgdir}}/etc/security/
+          touch ${{targets.subpkgdir}}/etc/security/limits.conf
+          cat << EOF >> ${{targets.subpkgdir}}/etc/security/limits.conf
+          trino soft nofile 131072
+          trino hard nofile 131072
+          trino soft nproc 128000
+          trino hard nproc 128000
+          EOF
+
   - range: plugins
     name: trino-plugin-${{range.key}}
     description: Trino Plugin ${{range.key}}
@@ -130,8 +146,14 @@ subpackages:
         - trino
     pipeline:
       - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/trino/lib
+          cp ./core/trino-server/target/trino-server-${{package.version}}/plugin/${{range.value}}/* ${{targets.subpkgdir}}/usr/lib/trino/lib/
+
           mkdir -p ${{targets.subpkgdir}}/usr/lib/trino/plugin/${{range.value}}
-          cp -r ./core/trino-server/target/trino-server-${{package.version}}/plugin/${{range.value}} ${{targets.subpkgdir}}/usr/lib/trino/plugin/
+          for path in ./core/trino-server/target/trino-server-${{package.version}}/plugin/${{range.value}}/*; do
+            filename=$(basename $path)
+            ln -s "../../lib/${filename}" "${{targets.subpkgdir}}/usr/lib/trino/plugin/${{range.value}}/${filename}"
+          done
 
 update:
   enabled: true

--- a/trino/CVE-2023-36478.patch
+++ b/trino/CVE-2023-36478.patch
@@ -1,0 +1,105 @@
+From 15f2354c4879b4f8c1c6f1244d226f2af8c2a2de Mon Sep 17 00:00:00 2001
+From: Philippe Deslauriers <philde@chainguard.dev>
+Date: Sun, 22 Oct 2023 15:28:31 -0700
+Subject: [PATCH] Force upgrade of jetty to fix vulnerabilities
+
+Signed-off-by: Philippe Deslauriers <philde@chainguard.dev>
+---
+ pom.xml | 74 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 74 insertions(+)
+
+diff --git a/pom.xml b/pom.xml
+index abaa9e84..6f834f1b 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -187,6 +187,8 @@
+         <dep.antlr.version>4.13.1</dep.antlr.version>
+         <dep.asm.version>9.6</dep.asm.version>
+ 
++        <dep.jetty.version>11.0.17</dep.jetty.version>
++
+         <dep.docker.images.version>87</dep.docker.images.version>
+ 
+         <!--
+@@ -1877,6 +1879,78 @@
+                 <version>4.0.2</version>
+             </dependency>
+ 
++            <dependency>
++                <groupId>org.eclipse.jetty</groupId>
++                <artifactId>jetty-client</artifactId>
++                <version>${dep.jetty.version}</version>
++            </dependency>
++
++            <dependency>
++                <groupId>org.eclipse.jetty</groupId>
++                <artifactId>jetty-http</artifactId>
++                <version>${dep.jetty.version}</version>
++            </dependency>
++
++            <dependency>
++                <groupId>org.eclipse.jetty</groupId>
++                <artifactId>jetty-io</artifactId>
++                <version>${dep.jetty.version}</version>
++            </dependency>
++
++            <dependency>
++                <groupId>org.eclipse.jetty</groupId>
++                <artifactId>jetty-jmx</artifactId>
++                <version>${dep.jetty.version}</version>
++            </dependency>
++
++            <dependency>
++                <groupId>org.eclipse.jetty</groupId>
++                <artifactId>jetty-security</artifactId>
++                <version>${dep.jetty.version}</version>
++            </dependency>
++
++            <dependency>
++                <groupId>org.eclipse.jetty</groupId>
++                <artifactId>jetty-server</artifactId>
++                <version>${dep.jetty.version}</version>
++            </dependency>
++
++            <dependency>
++                <groupId>org.eclipse.jetty</groupId>
++                <artifactId>jetty-servlet</artifactId>
++                <version>${dep.jetty.version}</version>
++            </dependency>
++
++            <dependency>
++                <groupId>org.eclipse.jetty</groupId>
++                <artifactId>jetty-util</artifactId>
++                <version>${dep.jetty.version}</version>
++            </dependency>
++
++            <dependency>
++                <groupId>org.eclipse.jetty.http2</groupId>
++                <artifactId>http2-client</artifactId>
++                <version>${dep.jetty.version}</version>
++            </dependency>
++
++            <dependency>
++                <groupId>org.eclipse.jetty.http2</groupId>
++                <artifactId>http2-hpack</artifactId>
++                <version>${dep.jetty.version}</version>
++            </dependency>
++
++            <dependency>
++                <groupId>org.eclipse.jetty.http2</groupId>
++                <artifactId>http2-http-client-transport</artifactId>
++                <version>${dep.jetty.version}</version>
++            </dependency>
++
++            <dependency>
++                <groupId>org.eclipse.jetty.http2</groupId>
++                <artifactId>http2-server</artifactId>
++                <version>${dep.jetty.version}</version>
++            </dependency>
++
+             <dependency>
+                 <groupId>org.flywaydb</groupId>
+                 <artifactId>flyway-core</artifactId>
+-- 
+2.42.0
+

--- a/trino/CVE-2023-5072.patch
+++ b/trino/CVE-2023-5072.patch
@@ -1,0 +1,30 @@
+From 6dcbfcc9e60eac7ae5c636a6f8d4152b85baff27 Mon Sep 17 00:00:00 2001
+From: Philippe Deslauriers <philde@chainguard.dev>
+Date: Mon, 23 Oct 2023 09:33:52 -0700
+Subject: [PATCH] Fix CVE-2023-5072
+
+Signed-off-by: Philippe Deslauriers <philde@chainguard.dev>
+---
+ pom.xml | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/pom.xml b/pom.xml
+index 6f834f1b..8f4c2d29 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -1982,6 +1982,12 @@
+                 <version>19.0.0</version>
+             </dependency>
+ 
++            <dependency>
++                <groupId>org.json</groupId>
++                <artifactId>json</artifactId>
++                <version>20231013</version>
++            </dependency>
++
+             <dependency>
+                 <groupId>org.locationtech.jts</groupId>
+                 <artifactId>jts-core</artifactId>
+-- 
+2.42.0
+


### PR DESCRIPTION
The previous packaging was only building the `:trino-server`, and caused plugins to be downloaded from Maven, instead of being built locally. This PR fixes and simplifies the build process.

We also bumped dependencies to fix CVE-2023-36478 and CVE-2023-5072
