### PR TITLE
oauth2-proxy: fix GHSA-m425-mq94-257g

### DIFF
--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: oauth2-proxy
   version: 7.5.1
-  epoch: 3
+  epoch: 4
   description: Reverse proxy and static file server that provides authentication using various providers to validate accounts by email, domain or group.
   copyright:
     - license: MIT
@@ -28,8 +28,9 @@ pipeline:
       output: oauth2-proxy
       ldflags: -s -w -X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.Version=${{package.version}}
       # GHSA-vvpx-j8f3-3w6h
+      # GHSA-m425-mq94-257g
       # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
-      deps: golang.org/x/net@v0.17.0
+      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3
 
   - runs: |
       # Make sure there is at least an empty key file.


### PR DESCRIPTION
```
wolfictl scan  packages/aarch64/oauth2-proxy-7.5.1-r3.apk
🔎 Scanning "packages/aarch64/oauth2-proxy-7.5.1-r3.apk"
✅ No vulnerabilities found
```