### PR TITLE
Add logging operator compat subpackage for fluentd

### DIFF
--- a/ruby3.2-fluentd-1.16.yaml
+++ b/ruby3.2-fluentd-1.16.yaml
@@ -2,7 +2,7 @@ package:
   # fluentd supported versions: https://github.com/fluent/fluentd/blob/master/SECURITY.md
   name: ruby3.2-fluentd-1.16
   version: 1.16.2
-  epoch: 2
+  epoch: 3
   description: Fluentd is an open source data collector designed to scale and simplify log management. It can collect, process and ship many kinds of data in near real-time.
   copyright:
     - license: Apache-2.0
@@ -64,6 +64,18 @@ pipeline:
              ${GEM_DIR}/*.md \
              ${GEM_DIR}/.github
 
+subpackages:
+  - name: ${{package.name}}-logging-operator-compat
+    description: Entrypoint used by the logging operator image
+    dependencies:
+      runtime:
+        - busybox
+    pipeline:
+      - runs: |
+          git clone https://github.com/kube-logging/fluentd-images.git
+          install -Dm755 ./fluentd-images/v1.16/entrypoint.sh "${{targets.subpkgdir}}/bin/entrypoint.sh"
+          install -Dm755 ./fluentd-images/v1.16/healthy.sh "${{targets.subpkgdir}}/bin/healthy.sh"
+          install -Dm644 ./fluentd-images/v1.16/fluent.conf "${{targets.subpkgdir}}/fluentd/etc/fluent.conf"
 update:
   enabled: true
   github:

--- a/ruby3.2-fluentd-1.16.yaml
+++ b/ruby3.2-fluentd-1.16.yaml
@@ -73,9 +73,11 @@ subpackages:
     pipeline:
       - runs: |
           git clone https://github.com/kube-logging/fluentd-images.git
-          install -Dm755 ./fluentd-images/v1.16/entrypoint.sh "${{targets.subpkgdir}}/bin/entrypoint.sh"
-          install -Dm755 ./fluentd-images/v1.16/healthy.sh "${{targets.subpkgdir}}/bin/healthy.sh"
-          install -Dm644 ./fluentd-images/v1.16/fluent.conf "${{targets.subpkgdir}}/fluentd/etc/fluent.conf"
+          cd fluentd-images
+          git checkout 773503fd12bcdb75f042ea3deb712ccb86a31d61
+          install -Dm755 ./v1.16/entrypoint.sh "${{targets.subpkgdir}}/bin/entrypoint.sh"
+          install -Dm755 ./v1.16/healthy.sh "${{targets.subpkgdir}}/bin/healthy.sh"
+          install -Dm644 ./v1.16/fluent.conf "${{targets.subpkgdir}}/fluentd/etc/fluent.conf"
 
 update:
   enabled: true

--- a/ruby3.2-fluentd-1.16.yaml
+++ b/ruby3.2-fluentd-1.16.yaml
@@ -26,11 +26,11 @@ package:
 environment:
   contents:
     packages:
+      - build-base
+      - busybox
       - ca-certificates-bundle
       - ruby-3.2
       - ruby-3.2-dev
-      - build-base
-      - busybox
 
 vars:
   gem: fluentd
@@ -76,6 +76,7 @@ subpackages:
           install -Dm755 ./fluentd-images/v1.16/entrypoint.sh "${{targets.subpkgdir}}/bin/entrypoint.sh"
           install -Dm755 ./fluentd-images/v1.16/healthy.sh "${{targets.subpkgdir}}/bin/healthy.sh"
           install -Dm644 ./fluentd-images/v1.16/fluent.conf "${{targets.subpkgdir}}/fluentd/etc/fluent.conf"
+
 update:
   enabled: true
   github:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

The[ logging operator](https://kube-logging.dev/) builds its own fluentd image which uses a custom entrypoint and healthcheck script. This just grabs those scripts and places them in a subpackage for fluentd 1.16

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates