### PR TITLE
`zarf/0.31.0` package upgrade.

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -1,6 +1,6 @@
 package:
   name: zarf
-  version: 0.30.1
+  version: 0.31.0
   epoch: 0
   description: DevSecOps for Air Gap & Limited-Connection Systems.
   copyright:
@@ -9,9 +9,9 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - busybox
       - bash
+      - busybox
+      - ca-certificates-bundle
       - go
       - nodejs
 
@@ -19,13 +19,14 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/defenseunicorns/zarf
-      expected-commit: 785c5a0f7cf3ce178eeb19b2395ebf5131b043e3
+      expected-commit: e255baae814e57a094c0af03fd632c9c7cdc9a1c
       tag: v${{package.version}}
 
-  - runs: |
-      mkdir -p ${{targets.destdir}}/usr/bin/
-      make build-ui
-      go build -o ${{targets.destdir}}/usr/bin/zarf -ldflags="-s -w -X 'github.com/defenseunicorns/zarf/src/config.CLIVersion=$(git describe --tags)'" .
+  - uses: go/build
+    with:
+      packages: .
+      output: zarf
+      ldflags: -s -w -X 'github.com/defenseunicorns/zarf/src/config.CLIVersion=v${{package.version}}'
 
   - uses: strip
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixed & Suppress: #7829 

Previously we were building the UI even though we were not packaging it into the apk.
In this new version, they have separated the UI into different repository. 

I have removed the `make build-ui` part and use `go/build` pipeline.


#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

