### PR TITLE
mitigate GHSA-m425-mq94-257g for pulumi-kubernetes-operator

### DIFF
--- a/pulumi-kubernetes-operator.yaml
+++ b/pulumi-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-kubernetes-operator
   version: 1.13.0
-  epoch: 4
+  epoch: 5
   description: A Kubernetes Operator that automates the deployment of Pulumi Stacks
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,10 @@ pipeline:
       - runs: |
           # Mitigate CVE-2023-39325 and CVE-2023-3978
           go get golang.org/x/net@v0.17.0
+
+          # Remediate GHSA-m425-mq94-257g
+          go get google.golang.org/grpc@v1.58.3
+
           go mod tidy
 
           # Original Go build args found in ./scripts/build.sh


### PR DESCRIPTION
- mitigate GHSA-m425-mq94-257g for pulumi-kubernetes-operator

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/427


