### PR TITLE
`nspr`: add package

### DIFF
--- a/nspr.yaml
+++ b/nspr.yaml
@@ -1,0 +1,71 @@
+package:
+  name: nspr
+  version: "4.35"
+  epoch: 0
+  description: Netscape Portable Runtime
+  copyright:
+    - license: MPL-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - automake
+      - autoconf
+      - linux-headers
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v${{package.version}}/src/nspr-${{package.version}}.tar.gz
+      expected-sha256: 7ea3297ea5969b5d25a5dd8d47f2443cda88e9ee746301f6e1e1426f8a6abc8f
+
+  # Loosely based around: https://gitlab.archlinux.org/archlinux/packaging/packages/nspr/-/blob/main/PKGBUILD
+  - uses: autoconf/configure
+    working-directory: nspr
+    with:
+      opts: |
+        --prefix=/usr \
+        --libdir=/usr/lib \
+        --includedir=/usr/include/nspr \
+        --enable-optimize \
+        --disable-debug \
+        --enable-64bit
+
+  - uses: autoconf/make
+    working-directory: nspr
+
+  - uses: autoconf/make-install
+    working-directory: nspr
+
+  # Cleanup leftovers from the build.
+  - runs: |
+      rm -r "${{targets.destdir}}"/usr/include/nspr/md
+      rm -r "${{targets.destdir}}"/usr/bin/compile-et.pl
+      rm -r "${{targets.destdir}}"/usr/bin/prerr.properties
+
+  # Link the NSPR package config file into the right place.
+  - working-directory: nspr
+    runs: |
+      mkdir -p "${{target.destdir}}/usr/lib/pkgconfig/"
+      ln -s nspr.pc "${{target.destdir}}/usr/lib/pkgconfig/mozilla-nspr.pc"
+
+  - uses: strip
+
+subpackages:
+  - name: nspr-dev
+    pipeline:
+      - uses: split/dev
+        working-directory: nspr
+    dependencies:
+      runtime:
+        - nspr
+        - linux-headers
+    description: nspr dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 7953


### PR DESCRIPTION
The "Netscape Portable Runtime" is a dependency of `nss`, another package I'm chipping away at.

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
