### PR TITLE
Add k8s-hub deps batch 1

### DIFF
--- a/py3-async-generator.yaml
+++ b/py3-async-generator.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/async_generator/
+package:
+  name: py3-async-generator
+  version: 1.10
+  epoch: 0
+  description: Async generators and context managers for Python 3.5+
+  copyright:
+    - license: MIT -or- Apache License 2.0
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 2c5e2e201c4dcd40b112eb3193c73f2c2b84d263
+      repository: https://github.com/python-trio/async_generator
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: python-trio/async_generator
+    strip-prefix: v
+    use-tag: true

--- a/py3-bcrypt.yaml
+++ b/py3-bcrypt.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/bcrypt/
+package:
+  name: py3-bcrypt
+  version: 4.0.1
+  epoch: 0
+  description: Modern password hashing for your software and your servers
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 98141be0809acd4accd1193f2c3b8cb9e29f022a
+      repository: https://github.com/pyca/bcrypt
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: pyca/bcrypt
+    use-tag: true

--- a/py3-certipy.yaml
+++ b/py3-certipy.yaml
@@ -1,0 +1,38 @@
+# Generated from https://pypi.org/project/certipy/
+package:
+  name: py3-certipy
+  version: 0.1.3
+  epoch: 0
+  description: Utility to create and sign CAs and certificates
+  copyright:
+    - license: BSD
+  dependencies:
+    runtime:
+      - py3-pyopenssl
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 695704b7716b033375c9a1324d0d30f27110a28895c40151a90ec07ff1032859
+      uri: https://files.pythonhosted.org/packages/3a/b3/f9228354c1eac06cd3577a981571b9188392d73d583fcaa7a8f3fb374a56/certipy-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 370308

--- a/py3-escapism.yaml
+++ b/py3-escapism.yaml
@@ -1,0 +1,39 @@
+package:
+  name: py3-escapism
+  version: 1.0.1
+  epoch: 0
+  description: Simple, generic API for escaping strings.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 29e4604e1419d1b347ec1ada5d8a84af865953b0
+      repository: https://github.com/minrk/escapism
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: minrk/escapism
+    use-tag: true

--- a/py3-jupyter-telemetry.yaml
+++ b/py3-jupyter-telemetry.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/jupyter-telemetry/
+package:
+  name: py3-jupyter-telemetry
+  version: 0.1.0
+  epoch: 0
+  description: Jupyter telemetry library
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - py3-jsonschema
+      - py3-python-json-logger
+      - py3-traitlets
+      - py3-ruamel-yaml
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 445c613ae3df70d255fe3de202f936bba8b77b4055c43207edf22468ac875314
+      uri: https://files.pythonhosted.org/packages/c4/59/edd04590235d9afe2b2b49ec449c6146dc71b717110f4a1034d52eb54303/jupyter_telemetry-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 66567

--- a/py3-jupyterhub-hmacauthenticator.yaml
+++ b/py3-jupyterhub-hmacauthenticator.yaml
@@ -1,0 +1,37 @@
+# Generated from https://pypi.org/project/jupyterhub-hmacauthenticator/
+package:
+  name: py3-jupyterhub-hmacauthenticator
+  version: 1.0
+  epoch: 0
+  description: Dummy Authenticator for JupyterHub
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: b2b220a5d3762dd43beb6e29ed1bd0e414b3de8ef8b2d1835b9986260a19c374
+      uri: https://files.pythonhosted.org/packages/cf/40/2b3c5785628d3d707fcf6ff6ce1f22652cf0dff02040b411d96389ea659c/jupyterhub-hmacauthenticator-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 370310

--- a/py3-jupyterhub-idle-culler.yaml
+++ b/py3-jupyterhub-idle-culler.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/jupyterhub-idle-culler/
+package:
+  name: py3-jupyterhub-idle-culler
+  version: 1.2.1
+  epoch: 0
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - py3-tornado
+      - py3-python-dateutil
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 238f692584c99ec4ff5da11cbdca877ad977cc19
+      repository: https://github.com/jupyterhub/jupyterhub-idle-culler
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: jupyterhub/jupyterhub-idle-culler
+    use-tag: true

--- a/py3-jupyterhub-tmpauthenticator.yaml
+++ b/py3-jupyterhub-tmpauthenticator.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/jupyterhub-tmpauthenticator/
+package:
+  name: py3-jupyterhub-tmpauthenticator
+  version: 1.0.0
+  epoch: 0
+  description: JupyterHub authenticator that hands out temporary accounts for everyone
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 5c62463c9b45699d819d3917f8ac0cda5a843e6c
+      repository: https://github.com/jupyterhub/tmpauthenticator
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: jupyterhub/tmpauthenticator
+    strip-prefix: v
+    use-tag: true

--- a/py3-ldap3.yaml
+++ b/py3-ldap3.yaml
@@ -1,0 +1,42 @@
+# Generated from https://pypi.org/project/ldap3/
+package:
+  name: py3-ldap3
+  version: 2.9.1
+  epoch: 0
+  description: A strictly RFC 4510 conforming LDAP V3 pure Python client library
+  copyright:
+    - license: LGPL-3.0-or-later
+  dependencies:
+    runtime:
+      - py3-pyasn1
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 3a2f89663c73d862b8ba7ca9e974012952ed3024
+      repository: https://github.com/cannatag/ldap3
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: cannatag/ldap3
+    strip-prefix: v
+    use-tag: true

