### PR TITLE
Add fluxbox package

### DIFF
--- a/fluxbox.yaml
+++ b/fluxbox.yaml
@@ -14,11 +14,18 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - freetype-dev
+      - fribidi-dev
       - gettext-dev
       - imlib2-dev
       - libtool
       - libx11-dev
       - libxext-dev
+      - libxft-dev
+      - libxinerama-dev
+      - libxpm-dev
+      - libxrandr-dev
+      - libxrender-dev
       - pkgconf-dev
 
 pipeline:

--- a/fluxbox.yaml
+++ b/fluxbox.yaml
@@ -15,6 +15,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - gettext-dev
+      - imlib2-dev
       - libtool
       - libx11-dev
       - libxext-dev
@@ -33,6 +34,7 @@ pipeline:
   - name: 'Configure binutils'
     runs: |
       ./configure \
+        --enable-imlib2 \
         --disable-nls
 
   - uses: autoconf/make

--- a/fluxbox.yaml
+++ b/fluxbox.yaml
@@ -22,10 +22,10 @@ environment:
 
 pipeline:
   # Upstream repo does not cut new tags or releases. See note at bottom of file.
-  - uses: git-checkout
+  - uses: fetch
     with:
-      expected-commit: 0f95d62b1b1add8ee7327305db7d372010fdb2f4
-      repository: https://github.com/fluxbox/fluxbox.git
+      uri: https://github.com/fluxbox/fluxbox/archive/0f95d62b1b1add8ee7327305db7d372010fdb2f4.tar.gz
+      expected-sha256: 6bcd91faac07066e5c9c952625500219774ff1dc7d5960264d0ae005fb562a97
 
   - runs: |
       ./autogen.sh

--- a/fluxbox.yaml
+++ b/fluxbox.yaml
@@ -1,0 +1,49 @@
+package:
+  name: fluxbox
+  version: 1.3.7
+  epoch: 0
+  description: Fluxbox Window Manager
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gettext-dev
+      - libtool
+      - libx11-dev
+      - libxext-dev
+      - pkgconf-dev
+
+pipeline:
+  # Upstream repo does not cut new tags or releases. See note at bottom of file.
+  - uses: git-checkout
+    with:
+      expected-commit: 0f95d62b1b1add8ee7327305db7d372010fdb2f4
+      repository: https://github.com/fluxbox/fluxbox.git
+
+  - runs: |
+      ./autogen.sh
+
+  - name: 'Configure binutils'
+    runs: |
+      ./configure \
+        --disable-nls
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+# Upstream repository no longer cuts any tags or releases (since 2015). The
+# last tag cut was v1.3.7 back in 2015, but there have been several commits
+# since then, including fixes to compile against gcc 11+. This is why updates
+# are disabled, as we're fixing to a given commit ID in the main branch.
+update:
+  enabled: false


### PR DESCRIPTION
Adds a 'fluxbox' package which is required by some other images, including docker-selenium.

Note, fluxbox does not actively have any new releases or tags cut, but still has active contributions, hence the comments added in the melange file