### PR TITLE
kots: fix GHSA-m425-mq94-257g

### DIFF
--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
   version: 1.103.3
-  epoch: 0
+  epoch: 1
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0
@@ -45,6 +45,9 @@ pipeline:
 
       # Configure Yarn
       yarn install --pure-lockfile --network-concurrency 1
+
+      # Mitigate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.58.3
 
       # removing tests for now to see if this builds
       make -C web deps lint build-kotsadm


### PR DESCRIPTION
```

wolfictl scan packages/aarch64/kots-1.103.3-r1.apk
🔎 Scanning "packages/aarch64/kots-1.103.3-r1.apk"
Checking CVE GHSA-2x32-jm95-2cpx
Checking CVE GHSA-m9hp-7r99-94h5
Checking CVE GHSA-vh7g-p26c-j2cw
Checking CVE GHSA-jq35-85cj-fj4p
Checking CVE GHSA-2x32-jm95-2cpx
Checking CVE GHSA-m9hp-7r99-94h5
Checking CVE GHSA-vh7g-p26c-j2cw
Checking CVE GHSA-jq35-85cj-fj4p
├── 📄 /usr/bin/kots
│       📦 github.com/dexidp/dex v0.0.0-20230320125501-2bb4896d120e (go-module)
│       📦 github.com/docker/docker v23.0.3+incompatible (go-module)
│
└── 📄 /usr/bin/kotsadm
        📦 github.com/dexidp/dex v0.0.0-20230320125501-2bb4896d120e (go-module)
        📦 github.com/docker/docker v23.0.3+incompatible (go-module)
```