### PR TITLE
keda-2.11: fix CVE-2023-45142

### DIFF
--- a/keda-2.11.yaml
+++ b/keda-2.11.yaml
@@ -4,7 +4,7 @@ package:
   name: keda-2.11
   # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
   version: 2.11.2
-  epoch: 7
+  epoch: 8
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -32,16 +32,22 @@ pipeline:
       expected-commit: 517ed30cc311b0b81e39112cff0fa8e3251aed69
 
   - runs: |
-      # CVE-2023-45142
-      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.44.0
-      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.19.0
-      go get go.opentelemetry.io/otel/metric@v1.19.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v0.42.0
       # CVE-2023-39325
       go mod edit -dropreplace=golang.org/x/net
       go get golang.org/x/net@v0.17.0
+
+      # google.golang.org/grpc@v1.58.3 changes the required sigs.k8s.io/custom-metrics-apiserver version
+      go mod edit -replace=sigs.k8s.io/custom-metrics-apiserver=sigs.k8s.io/custom-metrics-apiserver@v1.28.0
+
+      # CVE-2023-45142 CVE-2023-47108
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v0.42.0
+      go get go.opentelemetry.io/otel/sdk@v1.21.0
+      go mod edit -droprequire=go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+
       go mod tidy
       go mod vendor
       go clean -cache -modcache


### PR DESCRIPTION
```
wolfictl scan packages/aarch64/keda-2.11-adapter-2.11.2-r8.apk
🔎 Scanning "packages/aarch64/keda-2.11-adapter-2.11.2-r8.apk"
✅ No vulnerabilities found
```