### PR TITLE
update terraform package to mitigate GHSA-m425-mq94-257g

### DIFF
--- a/terraform.yaml
+++ b/terraform.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform
   version: 1.5.5
-  epoch: 6
+  epoch: 7
   copyright:
     - license: MPL-2.0
 
@@ -18,6 +18,8 @@ pipeline:
 
   - runs: |
       go get golang.org/x/net@v0.17.0
+      # fix GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.59.0
       go mod tidy
 
   - uses: go/build


### PR DESCRIPTION
- update terraform package to mitigate GHSA-m425-mq94-257g


### Pre-review Checklist



#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/399
