### PR TITLE
fixing oci entrypoints for using temporal-server

### DIFF
--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -5,6 +5,9 @@ package:
   description: Temporal server executes units of application logic, Workflows, in a resilient manner that automatically handles intermittent failures, and retries failed operations
   copyright:
     - license: MIT License
+  dependencies:
+    runtime:
+      - tctl
 
 environment:
   contents:
@@ -14,6 +17,7 @@ environment:
       - build-base
       - go
       - ca-certificates-bundle
+      - tctl
   environment:
     CGO_ENABLED: 0
 
@@ -26,12 +30,6 @@ pipeline:
 
   - runs: |
       go get golang.org/x/net@v0.17.0
-
-      # Mitigate CVE-2023-47108/GHSA-8pgv-569h-w5rw
-      go mod edit -replace=go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc=go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
-      go mod edit -replace=go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc=go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
-      go mod edit -replace=go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc=go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@v0.42.0
-      go mod edit -replace=go.opentelemetry.io/otel/exporters/otlp/otlpmetric=go.opentelemetry.io/otel/exporters/otlp/otlpmetric@v0.42.0
 
       # Remediate GHSA-m425-mq94-257g
       go get google.golang.org/grpc@v1.58.3
@@ -75,11 +73,22 @@ subpackages:
       runtime:
         - bash
         - temporal-docker-builds
+        - tctl
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc/temporal/config/dynamicconfig
           cp config/dynamicconfig/docker.yaml ${{targets.subpkgdir}}/etc/temporal/config/dynamicconfig
           cp docker/config_template.yaml ${{targets.subpkgdir}}/etc/temporal/config
+
+  - name: temporal-server-schema
+    description: Schema for using temporal server needby temporal admin tools
+    dependencies:
+      runtime:
+        - bash
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc/temporal/schema
+          cp -r schema ${{targets.subpkgdir}}/etc/temporal/schema
 
 update:
   enabled: true

--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -64,20 +64,11 @@ subpackages:
     dependencies:
       runtime:
         - bash
-        - dockerize
         - temporal-docker-builds
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/etc/temporal
-
-          cp temporal-docker-builds/entrypoint.sh ${{targets.subpkgdir}}/etc/temporal
-          chmod +x ${{targets.subpkgdir}}/etc/temporal/entrypoint.sh
-
-          cp temporal-docker-builds/start-temporal.sh ${{targets.subpkgdir}}/etc/temporal
-          chmod +x ${{targets.subpkgdir}}/etc/temporal/start-temporal.sh
-
-          mkdir -p ${{targets.subpkgdir}}/etc/temporal/config
-          cp config/dynamicconfig/docker.yaml /etc/temporal/config/dynamicconfig/docker.yaml
+          mkdir -p ${{targets.subpkgdir}}/etc/temporal/config/dynamicconfig
+          cp config/dynamicconfig/docker.yaml ${{targets.subpkgdir}}/etc/temporal/config/dynamicconfig
           cp docker/config_template.yaml ${{targets.subpkgdir}}/etc/temporal/config
 
 update:

--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal-server
   version: 1.22.2
-  epoch: 0
+  epoch: 1
   description: Temporal server executes units of application logic, Workflows, in a resilient manner that automatically handles intermittent failures, and retries failed operations
   copyright:
     - license: MIT License
@@ -58,6 +58,23 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           install -Dm755 temporal-sql-tool "${{targets.subpkgdir}}"/usr/bin/temporal-sql-tool
       - uses: strip
+
+  - name: temporal-server-oci-entrypoint
+    description: Entrypoint for using temporal server in OCI containers
+    dependencies:
+      runtime:
+        - bash
+        - dockerize
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/home/temporal-server/
+           # This needs to be fixed since its entrypoint comes from different repo https://github.com/temporalio/docker-builds/blob/main/docker/entrypoint.sh
+
+           #  cp etc/temporal/entrypoint.sh ${{targets.subpkgdir}}/home/temporal-server/
+           #  chmod +x ${{targets.subpkgdir}}/home/temporal-server/entrypoint.sh
+
+          mkdir -p ${{targets.subpkgdir}}/home/temporal-server/config
+          cp docker/config_template.yaml ${{targets.subpkgdir}}/home/temporal-server/config
 
 update:
   enabled: true

--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -65,16 +65,20 @@ subpackages:
       runtime:
         - bash
         - dockerize
+        - temporal-docker-builds
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/home/temporal-server/
-           # This needs to be fixed since its entrypoint comes from different repo https://github.com/temporalio/docker-builds/blob/main/docker/entrypoint.sh
+          mkdir -p ${{targets.subpkgdir}}/etc/temporal
 
-           #  cp etc/temporal/entrypoint.sh ${{targets.subpkgdir}}/home/temporal-server/
-           #  chmod +x ${{targets.subpkgdir}}/home/temporal-server/entrypoint.sh
+          cp temporal-docker-builds/entrypoint.sh ${{targets.subpkgdir}}/etc/temporal
+          chmod +x ${{targets.subpkgdir}}/etc/temporal/entrypoint.sh
 
-          mkdir -p ${{targets.subpkgdir}}/home/temporal-server/config
-          cp docker/config_template.yaml ${{targets.subpkgdir}}/home/temporal-server/config
+          cp temporal-docker-builds/start-temporal.sh ${{targets.subpkgdir}}/etc/temporal
+          chmod +x ${{targets.subpkgdir}}/etc/temporal/start-temporal.sh
+
+          mkdir -p ${{targets.subpkgdir}}/etc/temporal/config
+          cp config/dynamicconfig/docker.yaml /etc/temporal/config/dynamicconfig/docker.yaml
+          cp docker/config_template.yaml ${{targets.subpkgdir}}/etc/temporal/config
 
 update:
   enabled: true

--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -26,6 +26,16 @@ pipeline:
 
   - runs: |
       go get golang.org/x/net@v0.17.0
+
+      # Mitigate CVE-2023-47108/GHSA-8pgv-569h-w5rw
+      go mod edit -replace=go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc=go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+      go mod edit -replace=go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc=go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
+      go mod edit -replace=go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc=go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@v0.42.0
+      go mod edit -replace=go.opentelemetry.io/otel/exporters/otlp/otlpmetric=go.opentelemetry.io/otel/exporters/otlp/otlpmetric@v0.42.0
+
+      # Remediate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.58.3
+
       go mod tidy
       make bins
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
