### PR TITLE
Bump openssl to fix CVE-2023-5363

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,6 +1,6 @@
 package:
   name: openssl
-  version: 3.1.3
+  version: 3.1.4
   epoch: 0
   description: "the OpenSSL cryptography suite"
   copyright:
@@ -32,7 +32,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://www.openssl.org/source/openssl-${{package.version}}.tar.gz
-      expected-sha256: f0316a2ebd89e7f2352976445458689f80302093788c466692fb2a188b2eacf6
+      expected-sha256: 840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3
 
   - name: Configure and build
     runs: |


### PR DESCRIPTION
https://www.openssl.org/news/secadv/20231024.txt

