### PR TITLE
remediate GHSA-6xv5-86q9-7xr8 for argo-cd-2.7

### DIFF
--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.7
   version: 2.7.14
-  epoch: 7
+  epoch: 8
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -52,6 +52,9 @@ pipeline:
 
       # Remediate GHSA-m425-mq94-257g
       go get google.golang.org/grpc@v1.56.3
+
+      # Remediate GHSA-6xv5-86q9-7xr8
+      go get github.com/cyphar/filepath-securejoin@v0.2.4
 
       go mod tidy
 


### PR DESCRIPTION
- remediate GHSA-6xv5-86q9-7xr8 for argo-cd-2.7

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: 



