### PR TITLE
keda: fix GHSA-m425-mq94-257g

### DIFF
--- a/keda-2.10.yaml
+++ b/keda-2.10.yaml
@@ -4,7 +4,7 @@ package:
   name: keda-2.10
   # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
   version: 2.10.1
-  epoch: 4
+  epoch: 5
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -42,6 +42,9 @@ pipeline:
       # CVE-2023-39325
       go mod edit -dropreplace=golang.org/x/net
       go get golang.org/x/net@v0.17.0
+      # Remediate GHSA-m425-mq94-257g
+      go mod edit -droprequire=google.golang.org/grpc
+      go get google.golang.org/grpc@v1.58.3
       go mod tidy
       go mod vendor
       go clean -cache -modcache

--- a/keda.yaml
+++ b/keda.yaml
@@ -2,7 +2,7 @@ package:
   name: keda
   # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
   version: 2.12.0
-  epoch: 3
+  epoch: 4
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -37,6 +37,9 @@ pipeline:
       go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v0.42.0
       # CVE-2023-39325
       go get golang.org/x/net@v0.17.0
+      # Remediate GHSA-m425-mq94-257g
+      go mod edit -droprequire=google.golang.org/grpc
+      go get google.golang.org/grpc@v1.58.3
       go mod tidy
       go mod vendor
       go clean -cache -modcache


### PR DESCRIPTION
```
wolfictl scan packages/aarch64/keda-2.10-2.10.1-r4.apk
🔎 Scanning "packages/aarch64/keda-2.10-2.10.1-r4.apk"
✅ No vulnerabilities found
```