### PR TITLE
Add ImageMagick.

### DIFF
--- a/imagemagick.yaml
+++ b/imagemagick.yaml
@@ -1,35 +1,36 @@
 package:
-    name: imagemagick
-    version: 7.1.1.21
-    epoch: 0
-    description: Tools and libraries for manipulating common image formats
-    copyright:
-        - license: ImageMagick
+  name: imagemagick
+  version: 7.1.1.21
+  epoch: 0
+  description: Tools and libraries for manipulating common image formats
+  copyright:
+    - license: ImageMagick
+
 environment:
-    contents:
-        packages:
-            - busybox
-            - ca-certificates-bundle
-            - build-base
-            - automake
-            - autoconf
-            - chrpath
-            - fftw-dev
-            - fontconfig-dev
-            - freetype-dev
-            - ghostscript-dev
-            - lcms2-dev
-            - libjpeg-turbo-dev
-            - libpng-dev
-            - libtool
-            - libwebp-dev
-            - libx11-dev
-            - libxext-dev
-            - libxml2-dev
-            - pango-dev
-            - perl-dev
-            - tiff-dev
-            - zlib-dev
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - chrpath
+      - fftw-dev
+      - fontconfig-dev
+      - freetype-dev
+      - ghostscript-dev
+      - lcms2-dev
+      - libjpeg-turbo-dev
+      - libpng-dev
+      - libtool
+      - libwebp-dev
+      - libx11-dev
+      - libxext-dev
+      - libxml2-dev
+      - pango-dev
+      - perl-dev
+      - tiff-dev
+      - zlib-dev
 
 var-transforms:
   - from: ${{package.version}}
@@ -38,36 +39,40 @@ var-transforms:
     to: mangled-package-version
 
 pipeline:
-    - uses: fetch
-      with:
-        expected-sha256: 09402e5f17c6575ef9f010bb2e21ae1710f1f3426f115ad4317ee9129c32608e
-        uri: https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${{vars.mangled-package-version}}.tar.gz
-    - uses: autoconf/configure
-    - uses: autoconf/make
-    - uses: autoconf/make-install
-    - uses: strip
+  - uses: fetch
+    with:
+      expected-sha256: 09402e5f17c6575ef9f010bb2e21ae1710f1f3426f115ad4317ee9129c32608e
+      uri: https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${{vars.mangled-package-version}}.tar.gz
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
 
 subpackages:
+  - name: imagemagick-doc
+    description: "ImageMagick documentation and manpages"
+    pipeline:
+      - uses: split/manpages
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share
+          mv "${{targets.destdir}}"/usr/share/doc/ "${{targets.subpkgdir}}"/usr/share
 
-    - name: imagemagick-doc
-      description: "ImageMagick documentation and manpages"
-      pipeline:
-        - uses: split/manpages
-        - runs: |
-            mkdir -p "${{targets.subpkgdir}}"/usr/share
-            mv "${{targets.destdir}}"/usr/share/doc/ "${{targets.subpkgdir}}"/usr/share
+  - name: imagemagick-static
+    description: ImageMagick static libraries
+    pipeline:
+      - uses: split/static
 
-    - name: imagemagick-static
-      description: ImageMagick static libraries
-      pipeline:
-        - uses: split/static
-    - name: imagemagick-dev
-      description: ImageMagick dev headers
-      pipeline:
-        - uses: split/dev
-      dependencies:
-        runtime:
-            - imagemagick
+  - name: imagemagick-dev
+    description: ImageMagick dev headers
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - imagemagick
 
 update:
   enabled: true

--- a/imagemagick.yaml
+++ b/imagemagick.yaml
@@ -93,9 +93,9 @@ subpackages:
 #        - uses: split/FIXME
 #      description: imagemagick FIXME
 #    - name: imagemagick-jpeg
-#      pipeline:
-#        - uses: split/FIXME
 #      description: imagemagick FIXME
+#      pipeline:
+#        - runs: |
 #    - name: imagemagick-pango
 #      pipeline:
 #        - uses: split/FIXME
@@ -124,8 +124,8 @@ subpackages:
 update:
   enabled: true
   version-transform:
-    - match: -
-    - replace: \. 
+    - match: "-"
+    - replace: \.
   github:
     identifier: ImageMagick/ImageMagick
     use-tag: true

