### PR TITLE
kubernetes-dns-node-cache: fix GHSA-m425-mq94-257g

### DIFF
--- a/kubernetes-dns-node-cache.yaml
+++ b/kubernetes-dns-node-cache.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dns-node-cache
   version: 1.22.20
-  epoch: 5
+  epoch: 6
   description: NodeLocal DNSCache improves Cluster DNS performance by running a DNS caching agent on cluster nodes as a DaemonSet.
   copyright:
     - license: Apache-2.0
@@ -9,18 +9,18 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-baselayout
       - build-base
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
+      - wolfi-baselayout
 
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 7bcdf8411514fd4e22de11e93f33559c7304ed21
       repository: https://github.com/kubernetes/dns
       tag: ${{package.version}}
-      expected-commit: 7bcdf8411514fd4e22de11e93f33559c7304ed21
 
   - runs: |
       # Mitigate GHSA-xc8m-28vv-4pjc, GHSA-cgcv-5272-97pr, GHSA-qc2g-gmh6-95p4
@@ -28,21 +28,25 @@ pipeline:
       # CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
 
+
+      # Mitigate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.56.3
       go mod tidy
       go mod vendor
 
   - uses: go/build
     with:
-      packages: ./cmd/node-cache
-      output: node-cache
       ldflags: -s -w -X github.com/kubernetes/dns/pkg/version.Version=v${{package.version}}
+      output: node-cache
+      packages: ./cmd/node-cache
 
   - uses: strip
 
 update:
   enabled: true
+  manual: false
   github:
-    strip-prefix: v
     identifier: kubernetes/dns
+    strip-prefix: v
     tag-filter: v
     use-tag: true

--- a/kubernetes-dns-node-cache.yaml
+++ b/kubernetes-dns-node-cache.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dns-node-cache
-  version: 1.22.20
-  epoch: 6
+  version: 1.22.27
+  epoch: 0
   description: NodeLocal DNSCache improves Cluster DNS performance by running a DNS caching agent on cluster nodes as a DaemonSet.
   copyright:
     - license: Apache-2.0
@@ -18,9 +18,9 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 7bcdf8411514fd4e22de11e93f33559c7304ed21
       repository: https://github.com/kubernetes/dns
       tag: ${{package.version}}
+      expected-commit: 8f97b00511619ccfc5c6e5ad15993a55de40d83b
 
   - runs: |
       # Mitigate GHSA-xc8m-28vv-4pjc, GHSA-cgcv-5272-97pr, GHSA-qc2g-gmh6-95p4


### PR DESCRIPTION
```
wolfictl scan packages/aarch64/kubernetes-dns-node-cache-1.22.20-r6.apk --govulncheck
🔎 Scanning "packages/aarch64/kubernetes-dns-node-cache-1.22.20-r6.apk"
Checking CVE GHSA-f9jg-8p32-2f55
Checking CVE GHSA-q78c-gwqw-jcmc
└── 📄 /usr/bin/node-cache
        📦 k8s.io/kubernetes v1.24.15 (go-module)
```