### PR TITLE
improve withdrawal workflow

### DIFF
--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -7,26 +7,16 @@ on:
 concurrency: build
 
 jobs:
-  build:
+  withdraw:
     name: Withdraw packages
-    runs-on: ubuntu-16-core
+    runs-on: ubuntu-latest
 
     permissions:
       id-token: write
-      packages: write
       contents: read
 
     steps:
-      # In some cases, we runs out of disk space during tests, so this hack frees up approx 10G.
-      # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
-      - name: Free up runner disk space
-        shell: bash
-        run: |
-          set -x
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       - name: "Install wolfictl onto PATH"
         run: |
@@ -35,16 +25,16 @@ jobs:
           docker run --rm -i -v $TMP:/out --entrypoint /bin/sh ghcr.io/wolfi-dev/sdk:latest@sha256:4d0f3a583bbd631ea40bc0f284a5918cf47d50a3f421084212316f4b63ba50be -c "cp /usr/bin/wolfictl /out"
           echo "$TMP" >> $GITHUB_PATH
 
-      - id: auth
-        name: 'Authenticate to Google Cloud'
-        uses: google-github-actions/auth@v0
+      - name: 'Authenticate to Google Cloud'
+        id: auth
+        uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
         with:
           workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
           service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
 
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
         with:
-          project_id: prod-images-c6e5
+          project_id: "prod-images-c6e5"
 
       - run: echo "${{ secrets.MELANGE_RSA }}" > ./wolfi-signing.rsa
       - run: |
@@ -75,3 +65,16 @@ jobs:
           for arch in x86_64 aarch64; do
             gsutil cp $arch/APKINDEX.tar.gz gs://wolfi-production-registry-destination/os/$arch/APKINDEX.tar.gz || true
           done
+
+      - uses: rtCamp/action-slack-notify@v2.2.1
+        if: failure()
+        env:
+          SLACK_ICON: http://github.com/chainguard-dev.png?size=48
+          SLACK_USERNAME: guardian
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: chainguard-images-alerts
+          SLACK_COLOR: '#8E1600'
+          MSG_MINIMAL: 'true'
+          SLACK_TITLE: '[withdraw-packages] failure: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          SLACK_MESSAGE: |
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
- use a smaller cheaper runner
- don't bother freeing up disk space
- pin actions to shas
- update Slack on failure