### PR TITLE
cluster-autoscaler-1.26: fixing CVE-2023-5528

### DIFF
--- a/cluster-autoscaler-1.26.yaml
+++ b/cluster-autoscaler-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.26
   version: 1.26.4
-  epoch: 4
+  epoch: 5
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -26,13 +26,29 @@ pipeline:
       tag: cluster-autoscaler-${{package.version}}
       expected-commit: 4256b234be902d9697537ffa226a6df445151bc3
 
+  - runs: |
+      cd cluster-autoscaler
+
+      # CVE-2023-2253
+      go get github.com/docker/distribution@v2.8.2
+
+      # CVE-2023-5528 CVE-2023-47108
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
+      go get go.opentelemetry.io/otel/sdk@v1.21.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+      go get k8s.io/kubernetes@v1.26.11
+      go mod edit -replace=k8s.io/apiserver=k8s.io/apiserver@v0.26.11
+
+      go mod tidy
+      go mod vendor
+
   - uses: go/build
     with:
       modroot: cluster-autoscaler
       packages: .
       output: cluster-autoscaler
       ldflags: -s -w
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 k8s.io/kubernetes@v1.26.8
       vendor: true
 
   - uses: strip


### PR DESCRIPTION
```
wolfictl scan  packages/aarch64/cluster-autoscaler-1.26-1.26.4-r5.apk
🔎 Scanning "packages/aarch64/cluster-autoscaler-1.26-1.26.4-r5.apk
✅ No vulnerabilities found
```