### PR TITLE
Fixes for GHSA-2c7c-3mj9-8fqh and GHSA-8pgv-569h-w5rw

### DIFF
--- a/grafana.yaml
+++ b/grafana.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana
   version: 10.2.2
-  epoch: 3
+  epoch: 2
   description: The open and composable observability and data visualization platform.
   copyright:
     - license: AGPL-3.0-or-later

--- a/grafana.yaml
+++ b/grafana.yaml
@@ -31,7 +31,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+      deps: github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/otel/trace@v1.21.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
 
   - runs: |
       yarn install

--- a/grafana.yaml
+++ b/grafana.yaml
@@ -31,7 +31,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/otel/trace@v1.21.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+      deps: github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/trace@v1.21.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel/sdk@v1.21.0
 
   - runs: |
       yarn install

--- a/grafana.yaml
+++ b/grafana.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana
   version: 10.2.2
-  epoch: 1
+  epoch: 3
   description: The open and composable observability and data visualization platform.
   copyright:
     - license: AGPL-3.0-or-later
@@ -28,6 +28,10 @@ pipeline:
       repository: https://github.com/grafana/grafana
       tag: v${{package.version}}
       expected-commit: 161e3cac5075540918e3a39004f2364ad104d5bb
+
+  - uses: go/bump
+    with:
+      deps: github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
 
   - runs: |
       yarn install


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
GHSA-2c7c-3mj9-8fqh and GHSA-8pgv-569h-w5rw

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
