### PR TITLE
New package `ninja-build`.

### DIFF
--- a/ninja-build.yaml
+++ b/ninja-build.yaml
@@ -1,0 +1,50 @@
+# Note that there's also samurai that provides ninja. It's typically a better
+# option given how it schedules jobs more predictably. For one example where
+# this was a problem in the upstream package:
+# https://github.com/wolfi-dev/os/issues/7334
+# `ninja` gets installed into /usr/lib/ninja-build/bin/ninja to follow precedent
+# from alpine, so that it doesn't conflict with samurai. In order to use this
+# for builds, you have to install this package, as well as add
+# `/usr/lib/ninja-build/bin` to your PATH.
+package:
+  name: ninja-build
+  version: 1.11.1
+  epoch: 0
+  description: "Ninja is a small build system with a focus on speed."
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ninja-build/ninja
+      tag: v${{package.version}}
+      expected-commit: a524bf3f6bacd1b4ad85d719eed2737d8562f27a
+
+  # We install into a custom location to ensure that if you want to use this
+  # you really have to go out of your way to do so. This is because we want
+  # to discourage the use of ninja in favor of samurai.
+  # `opts` come after the flags defined in the pipeline, and the last one wins
+  # https://cmake.org/cmake/help/latest/manual/cmake.1.html
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DCMAKE_INSTALL_PREFIX=/usr/lib/ninja-build
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+update:
+  enabled: true
+  github:
+    identifier: ninja-build/ninja
+    strip-prefix: v


### PR DESCRIPTION
```
b76dee3721d8:/work/packages# apk info -L ninja-build
ninja-build-1.11.1-r0 contains:
usr/lib/ninja-build/bin/ninja
var/lib/db/sbom/ninja-build-1.11.1-r0.spdx.json
```

```
vaikas@vaikas-MBP os % wolfictl scan packages/aarch64/ninja-build-1.11.1-r0.apk
🔎 Scanning "packages/aarch64/ninja-build-1.11.1-r0.apk"
✅ No vulnerabilities found
```

I also used this (local ofc) package to build the py3-pandas from the head (now 2.1.2, released 5 days ago) and also validated the previous ones (2.1.1 that I was debugging before now works).

```
ℹ️  aarch64   | wrote packages/aarch64/py3-pandas-2.1.2-r0.apk
ℹ️  aarch64   | generating apk index from packages in packages/aarch64
ℹ️            | processing package packages/aarch64/py3-pandas-2.1.2-r0.apk
ℹ️            | loaded 3/3 packages from index packages/aarch64/APKINDEX.tar.gz
ℹ️            | updating index at packages/aarch64/APKINDEX.tar.gz with new packages: [py3-pandas-2.1.2-r0]
ℹ️            | signing apk index at packages/aarch64/APKINDEX.tar.gz
ℹ️            | signing index packages/aarch64/APKINDEX.tar.gz with key local-melange.rsa
ℹ️            | appending signature to index packages/aarch64/APKINDEX.tar.gz
ℹ️            | writing signed index to packages/aarch64/APKINDEX.tar.gz
ℹ️            | signed index packages/aarch64/APKINDEX.tar.gz with key local-melange.rsa
make[1]: Leaving directory '/Users/vaikas/projects/go/src/github.com/wolfi-dev/os'
```

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #7334 (well, this is a workaround)

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
