### PR TITLE
tiff: Patch for CVE-2023-6277

### DIFF
--- a/tiff.yaml
+++ b/tiff.yaml
@@ -1,7 +1,7 @@
 package:
   name: tiff
   version: 4.6.0
-  epoch: 0
+  epoch: 1
   description: Provides support for the Tag Image File Format or TIFF
   copyright:
     - license: libtiff
@@ -27,6 +27,11 @@ pipeline:
     with:
       expected-sha256: e178649607d1e22b51cf361dd20a3753f244f022eefab1f2f218fc62ebaf87d2
       uri: https://download.osgeo.org/libtiff/tiff-${{package.version}}.tar.xz
+
+  - uses: patch
+    with:
+      # Source: https://gitlab.com/libtiff/libtiff/-/merge_requests/545
+      patches: CVE-2023-6277.patch
 
   - uses: autoconf/configure
 

--- a/tiff/CVE-2023-6277.patch
+++ b/tiff/CVE-2023-6277.patch
@@ -1,0 +1,216 @@
+From d6bbe53a96b031ab8b53d20241825ddf9e8bf8f1 Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Fri, 27 Oct 2023 22:11:10 +0200
+Subject: [PATCH 1/3] At image reading, compare data size of some tags / data
+ structures (StripByteCounts, StripOffsets, StripArray, TIFF directory) with
+ file size to prevent provoked out-of-memory attacks.
+
+See issue #614.
+---
+ libtiff/tif_dirread.c | 90 +++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 90 insertions(+)
+
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+index 2c49dc6a..c52d41f0 100644
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -1308,6 +1308,21 @@ TIFFReadDirEntryArrayWithLimit(TIFF *tif, TIFFDirEntry *direntry,
+     datasize = (*count) * typesize;
+     assert((tmsize_t)datasize > 0);
+ 
++    /* Before allocating a huge amount of memory for corrupted files, check if
++     * size of requested memory is not greater than file size.
++     */
++    uint64_t filesize = TIFFGetFileSize(tif);
++    if (datasize > filesize)
++    {
++        TIFFWarningExtR(tif, "ReadDirEntryArray",
++                        "Requested memory size for tag %d (0x%x) %" PRIu32
++                        " is greather than filesize %" PRIu64
++                        ". Memory not allocated, tag not read",
++                        direntry->tdir_tag, direntry->tdir_tag, datasize,
++                        filesize);
++        return (TIFFReadDirEntryErrAlloc);
++    }
++
+     if (isMapped(tif) && datasize > (uint64_t)tif->tif_size)
+         return TIFFReadDirEntryErrIo;
+ 
+@@ -5266,6 +5281,20 @@ static int EstimateStripByteCounts(TIFF *tif, TIFFDirEntry *dir,
+     if (!_TIFFFillStrilesInternal(tif, 0))
+         return -1;
+ 
++    /* Before allocating a huge amount of memory for corrupted files, check if
++     * size of requested memory is not greater than file size. */
++    uint64_t filesize = TIFFGetFileSize(tif);
++    uint64_t allocsize = (uint64_t)td->td_nstrips * sizeof(uint64_t);
++    if (allocsize > filesize)
++    {
++        TIFFWarningExtR(tif, module,
++                        "Requested memory size for StripByteCounts of %" PRIu64
++                        " is greather than filesize %" PRIu64
++                        ". Memory not allocated",
++                        allocsize, filesize);
++        return -1;
++    }
++
+     if (td->td_stripbytecount_p)
+         _TIFFfreeExt(tif, td->td_stripbytecount_p);
+     td->td_stripbytecount_p = (uint64_t *)_TIFFCheckMalloc(
+@@ -5807,6 +5836,20 @@ static uint16_t TIFFFetchDirectory(TIFF *tif, uint64_t diroff,
+             dircount16 = (uint16_t)dircount64;
+             dirsize = 20;
+         }
++        /* Before allocating a huge amount of memory for corrupted files, check
++         * if size of requested memory is not greater than file size. */
++        uint64_t filesize = TIFFGetFileSize(tif);
++        uint64_t allocsize = (uint64_t)dircount16 * dirsize;
++        if (allocsize > filesize)
++        {
++            TIFFWarningExtR(
++                tif, module,
++                "Requested memory size for TIFF directory of %" PRIu64
++                " is greather than filesize %" PRIu64
++                ". Memory not allocated, TIFF directory not read",
++                allocsize, filesize);
++            return 0;
++        }
+         origdir = _TIFFCheckMalloc(tif, dircount16, dirsize,
+                                    "to read TIFF directory");
+         if (origdir == NULL)
+@@ -5921,6 +5964,20 @@ static uint16_t TIFFFetchDirectory(TIFF *tif, uint64_t diroff,
+                           "directories not supported");
+             return 0;
+         }
++        /* Before allocating a huge amount of memory for corrupted files, check
++         * if size of requested memory is not greater than file size. */
++        uint64_t filesize = TIFFGetFileSize(tif);
++        uint64_t allocsize = (uint64_t)dircount16 * dirsize;
++        if (allocsize > filesize)
++        {
++            TIFFWarningExtR(
++                tif, module,
++                "Requested memory size for TIFF directory of %" PRIu64
++                " is greather than filesize %" PRIu64
++                ". Memory not allocated, TIFF directory not read",
++                allocsize, filesize);
++            return 0;
++        }
+         origdir = _TIFFCheckMalloc(tif, dircount16, dirsize,
+                                    "to read TIFF directory");
+         if (origdir == NULL)
+@@ -5968,6 +6025,8 @@ static uint16_t TIFFFetchDirectory(TIFF *tif, uint64_t diroff,
+             }
+         }
+     }
++    /* No check against filesize needed here because "dir" should have same size
++     * than "origdir" checked above. */
+     dir = (TIFFDirEntry *)_TIFFCheckMalloc(
+         tif, dircount16, sizeof(TIFFDirEntry), "to read TIFF directory");
+     if (dir == 0)
+@@ -7164,6 +7223,20 @@ static int TIFFFetchStripThing(TIFF *tif, TIFFDirEntry *dir, uint32_t nstrips,
+             return (0);
+         }
+ 
++        /* Before allocating a huge amount of memory for corrupted files, check
++         * if size of requested memory is not greater than file size. */
++        uint64_t filesize = TIFFGetFileSize(tif);
++        uint64_t allocsize = (uint64_t)nstrips * sizeof(uint64_t);
++        if (allocsize > filesize)
++        {
++            TIFFWarningExtR(tif, module,
++                            "Requested memory size for StripArray of %" PRIu64
++                            " is greather than filesize %" PRIu64
++                            ". Memory not allocated",
++                            allocsize, filesize);
++            _TIFFfreeExt(tif, data);
++            return (0);
++        }
+         resizeddata = (uint64_t *)_TIFFCheckMalloc(
+             tif, nstrips, sizeof(uint64_t), "for strip array");
+         if (resizeddata == 0)
+@@ -7263,6 +7336,23 @@ static void allocChoppedUpStripArrays(TIFF *tif, uint32_t nstrips,
+     }
+     bytecount = last_offset + last_bytecount - offset;
+ 
++    /* Before allocating a huge amount of memory for corrupted files, check if
++     * size of StripByteCount and StripOffset tags is not greater than
++     * file size.
++     */
++    uint64_t allocsize = (uint64_t)nstrips * sizeof(uint64_t) * 2;
++    uint64_t filesize = TIFFGetFileSize(tif);
++    if (allocsize > filesize)
++    {
++        TIFFWarningExtR(tif, "allocChoppedUpStripArrays",
++                        "Requested memory size for StripByteCount and "
++                        "StripOffsets %" PRIu64
++                        " is greather than filesize %" PRIu64
++                        ". Memory not allocated",
++                        allocsize, filesize);
++        return;
++    }
++
+     newcounts =
+         (uint64_t *)_TIFFCheckMalloc(tif, nstrips, sizeof(uint64_t),
+                                      "for chopped \"StripByteCounts\" array");
+-- 
+GitLab
+
+
+From 264a28eff71cf0038ba7b235238512fa594fa42f Mon Sep 17 00:00:00 2001
+From: Su_Laus <sulau@freenet.de>
+Date: Mon, 30 Oct 2023 21:21:57 +0100
+Subject: [PATCH 2/3] At image reading, compare data size of some tags / data
+ structures (StripByteCounts, StripOffsets, StripArray, TIFF directory) with
+ file size to prevent provoked out-of-memory attacks.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+See issue #614.
+
+Correct declaration of ‘filesize’ shadows a previous local.
+---
+ libtiff/tif_dirread.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+index c52d41f0..fe8d6f80 100644
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -5305,7 +5305,6 @@ static int EstimateStripByteCounts(TIFF *tif, TIFFDirEntry *dir,
+     if (td->td_compression != COMPRESSION_NONE)
+     {
+         uint64_t space;
+-        uint64_t filesize;
+         uint16_t n;
+         filesize = TIFFGetFileSize(tif);
+         if (!(tif->tif_flags & TIFF_BIGTIFF))
+-- 
+GitLab
+
+
+From abb4476fd2be87fc8ded3078e019f22f84ee0e8c Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Tue, 31 Oct 2023 15:04:37 +0000
+Subject: [PATCH 3/3] Apply 1 suggestion(s) to 1 file(s)
+
+---
+ libtiff/tif_dirread.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+index fe8d6f80..58a42760 100644
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -5306,7 +5306,6 @@ static int EstimateStripByteCounts(TIFF *tif, TIFFDirEntry *dir,
+     {
+         uint64_t space;
+         uint16_t n;
+-        filesize = TIFFGetFileSize(tif);
+         if (!(tif->tif_flags & TIFF_BIGTIFF))
+             space = sizeof(TIFFHeaderClassic) + 2 + dircount * 12 + 4;
+         else
+-- 
+GitLab
+


### PR DESCRIPTION
Apply the patch to tiff for CVE-2023-6277

The upstream project disagrees with the CVE, but here's the patch nonetheless, source: https://gitlab.com/libtiff/libtiff/-/merge_requests/545

Note: "Scan packages for CVEs" will fail, but will stop reporting shortly after we merge the advisory
