### PR TITLE
add elasticsearch

### DIFF
--- a/elasticsearch.yaml
+++ b/elasticsearch.yaml
@@ -1,0 +1,56 @@
+package:
+  name: elasticsearch
+  version: 8.10.4
+  epoch: 0
+  description: "Free and Open, Distributed, RESTful Search Engine"
+  copyright:
+    - license: Apache-2.0 AND Elastic-2.0
+  dependencies:
+    runtime:
+      - bash # some helper scripts use bash
+      - openjdk-17-jre
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - gradle-8~8.2.1
+      - openjdk-17
+      - glibc-locale-en
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/elastic/elasticsearch
+      tag: v${{package.version}}
+      expected-commit: b4a62ac808e886ff032700c391f45f1408b2538c
+
+  - runs: |
+      export LANG=en_US.UTF-8
+      export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+      export ES_JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+
+      gradle localDistro
+
+      mkdir -p ${{targets.destdir}}/usr/share/java/elasticsearch
+
+      build_path=build/distribution/local
+
+      mv $build_path/elasticsearch-${{package.version}}-SNAPSHOT/bin ${{targets.destdir}}/usr/share/java/elasticsearch/.
+      mv $build_path/elasticsearch-${{package.version}}-SNAPSHOT/config ${{targets.destdir}}/usr/share/java/elasticsearch/.
+      mv $build_path/elasticsearch-${{package.version}}-SNAPSHOT/lib ${{targets.destdir}}/usr/share/java/elasticsearch/.
+      mv $build_path/elasticsearch-${{package.version}}-SNAPSHOT/modules ${{targets.destdir}}/usr/share/java/elasticsearch/.
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+
+      for i in ${{targets.destdir}}/usr/share/java/elasticsearch/bin/*; do
+        name=$(basename $i)
+        ln -sf /usr/share/java/elasticsearch/bin/$name ${{targets.destdir}}/usr/bin/$name
+      done
+
+update:
+  enabled: true
+  github:
+    identifier: elastic/elasticsearch
+    strip-prefix: v


### PR DESCRIPTION
add `elasticsearch` dual licensed by [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) and [Elastic-2.0](https://spdx.org/licenses/Elastic-2.0.html)

Note: in `./gradlew` uses *gradle 8.2* and the build does not work with *8.4* (latest version). I've pinned `gradle-8=8.2.1-r1`   until it is resolved.

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
