### PR TITLE
Convert 12 more packages with embedded go gets into go/bump.

### DIFF
--- a/cilium.yaml
+++ b/cilium.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium
   version: 1.14.4
-  epoch: 1
+  epoch: 2
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -43,13 +43,11 @@ pipeline:
     with:
       patches: loopback-location.patch
 
+  - uses: go/bump
+    with:
+      deps: github.com/go-jose/go-jose/v3@v3.0.1
+
   - runs: |
-      # GHSA-2c7c-3mj9-8fqh
-      go get github.com/go-jose/go-jose/v3@v3.0.1
-
-      go mod tidy
-      go mod vendor
-
       # Remove groupadd from Makefile: it's not doing anything useful in
       # a package build anyway, and it's not available in busybox.
       find . -name Makefile -exec sed -i '/groupadd/d' {} \;

--- a/cluster-autoscaler-1.25.yaml
+++ b/cluster-autoscaler-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.25
   version: 1.25.3
-  epoch: 6
+  epoch: 7
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,6 @@ pipeline:
       cd cluster-autoscaler
 
       # CVE-2023-5528
-      go get k8s.io/kubernetes@v1.25.16
       go mod edit -replace=k8s.io/apiserver=k8s.io/apiserver@v0.25.16
 
       go mod tidy
@@ -38,7 +37,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3
+      deps: k8s.io/kubernetes@v1.25.16 github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3
       modroot: cluster-autoscaler
 
   - uses: go/build

--- a/cluster-autoscaler-1.26.yaml
+++ b/cluster-autoscaler-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.26
   version: 1.26.5
-  epoch: 0
+  epoch: 1
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -26,20 +26,10 @@ pipeline:
       tag: cluster-autoscaler-${{package.version}}
       expected-commit: bd0db52e132bf6116d649f346e21f6ce8429ac91
 
-  - runs: |
-      cd cluster-autoscaler
-
-      # CVE-2023-2253
-      go get github.com/docker/distribution@v2.8.2
-
-      # CVE-2023-5528 CVE-2023-47108
-      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
-      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
-      go get go.opentelemetry.io/otel/sdk@v1.21.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
-
-      go mod tidy
-      go mod vendor
+  - uses: go/bump
+    with:
+      deps: github.com/docker/distribution@v2.8.2 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0 go.opentelemetry.io/otel/sdk@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+      modroot: cluster-autoscaler
 
   - uses: go/build
     with:

--- a/cluster-autoscaler-1.27.yaml
+++ b/cluster-autoscaler-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.27
   version: 1.27.4
-  epoch: 0
+  epoch: 1
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -26,20 +26,10 @@ pipeline:
       tag: cluster-autoscaler-${{package.version}}
       expected-commit: 8fbf8ffd301340c68d20f024c567eccb854ee85f
 
-  - runs: |
-      cd cluster-autoscaler
-
-      # CVE-2023-2253
-      go get github.com/docker/distribution@v2.8.2
-
-      # CVE-2023-5528 CVE-2023-47108
-      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
-      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
-      go get go.opentelemetry.io/otel/sdk@v1.21.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
-
-      go mod tidy
-      go mod vendor
+  - uses: go/bump
+    with:
+      deps: github.com/docker/distribution@v2.8.2 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0 go.opentelemetry.io/otel/sdk@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+      modroot: cluster-autoscaler
 
   - uses: go/build
     with:

--- a/cluster-autoscaler-1.28.yaml
+++ b/cluster-autoscaler-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.28
   version: 1.28.1
-  epoch: 0
+  epoch: 1
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -26,17 +26,10 @@ pipeline:
       tag: cluster-autoscaler-${{package.version}}
       expected-commit: 2f1151dc299c8813da226a4f9a3efb87951c0bee
 
-  - runs: |
-      cd cluster-autoscaler
-
-      # CVE-2023-5528 CVE-2023-47108
-      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
-      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
-      go get go.opentelemetry.io/otel/sdk@v1.21.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
-
-      go mod tidy
-      go mod vendor
+  - uses: go/bump
+    with:
+      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0 go.opentelemetry.io/otel/sdk@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+      modroot: cluster-autoscaler
 
   - uses: go/build
     with:

--- a/cri-tools.yaml
+++ b/cri-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: cri-tools
   version: 1.28.0
