### PR TITLE
telegraf: add new version streams

### DIFF
--- a/telegraf-1.28.yaml
+++ b/telegraf-1.28.yaml
@@ -1,0 +1,55 @@
+package:
+  name: telegraf-1.28
+  version: 1.28.0
+  epoch: 0
+  description: Telegraf is an agent for collecting, processing, aggregating, and writing metric
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - telegraf=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gnutar
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      tag: v${{package.version}}
+      expected-commit: 3ef34beda1d39e02d3871ea739bf4252f439cabf
+      repository: https://github.com/influxdata/telegraf
+
+  - if: ${{build.arch}} == 'x86_64'
+    runs: |
+      make package include_packages="linux_amd64.tar.gz"
+
+  - if: ${{build.arch}} == 'aarch64'
+    runs: |
+      make package include_packages="linux_arm64.tar.gz"
+
+  - runs: |
+      tar -xf build/dist/telegraf-${{package.version}}*.tar.gz
+      mkdir -p ${{targets.destdir}}/etc/
+      mv telegraf-${{package.version}}/etc/* ${{targets.destdir}}/etc/
+
+      mkdir -p ${{targets.destdir}}/usr/
+      mv telegraf-${{package.version}}/usr/* ${{targets.destdir}}/usr
+
+      mkdir -p ${{targets.destdir}}/var
+      mv telegraf-${{package.version}}/var/* ${{targets.destdir}}/var
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: influxdata/telegraf
+    strip-prefix: v
+    tag-filter: v1.28.
+    use-tag: true

--- a/telegraf-1.29.yaml
+++ b/telegraf-1.29.yaml
@@ -1,0 +1,55 @@
+package:
+  name: telegraf-1.29
+  version: 1.29.0
+  epoch: 0
+  description: Telegraf is an agent for collecting, processing, aggregating, and writing metric
+  copyright:
+    - license: MIT
+  dependencies:
+    provides:
+      - telegraf=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gnutar
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      tag: v${{package.version}}
+      expected-commit: f7f976ec37fc3d9f96aec30cd96cee965f232568
+      repository: https://github.com/influxdata/telegraf
+
+  - if: ${{build.arch}} == 'x86_64'
+    runs: |
+      make package include_packages="linux_amd64.tar.gz"
+
+  - if: ${{build.arch}} == 'aarch64'
+    runs: |
+      make package include_packages="linux_arm64.tar.gz"
+
+  - runs: |
+      tar -xf build/dist/telegraf-${{package.version}}*.tar.gz
+      mkdir -p ${{targets.destdir}}/etc/
+      mv telegraf-${{package.version}}/etc/* ${{targets.destdir}}/etc/
+
+      mkdir -p ${{targets.destdir}}/usr/
+      mv telegraf-${{package.version}}/usr/* ${{targets.destdir}}/usr
+
+      mkdir -p ${{targets.destdir}}/var
+      mv telegraf-${{package.version}}/var/* ${{targets.destdir}}/var
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: influxdata/telegraf
+    strip-prefix: v
+    tag-filter: v1.29.
+    use-tag: true


### PR DESCRIPTION
our new EOL Bot detected current telegraf versions 1.26 , 1,27  on wolfi has been EOL'ed adding new supported versions 1.28 , 1.29 