### PR TITLE
py3-cffi : move uri from heptapod to pyhosted

### DIFF
--- a/py3-cffi.yaml
+++ b/py3-cffi.yaml
@@ -26,8 +26,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 15ed1fbb59f1d13aa14008ee67554750523b8a6ddf3f9e4089328afa6bb14b3d
-      uri: https://foss.heptapod.net/pypy/cffi/-/archive/v${{package.version}}/cffi-v${{package.version}}.tar.gz
+      expected-sha256: d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9
+      uri: https://files.pythonhosted.org/packages/source/c/cffi/cffi-${{package.version}}.tar.gz
 
   - name: Python Build
     runs: python setup.py build


### PR DESCRIPTION
https://foss.heptapod.net/pypy/cffi is archived and is moved to GitHub 