### PR TITLE
Fix the redis/igbinary packages.

### DIFF
--- a/php-8.1-igbinary.yaml
+++ b/php-8.1-igbinary.yaml
@@ -1,0 +1,67 @@
+package:
+  name: php-8.1-igbinary
+  version: 3.2.14
+  epoch: 0
+  description: "Igbinary is a drop in replacement for the standard php serializer."
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - php-8.1
+      - ${{package.name}}-config
+    provides:
+      - php-igbinary=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.1
+      - php-8.1-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/igbinary/igbinary
+      tag: ${{package.version}}
+      expected-commit: 102ad68159791e76667f8455cbc171e6ec78253c
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      ./configure CFLAGS="-O2 -g" --enable-igbinary
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      set -x
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-igbinary-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
+  - name: ${{package.name}}-dev
+    description: PHP 8.1 igbinary development headers
+    dependencies:
+      provides:
+        - php-igbinary-dev=${{package.full-version}}
+    pipeline:
+      - uses: split/dev
+
+
+update:
+  enabled: true
+  github:
+    identifier: igbinary/igbinary

--- a/php-8.1-igbinary.yaml
+++ b/php-8.1-igbinary.yaml
@@ -7,8 +7,8 @@ package:
     - license: BSD-3-Clause
   dependencies:
     runtime:
-      - php-8.1
       - ${{package.name}}-config
+      - php-8.1
     provides:
       - php-igbinary=${{package.full-version}}
 
@@ -52,6 +52,7 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
+
   - name: ${{package.name}}-dev
     description: PHP 8.1 igbinary development headers
     dependencies:
@@ -59,7 +60,6 @@ subpackages:
         - php-igbinary-dev=${{package.full-version}}
     pipeline:
       - uses: split/dev
-
 
 update:
   enabled: true

--- a/php-8.1-redis.yaml
+++ b/php-8.1-redis.yaml
@@ -1,5 +1,5 @@
 package:
-  name: php-redis
+  name: php-8.1-redis
   version: 5.3.7
   epoch: 0
   description: "A PHP extension for Redis"
@@ -7,16 +7,21 @@ package:
     - license: PHP-3.01
   dependencies:
     runtime:
-      - php
+      - php-8.1
+      - php-8.1-igbinary
+      - ${{package.name}}-config
+    provides:
+      - php-redis=${{package.full-version}}
 
 environment:
   contents:
     packages:
-      - build-base
       - autoconf
+      - build-base
       - busybox
-      - php
-      - php-dev
+      - php-8.1
+      - php-8.1-dev
+      - php-8.1-igbinary-dev
       - php-igbinary
 
 pipeline:
@@ -37,6 +42,23 @@ pipeline:
   - name: Make install
     runs: |
       INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-redis-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
+  - name: ${{package.name}}-dev
+    description: PHP 8.1 redis development headers
+    dependencies:
+      provides:
+        - php-redis-dev=${{package.full-version}}
+    pipeline:
+      - uses: split/dev
 
 update:
   enabled: true

--- a/php-8.1-redis.yaml
+++ b/php-8.1-redis.yaml
@@ -7,9 +7,9 @@ package:
     - license: PHP-3.01
   dependencies:
     runtime:
+      - ${{package.name}}-config
       - php-8.1
       - php-8.1-igbinary
-      - ${{package.name}}-config
     provides:
       - php-redis=${{package.full-version}}
 
@@ -52,6 +52,7 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
+
   - name: ${{package.name}}-dev
     description: PHP 8.1 redis development headers
     dependencies:

--- a/php-8.2-igbinary.yaml
+++ b/php-8.2-igbinary.yaml
@@ -1,5 +1,5 @@
 package:
-  name: php-igbinary
+  name: php-8.2-igbinary
   version: 3.2.14
   epoch: 0
   description: "Igbinary is a drop in replacement for the standard php serializer."
@@ -7,7 +7,10 @@ package:
     - license: BSD-3-Clause
   dependencies:
     runtime:
-      - php
+      - php-8.2
+      - ${{package.name}}-config
+    provides:
+      - php-igbinary=${{package.full-version}}
 
 environment:
   contents:
@@ -15,8 +18,8 @@ environment:
       - build-base
       - autoconf
       - busybox
-      - php
-      - php-dev
+      - php-8.2
+      - php-8.2-dev
 
 pipeline:
   - uses: git-checkout
@@ -39,6 +42,24 @@ pipeline:
     runs: |
       set -x
       INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-igbinary-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
+  - name: ${{package.name}}-dev
+    description: PHP 8.2 igbinary development headers
+    dependencies:
+      provides:
+        - php-igbinary-dev=${{package.full-version}}
+    pipeline:
+      - uses: split/dev
+
 
 update:
   enabled: true

--- a/php-8.2-igbinary.yaml
+++ b/php-8.2-igbinary.yaml
@@ -7,16 +7,16 @@ package:
     - license: BSD-3-Clause
   dependencies:
     runtime:
-      - php-8.2
       - ${{package.name}}-config
+      - php-8.2
     provides:
       - php-igbinary=${{package.full-version}}
 
 environment:
   contents:
     packages:
-      - build-base
       - autoconf
+      - build-base
       - busybox
       - php-8.2
       - php-8.2-dev
@@ -52,6 +52,7 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
+
   - name: ${{package.name}}-dev
     description: PHP 8.2 igbinary development headers
     dependencies:
@@ -59,7 +60,6 @@ subpackages:
         - php-igbinary-dev=${{package.full-version}}
     pipeline:
       - uses: split/dev
-
 
 update:
   enabled: true

--- a/php-8.2-redis.yaml
+++ b/php-8.2-redis.yaml
@@ -1,0 +1,65 @@
+package:
+  name: php-8.2-redis
+  version: 5.3.7
+  epoch: 0
+  description: "A PHP extension for Redis"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - php-8.2
+      - php-8.2-igbinary
+      - ${{package.name}}-config
+    provides:
+      - php-redis=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.2
+      - php-8.2-dev
+      - php-8.2-igbinary-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/phpredis/phpredis
+      tag: ${{package.version}}
+      expected-commit: 98d64ba86f37d2d3048500461f50b05f302f36ea
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure --enable-redis-igbinary
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-redis-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
+  - name: ${{package.name}}-dev
+    description: PHP 8.2 redis development headers
+    dependencies:
+      provides:
+        - php-redis-dev=${{package.full-version}}
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: phpredis/phpredis

--- a/php-8.2-redis.yaml
+++ b/php-8.2-redis.yaml
@@ -7,9 +7,9 @@ package:
     - license: PHP-3.01
   dependencies:
     runtime:
+      - ${{package.name}}-config
       - php-8.2
       - php-8.2-igbinary
-      - ${{package.name}}-config
     provides:
       - php-redis=${{package.full-version}}
 
@@ -51,6 +51,7 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
+
   - name: ${{package.name}}-dev
     description: PHP 8.2 redis development headers
     dependencies:


### PR DESCRIPTION
They were missing the php version dependency, so these would not work with anything than what they were built with. This also makes them serviceable (adds -config subpackage), so you can customize with your own -config package. Create -dev subpackage that only has the headers.

Add dependency from redis -> igbinary, which was also missing.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
