### PR TITLE
mitigate GHSA-m425-mq94-257g for kubernetes-csi-livenessprobe

### DIFF
--- a/kubernetes-csi-livenessprobe.yaml
+++ b/kubernetes-csi-livenessprobe.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-livenessprobe
   version: 2.11.0
-  epoch: 3
+  epoch: 4
   description: A sidecar container that can be included in a CSI plugin pod to enable integration with Kubernetes Liveness Probe.
   copyright:
     - license: Apache-2.0
@@ -26,8 +26,8 @@ pipeline:
       ldflags: "-s -w -X main.version=v${{package.version}} -extldflags '-static'"
       vendor: "true"
       output: livenessprobe
-      # CVE-2023-39325 and CVE-2023-3978
-      deps: golang.org/x/net@v0.17.0
+      # CVE-2023-39325 and CVE-2023-3978 / GHSA-m425-mq94-257g
+      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3
 
   - uses: strip
 


### PR DESCRIPTION
- mitigate GHSA-m425-mq94-257g for kubernetes-csi-livenessprobe

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/423



