### PR TITLE
add batch of python 3.11 -> 3.12 epoch bumps

### DIFF
--- a/py3-annotated-types.yaml
+++ b/py3-annotated-types.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-annotated-types
   version: 0.6.0
-  epoch: 0
+  epoch: 1
   description: Reusable constraint types to use with typing.Annotated
   copyright:
     - license: MIT
@@ -22,6 +22,9 @@ environment:
       - py3-setuptools
       - py3-build
       - py3-installer
+  environment:
+    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
+    SOURCE_DATE_EPOCH: 315532800
 
 pipeline:
   - uses: git-checkout

--- a/py3-conda-package-streaming.yaml
+++ b/py3-conda-package-streaming.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-conda-package-streaming
   version: 0.9.0
-  epoch: 1
+  epoch: 2
   description: An efficient library to read from new and old format .conda and .tar.bz2 conda packages.
   copyright:
     - license: "BSD-3-Clause"

--- a/py3-crcmod.yaml
+++ b/py3-crcmod.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-crcmod
   version: "1.7"
-  epoch: 0
+  epoch: 1
   description: Cyclic Redundancy Check (CRC) implementation in Python
   copyright:
     - license: 'MIT'

--- a/py3-cycler.yaml
+++ b/py3-cycler.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cycler
   version: 0.12.1
-  epoch: 0
+  epoch: 1
   description: Composable style cycles
   copyright:
     - license: BSD-3-Clause

--- a/py3-distro.yaml
+++ b/py3-distro.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-distro
   version: 1.8.0
-  epoch: 0
+  epoch: 1
   description: "A Linux OS platform information API"
   copyright:
     - license: Apache-2.0

--- a/py3-editables.yaml
+++ b/py3-editables.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-editables
   version: "0.5"
-  epoch: 1
+  epoch: 2
   description: Editable installations
   copyright:
     - license: "MIT"

--- a/py3-flask-opentracing.yaml
+++ b/py3-flask-opentracing.yaml
@@ -2,13 +2,13 @@
 package:
   name: py3-flask-opentracing
   version: 1.1.0
-  epoch: 1
+  epoch: 2
   description: OpenTracing support for Flask applications
   copyright:
     - license: BSD
   dependencies:
     runtime:
-      - python-3.11
+      - python3
 
 environment:
   contents:
@@ -16,8 +16,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3.11-setuptools
-      - python-3.11
+      - py3-setuptools
+      - python3
       - wolfi-base
 
 pipeline:

--- a/py3-kiwisolver.yaml
+++ b/py3-kiwisolver.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-kiwisolver
   version: 1.4.5
-  epoch: 2
+  epoch: 3
   description: A fast implementation of the Cassowary constraint solver
   copyright:
     - license: BSD-3-Clause-Attribution

--- a/py3-pep517.yaml
+++ b/py3-pep517.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pep517
   version: 0.13.1
-  epoch: 0
+  epoch: 1
   description: "wrappers to build python3 packages with PEP 517 hooks"
   copyright:
     - license: MIT

--- a/py3-psycopg.yaml
+++ b/py3-psycopg.yaml
@@ -1,36 +1,36 @@
 package:
   name: py3-psycopg
-  version: 3.1.10
-  epoch: 1
+  version: 3.1.12
+  epoch: 0
   description: PostgreSQL database adapter for Python
   copyright:
     - license: GNU Lesser General Public License v3 (LGPLv3)
   dependencies:
     runtime:
+      - libpq-15
       - py3-typing-extensions
       - py3-tzdata
       - python3
-      - libpq-15
 
 environment:
   contents:
     packages:
-      - ca-certificates-bundle
-      - wolfi-base
-      - busybox
       - build-base
-      - py3-wheel
+      - busybox
+      - ca-certificates-bundle
       - poetry
       - py3-gpep517
-      - python3
       - py3-setuptools
+      - py3-wheel
+      - python3
+      - wolfi-base
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/psycopg/psycopg
       tag: ${{package.version}}
