### PR TITLE
fix the postgresql-11 bitnami scripts

### DIFF
--- a/postgresql-11.yaml
+++ b/postgresql-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-11
   version: "11.22"
-  epoch: 3
+  epoch: 4
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -17,6 +17,7 @@ environment:
       - ca-certificates-bundle
       - execline-dev
       - flex
+      - git
       - libedit-dev
       - libxml2-dev
       - openssl-dev
@@ -107,10 +108,27 @@ subpackages:
         - bash
         - pgaudit-11
     pipeline:
-      - uses: bitnami/compat
-        with:
-          image: postgresql
-          version-path: 11/debian-11
+      - runs: |
+          # right before the postgresql/11/debian-11 directory was deleted
+          # https://github.com/bitnami/containers/commits/main?after=69569bab0f3fc09fe53829e620228adef40275cf+209&branch=main&qualified_name=refs%2Fheads%2Fmain
+          # Deprecate PostgreSQL 11 and Odoo 14
+          git clone https://github.com/bitnami/containers.git bitnami
+          cd bitnami
+          git checkout 41ba7ded693dcaa167a47761230c50e01e71f9eb
+          cd ..
+          mkdir -p ${{targets.subpkgdir}}
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami
+          mkdir -p "${{targets.subpkgdir}}"/bitnami/postgresql
+
+          if [ -d "./bitnami/bitnami/postgresql/11/debian-11/prebuildfs" ]; then
+            cp -rf ./bitnami/bitnami/postgresql/11/debian-11/prebuildfs/* ${{targets.subpkgdir}}/
+          fi
+
+          if [ -d "./bitnami/bitnami/postgresql/11/debian-11/rootfs" ]; then
+            cp -rf ./bitnami/bitnami/postgresql/11/debian-11/rootfs/* ${{targets.subpkgdir}}/
+          fi
+
+          chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf
@@ -146,11 +164,6 @@ subpackages:
           ln -sf /usr/bin/pg_rewind ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/pg_rewind
           ln -sf /usr/bin/pg_isready /${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/pg_isready
 
+# postgresql-11 is now EOL and no longer receives updates
 update:
-  enabled: true
-  version-separator: _
-  github:
-    identifier: postgres/postgres
-    strip-prefix: REL_
-    tag-filter: REL_11
-    use-tag: true
+  enabled: false


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
