### PR TITLE
Fluent-bit.yaml binary location update

### DIFF
--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -16,15 +16,15 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - dpkg
       - flex
       - glibc
       - libpq-15
       - openssl-dev
       - postgresql-15-dev
+      - systemd-dev
       - yaml-dev
       - zlib-dev
-      - dpkg
-      - systemd-dev
 
 pipeline:
   - uses: git-checkout
@@ -81,6 +81,7 @@ subpackages:
       runtime:
         - fluent-bit
     description: fluent-bit dev
+
   - name: fluent-bit-compat
     pipeline:
       - runs: |

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -81,6 +81,12 @@ subpackages:
       runtime:
         - fluent-bit
     description: fluent-bit dev
+  - name: fluent-bit-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/fluent-bit/bin/
+          # The upstream chart expects the fluent-bit binary to be in /fluent-bit/bin/fluent-bit
+          ln -sf /usr/bin/fluent-bit ${{targets.subpkgdir}}/fluent-bit/bin/fluent-bit
 
 update:
   enabled: true

--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-bit
   version: 2.2.0
-  epoch: 0
+  epoch: 1
   description: Fast and Lightweight Log processor and forwarder
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Adds fluent-bit-compat  to symlink binary to expected location, upstream charts expects binary to be at /fluent-bit/bin/fluent-bit

- [x] `epoch` bumped