### PR TITLE
Update ncurses to latest.

### DIFF
--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,6 +1,6 @@
 package:
   name: ncurses
-  version: 6.4_p20230722
+  version: 6.4_p20231125
   epoch: 1
   description: "console display library"
   copyright:
@@ -28,7 +28,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{vars.mangled-package-version}}.tgz
-      expected-sha512: 262e1efbb5fbfe44f8efe2737c08cdf304f39671bab03cdc1c61ddf2ff7025e3f335d7b06ff812344b9d305c6c7baac7d624a691011caea6ab39932f417ec58e
+      expected-sha512: 9309d720da505df45fb8a7cec957bfa6839f71945fa4dbcba8bae2dfa2fbbf37bb40d73207d5dea4e746c6452ad79f484341313d5de2c8947ba8d1a12deaabd4
 
   - name: Configure
     runs: |

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
   version: 6.4_p20231125
-  epoch: 1
+  epoch: 0
   description: "console display library"
   copyright:
     - license: MIT


### PR DESCRIPTION
While working on the package tests for melange, noticed the ncurses was failing:
https://github.com/chainguard-dev/melange/actions/runs/7008726917/job/19065682639?pr=864

```
⚠️  x86_64    | --2023-11-27 17:40:51--  https://invisible-mirror.net/archives/ncurses/current/ncurses-6.4-20230722.tgz
⚠️  x86_64    | Resolving invisible-mirror.net... 160.153.42.69
⚠️  x86_64    | Connecting to invisible-mirror.net|160.153.42.69|:443... connected.
⚠️  x86_64    | HTTP request sent, awaiting response... 404 Not Found
```

And sure enough, it's not there anymore. So bump the later one.

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
