### PR TITLE
Poll releases instead of tags for updates, plus misc changes

### DIFF
--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -21,6 +21,7 @@ environment:
       - ca-certificates-bundle
       - nodejs-18
       - openjdk-17
+      - openjdk-17-default-jvm
       - wolfi-base
       - wolfi-baselayout
   environment:
@@ -40,6 +41,10 @@ pipeline:
       patches: bump-xmlsec.patch
 
   - runs: |
+      # Upstream removed `keycloak-js-adapter` as a build-time dependency (March 2023).
+      # The maven build now pulls this in as a pre-compiled jar. Filed upstream
+      # issue to query: https://github.com/keycloak/keycloak/issues/24320.
+
       # Keycloak installation. Note we use the maven wrapper as configured in
       # the source repo to build - ensures the correct maven version for
       # building the project, preventing issues such as CI hangs.

--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak
   version: 22.0.5
-  epoch: 1
+  epoch: 2
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - paths:
@@ -10,22 +10,22 @@ package:
       license: Apache-2.0
   dependencies:
     runtime:
-      - bash # some helper scripts use bash
+      - bash # Keycloak helper scripts require bash, aren't compatible with busybox.
       - openjdk-17-default-jvm
 
 environment:
   contents:
     packages:
+      - bash
       - busybox
       - ca-certificates-bundle
-      - curl
-      - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
-      - bash
       - nodejs-18
+      - openjdk-17
       - wolfi-base
       - wolfi-baselayout
+  environment:
+    LANG: en_US.UTF-8
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 pipeline:
   - uses: git-checkout
@@ -40,9 +40,9 @@ pipeline:
       patches: bump-xmlsec.patch
 
   - runs: |
-      export LANG=en_US.UTF-8
-      export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
-
+      # Keycloak installation. Note we use the maven wrapper as configured in
+      # the source repo to build - ensures the correct maven version for
+      # building the project, preventing issues such as CI hangs.
       ./mvnw clean install -DskipTests=true -Dnode.version=$(node --version) -Pdistribution -q
 
       mkdir -p ${{targets.destdir}}/usr/share/java
@@ -55,9 +55,10 @@ pipeline:
       done
 
 update:
+  # The upstream repos releases contains a 'nightly' release. Which we want to
+  # exclude from discovery.
+  ignore-regex-patterns:
+    - '.*nightly.*'
   enabled: true
   github:
     identifier: keycloak/keycloak
-    use-tag: true
-    # There are a lot of older minor versions and tag schemes that make this flaky, restrict to just this major version
-    tag-filter: "22."


### PR DESCRIPTION
Poll for updates using git releases instead of tags. Added filter to exclude the only non-conventional release name. Also applied some general updates to align with some recent changes made to our FIPS image variant.