### PR TITLE
influxd: fix GHSA-m425-mq94-257g

### DIFF
--- a/influxd.yaml
+++ b/influxd.yaml
@@ -1,7 +1,7 @@
 package:
   name: influxd
   version: 2.7.3
-  epoch: 0
+  epoch: 1
   description: Scalable datastore for metrics, events, and real-time analytics
   copyright:
     - license: MIT
@@ -31,6 +31,8 @@ pipeline:
       unset LDFLAGS
       # Mitigate CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
+      # Remediate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.58.3
       go mod tidy
 
       make generate-web-assets


### PR DESCRIPTION
```
wolfictl scan packages/aarch64/influxd-2.7.3-r1.apk --govulncheck
🔎 Scanning "packages/aarch64/influxd-2.7.3-r1.apk"
✅ No vulnerabilities found

wolfictl scan packages/aarch64/influxd-2.7.3-r0.apk --govulncheck
🔎 Scanning "packages/aarch64/influxd-2.7.3-r0.apk"
Checking CVE GHSA-m425-mq94-257g
Checking CVE GHSA-qppj-fm5r-hxr3
└── 📄 /usr/bin/influxd
        📦 google.golang.org/grpc v1.47.0 (g
```