### PR TITLE
php-8.3.0 release version. Do not promote yet though.

### DIFF
--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,6 +1,6 @@
 package:
   name: php-8.3
-  version: 8.3_rc5
+  version: 8.3.0
   epoch: 0
   description: "the PHP programming language"
   copyright:
@@ -46,30 +46,21 @@ environment:
       - sqlite-dev
       - unixodbc-dev
 
-# transform melange version to contain ".0" rather than "_" so we can use a
-# var in the fetch URL. Note that apparently you can't use upper case letters
-# in the version either, so just use lower case above, and then transform here.
-var-transforms:
-  - from: ${{package.version}}
-    match: \_rc
-    replace: '.0RC'
-    to: mangled-package-version
-
 pipeline:
   - uses: fetch
     with:
-      uri: https://downloads.php.net/~jakub/php-${{vars.mangled-package-version}}.tar.gz
-      expected-sha512: e247bc85f068ac160ee87c56e9187345013e294932c53ce7774f8a66d0297ad4a8add15a96114e5665c3014ad25c642ec620d33d265c51b44e005c91d2dc0d79
+      uri: https://www.php.net/distributions/php-${{package.version}}.tar.gz
+      expected-sha512: 2c1357de391029986aea9f958f50f762d2f35b221c295242fbae31409c91ee27c591aa232489030c1010dd238a530f733d5fb5cb6d594643b273f107e9df956a
       extract: false
 
   - name: Prepare Build Folder
     runs: |
-      mv php-${{vars.mangled-package-version}}.tar.gz $HOME
-      tar zxf $HOME/php-${{vars.mangled-package-version}}.tar.gz
+      mv php-${{package.version}}.tar.gz $HOME
+      tar zxf $HOME/php-${{package.version}}.tar.gz
 
   - name: Configure
     runs: |
-      cd $HOME/php-${{vars.mangled-package-version}}
+      cd $HOME/php-${{package.version}}
       EXTENSION_DIR=/usr/lib/php/modules ./configure \
         --prefix=/usr \
         --libdir=/usr/lib/php \
@@ -136,11 +127,11 @@ pipeline:
 
   - uses: autoconf/make
     with:
-      dir: $HOME/php-${{vars.mangled-package-version}}
+      dir: $HOME/php-${{package.version}}
 
   - name: Make Install
     runs: |
-      cd $HOME/php-${{vars.mangled-package-version}}
+      cd $HOME/php-${{package.version}}
       INSTALL_ROOT=${{targets.destdir}} DESTDIR=${{targets.destdir}} make install
       mkdir -p "${{targets.destdir}}/bin" && ln -s /usr/bin/php "${{targets.destdir}}/bin/php"
 
@@ -198,7 +189,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
-          mv $HOME/php-${{vars.mangled-package-version}}/php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
+          mv $HOME/php-${{package.version}}/php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
 
   - range: extensions
     name: "${{package.name}}-${{range.key}}"
@@ -315,7 +306,10 @@ subpackages:
             echo 'decorate_workers_output = no'; \
           } | tee ${{targets.subpkgdir}}/etc/php/php-fpm.d/zz-apko.conf
 
-# The release candidates are in a different location, so we can't really
-# monitor the github tags for these since they differ.
 update:
-  enabled: false
+  enabled: true
+  github:
+    identifier: php/php-src
+    strip-prefix: php-
+    tag-filter: php-8.3
+    use-tag: true


### PR DESCRIPTION
PHP-8.3.0 was released, so move from RC to release version. Do not make it the default yet, so one has to explicitly ask for php-8.3

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
