### PR TITLE
falco: add `falco-no-driver` subpackage

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -42,7 +42,6 @@ environment:
       - libbpf-dev
       - libcurl-openssl4
       - libelf
-      - libelf-static
       - libsystemd
       - libtbb-dev
       - libtool
@@ -131,11 +130,14 @@ subpackages:
               cmake \
                 -DCMAKE_INSTALL_PREFIX=/usr \
                 -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+                -DBUILD_SHARED_LIBS=On \
                 -DFALCO_ETC_DIR=/etc/falco \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DMINIMAL_BUILD=Off \
                 -DUSE_BUNDLED_DEPS=Off \
                 -DUSE_BUNDLED_LIBELF=Off \
+                -DUSE_BUNDLED_TBB=Off \
+                -DUSE_BUNDLED_RE2=Off \
                 -DBUILD_BPF=Off \
                 -DBUILD_LIBSCAP_MODERN_BPF=Off \
                 -DLIBSCAP_INCLUDE_DIRS=/usr/lib/falco-libscap-modern-ebpf \
@@ -143,7 +145,7 @@ subpackages:
                 -DBUILD_FALCO_MODERN_BPF=On \
               ..
           - runs: |
-              make falco
+              make -ltbb falco
               install -Dm755 ./userspace/falco/falco "${{targets.subpkgdir}}"/usr/bin/falco
       - uses: strip
 

--- a/falco.yaml
+++ b/falco.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco
   version: 0.36.1
-  epoch: 1
+  epoch: 2
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -12,57 +12,61 @@ package:
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - clang-16
-      - gcc
-      - cmake
-      - make
-      - git
-      - bash
-      - perl
-      - linux-headers
-      - autoconf
-      - automake
-      - m4
-      - libtool
-      - elfutils-dev
-      - libelf
-      - libelf-static
-      - patch
-      - binutils
-      - libbpf
-      - openssl
-      - openssl-dev
-      - yaml-dev
-      - c-ares
-      - c-ares-dev
-      - protobuf
-      - protobuf-dev
-      - protobuf-c-dev
-      - re2
-      - re2-dev
-      - zlib-dev
-      - libcurl-openssl4
-      - llvm16
       - abseil-cpp
       - abseil-cpp-dev
       - abseillib
-      - jq-dev
+      - autoconf
+      - automake
+      - bash
+      - binutils
+      - bpftool
+      - build-base
+      - busybox
+      - c-ares
+      - c-ares-dev
+      - ca-certificates-bundle
+      - clang-16
+      - clang-16-dev
+      - cmake
       - curl-dev
+      - elfutils-dev
+      - falco-libscap-modern-ebpf
+      - gcc
+      - git
+      - glibc-dev
       - grpc
       - grpc-dev
       - icu
       - icu-dev
+      - jq-dev
+      - libbpf
+      - libcurl-openssl4
+      - libelf
+      - libelf-static
+      - libsystemd
+      - libtbb-dev
+      - libtool
+      - libzstd1
+      - linux-headers
+      - llvm16
+      - m4
+      - make
+      - openssl
+      - openssl-dev
+      - patch
+      - perl
+      - protobuf
+      - protobuf-c-dev
+      - protobuf-dev
+      - re2
+      - re2-dev
+      - systemd-dev
       - yaml-cpp
       - yaml-cpp-dev
-      - systemd-dev
-      - libsystemd
-      - libzstd1
+      - yaml-dev
+      - zlib-dev
       - zstd
       - zstd-dev
-      - libtbb-dev
 
 pipeline:
   - uses: git-checkout
@@ -98,8 +102,42 @@ pipeline:
       - runs: |
           make falco
           install -Dm755 ./userspace/falco/falco "${{targets.destdir}}"/usr/bin/falco
+      - uses: strip
 
