### PR TITLE
Add py3-docker-squash

### DIFF
--- a/py3-docker-squash.yaml
+++ b/py3-docker-squash.yaml
@@ -1,0 +1,46 @@
+# Generated from https://pypi.org/project/docker-squash/
+package:
+  name: py3-docker-squash
+  version: 1.1.0
+  epoch: 0
+  description: Docker layer squashing tool
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+      - py3-packaging
+      - py3-docker
+
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: f5aa24f4a744f9fa75955388560048ddeabbec8f
+      repository: https://github.com/goldmann/docker-squash
+      tag: ${{package.version}}
+
+  - runs: |
+      # Use packaging.version.parse instead of distutils.StrictVersion
+      # because the latter is not available in Python 3.12.
+      find -name '*.py' -exec \
+        sed -i 's/from distutils.version import StrictVersion/from packaging import version/g' {} \;
+      find -name '*.py' -exec sed -i 's/StrictVersion/version.parse/g' {} \;
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: goldmann/docker-squash

--- a/py3-docker-squash.yaml
+++ b/py3-docker-squash.yaml
@@ -1,6 +1,9 @@
 # Generated from https://pypi.org/project/docker-squash/
 package:
   name: py3-docker-squash
+  # When bumping this version, please remove the StrictVersion patching
+  # if https://github.com/goldmann/docker-squash/pull/234 was merged
+  # and released.
   version: 1.1.0
   epoch: 0
   description: Docker layer squashing tool

--- a/py3-docker-squash.yaml
+++ b/py3-docker-squash.yaml
@@ -31,8 +31,8 @@ pipeline:
       # Use packaging.version.parse instead of distutils.StrictVersion
       # because the latter is not available in Python 3.12.
       find -name '*.py' -exec \
-        sed -i 's/from distutils.version import StrictVersion/from packaging import version/g' {} \;
-      find -name '*.py' -exec sed -i 's/StrictVersion/version.parse/g' {} \;
+        sed -i 's/from distutils.version import StrictVersion/from packaging import version as packaging_version/g' {} \;
+      find -name '*.py' -exec sed -i 's/StrictVersion/packaging_version.parse/g' {} \;
 
   - name: Python Build
     uses: python/build-wheel

--- a/py3-docker-squash.yaml
+++ b/py3-docker-squash.yaml
@@ -18,10 +18,10 @@ package:
 environment:
   contents:
     packages:
+      - build-base
+      - busybox
       - ca-certificates-bundle
       - wolfi-base
-      - busybox
-      - build-base
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
We need to use packaging.version instead of distutils.StrictVersion because the latter is not available on Python 3.12. I am working on upstreaming this change as well, but using `sed` here in the meantime.

* "py3-docker-squash-1.1.0: new package"

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`): No, but this is the latest version.


```
❯ wolfictl scan packages/aarch64/*.apk
Will process: py3-docker-squash-1.1.0-r0.apk

✅ No vulnerabilities found

```