### PR TITLE
mitigate CVE-2023-1428 for wavefront-proxy

### DIFF
--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: wavefront-proxy
-  version: "13.4" # When version is bumped, check if patches are still needed to address CVE-2023-34462
-  epoch: 0
+  version: "13.4" # When version is bumped, check if patches are still needed to address CVE-2023-1428
+  epoch: 1
   description: Wavefront Proxy Project
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,10 @@ pipeline:
       repository: https://github.com/wavefronthq/wavefront-proxy
       tag: proxy-${{package.version}}
       expected-commit: f37ab5c70c8614fcaa5b6aeda0b448a80e733064
+
+  - uses: patch
+    with:
+      patches: CVE-2023-1428.patch
 
   - runs: |
       export LANG=en_US.UTF-8

--- a/wavefront-proxy/CVE-2023-1428.patch
+++ b/wavefront-proxy/CVE-2023-1428.patch
@@ -1,0 +1,12 @@
+diff --git a/proxy/pom.xml b/proxy/pom.xml
+index 44a5115f..9802e678 100644
+--- a/proxy/pom.xml
++++ b/proxy/pom.xml
+@@ -560,6 +560,7 @@
+     <dependency>
+       <groupId>io.grpc</groupId>
+       <artifactId>grpc-protobuf</artifactId>
++      <version>1.53.0</version>
+       <scope>compile</scope>
+     </dependency>
+     <dependency>


### PR DESCRIPTION
- mitigate CVE-2023-1428 for wavefront-proxy

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/545


