### PR TITLE
systemd: fix development symlink install path for libsystemd

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "255"
-  epoch: 0
+  epoch: 1
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -53,8 +53,8 @@ subpackages:
     description: "systemd library"
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/lib
-          mv ${{targets.destdir}}/usr/lib/libsystemd.so* ${{targets.subpkgdir}}/lib
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/libsystemd.so* ${{targets.subpkgdir}}/usr/lib
 
 update:
   enabled: true


### PR DESCRIPTION
The development symlink was installed to `/lib`, while the target is now in `/usr/lib` due to upstream build changes.