### PR TITLE
py3-pandas: switch back to samurai

### DIFF
--- a/py3-pandas.yaml
+++ b/py3-pandas.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pandas
   version: 2.1.2
-  epoch: 0
+  epoch: 1
   description: Powerful data structures for data analysis, time series, and statistics
   copyright:
     - license: 'BSD-3-Clause'
@@ -22,7 +22,6 @@ environment:
       - cython
       - meson
       - numpy
-      - ninja-build
       - py3-dateutil
       - py3-gpep517
       - py3-meson-python
@@ -42,10 +41,11 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: a60ad39b4a9febdea9a59d602dad44b1538b0ea5
 
+  - uses: patch
+    with:
+      patches: meson-fix.patch
+
   - runs: |
-      # Note we have to currently build this with `ninja` instead of samurai
-      # https://github.com/wolfi-dev/os/issues/7334
-      export PATH=/usr/lib/ninja-build/bin:$PATH
       # You have to do this dance with the FDs because without it things fail.
       # I don't know why, but other places do this, so I'm just copying them.
       python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 3 3>&1 >&2

--- a/py3-pandas/meson-fix.patch
+++ b/py3-pandas/meson-fix.patch
@@ -1,0 +1,18 @@
+diff --git a/pandas/_libs/meson.build b/pandas/_libs/meson.build
+index b4662d6..34bfb2b 100644
+--- a/pandas/_libs/meson.build
++++ b/pandas/_libs/meson.build
+@@ -62,11 +62,11 @@ libs_sources = {
+     # Dict of extension name -> dict of {sources, include_dirs, and deps}
+     # numpy include dir is implicitly included
+     'algos': {'sources': ['algos.pyx', _algos_common_helper, _algos_take_helper, _khash_primitive_helper]},
+-    'arrays': {'sources': ['arrays.pyx']},
++    'arrays': {'sources': ['arrays.pyx', _khash_primitive_helper]},
+     'groupby': {'sources': ['groupby.pyx']},
+     'hashing': {'sources': ['hashing.pyx']},
+     'hashtable': {'sources': ['hashtable.pyx', _khash_primitive_helper, _hashtable_class_helper, _hashtable_func_helper]},
+-    'index': {'sources': ['index.pyx', _index_class_helper]},
++    'index': {'sources': ['index.pyx', _khash_primitive_helper, _index_class_helper]},
+     'indexing': {'sources': ['indexing.pyx']},
+     'internals': {'sources': ['internals.pyx']},
+     'interval': {'sources': ['interval.pyx', _intervaltree_helper],


### PR DESCRIPTION
Add a patch to add the missing dependency relationships, so that Samurai gets the build order right.