### PR TITLE
fix directories kubeflow-pipelines frontend package

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
-  version: 2.1.3
-  epoch: 7
+  version: 2.3.0
+  epoch: 0
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -12,23 +12,22 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
+      - argo-cd
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
+      - eslint
+      - git
       - go
       - go-licenses
-      - git
-      - argo-cd
-      - python3-dev
-      - py3-setuptools
-      - py3-gpep517
-      - py3-wheel
-      - py3-pip
+      - jq
       - kubectl
       - nodejs
-      - jq
-      - eslint
+      - py3-gpep517
+      - py3-pip
+      - py3-setuptools
+      - py3-wheel
+      - python3-dev
 
 data:
   - name: backends-go-builds
@@ -44,7 +43,7 @@ pipeline:
     with:
       repository: https://github.com/kubeflow/pipelines
       tag: sdk-${{package.version}}
-      expected-commit: 2b05ec867fad84e24fe73ef7515e3b5849297e79
+      expected-commit: 4003e562713bd04fa94387d8b53dfbe3cf31cb12
 
   - uses: patch
     with:
@@ -57,6 +56,11 @@ pipeline:
   - uses: patch
     with:
       patches: add-samples.patch
+
+  # ERROR: No matching distribution found for kfp==2.0.1
+  - uses: patch
+    with:
+      patches: kfp.patch
 
 subpackages:
   - range: backends-go-builds
@@ -151,22 +155,17 @@ subpackages:
     description: "Kubeflow Pipelines frontend"
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mkdir -p ${{targets.subpkgdir}}/server
+          mkdir -p ${{targets.subpkgdir}}/client
           cd frontend/
           npm ci
           npm run postinstall
           npm run build
