### PR TITLE
jruby: new package 🎉 

### DIFF
--- a/jruby-9.4.yaml
+++ b/jruby-9.4.yaml
@@ -1,0 +1,55 @@
+package:
+  name: jruby-9.4
+  version: 9.4.5.0
+  epoch: 0
+  description: JRuby, an implementation of Ruby on the JVM
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - bash
+      - busybox
+      - ca-certificates-bundle
+      - maven
+      - openjdk-8
+      - openjdk-8-default-jvm
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/jruby/jruby
+      tag: ${{package.version}}
+      expected-commit: 1abae2700ffd6ddec93b661400c9744e9bb45eff
+
+  - runs: |
+      export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
+      mvn install
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/usr/share/jruby
+
+      mkdir -p ${{targets.destdir}}/usr/share/jruby/bin
+      rm -rf bin/*.bat
+      rm -rf bin/*.dll
+      rm -rf bin/*.exe
+
+      rm -rf lib/jni/*Darwin*
+      rm -rf lib/jni/*-SunOS*
+      rm -rf lib/jni/*-Windows*
+      rm -rf lib/jni/*-AIX*
+      rm -rf lib/jni/*-*BSD*
+      mv bin/* "${{targets.destdir}}"/usr/share/jruby/bin/
+      rm -rf lib/target
+      mv lib "${{targets.destdir}}"/usr/share/jruby
+      for f in "${{targets.destdir}}"/usr/share/jruby/bin/*; do
+        filename=$(basename "$f")
+        ln -sf  /usr/share/jruby/bin/"$filename" "${{targets.destdir}}"/usr/bin/"$filename"
+      done
+
+update:
+  enabled: true
+  github:
+    identifier: jruby/jruby
+    use-tag: true
+    tag-filter-prefix: 9.4.


### PR DESCRIPTION
jruby: new package 🎉  

Fixes #9403 
### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)


