### PR TITLE
mitigate CVE-2023-5528 for kubernetes-dns-node-cache

### DIFF
--- a/kubernetes-dns-node-cache.yaml
+++ b/kubernetes-dns-node-cache.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dns-node-cache
   version: 1.22.28
-  epoch: 0
+  epoch: 1
   description: NodeLocal DNSCache improves Cluster DNS performance by running a DNS caching agent on cluster nodes as a DaemonSet.
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,7 @@ pipeline:
       packages: ./cmd/node-cache
       output: node-cache
       ldflags: -s -w -X github.com/kubernetes/dns/pkg/version.Version=v${{package.version}}
+      deps: k8s.io/kubernetes@v1.26.11
 
   - uses: strip
 


### PR DESCRIPTION
- mitigate CVE-2023-5528 for kubernetes-dns-node-cache

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/567


