### PR TITLE
java-cacerts: fix content to remove targets.destdir

### DIFF
--- a/java-cacerts.yaml
+++ b/java-cacerts.yaml
@@ -2,7 +2,7 @@ package:
   name: java-cacerts
   # Update this when ca-certificates is updated.
   version: 20230106
-  epoch: 1
+  epoch: 2
   description: "default certificate authorities for Java"
   copyright:
     - license: MIT
@@ -27,7 +27,7 @@ pipeline:
       mkdir -p "${{targets.destdir}}"/etc/ca-certificates/update.d
       cat > "${{targets.destdir}}"/etc/ca-certificates/update.d/java-cacerts <<EOF
       exec trust extract --overwrite --format=java-cacerts --filter=ca-anchors \
-        --purpose server-auth "${{targets.destdir}}"/etc/ssl/certs/java/cacerts
+        --purpose server-auth /etc/ssl/certs/java/cacerts
       EOF
       chmod +x "${{targets.destdir}}"/etc/ca-certificates/update.d/java-cacerts
 

--- a/java-cacerts.yaml
+++ b/java-cacerts.yaml
@@ -6,6 +6,10 @@ package:
   description: "default certificate authorities for Java"
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      - ca-certificates
+      - p11-kit-trust
 
 environment:
   contents:


### PR DESCRIPTION
Before:

```
$ curl -L https://packages.wolfi.dev/os/x86_64/java-cacerts-20230106-r1.apk | tar -Oxz etc/ca-certificates/update.d/java-cacerts

exec trust extract --overwrite --format=java-cacerts --filter=ca-anchors   --purpose server-auth "/home/build/melange-out/java-cacerts"/etc/ssl/certs/java/cacerts
```

After:

```
$ tar -Oxf packages/aarch64/java-cacerts-20230106-r2.apk etc/ca-certificates/update.d/java-cacerts

exec trust extract --overwrite --format=java-cacerts --filter=ca-anchors   --purpose server-auth /etc/ssl/certs/java/cacerts
```

cc @johnfosborneiii 