### PR TITLE
Add jupyterhub k8s-hub

### DIFF
--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -1,0 +1,73 @@
+package:
+  name: jupyterhub-k8s-hub
+  version: 3.2.1
+  epoch: 0
+  description: Zero to JupyterHub with Kubernetes
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - python3
+      - py3-kubernetes-asyncio
+      - py3-jupyterhub
+      - py3-jupyterhub-firstuseauthenticator
+      - py3-jupyterhub-hmacauthenticator
+      - py3-jupyterhub-ldapauthenticator
+      - py3-jupyterhub-ltiauthenticator
+      - py3-jupyterhub-nativeauthenticator
+      - py3-jupyterhub-tmpauthenticator
+      - py3-nullauthenticator
+      - py3-oauthenticator
+      - py3-mwoauth
+      - py3-pyjwt
+      - py3-jupyterhub-kubespawner
+      - py3-pymysql
+      - py3-psycopg2
+      - py3-pycurl
+      - py3-sqlalchemy-cockroachdb
+      - py3-statsd
+      - py3-jupyterhub-idle-culler
+      - py3-tornado
+      - py3-dateutil
+      - configurable-http-proxy
+      - iptables
+      - tini
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - python3
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/jupyterhub/zero-to-jupyterhub-k8s
+      tag: ${{package.version}}
+      expected-commit: c0a696f56433be64ac85a3bc6e0bff329285e80a
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/etc/jupyterhub
+      cp -r jupyterhub/files/hub/* "${{targets.destdir}}"/etc/jupyterhub/
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by jupyterhub-k8s-hub"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/local/etc/jupyterhub
+          ln -sf /etc/jupyterhub/jupyterhub_config.py ${{targets.subpkgdir}}/usr/local/etc/jupyterhub/jupyterhub_config.py
+          ln -sf /etc/jupyterhub/z2jh.py ${{targets.subpkgdir}}/usr/local/etc/jupyterhub/z2jh.py
+    dependencies:
+      provides:
+        - jupyterhub-k8s-hub
+
+update:
+  enabled: true
+  github:
+    identifier: jupyterhub/zero-to-jupyterhub-k8s


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
