### PR TITLE
Add nrjmx

### DIFF
--- a/nrjmx.yaml
+++ b/nrjmx.yaml
@@ -1,0 +1,53 @@
+package:
+  name: nrjmx
+  version: 2.5.0
+  epoch: 0
+  description: Command line tool to connect to a JMX server and retrieve the MBeans it exposes
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - openjdk-17-jre
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - maven
+      - openjdk-17
+      - openjdk-17-default-jvm
+      - bash
+      - wolfi-base
+      - wolfi-baselayout
+  environment:
+    LANG: en_US.UTF-8
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/newrelic/nrjmx
+      tag: v${{package.version}}
+      expected-commit: 90d44704c70cd03f6c28de4cb796a0a33e0365d3
+
+  - uses: maven/configure-mirror
+
+  - runs: |
+      mvn clean package -P \!deb,\!rpm,\!tarball,\!test -DskipTests
+
+      mkdir -p ${{targets.destdir}}/usr/share/java/nrjmx/bin
+
+      install -m755 ./bin/* ${{targets.destdir}}/usr/share/java/nrjmx/bin/
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      for i in nrjmx nrjmx.jar; do
+        ln -sf /usr/share/java/nrjmx/bin/$i ${{targets.destdir}}/usr/bin/$i
+      done
+
+update:
+  enabled: true
+  github:
+    identifier: newrelic/nrjmx
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
