### PR TITLE
coreutils: provide stdbuf and others

### DIFF
--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: coreutils
   version: "9.4"
-  epoch: 1
+  epoch: 2
   description: "GNU core utilities"
   copyright:
     - license: GPL-3.0-or-later
@@ -45,7 +45,6 @@ pipeline:
 
   - uses: strip
 
-  # Move things around to match busybox locations
   - runs: |
       cd "${{targets.destdir}}"
 
@@ -54,8 +53,14 @@ pipeline:
 
       install -d bin usr/sbin
 
+      # Move things around to match busybox locations
       for i in base64 cat chgrp chmod chown cp date dd df echo false ln ls mkdir mknod mktemp mv nice printenv pwd rm rmdir sleep stat stty sync touch true uname; do
         rm usr/bin/$i
+        ln -s ../usr/bin/coreutils bin/$i
+      done
+
+      # Busybox doesn't have these, but coreutils does.
+      for i in chroot env nohup stdbuf timeout; do
         ln -s ../usr/bin/coreutils bin/$i
       done
 


### PR DESCRIPTION
Our coreutils package doesn't provide `stdbuf` today, or others listed here: https://www.gnu.org/software/coreutils/manual/html_node/Modified-command-invocation.html

This symlinks coreutils to these locations so they can be used.