### PR TITLE
Add temporal-ui-server

### DIFF
--- a/temporal-ui-server.yaml
+++ b/temporal-ui-server.yaml
@@ -1,0 +1,54 @@
+package:
+  name: temporal-ui-server
+  version: 2.19.0
+  epoch: 0
+  description: Golang Server for https://github.com/temporalio/ui
+  copyright:
+    - license: MIT License
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - busybox
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/temporalio/ui-server
+      tag: v${{package.version}}
+      expected-commit: 32c10ff87081bfff673e309f3c589663a0e13221
+
+  - uses: go/build
+    with:
+      packages: ./cmd/server
+      output: ui-server
+      ldflags: -s -w
+      deps: golang.org/x/net@v0.17.0
+
+  - uses: strip
+
+subpackages:
+  - name: temporal-ui-server-oci-entrypoint
+    description: Entrypoint for using temporal ui-server in OCI containers
+    dependencies:
+      runtime:
+        - bash
+        - dockerize
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/home/ui-server/
+          cp docker/start-ui-server.sh ${{targets.subpkgdir}}/home/ui-server/
+          chmod +x ${{targets.subpkgdir}}/home/ui-server/start-ui-server.sh
+
+          mkdir -p ${{targets.subpkgdir}}/home/ui-server/config
+          cp docker/config-template.yaml ${{targets.subpkgdir}}/home/ui-server/
+
+update:
+  enabled: true
+  github:
+    identifier: temporalio/ui-server
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
The temporal-ui-server OCI entrypoint uses dockerize, so we need https://github.com/wolfi-dev/os/pull/7275 first.

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)