### PR TITLE
kubernetes: build with our latest Go

### DIFF
--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.24
   version: 1.24.17
-  epoch: 3
+  epoch: 4
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go-1.20~=1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.24.16/.go-version
+      - go-1.20~1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.24.17/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -13,7 +13,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go-1.20~1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.24.17/.go-version
+      - go~1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.24.17/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.24.yaml
+++ b/kubernetes-1.24.yaml
@@ -5,6 +5,9 @@ package:
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - kubernetes=${{package.full-version}}
 
 environment:
   contents:
@@ -13,7 +16,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go~1.20.6 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.24.17/.go-version
+      - go
       - go-bindata
       - linux-headers
       - grep
@@ -47,6 +50,7 @@ pipeline:
       ./hack/lint-dependencies.sh
 
   - runs: |
+      # Use our Go version instead of downloading another one
       export FORCE_HOST_GO=true
 
       WHAT=""

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.25
   version: 1.25.15
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go-1.20~=1.20.8 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.25.14/.go-version
+      - go-1.20~1.20.8 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.25.15/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -5,6 +5,9 @@ package:
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - kubernetes=${{package.full-version}}
 
 environment:
   contents:
@@ -13,7 +16,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go~1.20.8 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.25.15/.go-version
+      - go
       - go-bindata
       - linux-headers
       - grep
@@ -47,6 +50,7 @@ pipeline:
       ./hack/lint-dependencies.sh
 
   - runs: |
+      # Use our Go version instead of downloading another one
       export FORCE_HOST_GO=true
 
       WHAT=""

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -13,7 +13,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go-1.20~1.20.8 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.25.15/.go-version
+      - go~1.20.8 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.25.15/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -5,6 +5,9 @@ package:
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - kubernetes=${{package.full-version}}
 
 environment:
   contents:
@@ -13,7 +16,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go~1.20.8 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.26.10/.go-version
+      - go
       - go-bindata
       - linux-headers
       - grep
@@ -47,6 +50,7 @@ pipeline:
       ./hack/lint-dependencies.sh
 
   - runs: |
+      # Use our Go version instead of downloading another one
       export FORCE_HOST_GO=true
 
       WHAT=""

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -13,7 +13,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go-1.20~1.20.8 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.26.10/.go-version
+      - go~1.20.8 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.26.10/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.26
   version: 1.26.10
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go-1.20~=1.20.8 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.26.9/.go-version
+      - go-1.20~1.20.8 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.26.10/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -7,7 +7,7 @@ package:
     - license: Apache-2.0
   dependencies:
     provides:
-      - kubernetes=1.27
+      - kubernetes=${{package.full-version}}
 
 environment:
   contents:
@@ -16,7 +16,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go~1.20.10 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.27.7/.go-version
+      - go
       - go-bindata
       - linux-headers
       - grep
@@ -50,6 +50,7 @@ pipeline:
       ./hack/lint-dependencies.sh
 
   - runs: |
+      # Use our Go version instead of downloading another one
       export FORCE_HOST_GO=true
 
       WHAT=""

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -16,7 +16,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go-1.20~1.20.10 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.27.7/.go-version
+      - go~1.20.10 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.27.7/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.27
   version: 1.27.7
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go-1.20~=1.20.8 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.27.6/.go-version
+      - go-1.20~1.20.10 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.27.7/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.28.yaml
+++ b/kubernetes-1.28.yaml
@@ -7,7 +7,7 @@ package:
     - license: Apache-2.0
   dependencies:
     provides:
-      - kubernetes=1.28
+      - kubernetes=${{package.full-version}}
 
 environment:
   contents:
@@ -16,7 +16,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go~1.20.10 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.28.3/.go-version
+      - go
       - go-bindata
       - linux-headers
       - grep
@@ -44,7 +44,7 @@ pipeline:
       expected-commit: a8a1abc25cad87333840cd7d54be2efaf31a3177
 
   - runs: |
-      # Use our Go, otherwise make will install another version which might not have our vuln fixes.
+      # Use our Go version instead of downloading another one
       export FORCE_HOST_GO=true
 
       WHAT=""

--- a/kubernetes-1.28.yaml
+++ b/kubernetes-1.28.yaml
@@ -16,7 +16,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go-1.20~1.20.10 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.28.3/.go-version
+      - go~1.20.10 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.28.3/.go-version
       - go-bindata
       - linux-headers
       - grep

--- a/kubernetes-1.28.yaml
+++ b/kubernetes-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.28
   version: 1.28.3
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,7 @@ environment:
       - bash
       - ca-certificates-bundle
       - build-base
-      - go-1.20~=1.20.8 # Pin to the version used upstream:https://github.com/kubernetes/kubernetes/blob/v1.28.2/.go-version
+      - go-1.20~1.20.10 # Pin to the version used upstream: https://github.com/kubernetes/kubernetes/blob/v1.28.3/.go-version
       - go-bindata
       - linux-headers
       - grep


### PR DESCRIPTION
Fixes https://github.com/wolfi-dev/os/issues/7413

go-apk apparently doesn't correctly understand `~=` today, so we'll use `~` instead.

In trying to make this change and keep consistent with upstream's preferred Go version, we discovered depending on go~1.20.6 breaks our bootstrappability check, since there's no package that exists to create go 1.20.6 (only 1.20.10, latest)

Rather than package that just so k8s can build itself that way, I've unpinned the preferred go version, and k8s will be built with the latest-and-greatest Go available, using `FORCE_HOST_GO` (as foretold in https://github.com/wolfi-dev/os/pull/4551 🕺)