### PR TITLE
argo-cd-2.9: new version stream

### DIFF
--- a/argo-cd-2.9.yaml
+++ b/argo-cd-2.9.yaml
@@ -1,0 +1,115 @@
+package:
+  name: argo-cd-2.9
+  version: 2.9.0
+  epoch: 0
+  description: Declarative continuous deployment for Kubernetes.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - argo-cd=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - nodejs-20
+      - python3
+      - yarn
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/argoproj/argo-cd
+      tag: v${{package.version}}
+      expected-commit: 9cf0c69bbe70393db40e5755e34715f30179ee09
+
+  - runs: |
+      cd ui
+      yarn install
+      yarn cache clean
+      NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTIONS=--max_old_space_size=8192 yarn build
+
+      cd ..
+
+      # Our global LDFLAGS conflict with a Makefile parameter
+      unset LDFLAGS
+      # Our global `-pie` flag results in a binary that cannot be copied to a non chainguard image
+      # Disable the `-pie` flag here since ArgoCD's helm charts like to copy around the multicall binary to different images (ie: dex)
+
+      unset GOFLAGS
+
+      # CVE-2023-3955/GHSA-q78c-gwqw-jcmc
+      go get k8s.io/kubernetes@v1.24.17
+      go get google.golang.org/grpc@v1.56.3
+      go get golang.org/x/net@v0.17.0
+
+      go mod tidy
+
+      make argocd-all
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv dist/argocd* ${{targets.destdir}}/usr/bin/
+
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-server
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-repo-server
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-cmp-server
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-application-controller
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-notifications
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-applicationset-controller
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-k8s-auth
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-repo-server
+    description: "ArgoCD repo server"
+    dependencies:
+      runtime:
+        - argo-cd-2.9-compat
+        - git
+        - git-lfs
+        - gnupg
+        - gpg
+        - gpg-agent
+        - tzdata
+        - helm
+        - kustomize
+        - openssh
+      provides:
+        - argo-cd-repo-server=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          cp hack/gpg-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/gpg-wrapper.sh
+          cp hack/git-verify-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/git-verify-wrapper.sh
+
+  - name: ${{package.name}}-compat
+    description: "Compatibility package for locating binaries according to upstream helm charts"
+    pipeline:
+      - runs: |
+          # ArgoCD manifests and helm charts all hardcode the executables path to /usr/local/bin/*
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
+          # This must be copied and not symlinked due to how `argocd` copies executables between (init)containers
+          # example: https://github.com/argoproj/argo-helm/blob/argo-cd-5.33.1/charts/argo-cd/templates/dex/deployment.yaml#L136-L143
+          cp ${{targets.destdir}}/usr/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd
+
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-server
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-repo-server
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-cmp-server
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-application-controller
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-notifications
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-applicationset-controller
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-k8s-auth
+    dependencies:
+      provides:
+        - argo-cd-compat=${{package.full-version}}
+
+update:
+  enabled: true
+  github:
+    identifier: argoproj/argo-cd
+    strip-prefix: v
+    tag-filter: v2.9.


### PR DESCRIPTION

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)


