### PR TITLE
adds sqlpad package

### DIFF
--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -1,6 +1,6 @@
 package:
   name: sqlpad
-  version: 7.1.2
+  version: 7.1.3
   epoch: 0
   description: Web-based SQL editor. Legacy project in maintenance mode.
   copyright:
@@ -22,7 +22,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/sqlpad/sqlpad
-      expected-commit: 42d7e3c9cbd5af4e7d36cbb97a8d96ba2ffe9b67
+      expected-commit: f42ce1a84e1327e69178f38e7b3a2462dcaeeb7c
       tag: v${{package.version}}
 
   - uses: patch

--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -1,13 +1,13 @@
 package:
   name: sqlpad
-  version: 7.1.3
+  version: 7.1.3 # when updating check the patch below as it contains dependency version updates which may downgrade if upstream upgrades them
   epoch: 0
   description: Web-based SQL editor. Legacy project in maintenance mode.
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - nodejs-18
+      - nodejs-18 # currently needs node 18, to check in the future see, https://github.com/sqlpad/sqlpad/blob/master/.nvmrc
       - yarn
 
 environment:

--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -25,9 +25,16 @@ pipeline:
       expected-commit: 42d7e3c9cbd5af4e7d36cbb97a8d96ba2ffe9b67
       tag: v${{package.version}}
 
+  - uses: patch
+    with:
+      patches: server-package-json.patch
+
+  - uses: patch
+    with:
+      patches: build-sh.patch
+
   - runs: |
       ./scripts/build.sh
-
       mkdir -p ${{targets.destdir}}/usr/bin
       mv server ${{targets.destdir}}/usr/bin/sqlpad-server
 

--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -1,0 +1,40 @@
+package:
+  name: sqlpad
+  version: 7.1.2
+  epoch: 0
+  description: Web-based SQL editor. Legacy project in maintenance mode.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - nodejs-18
+      - yarn
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - build-base
+      - yarn
+      - nodejs-18
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/sqlpad/sqlpad
+      expected-commit: 42d7e3c9cbd5af4e7d36cbb97a8d96ba2ffe9b67
+      tag: v${{package.version}}
+
+  - runs: |
+      ./scripts/build.sh
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv server ${{targets.destdir}}/usr/bin/sqlpad-server
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: sqlpad/sqlpad
+    strip-prefix: v

--- a/sqlpad/build-sh.patch
+++ b/sqlpad/build-sh.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/build.sh b/scripts/build.sh
+index 40b4f4d8..6741bc8d 100755
+--- a/scripts/build.sh
++++ b/scripts/build.sh
+@@ -13,7 +13,7 @@ fi
+ # Install node modules per package-lock.json
+ yarn
+ (cd $SQLPAD_CLIENT_DIR && yarn)
+-(cd $SQLPAD_SERVER_DIR && yarn)
++(cd $SQLPAD_SERVER_DIR && yarn --production)
+ 
+ # Build front-end
+ (cd $SQLPAD_CLIENT_DIR && yarn build)

--- a/sqlpad/server-package-json.patch
+++ b/sqlpad/server-package-json.patch
@@ -1,0 +1,14 @@
+diff --git a/server/package.json b/server/package.json
+index 19d52f20..4956d34d 100644
+--- a/server/package.json
++++ b/server/package.json
+@@ -126,6 +126,8 @@
+     "traverse": "^0.6.6"
+   },
+   "resolutions": {
+-    "supertest/**/cookiejar": "^2.1.4"
++    "supertest/**/cookiejar": "^2.1.4",
++    "semver": "6.3.1",
++    "@node-saml/node-saml": "4.0.5"
+   }
+ }


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
