### PR TITLE
updates location of app in sqlpad

### DIFF
--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -35,10 +35,18 @@ pipeline:
 
   - runs: |
       ./scripts/build.sh
-      mkdir -p "${{targets.destdir}}/usr/app"
-      mv server ${{targets.destdir}}/usr/app
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv server ${{targets.destdir}}/usr/bin/sqlpad-server
 
   - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/app
+          ln -s ${{targets.destdir}}/usr/bin/sqlpad-server ${{targets.subpkgdir}}/usr/app/
 
 update:
   enabled: true

--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -46,7 +46,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/app
-          ln -s ${{targets.destdir}}/usr/bin/sqlpad-server ${{targets.subpkgdir}}/usr/app/
+          ln -s /usr/bin/sqlpad-server ${{targets.subpkgdir}}/usr/app
 
 update:
   enabled: true

--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -1,7 +1,7 @@
 package:
   name: sqlpad
   version: 7.1.3 # when updating check the patch below as it contains dependency version updates which may downgrade if upstream upgrades them
-  epoch: 0
+  epoch: 1
   description: Web-based SQL editor. Legacy project in maintenance mode.
   copyright:
     - license: MIT
@@ -35,8 +35,8 @@ pipeline:
 
   - runs: |
       ./scripts/build.sh
-      mkdir -p ${{targets.destdir}}/usr/bin
-      mv server ${{targets.destdir}}/usr/bin/sqlpad-server
+      mkdir -p "${{targets.destdir}}/usr/app"
+      mv server ${{targets.destdir}}/usr/app
 
   - uses: strip
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
