### PR TITLE
fix multicall patching and add assertion

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.28.3
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -77,6 +77,9 @@ pipeline:
       go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.19.0
       go get go.opentelemetry.io/otel/metric@v1.19.0
 
+      # CVE-2023-46129
+      go get github.com/nats-io/nkeys@v0.4.6
+
       go mod tidy
 
       ./scripts/build
@@ -101,12 +104,19 @@ pipeline:
       mv bin/k3s "${{targets.destdir}}"/bin/_k3s-inner
 
       # Modify the packaging script to exclusively use symlinks to our moved "inner" binary
-      sed -i 's|ln -s k3s bin/$i|ln -s /bin/_k3s-inner bin/$i|g' ./scripts/package-cli
+      sed -i 's|ln -s k3s${BINARY_POSTFIX} bin/$i${BINARY_POSTFIX}|ln -s /bin/_k3s-inner${BINARY_POSTFIX} bin/$i${BINARY_POSTFIX}|g' ./scripts/package-cli
 
       # Remove the upload portion from the upstream package-cli script
       sed -e '/scripts\/build-upload/d' -i scripts/package-cli
 
+      # Upstream handles the ctr link at install time, since we don't have an "install" phase, we do it here
+      rm -rf bin/ctr && ln -s /bin/_k3s-inner bin/ctr
+
       ./scripts/package-cli
+
+      # Check that the multicall symlinks were created
+      [ "$(readlink ./bin/k3s-server)" = "/bin/_k3s-inner" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }
+      [ "$(readlink ./bin/loopback)" = "cni" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }
 
       # Finally, install the "outer" k3s multicall binary. This should only
       # contain the go runtime plus the self extracting multicall logic, and


### PR DESCRIPTION
the latest `1.28.3` upstream bump ([ref](https://github.com/k3s-io/k3s/pull/7259)) changed the packaging scripts and invalidated the multicall symlink setup.

this updates it to match upstream, and adds an assertion to fail here rather than downstream