### PR TITLE
Add nri-consul

### DIFF
--- a/nri-consul.yaml
+++ b/nri-consul.yaml
@@ -1,0 +1,37 @@
+package:
+  name: nri-consul
+  version: 2.7.2
+  epoch: 0
+  description: New Relic Infrastructure Consul Integration
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/newrelic/nri-consul
+      expected-commit: 15b1cd07fadf7d2d45ff999e7c80fd066f738537
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./src/
+      output: nri-consul
+      ldflags: -s -w
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: newrelic/nri-consul
+    strip-prefix: v

--- a/nri-consul.yaml
+++ b/nri-consul.yaml
@@ -6,7 +6,7 @@ package:
   copyright:
     - license: MIT
 
-  pipeline:
+pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/newrelic/nri-consul

--- a/nri-consul.yaml
+++ b/nri-consul.yaml
@@ -5,15 +5,6 @@ package:
   description: New Relic Infrastructure Consul Integration
   copyright:
     - license: MIT
-
-environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
-      - build-base
-
 pipeline:
   - uses: git-checkout
     with:

--- a/nri-consul.yaml
+++ b/nri-consul.yaml
@@ -5,7 +5,8 @@ package:
   description: New Relic Infrastructure Consul Integration
   copyright:
     - license: MIT
-pipeline:
+
+  pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/newrelic/nri-consul

--- a/nri-consul.yaml
+++ b/nri-consul.yaml
@@ -18,7 +18,7 @@ package:
       modroot: .
       packages: ./src/
       output: nri-consul
-      ldflags: -s -w
+      ldflags: -w
 
   - uses: strip
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
