### PR TITLE
fix: GHSA-m425-mq94-257g and GHSA-rcjv-mgp8-qvmr

### DIFF
--- a/prometheus-adapter.yaml
+++ b/prometheus-adapter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-adapter
   version: 0.11.1
-  epoch: 3
+  epoch: 4
   description: Prometheus Adapter for Kubernetes Metrics APIs
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,14 @@ pipeline:
   - runs: |
       # Handle CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
+
+      # Remediate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.58.3
+
+      # Mitigate GHSA-rcjv-mgp8-qvmr (These are interrelated Go modules.)
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.19.0
       go mod tidy
 
       make prometheus-adapter


### PR DESCRIPTION
```
wolfictl scan  packages/aarch64/prometheus-adapter-0.11.1-r5.apk --govulncheck
drop 86da9f7c fix: GHSA-m425-mq94-257g and CVE-2023-4612
🔎 Scanning "packages/aarch64/prometheus-adapter-0.11.1-r5.apk"
✅ No vulnerabilities found
```