### PR TITLE
fix cves zookeeper logback-core

### DIFF
--- a/zookeeper-3.8.yaml
+++ b/zookeeper-3.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.8
   version: 3.8.3.0
-  epoch: 6
+  epoch: 7
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0
@@ -43,6 +43,10 @@ pipeline:
   - uses: patch
     with:
       patches: upgrade-the-jetty-version.patch
+
+  - uses: patch
+    with:
+      patches: upgrade-the-logback-core-version.patch
 
   - runs: |
       export LANG=en_US.UTF-8

--- a/zookeeper-3.8/upgrade-the-logback-core-version.patch
+++ b/zookeeper-3.8/upgrade-the-logback-core-version.patch
@@ -1,0 +1,26 @@
+From c27bcdc79c508b262ab2384f7adb1b1911812ba4 Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Wed, 6 Dec 2023 20:48:28 +0300
+Subject: [PATCH] upgrade logback-version
+
+Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+---
+ pom.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pom.xml b/pom.xml
+index 6158b7f4e..d05cac978 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -551,7 +551,7 @@
+ 
+     <!-- dependency versions -->
+     <slf4j.version>1.7.30</slf4j.version>
+-    <logback-version>1.2.10</logback-version>
++    <logback-version>1.2.13</logback-version>
+     <audience-annotations.version>0.12.0</audience-annotations.version>
+     <jmockit.version>1.48</jmockit.version>
+     <junit.version>5.6.2</junit.version>
+-- 
+2.39.3 (Apple Git-145)
+

--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.9
   version: 3.9.1.0
-  epoch: 6
+  epoch: 7
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0
@@ -43,6 +43,10 @@ pipeline:
   - uses: patch
     with:
       patches: upgrade-the-jetty-version.patch
+
+  - uses: patch
+    with:
+      patches: upgrade-the-logback-core-version.patch
 
   - runs: |
       export LANG=en_US.UTF-8

--- a/zookeeper-3.9/upgrade-the-logback-core-version.patch
+++ b/zookeeper-3.9/upgrade-the-logback-core-version.patch
@@ -1,0 +1,26 @@
+From c27bcdc79c508b262ab2384f7adb1b1911812ba4 Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Wed, 6 Dec 2023 20:48:28 +0300
+Subject: [PATCH] upgrade logback-version
+
+Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+---
+ pom.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pom.xml b/pom.xml
+index 6158b7f4e..d05cac978 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -551,7 +551,7 @@
+ 
+     <!-- dependency versions -->
+     <slf4j.version>1.7.30</slf4j.version>
+-    <logback-version>1.2.10</logback-version>
++    <logback-version>1.2.13</logback-version>
+     <audience-annotations.version>0.12.0</audience-annotations.version>
+     <jmockit.version>1.48</jmockit.version>
+     <junit.version>5.6.2</junit.version>
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
