### PR TITLE
adds temporal cli compat

### DIFF
--- a/temporal.yaml
+++ b/temporal.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal
   version: 0.10.7
-  epoch: 1
+  epoch: 2
   description: Command-line interface for running Temporal Server and interacting with Workflows, Activities, Namespaces, and other parts of Temporal
   copyright:
     - license: MIT License
@@ -40,6 +40,14 @@ subpackages:
           packages: ./cmd/docgen
           output: temporal-docgen
           ldflags: -s -w
+      - uses: strip
+
+  - name: temporal-compat
+    description: "Compat package for temporal"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
+          ln -s /usr/bin/temporal "${{targets.contextdir}}"/usr/local/bin
       - uses: strip
 
 update:

--- a/temporal.yaml
+++ b/temporal.yaml
@@ -48,12 +48,9 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
           ln -s /usr/bin/temporal "${{targets.contextdir}}"/usr/local/bin
-      - uses: strip
 
 update:
   enabled: true
   github:
     identifier: temporalio/cli
     strip-prefix: v
-    use-tag: true
-    tag-filter: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
