### PR TITLE
don't leak build workspace in symlink

### DIFF
--- a/postgresql-12.yaml
+++ b/postgresql-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-12
   version: "12.17"
-  epoch: 6
+  epoch: 7
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -101,7 +101,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/postgres/initdb
           install -Dm755 postgresql-entrypoint.sh ${{targets.contextdir}}/usr/bin/postgresql-entrypoint.sh
-          ln -s ${{targets.subpkgdir}}/usr/bin/postgresql-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
+          ln -s /usr/bin/postgresql-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
 
   - name: postgresql-12-bitnami-compat
     description: "compat package with postgresql image"

--- a/postgresql-13.yaml
+++ b/postgresql-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-13
   version: "13.13"
-  epoch: 6
+  epoch: 7
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -100,7 +100,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/postgres/initdb
           install -Dm755 postgresql-entrypoint.sh ${{targets.contextdir}}/usr/bin/postgresql-entrypoint.sh
-          ln -s ${{targets.subpkgdir}}/usr/bin/postgresql-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
+          ln -s /usr/bin/postgresql-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
 
   - name: postgresql-13-bitnami-compat
     description: "compat package with postgresql image"

--- a/postgresql-14.yaml
+++ b/postgresql-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-14
   version: "14.10"
-  epoch: 6
+  epoch: 7
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -101,7 +101,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/postgres/initdb
           install -Dm755 postgresql-entrypoint.sh ${{targets.contextdir}}/usr/bin/postgresql-entrypoint.sh
-          ln -s ${{targets.subpkgdir}}/usr/bin/postgresql-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
+          ln -s /usr/bin/postgresql-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
 
   - name: postgresql-14-bitnami-compat
     description: "compat package with postgresql image"

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-15
   version: "15.5"
-  epoch: 6
+  epoch: 7
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -97,7 +97,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/postgres/initdb
           install -Dm755 postgresql-entrypoint.sh ${{targets.contextdir}}/usr/bin/postgresql-entrypoint.sh
-          ln -s ${{targets.subpkgdir}}/usr/bin/postgresql-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
+          ln -s /usr/bin/postgresql-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
 
   - name: postgresql-15-bitnami-compat
     description: "compat package with postgresql image"

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.1"
-  epoch: 6
+  epoch: 7
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
@@ -98,7 +98,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/var/lib/postgres/initdb
           install -Dm755 postgresql-entrypoint.sh ${{targets.contextdir}}/usr/bin/postgresql-entrypoint.sh
-          ln -s ${{targets.subpkgdir}}/usr/bin/postgresql-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
+          ln -s /usr/bin/postgresql-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
 
   - name: postgresql-16-bitnami-compat
     description: "compat package with postgresql image"


### PR DESCRIPTION
ref: https://github.com/wolfi-dev/os/pull/9905

introduced a link to the build workspace, resulting in:

```bash
lrwxrwxrwx  0 root     root        0 Dec 31  1969 var/lib/postgres/initdb/postgresql-entrypoint.sh -> /home/build/melange-out/postgresql-15-oci-entrypoint/usr/bin/postgresql-entrypoint.sh
```