### PR TITLE
Add configargparse, vcrpy.

### DIFF
--- a/py3-configargparse.yaml
+++ b/py3-configargparse.yaml
@@ -1,0 +1,28 @@
+# Generated from https://pypi.org/project/ConfigArgParse/
+package:
+    name: py3-configargparse
+    version: "1.7"
+    epoch: 0
+    description: A drop-in replacement for argparse that allows options to also be set via config files and/or environment variables.
+    copyright:
+        - license: MIT
+    dependencies:
+        runtime:
+            - python-3
+environment:
+    contents:
+        packages:
+            - ca-certificates-bundle
+            - wolfi-base
+            - busybox
+            - build-base
+            - python-3
+            - py3-setuptools
+pipeline:
+    - uses: fetch
+      with:
+        expected-sha256: e7067471884de5478c58a511e529f0f9bd1c66bfef1dea90935438d6c23306d1
+        uri: https://files.pythonhosted.org/packages/source/C/ConfigArgParse/ConfigArgParse-${{package.version}}.tar.gz
+    - name: Python Build
+      uses: python/build-wheel
+    - uses: strip

--- a/py3-configargparse.yaml
+++ b/py3-configargparse.yaml
@@ -1,28 +1,50 @@
 # Generated from https://pypi.org/project/ConfigArgParse/
 package:
-    name: py3-configargparse
-    version: "1.7"
-    epoch: 0
-    description: A drop-in replacement for argparse that allows options to also be set via config files and/or environment variables.
-    copyright:
-        - license: MIT
-    dependencies:
-        runtime:
-            - python-3
+  name: py3-configargparse
+  version: 1.7
+  epoch: 0
+  description: A drop-in replacement for argparse that allows options to also be set via config files and/or environment variables.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python-3
+    provides:
+      # The name casing in the pypi package is different from our name.
+      - py3-ConfigArgParse=${{package.full-version}}
+
 environment:
-    contents:
-        packages:
-            - ca-certificates-bundle
-            - wolfi-base
-            - busybox
-            - build-base
-            - python-3
-            - py3-setuptools
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-setuptools
+      - python-3
+      - wolfi-base
+
 pipeline:
-    - uses: fetch
-      with:
-        expected-sha256: e7067471884de5478c58a511e529f0f9bd1c66bfef1dea90935438d6c23306d1
-        uri: https://files.pythonhosted.org/packages/source/C/ConfigArgParse/ConfigArgParse-${{package.version}}.tar.gz
-    - name: Python Build
-      uses: python/build-wheel
-    - uses: strip
+  - uses: git-checkout
+    with:
+      repository: https://github.com/bw2/ConfigArgParse
+      tag: ${{package.version}}
+      expected-commit: ee77f44d03415f2afe73c82096bae2293db29a3b
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: bw2/ConfigArgParse
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        DBSNP_PATH=./package_test_here python ./config_test.py --my-config ./config.txt f1.vcf f2.vcf

--- a/py3-configargparse/config.txt
+++ b/py3-configargparse/config.txt
@@ -1,0 +1,3 @@
+# settings for config_test.py
+genome = HCMV     # cytomegalovirus genome
+dbsnp = /data/dbsnp/variants.vcf

--- a/py3-configargparse/config_test.py
+++ b/py3-configargparse/config_test.py
@@ -1,0 +1,16 @@
+import configargparse
+
+p = configargparse.ArgParser(default_config_files=['/etc/app/conf.d/*.conf', '~/.my_settings'])
+p.add('-c', '--my-config', required=True, is_config_file=True, help='config file path')
+p.add('--genome', required=True, help='path to genome file')  # this option can be set in a config file because it starts with '--'
+p.add('-v', help='verbose', action='store_true')
+p.add('-d', '--dbsnp', help='known variants .vcf', env_var='DBSNP_PATH')  # this option can be set in a config file because it starts with '--'
+p.add('vcf', nargs='+', help='variant file(s)')
+
+options = p.parse_args()
+
+print(options)
+print("----------")
+print(p.format_help())
+print("----------")
+print(p.format_values())    # useful for logging where different settings came from

