### PR TITLE
mitigate GHSA-m425-mq94-257g/ CVE-2023-44487 for pulumi-language-java

### DIFF
--- a/pulumi-language-java.yaml
+++ b/pulumi-language-java.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-java
   version: 0.9.8
-  epoch: 2
+  epoch: 3
   description: Pulumi Language SDK for Java
   copyright:
     - license: Apache-2.0
@@ -27,8 +27,8 @@ pipeline:
       packages: ./cmd/pulumi-language-java
       output: pulumi-language-java
       ldflags: -s -w -X github.com/pulumi/pulumi-java/pkg/version.Version=v${{package.version}}
-      # Mitigate CVE-2023-39325 and CVE-2023-3978
-      deps: golang.org/x/net@v0.17.0
+      # Mitigate CVE-2023-39325 and CVE-2023-3978 / Mitigate GHSA-m425-mq94-257g / CVE-2023-44487 (grpc)
+      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3
 
   - uses: strip
 


### PR DESCRIPTION
- mitigate GHSA-m425-mq94-257g/ CVE-2023-44487 for pulumi-language-java

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/409

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

