### PR TITLE
adding upstream patch to xmlsec

### DIFF
--- a/xmlsec.yaml
+++ b/xmlsec.yaml
@@ -48,6 +48,10 @@ pipeline:
       expected-commit: 641b8f49b883064597236487b09b48dd95f06926
       tag: xmlsec_${{vars.mangled-package-version}}
 
+  - uses: patch
+    with:
+      patches: PR_729.patch
+  
   - name: Autogen
     runs: |
       git clean -fdx . && NOCONFIGURE=1

--- a/xmlsec.yaml
+++ b/xmlsec.yaml
@@ -9,31 +9,31 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
+      - binutils
+      - build-base
       - busybox
       - ca-certificates-bundle
-      - build-base
-      - automake
-      - autoconf
+      - libgcrypt-dev
+      - libltdl
+      - libssl3
+      - libtool
       - libxml2
       - libxml2-dev
       - libxml2-py3
       - libxml2-utils
+      - libxslt-dev
       - linux-headers
-      - wget
       - make
+      - nss-db
+      - openssl-dev
       - pkgconf
       - pkgconf-dev
-      - binutils
-      - scanelf
-      - libtool
-      - libltdl
-      - libxslt-dev
-      - openssl-dev
-      - libssl3
-      - nss-db
-      - libgcrypt-dev
       - python3
       - python3-dev
+      - scanelf
+      - wget
 
 var-transforms:
   - from: ${{package.version}}
@@ -51,7 +51,7 @@ pipeline:
   - uses: patch
     with:
       patches: PR_729.patch
-  
+
   - name: Autogen
     runs: |
       git clean -fdx . && NOCONFIGURE=1

--- a/xmlsec.yaml
+++ b/xmlsec.yaml
@@ -1,7 +1,7 @@
 package:
   name: xmlsec
   version: 1.3.2
-  epoch: 0
+  epoch: 1
   description: C based implementation for XML Signature Syntax and Processing and XML Encryption Syntax and Processing
   copyright:
     - license: MIT

