### PR TITLE
gomplate: fix GHSA-m425-mq94-257g

### DIFF
--- a/gomplate.yaml
+++ b/gomplate.yaml
@@ -1,7 +1,7 @@
 package:
   name: gomplate
   version: 3.11.5
-  epoch: 6
+  epoch: 7
   description: A go templating utility.
   copyright:
     - license: MIT
@@ -29,6 +29,8 @@ pipeline:
 
       # Mitigate CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
+      # Mitigate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.57.1
       go mod tidy
 
       go build -o ${{targets.destdir}}/usr/bin \


### PR DESCRIPTION
```
wolfictl scan  packages/aarch64/gomplate-3.11.5-r7.apk --govulncheck
🔎 Scanning "packages/aarch64/gomplate-3.11.5-r7.apk"
✅ No vulnerabilities found

wolfictl scan  packages/aarch64/gomplate-3.11.5-r6.apk --govulncheck
🔎 Scanning "packages/aarch64/gomplate-3.11.5-r6.apk"
Checking CVE GHSA-m425-mq94-257g
Checking CVE GHSA-qppj-fm5r-hxr3
└── 📄 /usr/bin/gomplate
        📦 google.golang.org/grpc v1.46.2
```