### PR TITLE
gitlab-kas: fix CVE-2023-45142

### DIFF
--- a/gitlab-kas.yaml
+++ b/gitlab-kas.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitlab-kas
   version: 16.6.0
-  epoch: 0
+  epoch: 1
   description: GitLab Kas is a component installed together with GitLab. It is required to manage the GitLab agent for Kubernetes.
   copyright:
     - license: MIT
@@ -22,6 +22,7 @@ pipeline:
       packages: ./cmd/kas
       output: kas
       ldflags: "-w -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v16/cmd.Version=v${{package.version}} -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v16/cmd.Commit=v${{package.version}} -X gitlab.com/gitlab-org/cluster-integration/gitlab-agent/v16/cmd.BuildTime=$(date +%F-%T)"
+      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0 go.opentelemetry.io/otel/sdk@v1.21.0
 
   - uses: strip
 


### PR DESCRIPTION
```
wolfictl scan packages/aarch64/gitlab-kas-16.6.0-r0.apk
🔎 Scanning "packages/aarch64/gitlab-kas-16.6.0-r0.apk"
✅ No vulnerabilities found
```