### PR TITLE
command-not-found: new package

### DIFF
--- a/command-not-found.yaml
+++ b/command-not-found.yaml
@@ -1,0 +1,34 @@
+package:
+  name: command-not-found
+  version: 0.3
+  epoch: 0
+  description: friendly command not found handling
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 93b144df20c08cc2a6d50531f2d06ad23d704576f793440ff5de454f29670e3b
+      uri: https://github.com/kaniini/command-not-found/archive/v${{package.version}}/command-not-found-${{package.version}}.tar.gz
+
+  - runs: |
+      install -D -m755 command-not-found.sh "${{targets.destdir}}"/usr/libexec/command-not-found
+      install -D -m755 profiles/command-not-found.ash "${{targets.destdir}}"/etc/profile.d/command-not-found.sh
+
+update:
+  enabled: true
+  github:
+    identifier: kaniini/command-not-found
+    tag-filter: v
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)