### PR TITLE
update cmake to 3.27.9

### DIFF
--- a/cmake.yaml
+++ b/cmake.yaml
@@ -1,6 +1,6 @@
 package:
   name: cmake
-  version: 3.27.7
+  version: 3.27.9
   epoch: 0
   description: "CMake is an open-source, cross-platform family of tools designed to build, test and package software"
   copyright:
@@ -9,19 +9,19 @@ package:
 environment:
   contents:
     packages:
-      - wolfi-base
-      - busybox
-      - ca-certificates-bundle
       - build-base
+      - busybox
       - bzip2-dev
+      - ca-certificates-bundle
       - expat-dev
-      - openssl-dev
-      - nghttp2-dev
       - libarchive-dev
       - libuv-dev
       - ncurses-dev
+      - nghttp2-dev
+      - openssl-dev
       - rhash-dev
       - samurai
+      - wolfi-base
       - xz-dev
       - zlib-dev
 
@@ -29,7 +29,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://www.cmake.org/files/v3.27/cmake-${{package.version}}.tar.gz
-      expected-sha256: 08f71a106036bf051f692760ef9558c0577c42ac39e96ba097e7662bd4158d8e
+      expected-sha256: 609a9b98572a6a5ea477f912cffb973109ed4d0a6a6b3f9e2353d2cdc048708e
 
   # Depending on system cppdap, jsoncpp, and curl would create a circular
   # dependency; thus, we use bundled ones.


### PR DESCRIPTION
Fixes #9153 
```


apk add --allow-untrusted packages/x86_64/cmake-3.27.9-r0.apk 
WARNING: opening ./../../packages: No such file or directory
(1/7) Installing libattr1 (2.5.1-r2)
(2/7) Installing libacl1 (2.3.1-r4)
(3/7) Installing liblz4-1 (1.9.4-r3)
(4/7) Installing libarchive (3.7.2-r0)
(5/7) Installing librhash0 (1.4.4-r1)
(6/7) Installing libuv (1.47.0-r0)
(7/7) Installing cmake (3.27.9-r0)
OK: 1087 MiB in 71 packages
/work/work # cmake --version
cmake version 3.27.9

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

Was able to build packages using cmake 


```
 x86_64    | installing xz (5.4.5-r0)
