### PR TITLE
kubernetes-csi-node-driver-registrar: fix GHSA-m425-mq94-257g

### DIFF
--- a/kubernetes-csi-node-driver-registrar-2.9.yaml
+++ b/kubernetes-csi-node-driver-registrar-2.9.yaml
@@ -1,8 +1,7 @@
 package:
-  # Supported versions policy: https://kubernetes-csi.github.io/docs/node-driver-registrar.html
   name: kubernetes-csi-node-driver-registrar-2.9
   version: 2.9.0
-  epoch: 5
+  epoch: 6
   description: Sidecar container that registers a CSI driver with the kubelet using the kubelet plugin registration mechanism.
   copyright:
     - license: Apache-2.0
@@ -13,31 +12,29 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
 
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: deed783528cd828baedc5493a866a0217f7b08fe
       repository: https://github.com/kubernetes-csi/node-driver-registrar
       tag: v${{package.version}}
-      expected-commit: deed783528cd828baedc5493a866a0217f7b08fe
 
   - uses: go/build
     with:
-      packages: ./cmd/csi-node-driver-registrar
-      ldflags: "-s -w -X main.version=v${{package.version}} -extldflags '-static'"
-      vendor: "true"
+      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3
+      ldflags: -s -w -X main.version=v${{package.version}} -extldflags '-static'
       output: csi-node-driver-registrar
-      # CVE-2023-39325 and CVE-2023-3978
-      deps: golang.org/x/net@v0.17.0
+      packages: ./cmd/csi-node-driver-registrar
+      vendor: "true"
 
   - uses: strip
 
 subpackages:
   - name: ${{package.name}}-compat
-    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
     pipeline:
       - runs: |
           # The helm chart expects the binaries to be in / instead of /usr/bin
@@ -46,9 +43,11 @@ subpackages:
     dependencies:
       provides:
         - kubernetes-csi-node-driver-registrar-compat=${{package.full-version}}
+    description: Compatibility package to place binaries in the location expected by upstream helm charts
 
 update:
   enabled: true
+  manual: false
   github:
     identifier: kubernetes-csi/node-driver-registrar
     strip-prefix: v


### PR DESCRIPTION
```
➜  os git:(main) ✗ ../wolfictl/wolfictl scan packages/aarch64/kubernetes-csi-node-driver-registrar-2.9-2.9.0-r6.apk
🔎 Scanning "packages/aarch64/kubernetes-csi-node-driver-registrar-2.9-2.9.0-r6.apk"
✅ No vulnerabilities found
➜  os git:(main) ✗ ../wolfictl/wolfictl scan packages/aarch64/kubernetes-csi-node-driver-registrar-2.9-2.9.0-r5.apk
🔎 Scanning "packages/aarch64/kubernetes-csi-node-driver-registrar-2.9-2.9.0-r5.apk"
Checking CVE GHSA-m425-mq94-257g
Checking CVE GHSA-qppj-fm5r-hxr3
└── 📄 /usr/bin/csi-node-driver-registrar
        📦 google.golang.org/grpc v1.58.0
```