### PR TITLE
k8ssandra-operator: remove dependency on main package.

### DIFF
--- a/k8ssandra-operator.yaml
+++ b/k8ssandra-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8ssandra-operator
   version: 1.10.3
-  epoch: 2
+  epoch: 3
   description: The Kubernetes operator for K8ssandra
   copyright:
     - license: Apache-2.0
@@ -35,9 +35,6 @@ pipeline:
 
 subpackages:
   - name: "${{package.name}}-compat"
-    dependencies:
-      runtime:
-        - "${{package.name}}"
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"
     pipeline:
       - runs: |


### PR DESCRIPTION
Allows us to reuse the compat package with FIPS variants.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->


Related: #9192 