### PR TITLE
opensearch-2: Resolve CVE-2022-45146

### DIFF
--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-2
   version: 2.11.1
-  epoch: 0
+  epoch: 1 # Remove CVE-2022-45146 patch when bumping to 2.12 or later
   description:
   target-architecture:
     - all
@@ -30,6 +30,11 @@ pipeline:
       repository: https://github.com/opensearch-project/OpenSearch
       tag: ${{package.version}}
       expected-commit: 6b1986e964d440be9137eba1413015c31c5a7752
+
+  - uses: patch
+    with:
+      # Patch from: https://patch-diff.githubusercontent.com/raw/opensearch-project/OpenSearch/pull/10297.patch
+      patches: CVE-2022-45146.patch
 
   - runs: |
       export LANG=en_US.UTF-8

--- a/opensearch-2/CVE-2022-45146.patch
+++ b/opensearch-2/CVE-2022-45146.patch
@@ -1,0 +1,63 @@
+From e0f639b78194304de5237a913a3c0caa7d621c7b Mon Sep 17 00:00:00 2001
+From: "dependabot[bot]" <49699333+dependabot[bot]@users.noreply.github.com>
+Date: Thu, 5 Oct 2023 00:56:46 +0000
+Subject: [PATCH 1/3] Bump org.bouncycastle:bc-fips in
+ /distribution/tools/plugin-cli
+
+Bumps org.bouncycastle:bc-fips from 1.0.2.3 to 1.0.2.4.
+
+---
+updated-dependencies:
+- dependency-name: org.bouncycastle:bc-fips
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+---
+ distribution/tools/plugin-cli/build.gradle | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/distribution/tools/plugin-cli/build.gradle b/distribution/tools/plugin-cli/build.gradle
+index 2db3fef55d02..b61a00aba04b 100644
+--- a/distribution/tools/plugin-cli/build.gradle
++++ b/distribution/tools/plugin-cli/build.gradle
+@@ -38,7 +38,7 @@ dependencies {
+   compileOnly project(":server")
+   compileOnly project(":libs:opensearch-cli")
+   api "org.bouncycastle:bcpg-fips:1.0.7.1"
+-  api "org.bouncycastle:bc-fips:1.0.2.3"
++  api "org.bouncycastle:bc-fips:1.0.2.4"
+   testImplementation project(":test:framework")
+   testImplementation 'com.google.jimfs:jimfs:1.3.0'
+   testRuntimeOnly("com.google.guava:guava:${versions.guava}") {
+
+From 71123e5c35b11814df2a8aafe6d76a81ae0e5e41 Mon Sep 17 00:00:00 2001
+From: "dependabot[bot]" <dependabot[bot]@users.noreply.github.com>
+Date: Thu, 5 Oct 2023 01:02:22 +0000
+Subject: [PATCH 2/3] Updating SHAs
+
+Signed-off-by: dependabot[bot] <support@github.com>
+---
+ distribution/tools/plugin-cli/licenses/bc-fips-1.0.2.3.jar.sha1 | 1 -
+ distribution/tools/plugin-cli/licenses/bc-fips-1.0.2.4.jar.sha1 | 1 +
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+ delete mode 100644 distribution/tools/plugin-cli/licenses/bc-fips-1.0.2.3.jar.sha1
+ create mode 100644 distribution/tools/plugin-cli/licenses/bc-fips-1.0.2.4.jar.sha1
+
+diff --git a/distribution/tools/plugin-cli/licenses/bc-fips-1.0.2.3.jar.sha1 b/distribution/tools/plugin-cli/licenses/bc-fips-1.0.2.3.jar.sha1
+deleted file mode 100644
+index c71320050b7d..000000000000
+--- a/distribution/tools/plugin-cli/licenses/bc-fips-1.0.2.3.jar.sha1
++++ /dev/null
+@@ -1 +0,0 @@
+-da62b32cb72591f5b4d322e6ab0ce7de3247b534
+\ No newline at end of file
+diff --git a/distribution/tools/plugin-cli/licenses/bc-fips-1.0.2.4.jar.sha1 b/distribution/tools/plugin-cli/licenses/bc-fips-1.0.2.4.jar.sha1
+new file mode 100644
+index 000000000000..da37449f80d7
+--- /dev/null
++++ b/distribution/tools/plugin-cli/licenses/bc-fips-1.0.2.4.jar.sha1
+@@ -0,0 +1 @@
++9008d04fc13da6455e6a792935b93b629757335d
+\ No newline at end of file


### PR DESCRIPTION
Dependency was bumped here: https://github.com/opensearch-project/OpenSearch/pull/10297

It'll be released in the next version, but this PR brings the patch to Wolfi.

Advisory: https://github.com/wolfi-dev/advisories/pull/599