### PR TITLE
kyverno: ignore rc and beta versions

### DIFF
--- a/kyverno.yaml
+++ b/kyverno.yaml
@@ -70,8 +70,8 @@ subpackages:
 update:
   enabled: true
   ignore-regex-patterns:
-    - '*-beta*'
-    - '*-rc*'
+    - '-beta'
+    - '-rc'
   github:
     identifier: kyverno/kyverno
     strip-prefix: v

--- a/kyverno.yaml
+++ b/kyverno.yaml
@@ -1,6 +1,6 @@
 package:
   name: kyverno
-  version: 1.10.5
+  version: 1.10.4
   epoch: 0
   description: Kubernetes Native Policy Management
   copyright:
@@ -22,20 +22,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 1144e2454b17415321ea4f8e3e1f23ee3059a65d
+      expected-commit: 2da9474b402802aa3ac330f9d8a555d33b93b903
       repository: https://github.com/kyverno/kyverno
       tag: v${{package.version}}
 
   - runs: |
-      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
-      go get golang.org/x/net@v0.17.0
-
       # Mitigate GHSA-m425-mq94-257g
       go get google.golang.org/grpc@v1.58.3
-
-      # Mitigate CVE-2023-33959 and CVE-2023-25656
-      go get github.com/notaryproject/notation-go@v1.0.0-rc.6
-
       go mod tidy
       make build-all
       mkdir -p ${{targets.destdir}}/usr/bin
@@ -76,6 +69,9 @@ subpackages:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - '*-beta*'
+    - '*-rc*'
   github:
     identifier: kyverno/kyverno
     strip-prefix: v


### PR DESCRIPTION
kyverno: ignore rc and beta version and build for 1.10.4 release

This needs to be merge https://github.com/wolfi-dev/os/pull/8027 and packages needs to be withdrawn before this PR is merged 