### PR TITLE
Add tinydir v1.2.5, valijson v1.0.1 and uthash v2.3.0 for building sinsp

### DIFF
--- a/tinydir.yaml
+++ b/tinydir.yaml
@@ -1,0 +1,32 @@
+package:
+  name: tinydir
+  version: "1.2.5"
+  epoch: 0
+  description: "Lightweight, portable C library that simplifies interaction with directories and files in a filesystem"
+  copyright:
+    - license: "BSD-2-Clause"
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - wolfi-baselayout
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cxong/tinydir.git
+      tag: ${{package.version}}
+      expected-commit: 4acafe7916720645bf65e19be8603acfe7acdba1
+
+  - runs: mkdir -p ${{targets.destdir}}/usr/include
+
+  - runs: cp tinydir.h ${{targets.destdir}}/usr/include/
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: cxong/tinydir

--- a/uthash.yaml
+++ b/uthash.yaml
@@ -1,0 +1,33 @@
+package:
+  name: uthash
+  version: "2.3.0"
+  epoch: 0
+  description: "Header file for providing hash table for C structures"
+  copyright:
+    - license: "BSD-2-Clause"
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - wolfi-baselayout
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/troydhanson/uthash.git
+      tag: v${{package.version}}
+      expected-commit: e493aa90a2833b4655927598f169c31cfcdf7861
+
+  - runs: mkdir -p ${{targets.destdir}}/usr/include
+
+  - runs: cp src/uthash.h ${{targets.destdir}}/usr/include/
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: troydhanson/uthash
+    strip-prefix: v

--- a/uthash.yaml
+++ b/uthash.yaml
@@ -31,3 +31,4 @@ update:
   github:
     identifier: troydhanson/uthash
     strip-prefix: v
+    use-tag: true

--- a/valijson.yaml
+++ b/valijson.yaml
@@ -1,0 +1,47 @@
+package:
+  name: valijson
+  version: "1.0.1"
+  epoch: 0
+  description: "C++ library for validating JSON schema"
+  copyright:
+    - license: "BSD-2-Clause"
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - cmake
+      - wolfi-baselayout
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tristanpenman/valijson.git
+      tag: v${{package.version}}
+      expected-commit: f7399c1a244982632671906d17f3ea77f3ccfc67
+
+  - uses: cmake/configure
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+subpackages:
+  - name: valijson-static
+    description: "C++ library for validating JSON - static libraries"
+    pipeline:
+      - uses: split/static
+
+  - name: valijson-dev
+    description: "C++ library for validating JSON - development headers"
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: tristanpenman/valijson
+    strip-prefix: v


### PR DESCRIPTION
…lco-sinsp

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
