### PR TITLE
argo-cd-2.7/2.7.15 package update and  Mitigate CVE-2023-47108/GHSA-8pgv-569h-w5rw

### DIFF
--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.7
-  version: 2.7.14
-  epoch: 8
+  version: 2.7.15
+  epoch: 0
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,7 @@ pipeline:
     with:
       repository: https://github.com/argoproj/argo-cd
       tag: v${{package.version}}
-      expected-commit: a40c95a6383baa0d9f670586a5c295021f59337c
+      expected-commit: c9ae6a10c3644ac54b6b039ff7d66572f126345c
 
   - runs: |
       cd ui

--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -47,11 +47,11 @@ pipeline:
       # CVE-2023-3955/GHSA-q78c-gwqw-jcmc
       go get k8s.io/kubernetes@v1.24.17
 
-      # CVE-2023-39325 and CVE-2023-3978
-      go get golang.org/x/net@v0.17.0
-
-      # Remediate GHSA-m425-mq94-257g
-      go get google.golang.org/grpc@v1.56.3
+      # Mitigate CVE-2023-47108/GHSA-8pgv-569h-w5rw
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+      go get go.opentelemetry.io/otel@v1.21.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+      go get go.opentelemetry.io/otel/sdk@v1.21.0
 
       go mod tidy
 


### PR DESCRIPTION
- argo-cd-2.7/2.7.15 package update and  Mitigate CVE-2023-47108/GHSA-8pgv-569h-w5rw

### Pre-review Checklist


#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/531

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

