### PR TITLE
terragrunt/0.54.8 pacakge update and fix CVE-2023-48795

### DIFF
--- a/terragrunt.yaml
+++ b/terragrunt.yaml
@@ -1,6 +1,6 @@
 package:
   name: terragrunt
-  version: 0.54.7
+  version: 0.54.8
   epoch: 0
   description: Thin wrapper for Terraform providing extra tools
   copyright:
@@ -20,8 +20,13 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 07a6fb73bb398ccd893ef27021ff037a2a157e2453cd29787d6f6d199f8fa0a9
+      expected-sha256: 12026ce5fc78197367301148ee8317e065b682638430443de47c35fda978e28b
       uri: https://github.com/gruntwork-io/terragrunt/archive/refs/tags/v${{package.version}}.tar.gz
+  
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      go-version: "1.21"
 
   - runs: |
       go build -v -o bin/terragrunt -ldflags "-s -w -X  github.com/gruntwork-io/go-commons/version.Version=v${{package.version}}"

--- a/terragrunt.yaml
+++ b/terragrunt.yaml
@@ -22,7 +22,7 @@ pipeline:
     with:
       expected-sha256: 12026ce5fc78197367301148ee8317e065b682638430443de47c35fda978e28b
       uri: https://github.com/gruntwork-io/terragrunt/archive/refs/tags/v${{package.version}}.tar.gz
-  
+
   - uses: go/bump
     with:
       deps: golang.org/x/crypto@v0.17.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #10147 


#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
