### PR TITLE
Revert "Update images digests"

### DIFF
--- a/.github/workflows/build-world.yaml
+++ b/.github/workflows/build-world.yaml
@@ -24,7 +24,7 @@ jobs:
     # permissions:
 
     container:
-      image: ghcr.io/wolfi-dev/sdk:latest@sha256:844ffd2d222627faee5c8793c1103fa523a8c79529ec6917ed3feda289380a1e
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:fe85df7dc646f29552dab0ebd7e6e6e1cc6f4a5ce83e724693cf0fece5b8f8ac
       # TODO: Deprivilege
       options: |
         --cap-add NET_ADMIN --cap-add SYS_ADMIN --device /dev/fuse --security-opt seccomp=unconfined --security-opt apparmor:unconfined

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
     # permissions:
 
     container:
-      image: ghcr.io/wolfi-dev/sdk:latest@sha256:844ffd2d222627faee5c8793c1103fa523a8c79529ec6917ed3feda289380a1e
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:fe85df7dc646f29552dab0ebd7e6e6e1cc6f4a5ce83e724693cf0fece5b8f8ac
       # TODO: Deprivilege
       options: |
         --cap-add NET_ADMIN --cap-add SYS_ADMIN --device /dev/fuse --security-opt seccomp=unconfined --security-opt apparmor:unconfined
@@ -102,7 +102,7 @@ jobs:
 
     container:
       # NOTE: This step only signs and uploads, so it doesn't need any privileges
-      image: ghcr.io/wolfi-dev/sdk:latest@sha256:844ffd2d222627faee5c8793c1103fa523a8c79529ec6917ed3feda289380a1e
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:fe85df7dc646f29552dab0ebd7e6e6e1cc6f4a5ce83e724693cf0fece5b8f8ac
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -27,7 +27,7 @@ jobs:
         run: |
           # Copy wolfictl out of the wolfictl image and onto PATH
           TMP=$(mktemp -d)
-          docker run --rm -i -v $TMP:/out --entrypoint /bin/sh ghcr.io/wolfi-dev/sdk:latest@sha256:844ffd2d222627faee5c8793c1103fa523a8c79529ec6917ed3feda289380a1e -c "cp /usr/bin/wolfictl /out"
+          docker run --rm -i -v $TMP:/out --entrypoint /bin/sh ghcr.io/wolfi-dev/sdk:latest@sha256:fe85df7dc646f29552dab0ebd7e6e6e1cc6f4a5ce83e724693cf0fece5b8f8ac -c "cp /usr/bin/wolfictl /out"
           echo "$TMP" >> $GITHUB_PATH
 
       # Assuming that we have a list of changed files such as `foo.yaml` and `bar.yaml`, this
@@ -58,7 +58,7 @@ jobs:
       group: wolfi-builder-${{ matrix.arch }}
     needs: changes
     container:
-      image: ghcr.io/wolfi-dev/sdk:latest@sha256:844ffd2d222627faee5c8793c1103fa523a8c79529ec6917ed3feda289380a1e
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:fe85df7dc646f29552dab0ebd7e6e6e1cc6f4a5ce83e724693cf0fece5b8f8ac
       options: |
         --cap-add NET_ADMIN --cap-add SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor:unconfined
     outputs:
@@ -142,7 +142,7 @@ jobs:
     name: "Scan packages for CVEs"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/wolfi-dev/sdk:latest@sha256:844ffd2d222627faee5c8793c1103fa523a8c79529ec6917ed3feda289380a1e
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:fe85df7dc646f29552dab0ebd7e6e6e1cc6f4a5ce83e724693cf0fece5b8f8ac
     needs: build
     if: needs.build.outputs.packages_were_built == 'true'
 

--- a/.github/workflows/lint-world.yaml
+++ b/.github/workflows/lint-world.yaml
@@ -29,7 +29,7 @@ jobs:
       group: wolfi-os-builder-${{ matrix.arch }}
 
     container:
-      image: ghcr.io/wolfi-dev/sdk:latest@sha256:844ffd2d222627faee5c8793c1103fa523a8c79529ec6917ed3feda289380a1e
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:fe85df7dc646f29552dab0ebd7e6e6e1cc6f4a5ce83e724693cf0fece5b8f8ac
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -22,7 +22,7 @@ jobs:
         run: |
           # Copy wolfictl out of the wolfictl image and onto PATH
           TMP=$(mktemp -d)
