### PR TITLE
postgresql-1X: use provider-priority to preference the newest package

### DIFF
--- a/postgresql-11.yaml
+++ b/postgresql-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-11
   version: "11.22"
-  epoch: 6
+  epoch: 7
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -86,6 +86,8 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libpq.so* ${{targets.subpkgdir}}/usr/lib/
+    dependencies:
+      provider-priority: 11
 
   - name: postgresql-11-oci-entrypoint
     description: Entrypoint for using PostgreSQL in OCI containers

--- a/postgresql-12.yaml
+++ b/postgresql-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-12
   version: "12.17"
-  epoch: 2
+  epoch: 3
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -84,6 +84,8 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libpq.so* ${{targets.subpkgdir}}/usr/lib/
+    dependencies:
+      provider-priority: 12
 
   - name: postgresql-12-oci-entrypoint
     description: Entrypoint for using PostgreSQL in OCI containers

--- a/postgresql-13.yaml
+++ b/postgresql-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-13
   version: "13.13"
-  epoch: 2
+  epoch: 3
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -83,6 +83,8 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libpq.so* ${{targets.subpkgdir}}/usr/lib/
+    dependencies:
+      provider-priority: 13
 
   - name: postgresql-13-oci-entrypoint
     description: Entrypoint for using PostgreSQL in OCI containers

--- a/postgresql-14.yaml
+++ b/postgresql-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-14
   version: "14.10"
-  epoch: 2
+  epoch: 3
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -84,6 +84,8 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libpq.so* ${{targets.subpkgdir}}/usr/lib/
+    dependencies:
+      provider-priority: 14
 
   - name: postgresql-14-oci-entrypoint
     description: Entrypoint for using PostgreSQL in OCI containers

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-15
   version: "15.5"
-  epoch: 2
+  epoch: 3
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -80,6 +80,8 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libpq.so* ${{targets.subpkgdir}}/usr/lib/
+    dependencies:
+      provider-priority: 15
 
   - name: postgresql-15-oci-entrypoint
     description: Entrypoint for using PostgreSQL in OCI containers

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.1"
-  epoch: 2
+  epoch: 3
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -81,6 +81,8 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libpq.so* ${{targets.subpkgdir}}/usr/lib/
+    dependencies:
+      provider-priority: 16
 
   - name: postgresql-16-oci-entrypoint
     description: Entrypoint for using PostgreSQL in OCI containers


### PR DESCRIPTION
Use the newest version of libpq by using `provider-priority` to steer the solver.

Fixes: #9261 