### PR TITLE
freerdp/3.1.0: Add version stream for freerdp 3.x

### DIFF
--- a/freerdp-3.yaml
+++ b/freerdp-3.yaml
@@ -1,10 +1,13 @@
 package:
-  name: freerdp
-  version: 2.11.2
+  name: freerdp-3
+  version: 3.1.0
   epoch: 0
   description: FreeRDP client
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - freerdp=${{package.full-version}}
 
 environment:
   contents:
@@ -14,12 +17,19 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cairo-dev
       # - bsd-compat-headers
       - cmake
       - cups-dev
+      - docbook-xml
+      - ffmpeg-dev
+      - fuse3-dev
       - gsm-dev
       - gst-plugins-base-dev
+      - icu-dev
+      - krb5-dev
       - libjpeg-turbo-dev
+      - libswscale7
       - libusb-dev
       - libx11-dev
       - libxcursor-dev
@@ -31,16 +41,19 @@ environment:
       - libxkb-dev
       - libxkbcommon-dev
       - libxrender-dev
+      - libxslt
       - libxv-dev
       - linux-headers
       - openssl-dev>3
+      - pkcs11-helper-dev
       - samurai
+      - wayland-dev
 
 pipeline:
   - uses: fetch
     with:
       uri: https://github.com/FreeRDP/FreeRDP/archive/${{package.version}}.tar.gz
-      expected-sha512: 722d95d7591b5ce6a7e8a3b6ac8999df278dbcfc286a532f56bcbc4a3881e75b02c7e3cd4b296e67bc19d1165020acdcca198bf4bcc92aea5611760037fcc57f
+      expected-sha512: 0a463c241d09ea354fdd943c010a2ecca1ad20f6ba5ea037422884f3b668ac6c4c30f73d12077368cd54f74418ef65b267628934a050fcbb3ff1e96d84ae954e
 
   - runs: |
       CFLAGS="$CFLAGS -fPIC" \
@@ -52,7 +65,6 @@ pipeline:
         -DWITH_ALSA=ON \
         -DWITH_CUPS=ON \
         -DWITH_CHANNELS=ON \
-        -DBUILTIN_CHANNELS=OFF \
         -DWITH_DIRECTFB=OFF \
         -DWITH_FFMPEG=OFF \
         -DWITH_GSM=ON \
@@ -82,20 +94,20 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: freerdp-doc
+  - name: ${{package.name}}-doc
     description: freerdp man pages
     pipeline:
       - uses: split/manpages
 
-  - name: freerdp-dev
+  - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
     dependencies:
       runtime:
-        - freerdp
+        - freerdp-3
     description: freerdp dev
 
-  - name: freerdp-libs
+  - name: ${{package.name}}-libs
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
@@ -106,4 +118,4 @@ update:
   enabled: true
   github:
     identifier: FreeRDP/FreeRDP
-    tag-filter-prefix: 2.
+    tag-filter-prefix: 3.


### PR DESCRIPTION
Fixes: https://github.com/wolfi-dev/os/pull/9854 https://github.com/wolfi-dev/os/pull/10344

Related:
- Added new packages required for `cmake` to succeed
- `BUILTIN_CHANNELS` was removed in https://github.com/FreeRDP/FreeRDP/pull/7647
- Replaced tab characters found in original YAML (see below)

```
cat -A freerdp.yaml
...
  - runs: |$
      CFLAGS="$CFLAGS -fPIC" \$
      CXXFLAGS="$CXXFLAGS -fPIC" \$
      cmake -B build -G Ninja \$
      ^I-DCMAKE_BUILD_TYPE=MinSizeRel \$
      ^I-DCMAKE_INSTALL_PREFIX=/usr \$
      ^I-DCMAKE_INSTALL_LIBDIR=lib \$
      ^I-DWITH_ALSA=ON \$
      ^I-DWITH_CUPS=ON \$
      ^I-DWITH_CHANNELS=ON \$
      ^I-DBUILTIN_CHANNELS=OFF \$
      ^I-DWITH_DIRECTFB=OFF \$
      ^I-DWITH_FFMPEG=OFF \$
      ^I-DWITH_GSM=ON \$
      ^I-DWITH_GSTREAMER_1_0=ON \$
      ^I-DWITH_IPP=OFF \$
      ^I-DWITH_JPEG=ON \$
      ^I-DWITH_OPENSSL=ON \$
      ^I-DWITH_PCSC=OFF \$
      ^I-DWITH_PULSE=OFF \$
      ^I-DWITH_WAYLAND=ON \$
      ^I-DWITH_SERVER=ON \$
      ^I-DWITH_X11=ON \$
      ^I-DWITH_XCURSOR=ON \$
      ^I-DWITH_XEXT=ON \$
      ^I-DWITH_XKBFILE=ON \$
      ^I-DWITH_XI=ON \$
      ^I-DWITH_XINERAMA=ON \$
      ^I-DWITH_XRENDER=ON \$
      ^I-DWITH_XV=ON \$
      ^I-DWITH_ZLIB=ON \$
      ^I-DWITH_NEON=OFF$
       cmake --build build$
...
```

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0