--- a/imagemagick.yaml
+++ b/imagemagick.yaml
@@ -44,8 +44,8 @@ var-transforms:
 pipeline:
     - uses: fetch
       with:
-        expected-sha256: 1e44faec8bf603e8c894a7c039fb1b4bb83dc0c429c79c74577e73ceefe4a238
-        uri: https://imagemagick.org/archive/releases/ImageMagick-${{vars.mangled-package-version}}.tar.xz
+        expected-sha256: 09402e5f17c6575ef9f010bb2e21ae1710f1f3426f115ad4317ee9129c32608e
+        uri: https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${{vars.mangled-package-version}}.tar.gz
     - uses: autoconf/configure
     - uses: autoconf/make
     - uses: autoconf/make-install
@@ -121,4 +121,11 @@ subpackages:
 #        - uses: split/FIXME
 #      description: imagemagick FIXME
 
-
+update:
+  enabled: true
+  version-transform:
+    - match: -
+    - replace: \. 
+  github:
+    identifier: ImageMagick/ImageMagick
+    use-tag: true

--- a/imagemagick.yaml
+++ b/imagemagick.yaml
@@ -30,10 +30,6 @@ environment:
             - perl-dev
             - tiff-dev
             - zlib-dev
-# We currently don't have support for the following
-#            - libheif-dev
-#            - libraw-dev
-#            - librsvg-dev
 
 var-transforms:
   - from: ${{package.version}}
@@ -72,54 +68,6 @@ subpackages:
       dependencies:
         runtime:
             - imagemagick
-#    - name: imagemagick-c++
-#      pipeline:
-#        - uses: split/FIXME
-#      description: imagemagick FIXME
-#    - name: imagemagick-libs
-#      pipeline:
-#        - uses: split/FIXME
-#      description: imagemagick FIXME
-#    - name: imagemagick-perlmagick
-#      pipeline:
-#        - uses: split/FIXME
-#      description: imagemagick FIXME
-#    - name: imagemagick-perlmagick-doc
-#      pipeline:
-#        - uses: split/manpages
-#      description: imagemagick manpages
-#    - name: imagemagick-heic
-#      pipeline:
-#        - uses: split/FIXME
-#      description: imagemagick FIXME
-#    - name: imagemagick-jpeg
-#      description: imagemagick FIXME
-#      pipeline:
-#        - runs: |
-#    - name: imagemagick-pango
-#      pipeline:
-#        - uses: split/FIXME
-#      description: imagemagick FIXME
-#    - name: imagemagick-pdf
-#      pipeline:
-#        - uses: split/FIXME
-#      description: imagemagick FIXME
-#    - name: imagemagick-raw
-#      pipeline:
-#        - uses: split/FIXME
-#      description: imagemagick FIXME
-#    - name: imagemagick-svg
-#      pipeline:
-#        - uses: split/FIXME
-#      description: imagemagick FIXME
-#    - name: imagemagick-tiff
-#      pipeline:
-#        - uses: split/FIXME
-#      description: imagemagick FIXME
-#    - name: imagemagick-webp
-#      pipeline:
-#        - uses: split/FIXME
-#      description: imagemagick FIXME
 
 update:
   enabled: true

