### PR TITLE
gitlab-pages: fix GHSA-m425-mq94-257g

### DIFF
--- a/gitlab-pages.yaml
+++ b/gitlab-pages.yaml
@@ -5,7 +5,7 @@ package:
   # The release-monitor identified is for the gitlab-runner,
   # but these seem to be co-versioned.
   version: 16.5.0
-  epoch: 0
+  epoch: 1
   description: GitLab Pages daemon used to serve static websites for GitLab users.
   copyright:
     - license: MIT
@@ -29,6 +29,8 @@ pipeline:
 
   - runs: |
       go get golang.org/x/net@v0.17.0
+      # Mitigate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.57.1
       go mod tidy
       make gitlab-pages "LAST_TAG=v${{package.version}}" "VERSION=v${{package.version}}"
 


### PR DESCRIPTION
```
wolfictl scan packages/aarch64/gitlab-pages-16.5.0-r41.apk --govulncheck
🔎 Scanning "packages/aarch64/gitlab-pages-16.5.0-r41.apk"
✅ No vulnerabilities found

wolfictl scan packages/aarch64/gitlab-pages-16.5.0-r0.apk --govulncheck
🔎 Scanning "packages/aarch64/gitlab-pages-16.5.0-r0.apk"
Checking CVE GHSA-m425-mq94-257g
Checking CVE GHSA-qppj-fm5r-hxr3
└── 📄 /bin/gitlab-pages
        📦 google.golang.org/grpc v1.40.0 (
```