### PR TITLE
fix: bump kubeflow-pipelines epoch for new subpackage to build

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: 2.0.4
-  epoch: 1
+  epoch: 2
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:


### PR DESCRIPTION
Bump epoch of kubeflow-pipelines to 2 for building the new subpackage `kubeflow-pipelines-metadata-envoy-config`.