### PR TITLE
mitigate CVE-2023-48795 for kubernetes-1.25

### DIFF
--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -47,6 +47,9 @@ pipeline:
       # Mitigate GHSA-hqxw-f8mx-cpmw / CVE-2023-2253
       ./hack/pin-dependency.sh github.com/docker/distribution v2.8.2
       # Mitigate CVE-2023-48795
+      ./hack/pin-dependency.sh golang.org/x/sys v0.15.0
+      ./hack/pin-dependency.sh golang.org/x/term v0.15.0
+      ./hack/pin-dependency.sh golang.org/x/text v0.14.0
       ./hack/pin-dependency.sh golang.org/x/crypto v0.17.0
       ./hack/update-vendor.sh
       ./hack/lint-dependencies.sh

--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.25
   version: 1.25.16
-  epoch: 2
+  epoch: 3
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -46,6 +46,8 @@ pipeline:
   - runs: |
       # Mitigate GHSA-hqxw-f8mx-cpmw / CVE-2023-2253
       ./hack/pin-dependency.sh github.com/docker/distribution v2.8.2
+      # Mitigate CVE-2023-48795
+      ./hack/pin-dependency.sh golang.org/x/crypto v0.17.0
       ./hack/update-vendor.sh
       ./hack/lint-dependencies.sh
 


### PR DESCRIPTION
- mitigate CVE-2023-48795 for kubernetes-1.25

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/675
