### PR TITLE
temporal-ui-server: Drop explicit dockerize dep

### DIFF
--- a/temporal-ui-server.yaml
+++ b/temporal-ui-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal-ui-server
   version: 2.21.3
-  epoch: 1
+  epoch: 2
   description: Golang Server for https://github.com/temporalio/ui
   copyright:
     - license: MIT License
@@ -35,7 +35,6 @@ subpackages:
     dependencies:
       runtime:
         - bash
-        - dockerize
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/home/ui-server/


### PR DESCRIPTION
The oci entrypoint will just provide the scripts, dockerize can come in separately.