### PR TITLE
Remove unnecessary `tensorflow-core` runtime dep from `model-analysis` and `serving-api`

### DIFF
--- a/py3-tensorflow-model-analysis.yaml
+++ b/py3-tensorflow-model-analysis.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tensorflow-model-analysis
   version: 0.45.0
-  epoch: 0
+  epoch: 1
   description: Model analysis tools for TensorFlow
   copyright:
     - license: Apache-2.0
@@ -21,8 +21,8 @@ package:
       - py3-scipy
       - py3-six
       - py3-attrs
-      - tensorflow-core
       - py3-tensorflow-metadata
+      - py3-tensorflow-core
       - python-3
 
 environment:

--- a/py3-tensorflow-serving-api.yaml
+++ b/py3-tensorflow-serving-api.yaml
@@ -1,14 +1,13 @@
 package:
   name: py3-tensorflow-serving-api
-  version: 2.13.1
-  epoch: 0
+  version: 2.14.0
+  epoch: 1
   description: A flexible, high-performance serving system for machine learning models
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - py3-grpcio
-      - tensorflow-core
       - py3-tensorflow-core
       - py3-protobuf
       - python-3
@@ -35,19 +34,24 @@ environment:
       - patch
       - automake
       - autoconf
+      - py3-tensorflow-core
   environment:
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: ae482b9dd12bf8dde38dd91a384a85f96a5fc09c
+      expected-commit: 84b6b8e47fb92b67df69caa88df356e73adc2ad9
       repository: https://github.com/tensorflow/serving
       tag: ${{package.version}}
 
   - runs: |
       bazel build --verbose_failures -c opt tensorflow_serving/tools/pip_package:build_pip_package
       sed -i "s|bazel-genfiles/|bazel-out/k8-opt/bin/|g" tensorflow_serving/tools/pip_package/build_pip_package.sh
+
+      # FIXME: Hack-ish workaround until we have the latest tensorflow in the Wolfi.
+      sed -i "s|>=2.14.0,<3|==2.13.0|g" tensorflow_serving/tools/pip_package/setup.py
+
       mkdir -p dist
       srcdir=$(pwd)
       bazel-bin/tensorflow_serving/tools/pip_package/build_pip_package "${srcdir}/dist"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
