### PR TITLE
llvm-libcxx: fix build flags

### DIFF
--- a/llvm-libcxx-16.yaml
+++ b/llvm-libcxx-16.yaml
@@ -23,7 +23,6 @@ environment:
       - python3
       - curl
       - clang
-      - libstdc++-dev
 
 pipeline:
   - uses: git-checkout
@@ -33,15 +32,14 @@ pipeline:
       expected-commit: 7cbf1a2591520c2491aa35339f227775f4d3adf6
 
   - runs: |
-      gccver=$(gcc -dumpversion)
-      CC=clang CXX=clang cmake -G Ninja -S runtimes -B build \
-        -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
+      cmake -G Ninja -S runtimes -B build \
+        -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
         -DLLVM_INCLUDE_TESTS=OFF \
-        -DLIBCXX_INCLUDE_BENCHMARKS=OFF \
-        -DLIBCXX_CXX_ABI=libstdc++ \
-        -DLLVM_BUILD_LLVM_DYLIB=ON \
-        -DLIBCXX_CXX_ABI_INCLUDE_PATHS=/usr/include/c++/$gccver/
+        -DLIBCXX_INCLUDE_BENCHMARKS=OFF
 
   - runs: |
       cmake --build build

--- a/llvm-libcxx-16.yaml
+++ b/llvm-libcxx-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-libcxx-16
   version: 16.0.6
-  epoch: 1
+  epoch: 2
   description: The LLVM libc++ libraries
   copyright:
     - license: Apache-2.0

--- a/llvm-libcxx-17.yaml
+++ b/llvm-libcxx-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-libcxx-17
   version: 17.0.5
-  epoch: 0
+  epoch: 1
   description: The LLVM libc++ libraries
   copyright:
     - license: Apache-2.0

--- a/llvm-libcxx-17.yaml
+++ b/llvm-libcxx-17.yaml
@@ -23,7 +23,6 @@ environment:
       - python3
       - curl
       - clang
-      - libstdc++-dev
 
 pipeline:
   - uses: git-checkout
@@ -33,15 +32,14 @@ pipeline:
       expected-commit: 98bfdac5ce82d1679f8af9a57501471812ab68d7
 
   - runs: |
-      gccver=$(gcc -dumpversion)
-      CC=clang CXX=clang cmake -G Ninja -S runtimes -B build \
-        -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
+      cmake -G Ninja -S runtimes -B build \
+        -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
         -DLLVM_INCLUDE_TESTS=OFF \
-        -DLIBCXX_INCLUDE_BENCHMARKS=OFF \
-        -DLIBCXX_CXX_ABI=libstdc++ \
-        -DLLVM_BUILD_LLVM_DYLIB=ON \
-        -DLIBCXX_CXX_ABI_INCLUDE_PATHS=/usr/include/c++/$gccver/
+        -DLIBCXX_INCLUDE_BENCHMARKS=OFF
 
   - runs: |
       cmake --build build


### PR DESCRIPTION
Copy build flags from `llvm-libcxx-15` to `llvm-libcxx-16` and `llvm-libcxx-17`, current build flags break `llvm-libcxxabi` and makes them unusable to some proyects such as envoy.

Related: #8688, https://github.com/wolfi-dev/os/pull/5122

### Pre-review Checklist
#### For PRs that add patches
- [x] Patch source is documented
