### PR TITLE
add simple test to cedar package

### DIFF
--- a/cedar.yaml
+++ b/cedar.yaml
@@ -1,7 +1,7 @@
 package:
   name: cedar
   version: 2.4.2
-  epoch: 0
+  epoch: 1
   description: "Core implementation of the Cedar language"
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,17 @@ pipeline:
       cargo build --release -vv
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/cedar ${{targets.destdir}}/usr/bin/
+
+  - name: Simple test
+    runs: |
+      cat <<EOF > sample.cedar
+      permit (
+        principal == User::"alice",
+        action == Action::"view",
+        resource in Album::"jane_vacation"
+      );
+      EOF
+      RUST_BACKTRACE=full ${{targets.destdir}}/usr/bin/cedar check-parse --policies sample.cedar
 
   - uses: strip
 


### PR DESCRIPTION
Adding a test to debug this issue.

According to https://github.com/cedar-policy/cedar/issues/379 this was broken due to a bad dependency, which has since been yanked, so bumping the epoch passes the build and should work in the image.