### PR TITLE
kubeflow-jupyter-web-app: Fix CVE-2023-45803 and CVE-2023-46136

### DIFF
--- a/kubeflow-jupyter-web-app.yaml
+++ b/kubeflow-jupyter-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-jupyter-web-app
   version: 1.7.0
-  epoch: 6
+  epoch: 7
   description: Kubeflow jupyter web app component
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,8 @@ environment:
       - py3-setuptools
       - py3-wheel
       - py3-pip
+      - py3-urllib3
+      - py3-werkzeug
       - openssl
 
 pipeline:


### PR DESCRIPTION
Resolves vulnerabilities in dependencies by using the Wolfi version.

It looks like version `1.8.0` is out. I'd still prefer merging this PR to resolve the vulnerability, and then investigate the package update failure.