### PR TITLE
Add the cache dir to our prod builds.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,9 +76,11 @@ jobs:
       # method doesn't trigger new builds for dependent updates.
       - name: 'Build Wolfi'
         run: |
+          # Setup the melange cache dir on the host so we can use that in subsequent builds
+          mkdir ../.melangecache
           make \
             ARCH=${{ matrix.arch }} \
-            MELANGE_EXTRA_OPTS="--keyring-append=/gcsfuse/wolfi-registry/wolfi-signing.rsa.pub" \
+            MELANGE_EXTRA_OPTS="--keyring-append=/gcsfuse/wolfi-registry/wolfi-signing.rsa.pub --cache-dir=$(pwd)/../.melangecache"" \
             all -j1
 
       # Always run this step for https://github.com/wolfi-dev/os/issues/8698


### PR DESCRIPTION
This speeds up our mutli-package builds significantly, so it should help in the merge queue.

Fixes:

Related:

### Pre-review Checklist
