### PR TITLE
Fix camelcasing for py3-cachecontrol, py3-secretstorage.

### DIFF
--- a/py3-cachecontrol.yaml
+++ b/py3-cachecontrol.yaml
@@ -1,8 +1,8 @@
 # Generated from https://pypi.org/project/CacheControl/
 package:
-  name: py3-CacheControl
+  name: py3-cachecontrol
   version: 0.13.1
-  epoch: 0
+  epoch: 1
   description: httplib2 caching for requests
   copyright:
     - license: Apache-2.0
@@ -11,6 +11,8 @@ package:
       - py3-requests
       - py3-msgpack
       - python-3
+    provides:
+      - py3-CacheControl=${{package.full-version}}
 
 environment:
   contents:

--- a/py3-secretstorage.yaml
+++ b/py3-secretstorage.yaml
@@ -1,8 +1,8 @@
 # Generated from https://pypi.org/project/SecretStorage/
 package:
-  name: py3-SecretStorage
+  name: py3-secretstorage
   version: 3.3.3
-  epoch: 1
+  epoch: 2
   description: Python bindings to FreeDesktop.org Secret Service API
   copyright:
     - license: BSD 3-Clause License
@@ -11,6 +11,8 @@ package:
       - py3-cryptography
       - py3-jeepney
       - python3
+    provides:
+      - py3-SecretStorage=${{package.full-version}}
 
 environment:
   contents:


### PR DESCRIPTION
Also provide backwards compatible naming:

```
2ff0279f1d5d:/work/packages# apk add py3-cachecontrol
(7/7) Installing py3-cachecontrol (0.13.1-r1)
2ff0279f1d5d:/work/packages# apk add py3-secretstorage
(5/5) Installing py3-secretstorage (3.3.3-r2)

f1b7786d6f2e:/work/packages# apk add py3-CacheControl
(7/7) Installing py3-cachecontrol (0.13.1-r1)
f1b7786d6f2e:/work/packages# apk add py3-SecretStorage
(5/5) Installing py3-secretstorage (3.3.3-r2)
```


<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
