### PR TITLE
upgrade the jetty version for zookeeper 3.8 to fix the CVE-2023-36478

### DIFF
--- a/zookeeper-3.8.yaml
+++ b/zookeeper-3.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.8
   version: 3.8.3.0
-  epoch: 5
+  epoch: 6
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0
@@ -39,6 +39,10 @@ pipeline:
       repository: https://github.com/apache/zookeeper
       tag: release-${{vars.mangled-package-version}}
       expected-commit: 6ad6d364c7c0bcf0de452d54ebefa3058098ab56
+
+  - uses: patch
+    with:
+      patches: upgrade-the-jetty-version.patch
 
   - runs: |
       export LANG=en_US.UTF-8

--- a/zookeeper-3.8/upgrade-the-jetty-version.patch
+++ b/zookeeper-3.8/upgrade-the-jetty-version.patch
@@ -1,0 +1,26 @@
+From 28fd3caaac712914004c18eb27c8deb4000e4b28 Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Sat, 4 Nov 2023 23:52:54 +0300
+Subject: [PATCH] upgrade the jetty version
+
+Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+---
+ pom.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pom.xml b/pom.xml
+index 6158b7f4e..d8444cdea 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -560,7 +560,7 @@
+     <hamcrest.version>2.2</hamcrest.version>
+     <commons-cli.version>1.5.0</commons-cli.version>
+     <netty.version>4.1.94.Final</netty.version>
+-    <jetty.version>9.4.52.v20230823</jetty.version>
++    <jetty.version>9.4.53.v20231009</jetty.version>
+     <jackson.version>2.15.2</jackson.version>
+     <jline.version>2.14.6</jline.version>
+     <snappy.version>1.1.10.5</snappy.version>
+-- 
+2.39.3 (Apple Git-145)
+

--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.9
   version: 3.9.1.0
-  epoch: 5
+  epoch: 6
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0
@@ -39,6 +39,10 @@ pipeline:
       repository: https://github.com/apache/zookeeper
       tag: release-${{vars.mangled-package-version}}
       expected-commit: 1398af177833412e9ead6b9bb737dc9fd7418a45
+
+  - uses: patch
+    with:
+      patches: upgrade-the-jetty-version.patch
 
   - runs: |
       export LANG=en_US.UTF-8

--- a/zookeeper-3.9/upgrade-the-jetty-version.patch
+++ b/zookeeper-3.9/upgrade-the-jetty-version.patch
@@ -1,0 +1,26 @@
+From 28fd3caaac712914004c18eb27c8deb4000e4b28 Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Sat, 4 Nov 2023 23:52:54 +0300
+Subject: [PATCH] upgrade the jetty version
+
+Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+---
+ pom.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pom.xml b/pom.xml
+index 6158b7f4e..d8444cdea 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -560,7 +560,7 @@
+     <hamcrest.version>2.2</hamcrest.version>
+     <commons-cli.version>1.5.0</commons-cli.version>
+     <netty.version>4.1.94.Final</netty.version>
+-    <jetty.version>9.4.52.v20230823</jetty.version>
++    <jetty.version>9.4.53.v20231009</jetty.version>
+     <jackson.version>2.15.2</jackson.version>
+     <jline.version>2.14.6</jline.version>
+     <snappy.version>1.1.10.5</snappy.version>
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

I'm going to open it up as `Draft` because we are not sure about the CVE is a real one or a false positive (_yet_) since both scanners included grype, wolfictl and trivy didn't notice this CVE. 

cc @mamccorm 

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
