### PR TITLE
Add ruby3.2 manticore and openssl_pkcs8_pure

### DIFF
--- a/ruby3.2-manticore.yaml
+++ b/ruby3.2-manticore.yaml
@@ -1,0 +1,54 @@
+# Generated from https://github.com/cheald/manticore
+package:
+  name: ruby3.2-manticore
+  version: 0.9.1
+  epoch: 0
+  description: Manticore is an HTTP client built on the Apache HttpCore components
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby3.2-openssl_pkcs8_pure
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: http://github.com/cheald/manticore
+      tag: v${{package.version}}
+      expected-commit: acc25cac2999f4658a77a0f39f60ddbca8fe14a4
+
+  - uses: patch
+    with:
+      patches: 0001-remove-signing-key.patch
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      # Output file name has `java` suffix.
+      gem-file: ${{vars.gem}}-${{package.version}}-java.gem
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: manticore
+
+update:
+  enabled: true
+  github:
+    identifier: cheald/manticore
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-manticore/0001-remove-signing-key.patch
+++ b/ruby3.2-manticore/0001-remove-signing-key.patch
@@ -1,0 +1,33 @@
+From f394e9467b5dd8884f51d02d1ff1cd149bd47e4b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Furkan=20T=C3=BCrkal?= <furkan.turkal@chainguard.dev>
+Date: Mon, 18 Dec 2023 23:29:55 +0300
+Subject: [PATCH] remove signing key
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Furkan Türkal <furkan.turkal@chainguard.dev>
+---
+ manticore.gemspec | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/manticore.gemspec b/manticore.gemspec
+index dd80365..f76299e 100644
+--- a/manticore.gemspec
++++ b/manticore.gemspec
+@@ -21,12 +21,6 @@ Gem::Specification.new do |spec|
+ 
+   spec.required_ruby_version = '>= 2.3' # JRuby >= 9.1
+ 
+-  private_key = File.expand_path("~/.gemcert/gem-private_key.pem")
+-  if File.exists? private_key
+-    spec.signing_key = private_key
+-    spec.cert_chain  = ['gem-public_cert.pem']
+-  end
+-
+   spec.add_dependency "openssl_pkcs8_pure"
+ 
+   spec.add_development_dependency "jar-dependencies", "~> 0.4.1"
+-- 
+2.39.3 (Apple Git-145)
+

--- a/ruby3.2-openssl_pkcs8_pure.yaml
+++ b/ruby3.2-openssl_pkcs8_pure.yaml
@@ -1,0 +1,46 @@
+# Generated from http://github.com/cielavenir/openssl_pkcs8_pure
+package:
+  name: ruby3.2-openssl_pkcs8_pure
+  version: 0.0.0.2
+  epoch: 0
+  description: OpenSSL::PKey::[DSA/RSA/EC]#to_pem_pkcs8 written in Ruby
+  copyright:
+    - license: Ruby License (2-clause BSDL or Artistic)
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: http://github.com/cielavenir/openssl_pkcs8_pure
+      tag: v${{package.version}}
+      expected-commit: 380967a0e48f3029b80874fd5a3d21e0b33ce7f8
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: openssl_pkcs8_pure
+
+update:
+  enabled: true
+  github:
+    identifier: cielavenir/openssl_pkcs8_pure
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
