### PR TITLE
Add py3-tfx-bsl

### DIFF
--- a/py3-tfx-bsl.yaml
+++ b/py3-tfx-bsl.yaml
@@ -1,0 +1,54 @@
+package:
+  name: py3-tfx-bsl
+  version: 1.14.0
+  epoch: 0
+  description: Common code for TFX
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - py3-absl-py
+      - py3-apache-beam
+      - py3-google-api-python-client
+      - numpy
+      - py3-pandas
+      - py3-protobuf
+      - pyarrow
+      - tensorflow-core
+      - py3-tensorflow-core
+      - py3-tensorflow-metadata
+      - py3-tensorflow-serving-api
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3.10
+      - py3.10-setuptools
+      - py3.10-pip
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tensorflow/tfx-bsl
+      expected-commit: 98fe47e2368463565f95380048839d8c6ac8a682
+      tag: v${{package.version}}
+
+  - name: Download tfx-bsl from PyPI
+    runs: |
+      # FIXME: This is a hack to get around the fact that tfx-bsl is not
+      # get built as a wheel on Wolfi due to a bug in their BAZEL build
+      # system. See: https://github.com/wolfi-dev/os/pull/7199
+      # `tfx-bsl` also does not support >= Python 3.11.
+      pip install tfx-bsl --no-deps --ignore-requires-python --prefix=/usr --root=${{targets.destdir}} -i https://pypi.org/simple/ --extra-index-url https://pypi-nightly.tensorflow.org/simple
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: tensorflow/tfx-bsl
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
