### PR TITLE
Bump cilium-envoy commit

### DIFF
--- a/cilium-envoy.yaml
+++ b/cilium-envoy.yaml
@@ -2,8 +2,8 @@ package:
   name: cilium-envoy
   # cilium/proxy is refered by the build in cilium/cilium using
   # digest. the project itself does not have any tag nor release.
-  version: "1.25_git20230823"
-  epoch: 1
+  version: "1.25_git20231010"
+  epoch: 2
   description: Envoy proxy for Cilium with minimal Envoy extensions and Cilium policy enforcement filters.
   copyright:
     - license: Apache-2.0
@@ -39,7 +39,7 @@ environment:
 vars:
   # From latest cilium/cilium release:
   #   https://github.com/cilium/cilium/blob/v1.14.2/images/cilium/Dockerfile
-  CILIUM_PROXY_COMMIT: "e198a2824d309024cb91fb6a984445e73033291d"
+  CILIUM_PROXY_COMMIT: "f71a313bd0daee41470af31ce6ea20c750fe35dd"
 
 pipeline:
   - runs: |


### PR DESCRIPTION
Update to the cilium-envoy refered by 1.14.3. See
https://github.com/cilium/cilium/blob/v1.14.3/images/cilium/Dockerfile#L9

As the major-minor version is unchanged, I'm also bumping the epoch to avoid confusion to the solver.