### PR TITLE
grype: fix GHSA-m425-mq94-257g

### DIFF
--- a/grype.yaml
+++ b/grype.yaml
@@ -1,7 +1,7 @@
 package:
   name: grype
   version: 0.72.0
-  epoch: 0
+  epoch: 1
   description: Vulnerability scanner for container images, filesystems, and SBOMs
   copyright:
     - license: Apache-2.0
@@ -9,8 +9,8 @@ package:
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
 
 pipeline:
@@ -21,6 +21,8 @@ pipeline:
 
   # Update go.mod files, which are apparently stale in the 0.66.0 release
   - runs: |
+      # Mitigate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.56.3
       go mod tidy
 
   - runs: |


### PR DESCRIPTION
```
wolfictl scan  packages/aarch64/grype-0.72.0-r1.apk --govulncheck
🔎 Scanning "packages/aarch64/grype-0.72.0-r1.apk"
Checking CVE GHSA-jq35-85cj-fj4p
└── 📄 /usr/bin/grype
        📦 github.com/docker/docker v24.0.6+incompatible (go-module)
```