### PR TITLE
fix recovery.conf.sample not found for postgresql-11

### DIFF
--- a/postgresql-11.yaml
+++ b/postgresql-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-11
   version: "11.22"
-  epoch: 2
+  epoch: 3
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -115,8 +115,32 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/share
+
           ln -sf /usr/share/postgresql/pg_hba.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf/pg_hba.conf
           ln -sf /usr/share/postgresql/postgresql.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf/postgresql.conf
+
+          # Create symbolic links individually for each file
+          ln -sf /usr/share/postgresql/system_views.sql       ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/system_views.sql
+          ln -sf /usr/share/postgresql/sql_features.txt       ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/sql_features.txt
+          ln -sf /usr/share/postgresql/snowball_create.sql    ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/snowball_create.sql
+          ln -sf /usr/share/postgresql/recovery.conf.sample   ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/recovery.conf.sample
+          ln -sf /usr/share/postgresql/psqlrc.sample          ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/psqlrc.sample
+          ln -sf /usr/share/postgresql/postgres.shdescription ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/postgres.shdescription
+          ln -sf /usr/share/postgresql/postgres.description   ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/postgres.description
+          ln -sf /usr/share/postgresql/postgres.bki           ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/postgres.bki
+          ln -sf /usr/share/postgresql/pg_service.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/pg_service.conf.sample
+          ln -sf /usr/share/postgresql/pg_ident.conf.sample   ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/pg_ident.conf.sample
+          ln -sf /usr/share/postgresql/information_schema.sql ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/information_schema.sql
+          ln -sf /usr/share/postgresql/errcodes.txt           ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/errcodes.txt
+          ln -sf /usr/share/postgresql/conversion_create.sql  ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/conversion_create.sql
+
+          # Create symbolic links for directories
+          ln -sf  /usr/share/postgresql/timezonesets  ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/timezonesets
+          ln -sf  /usr/share/postgresql/timezone      ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/timezone
+          ln -sf  /usr/share/postgresql/tsearch_data  ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/tsearch_data
+          ln -sf  /usr/share/postgresql/extension     ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/extension
+
           ln -sf /usr/bin/initdb ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/initdb
           ln -sf /usr/bin/pg_ctl ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/pg_ctl
           ln -sf /usr/bin/pg_rewind ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/pg_rewind


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
