### PR TITLE
trino: Resolve CVE-2023-34062

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
   version: "433"
-  epoch: 0
+  epoch: 1
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0
@@ -34,7 +34,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: CVE-2023-5072.patch
+      patches: CVE-2023-5072.patch CVE-2023-34062.patch
 
   - runs: |
       set -x

--- a/trino/CVE-2023-34062.patch
+++ b/trino/CVE-2023-34062.patch
@@ -1,0 +1,32 @@
+From eced2abf787d4be55a33611e493e58f9ee7864b8 Mon Sep 17 00:00:00 2001
+From: Philippe Deslauriers <philde@chainguard.dev>
+Date: Mon, 27 Nov 2023 08:42:18 -0800
+Subject: [PATCH] Bump reactor-netty-http to resolve CVE-2023-34062
+
+Signed-off-by: Philippe Deslauriers <philde@chainguard.dev>
+---
+ pom.xml | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/pom.xml b/pom.xml
+index e4f007e8..925e023e 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -932,7 +932,13 @@
+             <dependency>
+                 <groupId>io.projectreactor</groupId>
+                 <artifactId>reactor-core</artifactId>
+-                <version>3.4.33</version>
++                <version>3.4.34</version>
++            </dependency>
++
++            <dependency>
++                <groupId>io.projectreactor.netty</groupId>
++                <artifactId>reactor-netty-http</artifactId>
++                <version>1.0.39</version>
+             </dependency>
+ 
+             <!-- io.confluent:kafka-avro-serializer uses multiple versions of this transitive dependency -->
+-- 
+2.42.0
+


### PR DESCRIPTION
Bump `reactor-netty-http` to resolve CVE-2023-34062