### PR TITLE
gitlab-exporter: vendor runtime deps 

### DIFF
--- a/gitlab-exporter.yaml
+++ b/gitlab-exporter.yaml
@@ -5,7 +5,7 @@
 package:
   name: gitlab-exporter
   version: 13.4.1
-  epoch: 0
+  epoch: 1
   description: GitLab Exporter is a Prometheus Web exporter.
   copyright:
     - license: MIT
@@ -21,6 +21,18 @@ package:
       - ruby3.2-faraday-excon
       - ruby3.2-rack
       - ruby3.2-bundler
+      - ruby3.2-redis
+      - ruby3.2-redis-namespace
+      - ruby3.2-sinatra
+      - ruby3.2-puma
+      - ruby3.2-pg
+      - ruby3.2-sidekiq
+      - ruby3.2-quantile
+      - ruby3.2-connection_pool
+      - ruby3.2-tilt
+      - ruby3.2-nio4r
+      - ruby3.2-rack-protection
+      - ruby3.2-mustermann
 
 environment:
   contents:
@@ -51,27 +63,16 @@ pipeline:
   # GitLab-Exporter Runtime Dependencies
   - runs: |
       # CVE-2023-40175 puma
-      sed -e 's/5.6.5/5.6.7/' -i gitlab-exporter.gemspec
-      sed -e 's/= 5.6.5/= 5.6.7/' -i Gemfile.lock
+      sed -e 's/5.6.5/>= 5.6.7/' -i gitlab-exporter.gemspec
+      sed -e 's/= 5.6.5/>= 5.6.7/' -i Gemfile.lock
 
       # CVE-2023-26141 sidekiq conflicting with the redis version as well
-      sed -e 's/6.4.0/6.5.10/' -i gitlab-exporter.gemspec
-      sed -e 's/= 6.4.0/= 6.5.10/' -i Gemfile.lock
-      sed -e 's/= 4.4.0/= 4.5.0/' -i Gemfile.lock
-      sed -e 's/4.4.0/4.5.0/' -i gitlab-exporter.gemspec
-
-      # Replace this with the actual path to your gitlab-exporter.gemspec file
-      GEMSPEC_FILE="./gitlab-exporter.gemspec"
-
-      # This is your target directory for installing the gems
-      # I'm assuming it's an environment variable, change as needed
-      INSTALL_GEM_DIR=${{targets.destdir}}$(ruby -e 'puts Gem.default_dir')/
-
-      # Use grep and sed to extract the lines containing runtime dependencies
-      grep 's.add_runtime_dependency' $GEMSPEC_FILE | sed -E 's/s.add_runtime_dependency[[:space:]]+"([^"]+)",[[:space:]]+"([^"]+)"/\1 \2/' | sed -e 's/~> //' -e 's/=> //' -e 's/= //' | while read -r GEM_NAME GEM_VERSION; do
-        # Run the gem install command
-        gem install $GEM_NAME -v $GEM_VERSION --install-dir $INSTALL_GEM_DIR
-      done
+      sed -e 's/6.4.0/>= 6.5.10/' -i gitlab-exporter.gemspec
+      sed -e 's/= 6.4.0/>= 6.5.10/' -i Gemfile.lock
+      sed -e 's/= 4.4.0/>= 4.5.0/' -i Gemfile.lock
+      sed -e 's/4.4.0/>= 4.5.0/' -i gitlab-exporter.gemspec
+      sed -e 's/2.2.5/>= 2.4.1/' -i gitlab-exporter.gemspec
+      sed -e 's/= 2.2.5/>= 2.4.1/' -i Gemfile.lock
 
   - uses: ruby/build
     with:

--- a/gitlab-exporter.yaml
+++ b/gitlab-exporter.yaml
@@ -15,11 +15,12 @@ package:
       - ruby-3.2
       - libpq-15
       - busybox
+      - gitlab-cng-base
       - gitlab-cng-exporter-scripts
       - ruby3.2-webrick
       - ruby3.2-faraday
       - ruby3.2-faraday-excon
-      - ruby3.2-rack
+      - ruby3.2-mustermann
       - ruby3.2-bundler
       - ruby3.2-redis
       - ruby3.2-redis-namespace
