### PR TITLE
thanos: fix GHSA-m425-mq94-257g

### DIFF
--- a/thanos-0.31.yaml
+++ b/thanos-0.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-0.31
   version: 0.31.0
-  epoch: 6
+  epoch: 7
   description: Highly available Prometheus setup with long term storage capabilities.
   copyright:
     - license: Apache-2.0
@@ -12,18 +12,18 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - busybox
       - bash
-      - go
+      - busybox
+      - ca-certificates-bundle
       - curl
+      - go
 
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 50c464132c265eef64254a9fd063b1e2419e09b7
       repository: https://github.com/thanos-io/thanos
       tag: v${{package.version}}
-      expected-commit: 50c464132c265eef64254a9fd063b1e2419e09b7
 
   - runs: |
       # Fails to build on go1.21 without this. Remove in next release.
@@ -32,8 +32,14 @@ pipeline:
       # Mitigate CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
 
+      # Mitigate GHSA-m425-mq94-257g
+      go mod edit -dropreplace=google.golang.org/grpc
+      go get google.golang.org/grpc@v1.58.3
+      go mod edit -replace github.com/sercand/kuberesolver=github.com/sercand/kuberesolver/v5@v5.1.1
+
       # Mitigate GHSA-rcjv-mgp8-qvmr (These are interrelated Go modules.)
       go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
+      go mod edit -droprequire=go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
       go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
       go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.19.0
 
@@ -47,6 +53,7 @@ pipeline:
 
 update:
   enabled: true
+  manual: false
   github:
     identifier: thanos-io/thanos
     strip-prefix: v

--- a/thanos-0.32.yaml
+++ b/thanos-0.32.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-0.32
   version: 0.32.5
-  epoch: 0
+  epoch: 1
   description: Highly available Prometheus setup with long term storage capabilities.
   copyright:
     - license: Apache-2.0
@@ -12,25 +12,31 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - busybox
       - bash
-      - go
+      - busybox
+      - ca-certificates-bundle
       - curl
+      - go
 
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 750e8a94eed5226cd4562117295d540a968c163c
       repository: https://github.com/thanos-io/thanos
       tag: v${{package.version}}
-      expected-commit: 750e8a94eed5226cd4562117295d540a968c163c
 
   - runs: |
       # Mitigate CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
 
+      # Mitigate GHSA-m425-mq94-257g
+      go mod edit -dropreplace=google.golang.org/grpc
+      go get google.golang.org/grpc@v1.58.3
+      go mod edit -replace github.com/sercand/kuberesolver=github.com/sercand/kuberesolver/v5@v5.1.1
+
       # Mitigate GHSA-rcjv-mgp8-qvmr (These are interrelated Go modules.)
       go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
+      go mod edit -droprequire=go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
       go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
       go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.19.0
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
