### PR TITLE
mitigate GHSA-2c7c-3mj9-8fqh for argo-cd-2.8 / argo-workflows / cert-manager-1.13 / cilium-envoy / cosign / dex / external-secrets-operator / flux-kustomize-controller / flux-source-controller

### DIFF
--- a/argo-cd-2.8.yaml
+++ b/argo-cd-2.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.8
   version: 2.8.7
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -49,6 +49,9 @@ pipeline:
       go get go.opentelemetry.io/otel@v1.21.0
       go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
       go get go.opentelemetry.io/otel/sdk@v1.21.0
+
+      # GHSA-2c7c-3mj9-8fqh
+      go get github.com/go-jose/go-jose/v3@v3.0.1
 
       go mod tidy
 

--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-workflows
   version: 3.5.1
-  epoch: 0
+  epoch: 1
   description: Workflow engine for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,10 @@ pipeline:
 
       yarn install
       yarn cache clean
+
+      # GHSA-2c7c-3mj9-8fqh
+      go get github.com/go-jose/go-jose/v3@v3.0.1
+      go mod tidy
 
       # Our global LDFLAGS conflict with a Makefile parameter
       unset LDFLAGS

--- a/cert-manager-1.13.yaml
+++ b/cert-manager-1.13.yaml
@@ -2,7 +2,7 @@ package:
   name: cert-manager-1.13
   # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
   version: 1.13.2
-  epoch: 1
+  epoch: 2
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -39,9 +39,14 @@ pipeline:
         go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
         go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
         go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.20.0
+
         # GHSA-jq35-85cj-fj4p
         go get github.com/docker/docker@v24.0.7
         go get oras.land/oras-go@v1.2.4
+
+        # GHSA-2c7c-3mj9-8fqh
+        go get github.com/go-jose/go-jose/v3@v3.0.1
+
         go mod tidy
         cd ../..
       done

--- a/cilium-envoy.yaml
+++ b/cilium-envoy.yaml
@@ -3,7 +3,7 @@ package:
   # cilium/proxy is refered by the build in cilium/cilium using
   # digest. the project itself does not have any tag nor release.
   version: "1.25_git20231010"
-  epoch: 3
+  epoch: 4
   description: Envoy proxy for Cilium with minimal Envoy extensions and Cilium policy enforcement filters.
   copyright:
     - license: Apache-2.0
@@ -64,6 +64,9 @@ pipeline:
 
       # Remediate CVE-2023-44487/GHSA-m425-mq94-257g
       go get google.golang.org/grpc@v1.56.3
+
+      # GHSA-2c7c-3mj9-8fqh
+      go get github.com/go-jose/go-jose/v3@v3.0.1
 
       go mod tidy
       go mod vendor

--- a/cosign.yaml
+++ b/cosign.yaml
@@ -1,7 +1,7 @@
 package:
   name: cosign
   version: 2.2.1
-  epoch: 0
+  epoch: 1
   description: Container Signing
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,8 @@ pipeline:
       packages: ./cmd/cosign
       output: cosign
       ldflags: -s -w -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}}
+      # GHSA-2c7c-3mj9-8fqh
+      deps: github.com/go-jose/go-jose/v3@v3.0.1
 
   - uses: strip
 

--- a/dex.yaml
+++ b/dex.yaml
@@ -2,7 +2,7 @@ package:
   name: dex
   # When bumping the version check if the GHSA mitigations below can be removed.
   version: 2.37.0
-  epoch: 8
+  epoch: 9
   description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors
   copyright:
     - license: Apache-2.0
@@ -41,6 +41,9 @@ pipeline:
 
       # Remediate GHSA-m425-mq94-257g
       go get google.golang.org/grpc@v1.56.3
+
+      # GHSA-2c7c-3mj9-8fqh
+      go get github.com/go-jose/go-jose/v3@v3.0.1
 
       go mod tidy
 

--- a/external-secrets-operator.yaml
+++ b/external-secrets-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: external-secrets-operator
   version: 0.9.9
-  epoch: 0
+  epoch: 1
   description: Integrate external secret management systems with Kubernetes
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,10 @@ pipeline:
       expected-commit: 8b0fa87f301abd5ac2d15a45493aa4609e433772
 
   - runs: |
+      # GHSA-2c7c-3mj9-8fqh
+      go get github.com/go-jose/go-jose/v3@v3.0.1
+      go mod tidy
+
       make build-$(go env GOARCH)
       mkdir -p ${{targets.destdir}}/usr/bin
       install -m755 -D bin/external-secrets-$(go env GOOS)-$(go env GOARCH) "${{targets.destdir}}"/usr/bin/external-secrets

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-kustomize-controller
   version: 1.1.1
-  epoch: 2
+  epoch: 3
   description: The GitOps Toolkit Kustomize reconciler
   copyright:
     - license: Apache-2.0
@@ -38,7 +38,7 @@ pipeline:
 
   - uses: go/build
     with:
-      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.57.1
+      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.57.1 github.com/go-jose/go-jose/v3@v3.0.1
       ldflags: -s -w
       output: kustomize-controller
       packages: .

--- a/flux-source-controller.yaml
+++ b/flux-source-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-source-controller
   version: 1.1.2
-  epoch: 2
+  epoch: 3
   description: The GitOps Toolkit source management component
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,9 @@ pipeline:
 
       # Mitigate GHSA-m425-mq94-257g
       go get google.golang.org/grpc@v1.57.1
+
+      # GHSA-2c7c-3mj9-8fqh
+      go get github.com/go-jose/go-jose/v3@v3.0.1
 
       mkdir -p "${{targets.destdir}}"/usr/bin
       CGO_ENABLED=1 CGO_LDFLAGS="-static -fuse-ld=lld" go build \


### PR DESCRIPTION
- mitigate GHSA-2c7c-3mj9-8fqh for argo-cd-2.8 
- mitigate GHSA-2c7c-3mj9-8fqh for argo-workflows
- mitigate GHSA-2c7c-3mj9-8fqh for cert-manager-1.13 
- mitigate GHSA-2c7c-3mj9-8fqh for cilium-envoy
- mitigate GHSA-2c7c-3mj9-8fqh for cosign
- mitigate GHSA-2c7c-3mj9-8fqh for dex 
- mitigate GHSA-2c7c-3mj9-8fqh for external-secrets-operator
- mitigate GHSA-2c7c-3mj9-8fqh for flux-kustomize-controller
- mitigate GHSA-2c7c-3mj9-8fqh for flux-source-controller

### Pre-review Checklist


#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/562


