### PR TITLE
bump php-8.3 to rc5.

### DIFF
--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
-  version: 8.3_rc3
-  epoch: 2
+  version: 8.3_rc5
+  epoch: 0
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -59,7 +59,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://downloads.php.net/~jakub/php-${{vars.mangled-package-version}}.tar.gz
-      expected-sha512: 65646f32ede196a622372cc13cb548785613e4ac82d7e776a71ad316cef75b1ead36f75a3bca95c488b9dc85803c0ea77ded9c838dac8df15591482ea77e7296
+      expected-sha512: e247bc85f068ac160ee87c56e9187345013e294932c53ce7774f8a66d0297ad4a8add15a96114e5665c3014ad25c642ec620d33d265c51b44e005c91d2dc0d79
       extract: false
 
   - name: Prepare Build Folder


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
