### PR TITLE
Package update: gitlab-shell/14.30.1

### DIFF
--- a/gitlab-shell.yaml
+++ b/gitlab-shell.yaml
@@ -4,7 +4,7 @@
 #nolint:git-checkout-must-use-github-updates
 package:
   name: gitlab-shell
-  version: 14.30.0
+  version: 14.30.1
   epoch: 0
   description: SSH access for GitLab
   copyright:
@@ -30,7 +30,7 @@ pipeline:
     with:
       repository: https://gitlab.com/gitlab-org/gitlab-shell
       tag: v${{package.version}}
-      expected-commit: 877e2217bc1577436c84f3a5f036cc7d883e54a6
+      expected-commit: ed9058beb6c837946237318a3cd0c7d388b10752
 
   - runs: |
       go get golang.org/x/net@v0.17.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #8371 

Related:

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