-  epoch: 3
+  epoch: 4
   description: CLI and validation tools for Kubelet Container Runtime Interface (CRI) .
   copyright:
     - license: Apache-2.0
@@ -21,10 +21,9 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 3c91ebf539bd2035d60813386f5b1f023937423f
 
-  - runs: |
-      # Fix for CVE-2023-2253
-      go get github.com/docker/distribution@v2.8.2
-      make vendor
+  - uses: go/bump
+    with:
+      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3
 
   - uses: go/build
     with:

--- a/dex.yaml
+++ b/dex.yaml
@@ -2,7 +2,7 @@ package:
   name: dex
   # When bumping the version check if the GHSA mitigations below can be removed.
   version: 2.37.0
-  epoch: 9
+  epoch: 10
   description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors
   copyright:
     - license: Apache-2.0
@@ -29,23 +29,17 @@ pipeline:
       expected-commit: 08bb7fb98b164ab078be17ecda4077b2d21c9bb3
       destination: dex
 
+  - uses: go/bump
+    with:
+      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 github.com/go-jose/go-jose/v3@v3.0.1
+      modroot: dex
+
   - runs: |
       cd dex
 
       # These build commands are adapted from the upstream `make release-binary` target.
       export GOBIN="$GOPATH/bin"
       LD_FLAGS="-w -X main.version=v${{package.version}} -extldflags \"-static\""
-
-      # Mitigate CVE-2023-39325 and CVE-2023-3978
-      go get golang.org/x/net@v0.17.0
-
-      # Remediate GHSA-m425-mq94-257g
-      go get google.golang.org/grpc@v1.56.3
-
-      # GHSA-2c7c-3mj9-8fqh
-      go get github.com/go-jose/go-jose/v3@v3.0.1
-
-      go mod tidy
 
       go build -o "$GOBIN/dex" -v -ldflags "$LD_FLAGS" ./cmd/dex
       go build -o "$GOBIN/docker-entrypoint" -v -ldflags "$LD_FLAGS" ./cmd/docker-entrypoint

--- a/dive.yaml
+++ b/dive.yaml
@@ -1,7 +1,7 @@
 package:
   name: dive
   version: 0.11.0
-  epoch: 8
+  epoch: 9
   description: A tool for exploring each layer in a docker image
   copyright:
     - license: MIT
@@ -21,35 +21,15 @@ pipeline:
       repository: https://github.com/wagoodman/dive
       tag: v${{package.version}}
       expected-commit: 800398060434ce8dfda6b4d182b72e2a9724e9f6
-      destination: dive
 
-  - runs: |
-      cd dive
-
-      # GHSA-77vh-xpmg-72qh
-      go get -u github.com/opencontainers/image-spec@v1.0.2
-
-      # CVE-2021-3121
-      go get -u github.com/golang/protobuf@v1.5.3
-
-      # GHSA-c3h9-896r-86jm
-      go get -u github.com/gogo/protobuf@v1.3.2
-
-      # GHSA-h86h-8ppg-mxmh
-      # GHSA-83g2-8m93-v3w7
-      # GHSA-69cg-p879-7622
-      # GHSA-vvpx-j8f3-3w6h
-      # CVE-2023-39325 and CVE-2023-3978
-      go get -u golang.org/x/net@v0.17.0
-
-      go mod tidy
-      go mod vendor
+  - uses: go/bump
+    with:
+      deps: github.com/opencontainers/image-spec@v1.0.2 github.com/gogo/protobuf@v1.3.2 golang.org/x/net@v0.17.0 github.com/docker/docker@v24.0.7
 
   - uses: go/build
     with:
       packages: .
       output: dive
