### PR TITLE
Remediate GHSA-m425-mq94-257g for coredns

### DIFF
--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: 1.11.1
-  epoch: 5
+  epoch: 6
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0
@@ -30,10 +30,6 @@ pipeline:
       expected-commit: ae2bbc29be1aaae0b3ded5d188968a6c97bb3144
 
   - runs: |
-      # Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978
-      go get golang.org/x/net@v0.17.0
-      go mod tidy
-
       # Ensures plugins get included
       make check
 
@@ -43,6 +39,8 @@ pipeline:
       packages: .
       output: coredns
       ldflags: -s -w -X github.com/coredns/coredns/coremain.GitCommit=v${{package.version}}
+      # Handle CVE-2022-41723 CVE-2023-39325 and CVE-2023-3978 / Remediate GHSA-m425-mq94-257g
+      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3
 
   - uses: strip
 


### PR DESCRIPTION
- Remediate GHSA-m425-mq94-257g for coredns

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/455