-  - uses: strip
+subpackages:
+  - name: falco-no-driver
+    description: Cloud Native Runtime Security with modern eBPF support and without driver loader
+    dependencies:
+      runtime:
+        - falco-rules
+    pipeline:
+      - working-directory: build
+        pipeline:
+          - runs: |
+              # BUILD_DRIVER=Off disable building the driver loader (hence falco-no-driver)
+              # BUILD_BPF=Off disable building the legacy eBPF driver
+              # BUILD_FALCO_MODERN_BPF=On enable modern eBPF support built directly into falco binary
+              # LIBSCAP_INCLUDE_DIRS path to pre-built libscap library with support for modern eBPF
+
+              # See https://falco.org/docs/install-operate/source/ and https://github.com/falcosecurity/libs/tree/master#build
+              # for further explanation of build flags
+
+              cmake \
+                -DCMAKE_INSTALL_PREFIX=/usr \
+                -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+                -DFALCO_ETC_DIR=/etc/falco \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DMINIMAL_BUILD=On \
+                -DUSE_BUNDLED_DEPS=Off \
+                -DBUILD_DRIVER=Off \
+                -DBUILD_BPF=Off \
+                -DBUILD_FALCO_MODERN_BPF=On \
+                -DLIBSCAP_INCLUDE_DIRS=/usr/lib/falco-libscap-modern-ebpf \
+              ..
+          - runs: |
+              make falco
+              install -Dm755 ./userspace/falco/falco "${{targets.subpkgdir}}"/usr/bin/falco
+      - uses: strip
 
 update:
   enabled: true

--- a/falco.yaml
+++ b/falco.yaml
@@ -5,6 +5,9 @@ package:
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - falco-rules
 
 environment:
   contents:
@@ -77,16 +80,34 @@ pipeline:
       # Replace the find_dependency with find_package macro for newer cmake, otherwise it will fail.
       sed -i 's/find_dependency(Protobuf CONFIG)/find_package(Protobuf CONFIG)/' /usr/lib64/cmake/grpc/gRPCConfig.cmake
 
-data:
-  - name: builds
-    items:
-      falco: Cloud Native Runtime Security; built with the driver loader
-      falco-no-driver: Cloud Native Runtime Security; built with modern eBPF support and without driver loader
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/etc/falco
+      cp ./falco.yaml "${{targets.destdir}}"/etc/falco/falco.yaml
+      sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < "${{targets.destdir}}"/etc/falco/falco.yaml
+
+  - working-directory: build
+    pipeline:
+      - runs: |
+          cmake \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+            -DFALCO_ETC_DIR=/etc/falco \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DUSE_BUNDLED_DEPS=Off \
+            -DMINIMAL_BUILD=On \
+            -DBUILD_DRIVER=On \
+            -DBUILD_FALCO_MODERN_BPF=Off \
+            -DBUILD_BPF=Off \
+          ..
+      - runs: |
+          make falco
+          install -Dm755 ./userspace/falco/falco "${{targets.destdir}}"/usr/bin/falco
+
+  - uses: strip
 
 subpackages:
-  - range: builds
-    name: ${{range.key}}
-    description: ${{range.value}}
+  - name: falco-no-driver
+    description: Cloud Native Runtime Security; built with modern eBPF support and without driver loader
     dependencies:
       runtime:
         - falco-rules
@@ -95,44 +116,34 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/etc/falco
           cp ./falco.yaml "${{targets.subpkgdir}}"/etc/falco/falco.yaml
           sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < "${{targets.subpkgdir}}"/etc/falco/falco.yaml
+      - working-directory: build
+        pipeline:
+          - runs: |
+              # BUILD_DRIVER=Off disables building the driver loader
+              # BUILD_BPF=Off disables building the legacy eBPF driver, we always have this disabled
+              # BUILD_FALCO_MODERN_BPF=On builds modern eBPF support directly into falco binary (no external driver)
+              # BUILD_LIBSCAP_MODERN_BPF=Off disables building the libscap library since libscap is prebuilt in falco-libs
+              # LIBSCAP_INCLUDE_DIRS path to pre-built libscap library with support for modern eBPF
 
-      - runs: |
-          mkdir -p build
-          cd build
-          
-          export DRIVER=On
-          export MODERN_BPF=Off
-          if [ "${{range.key}}" == "falco-no-driver" ]; then
-            export DRIVER=Off
-            export MODERN_BPF=On
-          fi
-          
-          # BUILD_DRIVER controls building the driver loader
-          # BUILD_BPF controls building the legacy eBPF driver, we always have this disabled for these builds
-          # BUILD_FALCO_MODERN_BPF controls building modern eBPF support directly into falco binary
-          # BUILD_LIBSCAP_MODERN_BPF controls building the libscap library; disabled since we prebuild libscap 
-          # LIBSCAP_INCLUDE_DIRS path to pre-built libscap library with (support for modern eBPF if needed)
+              # See https://falco.org/docs/install-operate/source/ and https://github.com/falcosecurity/libs/tree/master#build
+              # for further explanation of build flags
 
