### PR TITLE
gitlab: add gitlab-exporter

### DIFF
--- a/gitlab-exporter.yaml
+++ b/gitlab-exporter.yaml
@@ -1,0 +1,77 @@
+# source is gitlab so we can't use github updates to get expected commit
+# let's still auto create the PR, it will fail as expected commit will be wrong
+# however it will be easy to fix
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-exporter
+  version: 13.4.1
+  epoch: 0
+  description: GitLab Exporter is a Prometheus Web exporter.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - jemalloc
+      - ruby-3.2
+      - libpq-15
+      - busybox
+      - gitlab-cng-exporter-scripts
+      - ruby3.2-webrick
+      - ruby3.2-faraday
+      - ruby3.2-faraday-excon
+      - ruby3.2-rack
+      - ruby3.2-bundler
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libpq-15
+      - postgresql-15-dev
+      - ruby-3.2
+      - ruby-3.2-dev
+      - ruby3.2-bundler
+
+vars:
+  gem: gitlab-exporter
+
+pipeline:
+  # GitLab-Exporter
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/ruby/gems/gitlab-exporter.git
+      tag: v${{package.version}}
+      expected-commit: 590c4261bd09b341742ee5249225b3aaac421445
+
+  - uses: ruby/unlock-spec
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  # GitLab-Exporter Runtime Dependencies
+  - runs: |
+      gem install puma -v 5.6.5 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
+      gem install quantile -v 0.2.1 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
+      gem install sinatra -v 2.2.0 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
+      gem install redis -v 4.4.0 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
+      gem install pg -v 1.5.3 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
+      gem install connection_pool -v 2.2.5 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
+      gem install sidekiq -v 6.4.0 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
+      gem install redis-namespace -v 1.9.0 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
+
+  - uses: strip
+
+  - uses: ruby/clean
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 369817

--- a/gitlab-exporter.yaml
+++ b/gitlab-exporter.yaml
@@ -25,6 +25,7 @@ package:
 environment:
   contents:
     packages:
+      - bash
       - build-base
       - busybox
       - ca-certificates-bundle
@@ -47,6 +48,31 @@ pipeline:
 
   - uses: ruby/unlock-spec
 
+  # GitLab-Exporter Runtime Dependencies
+  - runs: |
+      # CVE-2023-40175 puma
+      sed -e 's/5.6.5/5.6.7/' -i gitlab-exporter.gemspec
+      sed -e 's/= 5.6.5/= 5.6.7/' -i Gemfile.lock
+
+      # CVE-2023-26141 sidekiq conflicting with the redis version as well
+      sed -e 's/6.4.0/6.5.10/' -i gitlab-exporter.gemspec
+      sed -e 's/= 6.4.0/= 6.5.10/' -i Gemfile.lock
+      sed -e 's/= 4.4.0/= 4.5.0/' -i Gemfile.lock
+      sed -e 's/4.4.0/4.5.0/' -i gitlab-exporter.gemspec
+
+      # Replace this with the actual path to your gitlab-exporter.gemspec file
+      GEMSPEC_FILE="./gitlab-exporter.gemspec"
+
+      # This is your target directory for installing the gems
+      # I'm assuming it's an environment variable, change as needed
+      INSTALL_GEM_DIR=${{targets.destdir}}$(ruby -e 'puts Gem.default_dir')/
+
+      # Use grep and sed to extract the lines containing runtime dependencies
+      grep 's.add_runtime_dependency' $GEMSPEC_FILE | sed -E 's/s.add_runtime_dependency[[:space:]]+"([^"]+)",[[:space:]]+"([^"]+)"/\1 \2/' | sed -e 's/~> //' -e 's/=> //' -e 's/= //' | while read -r GEM_NAME GEM_VERSION; do
+        # Run the gem install command
+        gem install $GEM_NAME -v $GEM_VERSION --install-dir $INSTALL_GEM_DIR
+      done
+
   - uses: ruby/build
     with:
       gem: ${{vars.gem}}
@@ -55,19 +81,6 @@ pipeline:
     with:
       gem: ${{vars.gem}}
       version: ${{package.version}}
-
-  # GitLab-Exporter Runtime Dependencies
-  - runs: |
-      gem install puma -v 5.6.5 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
-      gem install quantile -v 0.2.1 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
-      gem install sinatra -v 2.2.0 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
-      gem install redis -v 4.4.0 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
-      gem install pg -v 1.5.3 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
-      gem install connection_pool -v 2.2.5 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
-      gem install sidekiq -v 6.4.0 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
-      gem install redis-namespace -v 1.9.0 --install-dir ${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
-
-  - uses: strip
 
   - uses: ruby/clean
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
https://github.com/chainguard-dev/image-requests/issues/459
Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
