### PR TITLE
fix nvidia-device-plugin: plugin fails to start with go-1.21, upstrea…

### DIFF
--- a/nvidia-device-plugin.yaml
+++ b/nvidia-device-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: nvidia-device-plugin
   version: 0.14.2
-  epoch: 0
+  epoch: 1
   description: NVIDIA device plugin for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,10 @@ pipeline:
   - runs: |
       # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
       go get golang.org/x/net@v0.17.0
+
+      # Fetch unreleased go-nvml which contains fix for working with go-1.21 https://github.com/NVIDIA/go-nvml/pull/79
+      go get github.com/NVIDIA/go-nvml@e06766c5e74f5c0bed40007842bac458588a36b2
+
       go mod tidy
       go mod vendor
 


### PR DESCRIPTION
…m has fixed the issue but not released it yet so patching our package
