### PR TITLE
aws-cli: fix tag filter to enable updates

### DIFF
--- a/aws-cli.yaml
+++ b/aws-cli.yaml
@@ -7,27 +7,27 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - python3
-      - py3-setuptools
-      - py3-yaml
+      - groff
       - py3-botocore
+      - py3-colorama
       - py3-docutils
       - py3-jmespath
       - py3-rsa
       - py3-s3transfer
-      - py3-colorama
-      - groff
+      - py3-setuptools
+      - py3-yaml
+      - python3
 
 environment:
   contents:
     packages:
-      - wolfi-base
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
+      - py3-setuptools
       - python3
       - python3-dev
-      - py3-setuptools
+      - wolfi-base
 
 pipeline:
   - uses: fetch
@@ -48,4 +48,4 @@ update:
   github:
     identifier: aws/aws-cli
     use-tag: true
-    tag-filter: "1.27"
+    tag-filter: "1."


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
