### PR TITLE
Add new package `hickory-dns:0.24.0` and disable update on `trust-dns`

### DIFF
--- a/hickory-dns.yaml
+++ b/hickory-dns.yaml
@@ -1,0 +1,41 @@
+package:
+  name: hickory-dns
+  version: 0.24.0
+  epoch: 0
+  description: "A Rust based DNS client, server, and resolver"
+  copyright:
+    - license: MIT
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - rust
+      - libLLVM-15
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - openssl-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hickory-dns/hickory-dns
+      tag: v${{package.version}}
+      expected-commit: 408d0baca080d1b201cd33e616dc4abd160ef6c0
+
+  - name: Configure and build
+    runs: |
+      cargo build --release -p hickory-dns --all-features
+      mkdir -p ${{targets.destdir}}/usr/bin/
+      mv target/release/hickory-dns ${{targets.destdir}}/usr/bin/
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: hickory-dns/hickory-dns
+    strip-prefix: v
+    tag-filter: v

--- a/trust-dns.yaml
+++ b/trust-dns.yaml
@@ -33,8 +33,4 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: true
-  github:
-    identifier: bluejekyll/trust-dns
-    strip-prefix: v
-    tag-filter: v
+  enabled: false


### PR DESCRIPTION
### Trust-dns has been renamed to hickory-dns and there has been some changes in the release profiles

1. disabled update for `trust-dns` package
2. Add a new package for `hickory-dns`
---

Fixes: #7021 

Related: #6782

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates



