### PR TITLE
kubernetes-dns-node-cache ::: fix: CVE-2023-5528

### DIFF
--- a/kubernetes-dns-node-cache.yaml
+++ b/kubernetes-dns-node-cache.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dns-node-cache
   version: 1.22.28
-  epoch: 0
+  epoch: 1
   description: NodeLocal DNSCache improves Cluster DNS performance by running a DNS caching agent on cluster nodes as a DaemonSet.
   copyright:
     - license: Apache-2.0
@@ -9,29 +9,31 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-baselayout
       - build-base
-      - ca-certificates-bundle
       - busybox
+      - ca-certificates-bundle
       - go
+      - wolfi-baselayout
 
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: f04dfc20011a021fcb5de9572d63f383a16b7e43
       repository: https://github.com/kubernetes/dns
       tag: ${{package.version}}
-      expected-commit: f04dfc20011a021fcb5de9572d63f383a16b7e43
 
   - uses: go/build
     with:
-      packages: ./cmd/node-cache
-      output: node-cache
+      deps: k8s.io/kubernetes@v1.26.11
       ldflags: -s -w -X github.com/kubernetes/dns/pkg/version.Version=v${{package.version}}
+      output: node-cache
+      packages: ./cmd/node-cache
+      vendor: true
 
   - uses: strip
 
 update:
   enabled: true
   github:
-    strip-prefix: v
     identifier: kubernetes/dns
+    strip-prefix: v


### PR DESCRIPTION
```
wolfictl scan  packages/aarch64/kubernetes-dns-node-cache-1.22.28-r1.apk
🔎 Scanning "packages/aarch64/kubernetes-dns-node-cache-1.22.28-r1.apk"
✅ No vulnerabilities found
```