### PR TITLE
version upgrade `ruby3.2-net-imap` to `0.4.2`

### DIFF
--- a/ruby3.2-net-imap.yaml
+++ b/ruby3.2-net-imap.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-net-imap
-  version: 0.3.7
-  epoch: 1
+  version: 0.4.2
+  epoch: 0
   description: Ruby client api for Internet Message Access Protocol
   copyright:
     - license: Ruby
@@ -24,8 +24,12 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: a657e970febceefaa4be5804ae2adaa805f506eac49409629fcb9c4cb93e137d
+      expected-sha256: 4a490c50abb917d7574b7b709c9889dcac5984eee3069d0dc2ced6b8aff0b15c
       uri: https://github.com/ruby/net-imap/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: patch
+    with:
+      patches: gemspec-utf-8-encoding.patch
 
   - uses: ruby/build
     with:

--- a/ruby3.2-net-imap/gemspec-utf-8-encoding.patch
+++ b/ruby3.2-net-imap/gemspec-utf-8-encoding.patch
@@ -1,0 +1,13 @@
+diff --git a/net-imap.gemspec b/net-imap.gemspec
+index a98be7c..629b469 100644
+--- a/net-imap.gemspec
++++ b/net-imap.gemspec
+@@ -2,7 +2,7 @@
+ 
+ name = File.basename(__FILE__, ".gemspec")
+ version = ["lib", Array.new(name.count("-"), "..").join("/")].find do |dir|
+-  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
++  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb"), :encoding=> 'utf-8') do |line|
+     /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+   end rescue nil
+ end


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #7027 

Related: #7169


#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented

The patch is for an error because of some special character that is not working with default encoding.
