### PR TITLE
kpt package bump to v1.0.0-beta.49

### DIFF
--- a/kpt.yaml
+++ b/kpt.yaml
@@ -1,7 +1,7 @@
 package:
   name: kpt
-  version: 1.0.0_beta46
-  epoch: 1
+  version: 1.0.0_beta49
+  epoch: 0
   description: Automate Kubernetes Configuration Editing
   copyright:
     - license: Apache-2.0
@@ -19,12 +19,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/GoogleContainerTools/kpt
-      tag: v1.0.0-beta.46
-      expected-commit: 8b5e2f5450de1d468307d8026790914c92a25c1f
-
-  - uses: go/bump
-    with:
-      deps: github.com/docker/distribution@v2.8.2 golang.org/x/net@v0.17.0
+      tag: v1.0.0-beta.49
+      expected-commit: 030ff2a80f84db3c018ee9ac2f4abb923bcc69c3
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin


### PR DESCRIPTION
- kpt package bump to v1.0.0-beta.49

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/685

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0


