### PR TITLE
kubernetes-event-exporter bitnami

### DIFF
--- a/kubernetes-event-exporter.yaml
+++ b/kubernetes-event-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-event-exporter
-  version: 1.5
-  epoch: 0
+  version: 1.6
+  epoch: 1
   description: Export Kubernetes events to multiple destinations with routing and filtering
   copyright:
     - license: Apache-2.0
@@ -22,7 +22,7 @@ pipeline:
     with:
       repository: https://github.com/resmoio/kubernetes-event-exporter
       tag: v${{package.version}}
-      expected-commit: b892cb20dfbc6bcb8ca7b3963c8a6446161431ef
+      expected-commit: ff7498c5cc12f64886c9faed6664b0729abc442c
 
   - uses: go/build
     with:
@@ -33,6 +33,15 @@ pipeline:
       deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3
 
   - uses: strip
+
+subpackages:
+  - name: kubernetes-event-exporter-bitnami-compat
+    description: "compat package with bitnami/kubernetes-event-exporter image"
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: kubernetes-event-exporter
+          version-path: 1/debian-11
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