--- a/py3-vcrpy.yaml
+++ b/py3-vcrpy.yaml
@@ -1,37 +1,43 @@
 # Generated from https://pypi.org/project/vcrpy/
 package:
-    name: py3-vcrpy
-    version: 5.1.0
-    epoch: 0
-    description: Automatically mock your HTTP interactions to simplify and speed up testing
-    copyright:
-        - license: MIT
-    dependencies:
-        runtime:
-            - py3-pyyaml
-            - py3-wrapt
-            - py3-yarl
-            - py3-urllib3
-            - python-3
+  name: py3-vcrpy
+  version: 5.1.0
+  epoch: 0
+  description: Automatically mock your HTTP interactions to simplify and speed up testing
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-pyyaml
+      - py3-wrapt
+      - py3-yarl
+      - py3-urllib3
+      - python-3
+
 environment:
-    contents:
-        repositories:
-            - https://packages.wolfi.dev/os
-        keyring:
-            - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-        packages:
-            - ca-certificates-bundle
-            - wolfi-base
-            - busybox
-            - build-base
-            - python-3
-            - py3-setuptools
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-setuptools
+      - python-3
+      - wolfi-base
+
 pipeline:
-    - uses: fetch
-      with:
-        README: 'CONFIRM WITH: curl -L https://files.pythonhosted.org/packages/source/v/vcrpy/vcrpy-5.1.0.tar.gz | sha256sum'
-        expected-sha256: bbf1532f2618a04f11bce2a99af3a9647a32c880957293ff91e0a5f187b6b3d2
-        uri: https://files.pythonhosted.org/packages/source/v/vcrpy/vcrpy-${{package.version}}.tar.gz
-    - name: Python Build
-      uses: python/build-wheel
-    - uses: strip
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kevin1024/vcrpy
+      tag: v${{package.version}}
+      expected-commit: d6bded18205804c07d5cff9b81e88bda011929bc
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kevin1024/vcrpy
+    strip-prefix: v

--- a/py3-vcrpy.yaml
+++ b/py3-vcrpy.yaml
@@ -1,0 +1,37 @@
+# Generated from https://pypi.org/project/vcrpy/
+package:
+    name: py3-vcrpy
+    version: 5.1.0
+    epoch: 0
+    description: Automatically mock your HTTP interactions to simplify and speed up testing
+    copyright:
+        - license: MIT
+    dependencies:
+        runtime:
+            - py3-pyyaml
+            - py3-wrapt
+            - py3-yarl
+            - py3-urllib3
+            - python-3
+environment:
+    contents:
+        repositories:
+            - https://packages.wolfi.dev/os
+        keyring:
+            - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+        packages:
+            - ca-certificates-bundle
+            - wolfi-base
+            - busybox
+            - build-base
+            - python-3
+            - py3-setuptools
+pipeline:
+    - uses: fetch
+      with:
+        README: 'CONFIRM WITH: curl -L https://files.pythonhosted.org/packages/source/v/vcrpy/vcrpy-5.1.0.tar.gz | sha256sum'
+        expected-sha256: bbf1532f2618a04f11bce2a99af3a9647a32c880957293ff91e0a5f187b6b3d2
+        uri: https://files.pythonhosted.org/packages/source/v/vcrpy/vcrpy-${{package.version}}.tar.gz
+    - name: Python Build
+      uses: python/build-wheel
+    - uses: strip


### PR DESCRIPTION
Note you can install with py3-configargparse, or the camel case that's seen in the pypi.

```
db291e035e77:/work/packages# apk add py3-ConfigArgParse
<SNIPPITY SNIP SIP>
(13/14) Installing python-3.12 (3.12.1-r0)
(14/14) Installing py3-configargparse (1.7-r2)
OK: 59 MiB in 28 packages
```

```
2ff0279f1d5d:/work/packages# apk add py3-configargparse
<SNIPPITY SNIP SNIP>
(13/14) Installing python-3.12 (3.12.1-r0)
(14/14) Installing py3-configargparse (1.7-r2)
OK: 59 MiB in 28 packages
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
