### PR TITLE
CVE-2023-48795: First batch of remediation

### DIFF
--- a/apko.yaml
+++ b/apko.yaml
@@ -1,7 +1,7 @@
 package:
   name: apko
   version: 0.12.0
-  epoch: 1
+  epoch: 2
   description: Build OCI images using APK directly without Dockerfile
   copyright:
     - license: Apache-2.0
@@ -23,10 +23,13 @@ pipeline:
       repository: https://github.com/chainguard-dev/apko
       tag: v${{package.version}}
       expected-commit: 691fe51dd1d536460f8a955d1357eaba974208b5
-      destination: apko
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      go-version: "1.21"
 
   - runs: |
-      cd apko
       make apko
       install -m755 -D ./apko "${{targets.destdir}}"/usr/bin/apko
 

--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-workflows
   version: 3.5.2
-  epoch: 2
+  epoch: 3
   description: Workflow engine for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,11 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 5b6ad2be163ecd3f0251a931ab84dba3c6085ad2
 
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      replaces: github.com/whilp/git-urls=github.com/dlorenc/git-urls@v0.0.1
+
   - runs: |
       # NODE_OPTIONS has to been set
       sed -i 's/NODE_OPTIONS='\''[^'\'']*'\''/NODE_OPTIONS='\''--openssl-legacy-provider'\''/g' ui/package.json
@@ -35,10 +40,6 @@ pipeline:
 
       # Our global LDFLAGS conflict with a Makefile parameter
       unset LDFLAGS
-
-      # GHSA-3f2q-6294-fmq5 CVE-2023-46402
-      go mod edit -replace=github.com/whilp/git-urls=github.com/dlorenc/git-urls@v0.0.1
-      go mod tidy
 
       make dist/workflow-controller
       make dist/argo

--- a/cadvisor.yaml
+++ b/cadvisor.yaml
@@ -1,7 +1,7 @@
 package:
   name: cadvisor
   version: 0.48.1
-  epoch: 2
+  epoch: 3
   description: Analyzes resource usage and performance characteristics of running containers.
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.17.0
+      deps: golang.org/x/net@v0.17.0 golang.org/x/crypto@v0.17.0
       modroot: cmd
 
   - runs: |

--- a/cert-manager-1.11.yaml
+++ b/cert-manager-1.11.yaml
@@ -2,7 +2,7 @@ package:
   name: cert-manager-1.11
   # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
   version: 1.11.5
-  epoch: 8
+  epoch: 9
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,7 @@ pipeline:
   # to workaround, set CTR to anything $(command -v)able
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.17.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/docker/docker@v24.0.7 oras.land/oras-go@v1.2.4 github.com/cyphar/filepath-securejoin@v0.2.4
+      deps: golang.org/x/net@v0.17.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/docker/docker@v24.0.7 oras.land/oras-go@v1.2.4 github.com/cyphar/filepath-securejoin@v0.2.4 golang.org/x/crypto@v0.17.0
       replaces: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp=go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
 
   - runs: |
@@ -81,7 +81,7 @@ subpackages:
   - name: cmctl-1.11
     pipeline:
       - runs: |
-          make CTR=make cmctl-linux
+          make CTR=make _bin/cmctl/cmctl-linux-$(go env GOARCH)
       - runs: |
           install -Dm755 _bin/cmctl/cmctl-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/cmctl
       - uses: strip

--- a/cert-manager-1.12.yaml
+++ b/cert-manager-1.12.yaml
@@ -2,7 +2,7 @@ package:
   name: cert-manager-1.12
   # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
   version: 1.12.7
-  epoch: 1
+  epoch: 2
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,34 @@ pipeline:
       repository: https://github.com/cert-manager/cert-manager
       tag: v${{package.version}}
       expected-commit: 6d7629ba42b946978e3baaa75348c851f7ef9134
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      modroot: .
+
+  - uses: go/bump
+    with:
+      modroot: cmd/acmesolver
+
+  - uses: go/bump
+    with:
+      modroot: cmd/cainjector
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      modroot: cmd/controller
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      modroot: cmd/ctl
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      modroot: cmd/webhook
 
   # the makefile hardcodes the requirement for some container runtime (CTR), even when we don't need it
   # to workaround, set CTR to anything $(command -v)able
