### PR TITLE
Add gn package.

### DIFF
--- a/gn.yaml
+++ b/gn.yaml
@@ -1,0 +1,39 @@
+package:
+  name: gn
+  version: 0.0_git20231222
+  epoch: 0
+  description: "Meta-build system that generates build files for Ninja"
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang
+      - git
+      # Doesn't work on 3.12
+      - python-3.11
+      - samurai
+
+pipeline:
+  - runs: |
+      # googlesource repos don't provide stable download URLs, and this project doesn't use tags for versioning.
+      # our git-checkout pipeline requires a tag to checkout, so we need to do it this way...
+      git clone https://gn.googlesource.com/gn
+      cd gn
+
+      # Bump this commit when updating
+      git checkout 85944ebc24a90ec1e489e85a46fdc68542c3146f
+
+      python3 build/gen.py
+      ninja -C out
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv gn/out/gn ${{targets.destdir}}/usr/bin/gn
+
+update:
+  enabled: false


### PR DESCRIPTION


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
