### PR TITLE
Bump cosign and fix the go/bump pipeline to support variable go versi…

### DIFF
--- a/cosign.yaml
+++ b/cosign.yaml
@@ -1,7 +1,7 @@
 package:
   name: cosign
-  version: 2.2.1
-  epoch: 2
+  version: 2.2.2
+  epoch: 0
   description: Container Signing
   copyright:
     - license: Apache-2.0
@@ -22,11 +22,12 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/sigstore/cosign/archive/v${{package.version}}/cosign-v${{package.version}}.tar.gz
-      expected-sha256: 7bff4107639c516495ef5b987ed6411d6fc91f85b3d3f80672f785511903a4d1
+      expected-sha256: a1a9231d3768989b89f2b031b6d72adac0b0eb1e1276313efa0afdc9ed56398b
 
   - uses: go/bump
     with:
       deps: github.com/go-jose/go-jose/v3@v3.0.1
+      go-version: "1.21"
 
   - uses: go/build
     with:

--- a/pipelines/go/bump.yaml
+++ b/pipelines/go/bump.yaml
@@ -14,16 +14,19 @@ inputs:
   modroot:
     description: The root of the module
     default: .
+  go-version:
+    description: "The go version to set the go.mod syntax to"
+    default: 1.20
 
 pipeline:
   - runs: |
       # We have to run go mod tidy before and after in some cases (if old versions of go are used, we need to update the go.mod format)
       cd "${{inputs.modroot}}"
-      go mod tidy -go=1.20
+      go mod tidy -go=${{inputs.go-version}}
 
       gobump -packages "${{inputs.deps}}"
 
-      go mod tidy -go=1.20
+      go mod tidy -go=${{inputs.go-version}}
       if [ -d "./vendor" ]; then
         go mod vendor
       fi


### PR DESCRIPTION
…ons.

We need a minimum go version, but some deps require higher than that.

Ref: https://github.com/wolfi-dev/os/pull/9466