@@ -76,7 +104,7 @@ subpackages:
   - name: cmctl-1.12
     pipeline:
       - runs: |
-          make CTR=make cmctl-linux
+          make CTR=make _bin/cmctl/cmctl-linux-$(go env GOARCH)
       - runs: |
           install -Dm755 _bin/cmctl/cmctl-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/cmctl
       - uses: strip

--- a/cert-manager-1.12.yaml
+++ b/cert-manager-1.12.yaml
@@ -34,14 +34,6 @@ pipeline:
 
   - uses: go/bump
     with:
-      modroot: cmd/acmesolver
-
-  - uses: go/bump
-    with:
-      modroot: cmd/cainjector
-
-  - uses: go/bump
-    with:
       deps: golang.org/x/crypto@v0.17.0
       modroot: cmd/controller
 
@@ -58,6 +50,13 @@ pipeline:
   # the makefile hardcodes the requirement for some container runtime (CTR), even when we don't need it
   # to workaround, set CTR to anything $(command -v)able
   - runs: |
+      # This is needed because the go bumps above affect these packages
+      for mod in cainjector acmesolver; do
+        cd cmd/$mod
+        go mod tidy
+        cd ../..
+      done
+
       make CTR=make _bin/server/controller-linux-$(go env GOARCH)
       make CTR=make _bin/server/webhook-linux-$(go env GOARCH)
       make CTR=make _bin/server/cainjector-linux-$(go env GOARCH)

--- a/cert-manager-1.13.yaml
+++ b/cert-manager-1.13.yaml
@@ -2,7 +2,7 @@ package:
   name: cert-manager-1.13
   # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
   version: 1.13.3
-  epoch: 0
+  epoch: 1
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,34 @@ pipeline:
       repository: https://github.com/cert-manager/cert-manager
       tag: v${{package.version}}
       expected-commit: 876e386ee905aa86e2466c287e654613b0426927
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      modroot: .
+
+  - uses: go/bump
+    with:
+      modroot: cmd/acmesolver
+
+  - uses: go/bump
+    with:
+      modroot: cmd/cainjector
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      modroot: cmd/controller
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      modroot: cmd/ctl
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      modroot: cmd/webhook
 
   # the makefile hardcodes the requirement for some container runtime (CTR), even when we don't need it
   # to workaround, set CTR to anything $(command -v)able
@@ -76,7 +104,7 @@ subpackages:
   - name: cmctl-1.13
     pipeline:
       - runs: |
-          make CTR=make cmctl-linux
+          make CTR=make _bin/cmctl/cmctl-linux-$(go env GOARCH)
       - runs: |
           install -Dm755 _bin/cmctl/cmctl-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/cmctl
       - uses: strip

--- a/cert-manager-1.13.yaml
+++ b/cert-manager-1.13.yaml
@@ -34,14 +34,6 @@ pipeline:
 
   - uses: go/bump
     with:
-      modroot: cmd/acmesolver
-
-  - uses: go/bump
-    with:
-      modroot: cmd/cainjector
-
-  - uses: go/bump
-    with:
       deps: golang.org/x/crypto@v0.17.0
       modroot: cmd/controller
 
@@ -58,6 +50,13 @@ pipeline:
   # the makefile hardcodes the requirement for some container runtime (CTR), even when we don't need it
   # to workaround, set CTR to anything $(command -v)able
   - runs: |
+      # This is needed because the go bumps above affect these packages
+      for mod in cainjector acmesolver; do
+        cd cmd/$mod
+        go mod tidy
+        cd ../..
+      done
+
       make CTR=make _bin/server/controller-linux-$(go env GOARCH)
       make CTR=make _bin/server/webhook-linux-$(go env GOARCH)
       make CTR=make _bin/server/cainjector-linux-$(go env GOARCH)

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-helm-controller
   version: 0.37.1
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit Helm reconciler, for declarative Helming
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,10 @@ pipeline:
       expected-commit: 8094f19cee26d9a62240db8f3540e21dc2faa387
       repository: https://github.com/fluxcd/helm-controller
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
 
   - uses: go/build
     with:

--- a/flux-image-automation-controller.yaml
+++ b/flux-image-automation-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-image-automation-controller
   version: 0.37.0
