### PR TITLE
kubernetes: Fix packaging to prevent the `-dirty` suffix

### DIFF
--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.25
   version: 1.25.16
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -52,6 +52,7 @@ pipeline:
   - runs: |
       # Use our Go version instead of downloading another one
       export FORCE_HOST_GO=true
+      export KUBE_GIT_TREE_STATE=clean
 
       WHAT=""
       for c in ${{vars.components}} ; do

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.26
   version: 1.26.11
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -52,6 +52,7 @@ pipeline:
   - runs: |
       # Use our Go version instead of downloading another one
       export FORCE_HOST_GO=true
+      export KUBE_GIT_TREE_STATE=clean
 
       WHAT=""
       for c in ${{vars.components}} ; do

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.27
   version: 1.27.8
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -52,6 +52,7 @@ pipeline:
   - runs: |
       # Use our Go version instead of downloading another one
       export FORCE_HOST_GO=true
+      export KUBE_GIT_TREE_STATE=clean
 
       WHAT=""
       for c in ${{vars.components}} ; do

--- a/kubernetes-1.28.yaml
+++ b/kubernetes-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.28
   version: 1.28.4
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -46,6 +46,7 @@ pipeline:
   - runs: |
       # Use our Go version instead of downloading another one
       export FORCE_HOST_GO=true
+      export KUBE_GIT_TREE_STATE=clean
 
       WHAT=""
       for c in ${{vars.components}} ; do


### PR DESCRIPTION
The go modules built by our `kubernetes` packages contain the `-dirty` suffix, for example: `k8s.io/kubernetes@v1.25.16-dirty`. This prevents scanners from reading the version correctly and recognizing patched versions

```
$ wolfictl scan packages/aarch64/kubectl-1.25-1.25.16-r0.apk
🔎 Scanning "packages/aarch64/kubectl-1.25-1.25.16-r0.apk"
└── 📄 /usr/bin/kubectl-1.25
        📦 k8s.io/kubernetes v1.25.16-dirty (go-module)
            Low CVE-2021-25743 GHSA-f9jg-8p32-2f55 fixed in 1.26.0-alpha.3
            High CVE-2023-5528 GHSA-hq6q-c2x6-hmch fixed in 1.25.16

$ wolfictl scan packages/aarch64/kubectl-1.25-1.25.16-r1.apk
🔎 Scanning "packages/aarch64/kubectl-1.25-1.25.16-r1.apk"
└── 📄 /usr/bin/kubectl-1.25
        📦 k8s.io/kubernetes v1.25.16 (go-module)
            Low CVE-2021-25743 GHSA-f9jg-8p32-2f55 fixed in 1.26.0-alpha.3
```