### PR TITLE
mitigate CVE-2023-48795 and GHSA-7ww5-4wqc-m92c for melange

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -2,7 +2,7 @@ package:
   name: melange
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
   version: 0.5.4
-  epoch: 1
+  epoch: 2
   description: build APKs from source code
   copyright:
     - license: Apache-2.0
@@ -26,11 +26,14 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: bc76a3708fdc91882817652237cbe73bcc5f4591
 
-  - runs: |
-      # GHSA-3f2q-6294-fmq5 CVE-2023-46402
-      go mod edit -replace=github.com/whilp/git-urls=github.com/dlorenc/git-urls@v0.0.1
-      go mod tidy
+  - uses: go/bump
+    with:
+      modroot: .
+      go-version: "1.21"
+      replaces: github.com/whilp/git-urls=github.com/chainguard-dev/git-urls@v1.0.1
+      deps: golang.org/x/crypto@v0.17.0
 
+  - runs: |
       make melange
       install -m755 -D ./melange "${{targets.destdir}}"/usr/bin/melange
 

--- a/melange.yaml
+++ b/melange.yaml
@@ -31,7 +31,7 @@ pipeline:
       modroot: .
       go-version: "1.21"
       replaces: github.com/whilp/git-urls=github.com/chainguard-dev/git-urls@v1.0.1
-      deps: golang.org/x/crypto@v0.17.0
+      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11
 
   - runs: |
       make melange


### PR DESCRIPTION
- mitigate CVE-2023-48795 for melange
- mitigate GHSA-7ww5-4wqc-m92c for melange

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/673
