### PR TITLE
Use git checkout and mitigate CVE-2023-47108 for etcd

### DIFF
--- a/etcd.yaml
+++ b/etcd.yaml
@@ -2,7 +2,7 @@ package:
   name: etcd
   version: 3.5.10
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
-  epoch: 0
+  epoch: 1
   description: A highly-available key value store for shared configuration and service discovery.
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,26 @@ pipeline:
       expected-commit: 0223ca52b8d6d4953f708e5e4245c37cb4274115
 
   - runs: |
+      # CVE-2023-47108
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+      go get go.opentelemetry.io/otel@v1.21.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+      go get go.opentelemetry.io/otel/sdk@v1.21.0
+
+      go mod tidy
+
+      for mod in server tests etcdutl etcdctl; do
+        cd $mod
+        # CVE-2023-47108
+        go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+        go get go.opentelemetry.io/otel@v1.21.0
+        go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+        go get go.opentelemetry.io/otel/sdk@v1.21.0
+
+        go mod tidy
+        cd ..
+      done
+
       bash -x ./build.sh
       mkdir -p "${{targets.destdir}}"/var/lib/${{package.name}}
       chmod 700 "${{targets.destdir}}"/var/lib/${{package.name}}

--- a/etcd.yaml
+++ b/etcd.yaml
@@ -21,10 +21,11 @@ environment:
       - go
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/etcd-io/etcd/archive/v${{package.version}}.tar.gz
-      expected-sha256: 23ea051e3ad6c1a8fbf2fe7164a87c68c66d736311f29703a47f12bf2f924f78
+      repository: https://github.com/etcd-io/etcd
+      tag: v${{package.version}}
+      expected-commit: 0223ca52b8d6d4953f708e5e4245c37cb4274115
 
   - runs: |
       bash -x ./build.sh


### PR DESCRIPTION
- use gitcheckout and github releases to fetch and also when building populating the correct with the correct git sha

for this before when building we got 

```
-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=GitNotFound
```

now

```
-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=0223ca5
```

- mitigate GHSA-8pgv-569h-w5rw for etcd


### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/548

