### PR TITLE
py3-google-cloud-storage/2.12.0 package update

### DIFF
--- a/py3-google-cloud-storage.yaml
+++ b/py3-google-cloud-storage.yaml
@@ -1,8 +1,8 @@
 # Generated from https://pypi.org/project/google-cloud-storage/
 package:
   name: py3-google-cloud-storage
-  version: 2.11.0
-  epoch: 1
+  version: 2.12.0
+  epoch: 0
   description: Google Cloud Storage API client library
   copyright:
     - license: Apache 2.0
@@ -28,7 +28,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 9f256fc8e5829bb559b6eb26cd6b92b05e7f33db
+      expected-commit: 1ef0e1a94976780f1e847ec662344fe261757aec
       repository: https://github.com/googleapis/python-storage
       tag: v${{package.version}}
 


### PR DESCRIPTION
- py3-google-cloud-storage/2.12.0 package update

Closes: https://github.com/wolfi-dev/os/pull/6683
Fixes: https://github.com/wolfi-dev/os/issues/7022

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
