### PR TITLE
use autoconf for popt, split into subpkgs

### DIFF
--- a/popt.yaml
+++ b/popt.yaml
@@ -1,7 +1,7 @@
 package:
   name: popt
   version: 1.19
-  epoch: 0
+  epoch: 1
   description: commandline option parser
   copyright:
     - license: MIT
@@ -19,15 +19,14 @@ pipeline:
       uri: http://ftp.rpm.org/popt/releases/popt-1.x/popt-${{package.version}}.tar.gz
       expected-sha512: 5d1b6a15337e4cd5991817c1957f97fc4ed98659870017c08f26f754e34add31d639d55ee77ca31f29bb631c0b53368c1893bd96cf76422d257f7997a11f6466
 
-  - runs: |
-      ./configure \
-        --build=$CBUILD \
-        --host=$CHOST \
-        --prefix=/usr \
-        --libdir=/lib \
+  - uses: autoconf/configure
+    with:
+      opts: |
         --disable-static
-      make
-      make DESTDIR="${{targets.destdir}}" install
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
 
 subpackages:
   - name: popt-dev
@@ -37,6 +36,16 @@ subpackages:
       runtime:
         - popt
     description: popt dev
+
+  - name: popt-lang
+    pipeline:
+      - uses: split/locales
+    description: popt locales
+
+  - name: popt-doc
+    pipeline:
+      - uses: split/manpages
+    description: popt manpages
 
 update:
   enabled: true


### PR DESCRIPTION
splits locales and manpages into subpackages

uses `autoconf` for the build, and moves the libs from `/lib` to `/usr/lib`