### PR TITLE
Bump opentofu to alpha4.

### DIFF
--- a/opentofu.yaml
+++ b/opentofu.yaml
@@ -1,6 +1,6 @@
 package:
   name: opentofu
-  version: 1.6.0_alpha3
+  version: 1.6.0_alpha4
   epoch: 0
   copyright:
     - license: MPL-2.0
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: https://github.com/opentofu/opentofu
       tag: v${{vars.mangled-package-version}}
-      expected-commit: 52c9897b76ba18d559da87312451fc41cd104e55
+      expected-commit: 34b210d600e73144af34fc594ef12b5bddd7d175
 
   - uses: go/build
     with:


### PR DESCRIPTION
There's also an alpha5 but for completeness we should get them all and bump to that one next.
