### PR TITLE
jsoncpp: new package

### DIFF
--- a/jsoncpp.yaml
+++ b/jsoncpp.yaml
@@ -1,0 +1,45 @@
+package:
+  name: jsoncpp
+  version: 1.9.5
+  epoch: 0
+  description: "C++ library for parsing JSON"
+  copyright:
+    - license: 'Public-Domain OR MIT'
+
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/open-source-parsers/jsoncpp
+      tag: ${{package.version}}
+      expected-commit: 5defb4ed1a4293b8e2bf641e16b156fb9de498cc
+
+  - uses: meson/configure
+
+  - uses: meson/compile
+
+  - uses: meson/install
+
+  - uses: strip
+
+subpackages:
+  - name: jsoncpp-static
+    description: "C++ library for parsing JSON - static libraries"
+    pipeline:
+      - uses: split/static
+
+  - name: jsoncpp-dev
+    description: "C++ library for parsing JSON - development headers"
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: open-source-parsers/jsoncpp


### PR DESCRIPTION
### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)