### PR TITLE
don't run package withdrawals during builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,9 +9,8 @@ on:
 
   workflow_dispatch:
 
-# Only run one build at a time to prevent out of sync signatures
-concurrency:
-  group: build-${{ github.ref }}
+# Only run one build at a time to prevent out of sync signatures.
+concurrency: build
 
 jobs:
   build:

--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -3,6 +3,9 @@ name: Withdraw packages
 on:
   workflow_dispatch:
 
+# Don't withdraw during builds, to prevent out of sync signatures.
+concurrency: build
+
 jobs:
   build:
     name: Withdraw packages


### PR DESCRIPTION
This will also queue up postsubmit build workflows and run the most recent one when available.

This won't cancel any in-progress builds or withdraws, only queue things up.

https://docs.github.com/en/actions/using-jobs/using-concurrency