### PR TITLE
mitigate GHSA-m425-mq94-257g/ CVE-2023-44487 for argo-cd-2.7

### DIFF
--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.7
   version: 2.7.14
-  epoch: 6
+  epoch: 7
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -49,6 +49,9 @@ pipeline:
 
       # CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
+
+      # Remediate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.56.3
 
       go mod tidy
 


### PR DESCRIPTION
- mitigate GHSA-m425-mq94-257g/ CVE-2023-44487 for argo-cd-2.7

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/os/pull/7580

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

