### PR TITLE
Bump kubeflow-pipelines to 2.0.5

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
-  version: 2.0.4
-  epoch: 2
+  version: 2.0.5
+  epoch: 0
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -44,7 +44,7 @@ pipeline:
     with:
       repository: https://github.com/kubeflow/pipelines
       tag: ${{package.version}}
-      expected-commit: a226de2197f4188ecf066cecd13ad1027dd2f681
+      expected-commit: c5658f09ec38e82730a8eca0a1aabf0876087eec
 
   - uses: patch
     with:

--- a/kubeflow-pipelines/add-overrides.patch
+++ b/kubeflow-pipelines/add-overrides.patch
@@ -15,7 +15,7 @@ index 8395b2c49..8b21a4eb1 100644
 @@ -6,7 +6,7 @@
      "@google-cloud/storage": "^2.5.0",
      "@kubernetes/client-node": "^0.8.2",
-     "axios": ">=0.21.1",
+     "axios": ">=1.6.0",
 -    "crypto-js": "^3.1.8",
 +    "crypto-js": "4.2.0",
      "express": "^4.17.3",


### PR DESCRIPTION
Deprecates #9667

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
