### PR TITLE
update pulumi-language-yaml package to 1.4.0 / mitigate GHSA-m425-mq94-257g/ CVE-2023-44487

### DIFF
--- a/pulumi-language-yaml.yaml
+++ b/pulumi-language-yaml.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-yaml
-  version: 1.3.0
-  epoch: 5
+  version: 1.4.0
+  epoch: 0
   description: Pulumi Language SDK for YAML
   copyright:
     - license: Apache-2.0
@@ -20,14 +20,14 @@ pipeline:
       repository: https://github.com/pulumi/pulumi-yaml.git
       tag: v${{package.version}}
       destination: ${{package.name}}
-      expected-commit: 2135f7eeef902fe4ee3cf52f049b8f9f42ef3db5
+      expected-commit: 474812dc643a518a1687d627a2c84a22da5337d9
 
   - working-directory: ${{package.name}}
     pipeline:
       - runs: |
           set -x
-          # Mitigate CVE-2023-39325 and CVE-2023-3978
-          go get golang.org/x/net@v0.17.0
+          # Mitigate GHSA-m425-mq94-257g / CVE-2023-44487 (grpc)
+          go get google.golang.org/grpc@v1.57.1
           go mod tidy
 
           export CGO_ENABLED=0 GO111MODULE=on


### PR DESCRIPTION
also:
drop CVE-2023-39325 and CVE-2023-3978 which is already update in the 1.4.0 release


#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/408

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0


