### PR TITLE
upgrade to v1 of google actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -127,12 +127,12 @@ jobs:
 
       - id: auth
         name: 'Authenticate to Google Cloud'
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
           service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
 
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: prod-images-c6e5
 
@@ -222,12 +222,12 @@ jobs:
 
       - id: auth
         name: 'Authenticate to Google Cloud'
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
           service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
 
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: prod-images-c6e5
 

--- a/.github/workflows/janitor-clusters.yaml
+++ b/.github/workflows/janitor-clusters.yaml
@@ -27,11 +27,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # ratchet:actions/checkout@v4.1.1
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v1
         with:
           workload_identity_provider: ${{ matrix.workload_identity_provider }}
           service_account: ${{ matrix.fq_service_account }}
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ matrix.project }}
 

--- a/.github/workflows/reconcile-wolfi-index.yaml
+++ b/.github/workflows/reconcile-wolfi-index.yaml
@@ -20,12 +20,12 @@ jobs:
 
       - id: auth
         name: 'Authenticate to Google Cloud'
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
           service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
 
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: prod-images-c6e5
 

--- a/.github/workflows/update-cache.yaml
+++ b/.github/workflows/update-cache.yaml
@@ -23,12 +23,12 @@ jobs:
 
       - uses: chainguard-dev/actions/setup-melange@main
 
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v1
         with:
           workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
           service_account: ${{env.FQ_SERVICE_ACCOUNT}}
 
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{env.PROJECT}}
 


### PR DESCRIPTION
The v0 series are unmaintained and unsupported, and are spitting warnings:

```
The v0 series of google-github-actions/setup-gcloud is no longer maintained. It will not receive updates, improvements, or security patches. Please upgrade to the latest supported versions:
       https://github.com/google-github-actions/setup-gcloud
```