### PR TITLE
Add Emacs 29.1.90 (just because)

### DIFF
--- a/emacs.yaml
+++ b/emacs.yaml
@@ -1,0 +1,59 @@
+package:
+  name: emacs
+  version: "29.1.90"
+  epoch: 0
+  description: "An extensible, customizable, free/libre text editor"
+  copyright:
+    - license: GPL-3
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gawk
+      - libtool
+      - libxml2-dev
+      - ncurses-dev
+      - posix-libc-utils
+      - texinfo
+      - wolfi-baselayout
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/emacs-mirror/emacs
+      tag: emacs-${{package.version}}
+      expected-commit: d963bc6c6b69c084e64d421d5f4938c13ed24c0f
+
+  - runs: autoreconf -vif
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --with-x=no \
+        --with-gnutls=ifavailable \
+        --with-mailutils=no \
+        --with-pop=no
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: "emacs-doc"
+    pipeline:
+      - uses: split/manpages
+
+update:
+  enabled: true
+  github:
+    identifier: emacs-mirror/emacs
+    strip-prefix: emacs-
+    use-tag: true
+    tag-filter: emacs-

--- a/emacs.yaml
+++ b/emacs.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: "An extensible, customizable, free/libre text editor"
   copyright:
-    - license: GPL-3
+    - license: GPL-3.0
 
 environment:
   contents:


### PR DESCRIPTION
We can't in all seriousness be a distro (or undistro) without Emacs.

### Pre-review Checklist

#### For new package PRs only
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates

Here it is running in the sdk dev container:
![Screenshot 2023-11-09 at 1 17 14 PM](https://github.com/wolfi-dev/os/assets/328553/6a65b1aa-9158-48fd-a84d-7095e649be60)
