### PR TITLE
tini: don't use 'runs' with 'with'

### DIFF
--- a/tini.yaml
+++ b/tini.yaml
@@ -1,7 +1,7 @@
 package:
   name: tini
   version: 0.19.0
-  epoch: 1
+  epoch: 2
   description: A tiny but valid init for containers
   copyright:
     - license: MIT
@@ -21,13 +21,10 @@ pipeline:
       expected-sha256: 0fd35a7030052acd9f58948d1d900fe1e432ee37103c5561554408bdac6bbf0d
       uri: https://github.com/krallin/tini/archive/v${{package.version}}.tar.gz
 
-  - runs: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=None
-    with:
-      opts: CFLAGS="$CFLAGS -DPR_SET_CHILD_SUBREAPER=36 -DPR_GET_CHILD_SUBREAPER=37"
-
-  - runs: cmake --build build --target all tini-static
-    with:
-      opts: CFLAGS="$CFLAGS -DPR_SET_CHILD_SUBREAPER=36 -DPR_GET_CHILD_SUBREAPER=37"
+  - runs: |
+      export CFLAGS="$CFLAGS -DPR_SET_CHILD_SUBREAPER=36 -DPR_GET_CHILD_SUBREAPER=37"
+      cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=None
+      cmake --build build --target all tini-static
 
   - runs: |
       install -Dm755 build/tini ${{targets.destdir}}/sbin/tini


### PR DESCRIPTION
`with` has no effect when used with `run` (only `uses`), so this was not being built with the specified CFLAGS.