### PR TITLE
timestamp-authority: update grpc library

### DIFF
--- a/timestamp-authority.yaml
+++ b/timestamp-authority.yaml
@@ -28,7 +28,10 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: c21da35174dd1a44ff425f695f87e99061c52d99
 
-  - runs: make timestamp-cli timestamp-server
+  - runs: |
+      go get google.golang.org/grpc@v1.58.3
+      go mod tidy
+      make timestamp-cli timestamp-server
 
   - uses: strip
 


### PR DESCRIPTION
This fixes two vulnerabilities in this package. 