-      expected-commit: 8d2ba2d7587116b65911cdccdf24af0413f17865
+      expected-commit: 5498bb85c62cbe71da16731e9f25e8727a098c80
 
   - name: Python Build
     runs: |

--- a/py3-psycopg.yaml
+++ b/py3-psycopg.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-psycopg
   version: 3.1.10
-  epoch: 0
+  epoch: 1
   description: PostgreSQL database adapter for Python
   copyright:
     - license: GNU Lesser General Public License v3 (LGPLv3)

--- a/py3-pydot.yaml
+++ b/py3-pydot.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pydot
   version: 1.4.2
-  epoch: 0
+  epoch: 1
   description: Python interface to Graphviz's Dot
   copyright:
     - license: MIT

--- a/py3-pymysql.yaml
+++ b/py3-pymysql.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pymysql
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: Pure Python MySQL Driver
   copyright:
     - license: MIT License

--- a/py3-python-lsp-jsonrpc.yaml
+++ b/py3-python-lsp-jsonrpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-lsp-jsonrpc
   version: 1.1.2
-  epoch: 0
+  epoch: 1
   description: "JSON RPC 2.0 server library"
   copyright:
     - license: MIT

--- a/py3-ruamel-yaml-clib.yaml
+++ b/py3-ruamel-yaml-clib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ruamel-yaml-clib
   version: 0.2.8
-  epoch: 0
+  epoch: 1
   description: "C version of reader, parser and emitter for ruamel.yaml derived from libyaml."
   copyright:
     - license: MIT


### PR DESCRIPTION
fixes #6318, refs #8128: bump epoch in a batch of outdated Python packages. I tested building these in the dev container and didn't run int any issues:

```
[sdk] ❯ make package/py3-annotated-types package/py3-crcmod package/py3-conda-package-streaming package/py3-cycler package/py3-distro package/py3-editables package/py3-flask-opentracing package/py3-kiwisolver package/py3-pep517 package/py3-psycopg package/py3-pymysql package/py3-python-lsp-jsonrpc package/py3-ruamel-yaml-clib
. . .
[sdk] ❯ ls s -l packages/aarch64/*.apk
-rw-r--r--    1 root     root         25875 Nov  9 15:31 packages/aarch64/py3-annotated-types-0.6.0-r1.apk
-rw-r--r--    1 root     root         43579 Nov  9 15:32 packages/aarch64/py3-conda-package-streaming-0.9.0-r2.apk
-rw-r--r--    1 root     root         47958 Nov  9 15:32 packages/aarch64/py3-crcmod-1.7-r1.apk
-rw-r--r--    1 root     root         19483 Nov  9 15:32 packages/aarch64/py3-cycler-0.12.1-r1.apk
-rw-r--r--    1 root     root         64150 Nov  9 15:32 packages/aarch64/py3-distro-1.8.0-r1.apk
-rw-r--r--    1 root     root          8024 Nov  9 15:32 packages/aarch64/py3-editables-0.5-r2.apk
-rw-r--r--    1 root     root         22618 Nov  9 15:33 packages/aarch64/py3-flask-opentracing-1.1.0-r2.apk
-rw-r--r--    1 root     root         87184 Nov  9 15:36 packages/aarch64/py3-kiwisolver-1.4.5-r3.apk
-rw-r--r--    1 root     root         53297 Nov  9 15:36 packages/aarch64/py3-pep517-0.13.1-r1.apk
-rw-r--r--    1 root     root        676626 Nov  9 15:50 packages/aarch64/py3-psycopg-3.1.12-r0.apk
-rw-r--r--    1 root     root        161050 Nov  9 15:36 packages/aarch64/py3-pymysql-1.1.0-r1.apk
-rw-r--r--    1 root     root         26529 Nov  9 15:38 packages/aarch64/py3-python-lsp-jsonrpc-1.1.2-r1.apk
-rw-r--r--    1 root     root        160010 Nov  9 15:38 packages/aarch64/py3-ruamel-yaml-clib-0.2.8-r1.apk
```