### PR TITLE
istio-envoy-1.20: build envoy using libc++ as intended by upstream

### DIFF
--- a/istio-envoy-1.20.yaml
+++ b/istio-envoy-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-envoy-1.20
   version: 1.20.0
-  epoch: 0
+  epoch: 1
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
   copyright:
     - license: Apache-2.0
@@ -24,8 +24,6 @@ environment:
       - clang~15
       - cmake
       - coreutils
-      # We need to stick to gcc 12 for now, envoy doesn't build with gcc >= 13
-      - gcc-12-default
       - git
       - libtool
       - llvm-libcxx-15
@@ -51,8 +49,6 @@ pipeline:
   - runs: |
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
       mkdir -p .cache/bazel/_bazel_root
-
-      echo "build --config=clang" >> user.bazelrc
 
       bazel build --verbose_failures -c opt envoy
 


### PR DESCRIPTION
Build Istio Envoy 1.20 with `libc++` as intended by upstreams. We only need to stop forcing `--config=clang` because istio's `.bazelrc` specifies `--config=libc++20`.

Fixes: #8486

Related:

### Pre-review Checklist

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
