### PR TITLE
telegraf: fix GHSA-m425-mq94-257g

### DIFF
--- a/telegraf-1.26.yaml
+++ b/telegraf-1.26.yaml
@@ -1,8 +1,7 @@
 package:
   name: telegraf-1.26
   version: 1.26.3
-  epoch: 5
-  description:
+  epoch: 6
   copyright:
     - license: MIT
   dependencies:
@@ -12,22 +11,28 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - go
       - gnutar
+      - go
 
 pipeline:
   - uses: git-checkout
     with:
-      tag: v${{package.version}}
       expected-commit: 90f4eb296bf44b26959b136ef050445da64e85fa
       repository: https://github.com/influxdata/telegraf
+      tag: v${{package.version}}
 
   - runs: |
       go get golang.org/x/net@v0.17.0
       go get github.com/nats-io/nats-server/v2@v2.9.23
+
+      # Mitigate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.56.3
+
+      # Mitigate CVE-2023-46129
+      go get github.com/nats-io/nkeys@v0.4.6
       go mod tidy
 
   - if: ${{build.arch}} == 'x86_64'


### PR DESCRIPTION
```
wolfictl scan  packages/aarch64/telegraf-1.26-1.26.3-r7.apk --govulncheck
🔎 Scanning "packages/aarch64/telegraf-1.26-1.26.3-r7.apk"
Checking CVE GHSA-jq35-85cj-fj4p
Checking CVE GHSA-2w8w-qhg4-f78j
Checking CVE GHSA-fwv2-65wh-2w8c
└── 📄 /usr/bin/telegraf
        📦 github.com/docker/docker v23.0.4+incompatible (go-module)
        📦 github.com/jaegertracing/jaeger v1.38.0 (go-module)
        📦 github.com/snowflakedb/gosnowflake v1.6.13 (go-module)
```