### PR TITLE
Trino: Fix CVE-2023-6378

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
   version: "433"
-  epoch: 1
+  epoch: 2
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0
@@ -34,7 +34,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: CVE-2023-5072.patch CVE-2023-34062.patch
+      patches: CVE-2023-5072.patch CVE-2023-34062.patch CVE-2023-6378.patch
 
   - runs: |
       set -x

--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
-  version: "433"
-  epoch: 2
+  version: "434"
+  epoch: 0
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,7 @@ pipeline:
     with:
       repository: https://github.com/trinodb/trino.git
       tag: ${{package.version}}
-      expected-commit: 301c72792f616310cf227a0ef66fb5e86e07027c
+      expected-commit: aa431c77a6a187920f5d6433532a19647d901742
 
   - uses: patch
     with:
@@ -41,7 +41,7 @@ pipeline:
 
       export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
-      ./mvnw package -q -DskipTests -T 8  -pl '!:trino-docs,!:trino-server-rpm'
+      ./mvnw package -q -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all -T 8  -pl '!:trino-docs,!:trino-server-rpm,!:trino-tests,!:trino-product-tests,!:trino-product-tests-launcher' -am
 
       mkdir -p ${{targets.destdir}}/usr/lib/trino
       cp ./core/trino-server/target/trino-server-${{package.version}}/NOTICE ${{targets.destdir}}/usr/lib/trino/
@@ -148,7 +148,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib/trino/lib
-          cp ./core/trino-server/target/trino-server-${{package.version}}/plugin/${{range.value}}/* ${{targets.subpkgdir}}/usr/lib/trino/lib/
+          cp -r ./core/trino-server/target/trino-server-${{package.version}}/plugin/${{range.value}}/* ${{targets.subpkgdir}}/usr/lib/trino/lib/
 
           mkdir -p ${{targets.subpkgdir}}/usr/lib/trino/plugin/${{range.value}}
           for path in ./core/trino-server/target/trino-server-${{package.version}}/plugin/${{range.value}}/*; do

--- a/trino/CVE-2023-6378.patch
+++ b/trino/CVE-2023-6378.patch
@@ -1,0 +1,30 @@
+From cdf7a542094bc67266ef944e9a17d59878a90ccd Mon Sep 17 00:00:00 2001
+From: Philippe Deslauriers <philde@chainguard.dev>
+Date: Fri, 8 Dec 2023 12:34:48 -0800
+Subject: [PATCH] Resolve GHSA-vmq6-5m68-f53m by bumping logback-core
+
+Signed-off-by: Philippe Deslauriers <philde@chainguard.dev>
+---
+ pom.xml | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/pom.xml b/pom.xml
+index e4f007e8..dcdfe2c8 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -302,6 +302,12 @@
+                 <scope>import</scope>
+             </dependency>
+ 
++            <dependency>
++                <groupId>ch.qos.logback</groupId>
++                <artifactId>logback-core</artifactId>
++                <version>[1.4.12,2.0.0)</version>
++            </dependency>
++
+             <dependency>
+                 <groupId>com.adobe.testing</groupId>
+                 <artifactId>s3mock-testcontainers</artifactId>
+-- 
+2.42.0
+


### PR DESCRIPTION
Fix CVE-2023-6378 by bumping `log back-core` to `1.4.12`

There are other known vulnerabilities in this package - they won't be addressed in this PR.
