### PR TITLE
cass-config-builder

### DIFF
--- a/cass-config-builder.yaml
+++ b/cass-config-builder.yaml
@@ -1,0 +1,52 @@
+package:
+  name: cass-config-builder
+  version: 1.0.7
+  epoch: 0
+  description: |
+    Configuration builder for Apache Cassandra based on definitions at datastax/cass-config-definitions
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - openjdk-8
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - openjdk-8-default-jvm
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/datastax/cass-config-builder
+      expected-commit: 537bbf240a0ed3754ea0f73db23e411169fe0676
+      tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      # to mitigate the CVEs related to the package
+      patches: deps.patch
+
+  - runs: |
+      sed -i 's|git@\(.*\):|https://\1/|g' .gitmodules
+      cat .gitmodules
+      git submodule update --init
+
+  - runs: |
+      export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
+      ./gradlew copyDockerBuildCtx
+      mkdir -p "${{targets.destdir}}"/usr/local/bin
+      mkdir -p "${{targets.destdir}}"/definitions
+      cp -r build/docker/bin/* "${{targets.destdir}}"/usr/local/bin
+      cp -r build/docker/definitions/* "${{targets.destdir}}"/definitions
+      cp -r build/docker/*.jar "${{targets.destdir}}"/usr/local/bin/
+
+update:
+  enabled: true
+  github:
+    identifier: datastax/cass-config-builder
+    strip-prefix: v
+    use-tag: true

--- a/cass-config-builder/deps.patch
+++ b/cass-config-builder/deps.patch
@@ -1,0 +1,27 @@
+From 8808bf6f304a1ecac0f13e51aabcddf864189426 Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Tue, 28 Nov 2023 21:09:34 +0300
+Subject: [PATCH] upgrade snakeyaml and jackson-dataformat-cbor deps
+
+Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+---
+ build.gradle | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/build.gradle b/build.gradle
+index 3948c51..9125dad 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -92,7 +92,8 @@ dependencies {
+     implementation "org.clojure:core.match:0.3.0-alpha5"
+     implementation "org.clojure:core.memoize:0.5.9"
+     implementation "slingshot:slingshot:0.12.2"
+-    implementation "org.yaml:snakeyaml:1.23"
++    implementation "org.yaml:snakeyaml:2.0"
++    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.16.0"
+     implementation "cheshire:cheshire:5.8.0"
+     implementation ("selmer:selmer:1.12.27") { // templating lib
+         exclude module: 'hiccups'
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
