### PR TITLE
pnpm/8.12.1 package update again build with stage0

### DIFF
--- a/pnpm.yaml
+++ b/pnpm.yaml
@@ -1,6 +1,6 @@
 package:
   name: pnpm
-  version: 8.10.0
+  version: 8.12.1
   epoch: 0
   description: "Fast, disk space efficient package manager"
   copyright:
@@ -19,7 +19,7 @@ environment:
       - make
       - nodejs-18
       - npm
-      - pnpm
+      - pnpm-stage0
       - python3
       - wolfi-base
 
@@ -28,7 +28,7 @@ pipeline:
     with:
       repository: https://github.com/pnpm/pnpm
       tag: v${{package.version}}
-      expected-commit: 3eeb16fdc6a958b32f9810ebf69769c0d1ef33ce
+      expected-commit: e71c0f17e5e1053557aefbc1529f1a44af328380
 
   - runs: |
       /usr/bin/pnpm install


### PR DESCRIPTION
Fixes: #9853 

For some reason last available `pnpm-8.10.0` version doesn't work properly.
It is unable to find the `node-gyp` even after installing `nodejs` package. and give node-gyp cannot be found error:
```bash
/kargo/ui # pnpm install
node:internal/modules/cjs/loader:1144
  const err = new Error(message);
              ^

Error: Cannot find module 'node-gyp/bin/node-gyp.js'
Require stack:
- /usr/lib/node_modules/pnpm/dist/pnpm.cjs
- /usr/lib/node_modules/pnpm/bin/pnpm.cjs
    at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
    at Function.resolve (node:internal/modules/helpers:187:19)
    at ../node_modules/.pnpm/@npmcli+run-script@7.0.1/node_modules/@npmcli/run-script/lib/make-spawn-args.js (/usr/lib/node_modules/pnpm/dist/pnpm.cjs:136003:39)
    at __require (/usr/lib/node_modules/pnpm/dist/pnpm.cjs:12:50)
    at ../node_modules/.pnpm/@npmcli+run-script@7.0.1/node_modules/@npmcli/run-script/lib/run-script-pkg.js (/usr/lib/node_modules/pnpm/dist/pnpm.cjs:136351:25)
    at __require (/usr/lib/node_modules/pnpm/dist/pnpm.cjs:12:50)
    at ../node_modules/.pnpm/@npmcli+run-script@7.0.1/node_modules/@npmcli/run-script/lib/run-script.js (/usr/lib/node_modules/pnpm/dist/pnpm.cjs:136490:24)
    at __require (/usr/lib/node_modules/pnpm/dist/pnpm.cjs:12:50)
    at ../node_modules/.pnpm/pacote@17.0.4/node_modules/pacote/lib/dir.js (/usr/lib/node_modules/pnpm/dist/pnpm.cjs:136514:21)
    at __require (/usr/lib/node_modules/pnpm/dist/pnpm.cjs:12:50) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/usr/lib/node_modules/pnpm/dist/pnpm.cjs',
    '/usr/lib/node_modules/pnpm/bin/pnpm.cjs'
  ]
}

Node.js v20.10.0
```

I have built the newer version of the **pnpm** package using the **pnpm-stage0** and it works fine.
```bash
/kargo/ui # apk del pnpm
(1/1) Purging pnpm (8.10.0-r0)
OK: 136 MiB in 28 packages
/kargo/ui # apk add --allow-untrusted /work/packages/aarch64/pnpm-8.12.1-r0.apk 
(1/1) Installing pnpm (8.12.1-r0)
OK: 145 MiB in 29 packages
/kargo/ui # pnpm install
Lockfile is up to date, resolution step is skipped
Packages: +669
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Downloading registry.npmjs.org/antd/5.11.2: 9.14 MB/9.14 MB, done
Downloading registry.npmj
...
```

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
