### PR TITLE
cue: add CGO_ENABLED: 0

### DIFF
--- a/cue.yaml
+++ b/cue.yaml
@@ -1,7 +1,7 @@
 package:
   name: cue
   version: 0.6.0
-  epoch: 7
+  epoch: 8
   description: The home of the CUE language! Validate and define text-based and dynamic configuration
   copyright:
     - license: Apache-2.0
@@ -15,6 +15,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
+  environment:
+    CGO_ENABLED: 0
 
 pipeline:
   - uses: fetch


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

`CGO_ENABLED=0` was set in the `fetch` pipeline, I forgot to add it in when I updated the melange file to use the `go/build` pipeline 🤦‍♀️ 

<!--
Please include references to any related issues or delete this section otherwise.
 -->
 
Related: https://github.com/wolfi-dev/os/pull/7266