### PR TITLE
prepare compat nri-* packages for newrelic-infrastructure-bundle compability

### DIFF
--- a/nri-apache.yaml
+++ b/nri-apache.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-apache
   version: 1.12.1
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Apache Integration
   copyright:
     - license: Apache-2.0
@@ -31,8 +31,21 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
       install -Dm644 apache-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/apache-config.yml.sample
+      install -Dm644 legacy/apache-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/apache-definition.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/apache-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/apache-definition.yml
+    dependencies:
+      provides:
+        - nri-apache
 
 update:
   enabled: true

--- a/nri-cassandra.yaml
+++ b/nri-cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-cassandra
   version: 2.13.2
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Cassandra Integration
   copyright:
     - license: Apache-2.0
@@ -27,8 +27,21 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
       install -Dm644 cassandra-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/cassandra-config.yml.sample
+      install -Dm644 legacy/cassandra-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/cassandra-definition.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/cassandra-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/cassandra-definition.yml
+    dependencies:
+      provides:
+        - nri-cassandra
 
 update:
   enabled: true

--- a/nri-consul.yaml
+++ b/nri-consul.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-consul
   version: 2.7.2
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Consul Integration
   copyright:
     - license: MIT
@@ -20,7 +20,24 @@ pipeline:
       output: nri-consul
       ldflags: -w
 
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
+      install -Dm644 consul-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/consul-config.yml.sample
+      install -Dm644 legacy/consul-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/consul-definition.yml
+
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/consul-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/consul-definition.yml
+    dependencies:
+      provides:
+        - nri-consul
 
 update:
   enabled: true

--- a/nri-couchbase.yaml
+++ b/nri-couchbase.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-couchbase
   version: 2.6.1
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Couchbase Integration
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,24 @@ pipeline:
       output: nri-couchbase
       ldflags: -s -w
 
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
+      install -Dm644 couchbase-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/couchbase-config.yml.sample
+      install -Dm644 legacy/couchbase-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/couchbase-definition.yml
+
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/couchbase-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/couchbase-definition.yml
+    dependencies:
+      provides:
+        - nri-couchbase
 
 update:
   enabled: true

--- a/nri-discovery-kubernetes.yaml
+++ b/nri-discovery-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-discovery-kubernetes
   version: 1.7.1
-  epoch: 0
+  epoch: 1
   description: New Relic Kubernetes Auto-Discovery
   copyright:
     - license: Apache-2.0
@@ -31,6 +31,17 @@ pipeline:
       deps: golang.org/x/net@v0.17.0
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/${{package.name}}
+    dependencies:
+      provides:
+        - nri-discovery-kubernetes
 
 update:
   enabled: true

--- a/nri-elasticsearch.yaml
+++ b/nri-elasticsearch.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-elasticsearch
   version: 5.2.1
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Elasticsearch Integration
   copyright:
     - license: MIT
@@ -20,7 +20,24 @@ pipeline:
       output: nri-elasticsearch
       ldflags: -w
 
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
+      install -Dm644 elasticsearch-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/elasticsearch-config.yml.sample
+      install -Dm644 legacy/elasticsearch-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/elasticsearch-definition.yml
+
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/elasticsearch-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/elasticsearch-definition.yml
+    dependencies:
+      provides:
+        - nri-elasticsearch
 
 update:
   enabled: true

--- a/nri-f5.yaml
+++ b/nri-f5.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-f5
   version: 2.7.2
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure F5 Integration
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,24 @@ pipeline:
       output: nri-f5
       ldflags: -s -w
 
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
+      install -Dm644 f5-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/f5-config.yml.sample
+      install -Dm644 legacy/f5-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/f5-definition.yml
+
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/f5-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/f5-definition.yml
+    dependencies:
+      provides:
+        - nri-f5
 
 update:
   enabled: true

--- a/nri-haproxy.yaml
+++ b/nri-haproxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-haproxy
   version: 2.5.0
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure HAproxy Integration
   copyright:
     - license: MIT
@@ -23,8 +23,21 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
       install -Dm644 haproxy-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/haproxy-config.yml.sample
+      install -Dm644 legacy/haproxy-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/haproxy-definition.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/haproxy-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/haproxy-definition.yml
+    dependencies:
+      provides:
+        - nri-haproxy
 
 update:
   enabled: true

--- a/nri-jmx.yaml
+++ b/nri-jmx.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-jmx
   version: 3.5.0
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure JMX Integration
   copyright:
     - license: Apache-2.0
@@ -32,8 +32,21 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
       install -Dm644 jmx-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/jmx-config.yml.sample
+      install -Dm644 legacy/jmx-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/jmx-definition.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/jmx-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/jmx-definition.yml
+    dependencies:
+      provides:
+        - nri-jmx
 
 update:
   enabled: true

--- a/nri-kafka.yaml
+++ b/nri-kafka.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-kafka
   version: 3.4.9
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Kafka Integration
   copyright:
     - license: MIT
@@ -29,8 +29,21 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
       install -Dm644 kafka-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/kafka-config.yml.sample
