### PR TITLE
New package: `py3-codeowners`

### DIFF
--- a/py3-codeowners.yaml
+++ b/py3-codeowners.yaml
@@ -1,0 +1,38 @@
+# Generated from https://pypi.org/project/codeowners/
+package:
+  name: py3-codeowners
+  version: 0.6.0
+  epoch: 0
+  description: Codeowners parser for Python
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-typing-extensions
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/sbdchd/codeowners/archive/3ccfe4096487d9220a874f5c436d300fa4765e7a.tar.gz
+      expected-sha512: afc61c0cb3e7430c30289cafae17641814e0ecd1f5d54f44f62ee392af874647ad9cb8a134deff689f34966782413b82f8d681256b5f2e0a7f7d19339279b5c0
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  # The upstream repo stopped cutting releases, so check the pyproject.toml file.
+  enabled: true
+  manual: true
+  github:
+    identifier: sbdchd/codeowners


### PR DESCRIPTION
This change introduces a package for the python package `codeowners`.

The upstream source repo stopped cutting releases, so this uses the commit where `pyproject.yaml` bumps to 0.6 which is also the commit PyPI seems to have recorded (judging from `melange convert python`).

### Pre-review Checklist

#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
