### PR TITLE
openjdk 17 and 21: track GA releases and ignore pre-release builds

### DIFF
--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
-  version: 17.0.10.1
-  epoch: 0
+  version: 17.0.9 # TODO(jason): on version bump ensure to update downstream projects that are pinned to a specific prerelease version, i.e. https://github.com/chainguard-images/images/tree/main/images
+  epoch: 10 # in Wolfi we already have a previous 17.0.9-r9 release.  Note this is the wolfi epoch and NOT the upstream OpenJDK build number in their version string
   description:
   copyright:
     - license: GPL-2.0-only
@@ -38,18 +38,12 @@ environment:
       - openjdk-16-default-jvm
       - openjdk-16
 
-# transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
-var-transforms:
-  - from: ${{package.version}}
-    match: \.(\d+)$
-    replace: +$1
-    to: mangled-package-version
-
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openjdk/jdk17u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
-      expected-sha512: 914156038293f892146ec804573bea1d497f4c6e0702f99683db2f6df5a584eeec7c403eda8e0ca13171d84b75dcc024a0a020f886e26ff1399650680b914222
+      repository: https://github.com/openjdk/jdk17u.git
+      tag: jdk-${{package.version}}-ga
+      expected-commit: 9c16e89d275654cee98f5374434bea2097dda91e
 
   - working-directory: /home/build/googletest
     pipeline:
@@ -225,14 +219,18 @@ subpackages:
         - default-jdk=1.17
         - default-jdk-lts=1.17
 
+# OpenJDK versions use an interesting versioning approach.  You can read the Timeline section https://wiki.openjdk.org/display/JDKUpdates/JDK17u
+# The OpenJDK repo uses tags for prereleases and GA releases https://github.com/openjdk/jdk17u/tags
+# 1. Pre-releases are tagged with a tag like jdk-17.0.10+1
+# 2. GA releases are tagged with a tag like jdk-17.0.10-ga
+# 3. Patch releases are tagged with a tag like jdk-17.0.10+2
+# 4. The jdk-17.0.10-ga tag is updated to point to the new patch release commit
 update:
   enabled: true
   shared: true
-  version-transform:
-    - match: \+(\d+)$
-      replace: .$1
   github:
     identifier: openjdk/jdk17u
     strip-prefix: jdk-
-    tag-filter: jdk-17
+    strip-suffix: -ga
+    tag-filter: -ga
     use-tag: true

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -232,5 +232,5 @@ update:
     identifier: openjdk/jdk17u
     strip-prefix: jdk-
     strip-suffix: -ga
-    tag-filter: -ga
+    tag-filter-contains: -ga
     use-tag: true

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-21
-  version: 21.35
-  epoch: 1
+  version: 21.0.1
+  epoch: 0
   description:
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -38,18 +38,12 @@ environment:
       - openjdk-20-default-jvm
       - openjdk-20
 
-# transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
-var-transforms:
-  - from: ${{package.version}}
-    match: \.(\d+)$
-    replace: +$1
-    to: mangled-package-version
-
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
-      expected-sha512: 492a37fc73fda00c95e388e5ed894ed35f1631057401b4c5f7943a73f544fa595f1e89846b64dd7b757cea509d50d5e3a76b7e73d931a26ea9e5f20b89975572
+      repository: https://github.com/openjdk/jdk21u.git
+      tag: jdk-${{package.version}}-ga
+      expected-commit: 060c4f7589e7f13febd402f4dac3320f4c032b08
 
   - working-directory: /home/build/googletest
     pipeline:
@@ -222,14 +216,18 @@ subpackages:
         - default-jdk=1.21
         - default-jdk-lts=1.21
 
+# OpenJDK versions use an interesting versioning approach.  You can read the Timeline section https://wiki.openjdk.org/display/JDKUpdates/JDK+21u
+# The OpenJDK repo uses tags for prereleases and GA releases https://github.com/openjdk/jdk21u/tags
+# 1. Pre-releases are tagged with a tag like jdk-21.0.10+1
+# 2. GA releases are tagged with a tag like jdk-21.0.10-ga
+# 3. Patch releases are tagged with a tag like jdk-21.0.10+2
+# 4. The jdk-21.0.10-ga tag is updated to point to the new patch release commit
 update:
   enabled: true
   shared: true
-  version-transform:
-    - match: \+(\d+)$
-      replace: .$1
   github:
     identifier: openjdk/jdk21u
     strip-prefix: jdk-
-    tag-filter: jdk-21
+    strip-suffix: -ga
+    tag-filter: -ga
     use-tag: true

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -229,5 +229,5 @@ update:
     identifier: openjdk/jdk21u
     strip-prefix: jdk-
     strip-suffix: -ga
-    tag-filter: -ga
+    tag-filter-contains: -ga
     use-tag: true


### PR DESCRIPTION
This PR also updates the OpenJDK 21 version as the old config was tracking an old version tag.

We recently discovered the OpenJDK tag versioning includes pre-release builds. There's more details in the Timeline section of the [17 docs](https://wiki.openjdk.org/display/JDKUpdates/JDK11u) and [21](https://wiki.openjdk.org/display/JDKUpdates/JDK+21u).

This PR changes the OpenJDK 17 and 21 version to be the GA release and switched the update: config to track only GA releases.

After reviewing the upstream tags, when a new patch release is created AFTER a GA release, the git commit sha is updated on the GA tag. Meaning we will still receive automated updates when security patches are created for GA releases, the bot will update the expected-commit sha and bump the epoch.

Note: We are not withdrawing the 17.0.10.1 version as users will have likely already been using it.