### PR TITLE
Add gitignore entry for JetBrains IDEs config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dag.svg
 .melange.k8s.yaml
 .vscode/*
 packages.log
+*.iml
 
 # macOS
 .DS_Store


### PR DESCRIPTION
Add a `.gitignore` entry to ignore configuration files for JetBrains IDEs