### PR TITLE
Remediate CVE-2023-3955 for calico

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.26.3
-  epoch: 4
+  epoch: 5
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64
@@ -69,8 +69,8 @@ pipeline:
       go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
       go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.19.0
 
-      # Remediate GHSA-qc2g-gmh6-95p4
-      go mod edit -replace k8s.io/kubernetes=k8s.io/kubernetes@v1.26.6
+      # Remediate CVE-2023-3955
+      go mod edit -replace k8s.io/kubernetes=k8s.io/kubernetes@v1.26.8
 
       go mod tidy
   - working-directory: felix


### PR DESCRIPTION
- Remediate CVE-2023-3955 for calico

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/446



