### PR TITLE
adds  k8ssandra reaper operator

### DIFF
--- a/reaper-operator.yaml
+++ b/reaper-operator.yaml
@@ -1,0 +1,47 @@
+package:
+  name: reaper-operator
+  version: 0.3.6
+  epoch: 0
+  description: Kubernetes operator for Cassandra Reaper
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - wolfi-baselayout
+      - busybox
+      - build-base
+      - go
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/k8ssandra/reaper-operator
+      tag: v${{package.version}}
+      expected-commit: 2a746e60e8dfb7529e6acc7ce5adf714fd063fba
+
+  - uses: go/build
+    with:
+      packages: .
+      output: manager
+      deps: golang.org/x/net@v0.17.0 github.com/prometheus/client_golang@v1.11.1 golang.org/x/crypto@v0.0.0-20211202192323-5770296d904e golang.org/x/sys@v0.0.0-20220412211240-33da011f77ad golang.org/x/text@v0.3.8 gopkg.in/yaml.v3@v3.0.0-20220521103104-8f96da9f5d5e
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/manager ${{targets.subpkgdir}}/manager
+
+update:
+  enabled: true
+  github:
+    identifier: k8ssandra/reaper-operator
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