-  epoch: 1
+  epoch: 2
   description: GitOps Toolkit controller that patches container image tags in Git
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,10 @@ pipeline:
       repository: https://github.com/fluxcd/image-automation-controller
       tag: v${{package.version}}
       expected-commit: d5e199b983be3df27da3b3c59761d3670ba8f0a0
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin

--- a/flux-image-reflector-controller.yaml
+++ b/flux-image-reflector-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-image-reflector-controller
   version: 0.31.1
-  epoch: 0
+  epoch: 1
   description: GitOps Toolkit controller that scans container registries
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,10 @@ pipeline:
       repository: https://github.com/fluxcd/image-reflector-controller
       tag: v${{package.version}}
       expected-commit: 91ee4308d4dcdc80a18411f25cdab90c42afe096
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
 
   - uses: go/build
     with:

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-kustomize-controller
   version: 1.2.1
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit Kustomize reconciler
   copyright:
     - license: Apache-2.0
@@ -38,7 +38,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/go-jose/go-jose/v3@v3.0.1
+      deps: github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0
 
   - uses: go/build
     with:

--- a/flux-notification-controller.yaml
+++ b/flux-notification-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-notification-controller
   version: 1.2.3
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit event forwarded and notification dispatcher
   copyright:
     - license: Apache-2.0
@@ -20,8 +20,12 @@ pipeline:
       repository: https://github.com/fluxcd/notification-controller
       tag: v${{package.version}}
 
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      go-version: 1.21
+
   - runs: |
-      go mod tidy
       mkdir -p "${{targets.destdir}}"/usr/bin
       CGO_ENABLED=0 go build \
         -trimpath -a -o "${{targets.destdir}}"/usr/bin/notification-controller .

--- a/flux-source-controller.yaml
+++ b/flux-source-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-source-controller
   version: 1.2.3
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit source management component
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,11 @@ pipeline:
       expected-commit: 1a16ec546bc1e9c828b2ea1d0f045b4da7e75b18
       repository: https://github.com/fluxcd/source-controller
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      go-version: 1.21
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin

--- a/flux.yaml
+++ b/flux.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux
   version: 2.2.1
-  epoch: 0
+  epoch: 1
   description: Open and extensible continuous delivery solution for Kubernetes. Powered by GitOps Toolkit.
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,10 @@ pipeline:
     with:
       uri: https://github.com/fluxcd/flux2/archive/v${{package.version}}/v${{package.version}}.tar.gz
       expected-sha256: aa01a6b3ec41588d21a5eb637d1c77292e4ca4da68e92c606dd8a980d58ca4bd
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin

--- a/pipelines/go/bump.yaml
+++ b/pipelines/go/bump.yaml
@@ -10,7 +10,7 @@ needs:
 inputs:
   deps:
     description: The deps to bump, space separated
-    default: ""
+    required: true
   modroot:
     description: The root of the module
     default: .
@@ -26,9 +26,7 @@ pipeline:
       cd "${{inputs.modroot}}"
       go mod tidy -go=${{inputs.go-version}}
 
-      if [ ! -z "${{inputs.deps}}" ]; then
-        gobump -packages "${{inputs.deps}}" -replaces "${{inputs.replaces}}"
-      fi
+      gobump -packages "${{inputs.deps}}" -replaces "${{inputs.replaces}}"
 
       go mod tidy -go=${{inputs.go-version}}
       if [ -d "./vendor" ]; then

--- a/pipelines/go/bump.yaml
+++ b/pipelines/go/bump.yaml
@@ -10,7 +10,7 @@ needs:
 inputs:
   deps:
     description: The deps to bump, space separated
-    required: true
+    default: ""
   modroot:
     description: The root of the module
     default: .
@@ -26,7 +26,9 @@ pipeline:
       cd "${{inputs.modroot}}"
       go mod tidy -go=${{inputs.go-version}}
 
-      gobump -packages "${{inputs.deps}}" -replaces "${{inputs.replaces}}"
+      if [ ! -z "${{inputs.deps}}" ]; then
+        gobump -packages "${{inputs.deps}}" -replaces "${{inputs.replaces}}"
+      fi
 
       go mod tidy -go=${{inputs.go-version}}
       if [ -d "./vendor" ]; then


### PR DESCRIPTION
Start to bump golang.org/x/crypto on a few packages.