### PR TITLE
ollama/0.1.4 package update and CVE-2023-3978 / CVE-2023-39325 and CVE-2023-44487

### DIFF
--- a/ollama.yaml
+++ b/ollama.yaml
@@ -1,6 +1,6 @@
 package:
   name: ollama
-  version: 0.1.3
+  version: 0.1.4
   epoch: 0
   description: Get up and running with Llama 2 and other large language models locally
   copyright:
@@ -20,9 +20,12 @@ pipeline:
     with:
       repository: https://github.com/jmorganca/ollama
       tag: v${{package.version}}
-      expected-commit: 832b4db9d4baf22497145dde55f334b292ed665f
+      expected-commit: c345b4ca7c6540dcef70a2be3b4f3b768069ff3e
 
   - runs: |
+      # CVE-2023-3978 / CVE-2023-39325 and CVE-2023-44487
+      go get golang.org/x/net@v0.17.0
+
       go generate ./...
       CGO_ENABLED=1 go build -ldflags '-linkmode external -extldflags "-static"' .
       mkdir -p ${{targets.destdir}}/usr/bin


### PR DESCRIPTION
- ollama/0.1.4 package update and CVE-2023-3978 / CVE-2023-39325 and CVE-2023-44487

Closes: https://github.com/wolfi-dev/os/pull/7170

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
