### PR TITLE
Package update kube-fluentd-operator to `1.18.1`

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
-  version: 1.17.6
-  epoch: 8
+  version: 1.18.1
+  epoch: 0
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -35,7 +35,6 @@ environment:
       - wget
       - bash
       - go
-      # - shadow
 
 # https://github.com/javiercri/fluent-plugin-google-cloud/commit/619c813c265d51f4dd0b1cada3a07e615b47cdde
 vars:
@@ -46,12 +45,12 @@ pipeline:
     with:
       repository: https://github.com/vmware/kube-fluentd-operator
       tag: v${{package.version}}
-      expected-commit: 818fbdd8e007f029bc32433d5ee138f43d653e73
+      expected-commit: e568a6b2508153ee721bd22fc560338f6bad283d
 
   - runs: |
       echo 'gem: --no-rdoc --no-ri' >> ~/.gemrc
 
-      cd base-image
+      cd image
       GEM_DIR=${{targets.destdir}}$(ruby -e 'puts Gem.default_dir')
       mkdir -p ${GEM_DIR}
       bundle config set --local path ${GEM_DIR}
@@ -84,6 +83,10 @@ pipeline:
   - uses: strip
 
   - runs: |
+      # makefile has moved to the root of the repo without any changes
+      # This may break in future versions TODO : Remove this when the makefile works again from root of repo
+      cp Makefile ./config-reloader
+
       mkdir -p ${{targets.destdir}}/usr/bin
       cd config-reloader
 
@@ -102,7 +105,7 @@ subpackages:
         - bash
     pipeline:
       - runs: |
-          cd base-image
+          cd image
           mkdir -p ${{targets.subpkgdir}}/var/lib/kube-fluentd-operator/initdb
           cp entrypoint.sh ${{targets.subpkgdir}}/var/lib/kube-fluentd-operator/initdb/
           chmod +x ${{targets.subpkgdir}}/var/lib/kube-fluentd-operator/initdb/entrypoint.sh
@@ -111,7 +114,7 @@ subpackages:
     description: Default configuration for kube-fluentd-operator
     pipeline:
       - runs: |
-          cd base-image
+          cd image
           mkdir -p ${{targets.subpkgdir}}/etc/fluent
           cp failsafe.conf ${{targets.subpkgdir}}/etc/fluent/fluent.conf
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #8130 #7032 

Related:

### Pre-review Checklist


#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
