### PR TITLE
Support incremental package uploads

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,12 +79,17 @@ jobs:
             MELANGE_EXTRA_OPTS="--keyring-append=/gcsfuse/wolfi-registry/wolfi-signing.rsa.pub" \
             all -j1
 
-      - run: |
+      # Always run this step for https://github.com/wolfi-dev/os/issues/8698
+      - if: ${{ always() }}
+        name: 'Create artifacts tarball'
+        run: |
           # Clean up the symlinks and create an archive for uploading
           find ./packages/${{ matrix.arch }} -type l -exec rm -f {} \;
           tar -cvzf /tmp/packages-${{ matrix.arch }}.tar.gz ./packages/${{ matrix.arch }}
 
-      - name: 'Upload built packages archive to Github Artifacts'
+      # Always run this step for https://github.com/wolfi-dev/os/issues/8698
+      - if: ${{ always() }}
+        name: 'Upload built packages archive to GitHub Artifacts'
         uses: actions/upload-artifact@v3
         with:
           name: packages-${{ matrix.arch }}
@@ -92,9 +97,12 @@ jobs:
           retention-days: 1 # Low ttl since this is just an intermediary used once
           if-no-files-found: warn
 
-  upload:
+  upload-packages:
     runs-on: ubuntu-latest
     needs: build
+
+    # Always run this job for https://github.com/wolfi-dev/os/issues/8698
+    if: ${{ always() }}
 
     permissions:
       id-token: write
@@ -159,8 +167,75 @@ jobs:
             fi
           done
 
-      - name: 'Upload the repository to the bucket'
+      - name: 'Upload packages to GCS'
         run: |
+          for arch in "x86_64" "aarch64"; do
+            # Only attempt to upload when *.apk's exist
+            apks=$(ls ./packages/${arch}/*.apk 2>/dev/null || true)
+            if [ -n "$apks" ]; then
+              # apks will be cached in CDN for an hour by default.
+              # Don't upload the object if it already exists.
+              gcloud --quiet storage cp \
+                  --no-clobber \
+                  "./packages/${arch}/*.apk" "gs://wolfi-production-registry-destination/os/${arch}/"
+            fi
+          done
+
+      - name: 'Create APKINDEX tarball'
+        run: |
+          # Tar up any 'APKINDEX.*' files {aarch64,x86_64} x {tar.gz,json}
+          find ./packages/ -name 'APKINDEX.*' > to-include
+          tar -cvzf /tmp/indexes.tar.gz --files-from to-include
+
+      - name: 'Upload APKINDEX archive to GitHub Artifacts'
+        uses: actions/upload-artifact@v3
+        with:
+          name: indexes
+          path: /tmp/indexes.tar.gz
+          retention-days: 1 # Low ttl since this is just an intermediary used once
+          if-no-files-found: warn
+
+  upload-index:
+    runs-on: ubuntu-latest
+    needs: upload-packages
+
+    permissions:
+      id-token: write
+      contents: read
+
+    container:
+      # NOTE: This step only signs and uploads, so it doesn't need any privileges
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:bb5769922852c5a389e7ef2dfaab1d07312dd2cbad66552df77dfefe4c1d022d
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 'Trust the github workspace'
+        run: |
+          # This is to avoid fatal errors about "dubious ownership" because we are
+          # running inside of a container action with the workspace mounted in.
+          git config --global --add safe.directory "$(pwd)"
+
+      - id: auth
+        name: 'Authenticate to Google Cloud'
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
+          service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
+
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: prod-images-c6e5
+
+      - name: 'Download index archive'
+        uses: actions/download-artifact@v3
+        with:
+          path: /tmp/artifacts/
+          name: indexes
+
+      - name: 'Upload indexes to GCS'
+          tar xvf /tmp/artifacts/indexes.tar.gz
+
           for arch in "x86_64" "aarch64"; do
             # Don't cache the APKINDEX.
             gcloud --quiet storage cp \
@@ -170,16 +245,6 @@ jobs:
             gcloud --quiet storage cp \
                 --cache-control=no-store \
                 "./packages/${arch}/APKINDEX.json" "gs://wolfi-production-registry-destination/os/${arch}/"
-
-            # Only attempt to sign when *.apk's exist
-            apks=$(ls ./packages/${arch}/*.apk 2>/dev/null || true)
-            if [ -n "$apks" ]; then
-              # apks will be cached in CDN for an hour by default.
-              # Don't upload the object if it already exists.
-              gcloud --quiet storage cp \
-                  --no-clobber \
-                  "./packages/${arch}/*.apk" "gs://wolfi-production-registry-destination/os/${arch}/"
-            fi
           done
 
   postrun:


### PR DESCRIPTION
Fixes https://github.com/wolfi-dev/os/issues/8698

Currently, we build any out of date packages as part of this workflow. If the build step of the workflow failsf or any package, we don't proceed to the "upload" job, which means we don't upload any of the packages that were successfully built.

This change splits the "upload" job into "upload-packages" and "upload-index".

The "upload-packages" job will always run. It signs the packages and indexes, but only uploads the packages to GCS; the indexes get uploaded to GHA Artifacts.

The "upload-index" job only runs if the "build" job succeeded. It downloads the indexes from GHA Artifacts and uploads them to GCS.
