### PR TITLE
npm: remove node-gyp

### DIFF
--- a/npm.yaml
+++ b/npm.yaml
@@ -1,7 +1,7 @@
 package:
   name: npm
   version: 10.2.4
-  epoch: 0
+  epoch: 1
   description: "the npm package manager for javascript, mainline"
   copyright:
     - license: Artistic-2.0
@@ -9,9 +9,9 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
       - build-base
       - rsync
+      - wolfi-base
 
 pipeline:
   - uses: fetch
@@ -48,7 +48,7 @@ pipeline:
              -name 'readme.markdown' \) -delete
 
       rm -rf ./*/.git* ./*/doc ./*/docs ./*/examples ./*/scripts ./*/test
-      rm -rf ./node-gyp/gyp/.git*
+      rm -rf ./node-gyp/
 
       find . -type f -executable ! -name 'node-gyp*' -exec chmod -x {} \;
 
@@ -74,7 +74,6 @@ pipeline:
     runs: |
       ln -s ../lib/node_modules/npm/bin/npm-cli.js npm
       ln -s ../lib/node_modules/npm/bin/npx-cli.js npx
-      ln -s ../lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js node-gyp
 
   - working-directory: ${{targets.destdir}}/usr/share
     runs: |


### PR DESCRIPTION
remove node-gyp provided as part of npm as it causes unnecessary path issues with nodes > 19 
In kargo and ppm builds 
```
⚠️  aarch64   | node:internal/modules/cjs/loader:1048
⚠️  aarch64   |   const err = new Error(message);
⚠️  aarch64   |               ^
⚠️  aarch64   | 
⚠️  aarch64   | Error: Cannot find module 'node-gyp/bin/node-gyp.js'

```

```
exit 0
⚠️  x86_64    | node:internal/modules/cjs/loader:1077
⚠️  x86_64    |   const err = new Error(message);
⚠️  x86_64    |               ^
⚠️  x86_64    | 
⚠️  x86_64    | Error: Cannot find module 'node-gyp/bin/node-gyp.js'
⚠️  x86_64    | Require stack:
⚠️  x86_64    | - /usr/lib/node_modules/pnpm/dist/pnpm.cjs
⚠️  x86_64    | - /usr/lib/node_modules/pnpm/bin/pnpm.cjs
⚠️  x86_64    |     at Module._resolveFilename (node:internal/modules/cjs/loader:1077:15)
⚠️  x86_64    |     at Function.resolve (node:internal/modules/cjs/helpers:125:19)
⚠️  x86_64    |     at ../node_modules/.pnpm/@npmcli+run-script@7.0.1/node_modules/@npmcli/run-script/lib/make-spawn-args.js (/usr/lib/node_modules/pnpm/dist/pnpm.cjs:136003:39)
⚠️  x86_64    |     at __require (/usr/lib/node_modules/pnpm/dist/pnpm.cjs:12:50)
⚠️  x86_64    |     at ../node_modules/.pnpm/@npmcli+run-script@7.0.1/node_modules/@npmcli/run-script/lib/run-script-pkg.js (/usr/lib/node_modules/pnpm/dist/pnpm.cjs:136351:25)
```