-          cp -r ./server/* ${{targets.subpkgdir}}/usr/bin/
-          cp -r ./build/* ${{targets.subpkgdir}}/usr/bin/
-
-  - name: "kubeflow-pipelines-frontend-compat"
-    description: "Kubeflow Pipelines frontend compatibility package"
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/server
-          mkdir -p ${{targets.subpkgdir}}/client
-          ln -sf /usr/bin ${{targets.subpkgdir}}/server
-          ln -sf /usr/bin ${{targets.subpkgdir}}/client
+          cp -r ./build/* ${{targets.subpkgdir}}/client/
+          cd ./server
+          npm ci
+          npm run build
+          mv ./* ${{targets.subpkgdir}}/server/
 
   - name: "kubeflow-pipelines-metadata-writer"
     description: "Kubeflow Pipelines metadata_writer"

--- a/kubeflow-pipelines/bump_requirements.patch
+++ b/kubeflow-pipelines/bump_requirements.patch
@@ -1,68 +1,115 @@
+From 52b642609fea5d95816b3ccb3eb5299200f22fd9 Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Wed, 25 Oct 2023 22:59:19 +0300
+Subject: [PATCH]
+
+---
+ backend/metadata_writer/requirements.in  |  6 ++--
+ backend/metadata_writer/requirements.txt | 46 ++++++++++++------------
+ 2 files changed, 26 insertions(+), 26 deletions(-)
+
 diff --git a/backend/metadata_writer/requirements.in b/backend/metadata_writer/requirements.in
-index 27130c3..9eb1b92 100644
+index e45d3d7ba..c7d3f044b 100644
 --- a/backend/metadata_writer/requirements.in
 +++ b/backend/metadata_writer/requirements.in
 @@ -1,3 +1,3 @@
 -kubernetes>=8.0.0,<11.0.0
-+kubernetes
 -ml-metadata==1.14.0
-+ml-metadata
 -lru-dict>=1.1.7,<2.0.0
++kubernetes
++ml-metadata
 +lru-dict
 diff --git a/backend/metadata_writer/requirements.txt b/backend/metadata_writer/requirements.txt
-index cc3c614..b3d8470 100644
+index 071621f3a..7cefdc938 100644
 --- a/backend/metadata_writer/requirements.txt
 +++ b/backend/metadata_writer/requirements.txt
-@@ -4,29 +4,29 @@
+@@ -4,63 +4,63 @@
  #
  #    pip-compile --output-file=- -
  #
--absl-py==0.12.0           # via ml-metadata
--attrs==20.3.0             # via ml-metadata
--cachetools==5.0.0         # via google-auth
--certifi==2021.10.8        # via kubernetes, requests
--charset-normalizer==2.0.10  # via requests
--google-auth==2.4.1        # via kubernetes
--grpcio==1.43.0            # via ml-metadata
--idna==3.3                 # via requests
--kubernetes==10.1.0        # via -r -
--lru-dict==1.1.7           # via -r -
--ml-metadata==1.5.0        # via -r -
--oauthlib==3.1.1           # via requests-oauthlib
--protobuf==3.19.3          # via ml-metadata
--pyasn1-modules==0.2.8     # via google-auth
--pyasn1==0.4.8             # via pyasn1-modules, rsa
--python-dateutil==2.8.2    # via kubernetes
--pyyaml==3.13              # via kubernetes
--requests-oauthlib==1.3.0  # via kubernetes
--requests==2.27.1          # via kubernetes, requests-oauthlib
--rsa==4.8                  # via google-auth
--six==1.16.0               # via absl-py, google-auth, grpcio, kubernetes, ml-metadata, python-dateutil
--urllib3==1.26.8           # via kubernetes, requests
--websocket-client==1.2.3   # via kubernetes
-+absl-py           # via ml-metadata
-+attrs             # via ml-metadata
-+cachetools        # via google-auth
-+certifi           # via kubernetes, requests
-+charset-normalizer  # via requests
-+google-auth       # via kubernetes
-+grpcio            # via ml-metadata
-+idna              # via requests
-+kubernetes        # via -r -
-+lru-dict          # via -r -
-+ml-metadata       # via -r -
-+oauthlib          # via requests-oauthlib
-+protobuf          # via ml-metadata
-+pyasn1-modules    # via google-auth
-+pyasn1            # via pyasn1-modules, rsa
-+python-dateutil   # via kubernetes
-+pyyaml            # via kubernetes
-+requests-oauthlib # via kubernetes
-+requests          # via kubernetes, requests-oauthlib
-+rsa               # via google-auth
-+six               # via absl-py, google-auth, grpcio, kubernetes, ml-metadata, python-dateutil
-+urllib3           # via kubernetes, requests
-+websocket-client  # via kubernetes
+-absl-py==1.4.0
++absl-py
+     # via ml-metadata
+-attrs==21.4.0
++attrs
+     # via ml-metadata
+-cachetools==5.3.1
++cachetools
+     # via google-auth
+-certifi==2023.7.22
++certifi
+     # via
+     #   kubernetes
+     #   requests
+-charset-normalizer==3.2.0
++charset-normalizer
+     # via requests
+-google-auth==2.23.0
++google-auth
+     # via kubernetes
+-grpcio==1.58.0
++grpcio
+     # via ml-metadata
+-idna==3.4
++idna
+     # via requests
+-kubernetes==10.1.0
++kubernetes
+     # via -r -
+-lru-dict==1.2.0
++lru-dict
+     # via -r -
+-ml-metadata==1.14.0
++ml-metadata
+     # via -r -
+-oauthlib==3.2.2
++oauthlib
+     # via requests-oauthlib
+-protobuf==3.20.3
++protobuf
+     # via ml-metadata
+-pyasn1==0.5.0
++pyasn1
+     # via
+     #   pyasn1-modules
+     #   rsa
+-pyasn1-modules==0.3.0
++pyasn1-modules
+     # via google-auth
+-python-dateutil==2.8.2
++python-dateutil
+     # via kubernetes
+-pyyaml==3.13
++pyyaml
+     # via kubernetes
+-requests==2.31.0
++requests
+     # via
+     #   kubernetes
+     #   requests-oauthlib
+-requests-oauthlib==1.3.1
++requests-oauthlib
+     # via kubernetes
+-rsa==4.9
++rsa
+     # via google-auth
+-six==1.16.0
++six
+     # via
+     #   kubernetes
+     #   ml-metadata
+     #   python-dateutil
+-urllib3==1.26.16
++urllib3
+     # via
+     #   google-auth
+     #   kubernetes
+     #   requests
+-websocket-client==1.6.3
++websocket-client
+     # via kubernetes
  
  # The following packages are considered to be unsafe in a requirements file:
- # setuptools
+-- 
+2.39.3 (Apple Git-145)
+

--- a/kubeflow-pipelines/kfp.patch
+++ b/kubeflow-pipelines/kfp.patch
@@ -1,0 +1,25 @@
+From 38ded406f1790a3381132cd969f4f7d71f7c4204 Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Wed, 25 Oct 2023 23:17:05 +0300
+Subject: [PATCH]
+
+---
+ backend/requirements.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/backend/requirements.txt b/backend/requirements.txt
+index 68cfc0f33..37d572ee1 100644
+--- a/backend/requirements.txt
++++ b/backend/requirements.txt
+@@ -43,7 +43,7 @@ idna==3.4
+     # via requests
+ importlib-metadata==6.7.0
+     # via click
+-kfp==2.0.1
++kfp
+     # via -r -
+ kfp-pipeline-spec==0.2.2
+     # via kfp
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

we noticed that we were using the wrong directories for the image. At the times we were working on that package we were also have lots of other packages to do, so, we missed that one and made mistakes about the directories, so, the directories should be and we should also include .dist folder:

- [kubeflow/pipelines@570e56d/frontend/Dockerfile#L30-L31](https://github.com/kubeflow/pipelines/blob/570e56dd09af32e173cf041eed7497e4533ec186/frontend/Dockerfile#L30-L31)
- 
- [kubeflow/pipelines@570e56d/frontend/Dockerfile#L39](https://github.com/kubeflow/pipelines/blob/570e56dd09af32e173cf041eed7497e4533ec186/frontend/Dockerfile#L39)

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
