### PR TITLE
Add pytorch package.

### DIFF
--- a/pytorch.yaml
+++ b/pytorch.yaml
@@ -1,0 +1,58 @@
+package:
+  name: pytorch
+  version: 2.1.2
+  epoch: 0
+  description: Tensors and Dynamic neural networks in Python with strong GPU acceleration
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - py3-pip
+      - python3
+      - python3-dev
+      - samurai
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pytorch/pytorch.git
+      tag: v${{package.version}}
+      expected-commit: a8e7c98cb95ff97bb30a728c6b2a1ce6bff946eb
+
+  - runs: git submodule update --init --recursive
+
+  # Build deps
+  - runs: pip install -r requirements.txt
+
+  - name: Python Build
+    runs: |
+      python setup.py bdist_wheel
+
+  - runs: |
+      python -m venv .venv
+      # Bump pip to patch a CVE
+      .venv/bin/pip install --upgrade pip==23.3.2
+      .venv/bin/pip install --no-compile dist/*.whl
+      # For some reason numpy isn't installed by default but is required.
+      .venv/bin/pip install numpy==1.26.2 --no-compile
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/pytorch
+      mv .venv ${{targets.destdir}}/usr/share/pytorch/
+
+      # edit the venv paths
+      sed -i "s|/home/build|/usr/share/pytorch|g" ${{targets.destdir}}/usr/share/pytorch/.venv/bin/*
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pytorch/pytorch
+    strip-prefix: v


### PR DESCRIPTION
I installed this in a virtualenv instead of doing the full transtive packaging becuase there are too many conflicting versions of what pytorch needs and what we need.

I think this is probably a direction we'll need to explore for numerical libraries like this one.

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [X] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
