### PR TITLE
hubble & hubble-ui backend: new packages

### DIFF
--- a/hubble-ui.yaml
+++ b/hubble-ui.yaml
@@ -1,0 +1,70 @@
+package:
+  name: hubble-ui
+  version: 0.12.1
+  epoch: 2
+  description: "Observability & troubleshooting for Kubernetes services"
+  copyright:
+    - license: "Apache-2.0"
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+      - nginx
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - git
+      - go
+      - nodejs
+      # node-gyp currently needs 3.11: https://github.com/nodejs/node-gyp/issues/2869
+      - python-3.11
+      - wolfi-baselayout
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cilium/hubble-ui
+      tag: v${{package.version}}
+      expected-commit: 66a73845c733c99d195f8c0231463cb4be86e241
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/etc/frontend
+      cp nginx.conf "${{targets.destdir}}"/etc/frontend/nginx.conf
+
+      export DESTDIR="${{targets.destdir}}"
+      mkdir -p "${{targets.destdir}}"/app
+
+      # Make node app available
+      npm config set legacy-peer-deps true
+      npm cache clean --force
+      npm install
+      export NODE_ENV=production
+      npm run build
+
+      cp -r server/public/* "${{targets.destdir}}"/app/
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-backend
+    description: hubble ui backend
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: backend
+          packages: .
+          output: backend
+          subpackage: "true"
+          ldflags: "-w"
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: cilium/hubble-ui
+    strip-prefix: v

--- a/hubble-ui/nginx.conf
+++ b/hubble-ui/nginx.conf
@@ -1,0 +1,76 @@
+# The nginx.conf file melange creates differs from upstream
+worker_processes  auto;
+
+error_log  /dev/stdout notice;
+pid        /tmp/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    proxy_temp_path /tmp/proxy_temp;
+    client_body_temp_path /tmp/client_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /dev/stdout  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+
+    # Include /etc/nginx/conf.d/default.conf
+    server {
+        listen       8081;
+        listen       [::]:8081;
+        server_name  localhost;
+        root /app;
+        index index.html;
+        client_max_body_size 1G;
+
+        location / {
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+
+            # CORS
+            add_header Access-Control-Allow-Methods "GET, POST, PUT, HEAD, DELETE, OPTIONS";
+            add_header Access-Control-Allow-Origin *;
+            add_header Access-Control-Max-Age 1728000;
+            add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;
+            add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;
+            if ($request_method = OPTIONS) {
+                return 204;
+            }
+            # /CORS
+
+            location /api {
+                proxy_http_version 1.1;
+                proxy_pass_request_headers on;
+                proxy_hide_header Access-Control-Allow-Origin;
+                proxy_pass http://127.0.0.1:8090;
+            }
+
+            location / {
+                # Avoid recursive reindexing
+                # https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#front-controller-pattern-web-apps
+                try_files $uri /index.html;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
* "hubble & hubble-ui backend 0.12.1: new package"

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] This PR links to the upstream project's support policy (e.g. `endoflife.date`) https://github.com/cilium/hubble#releases

| Version                                              | Release Date         | Maintained | Supported Cilium Version | Artifacts                                                               |
|------------------------------------------------------|----------------------|------------|--------------------------|-------------------------------------------------------------------------|
| [v0.12](https://github.com/cilium/hubble/tree/v0.12) | 2023-10-12 (v0.12.2) | Yes        | Cilium 1.14 and older    | [GitHub Release](https://github.com/cilium/hubble/releases/tag/v0.12.2) |
