### PR TITLE
hubble: unpin dependency versions

### DIFF
--- a/hubble.yaml
+++ b/hubble.yaml
@@ -1,7 +1,7 @@
 package:
   name: hubble
   version: 0.12.2
-  epoch: 0
+  epoch: 1
   description: hubble is a command to list and diagnose Go processes currently running on your system.
   copyright:
     - license: Apache-2.0
@@ -22,12 +22,6 @@ pipeline:
       expected-commit: a855de250efd16693f30ad7227a29e76f6357e8f
 
   - runs: |
-      # For critical CVE-2023-39347
-      go get github.com/cilium/cilium@v1.14.2
-
-      # Resyncing the vendor dir
-      go mod vendor
-
       DESTDIR=${{targets.destdir}} BINDIR=/usr/bin make install
 
   - uses: strip


### PR DESCRIPTION
See:
- https://github.com/cilium/hubble/blob/v0.12.2/go.mod#L6
- https://github.com/cilium/hubble/blob/v0.12.2/go.mod#L69

```
❯ wolfictl scan packages/aarch64/*.apk
Will process: hubble-0.12.2-r0.apk
✅ No vulnerabilities found
Will process: hubble-compat-0.12.2-r0.apk
✅ No vulnerabilities found
```