### PR TITLE
`semgrep` package update to `1.52.0`

### DIFF
--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1,6 +1,6 @@
 package:
   name: semgrep
-  version: 1.50.0
+  version: 1.52.0
   epoch: 0
   description: "Lightweight static analysis for many languages. Find bug variants with patterns that look like source code."
   copyright:
@@ -19,6 +19,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - curl # needed for opam, it tries to use wget with missing flags instead.
+      - git
       - gmp-dev # linked against
       - libev-dev
       - ocaml
@@ -38,10 +39,11 @@ pipeline:
     with:
       repository: https://github.com/returntocorp/semgrep
       tag: v${{package.version}}
-      expected-commit: 115a458c1e942ed484a33cdbf29616da4ada8b20
+      expected-commit: d25045282758915ac787aa25725e6cab9917bd9e
 
   - runs: |
-      opam init --compiler=ocaml-base-compiler.4.14.0 -y
+      git submodule update --init --recursive
+      opam init --compiler=ocaml-base-compiler.4.14.0 --disable-sandboxing -y
       opam switch create 4.14.0+static ocaml-base-compiler.4.14.0
       eval $(opam env --switch=4.14.0+static)
       make dev-setup
@@ -93,6 +95,7 @@ subpackages:
 
 update:
   enabled: true
+  manual: false
   github:
     identifier: returntocorp/semgrep
     strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #9490 

The git clone does not get git submodules from GitHub.

> **I think we should include it in the melange git-checkout pipeline**
something like `- with-submodule` that will run `git submodule update --init --recursive` inside the git repository

Also disable sandboxing because of `Error: _64    | [ERROR] Sandboxing is not working on your platform wolfi:`

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
