### PR TITLE
ingress-nginx-controller: move setcap after strip

### DIFF
--- a/ingress-nginx-controller.yaml
+++ b/ingress-nginx-controller.yaml
@@ -2,7 +2,7 @@
 package:
   name: ingress-nginx-controller
   version: 1.9.4
-  epoch: 0
+  epoch: 1
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -169,9 +169,6 @@ pipeline:
       -X ${PKG}/version.COMMIT=${COMMIT_SHA} \
       -X ${PKG}/version.REPO=${REPO_INFO}" \
       -o "${{targets.destdir}}/usr/bin/nginx-ingress-controller" ${PKG}/cmd/nginx
-
-      setcap cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/nginx-ingress-controller \
-      && setcap -v cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/nginx-ingress-controller
 
       getcap ${{targets.destdir}}/usr/bin/nginx-ingress-controller
 
@@ -433,25 +430,10 @@ pipeline:
       echo "::::::::::::::::::::::::::::::::::::::::::::::"
       make DESTDIR="${{targets.destdir}}" install
 
-      echo "::::::::::::::::::::::::::::::::::::::::::"
-      echo ":::: SETCAP NGINX                     ::::"
-      echo "::::::::::::::::::::::::::::::::::::::::::"
-
       mkdir -p ${{targets.destdir}}/usr/bin
       mv ${{targets.destdir}}/usr/sbin/nginx ${{targets.destdir}}/usr/bin/
       rm -rf ${{targets.destdir}}/usr/html
       rm -rf ${{targets.destdir}}/usr/sbin
-
-      setcap cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/nginx \
-        && setcap -v cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/nginx
-
-       echo "::::::::::::::::::::::::::::::::::::::::::"
-       echo ":::: SETCAP DUMB INIT                  ::::"
-       echo "::::::::::::::::::::::::::::::::::::::::::"
-
-      setcap cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/dumb-init \
-        && setcap -v cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/dumb-init
-
 
       echo "::::::::::::::::::::::::::::::::::::::::::::"
       echo ":::::::::::::::: CLEANUP :::::::::::::::::::"
@@ -462,6 +444,28 @@ pipeline:
       rm -rf ${{targets.destdir}}/etc/nginx/owasp-modsecurity-crs/util/regression-tests
 
   - uses: strip
+
+  - runs: |
+      echo "::::::::::::::::::::::::::::::::::::::::::"
+      echo ":::: SETCAP NGINX CONTROLLER           ::::"
+      echo "::::::::::::::::::::::::::::::::::::::::::"
+
+      setcap cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/nginx-ingress-controller \
+      && setcap -v cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/nginx-ingress-controller
+
+      echo "::::::::::::::::::::::::::::::::::::::::::"
+      echo ":::: SETCAP NGINX                      ::::"
+      echo "::::::::::::::::::::::::::::::::::::::::::"
+
+      setcap cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/nginx \
+        && setcap -v cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/nginx
+
+      echo "::::::::::::::::::::::::::::::::::::::::::"
+      echo ":::: SETCAP DUMB INIT                  ::::"
+      echo "::::::::::::::::::::::::::::::::::::::::::"
+
+      setcap cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/dumb-init \
+        && setcap -v cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/dumb-init
 
 subpackages:
   - name: ingress-nginx-controller-compat


### PR DESCRIPTION
* "ingress-nginx-controller-1.9.4: strip before setcap to avoid capabilities being stripped"