### PR TITLE
Bump pulumi and pin it to python 3.11.

### DIFF
--- a/pulumi.yaml
+++ b/pulumi.yaml
@@ -1,6 +1,6 @@
 package:
   name: pulumi
-  version: 3.91.1
+  version: 3.94.2
   epoch: 1
   description: Infrastructure as Code in any programming language
   copyright:
@@ -15,8 +15,8 @@ environment:
       - go
       - nodejs
       - patch
-      - python3
-      - python3-dev
+      - python-3.11
+      - python-3.11-dev
       - yarn
   environment:
     CGO_ENABLED: "0"
@@ -28,7 +28,7 @@ pipeline:
       repository: https://github.com/pulumi/pulumi.git
       tag: v${{package.version}}
       destination: ${{package.name}}
-      expected-commit: 13e584ba91eb9ff39be4be844dcd767f93c18445
+      expected-commit: 55764eb6208e24b04d1d738e2df97e2ed774e6d0
 
   - working-directory: ${{package.name}}
     pipeline:


### PR DESCRIPTION
grpc doens't build with python 3.12 yet.

Fixes:

Related:

### Pre-review Checklist
