### PR TITLE
mitigate GHSA-m425-mq94-257g/ CVE-2023-44487 for secrets-store-csi-driver

### DIFF
--- a/secrets-store-csi-driver.yaml
+++ b/secrets-store-csi-driver.yaml
@@ -2,7 +2,7 @@ package:
   name: secrets-store-csi-driver
   # When bumping the version check if the CVE mitigations below can be removed.
   version: 1.3.4
-  epoch: 6
+  epoch: 7
   description: Secrets Store CSI driver for Kubernetes secrets
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,10 @@ pipeline:
   - runs: |
       # fix CVE-2023-39325 ,CVE-2023-3978 and CVE-2023-44487
       go get golang.org/x/net@v0.17.0
+
+      # Mitigate GHSA-m425-mq94-257g / CVE-2023-44487 (grpc)
+      go get google.golang.org/grpc@v1.56.3
+
       go mod tidy
 
       # Our global LDFLAGS conflict with a Makefile parameter: https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/Makefile#LL49C3-L49C3


### PR DESCRIPTION
- mitigate GHSA-m425-mq94-257g/ CVE-2023-44487 for secrets-store-csi-driver


#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/compare/add-secrets-store-csi-driver?expand=1

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

