### PR TITLE
kubernetes-csi-external-resizer: unpin dependencies

### DIFF
--- a/kubernetes-csi-external-resizer.yaml
+++ b/kubernetes-csi-external-resizer.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-resizer
   version: 1.9.1
-  epoch: 0
+  epoch: 1
   description: Sidecar container that watches Kubernetes PersistentVolumeClaims objects and triggers controller side expansion operation against a CSI endpoint
   copyright:
     - license: Apache-2.0
@@ -24,10 +24,6 @@ pipeline:
       expected-commit: e4935338ddb81bd859b7ac93fc018e216a6e4743
 
   - runs: |
-      # CVE-2023-39325 and CVE-2023-3978
-      go get golang.org/x/net@v0.17.0
-      go mod vendor
-
       make build
       mkdir -p ${{targets.destdir}}/usr/bin
       install -Dm755 ./bin/csi-resizer ${{targets.destdir}}/usr/bin/csi-resizer


### PR DESCRIPTION
See https://github.com/kubernetes-csi/external-resizer/blob/v1.9.1/go.mod#L55