### PR TITLE
envoy: build envoys using libc++ as intended by upstream

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -1,7 +1,7 @@
 package:
   name: envoy
   version: 1.28.0
-  epoch: 0
+  epoch: 1
   description: Cloud-native high-performance edge/middle/service proxy
   copyright:
     - license: Apache-2.0
@@ -28,10 +28,11 @@ environment:
       - llvm-lld-15
       - llvm15-tools
       - llvm15-cmake-default
+      - llvm-libcxx-15
+      - llvm-libcxx-15-dev
+      - llvm-libcxxabi-15
       - coreutils
       - patch
-      # We need to stick to gcc 12 for now, envoy doesn't build with gcc >= 13
-      - gcc-12-default
 
 pipeline:
   - uses: git-checkout
@@ -42,10 +43,6 @@ pipeline:
       destination: envoy
 
   - runs: |
-      # Apply https://github.com/envoyproxy/envoy/pull/29261/files so build
-      # can work with make > 4.3
-      cp -f luajit.patch envoy/bazel/foreign_cc
-
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
       mkdir -p .cache/bazel/_bazel_root
 
@@ -54,7 +51,7 @@ pipeline:
       sed -i 's/envoy_dependencies_extra()/envoy_dependencies_extra(ignore_root_user_error=True)/g' WORKSPACE
 
       ./bazel/setup_clang.sh /usr
-      echo "build --config=clang" >> user.bazelrc
+      echo "build --config=libc++" >> user.bazelrc
 
       bazel build --verbose_failures -c opt envoy
 


### PR DESCRIPTION
Make envoy builds use `libc++` as intended by upstreams.

Fixes: #8486

Related:

### Pre-review Checklist

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
