### PR TITLE
kubescape/3.0.0 package update and CVE-2023-39325 and CVE-2023-44487 fix

### DIFF
--- a/kubescape.yaml
+++ b/kubescape.yaml
@@ -1,6 +1,6 @@
 package:
   name: kubescape
-  version: 2.9.2
+  version: 3.0.0
   epoch: 0
   description: "Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources."
   copyright:
@@ -22,15 +22,18 @@ pipeline:
     with:
       repository: https://github.com/kubescape/kubescape
       tag: v${{package.version}}
-      expected-commit: e4110837c70807de7c37cca69f422f5951249d64
+      expected-commit: 3e2314a269f650f89e9bbdae590f02ea361fee0c
       destination: kubescape
 
   - runs: |
       cd kubescape
       export CGO_ENABLED=1
       make libgit2
+
+      # CVE-2023-39325 and CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
       python3 --version && python3 build.py
-      install -Dm755  ./build/kubescape-ubuntu-latest ${{targets.destdir}}/usr/bin/kubescape
+      install -Dm755 ./build/kubescape-ubuntu-latest ${{targets.destdir}}/usr/bin/kubescape
 
   - uses: strip
 


### PR DESCRIPTION
- kubescape/3.0.0 package update and CVE-2023-39325 and CVE-2023-44487 fix
Closes: https://github.com/wolfi-dev/os/pull/7237

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
