### PR TITLE
gitlab-runner/16.5.0 package update and CVE-2023-3978 / CVE-2023-39325 and CVE-2023-44487

### DIFF
--- a/gitlab-runner.yaml
+++ b/gitlab-runner.yaml
@@ -4,8 +4,8 @@
 #nolint:git-checkout-must-use-github-updates
 package:
   name: gitlab-runner
-  version: 16.4.1
-  epoch: 1
+  version: 16.5.0
+  epoch: 0
   description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
   copyright:
     - license: MIT
@@ -21,7 +21,11 @@ pipeline:
     with:
       repository: https://gitlab.com/gitlab-org/gitlab-runner
       tag: v${{package.version}}
-      expected-commit: d89a789a8800a94f7c2d98f0b9d85b79736b4f4a
+      expected-commit: 853330f9dd0a8e738629e142600edfb521c61204
+
+  - runs: |
+      # CVE-2023-3978 / CVE-2023-39325 and CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
- gitlab-runner/16.5.0 package update and CVE-2023-3978 / CVE-2023-39325 and CVE-2023-44487

Closes: https://github.com/wolfi-dev/os/pull/7175

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