-          # See https://falco.org/docs/install-operate/source/ and https://github.com/falcosecurity/libs/tree/master#build
-          # for further explanation of build flags
-          cmake \
-            -DCMAKE_INSTALL_PREFIX=/usr \
-            -DCMAKE_INSTALL_LIBDIR=/usr/lib \
-            -DFALCO_ETC_DIR=/etc/falco \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DMINIMAL_BUILD=On \
-            -DUSE_BUNDLED_DEPS=Off \
-            -DBUILD_BPF=Off \
-            -DBUILD_LIBSCAP_MODERN_BPF=Off \
-            -DLIBSCAP_INCLUDE_DIRS=/usr/lib/falco-libscap-modern-ebpf \
-            -DBUILD_DRIVER=${DRIVER} \
-            -DBUILD_FALCO_MODERN_BPF=${MODERN_BPF} \
-          ..
-      - runs: |
-          cd build
-          
-          make falco
-          install -Dm755 ./userspace/falco/falco "${{targets.subpkgdir}}"/usr/bin/falco
+              cmake \
+                -DCMAKE_INSTALL_PREFIX=/usr \
+                -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+                -DFALCO_ETC_DIR=/etc/falco \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DMINIMAL_BUILD=On \
+                -DUSE_BUNDLED_DEPS=Off \
+                -DBUILD_BPF=Off \
+                -DBUILD_LIBSCAP_MODERN_BPF=Off \
+                -DLIBSCAP_INCLUDE_DIRS=/usr/lib/falco-libscap-modern-ebpf \
+                -DBUILD_DRIVER=Off \
+                -DBUILD_FALCO_MODERN_BPF=On \
+              ..
+          - runs: |
+              make falco
+              install -Dm755 ./userspace/falco/falco "${{targets.subpkgdir}}"/usr/bin/falco
       - uses: strip
 
 update:

--- a/falco.yaml
+++ b/falco.yaml
@@ -39,7 +39,7 @@ environment:
       - icu
       - icu-dev
       - jq-dev
-      - libbpf
+      - libbpf-dev
       - libcurl-openssl4
       - libelf
       - libelf-static
@@ -133,8 +133,9 @@ subpackages:
                 -DCMAKE_INSTALL_LIBDIR=/usr/lib \
                 -DFALCO_ETC_DIR=/etc/falco \
                 -DCMAKE_BUILD_TYPE=Release \
-                -DMINIMAL_BUILD=On \
+                -DMINIMAL_BUILD=Off \
                 -DUSE_BUNDLED_DEPS=Off \
+                -DUSE_BUNDLED_LIBELF=Off \
                 -DBUILD_BPF=Off \
                 -DBUILD_LIBSCAP_MODERN_BPF=Off \
                 -DLIBSCAP_INCLUDE_DIRS=/usr/lib/falco-libscap-modern-ebpf \

--- a/falco.yaml
+++ b/falco.yaml
@@ -5,9 +5,6 @@ package:
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - falco-rules
 
 environment:
   contents:
@@ -80,63 +77,62 @@ pipeline:
       # Replace the find_dependency with find_package macro for newer cmake, otherwise it will fail.
       sed -i 's/find_dependency(Protobuf CONFIG)/find_package(Protobuf CONFIG)/' /usr/lib64/cmake/grpc/gRPCConfig.cmake
 
-  - runs: |
-      mkdir -p "${{targets.destdir}}"/etc/falco
-      install -Dm755 ./falco.yaml "${{targets.destdir}}"/etc/falco/falco.yaml
-      sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < "${{targets.destdir}}"/etc/falco/falco.yaml
+data:
+  - name: builds
+    items:
+      falco: Cloud Native Runtime Security; built with the driver loader
+      falco-no-driver: Cloud Native Runtime Security; built with modern eBPF support and without driver loader
 
-  - working-directory: build
+subpackages:
+  - range: builds
+    name: ${{range.key}}
+    description: ${{range.value}}
+    dependencies:
+      runtime:
+        - falco-rules
     pipeline:
       - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/etc/falco
