### PR TITLE
coreutils: Fix typo in flag

### DIFF
--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: coreutils
   version: "9.4"
-  epoch: 2
+  epoch: 3
   description: "GNU core utilities"
   copyright:
     - license: GPL-3.0-or-later
@@ -36,7 +36,7 @@ pipeline:
          --mandir=/usr/share/man \
          --infodir=/usr/share/info \
          --disable-nls \
-         --enable-no-install-programs=hostname,su,kill,uptime,groups \
+         --enable-no-install-program=hostname,su,kill,uptime,groups \
          --enable-single-binary=symlinks
 
   - uses: autoconf/make


### PR DESCRIPTION
This properly disables kill and uptime, which means we should no longer conflict with procps.