### PR TITLE
Add logstash-output-opensearch ruby deps batch 3

### DIFF
--- a/ruby3.2-chronic_duration.yaml
+++ b/ruby3.2-chronic_duration.yaml
@@ -1,0 +1,49 @@
+# Generated from https://github.com/hpoydar/chronic_duration
+package:
+  name: ruby3.2-chronic_duration
+  version: 0.10.6
+  epoch: 0
+  description: A simple Ruby natural language parser for elapsed time. (For example, 4 hours and 30 minutes, 6 minutes 4 seconds, 3 days, etc.) Returns all results in seconds. Will return an integer unless you get tricky and need a float. (4 minutes and 13.47 seconds, for example.) The reverse can also be performed via the output method.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby3.2-numerizer
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hpoydar/chronic_duration
+      tag: v${{package.version}}
+      expected-commit: 55f992d6715a0920fefb5c4051e9eff40f948a21
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: chronic_duration
+
+update:
+  enabled: true
+  github:
+    identifier: hpoydar/chronic_duration
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-clamp.yaml
+++ b/ruby3.2-clamp.yaml
@@ -1,0 +1,46 @@
+# Generated from https://github.com/mdub/clamp
+package:
+  name: ruby3.2-clamp
+  version: 1.3.2
+  epoch: 0
+  description: Clamp provides an object-model for command-line utilities.
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/mdub/clamp
+      tag: v${{package.version}}
+      expected-commit: 9aeed0671163ed949e57f0c28196a8b775a4883c
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: clamp
+
+update:
+  enabled: true
+  github:
+    identifier: mdub/clamp
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-coderay.yaml
+++ b/ruby3.2-coderay.yaml
@@ -1,0 +1,48 @@
+# Generated from http://github.com/rubychan/coderay
+package:
+  name: ruby3.2-coderay
+  version: 1.1.3
+  epoch: 0
+  description: Fast and easy syntax highlighting for selected languages, written in Ruby. Comes with RedCloth integration and LOC counter.
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+  environment:
+    RELEASE: true
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rubychan/coderay
+      tag: v${{package.version}}
+      expected-commit: d30855fe96e33fed39bd5aa7ba6879ba62306860
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: coderay
+
+update:
+  enabled: true
+  github:
+    identifier: rubychan/coderay
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-filesize.yaml
+++ b/ruby3.2-filesize.yaml
@@ -1,0 +1,42 @@
+# Generated from http://github.com/dominikh/filesize
+package:
+  name: ruby3.2-filesize
+  version: 0.1.1
+  epoch: 0
+  description: filesize is a small class for handling filesizes with both the SI and binary prefixes, allowing conversion from any size to any other size.
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/dominikh/filesize
+      tag: v${{package.version}}
+      expected-commit: e401692c0dc4f9aa0e3ba316b243e7084ecb9472
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: filesize
+
+update:
+  enabled: false # unmaintained, latest tag cut in 2018