--- a/imagemagick.yaml
+++ b/imagemagick.yaml
@@ -1,0 +1,116 @@
+package:
+    name: imagemagick
+    version: 7.1.1.21
+    epoch: 0
+    description: Tools and libraries for manipulating common image formats
+    copyright:
+        - license: ImageMagick
+environment:
+    contents:
+        packages:
+            - busybox
+            - ca-certificates-bundle
+            - build-base
+            - automake
+            - autoconf
+            - chrpath
+            - fftw-dev
+            - fontconfig-dev
+            - freetype-dev
+            - ghostscript-dev
+            - lcms2-dev
+            - libjpeg-turbo-dev
+            - libpng-dev
+            - libtool
+            - libwebp-dev
+            - libx11-dev
+            - libxext-dev
+            - libxml2-dev
+            - pango-dev
+            - perl-dev
+            - tiff-dev
+            - zlib-dev
+# We currently don't have support for the following
+#            - libheif-dev
+#            - libraw-dev
+#            - librsvg-dev
+
+pipeline:
+    - uses: fetch
+      with:
+        expected-sha256: 1e44faec8bf603e8c894a7c039fb1b4bb83dc0c429c79c74577e73ceefe4a238
+        uri: https://imagemagick.org/archive/releases/ImageMagick-7.1.1-21.tar.xz
+    - uses: autoconf/configure
+    - uses: autoconf/make
+    - uses: autoconf/make-install
+    - uses: strip
+
+subpackages:
+
+    - name: imagemagick-doc
+      description: "ImageMagick documentation and manpages"
+      pipeline:
+        - uses: split/manpages
+        - runs: |
+            mkdir -p "${{targets.subpkgdir}}"/usr/share
+            mv "${{targets.destdir}}"/usr/share/doc/ "${{targets.subpkgdir}}"/usr/share
+
+    - name: imagemagick-static
+      description: ImageMagick static libraries
+      pipeline:
+        - uses: split/static
+    - name: imagemagick-dev
+      description: ImageMagick dev headers
+      pipeline:
+        - uses: split/dev
+      dependencies:
+        runtime:
+            - imagemagick
+#    - name: imagemagick-c++
+#      pipeline:
+#        - uses: split/FIXME
+#      description: imagemagick FIXME
+#    - name: imagemagick-libs
+#      pipeline:
+#        - uses: split/FIXME
+#      description: imagemagick FIXME
+#    - name: imagemagick-perlmagick
+#      pipeline:
+#        - uses: split/FIXME
+#      description: imagemagick FIXME
+#    - name: imagemagick-perlmagick-doc
+#      pipeline:
+#        - uses: split/manpages
+#      description: imagemagick manpages
+#    - name: imagemagick-heic
+#      pipeline:
+#        - uses: split/FIXME
+#      description: imagemagick FIXME
+#    - name: imagemagick-jpeg
+#      pipeline:
+#        - uses: split/FIXME
+#      description: imagemagick FIXME
+#    - name: imagemagick-pango
+#      pipeline:
+#        - uses: split/FIXME
+#      description: imagemagick FIXME
+#    - name: imagemagick-pdf
+#      pipeline:
+#        - uses: split/FIXME
+#      description: imagemagick FIXME
+#    - name: imagemagick-raw
+#      pipeline:
+#        - uses: split/FIXME
+#      description: imagemagick FIXME
+#    - name: imagemagick-svg
+#      pipeline:
+#        - uses: split/FIXME
+#      description: imagemagick FIXME
+#    - name: imagemagick-tiff
+#      pipeline:
+#        - uses: split/FIXME
+#      description: imagemagick FIXME
+#    - name: imagemagick-webp
+#      pipeline:
+#        - uses: split/FIXME
+#      description: imagemagick FIXME

--- a/imagemagick.yaml
+++ b/imagemagick.yaml
@@ -37,7 +37,7 @@ environment:
 
 var-transforms:
   - from: ${{package.version}}
-    match: \.([^\.]*)$
+    match: \.([^\[.-]*)$
     replace: "-$1"
     to: mangled-package-version
 
@@ -123,9 +123,6 @@ subpackages:
 
 update:
   enabled: true
-  version-transform:
-    - match: "-"
-    - replace: \.
   github:
     identifier: ImageMagick/ImageMagick
     use-tag: true

--- a/imagemagick.yaml
+++ b/imagemagick.yaml
@@ -35,11 +35,17 @@ environment:
 #            - libraw-dev
 #            - librsvg-dev
 
+var-transforms:
+  - from: ${{package.version}}
+    match: \.([^\.]*)$
+    replace: "-$1"
+    to: mangled-package-version
+
 pipeline:
     - uses: fetch
       with:
         expected-sha256: 1e44faec8bf603e8c894a7c039fb1b4bb83dc0c429c79c74577e73ceefe4a238
-        uri: https://imagemagick.org/archive/releases/ImageMagick-7.1.1-21.tar.xz
+        uri: https://imagemagick.org/archive/releases/ImageMagick-${{vars.mangled-package-version}}.tar.xz
     - uses: autoconf/configure
     - uses: autoconf/make
     - uses: autoconf/make-install
@@ -114,3 +120,5 @@ subpackages:
 #      pipeline:
 #        - uses: split/FIXME
 #      description: imagemagick FIXME
+
+


### PR DESCRIPTION
This is in progress and still needs subpackages split out. We're also missing some libraries so some formats are not currently supported.

Will add update data shortly...

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
https://github.com/wolfi-dev/os/issues/6063
Related:
https://github.com/wolfi-dev/os/pull/6064

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ x ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ x ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
It's a variant of Apache
- [ x ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

