### PR TITLE
pulumi: remove dependency version patches

### DIFF
--- a/pulumi.yaml
+++ b/pulumi.yaml
@@ -1,7 +1,5 @@
 package:
   name: pulumi
-  # When this version is bumped, please check the dependency version
-  # patches below and remove if possible.
   version: 3.90.0
   epoch: 0
   description: Infrastructure as Code in any programming language
@@ -34,20 +32,6 @@ pipeline:
 
   - working-directory: ${{package.name}}
     pipeline:
-      - runs: |
-          for d in pkg sdk; do
-            (
-              cd $d
-
-              # CVE-2023-39325 and CVE-2023-3978
-              go get golang.org/x/net@v0.17.0
-              go mod tidy
-            )
-          done
-
-          # Use grpcio >=1.59.0 to be Python 3.12 compat
-          sed -i "s/grpcio==.*/grpcio==1.59.0/g" sdk/python/requirements.txt
-          sed -i "s/'grpcio==.*'/'grpcio==1.59.0'/g" sdk/python/lib/setup.py
       - runs: |
           set -x
 

--- a/pulumi.yaml
+++ b/pulumi.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi
   version: 3.90.0
-  epoch: 0
+  epoch: 1
   description: Infrastructure as Code in any programming language
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
See:
- https://github.com/pulumi/pulumi/blob/v3.90.0/sdk/go.mod#L31
- https://github.com/pulumi/pulumi/blob/v3.90.0/sdk/python/requirements.txt#L4

```
❯ wolfictl scan packages/aarch64/*.apk
Will process: pulumi-3.90.0-r0.apk
✅ No vulnerabilities found
Will process: pulumi-language-go-3.90.0-r0.apk
✅ No vulnerabilities found
Will process: pulumi-language-nodejs-3.90.0-r0.apk
✅ No vulnerabilities found
Will process: pulumi-language-python-3.90.0-r0.apk
✅ No vulnerabilities found
```