### PR TITLE
new package: lvm-lld-17

### DIFF
--- a/llvm-lld-17.yaml
+++ b/llvm-lld-17.yaml
@@ -1,0 +1,82 @@
+package:
+  name: llvm-lld-17
+  version: 17.0.4
+  epoch: 0
+  description: The LLVM Linker
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - llvm-lld=17
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang-17
+      - cmake
+      - curl
+      - git
+      - libedit-dev
+      - llvm-cmake-17
+      - llvm-libunwind-dev
+      - llvm17
+      - llvm17-dev
+      - samurai
+      - zlib-dev
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 47f5da4d28c60d69ab134c028ece0af8a5e18aca940d26a672265a381cafdc50
+      uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/lld-${{package.version}}.src.tar.xz
+
+  - runs: |
+      cmake -B build -G Ninja -Wno-dev \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_MODULE_PATH=/usr/lib/llvm${{vars.major-version}}/share/cmake/Modules \
+        -DLLVM_COMMON_CMAKE_UTILS="/usr/lib/llvm${{vars.major-version}}/share/cmake" \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_SKIP_INSTALL_RPATH=ON \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLD_BUILT_STANDALONE=ON \
+        -DLLVM_CONFIG=/usr/lib/llvm${{vars.major-version}}/bin/llvm-config \
+        -DLLVM_INCLUDE_DIRS=/usr/lib/llvm${{vars.major-version}}/include
+
+  - runs: |
+      cmake --build build
+
+  - runs: |
+      DESTDIR=${{targets.destdir}} cmake --install build
+
+subpackages:
+  - name: llvm-lld-17-static
+    pipeline:
+      - uses: split/static
+
+  - name: llvm-lld-17-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - llvm-lld-17
+    description: llvm-lld dev
+
+update:
+  enabled: true
+  github:
+    identifier: llvm/llvm-project
+    use-tag: true
+    tag-filter: llvmorg-17.
+    strip-prefix: llvmorg-


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
