### PR TITLE
Fix the amqp package, split into php-8.1, php-8.2.

### DIFF
--- a/php-8.1-amqp.yaml
+++ b/php-8.1-amqp.yaml
@@ -1,23 +1,26 @@
 package:
-  name: php-amqp
+  name: php-8.1-amqp
   version: 2.1.1
-  epoch: 0
+  epoch: 1 # NB intentionally meant to be picked over previous php-amqp
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
-      - php
+      - ${{package.name}}-config
+      - php-8.1
       - rabbitmq-c
+    provides:
+      - php-amqp=${{package.full-version}}
 
 environment:
   contents:
     packages:
-      - build-base
       - autoconf
+      - build-base
       - busybox
-      - php
-      - php-dev
+      - php-8.1
+      - php-8.1-dev
       - rabbitmq-c-dev
 
 pipeline:
@@ -41,6 +44,16 @@ pipeline:
     runs: |
       set -x
       INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-amqp-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=amqp.so" > "${{targets.subpkgdir}}/etc/php/conf.d/amqp.ini"
 
 update:
   enabled: true

--- a/php-8.2-amqp.yaml
+++ b/php-8.2-amqp.yaml
@@ -1,0 +1,64 @@
+package:
+  name: php-8.2-amqp
+  version: 2.1.1
+  epoch: 1 # NB intentionally meant to be picked over previous php-amqp
+  description: "PHP extension to communicate with any AMQP compliant server"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.2
+      - rabbitmq-c
+    provides:
+      - php-amqp=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.2
+      - php-8.2-dev
+      - rabbitmq-c-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-amqp/php-amqp
+      tag: "v${{package.version}}"
+      expected-commit: 64745e34cc37a6bcac801c2a5ac77f027c38ecd7
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      set -x
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-amqp-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=amqp.so" > "${{targets.subpkgdir}}/etc/php/conf.d/amqp.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: php-amqp/php-amqp
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -216,6 +216,6 @@ aws-c-common-dev-0.9.9-r0.apk
 py3-awscrt-0.19.12-r0.apk
 geos-3.12.1-r0.apk
 geos-dev-3.12.1-r0.apk
-
 php-igbinary-3.2.14-r0
 php-redis-5.3.7-r0
+php-amqp-2.1.1-r0


### PR DESCRIPTION
Now doing this for amqp as done before for others:
https://github.com/wolfi-dev/os/pull/8431
https://github.com/wolfi-dev/os/pull/8439

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
