### PR TITLE
mitigate CVE-2023-48795 and GHSA-7ww5-4wqc-m92c for eksctl

### DIFF
--- a/eksctl.yaml
+++ b/eksctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: eksctl
   version: 0.167.0
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/docker/docker@v24.0.7 oras.land/oras-go@v1.2.4
+      deps: github.com/docker/docker@v24.0.7 oras.land/oras-go@v1.2.4 golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11
 
   - runs: |
       make binary


### PR DESCRIPTION
- mitigate CVE-2023-48795 and GHSA-7ww5-4wqc-m92c for eksctl

detection: https://github.com/wolfi-dev/advisories/pull/691

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo: https://github.com/wolfi-dev/advisories/pull/692
