### PR TITLE
minio: update to latest and remove cve fixes

### DIFF
--- a/minio.yaml
+++ b/minio.yaml
@@ -2,7 +2,7 @@ package:
   name: minio
   # minio uses strange versioning, the upstream version is RELEASE.2023-10-25T06-33-25Z
   # when bumping this, also bump the tag in git-checkout below
-  version: 0.20231025.063325
+  version: 0.20231101.183725
   epoch: 0
   description: Multi-Cloud Object Storage
   copyright:
@@ -11,24 +11,20 @@ package:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
       - ca-certificates-bundle
       - go
-      - build-base
       - perl
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/minio/minio
-      tag: RELEASE.2023-10-25T06-33-25Z
-      expected-commit: c60f54e5be7302d82d0d8fc404c056fea4e2bf4e
+      tag: RELEASE.2023-11-01T18-37-25Z
+      expected-commit: 4b4a98d5e59354870325ad19703fba03d1b104c2
 
   - runs: |
-      # Mitigate GHSA-m425-mq94-257g
-      go get google.golang.org/grpc@v1.58.3
-      go mod tidy
-
       make build
       mkdir -p ${{targets.destdir}}/usr/bin
       mv minio ${{targets.destdir}}/usr/bin


### PR DESCRIPTION

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