--- a/xmlsec/PR_729.patch
+++ b/xmlsec/PR_729.patch
@@ -1,0 +1,150 @@
+From 098a4d0219d3ed672bf8e5934ca7482dc739b103 Mon Sep 17 00:00:00 2001
+From: Aleksey Sanin <aleksey@aleksey.com>
+Date: Mon, 20 Nov 2023 09:27:33 -0500
+Subject: [PATCH 1/3] Fix libxml2 includes
+
+---
+ include/xmlsec/xmlsec.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/xmlsec/xmlsec.h b/include/xmlsec/xmlsec.h
+index 5757fc57..6f910122 100644
+--- a/include/xmlsec/xmlsec.h
++++ b/include/xmlsec/xmlsec.h
+@@ -12,6 +12,7 @@
+ #define __XMLSEC_H__
+ 
+ #include <libxml/tree.h>
++#include <libxml/parser.h>
+ 
+ #include <xmlsec/version.h>
+ #include <xmlsec/exports.h>
+
+From bd909345a8dcf093ac7acb0bc2f415717dad77b4 Mon Sep 17 00:00:00 2001
+From: Aleksey Sanin <aleksey@aleksey.com>
+Date: Mon, 20 Nov 2023 09:36:38 -0500
+Subject: [PATCH 2/3] Fix libxml2 includes
+
+---
+ apps/xmlsec.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/apps/xmlsec.c b/apps/xmlsec.c
+index 7655c1db..4bedb16a 100644
+--- a/apps/xmlsec.c
++++ b/apps/xmlsec.c
+@@ -22,6 +22,7 @@
+ #include <libxml/xmlmemory.h>
+ #include <libxml/parser.h>
+ #include <libxml/xpath.h>
++#include <libxml/xmlsave.h>
+ #include <libxml/xpathInternals.h>
+ 
+ #ifndef XMLSEC_NO_XSLT
+@@ -3030,7 +3031,7 @@ xmlSecAppInit(void) {
+     /* Init libxml */
+     xmlInitParser();
+     LIBXML_TEST_VERSION
+-    xmlTreeIndentString = "\t";
++    xmlThrDefTreeIndentString("\t");
+ #ifndef XMLSEC_NO_XSLT
+     xmlIndentTreeOutput = 1;
+ #endif /* XMLSEC_NO_XSLT */
+
+From c29133fbeea739640ad4aace67cb4242b16f7757 Mon Sep 17 00:00:00 2001
+From: Aleksey Sanin <aleksey@aleksey.com>
+Date: Mon, 20 Nov 2023 09:43:23 -0500
+Subject: [PATCH 3/3] Fix all warnings
+
+---
+ apps/crypto.c             |  1 +
+ src/errors_helpers.h      | 10 +++++-----
+ src/mscrypto/certkeys.c   |  1 +
+ src/mscrypto/signatures.c |  1 +
+ 4 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/apps/crypto.c b/apps/crypto.c
+index 8561dd65..4411233d 100644
+--- a/apps/crypto.c
++++ b/apps/crypto.c
+@@ -12,6 +12,7 @@
+ #endif
+ 
+ #include <string.h>
++#include <stdlib.h>
+ 
+ #include <xmlsec/xmlsec.h>
+ #include <xmlsec/keys.h>
+diff --git a/src/errors_helpers.h b/src/errors_helpers.h
+index 1a4f4183..470fdde6 100644
+--- a/src/errors_helpers.h
++++ b/src/errors_helpers.h
+@@ -136,7 +136,7 @@ extern "C" {
+  */
+ #define xmlSecXmlError(errorFunction, errorObject) \
+     {                                                 \
+-        xmlErrorPtr error = xmlGetLastError();        \
++        const xmlError * error = xmlGetLastError();        \
+         int code = (error != NULL) ? error->code : 0; \
+         const char* message = (error != NULL) ? error->message : NULL; \
+         xmlSecError(XMLSEC_ERRORS_HERE,               \
+@@ -159,7 +159,7 @@ extern "C" {
+  */
+ #define xmlSecXmlError2(errorFunction, errorObject, msg, param) \
+     {                                                 \
+-        xmlErrorPtr error = xmlGetLastError();        \
++        const xmlError * error = xmlGetLastError();        \
+         int code = (error != NULL) ? error->code : 0; \
+         const char* message = (error != NULL) ? error->message : NULL; \
+         xmlSecError(XMLSEC_ERRORS_HERE,               \
+@@ -181,7 +181,7 @@ extern "C" {
+  */
+ #define xmlSecXmlParserError(errorFunction, ctxt, errorObject) \
+     {                                                 \
+-        xmlErrorPtr error = xmlCtxtGetLastError(ctxt);\
++        const xmlError * error = xmlCtxtGetLastError(ctxt);\
+         int code = (error != NULL) ? error->code : 0; \
+         const char* message = (error != NULL) ? error->message : NULL; \
+         xmlSecError(XMLSEC_ERRORS_HERE,               \
+@@ -205,7 +205,7 @@ extern "C" {
+  */
+ #define xmlSecXmlParserError2(errorFunction, ctxt, errorObject, msg, param) \
+     {                                                 \
+-        xmlErrorPtr error = xmlCtxtGetLastError(ctxt);\
++        const xmlError * error = xmlCtxtGetLastError(ctxt);\
+         int code = (error != NULL) ? error->code : 0; \
+         const char* message = (error != NULL) ? error->message : NULL; \
+         xmlSecError(XMLSEC_ERRORS_HERE,               \
+@@ -227,7 +227,7 @@ extern "C" {
+  */
+ #define xmlSecXsltError(errorFunction, ctxt, errorObject) \
+     {                                                 \
+-        xmlErrorPtr error = xmlGetLastError();        \
++        const xmlError * error = xmlGetLastError();        \
+         int code = (error != NULL) ? error->code : 0; \
+         const char* message = (error != NULL) ? error->message : NULL; \
+         xmlSecError(XMLSEC_ERRORS_HERE,               \
+diff --git a/src/mscrypto/certkeys.c b/src/mscrypto/certkeys.c
+index db74517a..7e02a199 100644
+--- a/src/mscrypto/certkeys.c
++++ b/src/mscrypto/certkeys.c
+@@ -18,6 +18,7 @@
+ #include "globals.h"
+ 
+ #include <string.h>
++#include <stdlib.h>
+ 
+ #ifndef XMLSEC_NO_GOST
+ #include "csp_oid.h"
+diff --git a/src/mscrypto/signatures.c b/src/mscrypto/signatures.c
+index 61b95407..c5c62ced 100644
+--- a/src/mscrypto/signatures.c
++++ b/src/mscrypto/signatures.c
+@@ -17,6 +17,7 @@
+ #include "globals.h"
+ 
+ #include <string.h>
++#include <stdlib.h>
+ 
+ #ifndef XMLSEC_NO_GOST
+ #include "csp_calg.h"


### PR DESCRIPTION
<!---
This adds an unreleased patch that has been merged into the upstream main branch.
Patch - https://patch-diff.githubusercontent.com/raw/lsh123/xmlsec/pull/729.patch
Fixes issue - https://github.com/lsh123/xmlsec/issues/728
-->

Rolling back to a previous release was not an option as only the latest version is supported upstream

#### For PRs that add patches
<!-- remove if unrelated -->
- [X] Patch source is documented
