### PR TITLE
Bundle all nri binaries into newrelic-infrastructure-bundle

### DIFF
--- a/newrelic-infrastructure-bundle.yaml
+++ b/newrelic-infrastructure-bundle.yaml
@@ -1,10 +1,33 @@
 package:
   name: newrelic-infrastructure-bundle
-  version: 3.2.22
-  epoch: 0
+  version: 3.2.23
+  epoch: 1
   description: New Relic Infrastructure containerised agent bundle
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - nri-apache-compat
+      - nri-cassandra-compat
+      - nri-consul-compat
+      - nri-couchbase-compat
+      - nri-elasticsearch-compat
+      - nri-f5-compat
+      - nri-haproxy-compat
+      - nri-jmx-compat
+      - nri-kafka-compat
+      - nri-memcached-compat
+      - nri-mongodb-compat
+      - nri-mysql-compat
+      - nri-nagios-compat
+      - nri-nginx-compat
+      - nri-postgresql-compat
+      - nri-rabbitmq-compat
+      - nri-redis-compat
+      - nrjmx
+      - nri-discovery-kubernetes-compat
+      - nri-mssql-compat
+      - openjdk-8-jre
 
 environment:
   contents:
@@ -20,32 +43,16 @@ pipeline:
     with:
       repository: https://github.com/newrelic/infrastructure-bundle
       tag: v${{package.version}}
-      expected-commit: 040474c71354595f481ce14b8e9798bd7bff78f5
+      expected-commit: 385248be75c128ff95d9891114fb10c72b3549f7
       destination: ${{package.name}}
 
-  - working-directory: ${{package.name}}
-    pipeline:
-      - runs: |
-          go run downloader.go
+  # NO-OP. We were using `go run downloader.go` to fetch the pre-compiled binaries
+  # from the upstream. However, one of the drawbacks of doing it this way is that binaries
+  # may contain CVEs since upstream repo doesn't apply prompt vulnerability migrations.
+  # Now, we packaged all the required binaries in Wolfi to bundle all of them during
+  # runtime rather than build-time.
 
-          case "${{build.arch}}" in
-              x86_64)   export TARGETARCH="amd64" ;;
-              aarch64)  export TARGETARCH="arm64" ;;
-              *)        echo "Unsupported architecture: ${{build.arch}}"; exit 1 ;;
-          esac
-
-          cd ./out/$TARGETARCH
-
-          mkdir -p ${{targets.destdir}}/var
-          mkdir -p ${{targets.destdir}}/etc
-          mkdir -p ${{targets.destdir}}/usr
-
-          mv ./var/db "${{targets.destdir}}"/var
-          mv ./etc/newrelic-infra "${{targets.destdir}}"/etc
-
-          mv ./usr/bin "${{targets.destdir}}"/usr
-          mv ./usr/share "${{targets.destdir}}"/usr
-      - uses: strip
+  - uses: strip
 
 update:
   enabled: true


### PR DESCRIPTION
```bash
/work # apk add --allow-untrusted newrelic-infrastructure-bundle-3.2.22-r1.apk
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/54) Installing nri-apache-compat (1.12.1-r1)
(2/54) Installing nri-cassandra-compat (2.13.2-r1)
(3/54) Installing nri-consul-compat (2.7.2-r1)
(4/54) Installing nri-couchbase-compat (2.6.1-r1)
(5/54) Installing nri-discovery-kubernetes-compat (1.7.1-r1)
(6/54) Installing nri-elasticsearch-compat (5.2.1-r1)
(7/54) Installing nri-f5-compat (2.7.2-r1)
(8/54) Installing nri-haproxy-compat (2.5.1-r0)
(9/54) Installing nri-jmx-compat (3.5.0-r1)
(10/54) Installing nri-kafka-compat (3.4.9-r1)
(11/54) Installing nri-memcached-compat (2.5.1-r1)
(12/54) Installing nri-mongodb-compat (2.8.1-r1)
(13/54) Installing nri-mssql-compat (2.10.1-r1)
(14/54) Installing nri-mysql-compat (1.10.2-r1)
(15/54) Installing nri-nagios-compat (2.9.0-r1)
(16/54) Installing nri-nginx-compat (3.4.1-r1)
(17/54) Installing nri-postgresql-compat (2.13.0-r1)
(18/54) Installing nri-rabbitmq-compat (2.13.1-r1)
(19/54) Installing nri-redis-compat (1.11.2-r1)
(20/54) Installing libbrotlicommon1 (1.1.0-r0)
(21/54) Installing libbrotlidec1 (1.1.0-r0)
(22/54) Installing bzip2 (1.0.8-r4)
(23/54) Installing libpng (1.6.40-r0)
(24/54) Installing freetype (2.13.2-r1)
(25/54) Installing fontconfig-config (2.14.2-r2)
(26/54) Installing expat (2.5.0-r3)
(27/54) Installing libfontconfig1 (2.14.2-r2)
(28/54) Installing java-cacerts (20230106-r1)
(29/54) Installing java-common (0.1-r0)
(30/54) Installing openjdk-17-jre-base (17.0.9.9-r0)
(31/54) Installing openjdk-17-jre (17.0.9.9-r0)
(32/54) Installing nrjmx (2.5.0-r0)
(33/54) Installing libxau (1.0.11-r3)
(34/54) Installing libxdmcp (1.1.4-r3)
(35/54) Installing libxcb (1.16-r0)
(36/54) Installing libx11 (1.8.7-r0)
(37/54) Installing libxcomposite (0.4.6-r0)
(38/54) Installing libxext (1.3.5-r3)
(39/54) Installing libxi (1.8.1-r0)
(40/54) Installing libxrender (0.9.11-r3)
(41/54) Installing libxtst (1.2.4-r4)
(42/54) Installing alsa-lib (1.2.10-r0)
(43/54) Installing libgcc (13.2.0-r3)
(44/54) Installing giflib (5.2.1-r2)
(45/54) Installing libjpeg-turbo (3.0.1-r0)
(46/54) Installing krb5-conf (1.0-r0)
(47/54) Installing libcom_err (1.47.0-r0)
(48/54) Installing keyutils-libs (1.6.3-r0)
(49/54) Installing libverto (0.3.2-r0)
(50/54) Installing krb5-libs (1.21.2-r0)
(51/54) Installing lcms2 (2.15-r1)
(52/54) Installing libstdc++ (13.2.0-r3)
(53/54) Installing openjdk-8-jre (8.382.05-r1)
(54/54) Installing newrelic-infrastructure-bundle (3.2.22-r1)
OK: 340 MiB in 68 packages
/work # apk add grype
(1/1) Installing grype (0.72.0-r0)
OK: 392 MiB in 69 packages
/ # grype /var/db/
 ✔ Indexed file system                                                                                                                                                /var/db
 ✔ Cataloged packages              [0 packages]
 ✔ Vulnerability DB                [updated]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
[0000]  WARN no explicit name and version provided for directory source, deriving artifact ID from the given path (which is not ideal)
No vulnerabilities found
```

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
