### PR TITLE
Switch to `fetch` pipeline for checksum validation.

### DIFF
--- a/libnspr.yaml
+++ b/libnspr.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnspr
   version: "4.35"
-  epoch: 1
+  epoch: 2
   description: "Netscape Portable Runtime (NSPR) provides a platform-neutral API for system level and libc-like functions."
   copyright:
     - license: MPL-2.0
@@ -14,16 +14,11 @@ environment:
       - mercurial
       - bash
 
-var-transforms:
-  - from: ${{package.version}}
-    match: \.
-    replace: _
-    to: libnspr-package-version
-
 pipeline:
-  # we need to use runs because melange dont have a mercurial checkout pipeline yet
-  - runs: |
-      hg clone -r NSPR_${{vars.libnspr-package-version}}_RTM https://hg.mozilla.org/projects/nspr
+  - uses: fetch
+    with:
+      uri: https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v${{package.version}}/src/nspr-${{package.version}}.tar.gz
+      expected-sha256: 7ea3297ea5969b5d25a5dd8d47f2443cda88e9ee746301f6e1e1426f8a6abc8f
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
The previous approach relied on checking out a branch/tag with no checksum verification, which means that it could float forward over time without failing.

This picks up my change's `fetch` pipeline, which isn't susceptible to the same supply chain weakness.
