### PR TITLE
Mitigate GHSA-87x9-7grx-m28v/GHSA-xhg5-42rf-296r and CVE-2023-47108 for kyverno

### DIFF
--- a/kyverno.yaml
+++ b/kyverno.yaml
@@ -30,6 +30,11 @@ pipeline:
       # Mitigate GHSA-87x9-7grx-m28v/GHSA-xhg5-42rf-296r
       go get github.com/notaryproject/notation-go@v1.0.1
 
+      # Mitigate CVE-2023-47108/GHSA-8pgv-569h-w5rw
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@v0.43.0
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
+
       make build-all
       mkdir -p ${{targets.destdir}}/usr/bin
       install -Dm755 cmd/kyverno/kyverno ${{targets.destdir}}/usr/bin/kyverno

--- a/kyverno.yaml
+++ b/kyverno.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno
   version: 1.11.0
-  epoch: 0
+  epoch: 1
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,9 @@ pipeline:
       tag: v${{package.version}}
 
   - runs: |
+      # Mitigate GHSA-87x9-7grx-m28v/GHSA-xhg5-42rf-296r
+      go get github.com/notaryproject/notation-go@v1.0.1
+
       make build-all
       mkdir -p ${{targets.destdir}}/usr/bin
       install -Dm755 cmd/kyverno/kyverno ${{targets.destdir}}/usr/bin/kyverno


### PR DESCRIPTION
- Mitigate GHSA-87x9-7grx-m28v/GHSA-xhg5-42rf-296r for kyverno
- Mitigate CVE-2023-47108

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/522



