### PR TITLE
trino/435 package update

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -1,6 +1,6 @@
 package:
   name: trino
-  version: "434"
+  version: "435"
   epoch: 0
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
@@ -30,7 +30,7 @@ pipeline:
     with:
       repository: https://github.com/trinodb/trino.git
       tag: ${{package.version}}
-      expected-commit: aa431c77a6a187920f5d6433532a19647d901742
+      expected-commit: c11e77e08431999ec80c636224889ddcf8d6267d
 
   - uses: patch
     with:

--- a/trino/CVE-2023-34062.patch
+++ b/trino/CVE-2023-34062.patch
@@ -1,32 +1,17 @@
-From eced2abf787d4be55a33611e493e58f9ee7864b8 Mon Sep 17 00:00:00 2001
-From: Philippe Deslauriers <philde@chainguard.dev>
-Date: Mon, 27 Nov 2023 08:42:18 -0800
-Subject: [PATCH] Bump reactor-netty-http to resolve CVE-2023-34062
-
-Signed-off-by: Philippe Deslauriers <philde@chainguard.dev>
----
- pom.xml | 8 +++++++-
- 1 file changed, 7 insertions(+), 1 deletion(-)
-
 diff --git a/pom.xml b/pom.xml
-index e4f007e8..925e023e 100644
+index 2284eccc29..06f36e7b85 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -932,7 +932,13 @@
-             <dependency>
-                 <groupId>io.projectreactor</groupId>
-                 <artifactId>reactor-core</artifactId>
--                <version>3.4.33</version>
-+                <version>3.4.34</version>
-+            </dependency>
-+
+@@ -933,6 +933,12 @@
+                 <version>3.4.34</version>
+             </dependency>
+ 
 +            <dependency>
 +                <groupId>io.projectreactor.netty</groupId>
 +                <artifactId>reactor-netty-http</artifactId>
 +                <version>1.0.39</version>
-             </dependency>
- 
++            </dependency>
++
              <!-- io.confluent:kafka-avro-serializer uses multiple versions of this transitive dependency -->
--- 
-2.42.0
-
+             <dependency>
+                 <groupId>io.swagger.core.v3</groupId>

--- a/trino/CVE-2023-5072.patch
+++ b/trino/CVE-2023-5072.patch
@@ -1,19 +1,9 @@
-From 6dcbfcc9e60eac7ae5c636a6f8d4152b85baff27 Mon Sep 17 00:00:00 2001
-From: Philippe Deslauriers <philde@chainguard.dev>
-Date: Mon, 23 Oct 2023 09:33:52 -0700
-Subject: [PATCH] Fix CVE-2023-5072
-
-Signed-off-by: Philippe Deslauriers <philde@chainguard.dev>
----
- pom.xml | 6 ++++++
- 1 file changed, 6 insertions(+)
-
 diff --git a/pom.xml b/pom.xml
-index 6f834f1b..8f4c2d29 100644
+index 2284eccc29..67869b9ee0 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -1982,6 +1982,12 @@
-                 <version>19.0.0</version>
+@@ -1991,6 +1991,12 @@
+                 <version>24.1.0</version>
              </dependency>
  
 +            <dependency>
@@ -25,6 +15,3 @@ index 6f834f1b..8f4c2d29 100644
              <dependency>
                  <groupId>org.locationtech.jts</groupId>
                  <artifactId>jts-core</artifactId>
--- 
-2.42.0
-

--- a/trino/CVE-2023-6378.patch
+++ b/trino/CVE-2023-6378.patch
@@ -1,18 +1,8 @@
-From cdf7a542094bc67266ef944e9a17d59878a90ccd Mon Sep 17 00:00:00 2001
-From: Philippe Deslauriers <philde@chainguard.dev>
-Date: Fri, 8 Dec 2023 12:34:48 -0800
-Subject: [PATCH] Resolve GHSA-vmq6-5m68-f53m by bumping logback-core
-
-Signed-off-by: Philippe Deslauriers <philde@chainguard.dev>
----
- pom.xml | 6 ++++++
- 1 file changed, 6 insertions(+)
-
 diff --git a/pom.xml b/pom.xml
-index e4f007e8..dcdfe2c8 100644
+index 2284eccc29..d4ec22786c 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -302,6 +302,12 @@
+@@ -300,6 +300,12 @@
                  <scope>import</scope>
              </dependency>
  
@@ -25,6 +15,3 @@ index e4f007e8..dcdfe2c8 100644
              <dependency>
                  <groupId>com.adobe.testing</groupId>
                  <artifactId>s3mock-testcontainers</artifactId>
--- 
-2.42.0
-


### PR DESCRIPTION


Fixes: #9907


#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
