### PR TITLE
fix: bump epoch for py3.12-setuptools

### DIFF
--- a/py3.12-setuptools.yaml
+++ b/py3.12-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.12-setuptools
   version: 69.0.0
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"


### PR DESCRIPTION
The following builds are failing due to apk choosing py3.11-setuptools instead of  python3.12-setuptools , this is a work around to make sure py3.12-setuptools is picked up 

https://github.com/wolfi-dev/os/actions/runs/6936400625/job/18868499525?pr=8868
https://github.com/wolfi-dev/os/actions/runs/6935287442/job/18865956092?pr=8860
https://github.com/wolfi-dev/os/actions/runs/6938053045/job/18873195658?pr=8872