@@ -31,8 +32,8 @@ package:
       - ruby3.2-connection_pool
       - ruby3.2-tilt
       - ruby3.2-nio4r
+      - ruby3.2-rack-2.2
       - ruby3.2-rack-protection
-      - ruby3.2-mustermann
 
 environment:
   contents:
@@ -64,15 +65,17 @@ pipeline:
   - runs: |
       # CVE-2023-40175 puma
       sed -e 's/5.6.5/>= 5.6.7/' -i gitlab-exporter.gemspec
-      sed -e 's/= 5.6.5/>= 5.6.7/' -i Gemfile.lock
 
       # CVE-2023-26141 sidekiq conflicting with the redis version as well
       sed -e 's/6.4.0/>= 6.5.10/' -i gitlab-exporter.gemspec
-      sed -e 's/= 6.4.0/>= 6.5.10/' -i Gemfile.lock
-      sed -e 's/= 4.4.0/>= 4.5.0/' -i Gemfile.lock
       sed -e 's/4.4.0/>= 4.5.0/' -i gitlab-exporter.gemspec
+
+      # Unlock strict version requirements of connection_pool, pg, redis-namespace and quantile
       sed -e 's/2.2.5/>= 2.4.1/' -i gitlab-exporter.gemspec
-      sed -e 's/= 2.2.5/>= 2.4.1/' -i Gemfile.lock
+      sed -e 's/1.5.3/>= 1.5.3/' -i gitlab-exporter.gemspec
+      sed -e 's/1.9.0/>= 1.9.0/' -i gitlab-exporter.gemspec
+      sed -e 's/0.2.1/>= 0.2.1/' -i gitlab-exporter.gemspec
+      sed -e "s:(=:(>=:g" -i Gemfile.lock
 
   - uses: ruby/build
     with:

--- a/ruby3.2-mustermann.yaml
+++ b/ruby3.2-mustermann.yaml
@@ -1,0 +1,49 @@
+# Generated from https://github.com/sinatra/mustermann
+package:
+  name: ruby3.2-mustermann
+  version: 3.0.0
+  epoch: 0
+  description: A library implementing patterns that behave like regular expressions.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby3.2-ruby2_keywords
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 3727530c67d6b79f4cca30b2629121998efd5dd80ffb192f306e625fa3539066
+      uri: https://github.com/sinatra/mustermann/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+      dir: mustermann
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+      dir: mustermann
+
+  - uses: ruby/clean
+
+vars:
+  gem: mustermann
+
+update:
+  enabled: false
+  github:
+    identifier: sinatra/mustermann
+    strip-prefix: v

--- a/ruby3.2-mustermann.yaml
+++ b/ruby3.2-mustermann.yaml
@@ -9,6 +9,7 @@ package:
   dependencies:
     runtime:
       - ruby3.2-ruby2_keywords
+      - ruby3.2-rack-2.2
 
 environment:
   contents:
@@ -21,10 +22,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 3727530c67d6b79f4cca30b2629121998efd5dd80ffb192f306e625fa3539066
-      uri: https://github.com/sinatra/mustermann/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 47b62650334c6d0d58bdaf4abb0df8f10ef663e1
+      tag: v${{package.version}}
+      repository: https://github.com/sinatra/mustermann
 
   - uses: ruby/build
     with:
@@ -43,7 +45,7 @@ vars:
   gem: mustermann
 
 update:
-  enabled: false
+  enabled: true
   github:
     identifier: sinatra/mustermann
     strip-prefix: v

--- a/ruby3.2-nio4r.yaml
+++ b/ruby3.2-nio4r.yaml
@@ -1,0 +1,44 @@
+# Generated from https://github.com/socketry/nio4r/tree/v2.5.9
+package:
+  name: ruby3.2-nio4r
+  version: 2.5.9
+  epoch: 0
+  description: Cross-platform asynchronous I/O primitives for scalable network clients and servers. Inspired by the Java NIO API, but simplified for ease-of-use.
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: e97ebdfc7869b35c414bd4a5b521ca75e9ee62bda6eb5a8dc8425de4bae3e9d0
+      uri: https://github.com/socketry/nio4r/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: nio4r
+
+update:
+  enabled: false
+  github:
+    identifier: socketry/nio4r
+    strip-prefix: v

