### PR TITLE
mitigate GHSA-2c7c-3mj9-8fqh for keda/kots/kyverno/oauth2-proxy/traefik/rekor

### DIFF
--- a/keda.yaml
+++ b/keda.yaml
@@ -2,7 +2,7 @@ package:
   name: keda
   # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
   version: 2.12.0
-  epoch: 5
+  epoch: 6
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -48,6 +48,9 @@ pipeline:
       go get go.opentelemetry.io/otel/sdk@v1.21.0
       go mod edit -droprequire=go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
       go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+
+      # GHSA-2c7c-3mj9-8fqh
+      go get github.com/go-jose/go-jose/v3@v3.0.1
 
       go mod tidy
       go mod vendor

--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
   version: 1.104.2
-  epoch: 0
+  epoch: 1
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0
@@ -45,6 +45,10 @@ pipeline:
 
       # Configure Yarn
       yarn install --pure-lockfile --network-concurrency 1
+
+
+      # GHSA-2c7c-3mj9-8fqh
+      go get github.com/go-jose/go-jose/v3@v3.0.1
 
       # removing tests for now to see if this builds
       make -C web deps lint build-kotsadm

--- a/kyverno.yaml
+++ b/kyverno.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno
   version: 1.11.0
-  epoch: 1
+  epoch: 2
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0
@@ -34,6 +34,9 @@ pipeline:
       go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
       go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@v0.43.0
       go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
+
+      # GHSA-2c7c-3mj9-8fqh
+      go get github.com/go-jose/go-jose/v3@v3.0.1
 
       make build-all
       mkdir -p ${{targets.destdir}}/usr/bin

--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: oauth2-proxy
   version: 7.5.1
-  epoch: 4
+  epoch: 5
   description: Reverse proxy and static file server that provides authentication using various providers to validate accounts by email, domain or group.
   copyright:
     - license: MIT
@@ -29,8 +29,8 @@ pipeline:
       ldflags: -s -w -X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.Version=${{package.version}}
       # GHSA-vvpx-j8f3-3w6h
       # GHSA-m425-mq94-257g
-      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
-      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487 / GHSA-2c7c-3mj9-8fqh
+      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 github.com/go-jose/go-jose/v3@v3.0.1
 
   - runs: |
       # Make sure there is at least an empty key file.

--- a/rekor.yaml
+++ b/rekor.yaml
@@ -1,7 +1,7 @@
 package:
   name: rekor
   version: 1.3.3
-  epoch: 0
+  epoch: 1
   description: Software Supply Chain Transparency Log
   target-architecture:
     - all
@@ -36,6 +36,8 @@ subpackages:
           packages: ./cmd/rekor-server
           output: rekor-server
           ldflags: -w
+          # GHSA-2c7c-3mj9-8fqh
+          deps: github.com/go-jose/go-jose/v3@v3.0.1
       - uses: strip
 
   - name: ${{package.name}}-cli
@@ -47,6 +49,8 @@ subpackages:
           packages: ./cmd/rekor-cli
           output: rekor-cli
           ldflags: -w
+          # GHSA-2c7c-3mj9-8fqh
+          deps: github.com/go-jose/go-jose/v3@v3.0.1
       - uses: strip
 
   - name: ${{package.name}}-backfill-redis

--- a/spire-server.yaml
+++ b/spire-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: spire-server
   version: 1.8.4
-  epoch: 1
+  epoch: 2
   description: The SPIFFE Runtime Environment (SPIRE) server
   copyright:
     - license: Apache-2.0
@@ -49,6 +49,9 @@ pipeline:
 
       # Mitigate CVE-2023-46737
       go get github.com/sigstore/cosign/v2@v2.2.1
+
+      # GHSA-2c7c-3mj9-8fqh
+      go get github.com/go-jose/go-jose/v3@v3.0.1
       go mod tidy
 
       make bin/spire-agent

--- a/traefik.yaml
+++ b/traefik.yaml
@@ -1,7 +1,7 @@
 package:
   name: traefik
   version: 2.10.5
-  epoch: 0
+  epoch: 1
   description: The Cloud Native Application Proxy
   copyright:
     - license: MIT
@@ -25,6 +25,10 @@ pipeline:
   - runs: |
       go mod edit -replace github.com/hashicorp/consul=github.com/hashicorp/consul@v1.14.7
       go get github.com/docker/docker@v20.10.24
+
+      # GHSA-2c7c-3mj9-8fqh
+      go get github.com/go-jose/go-jose/v3@v3.0.1
+
       go mod tidy
       VERSION=v${{package.version}} ./script/make.sh generate binary
       mkdir -p "${{targets.destdir}}/usr/bin"


### PR DESCRIPTION
- mitigate GHSA-2c7c-3mj9-8fqh for keda 
- mitigate GHSA-2c7c-3mj9-8fqh for kots 
- mitigate GHSA-2c7c-3mj9-8fqh for kyverno 
- mitigate GHSA-2c7c-3mj9-8fqh for oauth2-proxy 
- mitigate GHSA-2c7c-3mj9-8fqh for spire-server 
- mitigate GHSA-2c7c-3mj9-8fqh for traefik 
- mitigate GHSA-2c7c-3mj9-8fqh for rekor

### Pre-review Checklist


#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/560


