### PR TITLE
Add package pytest, makefile target test/<package>

### DIFF
--- a/py3-pytest.yaml
+++ b/py3-pytest.yaml
@@ -16,29 +16,44 @@ package:
       - py3-importlib-metadata
       - py3-colorama
       - python-3
+
 environment:
   contents:
     packages:
+      - build-base
+      - busybox
       - ca-certificates-bundle
       - wolfi-base
-      - busybox
-      - build-base
+
 pipeline:
   - uses: git-checkout
     with:
       expected-commit: 23906106968eb95afbd61adfbc7bbb795fc9aaa9
       repository: https://github.com/pytest-dev/pytest
       tag: ${{package.version}}
+
   - uses: git-checkout
     with:
       expected-commit: 23906106968eb95afbd61adfbc7bbb795fc9aaa9
       repository: https://github.com/pytest-dev/pytest
       tag: ${{package.version}}
+
   - name: Python Build
     uses: python/build-wheel
+
   - uses: strip
+
 update:
   enabled: true
   manual: false
   github:
     identifier: pytest-dev/pytest
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        pytest ./test_capitalize.py

--- a/py3-pytest.yaml
+++ b/py3-pytest.yaml
@@ -1,0 +1,44 @@
+# Generated from https://pypi.org/project/pytest/
+package:
+  name: py3-pytest
+  version: 7.4.3
+  epoch: 0
+  description: 'pytest: simple powerful testing with Python'
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-iniconfig
+      - py3-packaging
+      - py3-pluggy
+      - py3-exceptiongroup
+      - py3-tomli
+      - py3-importlib-metadata
+      - py3-colorama
+      - python-3
+environment:
+  contents:
+    packages:
+      - ca-certificates-bundle
+      - wolfi-base
+      - busybox
+      - build-base
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 23906106968eb95afbd61adfbc7bbb795fc9aaa9
+      repository: https://github.com/pytest-dev/pytest
+      tag: ${{package.version}}
+  - uses: git-checkout
+    with:
+      expected-commit: 23906106968eb95afbd61adfbc7bbb795fc9aaa9
+      repository: https://github.com/pytest-dev/pytest
+      tag: ${{package.version}}
+  - name: Python Build
+    uses: python/build-wheel
+  - uses: strip
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: pytest-dev/pytest

--- a/py3-pytest/test_capitalize.py
+++ b/py3-pytest/test_capitalize.py
@@ -1,0 +1,7 @@
+# test_capitalize.py
+
+def capital_case(x):
+    return x.capitalize()
+
+def test_capital_case():
+    assert capital_case('semaphore') == 'Semaphore'


### PR DESCRIPTION
Example run of make test/py3-pytest

```
Testing package py3-pytest with version py3-pytest-7.4.3-r0 from file ./py3-pytest.yaml
/Users/vaikas/homebrew/bin/melange test ./py3-pytest.yaml --source-dir ./py3-pytest/ --repository-append /Users/vaikas/projects/go/src/github.com/wolfi-dev/os/packages --keyring-append local-melange.rsa.pub --arch aarch64 --pipeline-dirs ./pipelines/ --repository-append https://packages.wolfi.dev/os --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub  --log-policy builtin:stderr

<SNIPPITY SNIP SNIP>

ℹ️  aarch64   | ============================= test session starts ==============================
ℹ️  aarch64   | platform linux -- Python 3.12.1, pytest-7.4.3, pluggy-1.3.0
ℹ️  aarch64   | rootdir: /home/build
ℹ️  aarch64   | collected 1 item
ℹ️  aarch64   |
ℹ️  aarch64   | test_capitalize.py .                                                     [100%]
ℹ️  aarch64   |
ℹ️  aarch64   | ============================== 1 passed in 0.01s ===============================
ℹ️  aarch64   | pod 80acfd84af7f4247e46d94ba567b1cccd24097d800f6136b9a51f22ba445e84d terminated.
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