--- a/ruby3.2-nio4r.yaml
+++ b/ruby3.2-nio4r.yaml
@@ -38,7 +38,7 @@ vars:
   gem: nio4r
 
 update:
-  enabled: false
+  enabled: true
   github:
     identifier: socketry/nio4r
     strip-prefix: v

--- a/ruby3.2-pg.yaml
+++ b/ruby3.2-pg.yaml
@@ -1,7 +1,7 @@
 # Generated from https://github.com/ged/ruby-pg
 package:
   name: ruby3.2-pg
-  version: 1.5.3
+  version: 1.5.4
   epoch: 0
   description: Pg is the Ruby interface to the PostgreSQL RDBMS. It works with PostgreSQL 9.3 and later.
   copyright:
@@ -22,7 +22,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: b8841eae21e0cc2cd35107e303e16312cfa7bbe44a471d9a5f32d94b2557ae85
+      expected-sha256: b82c3f90da548af0ca9f80aba57ef8b225d3d320a8af1962fc881657e6408df0
       uri: https://github.com/ged/ruby-pg/archive/refs/tags/v${{package.version}}.tar.gz
 
   - uses: ruby/build
@@ -40,7 +40,7 @@ vars:
   gem: pg
 
 update:
-  enabled: false
+  enabled: true
   github:
     identifier: ged/ruby-pg
     strip-prefix: v

--- a/ruby3.2-pg.yaml
+++ b/ruby3.2-pg.yaml
@@ -1,0 +1,46 @@
+# Generated from https://github.com/ged/ruby-pg
+package:
+  name: ruby3.2-pg
+  version: 1.5.3
+  epoch: 0
+  description: Pg is the Ruby interface to the PostgreSQL RDBMS. It works with PostgreSQL 9.3 and later.
+  copyright:
+    - license: BSD-2-Clause
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - libpq-15
+      - postgresql-15-dev
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: b8841eae21e0cc2cd35107e303e16312cfa7bbe44a471d9a5f32d94b2557ae85
+      uri: https://github.com/ged/ruby-pg/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: pg
+
+update:
+  enabled: false
+  github:
+    identifier: ged/ruby-pg
+    strip-prefix: v

--- a/ruby3.2-puma.yaml
+++ b/ruby3.2-puma.yaml
@@ -1,7 +1,7 @@
 # Generated from https://github.com/puma/puma
 package:
   name: ruby3.2-puma
-  version: 5.6.7
+  version: 6.4.0
   epoch: 0
   description: Puma is a simple, fast, threaded, and highly parallel HTTP 1.1 server for Ruby/Rack applications. Puma is intended for use in both development and production environments. It's great for highly parallel Ruby implementations such as Rubinius and JRuby as well as as providing process worker support to support CRuby well.
   copyright:
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: edeccaa7a261f481d206101d2e87640dba8d584fd1214135433f4e985da34e9c
+      expected-sha256: 8bdd1a4c75ed44950ed316667271d9c6f55b650bce1a245b86725a9ff3f054ba
       uri: https://github.com/puma/puma/archive/refs/tags/v${{package.version}}.tar.gz
 
   - uses: ruby/build
@@ -41,7 +41,7 @@ vars:
   gem: puma
 
 update:
-  enabled: false
+  enabled: true
   github:
     identifier: puma/puma
     strip-prefix: v

--- a/ruby3.2-puma.yaml
+++ b/ruby3.2-puma.yaml
@@ -1,0 +1,47 @@
+# Generated from https://github.com/puma/puma
+package:
+  name: ruby3.2-puma
+  version: 5.6.7
+  epoch: 0
+  description: Puma is a simple, fast, threaded, and highly parallel HTTP 1.1 server for Ruby/Rack applications. Puma is intended for use in both development and production environments. It's great for highly parallel Ruby implementations such as Rubinius and JRuby as well as as providing process worker support to support CRuby well.
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - ruby3.2-nio4r
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: edeccaa7a261f481d206101d2e87640dba8d584fd1214135433f4e985da34e9c
+      uri: https://github.com/puma/puma/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: puma
+
+update:
+  enabled: false
+  github:
+    identifier: puma/puma
+    strip-prefix: v

