### PR TITLE
Skip tests in corretto.

### DIFF
--- a/amazon-corretto-crypto-provider.yaml
+++ b/amazon-corretto-crypto-provider.yaml
@@ -1,7 +1,7 @@
 package:
   name: amazon-corretto-crypto-provider
   version: 2.3.2
-  epoch: 1
+  epoch: 2
   description: |
     The Amazon Corretto Crypto Provider (ACCP) is a collection of high-performance cryptographic implementations exposed via the standard JCA/JCE interfaces.
   copyright:
@@ -30,7 +30,7 @@ pipeline:
   - runs: |
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
       export CFLAGS="-Wno-error=ignored-attributes"
-      ./gradlew build
+      ./gradlew build -x test
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/share/java/amazon-corretto-crypto-provider


### PR DESCRIPTION
I happened to notice the tests take a ridiculous amount of time during this build, disabling speeds them up a lot.

Locally it cut the build time from 7m to 3m.