--- a/py3-mwoauth.yaml
+++ b/py3-mwoauth.yaml
@@ -1,0 +1,45 @@
+# Generated from https://pypi.org/project/mwoauth/
+package:
+  name: py3-mwoauth
+  # Upstream released v0.4.0 on PyPI, but no source tarball was uploaded. Also repository does not provide neither tags nor releases for 0.4.0.
+  # TODO: Use semver and enable `update`, once the issue is resolved: https://github.com/mediawiki-utilities/python-mwoauth/issues/50
+  version: 0.0_git20231018
+  epoch: 0
+  description: A generic MediaWiki OAuth handshake helper.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-pyjwt
+      - py3-oauthlib
+      - py3-requests
+      - py3-requests-oauthlib
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+vars:
+  COMMIT: 2cb6b7107e5fb80353a390c9ff4b74566ced679a
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/mediawiki-utilities/python-mwoauth/archive/2cb6b7107e5fb80353a390c9ff4b74566ced679a.tar.gz
+      expected-sha256: de31a42aae05d86fb8d02c0523556281a46da364f19c1b0d4386eb8a14b4b8f5
+      strip-components: 1
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: false

--- a/py3-onetimepass.yaml
+++ b/py3-onetimepass.yaml
@@ -1,0 +1,36 @@
+# Generated from https://pypi.org/project/onetimepass/
+package:
+  name: py3-onetimepass
+  version: 1.0.1
+  epoch: 0
+  description: Module for generating and validating HOTP and TOTP tokens
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 91192c0a79d3ad1afe9e438c295dc67595cd1a4d
+      repository: https://github.com/tadeck/onetimepass
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: false # No releases since 2015

--- a/py3-pamela.yaml
+++ b/py3-pamela.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/pamela/
+package:
+  name: py3-pamela
+  version: 1.1.0
+  epoch: 0
+  description: PAM interface using ctypes
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 47e95cf188d1975fe2b6251802c0be3aa2fa6884
+      repository: https://github.com/minrk/pamela
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: minrk/pamela
+    use-tag: true

--- a/py3-pyasn1.yaml
+++ b/py3-pyasn1.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/pyasn1/
+package:
+  name: py3-pyasn1
+  version: 0.5.1
+  epoch: 0
+  description: Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)
+  copyright:
+    - license: BSD-2-Clause
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: e4f92449e189ce070203b94af29b256bec9a5152
+      repository: https://github.com/pyasn1/pyasn1
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: pyasn1/pyasn1
+    strip-prefix: v

--- a/py3-pycurl.yaml
+++ b/py3-pycurl.yaml
@@ -1,0 +1,51 @@
+package:
+  name: py3-pycurl
+  version: 7.45.2
+  epoch: 0
+  description: PycURL -- A Python Interface To The cURL library
+  copyright:
+    - license: LGPL/MIT
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - python-3-dev
+      - py3-setuptools
+      - curl-dev
+      - openssl-dev
+
+# transform melange version from REL_7_45_2 to 7.45.2
+var-transforms:
+  - from: ${{package.version}}
+    match: \.
+    replace: _
+    to: mangled-package-version
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 84f775aa5879945ceab93f81e2a5ef2d956f8719
+      repository: https://github.com/pycurl/pycurl
+      tag: REL_${{vars.mangled-package-version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  version-separator: _
+  github:
+    identifier: pycurl/pycurl
+    strip-prefix: REL_
+    tag-filter: REL_
+    use-tag: true

--- a/py3-pyopenssl.yaml
+++ b/py3-pyopenssl.yaml
@@ -1,0 +1,41 @@
+# Generated from https://pypi.org/project/pyOpenSSL/
+package:
+  name: py3-pyopenssl
+  version: 23.3.0
+  epoch: 0
+  description: Python wrapper module around the OpenSSL library
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - py3-cryptography
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 5ba8ce10ed7c318e57516a7ec8447cbb5626d3f9
+      repository: https://github.com/pyca/pyopenssl
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: pyca/pyopenssl
+    use-tag: true

--- a/py3-sqlalchemy-cockroachdb.yaml
+++ b/py3-sqlalchemy-cockroachdb.yaml
@@ -1,0 +1,38 @@
+# Generated from https://pypi.org/project/sqlalchemy-cockroachdb/
+package:
+  name: py3-sqlalchemy-cockroachdb
+  version: 2.0.1
+  epoch: 0
+  description: CockroachDB dialect for SQLAlchemy
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - py3-sqlalchemy
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: ddb46e2da53d812bf7b8ef21c3cafb918004747f815a283f374796bf57a9497a
+      uri: https://files.pythonhosted.org/packages/72/74/7157d36dee9175864f803fdbc931913dac17b0d4eee24727dbdac1244543/sqlalchemy-cockroachdb-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 91411

--- a/py3-statsd.yaml
+++ b/py3-statsd.yaml
@@ -1,0 +1,40 @@
+# Generated from https://pypi.org/project/statsd/
+package:
+  name: py3-statsd
+  version: 4.0.1
+  epoch: 0
+  description: A simple statsd client.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+      - python-3
+      - py3-setuptools
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 1325f31ace0d2f219c5ca4cc3571cb343bd76ca6
+      repository: https://github.com/jsocol/pystatsd
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: jsocol/pystatsd
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
