### PR TITLE
Add k8ssandra system-logger

### DIFF
--- a/cass-operator.yaml
+++ b/cass-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: cass-operator
   version: 1.18.2
-  epoch: 0
+  epoch: 1
   description: Manages Cassandra cluster as standalone product or as part of the k8ssandra-operator
   copyright:
     - license: Apache-2.0
@@ -22,13 +22,23 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: f1f25eb8434876f4eb519a2e5504c171020916ad
 
-  - runs: go get golang.org/x/net@v0.17.0 # Mitigate CVE-2023-39325 and CVE-2023-3978
-
-  - runs: CGO_ENABLED=0 go build -a -o manager cmd/main.go
-
-  - runs: mkdir -p ${{targets.destdir}}/usr/bin; install -Dm755 ./manager ${{targets.destdir}}/usr/bin/manager
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd
+      output: manager
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      deps: golang.org/x/net@v0.17.0
 
   - uses: strip
+
+subpackages:
+  - name: cass-operator-config
+    description: "A configuration file for the Vector"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.destdir}}/etc/vector
+          cp ./config/logger/vector_config.toml ${{targets.destdir}}/etc/vector/vector.toml
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
