### PR TITLE
Add Gitlab mailroom

### DIFF
--- a/gitlab-mailroom.yaml
+++ b/gitlab-mailroom.yaml
@@ -4,8 +4,8 @@
 #nolint:git-checkout-must-use-github-updates
 package:
   name: gitlab-mailroom
-  version: 0.0.23
-  epoch: 2
+  version: 0.10.1
+  epoch: 0
   description: GitLab mail_room contains some merged functionality that GitLab requires, so this mirror fork is to help us release custom functionality.
   copyright:
     - license: MIT
@@ -34,12 +34,12 @@ vars:
   gem: mail_room
 
 pipeline:
-  # GitLab-Exporter
+  # GitLab-Mail_Room
   - uses: git-checkout
     with:
       repository: https://gitlab.com/gitlab-org/ruby/gems/gitlab-mail_room.git
       tag: v${{package.version}}
-      expected-commit: 578c314fc5d936978fafdea68952f9a5b2f7fe7d
+      expected-commit: bf4e63e2a8dbc9f4c65570dc3f91693bc24bad26
 
   - uses: ruby/unlock-spec
 
@@ -54,7 +54,6 @@ pipeline:
       gem install charlock_holmes:0.7.7 \
         redis-client:0.17.1 \
         redis:5.0.7 \
-        jwt:2.7.1 \
         oauth2:2.0.9 \
         redis-namespace:1.10.0 --install-dir $INSTALL_GEM_DIR
 
@@ -73,4 +72,4 @@ pipeline:
 update:
   enabled: true
   release-monitor:
-    identifier: 369817
+    identifier: 369819

--- a/gitlab-mailroom.yaml
+++ b/gitlab-mailroom.yaml
@@ -1,0 +1,76 @@
+# source is gitlab so we can't use github updates to get expected commit
+# let's still auto create the PR, it will fail as expected commit will be wrong
+# however it will be easy to fix
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: gitlab-mailroom
+  version: 0.0.23
+  epoch: 2
+  description: GitLab mail_room contains some merged functionality that GitLab requires, so this mirror fork is to help us release custom functionality.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - jemalloc
+      - ruby-3.2
+      - busybox
+      - gitlab-cng-mailroom-scripts
+      - ruby3.2-webrick
+      - ruby3.2-bundler
+      - ruby3.2-rack-oauth2
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - icu-dev
+      - ruby-3.2
+      - ruby-3.2-dev
+      - ruby3.2-bundler
+      - zlib-dev
+
+vars:
+  gem: mail_room
+
+pipeline:
+  # GitLab-Exporter
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/ruby/gems/gitlab-mail_room.git
+      tag: v${{package.version}}
+      expected-commit: 578c314fc5d936978fafdea68952f9a5b2f7fe7d
+
+  - uses: ruby/unlock-spec
+
+  - runs: |
+      # This is your target directory for installing the gems
+      # I'm assuming it's an environment variable, change as needed
+      INSTALL_GEM_DIR=${{targets.destdir}}$(ruby -e 'puts Gem.default_dir')/
+
+      # GitLab-Mail_Room dependencies installed when running the package.
+      # These dependencies are registered as development dependencies in the repository
+      # but installed when using the binary.
+      gem install charlock_holmes:0.7.7 \
+        redis-client:0.17.1 \
+        redis:5.0.7 \
+        jwt:2.7.1 \
+        oauth2:2.0.9 \
+        redis-namespace:1.10.0 --install-dir $INSTALL_GEM_DIR
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+      output: mail_room-${{package.version}}.gem
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 369817


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
https://github.com/chainguard-dev/image-requests/issues/455
Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
