### PR TITLE
kubeflow-katib: fix GHSA-m425-mq94-257g

### DIFF
--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -1,6 +1,6 @@
 package:
   name: kubeflow-katib
-  epoch: 8
+  epoch: 9
   version: 0.15.0
   description: Kubeflow Katib services
   copyright:
@@ -9,14 +9,14 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - go
-      - build-base
-      - python-3.10-dev
-      - py3.10-pip
       - gfortran
+      - go
       - pcre-dev
+      - py3.10-pip
+      - python-3.10-dev
 
 data:
   - name: go-builds
@@ -49,7 +49,7 @@ subpackages:
           output: katib-${{range.key}}
           ldflags: -w -X main.version=${{package.version}}
           subpackage: true
-          deps: golang.org/x/net@v0.17.0 github.com/docker/distribution@v2.8.2 github.com/docker/docker@v20.10.24
+          deps: golang.org/x/net@v0.17.0 github.com/docker/distribution@v2.8.2 github.com/docker/docker@v20.10.24 google.golang.org/grpc@v1.58.3
       - uses: strip
 
   - range: go-builds


### PR DESCRIPTION
fix GHSA-m425-mq94-257g

```
wolfictl scan packages/aarch64/katib-file-metricscollector-0.15.0-r9.apk --govulncheck
🔎 Scanning "packages/aarch64/katib-file-metricscollector-0.15.0-r9.apk"
✅ No vulnerabilities found
```