### PR TITLE
bump epoch missing after some changes

### DIFF
--- a/external-dns.yaml
+++ b/external-dns.yaml
@@ -1,7 +1,7 @@
 package:
   name: external-dns
   version: 0.14.0
-  epoch: 1
+  epoch: 2
   description: Configure external DNS servers (AWS Route53, Google CloudDNS and others) for Kubernetes Ingresses and Services.
   copyright:
     - paths:

--- a/external-secrets-operator.yaml
+++ b/external-secrets-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: external-secrets-operator
   version: 0.9.9
-  epoch: 2
+  epoch: 3
   description: Integrate external secret management systems with Kubernetes
   copyright:
     - license: Apache-2.0

--- a/falcoctl.yaml
+++ b/falcoctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: falcoctl
   version: 0.6.2
-  epoch: 4
+  epoch: 5
   description: Administrative tooling for Falco
   copyright:
     - license: Apache-2.0

--- a/frp.yaml
+++ b/frp.yaml
@@ -1,7 +1,7 @@
 package:
   name: frp
   version: 0.52.3
-  epoch: 1
+  epoch: 2
   description: A fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet.
   copyright:
     - license: Apache-2.0

--- a/fuse-overlayfs-snapshotter.yaml
+++ b/fuse-overlayfs-snapshotter.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs-snapshotter
   version: 1.0.8
-  epoch: 1
+  epoch: 2
   description: fuse-overlayfs plugin for rootless containerd
   copyright:
     - license: Apache-2.0

--- a/git-lfs.yaml
+++ b/git-lfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-lfs
   version: 3.4.0
-  epoch: 5
+  epoch: 6
   description: "large file support for git"
   copyright:
     - license: MIT

--- a/gitlab-pages.yaml
+++ b/gitlab-pages.yaml
@@ -3,7 +3,7 @@
 package:
   name: gitlab-pages
   version: 16.6.1
-  epoch: 1
+  epoch: 2
   description: GitLab Pages daemon used to serve static websites for GitLab users.
   copyright:
     - license: MIT

--- a/gitlab-shell.yaml
+++ b/gitlab-shell.yaml
@@ -5,7 +5,7 @@
 package:
   name: gitlab-shell
   version: 14.31.0
-  epoch: 1
+  epoch: 2
   description: SSH access for GitLab
   copyright:
     - license: MIT


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Changes added in https://github.com/wolfi-dev/os/pull/9433 missed to bump the epoch!

Fixes: changes added by https://github.com/wolfi-dev/os/pull/9433

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
