### PR TITLE
envoy-ratelimit: fix GHSA-m425-mq94-257g

### DIFF
--- a/envoy-ratelimit.yaml
+++ b/envoy-ratelimit.yaml
@@ -2,8 +2,8 @@ package:
   name: envoy-ratelimit
   # This project doesn't do releases and everything is commit based.
   # This corresponds to commit b9796237b9cb028d90424fd0859e10133c510a29
-  version: "0.0_git20231014"
-  epoch: 1
+  version: 0.0_git20231014
+  epoch: 3
   description: Go/gRPC service designed to enable generic rate limit scenarios from different types of applications.
   copyright:
     - license: Apache-2.0
@@ -14,9 +14,9 @@ vars:
 pipeline:
   - uses: fetch
     with:
-      uri: https://github.com/envoyproxy/ratelimit/archive/${{vars.commit}}.zip
       expected-sha256: eabb54820149c682351b0425d0a6ae1c62b044689de1ee0146f4230de2083c64
-      extract: false
+      extract: "false"
+      uri: https://github.com/envoyproxy/ratelimit/archive/${{vars.commit}}.zip
 
   - runs: |
       unzip -q ${{vars.commit}}.zip
@@ -25,19 +25,19 @@ pipeline:
 
   - uses: go/build
     with:
-      packages: ./src/service_cmd
+      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3
       modroot: ratelimit
-      deps: golang.org/x/net@v0.17.0
       output: ratelimit
+      packages: ./src/service_cmd
 
 subpackages:
-  - name: "envoy-ratelimit-compat"
-    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+  - name: envoy-ratelimit-compat
     pipeline:
       - runs: |
           # The helm chart expects the ratelimit binary to be in /bin instead of /usr/bin
           mkdir -p "${{targets.subpkgdir}}"/bin
           ln -sf /usr/bin/ratelimit ${{targets.subpkgdir}}/bin/ratelimit
+    description: Compatibility package to place binaries in the location expected by upstream helm charts
 
 update:
   enabled: false


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
