### PR TITLE
Fix rustls-ffi build.

### DIFF
--- a/rustls-ffi.yaml
+++ b/rustls-ffi.yaml
@@ -27,7 +27,7 @@ pipeline:
       # gcc 13 throws extra error, suppress them
       sed -i "s/CFLAGS := -Werror/CFLAGS := -Werror -Wno-maybe-uninitialized/" Makefile
 
-  - runs: autoconf/make
+  - uses: autoconf/make
 
   - uses: autoconf/make-install
 

--- a/rustls-ffi.yaml
+++ b/rustls-ffi.yaml
@@ -1,6 +1,6 @@
 package:
   name: rustls-ffi
-  version: 0.11.0
+  version: 0.12.0
   epoch: 0
   description: "C-to-rustls bindings"
   copyright:
@@ -13,7 +13,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - libLLVM-15
       - rust
       - wolfi-base
 
@@ -22,9 +21,13 @@ pipeline:
     with:
       repository: https://github.com/rustls/rustls-ffi
       tag: v${{package.version}}
-      expected-commit: 7b1839daca81b0955a36e4b7e39b70ee73f8275d
+      expected-commit: a1e41beba48a579eb4f083fec14a4ee9a35832ab
 
-  - uses: autoconf/make
+  - runs: |
+      # gcc 13 throws extra error, suppress them
+      sed -i "s/CFLAGS := -Werror/CFLAGS := -Werror -Wno-maybe-uninitialized/" Makefile
+
+  - runs: autoconf/make
 
   - uses: autoconf/make-install
 


### PR DESCRIPTION
This broke with gcc 13.

Ref: https://github.com/wolfi-dev/os/pull/9540