### PR TITLE
py3-pipenv: Unvendor `py3-platformdirs`

### DIFF
--- a/py3-pipenv.yaml
+++ b/py3-pipenv.yaml
@@ -2,13 +2,14 @@
 package:
   name: py3-pipenv
   version: 2023.11.15
-  epoch: 0
+  epoch: 1
   description: Python Development Workflow for Humans.
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - py3-certifi
+      - py3-platformdirs
       - py3-setuptools
       - py3-virtualenv
       - python-3
@@ -21,6 +22,7 @@ environment:
       - ca-certificates-bundle
       - py3-certifi
       - py3-pip
+      - py3-platformdirs
       - py3-setuptools
       - py3-virtualenv
       - python-3


### PR DESCRIPTION
This seems to fix the conflict between `py3-virtualenv` and this package!