### PR TITLE
bump mc to RELEASE.2023-12-02T02-03-28Z and fix GHSA-m425-mq94-257g/CVE-2023-44487 and drop dep bump

### DIFF
--- a/mc.yaml
+++ b/mc.yaml
@@ -1,9 +1,9 @@
 package:
   name: mc
-  # minio uses strange versioning, the upstream version is RELEASE.2023-03-23T20-03-04Z
+  # minio uses strange versioning, the upstream version is RELEASE.2023-12-02T02-03-28Z
   # when bumping this, also bump the tag in git-checkout below
-  version: 0.20230628.215417
-  epoch: 7
+  version: 0.20231202.020328
+  epoch: 0
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0
@@ -21,13 +21,10 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/minio/mc
-      tag: RELEASE.2023-06-28T21-54-17Z
-      expected-commit: eebdcdf36501cec35c893d7e8ab7a7473ff6860a
+      tag: RELEASE.2023-12-02T02-03-28Z
+      expected-commit: f5f7147b9ec4cf78eb67f1cdc91b63d191852e6a
 
   - runs: |
-      # fix CVE-2023-39325 and CVE-2023-3978.
-      go get golang.org/x/net@v0.17.0
-      go mod tidy
       make build
       mkdir -p ${{targets.destdir}}/usr/bin
       mv mc ${{targets.destdir}}/usr/bin


### PR DESCRIPTION
- bump mc to RELEASE.2023-12-02T02-03-28Z and fix GHSA-m425-mq94-257g/CVE-2023-44487 and drop dep bump


### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/585

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

