### PR TITLE
istio-envoy-1.18: build envoy using libc++ as intended by upstream

### DIFF
--- a/istio-envoy-1.18.yaml
+++ b/istio-envoy-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-envoy-1.18
   version: 1.18.5
-  epoch: 0
+  epoch: 1
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
   copyright:
     - license: Apache-2.0
@@ -34,10 +34,11 @@ environment:
       - llvm-lld-15
       - llvm15-tools
       - llvm15-cmake-default
+      - llvm-libcxx-15
+      - llvm-libcxx-15-dev
+      - llvm-libcxxabi-15
       - coreutils
       - patch
-      # We need to stick to gcc 12 for now, envoy doesn't build with gcc >= 13
-      - gcc-12-default
 
 pipeline:
   - uses: git-checkout
@@ -50,9 +51,7 @@ pipeline:
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
       mkdir -p .cache/bazel/_bazel_root
 
-      echo "build --config=clang" >> user.bazelrc
-
-      bazel build --verbose_failures -c opt envoy
+      bazel build --verbose_failures --config=libc++ -c opt envoy
 
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv bazel-bin/envoy ${{targets.destdir}}/usr/bin/envoy


### PR DESCRIPTION
Build Istio Envoy 1.18 with `libc++` as intended by upstreams.

Fixes: #8486

Related:

### Pre-review Checklist

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
