### PR TITLE
keda-2.12: fix CVE-2023-45142

### DIFF
--- a/keda.yaml
+++ b/keda.yaml
@@ -2,7 +2,7 @@ package:
   name: keda
   # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
   version: 2.12.0
-  epoch: 4
+  epoch: 5
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -30,16 +30,25 @@ pipeline:
       expected-commit: 9527a7f1f2797aa5662b2b45b1d26acf22a0cd09
 
   - runs: |
-      # CVE-2023-45142
-      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.19.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v0.42.0
       # CVE-2023-39325
       go get golang.org/x/net@v0.17.0
+
       # Remediate GHSA-m425-mq94-257g
       go mod edit -droprequire=google.golang.org/grpc
       go get google.golang.org/grpc@v1.58.3
+
+      # google.golang.org/grpc@v1.58.3 changes the required sigs.k8s.io/custom-metrics-apiserver version
+      go mod edit -replace=sigs.k8s.io/custom-metrics-apiserver=sigs.k8s.io/custom-metrics-apiserver@v1.28.0
+
+      # CVE-2023-45142
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v0.42.0
+      go get go.opentelemetry.io/otel/sdk@v1.21.0
+      go mod edit -droprequire=go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+
       go mod tidy
       go mod vendor
       go clean -cache -modcache


### PR DESCRIPTION
```
wolfictl scan packages/aarch64/keda-adapter-2.12.0-r8.apk
🔎 Scanning "packages/aarch64/keda-adapter-2.12.0-r8.apk"
✅ No vulnerabilities found

```