### PR TITLE
Remediate CVE-2023-3955 and GHSA-m425-mq94-257g for cluster-autoscaler-1.25/1.26/1.27/1.28

### DIFF
--- a/cluster-autoscaler-1.25.yaml
+++ b/cluster-autoscaler-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.25
   version: 1.25.3
-  epoch: 3
+  epoch: 4
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -32,7 +32,7 @@ pipeline:
       packages: .
       output: cluster-autoscaler
       ldflags: -s -w
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0
+      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3 k8s.io/kubernetes@v1.25.13
       vendor: true
 
   - uses: strip

--- a/cluster-autoscaler-1.25.yaml
+++ b/cluster-autoscaler-1.25.yaml
@@ -32,7 +32,7 @@ pipeline:
       packages: .
       output: cluster-autoscaler
       ldflags: -s -w
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3 k8s.io/kubernetes@v1.25.13
+      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 k8s.io/kubernetes@v1.25.13
       vendor: true
 
   - uses: strip

--- a/cluster-autoscaler-1.26.yaml
+++ b/cluster-autoscaler-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.26
   version: 1.26.4
-  epoch: 3
+  epoch: 4
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -32,7 +32,7 @@ pipeline:
       packages: .
       output: cluster-autoscaler
       ldflags: -s -w
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0
+      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3 k8s.io/kubernetes@v1.26.8
       vendor: true
 
   - uses: strip

--- a/cluster-autoscaler-1.26.yaml
+++ b/cluster-autoscaler-1.26.yaml
@@ -32,7 +32,7 @@ pipeline:
       packages: .
       output: cluster-autoscaler
       ldflags: -s -w
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3 k8s.io/kubernetes@v1.26.8
+      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 k8s.io/kubernetes@v1.26.8
       vendor: true
 
   - uses: strip

--- a/cluster-autoscaler-1.27.yaml
+++ b/cluster-autoscaler-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.27
   version: 1.27.3
-  epoch: 5
+  epoch: 6
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -32,7 +32,7 @@ pipeline:
       packages: .
       output: cluster-autoscaler
       ldflags: -s -w
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0
+      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3 k8s.io/kubernetes@v1.27.5
       vendor: true
 
   - uses: strip

--- a/cluster-autoscaler-1.27.yaml
+++ b/cluster-autoscaler-1.27.yaml
@@ -32,7 +32,7 @@ pipeline:
       packages: .
       output: cluster-autoscaler
       ldflags: -s -w
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3 k8s.io/kubernetes@v1.27.5
+      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 k8s.io/kubernetes@v1.27.5
       vendor: true
 
   - uses: strip

--- a/cluster-autoscaler-1.28.yaml
+++ b/cluster-autoscaler-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.28
   version: 1.28.0
-  epoch: 5
+  epoch: 6
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -33,7 +33,7 @@ pipeline:
       output: cluster-autoscaler
       ldflags: -s -w
       # CVE-2023-39325 and CVE-2023-3978
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0
+      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3 k8s.io/kubernetes@v1.28.1
       vendor: true
 
   - uses: strip

--- a/cluster-autoscaler-1.28.yaml
+++ b/cluster-autoscaler-1.28.yaml
@@ -33,7 +33,7 @@ pipeline:
       output: cluster-autoscaler
       ldflags: -s -w
       # CVE-2023-39325 and CVE-2023-3978
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3 k8s.io/kubernetes@v1.28.1
+      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 k8s.io/kubernetes@v1.28.1
       vendor: true
 
   - uses: strip


### PR DESCRIPTION
- Remediate CVE-2023-3955 and GHSA-m425-mq94-257g for cluster-autoscaler-1.25/1.26/1.27/1.28

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/447