❕ x86_64    | installing libzstd1 (1.5.5-r1)
❕ x86_64    | installing libarchive (3.7.2-r0)
❕ x86_64    | installing ncurses-terminfo-base (6.4-r2)
❕ x86_64    | installing ncurses (6.4-r2)
❕ x86_64    | installing libnghttp2-14 (1.58.0-r0)
❕ x86_64    | installing librhash0 (1.4.4-r1)
❕ x86_64    | installing libssl3 (3.2.0-r0)
❕ x86_64    | installing libuv (1.47.0-r1)
❕ x86_64    | installing cmake (3.27.9-r0)
❕ x86_64    | installing libpcap (1.10.4-r0)
❕ x86_64    | installing libpcap-dev (1.10.4-r0)
❕ x86_64    | installing openssl-dev (3.2.0-r0)
❕ x86_64    | installing samurai (1.2-r2)
❕ x86_64    | installing scanelf (1.3.7-r1)
❕ x86_64    | installing wget (1.21.4-r0)
ℹ️  x86_64    | creating group 1000(build)
ℹ️  x86_64    | did not generate /etc/os-release: already present
ℹ️  x86_64    | generating supervision tree
ℹ️  x86_64    | finished building filesystem
ℹ️  x86_64    | built image layer tarball as /tmp/apko-temp-268057640/apko-x86_64.tar.gz
ℹ️  x86_64    | using /tmp/apko-temp-268057640/apko-x86_64.tar.gz for image layer
ℹ️  x86_64    | pushed /tmp/apko-temp-268057640/apko-x86_64.tar.gz as /tmp/melange-guest-1708746356
ℹ️  x86_64    | successfully built workspace with apko
ℹ️  x86_64    | populating cache from 
ℹ️  x86_64    | populating workspace /tmp/melange-workspace-1453254411 from ./tcpdump/
ℹ️  x86_64    | ImgRef = /tmp/melange-guest-1708746356
ℹ️  x86_64    | executing: bwrap --bind /tmp/melange-guest-1708746356 / --bind /tmp/melange-workspace-1453254411 /home/build --bind /etc/resolv.conf /etc/resolv.conf --bind /work/work/melange-cache /var/cache/melange --unshare-pid --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv SOURCE_DATE_EPOCH 0 --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv GOTOOLCHAIN local --setenv HOME /home/build --setenv GOPATH /home/build/.cache/go --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap --setenv GOFLAGS  /bin/sh -c [ -x /sbin/ldconfig ] && /sbin/ldconfig /lib || true
ℹ️  x86_64    | running the main pipeline
ℹ️  x86_64    | running step fetch
ℹ️  x86_64    |   using fetch
❕ x86_64    |     ${{inputs.uri}}: https://www.tcpdump.org/release/tcpdump-4.99.4.tar.gz
❕ x86_64    |     ${{inputs.timeout}}: 5
❕ x86_64    |     ${{inputs.delete}}: false
❕ x86_64    |     ${{package.epoch}}: 0
❕ x86_64    |     ${{package.full-version}}: 4.99.4-r0
❕ x86_64    |     ${{targets.destdir}}: /home/build/melange-out/tcpdump
❕ x86_64    |     ${{host.triplet.gnu}}: x86_64-pc-linux-gnu
❕ x86_64    |     ${{host.triplet.rust}}: x86_64-unknown-linux-gnu
❕ x86_64    |     ${{cross.triplet.gnu.musl}}: x86_64-pc-linux-musl
❕ x86_64    |     ${{build.arch}}: x86_64
❕ x86_64    |     ${{inputs.retry-limit}}: 5
❕ x86_64    |     ${{inputs.strip-components}}: 1
❕ x86_64    |     ${{package.name}}: tcpdump
❕ x86_64    |     ${{targets.contextdir}}: /home/build/melange-out/tcpdump
❕ x86_64    |     ${{targets.package.tcpdump-doc}}: /home/build/melange-out/tcpdump-doc
❕ x86_64    |     ${{inputs.extract}}: true
❕ x86_64    |     ${{inputs.expected-sha256}}: 0232231bb2f29d6bf2426e70a08a7e0c63a0d59a9b44863b7f5e2357a6e49fea
❕ x86_64    |     ${{package.version}}: 4.99.4
❕ x86_64    |     ${{cross.triplet.gnu.glibc}}: x86_64-pc-linux-gnu
❕ x86_64    |     ${{targets.package.tcpdump}}: /home/build/melange-out/tcpdump
❕ x86_64    |     ${{inputs.dns-timeout}}: 20
ℹ️  x86_64    | running step Fetch and extract external object into workspace
❕ x86_64    |     ${{package.version}}: 4.99.4
❕ x86_64    |     ${{cross.triplet.gnu.musl}}: x86_64-pc-linux-musl
❕ x86_64    |     ${{targets.package.tcpdump}}: /home/build/melange-out/tcpdump
❕ x86_64    |     ${{inputs.extract}}: true
❕ x86_64    |     ${{inputs.expected-sha256}}: 0232231bb2f29d6bf2426e70a08a7e0c63a0d59a9b44863b7f5e2357a6e49fea
❕ x86_64    |     ${{package.full-version}}: 4.99.4-r0
❕ x86_64    |     ${{inputs.delete}}: false
❕ x86_64    |     ${{inputs.dns-timeout}}: 20
❕ x86_64    |     ${{inputs.strip-components}}: 1
❕ x86_64    |     ${{package.name}}: tcpdump


            | signed index packages/x86_64/APKINDEX.tar.gz with key local-melange.rsa
make[1]: Leaving directory '/work/work'
/work/work # apk add --allow-untrusted packages/x86_64/tcpdump-4.99.4-r0.apk
WARNING: opening ./../../packages: No such file or directory
(1/2) Installing libpcap (1.10.4-r0)
(2/2) Installing tcpdump (4.99.4-r0)
OK: 1100 MiB in 75 packages
/work/work # tcpdump
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
23:55:57.554055 ARP, Request who-has 172.17.0.1 tell cd2ca1c1f39e, length 28
23:55:57.554091 ARP, Reply 172.17.0.1 is-at 02:42:42:5d:b2:f4 (oui Unknown), length 28
23:55:57.554248 ARP, Request who-has cd2ca1c1f39e tell 172.17.0.1, length 28
23:55:57.554270 ARP, Reply cd2ca1c1f39e is-at 02:42:ac:11:00:02 (oui Unknown), length 28
23:55:57.586174 IP cd2ca1c1f39e.38139 > metadata.google.internal.domain: 42918+ PTR? 1.0.17.172.in-addr.arpa. (41)
23:55:57.589231 IP metadata.google.internal.domain > cd2ca1c1f39e.38139: 42918 NXDomain 0/1/0 (138)
23:55:57.690066 IP cd2ca1c1f39e.33050 > metadata.google.internal.domain: 41761+ PTR? 254.169.254.169.in-addr.arpa. (46)
23:55:57.690429 IP metadata.google.internal.domain > cd2ca1c1f39e.33050: 41761 1/0/0 PTR metadata.google.internal. (84)
```
