### PR TITLE
checkov bump to get 3.12. Fixes #6715

### DIFF
--- a/checkov.yaml
+++ b/checkov.yaml
@@ -1,7 +1,7 @@
 package:
   name: checkov
   version: 2.3.354
-  epoch: 0
+  epoch: 1
   description: "static code and composition analysis tool for IaC"
   copyright:
     - license: MIT


### PR DESCRIPTION

```
83248d36b1a3:/work/packages# apk add python-3.12
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/13) Installing bzip2 (1.0.8-r4)
(2/13) Installing expat (2.5.0-r3)
(3/13) Installing libffi (3.4.4-r2)
(4/13) Installing gdbm (1.23-r3)
(5/13) Installing xz (5.4.4-r0)
(6/13) Installing libgcc (13.2.0-r3)
(7/13) Installing libstdc++ (13.2.0-r3)
(8/13) Installing mpdecimal (2.5.1-r3)
(9/13) Installing ncurses-terminfo-base (6.4_p20230722-r1)
(10/13) Installing ncurses (6.4_p20230722-r1)
(11/13) Installing readline (8.2-r2)
(12/13) Installing sqlite (3.40.0-r1)
(13/13) Installing python-3.12 (3.12.0-r1)
OK: 57 MiB in 27 packages
83248d36b1a3:/work/packages# apk add checkov
(1/1) Installing checkov (2.3.354-r1)
OK: 82 MiB in 28 packages
```

```
vaikas@vaikas-MBP os % wolfictl scan packages/aarch64/checkov-2.3.354-r1.apk
🔎 Scanning "packages/aarch64/checkov-2.3.354-r1.apk"
✅ No vulnerabilities found
```

Fixes: #6715

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
