### PR TITLE
Remediate CVE-2023-44487/GHSA-m425-mq94-257g for cilium-envoy

### DIFF
--- a/cilium-envoy.yaml
+++ b/cilium-envoy.yaml
@@ -3,7 +3,7 @@ package:
   # cilium/proxy is refered by the build in cilium/cilium using
   # digest. the project itself does not have any tag nor release.
   version: "1.25_git20231010"
-  epoch: 2
+  epoch: 3
   description: Envoy proxy for Cilium with minimal Envoy extensions and Cilium policy enforcement filters.
   copyright:
     - license: Apache-2.0
@@ -61,6 +61,10 @@ pipeline:
   - runs: |
       # Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
+
+      # Remediate CVE-2023-44487/GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.56.3
+
       go mod tidy
       go mod vendor
 


### PR DESCRIPTION
- Remediate CVE-2023-44487/GHSA-m425-mq94-257g for cilium-envoy

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/440



