### PR TITLE
wasmtime package upgrade to 15.0.0 (FIX #8850)

### DIFF
--- a/wasmtime.yaml
+++ b/wasmtime.yaml
@@ -1,6 +1,6 @@
 package:
   name: wasmtime
-  version: 14.0.4
+  version: 15.0.0
   epoch: 0
   description: "A fast and secure runtime for WebAssembly"
   copyright:
@@ -9,25 +9,24 @@ package:
 environment:
   contents:
     packages:
-      - rust
-      - libLLVM-15
-      - wolfi-base
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
+      - libLLVM-15
+      - rust
+      - wolfi-base
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/bytecodealliance/wasmtime
       tag: v${{package.version}}
-      expected-commit: 5fc1252ff139d78b6c27d23d50a54732b0ab09aa
+      expected-commit: 6f0da842311d6de7afbb2936db347b516a298517
 
   - name: Configure and build
     runs: |
       git submodule update --init
       cargo build --release -vv
-      cargo build --release --manifest-path crates/c-api/Cargo.toml
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/wasmtime ${{targets.destdir}}/usr/bin/
 
@@ -38,6 +37,7 @@ subpackages:
     description: "c library for wasmtime"
     pipeline:
       - runs: |
+          cargo build --release --manifest-path crates/c-api/artifact/Cargo.toml
           mkdir -p ${{targets.subpkgdir}}/usr/lib/
           mv target/release/libwasmtime.* ${{targets.subpkgdir}}/usr/lib/
       - uses: strip


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #8850

The upstream has restructure the wasmtime C Lib https://github.com/bytecodealliance/wasmtime/pull/7341

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

