### PR TITLE
mitigate CVE-2023-48795 for calico

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -161,10 +161,6 @@ subpackages:
               LDFLAGS="$LDFLAGS -X node/buildinfo.BuildDate=$(date -u +'%FT%T%z')"
               LDFLAGS="$LDFLAGS -X node/buildinfo.GitRevision=$(git rev-parse HEAD || echo '<unknown>')"
 
-              # Mitigate CVE-2023-5528
-              go mod edit -replace=k8s.io/kubernetes=k8s.io/kubernetes@v1.26.11
-              go mod edit -replace=k8s.io/apiserver=k8s.io/apiserver@v0.26.11
-
               # Mitigate CVE-2023-48795
               go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.17.0
 

--- a/calico.yaml
+++ b/calico.yaml
@@ -34,8 +34,8 @@ environment:
       - go
       - iproute2
       - libbpf
-      - linux-headers
       - libpcap-dev
+      - linux-headers
       - llvm16
       - zlib-dev
       - zstd-dev

--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.26.4
-  epoch: 2
+  epoch: 3
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64
@@ -163,6 +163,10 @@ subpackages:
               # Mitigate CVE-2023-5528
               go mod edit -replace=k8s.io/kubernetes=k8s.io/kubernetes@v1.26.11
               go mod edit -replace=k8s.io/apiserver=k8s.io/apiserver@v0.26.11
+
+              # Mitigate CVE-2023-48795
+              go mod edit -replace=golang.org/x/crypto=golang.org/x/crypto@v0.17.0
+
               go mod tidy
 
               CGO_ENABLED=1 \

--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
-  version: 3.26.4
-  epoch: 3
+  version: 3.27.0
+  epoch: 0
   description: "Cloud native networking and network security"
   target-architecture:
     - x86_64
@@ -35,6 +35,7 @@ environment:
       - iproute2
       - libbpf
       - linux-headers
+      - libpcap-dev
       - llvm16
       - zlib-dev
       - zstd-dev
@@ -53,7 +54,7 @@ pipeline:
     with:
       repository: https://github.com/projectcalico/calico
       tag: v${{package.version}}
-      expected-commit: 6139b6dcd183f91e9a37f74547fa1a94475987fc
+      expected-commit: 711528eeb00fd90dde38e87ecee7d1c155cab0e6
   - working-directory: felix
     pipeline:
       # Equivalent to target: "build-bpf"


### PR DESCRIPTION
- mitigate CVE-2023-48795 for calico

Closes: https://github.com/wolfi-dev/os/pull/9992

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/627

