### PR TITLE
ml-metadata: Build `ml-metadata-store-server` as a subpackage

### DIFF
--- a/py3-ml-metadata.yaml
+++ b/py3-ml-metadata.yaml
@@ -51,7 +51,8 @@ subpackages:
     description: ML Metadata remote gRPC server
     pipeline:
       - runs: |
-          bazel build -c opt --define grpc_no_ares=true //ml_metadata/metadata_store:metadata_store_server
+          # Reduce the number of jobs to avoid OOM
+          bazel build -c opt --define grpc_no_ares=true --jobs $(($(grep -c ^processor /proc/cpuinfo) / 2)) //ml_metadata/metadata_store:metadata_store_server
 
           mkdir -p "${{targets.contextdir}}/usr/bin"
           cp bazel-bin/ml_metadata/metadata_store/metadata_store_server "${{targets.contextdir}}/usr/bin"

--- a/py3-ml-metadata.yaml
+++ b/py3-ml-metadata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ml-metadata
   version: 1.14.0
-  epoch: 2
+  epoch: 3
   description: For recording and retrieving metadata associated with ML developer and data scientist workflows.
   copyright:
     - license: MIT
@@ -25,7 +25,7 @@ environment:
       - python3-dev
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
-    BAZEL_CXXOPTS: -std=c++14
+    BAZEL_CXXOPTS: -std=c++17:-w
 
 pipeline:
   - uses: git-checkout
@@ -45,6 +45,17 @@ pipeline:
       python3 setup.py install --skip-build --root="${{targets.destdir}}"
 
   - uses: strip
+
+subpackages:
+  - name: ml-metadata-store-server
+    description: ML Metadata remote gRPC server
+    pipeline:
+      - runs: |
+          bazel build -c opt --define grpc_no_ares=true //ml_metadata/metadata_store:metadata_store_server
+
+          mkdir -p "${{targets.contextdir}}/usr/bin"
+          cp bazel-bin/ml_metadata/metadata_store/metadata_store_server "${{targets.contextdir}}/usr/bin"
+      - uses: strip
 
 update:
   enabled: true


### PR DESCRIPTION
Updating our existing `ml-metadata` package to also produce the `ml-metadata-store-server` subpackage.