### PR TITLE
Package what-utils for Wolfi

### DIFF
--- a/what-utils.yaml
+++ b/what-utils.yaml
@@ -26,6 +26,7 @@ pipeline:
       repository: https://github.com/dustinkirkland/what-utils
       tag: ${{package.version}}
       expected-commit: 0df6bd3c86d9cb411efd215242948e04d024eb87
+
   - runs: |
       for i in $(ls ./usr/bin/*); do
         install -m 755 -D $i "${{targets.destdir}}"/usr/bin/$(basename $i)

--- a/what-utils.yaml
+++ b/what-utils.yaml
@@ -1,0 +1,37 @@
+package:
+  name: what-utils
+  version: 2.1
+  epoch: 0
+  description: "Utilities for easily querying deb and apk packages on Ubuntu and Wolfi"
+  copyright:
+    - license: GPL-3.0
+  dependencies:
+    runtime:
+      - busybox
+      - command-not-found
+      - locate
+      - posix-libc-utils
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/dustinkirkland/what-utils
+      tag: ${{package.version}}
+      expected-commit: 0df6bd3c86d9cb411efd215242948e04d024eb87
+  - runs: |
+      for i in $(ls ./usr/bin/*); do
+        install -m 755 -D $i "${{targets.destdir}}"/usr/bin/$(basename $i)
+      done
+
+update:
+  enabled: true
+  github:
+    identifier: dustinkirkland/what-utils


### PR DESCRIPTION
what-utils is a package of utilities I created for Ubuntu, 10+ years ago, for asking questions of dpkg and apt.  I spent some time this morning getting it working with apk and Wolfi, and it seems to be working fairly well.

This package provides:

- usr/bin/what-source
- usr/bin/how-many-binary
- usr/bin/how-many-source
- usr/bin/what-repo
- usr/bin/what-license
- usr/bin/what-provides

Here are some examples:

```
61778f2f04de:~# what-source R-mathlib
R
61778f2f04de:~# what-source zstd-dev
zstd

61778f2f04de:~# what-provides ldd
/usr/bin/ldd is owned by posix-libc-utils-2.38-r8
61778f2f04de:~# what-provides strace
The program 'strace' may be found in these packages:
 * strace: Diagnostic, debugging and instructional userspace tracer

61778f2f04de:~# what-license /usr/bin/locate 
locate-4.9.0-r2 x86_64 {findutils} (GPL-3.0-or-later) [installed]
61778f2f04de:~# what-license /usr/bin/hexdump 
busybox-1.36.1-r4 x86_64 {busybox} (GPL-2.0-only) [installed]

61778f2f04de:~# how-many-binary 
4593
61778f2f04de:~# how-many-source 
1939

```
