### PR TITLE
Add logstash-output-opensearch ruby deps batch 4

### DIFF
--- a/ruby3.2-bouncy-castle-java.yaml
+++ b/ruby3.2-bouncy-castle-java.yaml
@@ -1,0 +1,60 @@
+# Generated from http://github.com/jruby/jruby/tree/master/gems/bouncy-castle-java/
+package:
+  name: ruby3.2-bouncy-castle-java
+  version: 1.5.0146.1
+  epoch: 0
+  description: Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+  environment:
+    # https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on
+    BCPROV_VERSION: 1.77
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/nahi/bouncy-castle-java
+      tag: ${{package.version}}
+      expected-commit: 401f0077cac504c62c449b860366f23393345c35
+
+  - uses: patch
+    with:
+      patches: 0001-add-gemspec.patch
+
+  - runs: |
+      # Bouncycastle does not actively maintain on GitHub so we need
+      # to download the newer versions of dependencies from Maven
+      cd lib
+      rm bcprov-jdk15-146.jar
+      curl -sLO https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/${BCPROV_VERSION}/bcprov-jdk18on-${BCPROV_VERSION}.jar
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: bouncy-castle-java
+
+update:
+  enabled: true
+  github:
+    identifier: nahi/bouncy-castle-java
+    use-tag: true

--- a/ruby3.2-bouncy-castle-java/0001-add-gemspec.patch
+++ b/ruby3.2-bouncy-castle-java/0001-add-gemspec.patch
@@ -1,0 +1,52 @@
+# Newer Ruby Gems versions does not support old `Gem::Builder` class.
+# This patch adds `gemspec` file to the project to support newer Ruby versions.
+From a9cab3b0fc08ef50843abfef42ac739f0cb76215 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Furkan=20T=C3=BCrkal?= <furkan.turkal@chainguard.dev>
+Date: Wed, 20 Dec 2023 14:12:43 +0300
+Subject: [PATCH] add gemspec
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Furkan Türkal <furkan.turkal@chainguard.dev>
+---
+ bouncy-castle-java.gemspec | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+ create mode 100644 bouncy-castle-java.gemspec
+
+diff --git a/bouncy-castle-java.gemspec b/bouncy-castle-java.gemspec
+new file mode 100644
+index 0000000..e2f988d
+--- /dev/null
++++ b/bouncy-castle-java.gemspec
+@@ -0,0 +1,27 @@
++# bouncy-castle-java.gemspec
++Gem::Specification.new do |s|
++  s.name        = 'bouncy-castle-java'
++  s.version     = '1.5.0146.1'
++  s.author      = 'Hiroshi Nakamura'
++  s.email       = 'nahi@ruby-lang.org'
++  s.homepage    = 'http://github.com/nahi/bouncy-castle-java/'
++  s.summary     = 'Gem redistribution of Bouncy Castle jars'
++  s.description = 'Gem redistribution of "Legion of the Bouncy Castle Java cryptography APIs" jars at http://www.bouncycastle.org/java.html'
++  s.files       = ['README', 'LICENSE.html'] + Dir.glob('lib/**/*')
++  s.platform    = Gem::Platform::RUBY
++  s.require_path = 'lib'
++
++  s.add_runtime_dependency 'rubygems', '~> 3.0'
++  # Add any other runtime dependencies here
++
++  s.requirements << 'RubyGems version >= 3.0'
++
++  s.add_development_dependency 'rake', '~> 13.0'
++
++  s.metadata = {
++    'source_code_uri' => 'http://github.com/nahi/bouncy-castle-java/',
++    'bug_tracker_uri' => 'http://github.com/nahi/bouncy-castle-java/issues'
++  }
++
++  s.license = 'MIT'  # Adjust the license as needed
++end
+-- 
+2.39.3 (Apple Git-145)
+

