### PR TITLE
calico: fixing CVE-2023-5528

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.26.4
-  epoch: 0
+  epoch: 1
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64
@@ -159,6 +159,11 @@ subpackages:
               LDFLAGS="$LDFLAGS -X node/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>')"
               LDFLAGS="$LDFLAGS -X node/buildinfo.BuildDate=$(date -u +'%FT%T%z')"
               LDFLAGS="$LDFLAGS -X node/buildinfo.GitRevision=$(git rev-parse HEAD || echo '<unknown>')"
+
+              # Mitigate CVE-2023-5528
+              go mod edit -replace=k8s.io/kubernetes=k8s.io/kubernetes@v1.26.11
+              go mod edit -replace=k8s.io/apiserver=k8s.io/apiserver@v0.26.11
+              go mod tidy
 
               CGO_ENABLED=1 \
                 CGO_LDFLAGS="$CGO_LDFLAGS" \


### PR DESCRIPTION
```
wolfictl scan  packages/aarch64/calico-node-3.26.4-r1.apk
🔎 Scanning "packages/aarch64/calico-node-3.26.4-r1.apk"
✅ No vulnerabilities found
```