### PR TITLE
Update py3-cloudpickle.yaml

### DIFF
--- a/py3-cloudpickle.yaml
+++ b/py3-cloudpickle.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cloudpickle
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: Extended pickling support for Python objects
   copyright:
     - license: BSD 3-Clause License

--- a/py3-cloudpickle.yaml
+++ b/py3-cloudpickle.yaml
@@ -23,7 +23,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/cloudpipe/cloudpickle
-      expected-commit: 90d66589f643f5d291e67ddd94e31c0ec1f2d92d
+      expected-commit: 227f24668b97b15e627e9a3e1e3bec526b101f5c
       tag: v${{package.version}}
 
   - name: Python Build

--- a/py3-cloudpickle.yaml
+++ b/py3-cloudpickle.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cloudpickle
-  version: 2.2.1
-  epoch: 1
+  version: 3.0.0
+  epoch: 0
   description: Extended pickling support for Python objects
   copyright:
     - license: BSD 3-Clause License
@@ -23,7 +23,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/cloudpipe/cloudpickle
-      expected-commit: 917bed6bc63355f50aeb4f001683be7f172b6b88
+      expected-commit: 90d66589f643f5d291e67ddd94e31c0ec1f2d92d
       tag: v${{package.version}}
 
   - name: Python Build


### PR DESCRIPTION
Fixes #7020

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
