### PR TITLE
libuv's checksum is wrong. Fixed it.

### DIFF
--- a/libuv.yaml
+++ b/libuv.yaml
@@ -1,7 +1,7 @@
 package:
   name: libuv
   version: 1.47.0
-  epoch: 0
+  epoch: 1
   description: "cross-platform asynchronous I/O library"
   copyright:
     - license: MIT AND ISC
@@ -18,7 +18,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://dist.libuv.org/dist/v${{package.version}}/libuv-v${{package.version}}-dist.tar.gz
-      expected-sha256: e585d22b4d158e1e6a4e51a91f4392250e3bd1f7828c0d270aad647b297da334
+      expected-sha256: 72a187104662b47f2a2b204da39d2acb05cf22a4fcb13ceaebe3b0ed0c0e2e43
 
   - uses: autoconf/configure
 


### PR DESCRIPTION
None of the PR template seems to apply here...

I downloaded the specified version of libuv and got a different checksum. Downloaded the signature and the file is signed by a key listed in the libuv MAINTAINERS file. However the keyserver they use was switched off 2+ years ago, so it's hard to validate properly.

```
$ curl  https://dist.libuv.org/dist/v1.47.0/libuv-v1.47.0-dist.tar.gz | sha256sum
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1615k  100 1615k    0     0  2815k      0 --:--:-- --:--:-- --:--:-- 2810k
72a187104662b47f2a2b204da39d2acb05cf22a4fcb13ceaebe3b0ed0c0e2e43  -
```

Should I have updated the epoch to "1" too?