### PR TITLE
actions-runner-controller/0.6.1 package update (Fix #7990)

### DIFF
--- a/actions-runner-controller.yaml
+++ b/actions-runner-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: actions-runner-controller
   version: 0.6.1
-  epoch: 3
+  epoch: 0
   description: Kubernetes controller for GitHub Actions self-hosted runners
   copyright:
     - license: Apache-2.0

--- a/actions-runner-controller.yaml
+++ b/actions-runner-controller.yaml
@@ -1,6 +1,6 @@
 package:
   name: actions-runner-controller
-  version: 0.5.0
+  version: 0.6.1
   epoch: 3
   description: Kubernetes controller for GitHub Actions self-hosted runners
   copyright:
@@ -18,11 +18,7 @@ pipeline:
     with:
       repository: https://github.com/actions/actions-runner-controller
       tag: gha-runner-scale-set-${{package.version}}
-      expected-commit: abc0b678d323b9016af467bdedd2c4fea85a7769
-
-  # This technically builds twice, but this ensures we perform all prereq stpes (like codegen)
-  - runs: |
-      make manager
+      expected-commit: 1a8abb6d3950d3a78715505312d88b201e6d8a49
 
   # Ref: https://github.com/actions/actions-runner-controller/blob/gha-runner-scale-set-0.5.0/Dockerfile#L35
   - uses: go/build


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #7990

Related:

Removed the `make manager` command as it is unnecessary to build the same thing twice. and the codegen that was mentioned is just adding [hedders](https://github.com/actions/actions-runner-controller/blob/master/hack/boilerplate.go.txt) to the go files.
Without it, everything works fine.
I am not sure why I am getting the error using melange but not when I interactively do it inside a wolfi-base container.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
