### PR TITLE
Mitigate CVE-2023-47108/GHSA-8pgv-569h-w5rw and CVE-2023-5528/GHSA-hq6q-c2x6-hmch for aws-ebs-csi-driver

### DIFF
--- a/aws-ebs-csi-driver.yaml
+++ b/aws-ebs-csi-driver.yaml
@@ -42,6 +42,10 @@ pipeline:
       go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.21.0
       go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
       go get go.opentelemetry.io/otel/sdk@v1.21.0
+
+      # Mitigate CVE-2023-5528/GHSA-hq6q-c2x6-hmch
+      go get k8s.io/kubernetes@v1.28.4
+
       make ARCH=$(go env GOARCH)
       mkdir -p ${{targets.destdir}}/usr/bin
       cp bin/aws-ebs-csi-driver ${{targets.destdir}}/usr/bin/

--- a/aws-ebs-csi-driver.yaml
+++ b/aws-ebs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-ebs-csi-driver
   version: 1.25.0
-  epoch: 1
+  epoch: 2
   description: CSI driver for Amazon EBS.
   copyright:
     - license: Apache-2.0
@@ -35,6 +35,13 @@ pipeline:
   - runs: |
       # Our global LDFLAGS conflict with a Makefile parameter
       unset LDFLAGS
+
+      # Mitigate CVE-2023-47108/GHSA-8pgv-569h-w5rw
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+      go get go.opentelemetry.io/otel@v1.21.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.21.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+      go get go.opentelemetry.io/otel/sdk@v1.21.0
       make ARCH=$(go env GOARCH)
       mkdir -p ${{targets.destdir}}/usr/bin
       cp bin/aws-ebs-csi-driver ${{targets.destdir}}/usr/bin/


### PR DESCRIPTION
- Mitigate CVE-2023-47108/GHSA-8pgv-569h-w5rw
- Mitigate CVE-2023-5528/GHSA-hq6q-c2x6-hmch

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

