### PR TITLE
prometheus-adapter: fixing CVE-2023-5528

### DIFF
--- a/prometheus-adapter.yaml
+++ b/prometheus-adapter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-adapter
   version: 0.11.2
-  epoch: 0
+  epoch: 1
   description: Prometheus Adapter for Kubernetes Metrics APIs
   copyright:
     - license: Apache-2.0
@@ -24,13 +24,11 @@ pipeline:
       # Handle CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
 
-      # Remediate GHSA-m425-mq94-257g
-      go get google.golang.org/grpc@v1.58.3
-
-      # Mitigate GHSA-rcjv-mgp8-qvmr (These are interrelated Go modules.)
-      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.19.0
+      # Mitigate CVE-2023-47108
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.21.0
       go mod tidy
 
       make prometheus-adapter


### PR DESCRIPTION
```
wolfictl scan  packages/aarch64/prometheus-adapter-0.11.2-r1.apk
🔎 Scanning "packages/aarch64/prometheus-adapter-0.11.2-r1.apk"
✅ No vulnerabilities found
```