### PR TITLE
ruby3.3 preview 3

### DIFF
--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,6 +1,6 @@
 package:
   name: ruby-3.3
-  version: 3.3.0_p2
+  version: 3.3.0_p3
   epoch: 0
   description: "the Ruby programming language"
   copyright:
@@ -35,8 +35,8 @@ vars:
 pipeline:
   - uses: fetch
     with:
-      uri: https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview2.tar.gz
-      expected-sha256: 30ce8b0fe11b37b5ac088f5a5765744b935eac45bb89a9e381731533144f5991
+      uri: https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview3.tar.gz
+      expected-sha256: 0969141be92e67e0edb84a8fb354acc98f01bd78e602a23a0f136045c82f4809
 
   - name: Configure
     runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
