### PR TITLE
envoy-ratelimit package bump and mitigate CVE-2023-47108

### DIFF
--- a/envoy-ratelimit.yaml
+++ b/envoy-ratelimit.yaml
@@ -1,20 +1,20 @@
 package:
   name: envoy-ratelimit
   # This project doesn't do releases and everything is commit based.
-  # This corresponds to commit b9796237b9cb028d90424fd0859e10133c510a29
-  version: 0.0_git20231014
-  epoch: 3
+  # This corresponds to commit 5e1be594aed24ce8b9cdbd37400a348d8eaba2e1
+  version: 0.0_git20231110
+  epoch: 0
   description: Go/gRPC service designed to enable generic rate limit scenarios from different types of applications.
   copyright:
     - license: Apache-2.0
 
 vars:
-  commit: b9796237b9cb028d90424fd0859e10133c510a29
+  commit: 5e1be594aed24ce8b9cdbd37400a348d8eaba2e1
 
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: eabb54820149c682351b0425d0a6ae1c62b044689de1ee0146f4230de2083c64
+      expected-sha256: 093393f17fa943cffd1a79099c53c4c30e3a24c57c30a9743cd16ddc604b068c
       extract: "false"
       uri: https://github.com/envoyproxy/ratelimit/archive/${{vars.commit}}.zip
 
@@ -25,7 +25,7 @@ pipeline:
 
   - uses: go/build
     with:
-      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3
+      deps: google.golang.org/grpc@v1.56.3 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0
       modroot: ratelimit
       output: ratelimit
       packages: ./src/service_cmd


### PR DESCRIPTION
- envoy-ratelimit package bump and mitigate CVE-2023-47108

### Pre-review Checklist


#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/546

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

