### PR TITLE
mitigate GHSA-m425-mq94-257g/CVE-2023-44487 for terraform-provider-aws package

### DIFF
--- a/terraform-provider-aws.yaml
+++ b/terraform-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-aws
   version: 5.22.0
-  epoch: 0
+  epoch: 1
   description: Terraform AWS provider
   copyright:
     - license: MPL-2.0
@@ -27,6 +27,7 @@ pipeline:
       packages: .
       output: terraform-provider-aws
       ldflags: -s -w
+      deps: google.golang.org/grpc@v1.58.3 # fix GHSA-m425-mq94-257g / CVE-2023-44487
 
   - runs: |
       GOARCH=$(go env GOARCH)


### PR DESCRIPTION
- mitigate GHSA-m425-mq94-257g/CVE-2023-44487 for terraform-provider-aws package

grpc/grpc-go: https://github.com/grpc/grpc-go/security/advisories/GHSA-m425-mq94-257g 

advisories: https://github.com/advisories/GHSA-m425-mq94-257g

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/400

