### PR TITLE
dotnet-8: new package

### DIFF
--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,0 +1,158 @@
+package:
+  name: dotnet-8
+  version: 8.0.0
+  epoch: 0
+  description: ".NET SDK"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - icu
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - ncurses-dev
+      - clang-15
+      - clang-15-default
+      - llvm15
+      - llvm15-dev
+      - llvm15-cmake-default
+      - llvm15-tools
+      - krb5-dev
+      - zlib-dev
+      - icu-dev
+      - openssl-dev
+      - lttng-ust-dev
+      - glibc-locale-en
+      - python3
+      - cmake
+      - samurai
+      - curl
+      - bash
+      - libunwind-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/dotnet/dotnet
+      tag: v${{package.version}}
+      expected-commit: 40e7f014ff784457efffa58074549735e30772ae
+      destination: /home/build/src
+
+  - working-directory: /home/build/src
+    pipeline:
+      - runs: |
+          sed -i -E 's|( /p:BuildDebPackage=false)|\1 /p:EnablePackageValidation=false|' src/runtime/eng/SourceBuild.props
+          sed -i -E 's|( /p:BuildDebPackage=false)|\1 --cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE|' src/runtime/eng/SourceBuild.props
+          ./prep.sh --bootstrap
+      #             /p:PrebuiltPackagesPath=/home/build/src/packages \
+      - runs: |
+          ./build.sh --online --clean-while-building \
+            -- \
+            /v:n \
+            /p:ContinueOnPrebuiltBaselineError=true \
+            /p:MinimalConsoleLogOutput=false \
+            /p:SkipPortableRuntimeBuild=true
+      - runs: |
+          mkdir -p "${{targets.destdir}}"/usr/share/dotnet
+          mkdir -p "${{targets.destdir}}"/usr/bin
+      - assertions:
+          required-steps: 1
+        pipeline:
+          - if: ${{build.arch}} == 'aarch64'
+            runs: |
+              tar zxf artifacts/arm64/Release/dotnet-sdk-*.tar.gz -C "${{targets.destdir}}"/usr/share/dotnet
+          - if: ${{build.arch}} == 'x86_64'
+            runs: |
+              tar zxf artifacts/x64/Release/dotnet-sdk-*.tar.gz -C "${{targets.destdir}}"/usr/share/dotnet
+      - runs: |
+          ln -s /usr/share/dotnet/dotnet "${{targets.destdir}}"/usr/bin/dotnet
+
+  - uses: strip
+
+subpackages:
+  - name: dotnet-8-runtime
+    description: "The .NET Core Runtime, version 8"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/dotnet/shared
+          mv "${{targets.destdir}}"/usr/share/dotnet/shared/Microsoft.NETCore.App "${{targets.subpkgdir}}"/usr/share/dotnet/shared/
+    dependencies:
+      runtime:
+        - dotnet-8
+
+  - name: dotnet-8-runtime-default
+    dependencies:
+      runtime:
+        - dotnet-8-runtime
+      provides:
+        - dotnet-runtime=8
+
+  - name: aspnet-8-runtime
+    description: "The ASP.NET Core Runtime, version 8"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/dotnet/shared
+          mv "${{targets.destdir}}"/usr/share/dotnet/shared/Microsoft.AspNetCore.App "${{targets.subpkgdir}}"/usr/share/dotnet/shared/
+    dependencies:
+      runtime:
+        - dotnet-8-runtime
+
+  - name: aspnet-8-runtime-default
+    dependencies:
+      runtime:
+        - aspnet-8-runtime
+      provides:
+        - aspnet-runtime=8
+
+  - name: dotnet-8-targeting-pack
+    description: "The .NET Core targeting pack, version 7"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/dotnet/packs
+          mv "${{targets.destdir}}"/usr/share/dotnet/packs/NETStandard.Library.* "${{targets.subpkgdir}}"/usr/share/dotnet/packs/
+          mv "${{targets.destdir}}"/usr/share/dotnet/packs/Microsoft.NETCore.App.* "${{targets.subpkgdir}}"/usr/share/dotnet/packs/
+
+  - name: aspnet-8-targeting-pack
+    description: "The ASP.NET targeting pack, version 7"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/dotnet/packs
+          mv "${{targets.destdir}}"/usr/share/dotnet/packs/Microsoft.AspNetCore.App.* "${{targets.subpkgdir}}"/usr/share/dotnet/packs/
+    dependencies:
+      runtime:
+        - dotnet-8-targeting-pack
+
+  - name: dotnet-8-sdk
+    description: "The .NET Core SDK, version 7"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/dotnet
+
+          for i in sdk sdk-manifests templates; do
+            mv "${{targets.destdir}}"/usr/share/dotnet/$i "${{targets.subpkgdir}}"/usr/share/dotnet/
+          done
+    dependencies:
+      runtime:
+        - dotnet-8-runtime
+        - dotnet-8-targeting-pack
+
+  - name: dotnet-8-sdk-default
+    dependencies:
+      runtime:
+        - dotnet-8-sdk
+      provides:
+        - dotnet-sdk=8
+
+update:
+  enabled: true
+  github:
+    identifier: dotnet/dotnet
+    strip-prefix: v
+    use-tag: true
+    tag-filter: "v8"


### PR DESCRIPTION
### Pre-review Checklist

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)