### PR TITLE
Add caveats when one needs to / does not need to withdraw packages.

### DIFF
--- a/WITHDRAWING_PACKAGES.md
+++ b/WITHDRAWING_PACKAGES.md
@@ -11,7 +11,7 @@ likely to need to withdraw packages.
 To do so:
 
 1. Add the package names that need to be withdrawn to `withdrawn-packages.txt`.
-2. Run the ]"Withdraw packages"](https://github.com/wolfi-dev/os/actions/workflows/withdraw-packages.yaml) workflow on GitHub.
+2. Run the ["Withdraw packages"](https://github.com/wolfi-dev/os/actions/workflows/withdraw-packages.yaml) workflow on GitHub.
 
 ## Technical details
 

--- a/WITHDRAWING_PACKAGES.md
+++ b/WITHDRAWING_PACKAGES.md
@@ -1,12 +1,17 @@
 # Withdrawing packages in Wolfi
 
 Sometimes a package needs to be withdrawn from Wolfi because it has been
-determined to be defective.
+determined to be defective. This is to avoid somebody from accidentally
+depending on it. If you are fixing the defective version, and in the process are
+bumping the epoch, most likely you do not need to withdraw the package as the
+newer version will be preferred by version selection process. Any other package
+fix that will create a more preferred version will also mean that you are not
+likely to need to withdraw packages.
 
 To do so:
 
 1. Add the package names that need to be withdrawn to `withdrawn-packages.txt`.
-2. Run the "Withdraw packages" workflow on GitHub.
+2. Run the ]"Withdraw packages"](https://github.com/wolfi-dev/os/actions/workflows/withdraw-packages.yaml) workflow on GitHub.
 
 ## Technical details
 


### PR DESCRIPTION
Just document some cases where withdrawing is not necessary. Add a link to the action.

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
