### PR TITLE
cassandra: fix sub package paths

### DIFF
--- a/cassandra.yaml
+++ b/cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra
   version: 4.1.3
-  epoch: 6
+  epoch: 7
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0
@@ -54,10 +54,7 @@ subpackages:
   - name: cassandra-compat
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/opt/cassandra
           install -d ${{targets.subpkgdir}}/etc/cassandra
-
-
           mkdir -p ${{targets.subpkgdir}}/opt
           mv ${{targets.destdir}}/usr/share/java/cassandra ${{targets.subpkgdir}}/opt/cassandra
 


### PR DESCRIPTION
```
 tar xvf  packages/x86_64/cassandra-compat-4.1.3-r6.apk
.SIGN.RSA.local-melange.rsa.pub
.PKGINFO
etc
etc/cassandra
opt
opt/cassandra
opt/cassandra/CASSANDRA-14092.txt
opt/cassandra/CHANGES.txt
opt/cassandra/LICENSE.txt
opt/cassandra/NEWS.txt
opt/cassandra/NOTICE.txt
opt/cassandra/bin
opt/cassandra/bin/cassandra
opt/cassandra/bin/cassandra.in.sh
opt/cassandra/bin/cqlsh
opt/cassandra/bin/cqlsh.py
opt/cassandra/bin/debug-cql
opt/cassandra/bin/nodetool
opt/cassandra/bin/sstableloader
opt/cassandra/bin/sstablescrub
opt/cassandra/bin/sstableupgrade
opt/cassandra/bin/sstableutil
opt/cassandra/bin/sstableverify
opt/cassandra/bin/stop-server
opt/cassandra/conf
opt/cassandra/conf/README.txt
opt/cassandra/conf/cassandra-env.sh
opt/cassandra/conf/cassandra-jaas.config
opt/cassandra/conf/cassandra-rackdc.properties
opt/cassandra/conf/cassandra-topology.properties.example
opt/cassandra/conf/cassandra.yaml
opt/cassandra/conf/commitlog_archiving.properties
opt/cassandra/conf/cqlshrc.sample
opt/cassandra/conf/credentials.sample
opt/cassandra/conf/hotspot_compiler
opt/cassandra/conf/jvm-clients.options
opt/cassandra/conf/jvm-server.options
opt/cassandra/conf/jvm11-clients.options
opt/cassandra/conf/jvm11-server.options
opt/cassandra/conf/jvm8-clients.options
opt/cassandra/conf/jvm8-server.options
opt/cassandra/conf/logback-tools.xml
opt/cassandra/conf/logback.xml
opt/cassandra/conf/metrics-reporter-config-sample.yaml
opt/cassandra/conf/triggers
opt/cassandra/conf/triggers/README.txt
opt/cassandra/data
opt/cassandra/doc
opt/cassandra/doc/SASI.md
opt/cassandra/doc/cql3
opt/cassandra/doc/cql3/CQL.css
opt/cassandra/doc/cql3/CQL.html
opt/cassandra/lib
opt/cassandra/lib/HdrHistogram-2.1.9.jar
opt/cassandra/lib/ST4-4.0.8.jar
opt/cassandra/lib/airline-0.8.jar
opt/cassandra/lib/antlr-runtime-3.5.2.jar
opt/cassandra/lib/apache-cassandra-4.1.3.jar
opt/cassandra/lib/asm-9.1.jar
opt/cassandra/lib/caffeine-2.9.2.jar
opt/cassandra/lib/cassandra-driver-core-3.11.0-shaded.jar
opt/cassandra/lib/cassandra-driver-internal-only-3.25.0.zip
opt/cassandra/lib/checker-qual-3.10.0.jar
opt/cassandra/lib/chronicle-bytes-2.20.111.jar
opt/cassandra/lib/chronicle-core-2.20.126.jar
opt/cassandra/lib/chronicle-queue-5.20.123.jar
opt/cassandra/lib/chronicle-threads-2.20.111.jar
opt/cassandra/lib/chronicle-wire-2.20.117.jar
opt/cassandra/lib/commons-cli-1.1.jar
opt/cassandra/lib/commons-codec-1.9.jar
opt/cassandra/lib/commons-lang3-3.11.jar
opt/cassandra/lib/commons-math3-3.2.jar
opt/cassandra/lib/concurrent-trees-2.4.0.jar
opt/cassandra/lib/ecj-4.6.1.jar
opt/cassandra/lib/error_prone_annotations-2.5.1.jar
opt/cassandra/lib/futures-2.1.6-py2.py3-none-any.zip
opt/cassandra/lib/geomet-0.1.0.zip
opt/cassandra/lib/guava-27.0-jre.jar
opt/cassandra/lib/high-scale-lib-1.0.6.jar
opt/cassandra/lib/hppc-0.8.1.jar
opt/cassandra/lib/ipaddress-5.3.3.jar
opt/cassandra/lib/j2objc-annotations-1.3.jar
opt/cassandra/lib/jackson-annotations-2.13.2.jar
opt/cassandra/lib/jackson-core-2.13.2.jar
opt/cassandra/lib/jackson-databind-2.13.4.2.jar
opt/cassandra/lib/jackson-datatype-jsr310-2.13.2.jar
opt/cassandra/lib/jamm-0.3.2.jar
opt/cassandra/lib/javax.inject-1.jar
opt/cassandra/lib/jbcrypt-0.4.jar
opt/cassandra/lib/jcl-over-slf4j-1.7.25.jar
opt/cassandra/lib/jcommander-1.30.jar
opt/cassandra/lib/jctools-core-3.1.0.jar
opt/cassandra/lib/jna-5.9.0.jar
opt/cassandra/lib/json-simple-1.1.jar
opt/cassandra/lib/jsr305-2.0.2.jar
opt/cassandra/lib/jvm-attach-api-1.5.jar
opt/cassandra/lib/log4j-over-slf4j-1.7.25.jar
opt/cassandra/lib/logback-classic-1.2.13.jar
opt/cassandra/lib/logback-core-1.2.13.jar
opt/cassandra/lib/lz4-java-1.8.0.jar
opt/cassandra/lib/metrics-core-3.1.5.jar
opt/cassandra/lib/metrics-jvm-3.1.5.jar
opt/cassandra/lib/metrics-logback-3.1.5.jar
opt/cassandra/lib/mxdump-0.14.jar
opt/cassandra/lib/netty-all-4.1.58.Final.jar
opt/cassandra/lib/netty-tcnative-boringssl-static-2.0.36.Final.jar
opt/cassandra/lib/ohc-core-0.5.1.jar
opt/cassandra/lib/ohc-core-j8-0.5.1.jar
opt/cassandra/lib/psjava-0.1.19.jar
opt/cassandra/lib/pure_sasl-0.6.2-py2-none-any.zip
opt/cassandra/lib/reporter-config-base-3.0.3.jar
opt/cassandra/lib/reporter-config3-3.0.3.jar
opt/cassandra/lib/sigar-1.6.4.jar
opt/cassandra/lib/sigar-bin
opt/cassandra/lib/sigar-bin/libsigar-amd64-freebsd-6.so
opt/cassandra/lib/sigar-bin/libsigar-amd64-linux.so
opt/cassandra/lib/sigar-bin/libsigar-amd64-solaris.so
opt/cassandra/lib/sigar-bin/libsigar-ia64-hpux-11.sl
opt/cassandra/lib/sigar-bin/libsigar-ia64-linux.so
opt/cassandra/lib/sigar-bin/libsigar-pa-hpux-11.sl
opt/cassandra/lib/sigar-bin/libsigar-ppc-aix-5.so
opt/cassandra/lib/sigar-bin/libsigar-ppc-linux.so
opt/cassandra/lib/sigar-bin/libsigar-ppc64-aix-5.so
opt/cassandra/lib/sigar-bin/libsigar-ppc64-linux.so
opt/cassandra/lib/sigar-bin/libsigar-ppc64le-linux.so
opt/cassandra/lib/sigar-bin/libsigar-s390x-linux.so
opt/cassandra/lib/sigar-bin/libsigar-sparc-solaris.so
opt/cassandra/lib/sigar-bin/libsigar-sparc64-solaris.so
opt/cassandra/lib/sigar-bin/libsigar-universal-macosx.dylib
opt/cassandra/lib/sigar-bin/libsigar-universal64-macosx.dylib
opt/cassandra/lib/sigar-bin/libsigar-x86-freebsd-5.so
opt/cassandra/lib/sigar-bin/libsigar-x86-freebsd-6.so
opt/cassandra/lib/sigar-bin/libsigar-x86-linux.so
opt/cassandra/lib/sigar-bin/libsigar-x86-solaris.so
opt/cassandra/lib/six-1.12.0-py2.py3-none-any.zip
opt/cassandra/lib/sjk-cli-0.14.jar
opt/cassandra/lib/sjk-core-0.14.jar
opt/cassandra/lib/sjk-json-0.14.jar
opt/cassandra/lib/sjk-stacktrace-0.14.jar
opt/cassandra/lib/slf4j-api-1.7.25.jar
opt/cassandra/lib/snakeyaml-1.32.jar
opt/cassandra/lib/snappy-java-1.1.10.4.jar
opt/cassandra/lib/snowball-stemmer-1.3.0.581.1.jar
opt/cassandra/lib/stream-2.5.2.jar
opt/cassandra/lib/zstd-jni-1.5.5-1.jar
opt/cassandra/logs
opt/cassandra/pylib
opt/cassandra/pylib/Dockerfile.ubuntu.py3
opt/cassandra/pylib/Dockerfile.ubuntu.py37
opt/cassandra/pylib/Dockerfile.ubuntu.py38
opt/cassandra/pylib/README.asc
opt/cassandra/pylib/cassandra-cqlsh-tests.sh
opt/cassandra/pylib/cqlshlib
opt/cassandra/pylib/cqlshlib/__init__.py
opt/cassandra/pylib/cqlshlib/authproviderhandling.py
opt/cassandra/pylib/cqlshlib/copyutil.py
opt/cassandra/pylib/cqlshlib/cql3handling.py
opt/cassandra/pylib/cqlshlib/cqlhandling.py
opt/cassandra/pylib/cqlshlib/cqlshhandling.py
opt/cassandra/pylib/cqlshlib/displaying.py
opt/cassandra/pylib/cqlshlib/formatting.py
opt/cassandra/pylib/cqlshlib/helptopics.py
opt/cassandra/pylib/cqlshlib/pylexotron.py
opt/cassandra/pylib/cqlshlib/saferscanner.py
opt/cassandra/pylib/cqlshlib/sslhandling.py
opt/cassandra/pylib/cqlshlib/test
opt/cassandra/pylib/cqlshlib/test/__init__.py
opt/cassandra/pylib/cqlshlib/test/ansi_colors.py
opt/cassandra/pylib/cqlshlib/test/basecase.py
opt/cassandra/pylib/cqlshlib/test/cassconnect.py
opt/cassandra/pylib/cqlshlib/test/run_cqlsh.py
opt/cassandra/pylib/cqlshlib/test/test_authproviderhandling.py
opt/cassandra/pylib/cqlshlib/test/test_authproviderhandling_config
opt/cassandra/pylib/cqlshlib/test/test_authproviderhandling_config/complex_auth_provider
opt/cassandra/pylib/cqlshlib/test/test_authproviderhandling_config/complex_auth_provider_creds
opt/cassandra/pylib/cqlshlib/test/test_authproviderhandling_config/complex_auth_provider_with_pass
opt/cassandra/pylib/cqlshlib/test/test_authproviderhandling_config/empty_example
opt/cassandra/pylib/cqlshlib/test/test_authproviderhandling_config/full_plain_text_example
opt/cassandra/pylib/cqlshlib/test/test_authproviderhandling_config/illegal_example
opt/cassandra/pylib/cqlshlib/test/test_authproviderhandling_config/no_classname_example
opt/cassandra/pylib/cqlshlib/test/test_authproviderhandling_config/partial_example
opt/cassandra/pylib/cqlshlib/test/test_authproviderhandling_config/plain_text_full_creds
opt/cassandra/pylib/cqlshlib/test/test_authproviderhandling_config/plain_text_partial_creds
opt/cassandra/pylib/cqlshlib/test/test_authproviderhandling_config/plain_text_partial_example
opt/cassandra/pylib/cqlshlib/test/test_constants.py
opt/cassandra/pylib/cqlshlib/test/test_copyutil.py
opt/cassandra/pylib/cqlshlib/test/test_cql_parsing.py
opt/cassandra/pylib/cqlshlib/test/test_cqlsh_completion.py
opt/cassandra/pylib/cqlshlib/test/test_cqlsh_output.py
opt/cassandra/pylib/cqlshlib/test/test_keyspace_init.cql
opt/cassandra/pylib/cqlshlib/test/test_unicode.py
opt/cassandra/pylib/cqlshlib/test/winpty.py
opt/cassandra/pylib/cqlshlib/tracing.py
opt/cassandra/pylib/cqlshlib/util.py
opt/cassandra/pylib/cqlshlib/wcwidth.py
opt/cassandra/pylib/requirements.txt
opt/cassandra/pylib/setup.py

```