### PR TITLE
Add gcc-9.5.0 for supporting falco

### DIFF
--- a/gcc-9.yaml
+++ b/gcc-9.yaml
@@ -15,21 +15,21 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-baselayout
-      - busybox
-      - build-base
-      - ca-certificates-bundle
-      - texinfo
-      - gawk
       - bison
+      - build-base
+      - busybox
+      - ca-certificates-bundle
       - flex-dev
+      - gawk
       - gmp-dev
-      - mpfr-dev
-      - mpc-dev
       - isl-dev
-      - zlib-dev
       - make
+      - mpc-dev
+      - mpfr-dev
+      - texinfo
+      - wolfi-baselayout
       - zip
+      - zlib-dev
 
 pipeline:
   - uses: fetch
@@ -143,4 +143,3 @@ subpackages:
 update:
   # EOL upstream
   enabled: false
-  

--- a/gcc-9.yaml
+++ b/gcc-9.yaml
@@ -1,0 +1,146 @@
+package:
+  name: gcc-9
+  version: 9.5.0
+  epoch: 0
+  description: "the GNU compiler collection - version 9"
+  copyright:
+    - license: GPL-3.0-or-later
+  options:
+    no-provides: true
+  dependencies:
+    runtime:
+      - binutils
+      - libstdc++-9-dev
+
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - build-base
+      - ca-certificates-bundle
+      - texinfo
+      - gawk
+      - bison
+      - flex-dev
+      - gmp-dev
+      - mpfr-dev
+      - mpc-dev
+      - isl-dev
+      - zlib-dev
+      - make
+      - zip
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://ftp.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
+      expected-sha512: cdd144ce4f747e051480410afc8506c90a57cb45da89071ddae377b1453bca3014422455ade9fe4563ebe51f4b6348cbc0c61905a9b8801cd597d51ad0ec62b3
+
+  - working-directory: /home/build/build
+    pipeline:
+      - name: 'Configure GCC'
+        runs: |
+          CFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
+          CXXFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
+          CPPFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
+          export CFLAGS CXXFLAGS CPPFLAGS
+
+          ../configure \
+            --prefix=/usr \
+            --program-suffix="-9" \
+            --disable-nls \
+            --disable-werror \
+            --with-glibc-version=2.35 \
+            --enable-initfini-array \
+            --disable-nls \
+            --disable-multilib \
+            --disable-libatomic \
+            --disable-libsanitizer \
+            --enable-host-shared \
+            --enable-shared \
+            --enable-threads \
+            --enable-tls \
+            --enable-default-pie \
+            --enable-default-ssp \
+            --with-system-zlib \
+            --enable-languages=c,c++ \
+            --enable-bootstrap \
+            --enable-gnu-indirect-function \
+            --enable-gnu-unique-object \
+            --enable-version-specific-runtime-libs \
+            --with-linker-hash-style=gnu \
+
+          make -j$(nproc)
+          make -j$(nproc) install DESTDIR="${{targets.destdir}}"
+
+  # We don't want to keep the .la files.
+  - runs: |
+      find ${{targets.destdir}} -name '*.la' -print -exec rm \{} \;
+
+  # Remove libffi
+  - runs: |
+      rm -f "${{targets.destdir}}"/usr/lib/libffi* "${{targets.destdir}}"/usr/share/man/man3/ffi*
+      find "${{targets.destdir}}" -name 'ffi*.h' | xargs rm -f
+
+  - name: 'Clean up documentation'
+    runs: |
+      rm -rf ${{targets.destdir}}/usr/share/info
+
+  - uses: strip
+
+subpackages:
+  - name: 'gcc-9-doc'
+    pipeline:
+      - uses: split/manpages
+
+  - name: 'libstdc++-9'
+    pipeline:
+      - runs: |
+          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+
+          mkdir -p "${{targets.subpkgdir}}"/$gcclibdir
+          mv "${{targets.destdir}}"/$gcclibdir/*++.so.* "${{targets.subpkgdir}}"/$gcclibdir
+    options:
+      no-provides: true
+
+  - name: 'libstdc++-9-dev'
+    pipeline:
+      - runs: |
+          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+
+          mkdir -p "${{targets.subpkgdir}}"/$gcclibdir
+          mkdir -p "${{targets.subpkgdir}}"/$gcclibdir/include
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx
+          mv "${{targets.destdir}}"/$gcclibdir/*++.a "${{targets.subpkgdir}}"/$gcclibdir/
+          mv "${{targets.destdir}}"/$gcclibdir/libstdc++.so "${{targets.subpkgdir}}"/$gcclibdir/
+          mv "${{targets.destdir}}"/$gcclibdir/include/*++* "${{targets.subpkgdir}}"/$gcclibdir/include/
+          mv "${{targets.destdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/* \
+            "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/
+
+  - name: 'gcc-9-default'
+    description: 'Use GCC 9 as system gcc'
+    dependencies:
+      provides:
+        - gcc=9.5.0
+      runtime:
+        - gcc-9
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+
+          for i in c++ g++ gcc gcc-ar gcc-nm gcc-ranlib; do
+            ln -sf "${{host.triplet.gnu}}-"$i"-9" "${{targets.subpkgdir}}"/usr/bin/"${{host.triplet.gnu}}-"$i
+          done
+
+          for i in c++ g++ cpp gcc gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do
+            ln -sf $i"-9" "${{targets.subpkgdir}}"/usr/bin/$i
+          done
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          ln -sf libgcc_s.so.1 "${{targets.subpkgdir}}"/usr/lib/libgcc_s.so
+
+update:
+  # EOL upstream
+  enabled: false
+  


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
