### PR TITLE
Fix gcc-12 package - libstdc++ had a broken symlink.

### DIFF
--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.3.0
-  epoch: 4
+  epoch: 5
   description: "the GNU compiler collection - version 12"
   copyright:
     - license: GPL-3.0-or-later
@@ -120,7 +120,7 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/$gcclibdir/include
           mkdir -p "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx
           mv "${{targets.destdir}}"/$gcclibdir/*++.a "${{targets.subpkgdir}}"/$gcclibdir/
-          mv "${{targets.destdir}}"/$gcclibdir/libstdc++.so "${{targets.subpkgdir}}"/$gcclibdir/
+          mv "${{targets.destdir}}"/$gcclibdir/libstdc++.so* "${{targets.subpkgdir}}"/$gcclibdir/
           mv "${{targets.destdir}}"/$gcclibdir/include/*++* "${{targets.subpkgdir}}"/$gcclibdir/include/
           mv "${{targets.destdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/* \
             "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/


### PR DESCRIPTION
This .so points to a missing target.

stat /usr/lib/gcc/aarch64-unknown-linux-gnu/12.3.0/libstdc++.so File: '/usr/lib/gcc/aarch64-unknown-linux-gnu/12.3.0/libstdc++.so' -> 'libstdc++.so.6.0.30'
