### PR TITLE
BLOCKED(Tensorflow 2.16): Add visualization-server

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -246,6 +246,68 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/etc/envoy/
           cp metadata-envoy-config.yaml ${{targets.subpkgdir}}/etc/envoy/metadata-envoy.yaml
 
+  - name: "kubeflow-pipelines-visualization-server"
+    description: "Kubeflow Pipelines visualization-server"
+    dependencies:
+      runtime:
+        - python3
+        - py3-bokeh
+        - py3-gcsfs
+        - py3-google-api-python-client
+        - py3-itables
+        - py3-ipykernel
+        - py3-ipython
+        - py3-jinja2
+        - py3-jupyter-client
+        - py3-markupsafe
+        - py3-nbconvert
+        - py3-nbformat
+        - py3-scikit-learn
+        - py3-tensorflow-core
+        - py3-tensorflow-metadata
+        - py3-tensorflow-model-analysis
+        - py3-tensorflow-data-validation
+        - py3-tensorflow-serving-api
+        - py3-tornado
+        - py3-mistune
+        - libgomp
+        - py3-apache-beam
+    pipeline:
+      - runs: |
+          cd backend/src/apiserver/visualization
+
+          # Remove all version constraints
+          sed -i 's/[<=>]=.*//g' requirements.in
+          sed -i 's/[<=>]=.*//g' requirements.txt
+
+          # Hack-fix for non-flat-layout project structure
+          mkdir -p ./src
+          mv *.py ./src
+
+          mkdir -p ${{targets.subpkgdir}}/etc/visualization-server
+          mv snapshots templates types ${{targets.subpkgdir}}/etc/visualization-server
+
+          python3 -m gpep517 build-wheel \
+            --wheel-dir dist \
+            --output-fd 3 3>&1 >&2
+          python3 -m installer -d "${{targets.subpkgdir}}" \
+            dist/*.whl
+          find ${{targets.subpkgdir}} -name "*.pyc" -exec rm -rf '{}' +
+
+  - name: "kubeflow-pipelines-visualization-server-compat"
+    description: "Kubeflow Pipelines visualization-server"
+    dependencies:
+      runtime:
+        - kubeflow-pipelines-visualization-server
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/kfp/visualization-server
+          ln -s /usr/lib/python3.12/site-packages/server.py "${{targets.subpkgdir}}"/kfp/visualization-server/
+          ln -s /etc/visualization-server/snapshots "${{targets.subpkgdir}}"/kfp/visualization-server/snapshots
+          ln -s /etc/visualization-server/templates "${{targets.subpkgdir}}"/kfp/visualization-server/templates
+          ln -s /etc/visualization-server/types "${{targets.subpkgdir}}"/kfp/visualization-server/types
+          rm -rf /usr/lib/python3.12/site-packages/typing.py # Newer Python versions have built-in typing module. Fixes "type object 'Callable' has no attribute '_abc_registry'" error.
+
 update:
   enabled: true
   ignore-regex-patterns:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
