### PR TITLE
Add grafana-grafonnet

### DIFF
--- a/grafana-grafonnet.yaml
+++ b/grafana-grafonnet.yaml
@@ -1,0 +1,39 @@
+package:
+  name: grafana-grafonnet
+  version: 0.0_git20231114
+  epoch: 0
+  description: Jsonnet library for generating Grafana dashboards
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+  environment:
+    GRAFONNET_VERSION: v10.0.0
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/grafana/grafonnet/archive/bb2afaffbcefeae1035cd691ab06a486e0022002.tar.gz
+      expected-sha256: 1e37ef6402aea0dcf2bf077490c25d0df1c3d7c7cc17ba56fe82ed62937dc371
+      strip-components: 1
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/opt/jsonnet/grafonnet
+      cd gen/grafonnet-$GRAFONNET_VERSION
+
+      install -m755 *.libsonnet "${{targets.destdir}}"/opt/jsonnet/grafonnet/
+      install -m755 *.json "${{targets.destdir}}"/opt/jsonnet/grafonnet/
+
+      for i in clean custom raw; do
+        mkdir -p ${{targets.destdir}}/opt/jsonnet/grafonnet/$i
+        mv $i "${{targets.destdir}}"/opt/jsonnet/grafonnet/$i/
+      done
+
+  - uses: strip
+
+update:
+  enabled: false # no releases or tags available


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