--- a/ruby3.2-gems.yaml
+++ b/ruby3.2-gems.yaml
@@ -1,0 +1,46 @@
+# Generated from https://github.com/rubygems/gems
+package:
+  name: ruby3.2-gems
+  version: 1.2.0
+  epoch: 0
+  description: Ruby wrapper for the RubyGems.org API
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 639a640c59be27e0488091309ea37c1485de1134
+      repository: https://github.com/rubygems/gems
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: gems
+
+update:
+  enabled: true
+  github:
+    identifier: rubygems/gems
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-method_source.yaml
+++ b/ruby3.2-method_source.yaml
@@ -1,0 +1,50 @@
+# Generated from https://github.com/banister/method_source
+package:
+  name: ruby3.2-method_source
+  version: 1.0.0
+  epoch: 0
+  description: retrieve the sourcecode for a method
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 7fc63b84241a017992efd923d13eb2dd81e93411
+      repository: https://github.com/banister/method_source
+      tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      patches: 0001-fix-gemspec.patch
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: method_source
+
+update:
+  enabled: true
+  github:
+    identifier: banister/method_source
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-method_source/0001-fix-gemspec.patch
+++ b/ruby3.2-method_source/0001-fix-gemspec.patch
@@ -1,0 +1,29 @@
+From 31a9cfb37ee4a13026ffc7b59e85c80f0b129804 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Furkan=20T=C3=BCrkal?= <furkan.turkal@chainguard.dev>
+Date: Tue, 19 Dec 2023 16:08:40 +0300
+Subject: [PATCH] fix gemspec
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Furkan Türkal <furkan.turkal@chainguard.dev>
+---
+ method_source.gemspec | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/method_source.gemspec b/method_source.gemspec
+index 8acb290..56189b6 100644
+--- a/method_source.gemspec
++++ b/method_source.gemspec
+@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
+   s.date = "2020-03-19"
+   s.description = "retrieve the sourcecode for a method".freeze
+   s.email = "jrmair@gmail.com".freeze
+-  s.files = ["CHANGELOG.md".freeze, ".gemtest".freeze, ".travis.yml".freeze, ".yardopts".freeze, "Gemfile".freeze, "LICENSE".freeze, "README.markdown".freeze, "Rakefile".freeze, "lib/method_source.rb".freeze, "lib/method_source/code_helpers.rb".freeze, "lib/method_source/source_location.rb".freeze, "lib/method_source/version.rb".freeze, "method_source.gemspec".freeze, "spec/method_source/code_helpers_spec.rb".freeze, "spec/method_source_spec.rb".freeze, "spec/spec_helper.rb".freeze]
++  s.files = ["CHANGELOG.md".freeze, ".gemtest".freeze, ".yardopts".freeze, "Gemfile".freeze, "LICENSE".freeze, "README.markdown".freeze, "Rakefile".freeze, "lib/method_source.rb".freeze, "lib/method_source/code_helpers.rb".freeze, "lib/method_source/source_location.rb".freeze, "lib/method_source/version.rb".freeze, "method_source.gemspec".freeze, "spec/method_source/code_helpers_spec.rb".freeze, "spec/method_source_spec.rb".freeze, "spec/spec_helper.rb".freeze]
+   s.homepage = "http://banisterfiend.wordpress.com".freeze
+   s.metadata["changelog_uri"] = "https://github.com/banister/method_source/blob/master/CHANGELOG.md".freeze
+   s.licenses = ["MIT".freeze]
+-- 
+2.39.3 (Apple Git-145)
+

--- a/ruby3.2-minitar.yaml
+++ b/ruby3.2-minitar.yaml
@@ -1,0 +1,46 @@
+# Generated from https://github.com/halostatue/minitar/
+package:
+  name: ruby3.2-minitar
+  version: 0.9
+  epoch: 0
+  description: Minimal pure-ruby support for POSIX tar(1) archives.
+  copyright:
+    - license: BSD-2-Clause
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 0fb4fa14db7d11f9e271d44709c5234000d41013
+      repository: https://github.com/halostatue/minitar
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: minitar
+
+update:
+  enabled: true
+  github:
+    identifier: halostatue/minitar
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-numerizer.yaml
+++ b/ruby3.2-numerizer.yaml
@@ -1,0 +1,46 @@
+# Generated from http://github.com/jduff/numerizer
+package:
+  name: ruby3.2-numerizer
+  version: 0.2.0
+  epoch: 0
+  description: Numerizer is a gem to help with parsing numbers in natural language from strings (ex forty two). It was extracted from the awesome Chronic gem http://github.com/evaryont/chronic.
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/jduff/numerizer
+      tag: v${{package.version}}
+      expected-commit: 83c0eedb5b49053b3e36434c3d640a8291587fd3
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: numerizer
+
+update:
+  enabled: true
+  github:
+    identifier: jduff/numerizer
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-polyglot.yaml
+++ b/ruby3.2-polyglot.yaml
@@ -1,0 +1,50 @@
+# Generated from http://github.com/cjheath/polyglot
+package:
+  name: ruby3.2-polyglot
+  version: 0.3.5
+  epoch: 0
+  description: Augment 'require' to load non-ruby file types
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 75f4d4d4521f8347a087e852ed81ec867d759854
+      repository: https://github.com/cjheath/polyglot
+      tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      patches: 0001-Add-custom-polyglot.gemspec.patch
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: polyglot
+
+update:
+  enabled: true
+  github:
+    identifier: cjheath/polyglot
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-polyglot/0001-Add-custom-polyglot.gemspec.patch
+++ b/ruby3.2-polyglot/0001-Add-custom-polyglot.gemspec.patch
@@ -1,0 +1,54 @@
+# This is a hacky-workaround to build the package instead of packaging
+# all of the required build-dependencies in Rakefile.
+From 3c4c9d776696dd1bc6de60f96bb78a7bcde249cb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Furkan=20T=C3=BCrkal?= <furkan.turkal@chainguard.dev>
+Date: Tue, 19 Dec 2023 16:26:11 +0300
+Subject: [PATCH] Add custom polyglot.gemspec
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Furkan Türkal <furkan.turkal@chainguard.dev>
+---
+ .gitignore       |  1 -
+ polyglot.gemspec | 20 ++++++++++++++++++++
+ 2 files changed, 20 insertions(+), 1 deletion(-)
+ create mode 100644 polyglot.gemspec
+
+diff --git a/.gitignore b/.gitignore
+index 99baee9..5e0ea91 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -1,3 +1,2 @@
+-polyglot.gemspec
+ .*.sw[op]
+ pkg
+diff --git a/polyglot.gemspec b/polyglot.gemspec
+new file mode 100644
+index 0000000..6239f82
+--- /dev/null
++++ b/polyglot.gemspec
+@@ -0,0 +1,20 @@
++# polyglot.gemspec
++lib = File.expand_path('lib', __dir__)
++$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
++require 'polyglot/version'
++
++Gem::Specification.new do |spec|
++  spec.name          = "polyglot"
++  spec.version       = Polyglot::VERSION::STRING
++  spec.authors       = ["Clifford Heath"]
++  spec.email         = %w[clifford.heath@gmail.com]
++  spec.summary       = %q{Augment 'require' to load non-Ruby file types}
++  spec.description   = %q{The Polyglot library allows a Ruby module to register a loader
++for the file type associated with a filename extension, and it
++augments 'require' to find and load matching files.}
++  spec.homepage      = "http://github.com/cjheath/polyglot"
++  spec.license       = "MIT"
++
++  spec.files         = Dir["lib/**/*", "README.md", "LICENSE.txt"]
++  spec.require_paths = ["lib"]
++end
+-- 
+2.39.3 (Apple Git-145)
+

