### PR TITLE
Remove gcloud-crc32c from gcloud.

### DIFF
--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: google-cloud-sdk
   version: 427.0.0
-  epoch: 2
+  epoch: 3
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0
@@ -53,6 +53,9 @@ pipeline:
 
       # This is a large binary with vulnerabilities in it, users can add it back later.
       google-cloud-sdk/bin/gcloud components remove anthoscli
+
+      # This is a large binary with vulnerabilities in it, users can add it back later.
+      google-cloud-sdk/bin/gcloud components remove gcloud-crc32c
 
       # Running gcloud adds a bunch of pyc files, remove those
       find google-cloud-sdk/ -name "*.pyc" -exec rm -rf '{}' +


### PR DESCRIPTION


Fixes:

Related:

### Pre-review Checklist
