### PR TITLE
Mitigate CVE-2023-47108/GHSA-8pgv-569h-w5rw for argo-cd-2.8

### DIFF
--- a/argo-cd-2.8.yaml
+++ b/argo-cd-2.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.8
   version: 2.8.6
-  epoch: 1
+  epoch: 2
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -43,6 +43,12 @@ pipeline:
 
       # CVE-2023-3955/GHSA-q78c-gwqw-jcmc
       go get k8s.io/kubernetes@v1.24.17
+
+      # Mitigate CVE-2023-47108/GHSA-8pgv-569h-w5rw
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+      go get go.opentelemetry.io/otel@v1.21.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+      go get go.opentelemetry.io/otel/sdk@v1.21.0
 
       go mod tidy
 


### PR DESCRIPTION
- Mitigate CVE-2023-47108/GHSA-8pgv-569h-w5rw for argo-cd-2.8

### Pre-review Checklist


#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/541


