### PR TITLE
melange: fix GHSA-m425-mq94-257g

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -2,7 +2,7 @@ package:
   name: melange
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
   version: 0.5.1
-  epoch: 0
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,9 @@ pipeline:
 
   - runs: |
       cd melange
+      # Mitigate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.58.3
+      go mod tidy
       make melange
       install -m755 -D ./melange "${{targets.destdir}}"/usr/bin/melange
 


### PR DESCRIPTION
```
wolfictl scan packages/aarch64/melange-0.5.1-r2.apk --govulncheck
🔎 Scanning "packages/aarch64/melange-0.5.1-r2.apk"
Checking CVE GHSA-jq35-85cj-fj4p
└── 📄 /usr/bin/melange
        📦 github.com/docker/docker v24.0.6+incompatible
```