### PR TITLE
mitigate CVE-2023-48795 for cilium

### DIFF
--- a/cilium.yaml
+++ b/cilium.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium
-  version: 1.14.4
-  epoch: 3
+  version: 1.14.5
+  epoch: 0
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -37,7 +37,7 @@ pipeline:
     with:
       repository: https://github.com/cilium/cilium
       tag: v${{package.version}}
-      expected-commit: 87dd2b644528d8a8f74e041a64ee2bed85ce5605
+      expected-commit: 85db28befd47d150ac6a4a89b58c562e76f65c6e
 
   - uses: patch
     with:
@@ -45,7 +45,8 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/go-jose/go-jose/v3@v3.0.1
+      deps: github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0
+      go-version: "1.21"
 
   - runs: |
       # Remove groupadd from Makefile: it's not doing anything useful in

--- a/cilium/loopback-location.patch
+++ b/cilium/loopback-location.patch
@@ -1,15 +1,15 @@
 Update the loopback binary location to be /usr/bin
 
 diff --git a/plugins/cilium-cni/install-plugin.sh b/plugins/cilium-cni/install-plugin.sh
-index 90d2a38184..683705d548 100755
+index f3d589acc8..9cd4673fbf 100755
 --- a/plugins/cilium-cni/install-plugin.sh
 +++ b/plugins/cilium-cni/install-plugin.sh
-@@ -19,7 +19,7 @@ if [ ! -f "${CNI_DIR}/bin/loopback" ]; then
- 	echo "Installing loopback driver..."
- 
+@@ -30,7 +30,7 @@ install_cni() {
+ # Install the CNI loopback driver if not installed already
+ if [ ! -f "${CNI_DIR}/bin/loopback" ]; then
  	# Don't fail hard if this fails as it is usually not required
--	cp /cni/loopback "${CNI_DIR}/bin/" || true
-+	cp /usr/bin/loopback "${CNI_DIR}/bin/" || true
+-	install_cni /cni/loopback || true
++	install_cni /usr/bin/loopback || true
  fi
  
- echo "Installing ${BIN_NAME} to ${CNI_DIR}/bin/ ..."
+ install_cni "/opt/cni/bin/${BIN_NAME}"


### PR DESCRIPTION
- mitigate CVE-2023-48795 for cilium

Closes: https://github.com/wolfi-dev/os/pull/9901

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/632