-      modroot: dive
       ldflags: -w -X main.version=v${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.buildTime=$(date +%F-%T)
 
   - uses: strip

--- a/docker-credential-acr-env.yaml
+++ b/docker-credential-acr-env.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-credential-acr-env
   version: 0.7.0
-  epoch: 7
+  epoch: 8
   description: ACR Docker Credential Helper
   copyright:
     - license: Apache-2.0
@@ -22,19 +22,9 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: c57b701bfc08d857fce060250ed9a254b075538d
 
-  - runs: |
-      # Mitigate  GHSA-3vm4-22fp-5rfm, GHSA-gwc9-m7rh-j2ww and GHSA-8c26-wmh5-6g9v
-      go get golang.org/x/crypto@v0.7.0
-
-      # GHSA-p782-xgp4-8hr8
-      go get -u golang.org/x/sys@v0.0.0-20220412211240-33da011f77ad
-
-      # GHSA-ppp9-7jff-5vj2
-      # GHSA-69ch-w2m2-3vjp
-      go get -u golang.org/x/text@v0.3.8
-
-      go mod tidy
-      go mod vendor
+  - uses: go/bump
+    with:
+      deps: golang.org/x/sys@v0.13.0 golang.org/x/text@v0.9.0 golang.org/x/crypto@v0.14.0
 
   - runs: |
       make build

--- a/docker-credential-gcr.yaml
+++ b/docker-credential-gcr.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-credential-gcr
   version: 2.1.20
-  epoch: 0
+  epoch: 1
   description: A Docker credential helper for GCR users
   copyright:
     - license: Apache-2.0
@@ -20,12 +20,9 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 201f90d6fe5ad4bce2aa3afbd3915a6b63e73b5a
 
-  - runs: |
-      # CVE-2023-39325 and CVE-2023-3978
-      go get -u golang.org/x/net@v0.17.0
-
-      go mod tidy -compat=1.17
-      go mod vendor
+  - uses: go/bump
+    with:
+      deps: golang.org/x/net@v0.17.0 github.com/docker/docker@v24.0.7
 
   - uses: go/build
     with:

--- a/dockerize.yaml
+++ b/dockerize.yaml
@@ -1,7 +1,7 @@
 package:
   name: dockerize
   version: 0.7.0
-  epoch: 0
+  epoch: 1
   description: Utility to simplify running applications in docker containers
   copyright:
     - license: MIT License
@@ -21,12 +21,9 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: c489c4f42d15df111d02d80fce5816bb024278f4
 
-  - runs: |
-      # Fix some CVEs.
-      go get -u golang.org/x/net@v0.17.0
-
-      go mod tidy -compat=1.20
-      go mod vendor
+  - uses: go/bump
+    with:
+      deps: golang.org/x/net@v0.17.0
 
   - uses: go/build
     with:

--- a/dynamic-localpv-provisioner.yaml
+++ b/dynamic-localpv-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: dynamic-localpv-provisioner
   version: 3.4.1
-  epoch: 4
+  epoch: 5
   description: Dynamic Local Volumes for Kubernetes Stateful workloads.
   copyright:
     - license: Apache-2.0
@@ -29,15 +29,11 @@ pipeline:
       tag: localpv-provisioner-${{package.version}}
       expected-commit: 3915c2c8409b0b37806b6219cc68363565018689
 
+  - uses: go/bump
+    with:
+      deps: github.com/prometheus/client_golang@v1.11.1 golang.org/x/text@v0.9.0 golang.org/x/net@v0.17.0 golang.org/x/crypto@v0.14.0 gopkg.in/yaml.v3@v3.0.0-20220521103104-8f96da9f5d5e github.com/Masterminds/goutils@v1.1.1 google.golang.org/grpc@v1.56.3
+
   - runs: |
-      go get github.com/prometheus/client_golang@v1.11.1
-      go get golang.org/x/text@v0.9.0
-      go get golang.org/x/net@v0.17.0
-      go get golang.org/x/crypto@v0.14.0
-      go get gopkg.in/yaml.v3@v3.0.0-20220521103104-8f96da9f5d5e
-      go get github.com/Masterminds/goutils@v1.1.1
-      go get google.golang.org/grpc@v1.56.3
-      go mod tidy
       make provisioner-localpv
       mkdir -p ${{targets.destdir}}/usr/bin
       GOOS=$(go env GOOS)

--- a/pipelines/go/bump.yaml
+++ b/pipelines/go/bump.yaml
@@ -19,11 +19,11 @@ pipeline:
   - runs: |
       # We have to run go mod tidy before and after in some cases (if old versions of go are used, we need to update the go.mod format)
       cd "${{inputs.modroot}}"
-      go mod tidy
+      go mod tidy -go=1.20
 
       gobump -packages "${{inputs.deps}}"
 
-      go mod tidy
+      go mod tidy -go=1.20
       if [ -d "./vendor" ]; then
         go mod vendor
       fi


### PR DESCRIPTION
This also adds a -go=1.20 to the pipeline itself. We had a few packages that were pinned to go 1.16 in their go.mods, which isn't updated by default to higher go versions.