-          docker run --rm -i -v $TMP:/out --entrypoint /bin/sh ghcr.io/wolfi-dev/sdk:latest@sha256:844ffd2d222627faee5c8793c1103fa523a8c79529ec6917ed3feda289380a1e -c "cp /usr/bin/wolfictl /out"
+          docker run --rm -i -v $TMP:/out --entrypoint /bin/sh ghcr.io/wolfi-dev/sdk:latest@sha256:fe85df7dc646f29552dab0ebd7e6e6e1cc6f4a5ce83e724693cf0fece5b8f8ac -c "cp /usr/bin/wolfictl /out"
           echo "$TMP" >> $GITHUB_PATH
 
       - name: 'Authenticate to Google Cloud'

--- a/.github/workflows/wolfictl-check-update.yaml
+++ b/.github/workflows/wolfictl-check-update.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Check
       id: check
       if: ${{ steps.files.outputs.all_changed_files != '' }}
-      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:3b0cef91853cd10619071234c663bc1b6db457548276bd513e301c8eb6c71ea0
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:7c137cd6a8e88f750a593b12d8a8a3b9064207fea2200bef60c8c862910d7694
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/wolfictl-lint.yaml
+++ b/.github/workflows/wolfictl-lint.yaml
@@ -19,13 +19,13 @@ jobs:
     - uses: actions/checkout@v4
     - name: Lint
       id: lint
-      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:3b0cef91853cd10619071234c663bc1b6db457548276bd513e301c8eb6c71ea0
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:7c137cd6a8e88f750a593b12d8a8a3b9064207fea2200bef60c8c862910d7694
       with:
         entrypoint: wolfictl
         args: lint --skip-rule no-makefile-entry-for-package
     - name: Enforce YAML formatting
       id: lint-yaml
-      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:3b0cef91853cd10619071234c663bc1b6db457548276bd513e301c8eb6c71ea0
+      uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:7c137cd6a8e88f750a593b12d8a8a3b9064207fea2200bef60c8c862910d7694
       with:
         entrypoint: wolfictl
         args: lint yam

--- a/.github/workflows/wolfictl-update-gh.yaml
+++ b/.github/workflows/wolfictl-update-gh.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:3b0cef91853cd10619071234c663bc1b6db457548276bd513e301c8eb6c71ea0
+    - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:7c137cd6a8e88f750a593b12d8a8a3b9064207fea2200bef60c8c862910d7694
       with:
         entrypoint: wolfictl
         args: update https://github.com/${{github.repository}} --release-monitoring-query=false --github-labels request-version-update --github-labels "automated pr"

--- a/.github/workflows/wolfictl-update-rm.yaml
+++ b/.github/workflows/wolfictl-update-rm.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:3b0cef91853cd10619071234c663bc1b6db457548276bd513e301c8eb6c71ea0
+    - uses: docker://ghcr.io/wolfi-dev/wolfictl:latest@sha256:7c137cd6a8e88f750a593b12d8a8a3b9064207fea2200bef60c8c862910d7694
       with:
         entrypoint: wolfictl
         args: update https://github.com/${{github.repository}} --github-release-query=false --github-labels request-version-update --github-labels "automated pr"

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ dev-container:
 	    -v "${PWD}:${PWD}" \
 	    -w "${PWD}" \
 	    -e SOURCE_DATE_EPOCH=0 \
-	    ghcr.io/wolfi-dev/sdk:latest@sha256:844ffd2d222627faee5c8793c1103fa523a8c79529ec6917ed3feda289380a1e
+	    ghcr.io/wolfi-dev/sdk:latest@sha256:fe85df7dc646f29552dab0ebd7e6e6e1cc6f4a5ce83e724693cf0fece5b8f8ac
 
 PACKAGES_CONTAINER_FOLDER ?= /work/packages
 TMP_REPOSITORIES_DIR := $(shell mktemp -d)
@@ -156,6 +156,6 @@ dev-container-wolfi:
 		--mount type=bind,source="${PWD}/local-melange.rsa.pub",destination="/etc/apk/keys/local-melange.rsa.pub",readonly \
 		--mount type=bind,source="$(TMP_REPOSITORIES_FILE)",destination="/etc/apk/repositories",readonly \
 		-w "$(PACKAGES_CONTAINER_FOLDER)" \
-		ghcr.io/wolfi-dev/sdk:latest@sha256:844ffd2d222627faee5c8793c1103fa523a8c79529ec6917ed3feda289380a1e
+		ghcr.io/wolfi-dev/sdk:latest@sha256:fe85df7dc646f29552dab0ebd7e6e6e1cc6f4a5ce83e724693cf0fece5b8f8ac
 	@rm "$(TMP_REPOSITORIES_FILE)"
 	@rmdir "$(TMP_REPOSITORIES_DIR)"


### PR DESCRIPTION
This reverts https://github.com/wolfi-dev/os/pull/8339

This update seems to break APKINDEXes for packages

Previously reverted https://github.com/wolfi-dev/os/pull/8381 but it was the wrong one.