### PR TITLE
mitigate CVE-2023-48795 for kube-fluentd-operator

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.1
-  epoch: 1
+  epoch: 2
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -86,6 +86,11 @@ pipeline:
     with:
       deps: golang.org/x/net@v0.17.0
       modroot: image
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      modroot: config-reloader
 
   - runs: |
       # makefile has moved to the root of the repo without any changes


### PR DESCRIPTION
- mitigate CVE-2023-48795 for kube-fluentd-operator

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/671
