### PR TITLE
cilium: remove runtime deps

### DIFF
--- a/cilium.yaml
+++ b/cilium.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium
   version: 1.14.3
-  epoch: 2
+  epoch: 3
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -92,9 +92,6 @@ subpackages:
 
   - name: ${{package.name}}-operator-generic
     description: Generic operator for cilium
-    dependencies:
-      runtime:
-        - gops
     pipeline:
       - runs: |
           cd /home/build/operator


### PR DESCRIPTION
Remove the `gops` runtime dep on `cilium-operator-generic` as it is not strictly needed.