### PR TITLE
Remediate CVE-2023-44487 and CVE-2023-3955 for aws-efs-csi-driver

### DIFF
--- a/aws-efs-csi-driver.yaml
+++ b/aws-efs-csi-driver.yaml
@@ -33,8 +33,8 @@ pipeline:
       expected-commit: efedacebb3516593861bd6927a178ce4408e68e6
 
   - runs: |
-      # Mitigate GHSA-xc8m-28vv-4pjc, GHSA-cgcv-5272-97pr, GHSA-qc2g-gmh6-95p4
-      go get k8s.io/kubernetes@v1.25.12
+      # Mitigate CVE-2023-3955/GHSA-q78c-gwqw-jcmc
+      go get k8s.io/kubernetes@v1.25.13
 
       # CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0

--- a/aws-efs-csi-driver.yaml
+++ b/aws-efs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-efs-csi-driver
   version: 1.7.0
-  epoch: 5
+  epoch: 6
   description: CSI driver for Amazon EFS.
   copyright:
     - license: Apache-2.0
@@ -38,6 +38,9 @@ pipeline:
 
       # CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
+
+      # Remediate CVE-2023-44487/GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.56.3
 
       go mod tidy
       go mod vendor


### PR DESCRIPTION
- Remediate CVE-2023-44487 and CVE-2023-3955 for aws-efs-csi-driver

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/444



