### PR TITLE
Fix incorrect 'compat' package name

### DIFF
--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -73,7 +73,7 @@ subpackages:
           install -Dm755 tdbg "${{targets.subpkgdir}}"/usr/bin/tdbg
       - uses: strip
 
-  - name: tdbg-compact
+  - name: tdbg-compat
     description: "Compat package for tdbg"
     pipeline:
       - runs: |
@@ -89,7 +89,7 @@ subpackages:
           install -Dm755 temporal-sql-tool "${{targets.subpkgdir}}"/usr/bin/temporal-sql-tool
       - uses: strip
 
-  - name: temporal-sql-tool-compact
+  - name: temporal-sql-tool-compat
     description: "Compat package for temporal-sql-tool"
     pipeline:
       - runs: |


### PR DESCRIPTION
Recent commit mis-spelt 'compat' as 'compact' for two new packages: https://github.com/wolfi-dev/os/pull/8897. These are not yet used elsewhere. This PR is to correct that