### PR TITLE
istio-envoy-1.19: build envoy using libc++ as intended by upstream

### DIFF
--- a/istio-envoy-1.19.yaml
+++ b/istio-envoy-1.19.yaml
@@ -2,7 +2,7 @@ package:
   name: istio-envoy-1.19
   # On the next version bump, please remove the make 4.4 patch.
   version: 1.19.4
-  epoch: 0
+  epoch: 1
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
   copyright:
     - license: Apache-2.0
@@ -35,6 +35,9 @@ environment:
       - llvm-lld-15
       - llvm15-tools
       - llvm15-cmake-default
+      - llvm-libcxx-15
+      - llvm-libcxx-15-dev
+      - llvm-libcxxabi-15
       - coreutils
       - patch
       # We need to stick to gcc 12 for now, envoy doesn't build with gcc >= 13
@@ -57,9 +60,7 @@ pipeline:
       sed -i "/sha256 = ENVOY_SHA256/a\\
           patches = [\"//:1b576a103463ca008c76800d1f67929c2a2ffaeb.diff\"], patch_args = [\"-p1\"]," WORKSPACE
 
-      echo "build --config=clang" >> user.bazelrc
-
-      bazel build --verbose_failures -c opt envoy
+      bazel build --verbose_failures --config=libc++ -c opt envoy
 
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv bazel-bin/envoy ${{targets.destdir}}/usr/bin/envoy


### PR DESCRIPTION
Build Istio Envoy 1.19 with `libc++` as intended by upstreams.

Fixes: #8486

Related:

### Pre-review Checklist

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
