### PR TITLE
mitigate CVE-2023-48795 for kube-state-metrics

### DIFF
--- a/kube-state-metrics.yaml
+++ b/kube-state-metrics.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-state-metrics
   version: 2.10.1
-  epoch: 1
+  epoch: 2
   description: Add-on agent to generate and expose cluster-level metrics.
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,12 @@ pipeline:
       repository: https://github.com/kubernetes/kube-state-metrics
       tag: v${{package.version}}
       expected-commit: c90c81cb3b6bc27d08791482f0517682b39f3ccd
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+      modroot: .
+      go-version: '1.21'
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin


### PR DESCRIPTION
- mitigate CVE-2023-48795 for kube-state-metrics

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/670
