### PR TITLE
systemd: put libsystemd back in /lib, use meson pipelines fully

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "255"
-  epoch: 1
+  epoch: 2
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -37,11 +37,13 @@ pipeline:
 
   - uses: meson/configure
 
-  - runs: |
-      meson setup build/
-      ninja -C build/
+  - uses: meson/compile
 
   - uses: meson/install
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/lib
+      mv ${{targets.destdir}}/usr/lib/libsystemd.so* ${{targets.destdir}}/lib/
 
 subpackages:
   - name: "systemd-dev"
@@ -53,8 +55,8 @@ subpackages:
     description: "systemd library"
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/lib
-          mv ${{targets.destdir}}/usr/lib/libsystemd.so* ${{targets.subpkgdir}}/usr/lib
+          mkdir -p ${{targets.subpkgdir}}/lib
+          mv ${{targets.destdir}}/lib/libsystemd.so.* ${{targets.subpkgdir}}/lib
 
 update:
   enabled: true


### PR DESCRIPTION
Some packages expect `libsystemd` to be in `/lib`, not `/usr/lib`.