### PR TITLE
add configurable-http-proxy

### DIFF
--- a/configurable-http-proxy.yaml
+++ b/configurable-http-proxy.yaml
@@ -41,7 +41,6 @@ pipeline:
       - runs: |
           npm install --package-lock-only
           npm ci --production
-          npm audit fix --package-lock-only --legacy-peer-deps
       - uses: strip
 
 update:

--- a/configurable-http-proxy.yaml
+++ b/configurable-http-proxy.yaml
@@ -1,0 +1,51 @@
+package:
+  name: configurable-http-proxy
+  version: 4.6.0
+  epoch: 0
+  description: "HTTP parser written against llparse"
+  copyright:
+    - license: BSD 3-Clause
+  dependencies:
+    runtime:
+      - nodejs-16
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - python3
+      - nodejs-16
+      - npm
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 789f171a5d4eca622e6c344b2cecdbc7aeba4e46
+      repository: https://github.com/jupyterhub/configurable-http-proxy
+      tag: ${{package.version}}
+
+  - uses: patch
+    with:
+      patches: 0001-fix-GHSA-72xf-g2v4-qvf3.patch
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/srv/${{package.name}}
+      cp chp-docker-entrypoint package.json index.js ${{targets.destdir}}/srv/${{package.name}}/
+      cp -r bin/ doc/ lib/ test/ ${{targets.destdir}}/srv/${{package.name}}/
+
+  - working-directory: ${{targets.destdir}}/srv/${{package.name}}
+    pipeline:
+      - runs: |
+          npm install --package-lock-only
+          npm ci --production
+          npm audit fix --package-lock-only --legacy-peer-deps || true
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: jupyterhub/configurable-http-proxy
+    use-tag: true

--- a/configurable-http-proxy.yaml
+++ b/configurable-http-proxy.yaml
@@ -41,7 +41,7 @@ pipeline:
       - runs: |
           npm install --package-lock-only
           npm ci --production
-          npm audit fix --package-lock-only --legacy-peer-deps || true
+          npm audit fix --package-lock-only --legacy-peer-deps
       - uses: strip
 
 update:

--- a/configurable-http-proxy/0001-fix-GHSA-72xf-g2v4-qvf3.patch
+++ b/configurable-http-proxy/0001-fix-GHSA-72xf-g2v4-qvf3.patch
@@ -1,0 +1,32 @@
+From 9fb6830f867ec7744c31464c0a56c44774af42d5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Furkan=20T=C3=BCrkal?= <furkan.turkal@chainguard.dev>
+Date: Mon, 13 Nov 2023 21:38:45 +0300
+Subject: [PATCH] fix GHSA-72xf-g2v4-qvf3
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Furkan Türkal <furkan.turkal@chainguard.dev>
+---
+ package.json | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/package.json b/package.json
+index e43466d..762cfb8 100644
+--- a/package.json
++++ b/package.json
+@@ -43,5 +43,9 @@
+     "test": "nyc jasmine JASMINE_CONFIG_PATH=test/jasmine.json",
+     "coverage-html": "nyc report --reporter=html",
+     "codecov": "nyc report --reporter=lcov && codecov"
++  },
++  "overrides": {
++    "tough-cookie": "^4.1.3",
++    "request": "^2.87.0"
+   }
+-}
++}
+\ No newline at end of file
+-- 
+2.39.2 (Apple Git-143)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
