### PR TITLE
mitigate CVE-2021-38561/CVE-2020-14040/CVE-2022-32149 for vt-cli

### DIFF
--- a/vt-cli.yaml
+++ b/vt-cli.yaml
@@ -1,8 +1,8 @@
 package:
   name: vt-cli
   version: 1.0.0
-  epoch: 2
-  description:
+  epoch: 3
+  description: "VirusTotal Command Line Interface"
   copyright:
     - license: Apache-2.0
 
@@ -20,6 +20,10 @@ pipeline:
       repository: https://github.com/VirusTotal/vt-cli
       tag: ${{package.version}}
       expected-commit: 5473568046e206663ebbd4c0c2463358915af59c
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/text@v0.3.8
 
   - uses: go/build
     with:


### PR DESCRIPTION
- mitigate CVE-2021-38561/CVE-2020-14040/CVE-2022-32149 for vt-cli

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/689

