### PR TITLE
Update py3-pandas to head, use git-checkout and github for releases. Re-enable update block.

### DIFF
--- a/py3-pandas.yaml
+++ b/py3-pandas.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pandas
-  version: 2.0.3
-  epoch: 1
+  version: 2.1.2
+  epoch: 0
   description: Powerful data structures for data analysis, time series, and statistics
   copyright:
     - license: 'BSD-3-Clause'
@@ -22,6 +22,7 @@ environment:
       - cython
       - meson
       - numpy
+      - ninja-build
       - py3-dateutil
       - py3-gpep517
       - py3-meson-python
@@ -35,20 +36,25 @@ environment:
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: c02f372a88e0d17f36d3093a644c73cfc1788e876a7c4bcb4020a77512e2043c
-      uri: https://github.com/pandas-dev/pandas/releases/download/v${{package.version}}/pandas-${{package.version}}.tar.gz
+      repository: https://github.com/pandas-dev/pandas
+      tag: v${{package.version}}
+      expected-commit: a60ad39b4a9febdea9a59d602dad44b1538b0ea5
 
   - runs: |
-      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 1
+      # Note we have to currently build this with `ninja` instead of samurai
+      # https://github.com/wolfi-dev/os/issues/7334
+      export PATH=/usr/lib/ninja-build/bin:$PATH
+      # You have to do this dance with the FDs because without it things fail.
+      # I don't know why, but other places do this, so I'm just copying them.
+      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 3 3>&1 >&2
       python3 -m installer -d "${{targets.destdir}}" dist/*.whl
 
   - uses: strip
 
 update:
-  # Pandas 2.1.1 fails to build from source, so skip updates for now.
-  # https://github.com/wolfi-dev/os/issues/7334
-  enabled: false
-  release-monitor:
-    identifier: 7578
+  enabled: true
+  github:
+    identifier: pandas-dev/pandas
+    strip-prefix: v


### PR DESCRIPTION
```
vaikas@vaikas-MBP os % wolfictl scan packages/aarch64/py3-pandas-2.1.2-r0.apk
🔎 Scanning "packages/aarch64/py3-pandas-2.1.2-r0.apk"
✅ No vulnerabilities found
```

Also ran this [small example](https://pandas.pydata.org/docs/user_guide/10min.html)

```
b76dee3721d8:/work/packages# python
Python 3.12.0 (main, Oct 12 2023, 17:58:08) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>> import pandas as pd
>>> s = pd.Series([1,3,5,np.nan, 6, 8])
>>> s
0    1.0
1    3.0
2    5.0
3    NaN
4    6.0
5    8.0
dtype: float64
>>> dates = pd.date_range("20130101", periods=6)
>>> dates
DatetimeIndex(['2013-01-01', '2013-01-02', '2013-01-03', '2013-01-04',
               '2013-01-05', '2013-01-06'],
              dtype='datetime64[ns]', freq='D')
>>> df = pd.DataFrame(np.random.randn(6, 4), index=dates, columns=list("ABCD"))
>>> df
                   A         B         C         D
2013-01-01 -2.136014  0.637371 -0.160265 -1.060921
2013-01-02  0.359922  1.526306  0.242914 -1.872659
2013-01-03  1.180646  0.521125  1.796536 -1.437376
2013-01-04 -0.592668 -0.237744 -0.179168  0.146163
2013-01-05  1.691391  0.489242 -1.172457 -1.354943
2013-01-06  0.777360 -0.413532 -1.567863  0.256717
>>> df.to_numpy()
array([[-2.13601386,  0.63737088, -0.16026491, -1.06092137],
       [ 0.35992215,  1.52630606,  0.24291405, -1.87265933],
       [ 1.18064567,  0.5211248 ,  1.79653634, -1.43737568],
       [-0.59266798, -0.23774386, -0.17916832,  0.1461629 ],
       [ 1.69139133,  0.48924177, -1.17245663, -1.35494307],
       [ 0.77736011, -0.41353187, -1.56786345,  0.2567167 ]])
```
<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
