### PR TITLE
external-dns: fix GHSA-m425-mq94-257g

### DIFF
--- a/external-dns.yaml
+++ b/external-dns.yaml
@@ -1,31 +1,34 @@
 package:
   name: external-dns
   version: 0.13.6
-  epoch: 5
+  epoch: 6
   description: Configure external DNS servers (AWS Route53, Google CloudDNS and others) for Kubernetes Ingresses and Services.
   copyright:
-    - license: Apache-2.0
-      paths:
-        - "*"
+    - paths:
+        - '*'
+      license: Apache-2.0
 
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - go
 
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 0483ffde22e60436f16be154b9fe1a388a1400d0
       repository: https://github.com/kubernetes-sigs/external-dns
       tag: v${{package.version}}
-      expected-commit: 0483ffde22e60436f16be154b9fe1a388a1400d0
 
   - runs: |
       # Mitigate CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
+
+      # Mitigate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.56.3
       go mod tidy
 
       # Our global LDFLAGS conflict with a Makefile parameter
@@ -38,6 +41,7 @@ pipeline:
 
 update:
   enabled: true
+  manual: false
   github:
     identifier: kubernetes-sigs/external-dns
     strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
