### PR TITLE
Revert "Update images digests"

### DIFF
--- a/.github/workflows/wolfictl-check-update.yaml
+++ b/.github/workflows/wolfictl-check-update.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Check
       id: check
       if: ${{ steps.files.outputs.all_changed_files != '' }}
-      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:fe5f62bc7f66008c1f6440149600fb2f307692bac227a04cb4cca75be92242e7
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:3b0cef91853cd10619071234c663bc1b6db457548276bd513e301c8eb6c71ea0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/wolfictl-lint.yaml
+++ b/.github/workflows/wolfictl-lint.yaml
@@ -19,13 +19,13 @@ jobs:
     - uses: actions/checkout@v4
     - name: Lint
       id: lint
-      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:fe5f62bc7f66008c1f6440149600fb2f307692bac227a04cb4cca75be92242e7
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:3b0cef91853cd10619071234c663bc1b6db457548276bd513e301c8eb6c71ea0
       with:
         entrypoint: wolfictl
         args: lint --skip-rule no-makefile-entry-for-package
     - name: Enforce YAML formatting
       id: lint-yaml
-      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:fe5f62bc7f66008c1f6440149600fb2f307692bac227a04cb4cca75be92242e7
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:3b0cef91853cd10619071234c663bc1b6db457548276bd513e301c8eb6c71ea0
       with:
         entrypoint: wolfictl
         args: lint yam

--- a/.github/workflows/wolfictl-update-gh.yaml
+++ b/.github/workflows/wolfictl-update-gh.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:fe5f62bc7f66008c1f6440149600fb2f307692bac227a04cb4cca75be92242e7
+    - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:3b0cef91853cd10619071234c663bc1b6db457548276bd513e301c8eb6c71ea0
       with:
         entrypoint: wolfictl
         args: update https://github.com/${{github.repository}} --release-monitoring-query=false --github-labels request-version-update --github-labels "automated pr"

--- a/.github/workflows/wolfictl-update-rm.yaml
+++ b/.github/workflows/wolfictl-update-rm.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:fe5f62bc7f66008c1f6440149600fb2f307692bac227a04cb4cca75be92242e7
+    - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:3b0cef91853cd10619071234c663bc1b6db457548276bd513e301c8eb6c71ea0
       with:
         entrypoint: wolfictl
         args: update https://github.com/${{github.repository}} --github-release-query=false --github-labels request-version-update --github-labels "automated pr"


### PR DESCRIPTION
Reverts wolfi-dev/os#8352

This change picked up https://github.com/chainguard-dev/go-apk/pull/148 which seems to break APKINDEX

edit: This was the wrong change, correct revert in #8383