### PR TITLE
sign index while generating

### DIFF
--- a/.github/workflows/reconcile-wolfi-index.yaml
+++ b/.github/workflows/reconcile-wolfi-index.yaml
@@ -44,8 +44,7 @@ jobs:
         run: |
           for arch in x86_64 aarch64; do
             pushd "${{ github.workspace }}/packages/"$arch
-              melange index -o APKINDEX.tar.gz -a $arch *.apk
-              melange sign-index --signing-key="${{ github.workspace }}/wolfi-signing.rsa" APKINDEX.tar.gz
+              melange index -o APKINDEX.tar.gz -a $arch *.apk --signing-key="${{ github.workspace }}/wolfi-signing.rsa"
               gsutil -h "Cache-Control:no-store" cp "${{ github.workspace }}/packages/${arch}/APKINDEX.tar.gz" gs://wolfi-production-registry-destination/os/${arch}/APKINDEX.tar.gz
               gsutil -h "Cache-Control:no-store" cp "${{ github.workspace }}/packages/${arch}/APKINDEX.json" gs://wolfi-production-registry-destination/os/${arch}/APKINDEX.json
             popd

--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -65,8 +65,7 @@ jobs:
         run: |
           for arch in x86_64 aarch64; do
             pushd "${{ github.workspace }}/packages/"$arch
-              melange index -o APKINDEX.tar.gz -a $arch *.apk
-              melange sign-index --signing-key="${{ github.workspace }}/wolfi-signing.rsa" APKINDEX.tar.gz
+              melange index -o APKINDEX.tar.gz -a $arch *.apk --signing-key="${{ github.workspace }}/wolfi-signing.rsa"
               gsutil -h "Cache-Control:no-store" cp "${{ github.workspace }}/packages/${arch}/APKINDEX.tar.gz" gs://wolfi-production-registry-destination/os/${arch}/APKINDEX.tar.gz
               gsutil -h "Cache-Control:no-store" cp "${{ github.workspace }}/packages/${arch}/APKINDEX.json" gs://wolfi-production-registry-destination/os/${arch}/APKINDEX.json
             popd


### PR DESCRIPTION
`melange index` extracts all the APKs, and `melange sign` does it all again. Instead, just pass the signing key in when generating the index, which will also sign it.

Our withdrawal workflow seems to fail while downloading all the APKs, so this might not be our bottleneck.

edit: draft while we figure out if we need to withdraw like this at all.