### PR TITLE
kubeflow-centraldashboard

### DIFF
--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,0 +1,50 @@
+package:
+  name: kubeflow-centraldashboard
+  version: 1.8.0
+  epoch: 0
+  description: "Fast, disk space efficient package manager"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - nodejs-18
+      - openssl
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubeflow/kubeflow
+      tag: v${{package.version}}
+      expected-commit: a1ea0e92559d13e05c4427094c7a26de1002fcc0
+
+  - uses: patch
+    with:
+      patches: add-overrides.patch
+
+  - runs: |
+      cd components/centraldashboard
+      export NODE_OPTIONS=--openssl-legacy-provider
+      # Build the frontend and copy the common package into it
+      npm rebuild && \
+      npm install --force --legacy-peer-deps && \
+      npm run build --force --legacy-peer-deps && \
+      npm prune --production --force --legacy-peer-deps
+      # Now move it all into place
+      mkdir -p "${{targets.destdir}}/app"
+      mv * "${{targets.destdir}}/app"
+
+update:
+  enabled: true
+  github:
+    identifier: kubeflow/kubeflow
+    use-tag: true
+    # There were some malformed early tags
+    tag-filter: v1
+    strip-prefix: v

--- a/kubeflow-centraldashboard/add-overrides.patch
+++ b/kubeflow-centraldashboard/add-overrides.patch
@@ -1,0 +1,41 @@
+From dfdfc7e6635f036a78bf3e92de3597a00cd999ca Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Sat, 2 Dec 2023 22:22:42 +0300
+Subject: [PATCH] add overrides
+
+Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+---
+ components/centraldashboard/package.json | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/components/centraldashboard/package.json b/components/centraldashboard/package.json
+index b0d1e751..b4244c9d 100644
+--- a/components/centraldashboard/package.json
++++ b/components/centraldashboard/package.json
+@@ -127,5 +127,21 @@
+         "webpack": "^4.41.0",
+         "webpack-cli": "^3.3.9",
+         "webpack-dev-server": "^3.8.2"
++    },
++    "overrides": {
++        "ajv": "^6.12.3",
++        "node-fetch": "^2.6.7",
++        "node-forge": "^1.3.0",
++        "axios": "^1.6.0",
++        "qs": "^6.7.3",
++        "underscore": "^1.12.1",
++        "minimatch": "^3.0.5",
++        "path-parse": "^1.0.7",
++        "word-wrap": "^1.2.4",
++        "protobufjs": "^6.11.4",
++        "request": "^2.88.0",
++        "monorepo-symlink-test": "^0.0.0",
++        "tough-cookie": "^4.1.3",
++        "ws": "^6.2.2"
+     }
+-}
++}
+\ No newline at end of file
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: https://github.com/wolfi-dev/advisories/pull/580

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
