### PR TITLE
add su-exec as a runtime dependency

### DIFF
--- a/postgresql-12.yaml
+++ b/postgresql-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-12
   version: "12.17"
-  epoch: 4
+  epoch: 5
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -96,6 +96,7 @@ subpackages:
     dependencies:
       runtime:
         - bash
+        - su-exec
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/postgres/initdb

--- a/postgresql-13.yaml
+++ b/postgresql-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-13
   version: "13.13"
-  epoch: 4
+  epoch: 5
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -95,6 +95,7 @@ subpackages:
     dependencies:
       runtime:
         - bash
+        - su-exec
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/postgres/initdb

--- a/postgresql-14.yaml
+++ b/postgresql-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-14
   version: "14.10"
-  epoch: 4
+  epoch: 5
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -96,6 +96,7 @@ subpackages:
     dependencies:
       runtime:
         - bash
+        - su-exec
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/postgres/initdb

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-15
   version: "15.5"
-  epoch: 4
+  epoch: 5
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -92,6 +92,7 @@ subpackages:
     dependencies:
       runtime:
         - bash
+        - su-exec
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/postgres/initdb

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.1"
-  epoch: 4
+  epoch: 5
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -93,6 +93,7 @@ subpackages:
     dependencies:
       runtime:
         - bash
+        - su-exec
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/postgres/initdb


### PR DESCRIPTION
the oci-entrypoint script we use has a hard dependency on `su-exec`