### PR TITLE
mitigate CVE-2023-48795 for grafana

### DIFF
--- a/grafana.yaml
+++ b/grafana.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana
   version: 10.2.3
-  epoch: 0
+  epoch: 1
   description: The open and composable observability and data visualization platform.
   copyright:
     - license: AGPL-3.0-or-later
@@ -31,8 +31,8 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/trace@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0
-      go-version: 1.21
+      deps: golang.org/x/crypto@v0.17.0 
+      go-version: "1.21"
 
   - runs: |
       yarn install

--- a/grafana.yaml
+++ b/grafana.yaml
@@ -31,7 +31,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0 
+      deps: golang.org/x/crypto@v0.17.0
       go-version: "1.21"
 
   - runs: |

--- a/py3-python-crfsuite.yaml
+++ b/py3-python-crfsuite.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-python-crfsuite
-  version: 0.9.9
+  version: 0.9.10
   epoch: 0
   description: Python binding for CRFsuite
   copyright:
@@ -27,7 +27,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: caa6261d6955466756f986b7fcfbd4fd50622963e3bdb5cc180c129c62b3a76d
+      expected-sha256: f38524631e2b533341f10f2c77689270dc6ecd5985495dccf7aa37b1045bc2e5
       uri: https://files.pythonhosted.org/packages/source/p/python-crfsuite/python-crfsuite-${{package.version}}.tar.gz
 
   - runs: |


### PR DESCRIPTION
Related: https://github.com/wolfi-dev/os/actions/runs/7265305538/job/19795092531?pr=10118

remove previous go/bump as it is already in upstream