### PR TITLE
fix: cert-manager 1.13 CVE-2023-47108

### DIFF
--- a/cert-manager-1.13.yaml
+++ b/cert-manager-1.13.yaml
@@ -35,10 +35,10 @@ pipeline:
         # CVE-2023-39325 and CVE-2023-3978
         go get golang.org/x/net@v0.17.0
 
-        # CVE-2023-45142
-        go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
-        go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.45.0
-        go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.18
+        # CVE-2023-47108
+        go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
+        go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+        go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.20.0
         go mod tidy
         cd ../..
       done

--- a/cert-manager-1.13.yaml
+++ b/cert-manager-1.13.yaml
@@ -2,7 +2,7 @@ package:
   name: cert-manager-1.13
   # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
   version: 1.13.2
-  epoch: 0
+  epoch: 1
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,7 @@ pipeline:
   # the makefile hardcodes the requirement for some container runtime (CTR), even when we don't need it
   # to workaround, set CTR to anything $(command -v)able
   - runs: |
-      for mod in controller webhook cainjector acmesolver; do
+      for mod in controller webhook cainjector acmesolver ctl; do
         cd cmd/$mod
         # CVE-2023-39325 and CVE-2023-3978
         go get golang.org/x/net@v0.17.0
@@ -39,6 +39,9 @@ pipeline:
         go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
         go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
         go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.20.0
+        # GHSA-jq35-85cj-fj4p
+        go get github.com/docker/docker@v24.0.7
+        go get oras.land/oras-go@v1.2.4
         go mod tidy
         cd ../..
       done


### PR DESCRIPTION
```
wolfictl scan  packages/aarch64/cert-manager-1.13-controller-1.13.2-r0.apk
🔎 Scanning "packages/aarch64/cert-manager-1.13-controller-1.13.2-r0.apk"
✅ No vulnerabilities found
```