### PR TITLE
epoch bump packages that use provider-priority

### DIFF
--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,7 +1,7 @@
 package:
   name: busybox
   version: 1.36.1
-  epoch: 2
+  epoch: 3
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only

--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl-rustls
   version: 8.4.0
-  epoch: 0
+  epoch: 1
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT

--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: 8.4.0
-  epoch: 1
+  epoch: 2
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.38
-  epoch: 6
+  epoch: 7
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
We had a bug in melange where `provider-priority` was not being written to package metadata, which we've since fixed. This PR will rebuild all packages where we use `provider-priority` so their metadata is correct.