### PR TITLE
aws-efs-csi-driver: fixing CVE-2023-5528

### DIFF
--- a/aws-efs-csi-driver.yaml
+++ b/aws-efs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-efs-csi-driver
   version: 1.7.1
-  epoch: 0
+  epoch: 1
   description: CSI driver for Amazon EFS.
   copyright:
     - license: Apache-2.0
@@ -35,6 +35,13 @@ pipeline:
   - runs: |
       # Our global LDFLAGS conflict with a Makefile parameter
       unset LDFLAGS
+
+      # Mitigate CVE-2023-5528
+      go get k8s.io/kubernetes@v1.26.11
+      go mod edit -replace=k8s.io/apiserver=k8s.io/apiserver@v0.26.11
+      go mod tidy
+      go mod vendor
+
       make ARCH=$(go env GOARCH)
       install -Dm755 bin/aws-efs-csi-driver ${{targets.destdir}}/usr/bin/aws-efs-csi-driver
 


### PR DESCRIPTION
```
wolfictl scan  packages/aarch64/aws-efs-csi-driver-1.7.1-r1.apk
🔎 Scanning "packages/aarch64/aws-efs-csi-driver-1.7.1-r1.apk"
✅ No vulnerabilities found
```