### PR TITLE
Bump the list of packages with non-conformant SBOMs in dev.

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: apk-tools
   version: 2.14.0
-  epoch: 0
+  epoch: 1
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only

--- a/bash.yaml
+++ b/bash.yaml
@@ -1,7 +1,7 @@
 package:
   name: bash
   version: 5.2.21
-  epoch: 0
+  epoch: 1
   description: "GNU bourne again shell"
   copyright:
     - license: GPL-3.0-or-later

--- a/brotli.yaml
+++ b/brotli.yaml
@@ -1,7 +1,7 @@
 package:
   name: brotli
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: "a generic lossless compression algorithm"
   copyright:
     - license: MIT

--- a/expat.yaml
+++ b/expat.yaml
@@ -1,7 +1,7 @@
 package:
   name: expat
   version: 2.5.0
-  epoch: 4
+  epoch: 5
   description: "XML SAX Parser library written in C"
   copyright:
     - license: MIT

--- a/git.yaml
+++ b/git.yaml
@@ -1,7 +1,7 @@
 package:
   name: git
   version: 2.43.0
-  epoch: 0
+  epoch: 1
   description: "distributed version control system"
   copyright:
     - license: GPL-2.0-or-later

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
   version: 6.4_p20231125
-  epoch: 0
+  epoch: 1
   description: "console display library"
   copyright:
     - license: MIT

--- a/nghttp2.yaml
+++ b/nghttp2.yaml
@@ -1,7 +1,7 @@
 package:
   name: nghttp2
   version: 1.58.0
-  epoch: 0
+  epoch: 1
   description: "experimental HTTP/2 client, server and library"
   copyright:
     - license: MIT

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.2.0
-  epoch: 0
+  epoch: 1
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0

--- a/pcre2.yaml
+++ b/pcre2.yaml
@@ -1,7 +1,7 @@
 package:
   name: pcre2
   version: "10.42"
-  epoch: 2
+  epoch: 3
   description: "perl-compatible regular expression library"
   copyright:
     - license: BSD-3-Clause

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: zlib
   version: "1.3"
-  epoch: 2
+  epoch: 3
   description: "a library implementing the zlib compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT


### PR DESCRIPTION
The downstream Chainguard image `-dev` variants are failing to pass NTIA conformance due to the following list of packages:
```
openssl-config,libcrypto3,libssl3,zlib,apk-tools,ncurses-terminfo-base,ncurses,bash,libbrotlicommon1,libbrotlidec1,libnghttp2-14,libexpat1,libpcre2-8-0,git
```

This should bump all of those so they get rebuilt with the latest `melange`.

ref: https://github.com/chainguard-images/images/actions/runs/7202190566/job/19619876567?pr=1943
