### PR TITLE
Trino: Always create plugin folder

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
   version: "430"
-  epoch: 1
+  epoch: 2
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0
@@ -48,6 +48,7 @@ pipeline:
       cp ./core/trino-server/target/trino-server-${{package.version}}/README.txt ${{targets.destdir}}/usr/lib/trino/
       cp -r ./core/trino-server/target/trino-server-${{package.version}}/bin ${{targets.destdir}}/usr/lib/trino/bin/
       cp -r ./core/trino-server/target/trino-server-${{package.version}}/lib ${{targets.destdir}}/usr/lib/trino/lib/
+      mkdir ${{targets.destdir}}/usr/lib/trino/plugin
 
       mkdir -p ${{targets.destdir}}/usr/bin/
       cp ./client/trino-cli/target/trino-cli-430-executable.jar ${{targets.destdir}}/usr/bin/trino


### PR DESCRIPTION
This is a minor change (since plugins are more or less required), but Trino won't start if the `plugin` folder is missing.