### PR TITLE
php-fpm_exporter

### DIFF
--- a/php-fpm_exporter.yaml
+++ b/php-fpm_exporter.yaml
@@ -1,0 +1,40 @@
+package:
+  name: php-fpm_exporter
+  version: 2.2.0
+  epoch: 0
+  description: A prometheus exporter for PHP-FPM.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hipages/php-fpm_exporter
+      tag: v${{package.version}}
+      expected-commit: c75d2df4037741c1cb146216d7156273d13ff91f
+
+  - runs: |
+      go get golang.org/x/net@v0.17.0
+      go mod tidy
+
+  - uses: goreleaser/build
+    with:
+      args: --skip-validate
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: hipages/php-fpm_exporter
+    strip-prefix: v

--- a/php-fpm_exporter.yaml
+++ b/php-fpm_exporter.yaml
@@ -24,8 +24,9 @@ pipeline:
       expected-commit: c75d2df4037741c1cb146216d7156273d13ff91f
 
   - runs: |
-     go get golang.org/x/net@v0.17.0
-     go mod tidy
+      rm go.mod
+      go mod init github.com/hipages/php-fpm_exporter # init in recent version
+      go mod tidy
 
   - uses: goreleaser/build
     with:

--- a/php-fpm_exporter.yaml
+++ b/php-fpm_exporter.yaml
@@ -24,8 +24,8 @@ pipeline:
       expected-commit: c75d2df4037741c1cb146216d7156273d13ff91f
 
   - runs: |
-      go get golang.org/x/net@v0.17.0
-      go mod tidy
+     go get golang.org/x/net@v0.17.0
+     go mod tidy
 
   - uses: goreleaser/build
     with:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