--- a/ruby3.2-quantile.yaml
+++ b/ruby3.2-quantile.yaml
@@ -1,0 +1,44 @@
+# Generated from http://github.com/matttproud/ruby_quantile_estimation
+package:
+  name: ruby3.2-quantile
+  version: 0.2.1
+  epoch: 0
+  description: Graham Cormode and S. Muthukrishnan's Effective Computation of Biased Quantiles over Data Streams in ICDE’05
+  copyright:
+    - license: Apache 2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: a31b7ae352f41563b42ac5a8bcb67d182c1d1aff03da77cc9e99b7d9da79f371
+      uri: http://github.com/matttproud/ruby_quantile_estimation/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: quantile
+
+update:
+  enabled: false
+  github:
+    identifier: matttproud/ruby_quantile_estimation
+    strip-prefix: v

--- a/ruby3.2-rack-2.2.yaml
+++ b/ruby3.2-rack-2.2.yaml
@@ -1,9 +1,8 @@
-# Generated from https://github.com/jeremyevans/tilt
 package:
-  name: ruby3.2-tilt
-  version: 2.3.0
+  name: ruby3.2-rack-2.2
+  version: 2.2.8
   epoch: 0
-  description: Generic interface to multiple Ruby template engines
+  description: Rack provides a minimal, modular and adaptable interface for developing web applications in Ruby
   copyright:
     - license: MIT
 
@@ -20,8 +19,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 344882278fc0a50a760a562e3c25f0997fc9b8816b4c5c259b4188604bf8d5c9
-      uri: https://github.com/jeremyevans/tilt/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-sha256: 0c6e718d3975e5b1e0bba4d960798ae3022d13334f76660da8f8311a55b69ab2
+      uri: https://github.com/rack/rack/archive/refs/tags/v${{package.version}}.tar.gz
 
   - uses: ruby/build
     with:
@@ -35,10 +34,10 @@ pipeline:
   - uses: ruby/clean
 
 vars:
-  gem: tilt
+  gem: rack
 
 update:
-  enabled: true
+  enabled: false
   github:
-    identifier: jeremyevans/tilt
+    identifier: rack/rack
     strip-prefix: v

--- a/ruby3.2-rack-protection.yaml
+++ b/ruby3.2-rack-protection.yaml
@@ -1,0 +1,51 @@
+# Generated from https://github.com/sinatra/sinatra/tree/main/rack-protection
+package:
+  name: ruby3.2-rack-protection
+  version: 3.1.0
+  epoch: 0
+  description: Protect against typical web attacks, works with all Rack apps, including Rails
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby3.2-rack
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 2da7032b96077b8c6790a8f850e665df6560334de58f7f125db4e1d5f068625a
+      uri: https://github.com/sinatra/sinatra/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/unlock-spec
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+      dir: rack-protection
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+      dir: rack-protection
+
+  - uses: ruby/clean
+
+vars:
+  gem: rack-protection
+
+update:
+  enabled: false
+  github:
+    identifier: sinatra/sinatra
+    strip-prefix: v

--- a/ruby3.2-rack-protection.yaml
+++ b/ruby3.2-rack-protection.yaml
@@ -8,7 +8,7 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - ruby3.2-rack
+      - ruby3.2-rack-2.2
 
 environment:
   contents:
@@ -45,7 +45,7 @@ vars:
   gem: rack-protection
 
 update:
-  enabled: false
+  enabled: true
   github:
     identifier: sinatra/sinatra
     strip-prefix: v

--- a/ruby3.2-redis-namespace.yaml
+++ b/ruby3.2-redis-namespace.yaml
@@ -1,4 +1,3 @@
-# Generated from https://github.com/resque/redis-namespace
 package:
   name: ruby3.2-redis-namespace
   version: 1.11.0

--- a/ruby3.2-redis.yaml
+++ b/ruby3.2-redis.yaml
@@ -41,7 +41,7 @@ vars:
   gem: redis
 
 update:
-  enabled: false
+  enabled: true
   github:
     identifier: redis/redis-rb
     strip-prefix: v

