### PR TITLE
Add minizip subpackage to zlib.

### DIFF
--- a/zlib.yaml
+++ b/zlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: zlib
   version: "1.3"
-  epoch: 1
+  epoch: 2
   description: "a library implementing the zlib compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT
@@ -13,6 +13,9 @@ environment:
       - busybox
       - ca-certificates-bundle
       - build-base
+      - autoconf
+      - libtool
+      - automake
 
 pipeline:
   - uses: fetch
@@ -51,6 +54,17 @@ subpackages:
     dependencies:
       runtime:
         - zlib
+
+  - name: "minizip"
+    description: "a library for manipulation with files from .zip archives"
+    pipeline:
+      - runs: |
+          cd contrib/minizip
+          autoreconf -fiv
+          ./configure --prefix=/usr \
+            --enable-static=no
+          make
+          make install DESTDIR="${{targets.contextdir}}"
 
 update:
   enabled: true


### PR DESCRIPTION
This utility is part of zlib but not built by default. It's commonly packaged into other distros.

Fixes:

Related:

