### PR TITLE
newrelic-fluent-bit-output needs to build with go 1.20

### DIFF
--- a/newrelic-fluent-bit-output.yaml
+++ b/newrelic-fluent-bit-output.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-fluent-bit-output
   version: 1.17.3
-  epoch: 7
+  epoch: 8
   description: A Fluent Bit output plugin that sends logs to New Relic
   copyright:
     - license: Apache-2.0
@@ -12,7 +12,7 @@ environment:
       - wolfi-baselayout
       - busybox
       - build-base
-      - go
+      - go-1.20
       - ca-certificates-bundle
 
 pipeline:


### PR DESCRIPTION
The newrelic-fluent-bit-output image pulling in this package crashes with `fatal: morestack on g0`. It looks to be a regression in go 1.21 (see issue below) so for the time being we need to build with go 1.20

https://github.com/golang/go/issues/62440#issuecomment-1734081574