### PR TITLE
fix: ignore ami rebuild tags for aws-for-fluent-bit

### DIFF
--- a/aws-for-fluent-bit.yaml
+++ b/aws-for-fluent-bit.yaml
@@ -82,6 +82,8 @@ subpackages:
       - uses: strip
 
 update:
+  ignore-regex-patterns:
+    - ^\d+\.\d+.\d+\.\d+$
   enabled: true
   github:
     identifier: aws/aws-for-fluent-bit


### PR DESCRIPTION
Fixes : unnecessary bot update requests like https://github.com/wolfi-dev/os/pull/8445 for aws-fluent-bit  
Filter only tags which we need to build , the ami rebuilds are the builds of the same tag 

