### PR TITLE
bump git checkout to v4 as it uses latest node LTS  version ,v3 uses …

### DIFF
--- a/.github/workflows/build-world.yaml
+++ b/.github/workflows/build-world.yaml
@@ -30,7 +30,7 @@ jobs:
         --cap-add NET_ADMIN --cap-add SYS_ADMIN --device /dev/fuse --security-opt seccomp=unconfined --security-opt apparmor:unconfined
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Trust the github workspace'
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
         --cap-add NET_ADMIN --cap-add SYS_ADMIN --device /dev/fuse --security-opt seccomp=unconfined --security-opt apparmor:unconfined
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Trust the github workspace'
         run: |
@@ -105,7 +105,7 @@ jobs:
       image: ghcr.io/wolfi-dev/sdk:latest@sha256:d7b6705864edf4873513e6bcacc0937f2f61385f4dacc9c9f07c3d4be8c6c9b1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Trust the github workspace'
         run: |

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -15,7 +15,7 @@ jobs:
       packages: ${{steps.package-list.outputs.packages}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Look for changed files
         id: changes
@@ -70,7 +70,7 @@ jobs:
       pull-requests: write # so we have permission to comment on pull requests
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Trust the github workspace'
         run: |

--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -19,7 +19,7 @@ jobs:
       actions: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: chainguard-dev/actions/digesta-bot@main
       with:
         token: ${{ secrets.DIGEST_BOT_WOLFI_PAT }}

--- a/.github/workflows/janitor-clusters.yaml
+++ b/.github/workflows/janitor-clusters.yaml
@@ -26,7 +26,7 @@ jobs:
             workload_identity_provider: "projects/567187841907/locations/global/workloadIdentityPools/staging-shared-9bd2/providers/staging-shared-gha"
 
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # ratchet:actions/checkout@v3.5.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # ratchet:actions/checkout@v4.1.1
       - uses: google-github-actions/auth@v0
         with:
           workload_identity_provider: ${{ matrix.workload_identity_provider }}

--- a/.github/workflows/lint-world.yaml
+++ b/.github/workflows/lint-world.yaml
@@ -32,7 +32,7 @@ jobs:
       image: ghcr.io/wolfi-dev/sdk:latest@sha256:d7b6705864edf4873513e6bcacc0937f2f61385f4dacc9c9f07c3d4be8c6c9b1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Trust the github workspace'
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,5 +16,5 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # ratchet:actions/checkout@v3.5.0
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # ratchet:actions/checkout@v4.1.1
     - run: ./lint.sh

--- a/.github/workflows/reconcile-wolfi-index.yaml
+++ b/.github/workflows/reconcile-wolfi-index.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: chainguard-dev/actions/setup-melange@main
 

--- a/.github/workflows/update-cache.yaml
+++ b/.github/workflows/update-cache.yaml
@@ -19,7 +19,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: chainguard-dev/actions/setup-melange@main
 

--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: chainguard-dev/actions/setup-melange@main
 

--- a/.github/workflows/wolfictl-check-update.yaml
+++ b/.github/workflows/wolfictl-check-update.yaml
@@ -16,7 +16,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Get changed files
       id: files

--- a/.github/workflows/wolfictl-lint.yaml
+++ b/.github/workflows/wolfictl-lint.yaml
@@ -16,7 +16,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Lint
       id: lint
       uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:f3ef674e9283cdf896875fbe150ab0f4fe5c1d41ce98842addc6dcf10e67e869

--- a/.github/workflows/wolfictl-update-gh.yaml
+++ b/.github/workflows/wolfictl-update-gh.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:f3ef674e9283cdf896875fbe150ab0f4fe5c1d41ce98842addc6dcf10e67e869
       with:

--- a/.github/workflows/wolfictl-update-rm.yaml
+++ b/.github/workflows/wolfictl-update-rm.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:f3ef674e9283cdf896875fbe150ab0f4fe5c1d41ce98842addc6dcf10e67e869
       with:


### PR DESCRIPTION
bump git checkout to v4 as it uses latest node LTS  version ,v3 uses …

