### PR TITLE
Add libsinsp to falco-libs

### DIFF
--- a/falco-libs.yaml
+++ b/falco-libs.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-libs
   version: 0.13.4
-  epoch: 0
+  epoch: 1
   description: Foundational components necessary to build Falco
   copyright:
     - license: Apache-2.0
@@ -9,6 +9,7 @@ package:
 environment:
   contents:
     packages:
+      - abseil-cpp-dev
       - autoconf
       - automake
       - bash
@@ -26,11 +27,13 @@ environment:
       - git
       - grpc-dev
       - gtest-dev
+      - icu-dev
       - jq-dev
       - json-c-dev
       - libbpf-dev
       - libelf
       - libelf-static
+      - libtbb
       - libtbb-dev
       - libtool
       - linux-headers
@@ -57,6 +60,7 @@ data:
     items:
       libscap: System capture library to manage the data capture process
       libscap-modern-ebpf: System capture library to manage the data capture process with modern eBPF driver
+      libsinsp: libsinsp
 
 subpackages:
   - range: libs
@@ -77,15 +81,23 @@ subpackages:
             -DUSE_BUNDLED_DEPS=Off \
             -DUSE_BUNDLED_JSONCPP=On \
             -DUSE_BUNDLED_VALIJSON=On \
-            -DMINIMAL_BUILD=On \
+            -DUSE_BUNDLED_TBB=Off \
             -DBUILD_LIBSCAP_MODERN_BPF=${MODERN_BPF} \
           ..
       - runs: |
           cd build
-          make scap
-
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/${{range.key}}
-          cp -R ../userspace/libscap/. "${{targets.subpkgdir}}"/usr/lib/${{range.key}}
+          if [ "${{range.key}}" == "libsinsp" ]; then
+            # sinsp depends on target scap.
+            # See https://github.com/falcosecurity/libs#build
+            make scap
+            make sinsp
+            mkdir -p "${{targets.subpkgdir}}"/usr/lib/libsinsp
+            cp -R ../userspace/libsinsp/. "${{targets.subpkgdir}}"/usr/lib/libsinsp
+          else
+            make scap
+            mkdir -p "${{targets.subpkgdir}}"/usr/lib/libscap
+            cp -R ../userspace/libscap/. "${{targets.subpkgdir}}"/usr/lib/libscap
+          fi
       - uses: strip
 
 update:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
