### PR TITLE
mitigate GHSA-jq35-85cj-fj4p / CVE-2023-48795 / CVE-2023-40577 for loki

### DIFF
--- a/loki.yaml
+++ b/loki.yaml
@@ -1,7 +1,7 @@
 package:
   name: loki
   version: 2.9.3
-  epoch: 0
+  epoch: 1
   description: Like Prometheus, but for logs.
   copyright:
     - license: AGPL-3.0
@@ -20,6 +20,10 @@ pipeline:
       repository: https://github.com/grafana/loki
       tag: v${{package.version}}
       expected-commit: 2535f9bedeae5f27abdbfaf0cc1a8e9f91b6c96d
+
+  - uses: go/bump
+    with:
+      deps: github.com/docker/docker@v24.0.7+incompatible golang.org/x/crypto@v0.17.0
 
   - uses: autoconf/make
 


### PR DESCRIPTION
- mitigate GHSA-jq35-85cj-fj4p / CVE-2023-48795 / CVE-2023-40577 for loki

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/687