+          cp ./falco.yaml "${{targets.subpkgdir}}"/etc/falco/falco.yaml
+          sed -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' < "${{targets.subpkgdir}}"/etc/falco/falco.yaml
+
+      - runs: |
+          mkdir -p build
+          cd build
+          
+          export DRIVER=On
+          export MODERN_BPF=Off
+          if [ "${{range.key}}" == "falco-no-driver" ]; then
+            export DRIVER=Off
+            export MODERN_BPF=On
+          fi
+          
+          # BUILD_DRIVER controls building the driver loader
+          # BUILD_BPF controls building the legacy eBPF driver, we always have this disabled for these builds
+          # BUILD_FALCO_MODERN_BPF controls building modern eBPF support directly into falco binary
+          # BUILD_LIBSCAP_MODERN_BPF controls building the libscap library; disabled since we prebuild libscap 
+          # LIBSCAP_INCLUDE_DIRS path to pre-built libscap library with (support for modern eBPF if needed)
+
+          # See https://falco.org/docs/install-operate/source/ and https://github.com/falcosecurity/libs/tree/master#build
+          # for further explanation of build flags
           cmake \
             -DCMAKE_INSTALL_PREFIX=/usr \
             -DCMAKE_INSTALL_LIBDIR=/usr/lib \
             -DFALCO_ETC_DIR=/etc/falco \
             -DCMAKE_BUILD_TYPE=Release \
-            -DUSE_BUNDLED_DEPS=Off \
             -DMINIMAL_BUILD=On \
-            -DBUILD_DRIVER=On \
-            -DBUILD_FALCO_MODERN_BPF=Off \
+            -DUSE_BUNDLED_DEPS=Off \
             -DBUILD_BPF=Off \
+            -DBUILD_LIBSCAP_MODERN_BPF=Off \
+            -DLIBSCAP_INCLUDE_DIRS=/usr/lib/falco-libscap-modern-ebpf \
+            -DBUILD_DRIVER=${DRIVER} \
+            -DBUILD_FALCO_MODERN_BPF=${MODERN_BPF} \
           ..
       - runs: |
+          cd build
+          
           make falco
-          install -Dm755 ./userspace/falco/falco "${{targets.destdir}}"/usr/bin/falco
-      - uses: strip
-
-subpackages:
-  - name: falco-no-driver
-    description: Cloud Native Runtime Security with modern eBPF support and without driver loader
-    dependencies:
-      runtime:
-        - falco-rules
-    pipeline:
-      - working-directory: build
-        pipeline:
-          - runs: |
-              # BUILD_DRIVER=Off disable building the driver loader (hence falco-no-driver)
-              # BUILD_BPF=Off disable building the legacy eBPF driver
-              # BUILD_FALCO_MODERN_BPF=On enable modern eBPF support built directly into falco binary
-              # LIBSCAP_INCLUDE_DIRS path to pre-built libscap library with support for modern eBPF
-
-              # See https://falco.org/docs/install-operate/source/ and https://github.com/falcosecurity/libs/tree/master#build
-              # for further explanation of build flags
-
-              cmake \
-                -DCMAKE_INSTALL_PREFIX=/usr \
-                -DCMAKE_INSTALL_LIBDIR=/usr/lib \
-                -DFALCO_ETC_DIR=/etc/falco \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DMINIMAL_BUILD=On \
-                -DUSE_BUNDLED_DEPS=Off \
-                -DBUILD_DRIVER=Off \
-                -DBUILD_BPF=Off \
-                -DBUILD_FALCO_MODERN_BPF=On \
-                -DLIBSCAP_INCLUDE_DIRS=/usr/lib/falco-libscap-modern-ebpf \
-              ..
-          - runs: |
-              make falco
-              install -Dm755 ./userspace/falco/falco "${{targets.subpkgdir}}"/usr/bin/falco
+          install -Dm755 ./userspace/falco/falco "${{targets.subpkgdir}}"/usr/bin/falco
       - uses: strip
 
 update:


### PR DESCRIPTION
Add `falco-no-driver` subpackage to build the falco binary without the driver loader and with modern eBPF support.

```
 $ wolfictl scan ./packages/aarch64/falco-no-driver-0.36.1-r1.apk
Will process: falco-no-driver-0.36.1-r1.apk
✅ No vulnerabilities found
```

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

