### PR TITLE
cluster-autoscaler-1.28 fix: CVE-2023-45142

### DIFF
--- a/cluster-autoscaler-1.28.yaml
+++ b/cluster-autoscaler-1.28.yaml
@@ -26,14 +26,26 @@ pipeline:
       tag: cluster-autoscaler-${{package.version}}
       expected-commit: 5bcb526e08c17ff93cc6093ee89a95730a90e45b
 
+  - runs: |
+      cd cluster-autoscaler
+
+      # CVE-2023-5528 CVE-2023-47108
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
+      go get go.opentelemetry.io/otel/sdk@v1.21.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+      go get k8s.io/kubernetes@v1.28.4
+      go mod edit -replace=k8s.io/apiserver=k8s.io/apiserver@v0.28.4
+
+      go mod tidy
+      go mod vendor
+
   - uses: go/build
     with:
       modroot: cluster-autoscaler
       packages: .
       output: cluster-autoscaler
       ldflags: -s -w
-      # CVE-2023-39325 and CVE-2023-3978 CVE-2023-47108
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 k8s.io/kubernetes@v1.28.1 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0 go.opentelemetry.io/otel/sdk@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
       vendor: true
 
   - uses: strip

--- a/cluster-autoscaler-1.28.yaml
+++ b/cluster-autoscaler-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.28
   version: 1.28.0
-  epoch: 6
+  epoch: 7
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -32,8 +32,8 @@ pipeline:
       packages: .
       output: cluster-autoscaler
       ldflags: -s -w
-      # CVE-2023-39325 and CVE-2023-3978
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 k8s.io/kubernetes@v1.28.1
+      # CVE-2023-39325 and CVE-2023-3978 CVE-2023-47108
+      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 k8s.io/kubernetes@v1.28.1 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0 go.opentelemetry.io/otel/sdk@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
       vendor: true
 
   - uses: strip


### PR DESCRIPTION
```
wolfictl scan packages/aarch64/cluster-autoscaler-1.28-compat-1.28.0-r6.apk
🔎 Scanning "packages/aarch64/cluster-autoscaler-1.28-compat-1.28.0-r6.apk"
drop 4f997bf1 fix: CVE-2023-45142
```