### PR TITLE
use SPDX-compliant license for Public Domain

### DIFF
--- a/dns-root-hints.yaml
+++ b/dns-root-hints.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: The DNS root hint(s)
   copyright:
-    - license: Public-Domain
+    - license: CC-PDDC
 
 environment:
   contents:

--- a/dnssec-root.yaml
+++ b/dnssec-root.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: The DNSSEC root key(s)
   copyright:
-    - license: Public-Domain
+    - license: CC-PDDC
 
 environment:
   contents:

--- a/jsoncpp.yaml
+++ b/jsoncpp.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: "C++ library for parsing JSON"
   copyright:
-    - license: 'Public-Domain OR MIT'
+    - license: 'CC-PDDC OR MIT'
 
 environment:
   contents:

--- a/libmd.yaml
+++ b/libmd.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: Message Digest functions from BSD systems
   copyright:
-    - license: Public Domain
+    - license: CC-PDDC
 
 environment:
   contents:

--- a/libtelnet.yaml
+++ b/libtelnet.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: Simple RFC-complient TELNET implementation as a C library.
   copyright:
-    - license: Public Domain
+    - license: CC-PDDC
 
 environment:
   contents:

--- a/mailcap.yaml
+++ b/mailcap.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: "Helper application and MIME type associations for file types"
   copyright:
-    - license: Public-Domain and MIT
+    - license: CC-PDDC and MIT
 
 environment:
   contents:

--- a/tzdata.yaml
+++ b/tzdata.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: "Timezone data provided by IANA"
   copyright:
-    - license: Public-Domain
+    - license: CC-PDDC
 
 environment:
   contents:

--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -5,7 +5,7 @@ package:
   description: Random collection of Linux utilities
   copyright:
     - license: |-
-        GPL-3.0-or-later AND GPL-2.0-or-later AND GPL-2.0-only AND PL-1.0-only AND LGPL-2.1-or-later AND LGPL-1.0-only AND BSD-1-Clause AND BSD-3-Clause AND BSD-4-Clause-UC AND MIT AND Public-Domain
+        GPL-3.0-or-later AND GPL-2.0-or-later AND GPL-2.0-only AND PL-1.0-only AND LGPL-2.1-or-later AND LGPL-1.0-only AND BSD-1-Clause AND BSD-3-Clause AND BSD-4-Clause-UC AND MIT AND CC-PDDC
 
 environment:
   contents:


### PR DESCRIPTION
SPDX doesn't recognize the license identifier `Public Domain` or `Public-Domain`, so SBOMs produced by such packages are considered invalid according to the NTIA conformance checker.

This moves these licenses to https://spdx.org/licenses/CC-PDDC.html instead, which SPDX recognizes.

@kaniini please tell me if this is wrong. 🙏 