### PR TITLE
nvidia: fix GHSA-m425-mq94-257g

### DIFF
--- a/nvidia-device-plugin.yaml
+++ b/nvidia-device-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: nvidia-device-plugin
   version: 0.14.2
-  epoch: 1
+  epoch: 2
   description: NVIDIA device plugin for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -9,17 +9,17 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
       - go
 
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 310542179780f3fccc7a87ae7609dc03936b0ab8
       repository: https://github.com/NVIDIA/k8s-device-plugin
       tag: v${{package.version}}
-      expected-commit: 310542179780f3fccc7a87ae7609dc03936b0ab8
 
   - runs: |
       # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
@@ -28,6 +28,9 @@ pipeline:
       # Fetch unreleased go-nvml which contains fix for working with go-1.21 https://github.com/NVIDIA/go-nvml/pull/79
       go get github.com/NVIDIA/go-nvml@e06766c5e74f5c0bed40007842bac458588a36b2
 
+
+      # Mitigate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.56.3
       go mod tidy
       go mod vendor
 
@@ -38,6 +41,7 @@ pipeline:
 
 update:
   enabled: true
+  manual: false
   github:
     identifier: NVIDIA/k8s-device-plugin
     strip-prefix: v


### PR DESCRIPTION
```
wolfictl scan packages/aarch64/nvidia-device-plugin-0.14.2-r2.apk
🔎 Scanning "packages/aarch64/nvidia-device-plugin-0.14.2-r2.apk"
✅ No vulnerabilities found
```