### PR TITLE
ko/0.15.1 package update

### DIFF
--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
-  version: 0.15.0
-  epoch: 1
+  version: 0.15.1
+  epoch: 0
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0
@@ -19,13 +19,12 @@ pipeline:
   - uses: git-checkout
     with:
       destination: ko
-      expected-commit: 31035ad2026bfbafaa4f009baefe72463af1b3a7
+      expected-commit: 2e9e58b187e1092534fbfc9889a04725da4a403d
       repository: https://github.com/ko-build/ko
       tag: v${{package.version}}
 
   - uses: go/build
     with:
-      deps: google.golang.org/grpc@v1.58.3
       ldflags: -w -X github.com/google/ko/pkg/commands.Version=${{package.version}}
       modroot: ko
       output: ko


### PR DESCRIPTION
- ko/0.15.1 package update

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/517

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

