### PR TITLE
Add missing wget and node deps for kubeflow-pipelines frontend

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: 2.0.3
-  epoch: 0
+  epoch: 1
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -155,6 +155,10 @@ subpackages:
 
   - name: "kubeflow-pipelines-frontend"
     description: "Kubeflow Pipelines frontend"
+    dependencies:
+      runtime:
+        - nodejs
+        - wget
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/server


### PR DESCRIPTION
Add `wget` and `nodejs` requirements to the kubeflow pipelines frontend runtime dependencies. These packages are required for the process to run, so it makes sense they live here.

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0

Here's what it looks like running locally now:

```
[sdk] ❯ node ./server/dist/server.js ./client 3000
{
  argo: {
    archiveArtifactory: 'minio',
    archiveBucketName: 'mlpipeline',
    archiveLogs: false,
    archivePrefix: 'logs'
  },
  pod: { logContainerName: 'main' },
  artifacts: 'Artifacts config contains credentials, so it is omitted',
  metadata: { envoyService: { host: 'localhost', port: '9090' } },
  pipeline: { host: 'localhost', port: '3001' },
  server: {
    apiVersion1Prefix: 'apis/v1beta1',
    apiVersion2Prefix: 'apis/v2beta1',
    basePath: '/pipeline',
    deployment: 'NOT_SPECIFIED',
    hideSideNav: false,
    port: 3000,
    staticDir: '/client'
  },
  viewer: {
    tensorboard: {
      podTemplateSpec: undefined,
      tfImageName: 'tensorflow/tensorflow'
    }
  },
  visualizations: { allowCustomVisualizations: false },
  gkeMetadata: { disabled: false },
  auth: {
    enabled: false,
    kubeflowUserIdHeader: 'x-goog-authenticated-user-email',
    kubeflowUserIdPrefix: 'accounts.google.com:'
  }
}
[HPM] Proxy created: /  ->  http://localhost:9090
[HPM] Proxy created: /  ->  http://127.0.0.1
[HPM] Subscribed to http-proxy events:  [ 'error', 'close' ]
[HPM] Proxy created: /  ->  http://127.0.0.1
[HPM] Subscribed to http-proxy events:  [ 'error', 'close' ]
[HPM] Proxy created: /  ->  http://127.0.0.1
[HPM] Subscribed to http-proxy events:  [ 'error', 'close' ]
[HPM] Proxy created: /  ->  http://127.0.0.1
[HPM] Subscribed to http-proxy events:  [ 'error', 'close' ]
[HPM] Proxy created: /  ->  http://localhost:3001
[HPM] Subscribed to http-proxy events:  [ 'proxyReq', 'error', 'close' ]
[HPM] Proxy created: /  ->  http://localhost:3001
[HPM] Subscribed to http-proxy events:  [ 'proxyReq', 'error', 'close' ]
[HPM] Proxy created: /  ->  http://localhost:3001
[HPM] Subscribed to http-proxy events:  [ 'proxyReq', 'error', 'close' ]
[HPM] Proxy created: /  ->  http://localhost:3001
[HPM] Subscribed to http-proxy events:  [ 'proxyReq', 'error', 'close' ]
Server listening at http://localhost:3000
```
