### PR TITLE
Adding falco dependecies to eliminate vulnerabilities

### DIFF
--- a/falco-plugins.yaml
+++ b/falco-plugins.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-plugins
   version: 0.9.1
-  epoch: 2
+  epoch: 0
   description: Plugins for Falco
   copyright:
     - license: Apache-2.0
@@ -34,4 +34,3 @@ update:
   github:
     identifier: falcosecurity/plugins
     strip-prefix: cloudtrail-
-    use-tag: true

--- a/falco-plugins.yaml
+++ b/falco-plugins.yaml
@@ -34,3 +34,4 @@ update:
   github:
     identifier: falcosecurity/plugins
     strip-prefix: cloudtrail-
+    tag-filter: cloudtrail-

--- a/falco-plugins.yaml
+++ b/falco-plugins.yaml
@@ -1,0 +1,37 @@
+package:
+  name: falco-plugins
+  version: 0.9.1
+  epoch: 2
+  description: Plugins for Falco
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go-1.21
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/falcosecurity/plugins.git
+      tag: cloudtrail-${{package.version}}
+      expected-commit: 16306f2ff88f06f08d5fa3412244bc25591e59cc
+
+  - runs: |
+      export CGO_ENABLED=1
+      make cloudtrail k8saudit json
+      mkdir -p ${{targets.destdir}}/usr/share/falco/plugins/
+      mv plugins/cloudtrail/libcloudtrail.so plugins/k8saudit/libk8saudit.so plugins/json/libjson.so ${{targets.destdir}}/usr/share/falco/plugins/
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: falcosecurity/plugins
+    strip-prefix: cloudtrail-
+    use-tag: true

--- a/falco-plugins.yaml
+++ b/falco-plugins.yaml
@@ -12,7 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - go-1.21
+      - go
 
 pipeline:
   - uses: git-checkout

--- a/falco.yaml
+++ b/falco.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco
   version: 0.36.2
-  epoch: 3
+  epoch: 4
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -57,6 +57,8 @@ environment:
       - zlib-dev
       - zstd
       - zstd-dev
+      - falcoctl
+      - falco-plugins
 
 pipeline:
   - uses: git-checkout

--- a/falco.yaml
+++ b/falco.yaml
@@ -7,7 +7,9 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - falco-plugins
       - falco-rules
+      - falcoctl
 
 environment:
   contents:
@@ -26,8 +28,6 @@ environment:
       - cmake
       - curl-dev
       - elfutils-dev
-      - falco-plugins
-      - falcoctl
       - git
       - grpc-dev
       - icu-dev

--- a/falco.yaml
+++ b/falco.yaml
@@ -26,8 +26,8 @@ environment:
       - cmake
       - curl-dev
       - elfutils-dev
-      - falcoctl
       - falco-plugins
+      - falcoctl
       - git
       - grpc-dev
       - icu-dev

--- a/falco.yaml
+++ b/falco.yaml
@@ -26,6 +26,8 @@ environment:
       - cmake
       - curl-dev
       - elfutils-dev
+      - falcoctl
+      - falco-plugins
       - git
       - grpc-dev
       - icu-dev
@@ -57,8 +59,6 @@ environment:
       - zlib-dev
       - zstd
       - zstd-dev
-      - falcoctl
-      - falco-plugins
 
 pipeline:
   - uses: git-checkout

--- a/falco/tbb.patch
+++ b/falco/tbb.patch
@@ -13,3 +13,15 @@ index 973655f2..c1771319 100644
  )
  
  
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 893dea2f..42e434f1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -232,7 +232,5 @@ add_subdirectory(userspace/falco)
+ 
+ if(NOT WIN32 AND NOT APPLE AND NOT EMSCRIPTEN AND NOT MUSL_OPTIMIZED_BUILD)
+-  include(plugins)
+-  include(falcoctl)
+ endif()
+ 
+ # Packages configuration


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
