### PR TITLE
aws-lb: add latest compat package

### DIFF
--- a/aws-load-balancer-controller.yaml
+++ b/aws-load-balancer-controller.yaml
@@ -38,6 +38,15 @@ pipeline:
 
   - uses: strip
 
+subpackages:
+  - name: "aws-load-balancer-controller-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          # The helm chart expects the binaries to be in / instead of /usr/bin
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/controller ${{targets.subpkgdir}}/controller
+
 update:
   enabled: true
   github:

--- a/aws-load-balancer-controller.yaml
+++ b/aws-load-balancer-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-load-balancer-controller
   version: 2.6.2
-  epoch: 0
+  epoch: 1
   description: A Kubernetes controller for Elastic Load Balancers
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
We use this compat package elsewhere, tied to a version for no reason.