### PR TITLE
Add jackson-json 1.9 maintenance branch package

### DIFF
--- a/jackson-json.yaml
+++ b/jackson-json.yaml
@@ -18,10 +18,10 @@ environment:
       - ant
 
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://github.com/FasterXML/jackson-1
-      expected-commit: 9ac68db819bce7b9546bc4bf1c44f82ca910fa31
+      uri: https://github.com/FasterXML/jackson-1/archive/9ac68db819bce7b9546bc4bf1c44f82ca910fa31.tar.gz
+      expected-sha256: 855657de4fa6e9801a61ff4176e9b95448a0e876833e8dc1b4784e96eb2b117f
 
   - runs: |
       export LANG=en_US.UTF-8

--- a/jackson-json.yaml
+++ b/jackson-json.yaml
@@ -1,0 +1,38 @@
+package:
+  name: jackson-json
+  version: 1.9.14
+  epoch: 0
+  description: Jackson JSON processor 1.9 maintenance package
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - openjdk-8
+      - openjdk-8-default-jvm
+      - bash
+      - wolfi-base
+      - ant
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/FasterXML/jackson-1
+      expected-commit: 9ac68db819bce7b9546bc4bf1c44f82ca910fa31
+
+  - runs: |
+      export LANG=en_US.UTF-8
+      export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
+      ant jars
+
+      mkdir -p ${{targets.destdir}}/usr/share/java
+      mv build/*.jar ${{targets.destdir}}/usr/share/java
+
+update:
+  enabled: true
+  github:
+    identifier: FasterXML/jackson-1
+    use-tag: false

--- a/jackson-json.yaml
+++ b/jackson-json.yaml
@@ -9,17 +9,18 @@ package:
 environment:
   contents:
     packages:
+      - ant
+      - bash
       - busybox
       - ca-certificates-bundle
       - openjdk-8
       - openjdk-8-default-jvm
-      - bash
       - wolfi-base
-      - ant
 
 pipeline:
   - uses: fetch
     with:
+      # releases/tags are not maintained, only the main branch receives patches
       uri: https://github.com/FasterXML/jackson-1/archive/9ac68db819bce7b9546bc4bf1c44f82ca910fa31.tar.gz
       expected-sha256: 855657de4fa6e9801a61ff4176e9b95448a0e876833e8dc1b4784e96eb2b117f
 
@@ -31,8 +32,10 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/share/java
       mv build/*.jar ${{targets.destdir}}/usr/share/java
 
+# the only time this repo gets updated is when there's a CVE
+# if a scanner picks up this package, update the fetched URI above manually
 update:
-  enabled: true
+  enabled: false
+  manual: true
   github:
     identifier: FasterXML/jackson-1
-    use-tag: false


### PR DESCRIPTION
This PR adds a fairly popular legacy Java package for the 1.9 version of the Jackson JSON parser. The project has a maintenance branch open for this 1.9 series that still receives occasional patches: https://github.com/FasterXML/jackson-1

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates