### PR TITLE
add extra ignore version patterns to address tags misspelled upstream

### DIFF
--- a/dynamic-localpv-provisioner.yaml
+++ b/dynamic-localpv-provisioner.yaml
@@ -43,7 +43,7 @@ pipeline:
 update:
   enabled: true
   ignore-regex-patterns:
-    - localpv-provisioner
+    - localp* # there are some misspellings in the upstream tags so using a wildcard here
   github:
     identifier: openebs/dynamic-localpv-provisioner
     strip-prefix: v

--- a/kubernetes-event-exporter.yaml
+++ b/kubernetes-event-exporter.yaml
@@ -50,7 +50,7 @@ subpackages:
 update:
   enabled: true
   ignore-regex-patterns:
-    - kubernetes-event-exporter-*
+    - kubernetes-e.*t-exporter-* # there are some misspellings in the upstream tags so using a wildcard here
   github:
     identifier: resmoio/kubernetes-event-exporter
     strip-prefix: v

--- a/libapr.yaml
+++ b/libapr.yaml
@@ -69,6 +69,9 @@ update:
   enabled: true
   ignore-regex-patterns:
     - '.*x-.*'
+    - APACHE*
+    - APR*
+    - STRIKER*
   github:
     identifier: apache/apr
     use-tag: true


### PR DESCRIPTION
some upstream projects have misspelled some tags so our existing ignore-regex-patterns were not omitting them.  Let's relax the regex a bit.

This PR doesn't change the pipelines so no epoch bump needed.