--- a/ruby3.2-jrjackson.yaml
+++ b/ruby3.2-jrjackson.yaml
@@ -1,0 +1,81 @@
+package:
+  name: ruby3.2-jrjackson
+  version: 0.4.18
+  epoch: 0
+  description: A mostly native JRuby wrapper for the java jackson json processor jar
+  copyright:
+    - license: Apache License 2.0
+  dependencies:
+    runtime:
+      - openjdk-11-default-jvm
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - jruby-9.4
+      - maven
+      - openjdk-11
+      - openjdk-11-default-jvm
+      - openjdk-11-jre
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-11-openjdk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 86e21566467349cb92ee5687f2933335ee227c93
+      repository: https://github.com/guyboertje/jrjackson
+      tag: v${{package.version}}
+
+  - uses: maven/configure-mirror
+
+  - runs: |
+      gem install bundler
+      gem install ruby-maven
+      gem install maven-tools
+      gem install jar-dependencies
+
+  - runs: sed -i "s/3\.1/3.12.1/g; s/1\.8/11/g" Mavenfile
+
+  - runs: mvn clean install -Dmaven.test.skip
+
+  - runs: |
+      # Extract the jackson_version to use in the maven dependency:copy commands
+      export JACKSON_VERSION=$(grep -A 1 'def self.jackson_version' ./lib/jrjackson/build_info.rb | tail -n 1 | awk -F "'" '{print $2}')
+
+      mkdir -p ./lib/com/fasterxml/jackson/core/jackson-annotations/${JACKSON_VERSION}
+      mkdir -p ./lib/com/fasterxml/jackson/core/jackson-core/${JACKSON_VERSION}
+      mkdir -p ./lib/com/fasterxml/jackson/core/jackson-databind/${JACKSON_VERSION}
+      mkdir -p ./lib/com/fasterxml/jackson/module/jackson-module-afterburner/${JACKSON_VERSION}
+      mkdir -p ./lib/jrjackson/jars
+
+      mvn dependency:copy -Dartifact=com.fasterxml.jackson.core:jackson-annotations:${JACKSON_VERSION} -DoutputDirectory=lib/com/fasterxml/jackson/core/jackson-annotations/${JACKSON_VERSION}
+      mvn dependency:copy -Dartifact=com.fasterxml.jackson.core:jackson-core:${JACKSON_VERSION} -DoutputDirectory=lib/com/fasterxml/jackson/core/jackson-core/${JACKSON_VERSION}
+      mvn dependency:copy -Dartifact=com.fasterxml.jackson.core:jackson-databind:${JACKSON_VERSION} -DoutputDirectory=lib/com/fasterxml/jackson/core/jackson-databind/${JACKSON_VERSION}
+      mvn dependency:copy -Dartifact=com.fasterxml.jackson.module:jackson-module-afterburner:${JACKSON_VERSION} -DoutputDirectory=lib/com/fasterxml/jackson/module/jackson-module-afterburner/${JACKSON_VERSION}
+
+  - runs: |
+      jruby -S gem build ${{vars.gem}}.gemspec
+
+  - uses: ruby/install
+    with:
+      # Output file name has `java` suffix.
+      gem-file: ${{vars.gem}}-${{package.version}}-java.gem
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: jrjackson
+
+update:
+  enabled: true
+  github:
+    identifier: guyboertje/jrjackson
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-jrjackson/pom.xml
+++ b/ruby3.2-jrjackson/pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+​
+​
+DO NOT MODIFY - GENERATED CODE
+​
+​
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.jrjackson.jruby</groupId>
+  <artifactId>jrjackson</artifactId>
+  <version>1.2.35</version>
+  <name>A JRuby wrapper for the java jackson json processor jar</name>
+  <description>A mostly native JRuby wrapper for the java jackson json processor jar</description>
+  <url>http://github.com/guyboertje/jrjackson</url>
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <name>Guy Boertje</name>
+      <email>guyboertje@gmail.com</email>
+    </developer>
+  </developers>
+  <scm>
+    <connection>https://github.com/guyboertje/jrjackson.git</connection>
+    <url>http://github.com/guyboertje/jrjackson</url>
+  </scm>
+  <properties>
+    <jruby.plugins.version>2.0.1</jruby.plugins.version>
+    <mavengem.wagon.version>1.0.3</mavengem.wagon.version>
+    <polyglot.dump.pom>pom.xml</polyglot.dump.pom>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.15.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.15.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.15.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-afterburner</artifactId>
+      <version>2.15.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby</artifactId>
+      <version>9.2.13.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  <repositories>
+    <repository>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
+    </repository>
+  </repositories>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>org.torquebox.mojo</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>${mavengem.wagon.version}</version>
+      </extension>
+      <extension>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-with-jar-extension</artifactId>
+        <version>${jruby.plugins.version}</version>
+      </extension>
+    </extensions>
+    <directory>${basedir}/pkg</directory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <outputDirectory>lib/jrjackson/jars</outputDirectory>
+          <finalName>jrjackson-1.2.35</finalName>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.4</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>lib/jrjackson/jars</directory>
+              <includes>
+                <include>jrjackson-1.2.35.jar</include>
+                <include>*/**/*.jar</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
+        <configuration>
+          <gemspec>jrjackson.gemspec</gemspec>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.12.1</version>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+          <showDeprecation>false</showDeprecation>
+          <showWarnings>false</showWarnings>
+          <executable>${JAVA_HOME}/bin/javac</executable>
+          <fork>true</fork>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/ruby3.2-jruby-openssl.yaml
+++ b/ruby3.2-jruby-openssl.yaml
@@ -1,0 +1,54 @@
+# Generated from https://github.com/jruby/jruby-openssl
+package:
+  name: ruby3.2-jruby-openssl
+  version: 0.14.2
+  epoch: 0
+  description: JRuby-OpenSSL is an add-on gem for JRuby that emulates the Ruby OpenSSL native library.
+  copyright:
+    - license: GPL-2.0-or-later AND EPL-1.0-or-later AND LGPL-2.1-or-later
+  dependencies:
+    runtime:
+      - ruby3.2-bouncy-castle-java
+      - openjdk-11-default-jvm
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: b0ca8d8a0d5cb58ca7f8b9e37eb1fda69bfeba7a
+      repository: https://github.com/jruby/jruby-openssl
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      # Output file name has `java` suffix.
+      gem-file: ${{vars.gem}}-${{package.version}}-java.gem
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: jruby-openssl
+
+update:
+  enabled: true
+  # There are some non-semantic tags that break our update block.
+  ignore-regex-patterns:
+    - '.*\.cr*'
+  github:
+    identifier: jruby/jruby-openssl
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
