### PR TITLE
ko: fix GHSA-m425-mq94-257g

### DIFF
--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.15.0
-  epoch: 0
+  epoch: 1
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0
@@ -9,8 +9,8 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
   environment:
     CGO_ENABLED: "0"
@@ -18,22 +18,25 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      destination: ko
+      expected-commit: 31035ad2026bfbafaa4f009baefe72463af1b3a7
       repository: https://github.com/ko-build/ko
       tag: v${{package.version}}
-      expected-commit: 31035ad2026bfbafaa4f009baefe72463af1b3a7
-      destination: ko
 
   - uses: go/build
     with:
-      packages: .
-      output: ko
-      modroot: ko
+      deps: google.golang.org/grpc@v1.58.3
       ldflags: -w -X github.com/google/ko/pkg/commands.Version=${{package.version}}
+      modroot: ko
+      output: ko
+      packages: .
+      vendor: true
 
   - uses: strip
 
 update:
   enabled: true
+  manual: false
   github:
     identifier: ko-build/ko
     strip-prefix: v


### PR DESCRIPTION

```
wolfictl scan packages/aarch64/ko-0.15.0-r1.apk --govulncheck
🔎 Scanning "packages/aarch64/ko-0.15.0-r1.apk"
Checking CVE GHSA-jq35-85cj-fj4p
└── 📄 /usr/bin/ko
        📦 github.com/docker/docker v24.0.6+incompatible
```