### PR TITLE
mitigate CVE-2023-47108 / GHSA-2c7c-3mj9-8fqh for argo-cd-2.9

### DIFF
--- a/argo-cd-2.9.yaml
+++ b/argo-cd-2.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.9
   version: 2.9.2
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -44,6 +44,12 @@ pipeline:
       # CVE-2023-3955/GHSA-q78c-gwqw-jcmc
       go get k8s.io/kubernetes@v1.24.17
       go get google.golang.org/grpc@v1.56.3
+
+      # Mitigate CVE-2023-47108/GHSA-8pgv-569h-w5rw
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.1
+      go get go.opentelemetry.io/otel@v1.21.0
+      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+      go get go.opentelemetry.io/otel/sdk@v1.21.0
 
       go mod tidy
 

--- a/argo-cd-2.9.yaml
+++ b/argo-cd-2.9.yaml
@@ -51,6 +51,9 @@ pipeline:
       go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
       go get go.opentelemetry.io/otel/sdk@v1.21.0
 
+      # Mitigate GHSA-2c7c-3mj9-8fqh
+      go get github.com/go-jose/go-jose/v3@v3.0.1
+
       go mod tidy
 
       make argocd-all


### PR DESCRIPTION
- mitigate CVE-2023-47108 for argo-cd-2.9
- mitigate GHSA-2c7c-3mj9-8fqh for argo-cd-2.9

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/575


