### PR TITLE
Remediate CVE-2023-3955 for argo-cd-2.7 and argo-cd-2.8

### DIFF
--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.7
   version: 2.7.14
-  epoch: 7
+  epoch: 8
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -44,8 +44,8 @@ pipeline:
       # CVE-2023-2253
       go get github.com/docker/distribution@v2.8.2
 
-      # CVE-2023-2728, CVE-2023-2727
-      go get k8s.io/kubernetes@v1.24.15
+      # CVE-2023-3955/GHSA-q78c-gwqw-jcmc
+      go get k8s.io/kubernetes@v1.24.17
 
       # CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0

--- a/argo-cd-2.8.yaml
+++ b/argo-cd-2.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.8
   version: 2.8.6
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -41,9 +41,8 @@ pipeline:
 
       unset GOFLAGS
 
-      # CVE-2023-2728, CVE-2023-2727
-      go get k8s.io/kubernetes@v1.24.15
-
+      # CVE-2023-3955/GHSA-q78c-gwqw-jcmc
+      go get k8s.io/kubernetes@v1.24.17
 
       go mod tidy
 


### PR DESCRIPTION
- Remediate CVE-2023-3955 for argo-cd-2.7 and argo-cd-2.8

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/445



