### PR TITLE
`pkcs11-helper/1.30.0`: new package

### DIFF
--- a/pkcs11-helper.yaml
+++ b/pkcs11-helper.yaml
@@ -1,0 +1,56 @@
+package:
+  name: pkcs11-helper
+  version: 1.30.0
+  epoch: 0
+  description: PKCS#11 Helper library that simplifies the interaction with PKCS#11 providers for end-user applications
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - linux-headers
+      - openssl-dev>3
+      - samurai
+      - p11-kit-dev
+      - autoconf
+      - automake
+      - libtool
+      - pkgconf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/OpenSC/pkcs11-helper
+      tag: pkcs11-helper-${{package.version}}
+      expected-commit: 8bed16034f629a0361fa8ff89deed2b43dc45d8b
+
+  - runs: aclocal && autoreconf -vfi -I/usr/share/aclocal
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: "pkcs11-helper-dev"
+    description: "headers for pkcs11-helper"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - pkcs11-helper
+
+update:
+  enabled: true
+  github:
+    identifier: OpenSC/pkcs11-helper
+    strip-prefix: pkcs11-helper-

--- a/pkcs11-helper.yaml
+++ b/pkcs11-helper.yaml
@@ -9,19 +9,19 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
       - bash
       - build-base
       - busybox
       - ca-certificates-bundle
       - cmake
+      - libtool
       - linux-headers
       - openssl-dev>3
-      - samurai
       - p11-kit-dev
-      - autoconf
-      - automake
-      - libtool
       - pkgconf-dev
+      - samurai
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

