### PR TITLE
temporal-ui-server: Fix oci entrypoint

### DIFF
--- a/temporal-ui-server.yaml
+++ b/temporal-ui-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal-ui-server
   version: 2.21.3
-  epoch: 0
+  epoch: 1
   description: Golang Server for https://github.com/temporalio/ui
   copyright:
     - license: MIT License
@@ -44,6 +44,8 @@ subpackages:
 
           mkdir -p ${{targets.subpkgdir}}/home/ui-server/config
           cp docker/config-template.yaml ${{targets.subpkgdir}}/home/ui-server/
+
+          ln -s /usr/bin/ui-server ${{targets.subpkgdir}}/home/ui-server/ui-server
 
 update:
   enabled: true


### PR DESCRIPTION
This was missing a symlink to the main binary.