### PR TITLE
remove runtime dependency for prometheus compat subpackages

### DIFF
--- a/prometheus-operator.yaml
+++ b/prometheus-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-operator
   version: 0.69.0
-  epoch: 0
+  epoch: 1
   description: Prometheus Operator creates/configures/manages Prometheus clusters atop Kubernetes
   copyright:
     - license: Apache-2.0
@@ -53,9 +53,6 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.contextdir}}/bin"
           ln -s /usr/bin/prometheus-config-reloader "${{targets.contextdir}}/bin/prometheus-config-reloader"
-    dependencies:
-      runtime:
-        - prometheus-config-reloader
 
 update:
   enabled: true

--- a/prometheus-pushgateway.yaml
+++ b/prometheus-pushgateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-pushgateway
   version: 1.6.2
-  epoch: 4
+  epoch: 5
   description: Push acceptor for ephemeral and batch jobs.
   copyright:
     - license: Apache-2.0
@@ -41,7 +41,6 @@ subpackages:
       provides:
         - prometheus-pushgateway-bitnami-compat=${{package.full-version}}
       runtime:
-        - prometheus-pushgateway
         # Required by startup scripts
         - busybox
         - bash


### PR DESCRIPTION
These compat subpackages don't provide version-specific behavior, so they can be used by other versions or variants of these packages, rather than producing equivalent version- or variant-specific compat packages.

However, the runtime dependency pulls in the latest version, which would conflict.

This removes those runtime deps.