### PR TITLE
kube-fluentd-operator/1.18.0 package update - Fix building error

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -51,7 +51,7 @@ pipeline:
   - runs: |
       echo 'gem: --no-rdoc --no-ri' >> ~/.gemrc
 
-      cd base-image
+      cd image
       GEM_DIR=${{targets.destdir}}$(ruby -e 'puts Gem.default_dir')
       mkdir -p ${GEM_DIR}
       bundle config set --local path ${GEM_DIR}
@@ -98,7 +98,7 @@ subpackages:
         - bash
     pipeline:
       - runs: |
-          cd base-image
+          cd image
           mkdir -p ${{targets.subpkgdir}}/var/lib/kube-fluentd-operator/initdb
           cp entrypoint.sh ${{targets.subpkgdir}}/var/lib/kube-fluentd-operator/initdb/
           chmod +x ${{targets.subpkgdir}}/var/lib/kube-fluentd-operator/initdb/entrypoint.sh
@@ -107,7 +107,7 @@ subpackages:
     description: Default configuration for kube-fluentd-operator
     pipeline:
       - runs: |
-          cd base-image
+          cd image
           mkdir -p ${{targets.subpkgdir}}/etc/fluent
           cp failsafe.conf ${{targets.subpkgdir}}/etc/fluent/fluent.conf
 


### PR DESCRIPTION
Fixes: #7032 
Related: #6319 

This PR fix build error since new version of kube-fluentd-operator create image not in a `base-image` directory but `image` directory

### Pre-review Checklist
#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
