### PR TITLE
fix: rebuild libxkbcommon

### DIFF
--- a/libxkbcommon.yaml
+++ b/libxkbcommon.yaml
@@ -2,7 +2,7 @@
 package:
   name: libxkbcommon
   version: 1.6.0
-  epoch: 0
+  epoch: 1
   description: keyboard handling library
   copyright:
     - license: MIT
@@ -32,6 +32,7 @@ pipeline:
 
   - runs: |
       meson \
+        --prefix=/usr \
         -Denable-wayland=true \
         -Denable-docs=false \
         -Denable-x11=true \


### PR DESCRIPTION
For some reason this package have a bad `.so` [detection](https://github.com/wolfi-dev/os/actions/runs/6472637313/job/17573705382#step:6:3423) in `1.6.0-r0` version and generate installation errors.

Package versions info:
```
libxkbcommon-1.5.0-r0 depends on:
so:ld-linux-x86-64.so.2
so:libc.so.6
so:libwayland-client.so.0
so:libxcb-xkb.so.1
so:libxcb.so.1
so:libxml2.so.2

libxkbcommon-1.5.0-r0 provides:
so:libxkbcommon-x11.so.0=0
so:libxkbcommon.so.0=0
so:libxkbregistry.so.0=0

---------------------------------------------

libxkbcommon-1.6.0-r0 depends on:
so:ld-linux-x86-64.so.2
so:libc.so.6
so:libwayland-client.so.0
so:libxcb-xkb.so.1
so:libxcb.so.1
so:libxkbcommon-x11.so.0
so:libxkbcommon.so.0
so:libxkbregistry.so.0
so:libxml2.so.2

libxkbcommon-1.6.0-r0 provides:
pc:xkbcommon-x11=1.6.0
pc:xkbcommon=1.6.0
pc:xkbregistry=1.6.0
```

I understand in `1.6.0-r0` build detect `1.5.0-r0` as a dependency and this make installation fail.

Installation logs:

```
docker run --rm -it cgr.dev/chainguard/wolfi-base@sha256:5fd82be4dfccc650c1985d57847f1af556bf23a8a5d86ec5fddf7d417ab147a4
4fcbc5f5abb5:/# apk update
fetch https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
 [https://packages.wolfi.dev/os]
OK: 26088 distinct packages available
4fcbc5f5abb5:/# apk add libxkbcommon
ERROR: unable to select packages:
  libxkbcommon-1.5.0-r0:
    conflicts: libxkbcommon-1.6.0-r0
    satisfies: world[libxkbcommon] libxkbcommon-1.6.0-r0[so:libxkbcommon-x11.so.0] libxkbcommon-1.6.0-r0[so:libxkbcommon.so.0]
               libxkbcommon-1.6.0-r0[so:libxkbregistry.so.0]
  libxkbcommon-1.6.0-r0:
    conflicts: libxkbcommon-1.5.0-r0
    satisfies: world[libxkbcommon]
```

The recompilation is a workaround but we can investigate melange `.so` detection process, no?

cc @lpcalisi 