--- a/ruby3.2-pry.yaml
+++ b/ruby3.2-pry.yaml
@@ -1,0 +1,50 @@
+# Generated from https://github.com/pry/pry
+package:
+  name: ruby3.2-pry
+  version: 0.14.2
+  epoch: 0
+  description: A runtime developer console and IRB alternative with powerful introspection capabilities
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby3.2-coderay
+      - ruby3.2-method_source
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 24f6190e42f24979886cf6d974b70bd7638fda46
+      repository: https://github.com/pry/pry
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: pry
+
+update:
+  enabled: true
+  github:
+    identifier: pry/pry
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-rubyzip.yaml
+++ b/ruby3.2-rubyzip.yaml
@@ -1,0 +1,48 @@
+# Generated from https://github.com/rubyzip/rubyzip/tree/v2.3.2
+package:
+  name: ruby3.2-rubyzip
+  version: 2.3.2
+  epoch: 0
+  description: rubyzip is a ruby module for reading and writing zip files
+  copyright:
+    - license: BSD 2-Clause
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 2f1c1ea400a15ce3edf9b75e742595f0ee6e661d
+      repository: https://github.com/rubyzip/rubyzip
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: rubyzip
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - show
+  github:
+    identifier: rubyzip/rubyzip
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-thread_safe.yaml
+++ b/ruby3.2-thread_safe.yaml
@@ -1,0 +1,46 @@
+# Generated from https://github.com/ruby-concurrency/thread_safe
+package:
+  name: ruby3.2-thread_safe
+  version: 0.3.6
+  epoch: 0
+  description: A collection of data structures and utilities to make thread-safe programming in Ruby easier
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: ccfd11b76d6cf74ba0e19278fba9ba1b7f5ea5ca
+      repository: https://github.com/ruby-concurrency/thread_safe
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: thread_safe
+
+update:
+  enabled: true
+  github:
+    identifier: ruby-concurrency/thread_safe
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-treetop.yaml
+++ b/ruby3.2-treetop.yaml
@@ -1,0 +1,49 @@
+# Generated from https://github.com/cjheath/treetop
+package:
+  name: ruby3.2-treetop
+  version: 1.6.12
+  epoch: 0
+  description: A Parsing Expression Grammar (PEG) Parser generator DSL for Ruby
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby3.2-polyglot
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: b6a60e16e80f288dd25d45e372e5249f190f4561
+      repository: https://github.com/cjheath/treetop
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: treetop
+
+update:
+  enabled: true
+  github:
+    identifier: cjheath/treetop
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
