### PR TITLE
drop dep bump

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -2,7 +2,7 @@ package:
   name: melange
   # When bumping the version check if the CVE/GHSA mitigations below can be removed.
   version: 0.5.5
-  epoch: 0
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0
@@ -25,13 +25,6 @@ pipeline:
       repository: https://github.com/chainguard-dev/melange
       tag: v${{package.version}}
       expected-commit: 3a7d2fcf7c05beee78d2e1315eaa441b879f129d
-
-  - uses: go/bump
-    with:
-      modroot: .
-      go-version: "1.21"
-      replaces: github.com/whilp/git-urls=github.com/chainguard-dev/git-urls@v1.0.1
-      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11
 
   - runs: |
       make melange


### PR DESCRIPTION
don't know why in https://github.com/wolfi-dev/os/pull/10253 the dep bump was not dropped, removing those now