### PR TITLE
mitigate GHSA-m425-mq94-257g/ CVE-2023-44487 and CVE-2023-45142  for calico

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -64,6 +64,11 @@ pipeline:
       # Remediate GHSA-m425-mq94-257g
       go get google.golang.org/grpc@v1.56.3
 
+      # Remediate CVE-2023-45142
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.19.0
+
       # Remediate GHSA-qc2g-gmh6-95p4
       go mod edit -replace k8s.io/kubernetes=k8s.io/kubernetes@v1.26.6
 

--- a/calico.yaml
+++ b/calico.yaml
@@ -62,7 +62,7 @@ pipeline:
       go get golang.org/x/net@v0.17.0
 
       # Remediate GHSA-m425-mq94-257g
-      go get google.golang.org/grpc@v1.56.3
+      go get google.golang.org/grpc@v1.58.3
 
       # Remediate CVE-2023-45142
       go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0

--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.26.3
-  epoch: 3
+  epoch: 4
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64
@@ -58,11 +58,11 @@ pipeline:
       # Remediate GHSA-hqxw-f8mx-cpmw
       go get github.com/docker/distribution@v2.8.2
 
-      # Remediate GHSA-cfgp-2977-2fmm
-      go get google.golang.org/grpc@v1.53.0
-
       # CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
+
+      # Remediate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.56.3
 
       # Remediate GHSA-qc2g-gmh6-95p4
       go mod edit -replace k8s.io/kubernetes=k8s.io/kubernetes@v1.26.6


### PR DESCRIPTION
- mitigate GHSA-m425-mq94-257g/ CVE-2023-44487 for calico
- mitigate CVE-2023-45142 

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/417

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

