### PR TITLE
Switch to `git-checkout`, remediate `GHSA-vfp6-jrw2-99g9`.

### DIFF
--- a/policy-controller.yaml
+++ b/policy-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: policy-controller
   version: 0.8.3
-  epoch: 0
+  epoch: 1
   description: "The policy admission controller used to enforce policy on a cluster on verifiable supply-chain metadata from cosign."
   copyright:
     - license: Apache-2.0
@@ -18,10 +18,17 @@ environment:
       - make
 
 pipeline:
-  - uses: fetch
+  # Use git-checkout so that vcs.revision is properly set
+  - uses: git-checkout
     with:
-      uri: https://github.com/sigstore/policy-controller/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: 40d7c74ef141dbc762a83b6672de6b5c4a218483377fc1723b85698ae495be62
+      repository: https://github.com/sigstore/policy-controller
+      tag: v${{package.version}}
+      expected-commit: 64f222cbf5b0be6bc04dcdd050b91cdc91803025
+
+  - runs: |
+      # Mitigate GHSA-vfp6-jrw2-99g9
+      go get github.com/sigstore/cosign/v2@v2.2.1
+      go mod tidy
 
   - runs: |
       mkdir -p "${{targets.destdir}}/usr/bin"


### PR DESCRIPTION
The `git-checkout` is needed for `vcs.revision`.

ref: https://github.com/advisories/GHSA-vfp6-jrw2-99g9

### Pre-review Checklist

#### For security-related PRs
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
