### PR TITLE
new pkg: logrotate

### DIFF
--- a/logrotate.yaml
+++ b/logrotate.yaml
@@ -1,0 +1,54 @@
+package:
+  name: logrotate
+  version: 3.21.0
+  epoch: 0
+  description: "tool to rotate logfiles"
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - acl-dev
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libtool
+      - popt-dev
+      - wolfi-base
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/logrotate/logrotate/releases/download/${{package.version}}/logrotate-${{package.version}}.tar.gz
+      expected-sha256: 1680947a9431de1aaa629fedde358696ff49a808ae903feecf996682949e3cff
+
+  - runs: |
+      ./autogen.sh
+      ./configure \
+      --build=$CBUILD \
+      --host=$CHOST \
+      --prefix=/usr \
+      --sysconfdir=/etc \
+      --mandir=/usr/share/man \
+      --localstatedir=/var \
+      --with-acl
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: logrotate-doc
+    pipeline:
+      - uses: split/manpages
+    description: logrotate manpages
+
+update:
+  enabled: true
+  github:
+    identifier: logrotate/logrotate


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #9959 

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.x
At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
