### PR TITLE
Associate yaml files with melange configs for vscode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ dag.svg
 .idea
 .packagerules
 .melange.k8s.yaml
-.vscode/*
 packages.log
 *.iml
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "yaml.schemas": {
+        "https://raw.githubusercontent.com/chainguard-dev/melange/main/pkg/config/schema.json": "*.yaml"
+    }
+}


### PR DESCRIPTION
The alternative to this would be to rename all files to `*.melanage.yaml`, but this feels less invasive. 🤷 