### PR TITLE
mitigate GHSA-m425-mq94-257g for conftest

### DIFF
--- a/conftest.yaml
+++ b/conftest.yaml
@@ -1,7 +1,7 @@
 package:
   name: conftest
   version: 0.46.0
-  epoch: 0
+  epoch: 1
   description: Write tests against structured configuration data using the Open Policy Agent Rego query language
   copyright:
     - license: Apache-2.0
@@ -22,8 +22,8 @@ pipeline:
       packages: .
       output: conftest
       ldflags: -w -s -X github.com/open-policy-agent/conftest/internal/commands.version=${{package.version}}
-      # CVE-2023-39325 and CVE-2023-44487
-      deps: golang.org/x/net@v0.17.0
+      # CVE-2023-39325 and CVE-2023-44487 / GHSA-m425-mq94-257g
+      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3
 
   - uses: strip
 


### PR DESCRIPTION
- mitigate GHSA-m425-mq94-257g for conftest

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/420

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

