### PR TITLE
kyverno: fix GHSA-m425-mq94-257g

### DIFF
--- a/kyverno.yaml
+++ b/kyverno.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno
-  version: 1.10.3
-  epoch: 7
+  version: 1.10.5
+  epoch: 0
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0
@@ -22,7 +22,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 8137b4b8afd7ab1464a42e717dc83f1cc471a4a1
+      expected-commit: 1144e2454b17415321ea4f8e3e1f23ee3059a65d
       repository: https://github.com/kyverno/kyverno
       tag: v${{package.version}}
 
@@ -31,7 +31,11 @@ pipeline:
       go get golang.org/x/net@v0.17.0
 
       # Mitigate GHSA-m425-mq94-257g
-      go get google.golang.org/grpc@v1.56.3
+      go get google.golang.org/grpc@v1.58.3
+
+      # Mitigate CVE-2023-33959 and CVE-2023-25656
+      go get github.com/notaryproject/notation-go@v1.0.0-rc.6
+
       go mod tidy
       make build-all
       mkdir -p ${{targets.destdir}}/usr/bin
@@ -72,7 +76,6 @@ subpackages:
 
 update:
   enabled: true
-  manual: false
   github:
     identifier: kyverno/kyverno
     strip-prefix: v

--- a/kyverno.yaml
+++ b/kyverno.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno
   version: 1.10.3
-  epoch: 6
+  epoch: 7
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0
@@ -12,23 +12,26 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-baselayout
       - build-base
-      - ca-certificates-bundle
       - busybox
-      - go
+      - ca-certificates-bundle
       - git
+      - go
+      - wolfi-baselayout
 
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 8137b4b8afd7ab1464a42e717dc83f1cc471a4a1
       repository: https://github.com/kyverno/kyverno
       tag: v${{package.version}}
-      expected-commit: 8137b4b8afd7ab1464a42e717dc83f1cc471a4a1
 
   - runs: |
       # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
       go get golang.org/x/net@v0.17.0
+
+      # Mitigate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.56.3
       go mod tidy
       make build-all
       mkdir -p ${{targets.destdir}}/usr/bin
@@ -69,6 +72,7 @@ subpackages:
 
 update:
   enabled: true
+  manual: false
   github:
     identifier: kyverno/kyverno
     strip-prefix: v


### PR DESCRIPTION
```
wolfictl scan packages/aarch64/kyverno-init-container-1.10.3-r7.apk --govulncheck
🔎 Scanning "packages/aarch64/kyverno-init-container-1.10.3-r7.apk"
Checking CVE GHSA-jq35-85cj-fj4p
Checking CVE GHSA-2h5h-59f5-c5x9
Checking CVE GHSA-frqx-jfcm-6jjr
Checking CVE GHSA-rcjv-mgp8-qvmr
└── 📄 /usr/bin/kyvernopre
        📦 github.com/docker/docker v23.0.3+incompatible (go-module)
        📦 github.com/sigstore/rekor v1.0.1 (go-module)
        📦 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0 (go-module)
```