### PR TITLE
revert: node-gyp changes from npm

### DIFF
--- a/npm.yaml
+++ b/npm.yaml
@@ -1,7 +1,7 @@
 package:
   name: npm
   version: 10.2.4
-  epoch: 1
+  epoch: 2
   description: "the npm package manager for javascript, mainline"
   copyright:
     - license: Artistic-2.0
@@ -48,7 +48,7 @@ pipeline:
              -name 'readme.markdown' \) -delete
 
       rm -rf ./*/.git* ./*/doc ./*/docs ./*/examples ./*/scripts ./*/test
-      rm -rf ./node-gyp/
+      rm -rf ./node-gyp/gyp/.git*
 
       find . -type f -executable ! -name 'node-gyp*' -exec chmod -x {} \;
 
@@ -74,6 +74,7 @@ pipeline:
     runs: |
       ln -s ../lib/node_modules/npm/bin/npm-cli.js npm
       ln -s ../lib/node_modules/npm/bin/npx-cli.js npx
+      ln -s ../lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js node-gyp
 
   - working-directory: ${{targets.destdir}}/usr/share
     runs: |


### PR DESCRIPTION
Reverts changes to npm until the node-gyp gets built first with npm 