### PR TITLE
update terraform package to 1.5.7 / mitigate GHSA-m425-mq94-257g / CVE-2023-44487

### DIFF
--- a/terraform.yaml
+++ b/terraform.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform
-  version: 1.5.5
-  epoch: 6
+  version: 1.5.7
+  epoch: 0
   copyright:
     - license: MPL-2.0
 
@@ -14,11 +14,11 @@ pipeline:
     with:
       repository: https://github.com/hashicorp/terraform
       tag: v${{package.version}}
-      expected-commit: c10eb21b390627a6259eef9cd883e6ddeccc5716
 
   - runs: |
       go get golang.org/x/net@v0.17.0
       go mod tidy
+      expected-commit: ee58ac1851c8a433005df9863ed47796a9f6b5e7
 
   - uses: go/build
     with:

--- a/terraform.yaml
+++ b/terraform.yaml
@@ -14,10 +14,6 @@ pipeline:
     with:
       repository: https://github.com/hashicorp/terraform
       tag: v${{package.version}}
-
-  - runs: |
-      go get golang.org/x/net@v0.17.0
-      go mod tidy
       expected-commit: ee58ac1851c8a433005df9863ed47796a9f6b5e7
 
   - uses: go/build
@@ -25,6 +21,8 @@ pipeline:
       packages: .
       output: terraform
       ldflags: -s -w
+      # fix GHSA-m425-mq94-257g / CVE-2023-44487 (grpc)
+      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3
 
   - uses: strip
 


### PR DESCRIPTION
- update terraform package to 1.5.7 / mitigate GHSA-m425-mq94-257g / CVE-2023-44487

the release 1.5.7 still have the same license as 1.5.5



#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/402

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0


