### PR TITLE
cue: update pipeline, fix CVEs

### DIFF
--- a/cue.yaml
+++ b/cue.yaml
@@ -1,7 +1,7 @@
 package:
   name: cue
   version: 0.6.0
-  epoch: 6
+  epoch: 7
   description: The home of the CUE language! Validate and define text-based and dynamic configuration
   copyright:
     - license: Apache-2.0
@@ -22,13 +22,14 @@ pipeline:
       uri: https://github.com/cue-lang/cue/archive/v${{package.version}}/v${{package.version}}.tar.gz
       expected-sha256: 8e884d9cf6138e05136ba7110ddd5ec20a312ed0d75868dc0a2fdb235e69f5e1
 
-  - runs: |
-      CGO_ENABLED=0 go build \
-        -trimpath -ldflags "-w -buildid= -X cuelang.org/go/cmd/cue/cmd.version=${{package.version}}" \
-        -o "${{targets.destdir}}/usr/bin/cue" ./cmd/cue
-      mkdir -p ${{targets.destdir}}/usr/share/bash-completion/completions
-      mkdir -p ${{targets.destdir}}/usr/share/zsh/site-functions
-      mkdir -p ${{targets.destdir}}/usr/share/fish/vendor_completions.d
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/cue
+      output: cue
+      ldflags: -w -buildid= -X cuelang.org/go/cmd/cue/cmd.version=${{package.version}}
+      # Mitigate CVE-2023-3978, CVE-2023-39325 and CVE-2023-44487
+      deps: golang.org/x/net@v0.17.0
 
   - uses: strip
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

- Update Melange file to use `go/build` pipeline
- Mitigate CVE-2023-3978, CVE-2023-39325 and CVE-2023-44487

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/chainguard-dev/image-requests/issues/481

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

https://github.com/wolfi-dev/advisories/pull/381