### PR TITLE
cosign/2.2.1 package update

### DIFF
--- a/cosign.yaml
+++ b/cosign.yaml
@@ -1,7 +1,7 @@
 package:
   name: cosign
-  version: 2.2.0
-  epoch: 6
+  version: 2.2.1
+  epoch: 0
   description: Container Signing
   copyright:
     - license: Apache-2.0
@@ -22,15 +22,13 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/sigstore/cosign/archive/v${{package.version}}/cosign-v${{package.version}}.tar.gz
-      expected-sha256: eceb7c537211e950f01b712b29a58164ed023ce5369b7e6fcfd7a730abbeab32
+      expected-sha256: 7bff4107639c516495ef5b987ed6411d6fc91f85b3d3f80672f785511903a4d1
 
   - uses: go/build
     with:
       packages: ./cmd/cosign
       output: cosign
       ldflags: -s -w -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}}
-      # CVE-2023-39325 and CVE-2023-3978 / Remediate GHSA-m425-mq94-257g
-      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3
 
   - uses: strip
 


### PR DESCRIPTION
- cosign/2.2.1 package update


### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/482


#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

