### PR TITLE
`py3-blinker/1.6.3` package version upgrade

### DIFF
--- a/py3-blinker.yaml
+++ b/py3-blinker.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-blinker
-  version: 1.6.2
+  version: 1.6.3
   epoch: 0
   description: Fast, simple object-to-object and broadcast signaling
   copyright:
@@ -17,6 +17,7 @@ environment:
       - busybox
       - build-base
       - python3
+      - py3-flit-core
       - py3-setuptools
       - py3-gpep517
       - py3-wheel
@@ -27,7 +28,7 @@ pipeline:
     with:
       repository: https://github.com/pallets-eco/blinker/
       tag: ${{package.version}}
-      expected-commit: 876a12a1988c1789799a1d6919abdce38a62a0ff
+      expected-commit: 3e534565a811c5e8d8ea01f5c5f7e5c1de4fcfde
 
   - runs: |
       python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 3 3>&1 >&2

--- a/py3-flask.yaml
+++ b/py3-flask.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-flask
   version: 3.0.0
-  epoch: 2
+  epoch: 1
   description: A simple framework for building complex web applications.
   copyright:
     - license: BSD

--- a/py3-flask.yaml
+++ b/py3-flask.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-flask
   version: 3.0.0
-  epoch: 1
+  epoch: 2
   description: A simple framework for building complex web applications.
   copyright:
     - license: BSD


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #7029

Related: #6432

It just needed py3-flit-core library to build the new version.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->



#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

