### PR TITLE
New packages php-8.[12]-msgpack.

### DIFF
--- a/php-8.1-msgpack.yaml
+++ b/php-8.1-msgpack.yaml
@@ -1,0 +1,67 @@
+package:
+  name: php-8.1-msgpack
+  version: 2.2.0
+  epoch: 0
+  description: "A PHP extension for msgpack"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.1
+    provides:
+      - php-msgpack=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.1
+      - php-8.1-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/msgpack/msgpack-php
+      # The tag has a msgpack- prefix, but the version does not.
+      tag: msgpack-${{package.version}}
+      expected-commit: 472e987b916b51df3d8e8fabd0608e243419c5d8
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure --with-msgpack
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-msgpack-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=msgpack.so" > "${{targets.subpkgdir}}/etc/php/conf.d/msgpack.ini"
+
+  - name: ${{package.name}}-dev
+    description: PHP 8.1 msgpack development headers
+    dependencies:
+      provides:
+        - php-msgpack-dev=${{package.full-version}}
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: msgpack/msgpack-php
+    tag-filter-prefix: msgpack-
+    strip-prefix: msgpack-

--- a/php-8.2-msgpack.yaml
+++ b/php-8.2-msgpack.yaml
@@ -1,0 +1,67 @@
+package:
+  name: php-8.2-msgpack
+  version: 2.2.0
+  epoch: 0
+  description: "A PHP extension for msgpack"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.2
+    provides:
+      - php-msgpack=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.2
+      - php-8.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/msgpack/msgpack-php
+      # The tag has a msgpack- prefix, but the version does not.
+      tag: msgpack-${{package.version}}
+      expected-commit: 472e987b916b51df3d8e8fabd0608e243419c5d8
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure --with-msgpack
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-msgpack-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=msgpack.so" > "${{targets.subpkgdir}}/etc/php/conf.d/msgpack.ini"
+
+  - name: ${{package.name}}-dev
+    description: PHP 8.2 msgpack development headers
+    dependencies:
+      provides:
+        - php-msgpack-dev=${{package.full-version}}
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: msgpack/msgpack-php
+    tag-filter-prefix: msgpack-
+    strip-prefix: msgpack-


### PR DESCRIPTION
php-8.2-msgpack
```
a0b67aabeecf:/work/packages# php -m | grep msgpack
msgpack
a0b67aabeecf:/work/packages# apk info -L php-8.2-msgpack
php-8.2-msgpack-2.2.0-r0 contains:
usr/lib/php/modules/msgpack.so
var/lib/db/sbom/php-8.2-msgpack-2.2.0-r0.spdx.json

a0b67aabeecf:/work/packages# apk info -L php-8.2-msgpack-config
php-8.2-msgpack-config-2.2.0-r0 contains:
etc/php/conf.d/msgpack.ini
var/lib/db/sbom/php-8.2-msgpack-config-2.2.0-r0.spdx.json

a0b67aabeecf:/work/packages# apk info -L php-8.2-msgpack-dev
php-8.2-msgpack-dev-2.2.0-r0 contains:
usr/include/php/ext/msgpack/php_msgpack.h
var/lib/db/sbom/php-8.2-msgpack-dev-2.2.0-r0.spdx.json
```

Scan:
```
vaikas@vaikas-MBP os % wolfictl scan packages/aarch64/php-8.2-msgpack-2.2.0-r0.apk
🔎 Scanning "packages/aarch64/php-8.2-msgpack-2.2.0-r0.apk"
✅ No vulnerabilities found
```

Update:
```
wolfictl check update  --override-version 0.0.1 php-8.2-msgpack.yaml
2023/11/15 12:44:35 wolfictl update: request query, to check visit https://docs.github.com/en/graphql/overview/explorer:
<SNIP SNIP SNIP>
2023/11/15 12:44:36 attempting to bump version to 2.2.0
2023/11/15 12:44:36 processing git-checkout node
2023/11/15 12:44:36   expected-commit: 472e987b916b51df3d8e8fabd0608e243419c5d8
2023/11/15 12:44:36 wolfictl check update: cloning sources from https://github.com/msgpack/msgpack-php tag msgpack-2.2.0 into a temporary directory, this may take a while
Enumerating objects: 527, done.
Counting objects: 100% (527/527), done.
Compressing objects: 100% (276/276), done.
Total 527 (delta 380), reused 347 (delta 242), pack-reused 0
2023/11/15 12:44:36 wolfictl check update: git-checkout was successful
```

And for php-8.1-msgpack:
```
a0b67aabeecf:/work/packages# php -m | grep msgpack
msgpack
a0b67aabeecf:/work/packages# apk info -L php-8.1-msgpack
php-8.1-msgpack-2.2.0-r0 contains:
usr/lib/php/modules/msgpack.so
var/lib/db/sbom/php-8.1-msgpack-2.2.0-r0.spdx.json

a0b67aabeecf:/work/packages# apk info -L php-8.1-msgpack-config
php-8.1-msgpack-config-2.2.0-r0 contains:
etc/php/conf.d/msgpack.ini
var/lib/db/sbom/php-8.1-msgpack-config-2.2.0-r0.spdx.json

a0b67aabeecf:/work/packages# apk info -L php-8.1-msgpack-dev
php-8.1-msgpack-dev-2.2.0-r0 contains:
usr/include/php/ext/msgpack/php_msgpack.h
var/lib/db/sbom/php-8.1-msgpack-dev-2.2.0-r0.spdx.json
```

Scan:
```
vaikas@vaikas-MBP os % wolfictl scan packages/aarch64/php-8.1-msgpack-2.2.0-r0.apk
🔎 Scanning "packages/aarch64/php-8.1-msgpack-2.2.0-r0.apk"
✅ No vulnerabilities found
```

Update:
```
wolfictl check update  --override-version 0.0.1 php-8.1-msgpack.yaml
2023/11/15 12:44:40 wolfictl update: request query, to check visit https://docs.github.com/en/graphql/overview/explorer:
<SNIP SNIP SNIP >
2023/11/15 12:44:41 attempting to bump version to 2.2.0
2023/11/15 12:44:41 processing git-checkout node
2023/11/15 12:44:41   expected-commit: 472e987b916b51df3d8e8fabd0608e243419c5d8
2023/11/15 12:44:41 wolfictl check update: cloning sources from https://github.com/msgpack/msgpack-php tag msgpack-2.2.0 into a temporary directory, this may take a while
Enumerating objects: 527, done.
Counting objects: 100% (527/527), done.
Compressing objects: 100% (276/276), done.
Total 527 (delta 380), reused 347 (delta 242), pack-reused 0
2023/11/15 12:44:42 wolfictl check update: git-checkout was successful
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
