### PR TITLE
update terraform-provider-aws package to mitigate GHSA-m425-mq94-257g

### DIFF
--- a/terraform-provider-aws.yaml
+++ b/terraform-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-aws
   version: 5.22.0
-  epoch: 0
+  epoch: 1
   description: Terraform AWS provider
   copyright:
     - license: MPL-2.0
@@ -21,6 +21,11 @@ pipeline:
       repository: https://github.com/hashicorp/terraform-provider-aws
       tag: v${{package.version}}
       expected-commit: b35c1b3529733ca7be22c640a29eda61ba624fd2
+
+  - runs: |
+      # fix GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.59.0
+      go mod tidy
 
   - uses: go/build
     with:


### PR DESCRIPTION
- update terraform-provider-aws package to mitigate GHSA-m425-mq94-257g


### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

