### PR TITLE
Add 3 py3 packages: pygithub, scp, semver

### DIFF
--- a/py3-pygithub.yaml
+++ b/py3-pygithub.yaml
@@ -1,0 +1,49 @@
+# Generated from https://pypi.org/project/PyGithub/
+package:
+  name: py3-pygithub
+  version: 2.1.1
+  epoch: 0
+  description: Use the full Github API v3
+  copyright:
+    - license: ""
+  dependencies:
+    runtime:
+      - py3-pynacl
+      - py3-python-dateutil
+      - py3-requests
+      - py3-pyjwt
+      - py3-typing-extensions
+      - py3-urllib3
+      - py3-Deprecated
+      - python-3
+    provides:
+      - py3-PyGithub=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: e584a90f6706c3b590a20e1c9caac7874ba6b122
+      repository: https://github.com/pygithub/pygithub
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  # There are some versions with post in it, ignore them
+  ignore-regex-patterns:
+    - post
+  enabled: true
+  github:
+    identifier: pygithub/pygithub
+    strip-prefix: v

--- a/py3-pygithub.yaml
+++ b/py3-pygithub.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 0
   description: Use the full Github API v3
   copyright:
-    - license: ""
+    - license: LGPL-3.0, GPL-3.0
   dependencies:
     runtime:
       - py3-pynacl

--- a/py3-scp.yaml
+++ b/py3-scp.yaml
@@ -1,0 +1,38 @@
+# Generated from https://pypi.org/project/scp/
+package:
+  name: py3-scp
+  version: 0.14.5
+  epoch: 0
+  description: scp module for paramiko
+  copyright:
+    - license: LGPL-2.1-or-later
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 4d919f874fc7e65846bf2f5dd44ae3e652b4e11f
+      repository: https://github.com/jbardin/scp.py
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: jbardin/scp.py
+    strip-prefix: v
+    use-tag: true

--- a/py3-semver.yaml
+++ b/py3-semver.yaml
@@ -1,0 +1,36 @@
+# Generated from https://pypi.org/project/semver/
+package:
+  name: py3-semver
+  version: 3.0.2
+  epoch: 0
+  description: Python helper for Semantic Versioning (https://semver.org)
+  copyright:
+    - license: BSD
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: ec9348aefd8e9f287f451fcf2e837621a40e3ca4
+      repository: https://github.com/python-semver/python-semver
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: python-semver/python-semver


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
