### PR TITLE
mitigate CVE-2023-48795 and GHSA-7ww5-4wqc-m92c for kots

### DIFF
--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
   version: 1.104.7
-  epoch: 0
+  epoch: 1
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,11 @@ pipeline:
     with:
       uri: https://github.com/replicatedhq/kots/archive/refs/tags/v${{package.version}}.tar.gz
       expected-sha256: 68b8ef5261d5894262bd33631bc800119f59ff8aae40da372e58577bcdac7c12
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      go-version: "1.21.0"
 
   - runs: |
       set -x

--- a/kots.yaml
+++ b/kots.yaml
@@ -25,7 +25,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0
+      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11
       go-version: "1.21.0"
 
   - runs: |


### PR DESCRIPTION
- mitigate CVE-2023-48795 for kots
- mitigate GHSA-7ww5-4wqc-m92c for kots

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/659

