### PR TITLE
Patch GHSA-3f2q-6294-fmq5 by switching to the forked repo.

### DIFF
--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.7
   version: 2.7.15
-  epoch: 0
+  epoch: 2
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -40,6 +40,9 @@ pipeline:
       # Disable the `-pie` flag here since ArgoCD's helm charts like to copy around the multicall binary to different images (ie: dex)
 
       unset GOFLAGS
+
+      # GHSA-3f2q-6294-fmq5 CVE-2023-46402
+      go mod edit -replace=github.com/whilp/git-urls=github.com/dlorenc/git-urls@v0.0.1
 
       # CVE-2023-2253
       go get github.com/docker/distribution@v2.8.2

--- a/argo-cd-2.8.yaml
+++ b/argo-cd-2.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.8
   version: 2.8.7
-  epoch: 1
+  epoch: 2
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -40,6 +40,9 @@ pipeline:
       # Disable the `-pie` flag here since ArgoCD's helm charts like to copy around the multicall binary to different images (ie: dex)
 
       unset GOFLAGS
+
+      # GHSA-3f2q-6294-fmq5 CVE-2023-46402
+      go mod edit -replace=github.com/whilp/git-urls=github.com/dlorenc/git-urls@v0.0.1
 
       # CVE-2023-3955/GHSA-q78c-gwqw-jcmc
       go get k8s.io/kubernetes@v1.24.17

--- a/argo-cd-2.9.yaml
+++ b/argo-cd-2.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.9
   version: 2.9.3
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -40,6 +40,9 @@ pipeline:
       # Disable the `-pie` flag here since ArgoCD's helm charts like to copy around the multicall binary to different images (ie: dex)
 
       unset GOFLAGS
+
+      # GHSA-3f2q-6294-fmq5 CVE-2023-46402
+      go mod edit -replace=github.com/whilp/git-urls=github.com/dlorenc/git-urls@v0.0.1
 
       # CVE-2023-3955/GHSA-q78c-gwqw-jcmc
       go get k8s.io/kubernetes@v1.24.17

--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-workflows
   version: 3.5.2
-  epoch: 0
+  epoch: 1
   description: Workflow engine for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -35,6 +35,11 @@ pipeline:
 
       # Our global LDFLAGS conflict with a Makefile parameter
       unset LDFLAGS
+
+      # GHSA-3f2q-6294-fmq5 CVE-2023-46402
+      go mod edit -replace=github.com/whilp/git-urls=github.com/dlorenc/git-urls@v0.0.1
+      go mod tidy
+
       make dist/workflow-controller
       make dist/argo
       make dist/argoexec

--- a/flux-notification-controller.yaml
+++ b/flux-notification-controller.yaml
@@ -30,6 +30,8 @@ pipeline:
       # Mitigate GHSA-m425-mq94-257g
       go get google.golang.org/grpc@v1.57.1
 
+      go mod tidy
+  
       mkdir -p "${{targets.destdir}}"/usr/bin
       CGO_ENABLED=0 go build \
         -trimpath -a -o "${{targets.destdir}}"/usr/bin/notification-controller .

--- a/flux-notification-controller.yaml
+++ b/flux-notification-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-notification-controller
   version: 1.1.0
-  epoch: 5
+  epoch: 6
   description: The GitOps Toolkit event forwarded and notification dispatcher
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,9 @@ pipeline:
       tag: v${{package.version}}
 
   - runs: |
+      # GHSA-3f2q-6294-fmq5 CVE-2023-46402
+      go mod edit -replace=github.com/whilp/git-urls=github.com/dlorenc/git-urls@v0.0.1
+
       # CVE-2023-39325 and CVE-2023-3978
       go get golang.org/x/net@v0.17.0
 

--- a/flux-notification-controller.yaml
+++ b/flux-notification-controller.yaml
@@ -31,7 +31,7 @@ pipeline:
       go get google.golang.org/grpc@v1.57.1
 
       go mod tidy
-  
+
       mkdir -p "${{targets.destdir}}"/usr/bin
       CGO_ENABLED=0 go build \
         -trimpath -a -o "${{targets.destdir}}"/usr/bin/notification-controller .

--- a/melange.yaml
+++ b/melange.yaml
@@ -2,7 +2,7 @@ package:
   name: melange
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
   version: 0.5.3
-  epoch: 0
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0
@@ -25,10 +25,12 @@ pipeline:
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
       expected-commit: 728624ec624ea06a461c8fbbc1feabe1fd8569b9
-      destination: melange
 
   - runs: |
-      cd melange
+      # GHSA-3f2q-6294-fmq5 CVE-2023-46402
+      go mod edit -replace=github.com/whilp/git-urls=github.com/dlorenc/git-urls@v0.0.1
+      go mod tidy
+
       make melange
       install -m755 -D ./melange "${{targets.destdir}}"/usr/bin/melange
 

--- a/pulumi-kubernetes-operator.yaml
+++ b/pulumi-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-kubernetes-operator
   version: 1.14.0
-  epoch: 0
+  epoch: 1
   description: A Kubernetes Operator that automates the deployment of Pulumi Stacks
   copyright:
     - license: Apache-2.0
@@ -19,25 +19,26 @@ pipeline:
     with:
       repository: https://github.com/pulumi/pulumi-kubernetes-operator.git
       tag: v${{package.version}}
-      destination: ${{package.name}}
       expected-commit: 7d9e693bc6e27f1e3881ce350cdf7fbde71b26be
 
-  - working-directory: ${{package.name}}
-    pipeline:
-      - runs: |
-          # Mitigate CVE-2023-39325 and CVE-2023-3978
-          go get golang.org/x/net@v0.17.0
+  - runs: |
+      # GHSA-3f2q-6294-fmq5 CVE-2023-46402
+      go mod edit -replace=github.com/whilp/git-urls=github.com/dlorenc/git-urls@v0.0.1
 
-          # Remediate GHSA-m425-mq94-257g
-          go get google.golang.org/grpc@v1.58.3
+      # Mitigate CVE-2023-39325 and CVE-2023-3978
+      go get golang.org/x/net@v0.17.0
 
-          go mod tidy
+      # Remediate GHSA-m425-mq94-257g
+      go get google.golang.org/grpc@v1.58.3
 
-          # Original Go build args found in ./scripts/build.sh
-          CGO_ENABLED=0 go build -o "${{targets.destdir}}/usr/bin/${{package.name}}" \
-            -ldflags "-s -w -X github.com/pulumi/pulumi-kubernetes-operator/version.Version=v${{package.version}} -extldflags \"-static\"" \
-            -tags netgo ./cmd/manager/main.go
-      - uses: strip
+      go mod tidy
+
+      # Original Go build args found in ./scripts/build.sh
+      CGO_ENABLED=0 go build -o "${{targets.destdir}}/usr/bin/${{package.name}}" \
+        -ldflags "-s -w -X github.com/pulumi/pulumi-kubernetes-operator/version.Version=v${{package.version}} -extldflags \"-static\"" \
+        -tags netgo ./cmd/manager/main.go
+
+  - uses: strip
 
 update:
   enabled: true


### PR DESCRIPTION
I forked git-urls to patch the vulnerability. I submitted a patch upstream, but haven't heard back from the maintainer yet: https://github.com/whilp/git-urls/pull/25

This switches go packages that use this to my fork.