--- a/ruby3.2-sidekiq.yaml
+++ b/ruby3.2-sidekiq.yaml
@@ -1,0 +1,52 @@
+# Generated from https://github.com/sidekiq/sidekiq
+package:
+  name: ruby3.2-sidekiq
+  version: 6.5.10
+  epoch: 0
+  description: Simple, efficient background processing for Ruby.
+  copyright:
+    - license: LGPL-3.0
+  dependencies:
+    runtime:
+      - ruby3.2-concurrent-ruby
+      - ruby3.2-connection_pool
+      - ruby3.2-rack
+      - ruby3.2-redis-client
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 83c27db32952e2e675644c9b7a55c2fa1babd6ec5c317befa6b5505b90c80e35
+      uri: https://github.com/sidekiq/sidekiq/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/unlock-spec
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: sidekiq
+
+update:
+  enabled: false
+  github:
+    identifier: sidekiq/sidekiq
+    strip-prefix: v

--- a/ruby3.2-sidekiq.yaml
+++ b/ruby3.2-sidekiq.yaml
@@ -1,7 +1,7 @@
 # Generated from https://github.com/sidekiq/sidekiq
 package:
   name: ruby3.2-sidekiq
-  version: 6.5.10
+  version: 7.1.6
   epoch: 0
   description: Simple, efficient background processing for Ruby.
   copyright:
@@ -10,7 +10,7 @@ package:
     runtime:
       - ruby3.2-concurrent-ruby
       - ruby3.2-connection_pool
-      - ruby3.2-rack
+      - ruby3.2-rack-2.2
       - ruby3.2-redis-client
 
 environment:
@@ -26,7 +26,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 83c27db32952e2e675644c9b7a55c2fa1babd6ec5c317befa6b5505b90c80e35
+      expected-sha256: 57fe45323b49a8cee8fa06766224e75168e1ca5a61b039bc062a0431b7907e5e
       uri: https://github.com/sidekiq/sidekiq/archive/refs/tags/v${{package.version}}.tar.gz
 
   - uses: ruby/unlock-spec
@@ -46,7 +46,7 @@ vars:
   gem: sidekiq
 
 update:
-  enabled: false
+  enabled: true
   github:
     identifier: sidekiq/sidekiq
     strip-prefix: v

--- a/ruby3.2-sinatra.yaml
+++ b/ruby3.2-sinatra.yaml
@@ -9,9 +9,9 @@ package:
   dependencies:
     runtime:
       - ruby3.2-mustermann
-      - ruby3.2-rack
-      - ruby3.2-rack-protection
       - ruby3.2-tilt
+      - ruby3.2-rack-2.2
+      - ruby3.2-rack-protection
 
 environment:
   contents:
@@ -46,7 +46,7 @@ vars:
   gem: sinatra
 
 update:
-  enabled: false
+  enabled: true
   github:
     identifier: sinatra/sinatra
     strip-prefix: v

--- a/ruby3.2-sinatra.yaml
+++ b/ruby3.2-sinatra.yaml
@@ -1,0 +1,52 @@
+# Generated from https://github.com/sinatra/sinatra
+package:
+  name: ruby3.2-sinatra
+  version: 3.1.0
+  epoch: 0
+  description: Sinatra is a DSL for quickly creating web applications in Ruby with minimal effort.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby3.2-mustermann
+      - ruby3.2-rack
+      - ruby3.2-rack-protection
+      - ruby3.2-tilt
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 2da7032b96077b8c6790a8f850e665df6560334de58f7f125db4e1d5f068625a
+      uri: https://github.com/sinatra/sinatra/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/unlock-spec
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: sinatra
+
+update:
+  enabled: false
+  github:
+    identifier: sinatra/sinatra
+    strip-prefix: v

--- a/ruby3.2-tilt.yaml
+++ b/ruby3.2-tilt.yaml
@@ -1,0 +1,44 @@
+# Generated from https://github.com/jeremyevans/tilt
+package:
+  name: ruby3.2-tilt
+  version: 2.3.0
+  epoch: 0
+  description: Generic interface to multiple Ruby template engines
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 344882278fc0a50a760a562e3c25f0997fc9b8816b4c5c259b4188604bf8d5c9
+      uri: https://github.com/jeremyevans/tilt/archive/refs/tags/v${{package.version}}.tar.gz
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: tilt
+
+update:
+  enabled: false
+  github:
+    identifier: jeremyevans/tilt
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
