### PR TITLE
kubernetes-csi-external-attacher: unpin dependencies

### DIFF
--- a/kubernetes-csi-external-attacher-4.4.yaml
+++ b/kubernetes-csi-external-attacher-4.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-attacher-4.4
   version: 4.4.1
-  epoch: 0
+  epoch: 1
   description: Sidecar container that watches Kubernetes VolumeAttachment objects and triggers ControllerPublish/Unpublish against a CSI endpoint
   copyright:
     - license: Apache-2.0
@@ -27,10 +27,6 @@ pipeline:
       expected-commit: f5243352d57f7df14d1d68d2487489860e7abbde
 
   - runs: |
-      # CVE-2023-39325 and CVE-2023-3978
-      go get golang.org/x/net@v0.17.0
-      go mod vendor
-
       make build
       mkdir -p ${{targets.destdir}}/usr/bin
       install -Dm755 ./bin/csi-attacher ${{targets.destdir}}/usr/bin/csi-attacher


### PR DESCRIPTION
See https://github.com/kubernetes-csi/external-attacher/blob/v4.4.1/go.mod#L50