### PR TITLE
Mitigate CVE-2023-47108 /  GHSA-jq35-85cj-fj4p / GHSA-6xv5-86q9-7xr8 for k3s and bump revision

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -93,6 +93,9 @@ pipeline:
       # CVE-2023-46129
       go get github.com/nats-io/nkeys@v0.4.6
 
+      # GHSA-6xv5-86q9-7xr8
+      go get github.com/cyphar/filepath-securejoin@v0.2.4
+
       go mod tidy
 
       ./scripts/build

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -85,6 +85,10 @@ pipeline:
       go get go.opentelemetry.io/otel/trace@v1.21.0
       go get go.opentelemetry.io/proto/otlp@v1.0.0
 
+      # GHSA-jq35-85cj-fj4
+      go mod edit -dropreplace=github.com/docker/docker
+
+      go get github.com/docker/docker@v24.0.7
 
       # CVE-2023-46129
       go get github.com/nats-io/nkeys@v0.4.6

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -36,7 +36,7 @@ var-transforms:
   # buys us enough time to add support for the k3s version scheme.
   - from: ${{package.version}}
     match: ^(.+)$
-    replace: $1+k3s1 # NOTE: Update k3s# if upstream ships a >k3s# revision
+    replace: $1+k3s2 # NOTE: Update k3s# if upstream ships a >k3s# revision
     to: full-package-version
 
 # Upstream uses `dapper` to initialize build environments, but since melange
@@ -47,7 +47,7 @@ pipeline:
     with:
       repository: https://github.com/k3s-io/k3s
       tag: v${{vars.full-package-version}}
-      expected-commit: 49411e7084f74b931882f1cf85bf2e17a5f02158
+      expected-commit: bbafb86e91ae3682a1811119d136203957df9061
   # Build things (almost) identical to upstream, with the k3s components
   # embedded in the "outer" multicall binary.
   - runs: |
@@ -198,4 +198,4 @@ update:
   github:
     identifier: k3s-io/k3s
     strip-prefix: v
-    strip-suffix: "+k3s1" # NOTE: Update k3s# if upstream ships a >k3s1 revision
+    strip-suffix: "+k3s2" # NOTE: Update k3s# if upstream ships a >k3s1 revision

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.28.3
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: Apache-2.0
@@ -58,24 +58,33 @@ pipeline:
 
       # Patch things that need patching
 
-      # CVE-2023-45142
+      # CVE-2023-47108
       go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/otlpmetric
+      go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc
       go mod edit -dropreplace=go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
       go mod edit -dropreplace=go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful
       go mod edit -dropreplace=go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
       go mod edit -dropreplace=go.opentelemetry.io/otel
+      go mod edit -dropreplace=go.opentelemetry.io/otel/sdk
+      go mod edit -dropreplace=go.opentelemetry.io/otel/trace
+      go mod edit -dropreplace=go.opentelemetry.io/proto/otlp
       go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
       go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/otlptrace
       go mod edit -dropreplace=go.opentelemetry.io/otel/metric
       go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/internal/retry
 
-      go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric@v0.42.0
-      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.44.0
-      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
-      go get go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful@v0.44.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.19.0
-      go get go.opentelemetry.io/otel/metric@v1.19.0
+      go get go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful@v0.46.1
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.1
+      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.1
+      go get go.opentelemetry.io/otel@v1.21.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@v0.44.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.21.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+      go get go.opentelemetry.io/otel/metric@v1.21.0
+      go get go.opentelemetry.io/otel/sdk@v1.21.0
+      go get go.opentelemetry.io/otel/trace@v1.21.0
+      go get go.opentelemetry.io/proto/otlp@v1.0.0
+
 
       # CVE-2023-46129
       go get github.com/nats-io/nkeys@v0.4.6


### PR DESCRIPTION
- Mitigate CVE-2023-47108 / GHSA-jq35-85cj-fj4p / GHSA-6xv5-86q9-7xr8 for k3s
- bump revision

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/557


