### PR TITLE
use gcsfuse when withdrawing packages

### DIFF
--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -11,9 +11,14 @@ jobs:
     name: Withdraw packages
     runs-on: ubuntu-16-core
 
+    container:
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:148f4be783abe7d35df1e83f9c55d08cc7d7f3ca8b180b24923fb421bc96f97f
+      # TODO: Deprivilege
+      options: |
+        --cap-add NET_ADMIN --cap-add SYS_ADMIN --device /dev/fuse --security-opt seccomp=unconfined --security-opt apparmor:unconfined
+
     permissions:
       id-token: write
-      packages: write
       contents: read
 
     steps:
@@ -46,16 +51,22 @@ jobs:
             done
           done
 
-      - name: 'Sync public package repository'
+      - name: 'Prepare package repository'
         run: |
-          mkdir "${{ github.workspace }}/packages"
-          gsutil -m rsync -r gs://wolfi-production-registry-destination/os/ "${{ github.workspace }}/packages/"
-          find "${{ github.workspace }}/packages" -print -exec touch \{} \;
+          # yay wolfi!
+          apk add gcsfuse
+
+          # Set up a gcsfuse RO mount to the public bucket. This is a cheap and
+          # cheerful way to recreate the make targets (class A HEADs) locally
+          # without syncing the whole bucket (class A+B).
+          mkdir -p /gcsfuse/wolfi-registry
+          gcsfuse -o ro --implicit-dirs --only-dir os wolfi-production-registry-destination /gcsfuse/wolfi-registry
 
       - name: 'Reconcile Wolfi index'
+        working-directory: /gcsfuse/wolfi-registry
         run: |
           for arch in x86_64 aarch64; do
-            pushd "${{ github.workspace }}/packages/"$arch
+            pushd "./packages/"$arch
               melange index -o APKINDEX.tar.gz -a $arch *.apk
               melange sign-index --signing-key="${{ github.workspace }}/wolfi-signing.rsa" APKINDEX.tar.gz
               gsutil -h "Cache-Control:no-store" cp "${{ github.workspace }}/packages/${arch}/APKINDEX.tar.gz" gs://wolfi-production-registry-destination/os/${arch}/APKINDEX.tar.gz


### PR DESCRIPTION
This should prevent us from needing to fetch each APK object while regenerating.

We'll still expand the APKs into a temp dir and not delete it, so this may still cause us to run out of disk.

edit: draft while we figure out if we need to withdraw like this at all.