### PR TITLE
bump minio to RELEASE.2023-10-25T06-33-25Z and mitigate  GHSA-m425-mq94-257g

### DIFF
--- a/minio.yaml
+++ b/minio.yaml
@@ -25,8 +25,6 @@ pipeline:
       expected-commit: 1c99fb106c3e1448ed92f8465d5695d055d432e7
 
   - runs: |
-      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
-      go get golang.org/x/net@v0.17.0
       go mod tidy
 
       make build

--- a/minio.yaml
+++ b/minio.yaml
@@ -1,9 +1,9 @@
 package:
   name: minio
-  # minio uses strange versioning, the upstream version is RELEASE.2023-09-04T19-57-37Z
+  # minio uses strange versioning, the upstream version is RELEASE.2023-10-25T06-33-25Z
   # when bumping this, also bump the tag in git-checkout below
-  version: 0.20230904.195737
-  epoch: 5
+  version: 0.20231025.063325
+  epoch: 0
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0
@@ -21,10 +21,12 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/minio/minio
-      tag: RELEASE.2023-09-04T19-57-37Z
-      expected-commit: 1c99fb106c3e1448ed92f8465d5695d055d432e7
+      tag: RELEASE.2023-10-25T06-33-25Z
+      expected-commit: c60f54e5be7302d82d0d8fc404c056fea4e2bf4e
 
   - runs: |
+      # Mitigate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.58.3
       go mod tidy
 
       make build


### PR DESCRIPTION
- drop Mitigate CVE-2023-3932 already fixed in upstream
- bump minio to RELEASE.2023-10-25T06-33-25Z and mitigate  GHSA-m425-mq94-257g

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/424

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0


