### PR TITLE
mitigate CVE-2023-5528 for cluster-autoscaler-1.25

### DIFF
--- a/cluster-autoscaler-1.25.yaml
+++ b/cluster-autoscaler-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.25
   version: 1.25.3
-  epoch: 4
+  epoch: 5
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -26,13 +26,23 @@ pipeline:
       tag: cluster-autoscaler-${{package.version}}
       expected-commit: 5a4d7d25a3c902a664fac39360b3e4635a74fdbd
 
+  - runs: |
+      cd cluster-autoscaler
+
+      # CVE-2023-5528
+      go get k8s.io/kubernetes@v1.25.16
+      go mod edit -replace=k8s.io/apiserver=k8s.io/apiserver@v0.25.16
+
+      go mod tidy
+      go mod vendor
+
   - uses: go/build
     with:
       modroot: cluster-autoscaler
       packages: .
       output: cluster-autoscaler
       ldflags: -s -w
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 k8s.io/kubernetes@v1.25.13
+      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3
       vendor: true
 
   - uses: strip


### PR DESCRIPTION
- mitigate CVE-2023-5528 for cluster-autoscaler-1.25

### Pre-review Checklist



#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/570


