### PR TITLE
Adding falco-no-driver package that supports modern-bpf

### DIFF
--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -5,6 +5,9 @@ package:
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - falco-rules
 
 environment:
   contents:
@@ -60,7 +63,7 @@ pipeline:
         -DBUILD_BPF=Off \
         -DFALCO_VERSION=${{package.version}} \
         ..
-      make falco
+      make falco -j$(nproc)
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin

--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -60,7 +60,7 @@ pipeline:
         -DBUILD_BPF=Off \
         -DFALCO_VERSION=${{package.version}} \
         ..
-      make falco -j6
+      make falco
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin

--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -5,11 +5,6 @@ package:
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - falco-plugins
-      - falco-rules
-      - falcoctl
 
 environment:
   contents:

--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -1,0 +1,82 @@
+package:
+  name: falco-no-driver
+  version: 0.36.2
+  epoch: 0
+  description: Cloud Native Runtime Security
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - falco-plugins
+      - falco-rules
+      - falcoctl
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - bash
+      - bpftool
+      - build-base
+      - busybox
+      - c-ares-dev
+      - clang
+      - cmake
+      - curl-dev
+      - elfutils-dev
+      - gcc-12-default
+      - git
+      - grpc-dev
+      - libbpf
+      - libbpf-dev
+      - libelf-static
+      - libtool
+      - openssl-dev
+      - pkgconf
+      - protobuf-dev
+      - yaml-cpp-dev
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/falcosecurity/falco
+      tag: ${{package.version}}
+      expected-commit: 1b62b5ccd1c64cd972ef0252262075cbf42a130c
+      recurse-submodules: true
+
+  - runs: |
+      mkdir skeleton-build && cd skeleton-build
+      cmake -DUSE_BUNDLED_DEPS=ON -DBUILD_FALCO_MODERN_BPF=ON -DCREATE_TEST_TARGETS=Off -DFALCO_VERSION=${{package.version}} ..
+      make ProbeSkeleton -j$(nproc)
+
+      mkdir -p /tmp
+      cp ./skel_dir/bpf_probe.skel.h /tmp
+
+  - runs: |
+      mkdir build && cd build
+      cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DUSE_BUNDLED_DEPS=On \
+        -DFALCO_ETC_DIR=/etc/falco \
+        -DBUILD_FALCO_MODERN_BPF=ON \
+        -DMODERN_BPF_SKEL_DIR=/tmp \
+        -DBUILD_DRIVER=Off \
+        -DBUILD_BPF=Off \
+        -DFALCO_VERSION=${{package.version}} \
+        ..
+      make falco -j6
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv ./build/userspace/falco/falco ${{targets.destdir}}/usr/bin/falco
+
+      mkdir -p "${{targets.destdir}}"/etc/falco
+      install -Dm755 ./falco.yaml "${{targets.destdir}}"/etc/falco/falco.yaml
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: falcosecurity/falco


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
