### PR TITLE
fix: ld-linux priority

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.38
-  epoch: 5
+  epoch: 6
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later
@@ -347,6 +347,7 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/etc
           mv "${{targets.destdir}}"/etc/ld.so.* "${{targets.subpkgdir}}"/etc/
     dependencies:
+      provider-priority: 10
       runtime:
         - wolfi-baselayout
 


### PR DESCRIPTION
```console
c286469f608a:/work# apk search ld-linux-aarch64.so.1
glibc-2.37-r3
ld-linux-2.38-r5
```

`glibc-2.37-r3` has priority over `ld-linux-2.38-r5`

Related: https://github.com/wolfi-dev/os/issues/5959


isolating bash package, `glibc` is in version`2.37-r3`

````console
docker run -it cgr.dev/chainguard/wolfi-base:latest
eae62fa1c99f:/#
eae62fa1c99f:/# apk update && apk add --initdb --keys-dir /etc/apk/keys --repositories-file /etc/apk/repositories --root /work bash
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
 [https://packages.wolfi.dev/os]
OK: 26780 distinct packages available
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/6) Installing ca-certificates-bundle (20230506-r0)
(2/6) Installing wolfi-baselayout (20230201-r6)
(3/6) Installing glibc (2.37-r3)
(4/6) Installing ncurses-terminfo-base (6.4_p20230722-r1)
(5/6) Installing ncurses (6.4_p20230722-r1)
(6/6) Installing bash (5.2.21-r0)
Executing glibc-2.37-r3.trigger
ERROR: glibc-2.37-r3.trigger: script exited with error 127
OK: 10 MiB in 6 packages
eae62fa1c99f:/#
````