### PR TITLE
zetasql: fix builds

### DIFF
--- a/zetasql.yaml
+++ b/zetasql.yaml
@@ -1,6 +1,6 @@
 package:
   name: zetasql
-  version: 2023.10.1
+  version: 2023.11.1
   epoch: 0
   description: ZetaSQL - Analyzer Framework for SQL
   copyright:
@@ -9,20 +9,20 @@ package:
 environment:
   contents:
     packages:
-      - busybox
-      - ca-certificates-bundle
-      - wolfi-baselayout
+      - bash
+      - bazel-6
       - binutils
       - build-base
-      - git
-      - bazel-6
-      - tzdata
+      - busybox
+      - ca-certificates-bundle
       - gcc-12
+      - git
       - openjdk-17
       - openjdk-17-default-jvm
       - patch
-      - bash
       - python3
+      - tzdata
+      - wolfi-baselayout
   environment:
     BAZEL_ARGS: "--config=g++"
     EXTRA_BAZEL_ARGS: "--tool_java_runtime_version=local_jdk"
@@ -33,7 +33,7 @@ pipeline:
     with:
       repository: https://github.com/google/zetasql
       tag: ${{package.version}}
-      expected-commit: a745bef47b315bb11fecab4eeefa2bcc41be5951
+      expected-commit: 589026c410c42de9aa8ee92ad16f745977140041
 
   - uses: patch
     with:
@@ -41,7 +41,8 @@ pipeline:
 
   - runs: |
       cd zetasql
-      bazel build --verbose_failures ${BAZEL_ARGS} -c opt ...
+      bazel build --verbose_failures ${BAZEL_ARGS} $EXTRA_BAZEL_ARGS -c opt ...
+      # TODO need to copy whats required after this from either bazel-bin or bazel-out
 
   - uses: strip
 

--- a/zetasql/multi-arch-for-linux.patch
+++ b/zetasql/multi-arch-for-linux.patch
@@ -1,25 +1,8 @@
-diff --git a/bazel/zetasql_deps_step_2.bzl b/bazel/zetasql_deps_step_2.bzl
-index e9bcff3..f776bdc 100644
---- a/bazel/zetasql_deps_step_2.bzl
-+++ b/bazel/zetasql_deps_step_2.bzl
-@@ -117,9 +117,9 @@ def zetasql_deps_step_2(
-         if not native.existing_rule("six_archive"):
-             http_archive(
-                 name = "six_archive",
--                url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
--                sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
--                strip_prefix = "six-1.10.0",
-+                url = "https://pypi.python.org/packages/source/s/six/six-1.16.0.tar.gz",
-+                sha256 = "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-+                strip_prefix = "six-1.16.0",
-                 build_file_content = """licenses(["notice"])
- 
- exports_files(["LICENSE"])
 diff --git a/java/com/google/zetasql/BUILD b/java/com/google/zetasql/BUILD
-index 9fc4e24..30e9fcb 100644
+index dec4bef..3bd4fab 100644
 --- a/java/com/google/zetasql/BUILD
 +++ b/java/com/google/zetasql/BUILD
-@@ -197,7 +197,7 @@ javadoc_library(
+@@ -198,7 +198,7 @@ javadoc_library(
  java_library(
      name = "jni_channel_linux",
      resources = select({


### PR DESCRIPTION
This just fixes the build for the latest version of ZetaSQL , we still need to fill the the todo section based on what we need to the packages 