+      install -Dm644 legacy/kafka-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/kafka-definition.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/kafka-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/kafka-definition.yml
+    dependencies:
+      provides:
+        - nri-kafka
 
 update:
   enabled: true

--- a/nri-memcached.yaml
+++ b/nri-memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-memcached
   version: 2.5.1
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure memcached Integration
   copyright:
     - license: MIT
@@ -23,8 +23,21 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
       install -Dm644 memcached-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/memcached-config.yml.sample
+      install -Dm644 legacy/memcached-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/memcached-definition.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/memcached-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/memcached-definition.yml
+    dependencies:
+      provides:
+        - nri-memcached
 
 update:
   enabled: true

--- a/nri-mongodb.yaml
+++ b/nri-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-mongodb
   version: 2.8.1
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure MongoDB Integration
   copyright:
     - license: MIT
@@ -23,8 +23,21 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
       install -Dm644 mongodb-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/mongodb-config.yml.sample
+      install -Dm644 legacy/mongodb-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/mongodb-definition.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/mongodb-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/mongodb-definition.yml
+    dependencies:
+      provides:
+        - nri-mongodb
 
 update:
   enabled: true

--- a/nri-mssql.yaml
+++ b/nri-mssql.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-mssql
   version: 2.10.1
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Mssql Integration
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,24 @@ pipeline:
       # GHSA-qppj-fm5r-hxr3, GHSA-4374-p667-p6c8 and GHSA-2wrh-6pvc-2jm9
       deps: golang.org/x/net@v0.17.0
 
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
+      install -Dm644 mssql-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/mssql-config.yml.sample
+      install -Dm644 legacy/mssql-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/mssql-definition.yml
+
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/mssql-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/mssql-definition.yml
+    dependencies:
+      provides:
+        - nri-mssql
 
 update:
   enabled: true

--- a/nri-mysql.yaml
+++ b/nri-mysql.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-mysql
   version: 1.10.2
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure MySQL Integration
   copyright:
     - license: Apache-2.0
@@ -23,8 +23,21 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
       install -Dm644 mysql-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/mysql-config.yml.sample
+      install -Dm644 legacy/mysql-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/mysql-definition.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/mysql-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/mysql-definition.yml
+    dependencies:
+      provides:
+        - nri-mysql
 
 update:
   enabled: true

--- a/nri-nagios.yaml
+++ b/nri-nagios.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-nagios
   version: 2.9.0
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Nagios Integration
   copyright:
     - license: MIT
@@ -23,8 +23,21 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
       install -Dm644 nagios-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/nagios-config.yml.sample
+      install -Dm644 legacy/nagios-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/nagios-definition.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/nagios-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/nagios-definition.yml
+    dependencies:
+      provides:
+        - nri-nagios
 
 update:
   enabled: true

--- a/nri-nginx.yaml
+++ b/nri-nginx.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-nginx
   version: 3.4.1
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Nginx Integration
   copyright:
     - license: Apache-2.0
@@ -23,8 +23,21 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
       install -Dm644 nginx-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/nginx-config.yml.sample
+      install -Dm644 legacy/nginx-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/nginx-definition.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/nginx-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/nginx-definition.yml
+    dependencies:
+      provides:
+        - nri-nginx
 
 update:
   enabled: true

--- a/nri-postgresql.yaml
+++ b/nri-postgresql.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-postgresql
   version: 2.13.0
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Postgresql Integration
   copyright:
     - license: MIT
@@ -23,8 +23,21 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
       install -Dm644 postgresql-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/postgresql-config.yml.sample
+      install -Dm644 legacy/postgresql-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/postgresql-definition.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/postgresql-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/postgresql-definition.yml
+    dependencies:
+      provides:
+        - nri-postgresql
 
 update:
   enabled: true

--- a/nri-rabbitmq.yaml
+++ b/nri-rabbitmq.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-rabbitmq
   version: 2.13.1
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure RabbitMQ Integration
   copyright:
     - license: MIT
@@ -23,8 +23,21 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
       install -Dm644 rabbitmq-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/rabbitmq-config.yml.sample
+      install -Dm644 legacy/rabbitmq-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/rabbitmq-definition.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/rabbitmq-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/rabbitmq-definition.yml
+    dependencies:
+      provides:
+        - nri-rabbitmq
 
 update:
   enabled: true

--- a/nri-redis.yaml
+++ b/nri-redis.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-redis
   version: 1.11.2
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Redis Integration
   copyright:
     - license: Apache-2.0
@@ -23,8 +23,21 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/etc/newrelic-infra/integrations.d
       install -Dm644 redis-config.yml.sample "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/redis-config.yml.sample
+      install -Dm644 legacy/redis-definition.yml "${{targets.destdir}}"/etc/newrelic-infra/integrations.d/redis-definition.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by newrelic-infrastructure-bundle"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin
+          ln -sf /usr/bin/${{package.name}} ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/bin/${{package.name}}
+          ln -sf /etc/newrelic-infra/integrations.d/redis-definition.yml ${{targets.subpkgdir}}/var/db/newrelic-infra/newrelic-integrations/redis-definition.yml
+    dependencies:
+      provides:
+        - nri-redis
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
