### PR TITLE
Adding vector:0.34.0: new package

### DIFF
--- a/vector.yaml
+++ b/vector.yaml
@@ -19,7 +19,7 @@ environment:
       - perl
       - pkgconf-dev
       - protobuf-dev
-      - rust=1.71.0-r0
+      - rust
       - wolfi-base
 
 pipeline:

--- a/vector.yaml
+++ b/vector.yaml
@@ -19,7 +19,7 @@ environment:
       - perl
       - pkgconf-dev
       - protobuf-dev
-      - rust=1.72.0-r0
+      - rust=1.72.0-r1
       - wolfi-base
 
 pipeline:

--- a/vector.yaml
+++ b/vector.yaml
@@ -2,9 +2,9 @@ package:
   name: vector
   version: "0.34.0"
   epoch: 0
-  description: End-to-end observability data pipeleine
+  description: End-to-end observability data pipeline
   copyright:
-    - license: Mozilla Public License 2.0
+    - license: MPL-2.0
 
 environment:
   contents:
@@ -31,7 +31,7 @@ pipeline:
 
   - runs: |
       sed -i '7s/deny/allow/' src/lib.rs
-      cargo build --release --no-default-features --features default
+      make build
 
   - runs: |
       install -Dm755 target/release/vector "${{targets.destdir}}"/usr/bin/vector

--- a/vector.yaml
+++ b/vector.yaml
@@ -1,0 +1,46 @@
+package:
+  name: vector
+  version: "0.34.0"
+  epoch: 0
+  description: End-to-end observability data pipeleine
+  copyright:
+    - license: Mozilla Public License 2.0
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - cyrus-sasl-dev
+      - librdkafka
+      - librdkafka-dev
+      - openssl
+      - openssl-dev
+      - perl
+      - pkgconf-dev
+      - protobuf-dev
+      - rust=1.72.0-r0
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/vectordotdev/vector
+      tag: v${{package.version}}
+      expected-commit: c909b660ca3cf3cc1c6d9cd7880cef8b61b2b426
+
+  - runs: |
+      cargo build --release --no-default-features --features default
+
+  - runs: |
+      install -Dm755 target/release/vector "${{targets.destdir}}"/usr/bin/vector
+      mkdir -p "${{targets.destdir}}"/etc/vector
+      cp config/vector.toml "${{targets.destdir}}"/etc/vector/vector.toml
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: vectordotdev/vector
+    strip-prefix: v

--- a/vector.yaml
+++ b/vector.yaml
@@ -36,7 +36,7 @@ pipeline:
   - runs: |
       install -Dm755 target/release/vector "${{targets.destdir}}"/usr/bin/vector
       mkdir -p "${{targets.destdir}}"/etc/vector
-      cp config/vector.toml "${{targets.destdir}}"/etc/vector/vector.toml
+      cp config/vector.yaml "${{targets.destdir}}"/etc/vector/vector.yaml
 
   - uses: strip
 

--- a/vector.yaml
+++ b/vector.yaml
@@ -19,7 +19,7 @@ environment:
       - perl
       - pkgconf-dev
       - protobuf-dev
-      - rust=1.72.0-r1
+      - rust=1.71.0-r0
       - wolfi-base
 
 pipeline:

--- a/vector.yaml
+++ b/vector.yaml
@@ -30,7 +30,7 @@ pipeline:
       expected-commit: c909b660ca3cf3cc1c6d9cd7880cef8b61b2b426
 
   - runs: |
-      sed -i 's/.*#![deny(warnings)].*$/\/\/&/' src/lib.rs
+      sed -i '7s/deny/allow/' src/lib.rs
       cargo build --release --no-default-features --features default
 
   - runs: |

--- a/vector.yaml
+++ b/vector.yaml
@@ -30,6 +30,7 @@ pipeline:
       expected-commit: c909b660ca3cf3cc1c6d9cd7880cef8b61b2b426
 
   - runs: |
+      sed -i '/#![deny(warnings)]/d' src/lib.rs
       cargo build --release --no-default-features --features default
 
   - runs: |

--- a/vector.yaml
+++ b/vector.yaml
@@ -30,7 +30,7 @@ pipeline:
       expected-commit: c909b660ca3cf3cc1c6d9cd7880cef8b61b2b426
 
   - runs: |
-      sed -i '/#![deny(warnings)]/d' src/lib.rs
+      sed -i 's/.*#![deny(warnings)].*$/\/\/&/' src/lib.rs
       cargo build --release --no-default-features --features default
 
   - runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
