### PR TITLE
add docker-selenium transitive deps 1

### DIFF
--- a/libid3tag.yaml
+++ b/libid3tag.yaml
@@ -1,0 +1,51 @@
+package:
+  name: libid3tag
+  version: 0.16.3
+  epoch: 0
+  description: MAD ID3 tagger for MP3 audio files
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - samurai
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://codeberg.org/tenacityteam/libid3tag
+      tag: ${{package.version}}
+      expected-commit: e02ecf1276b467a8a5dd20c55ce711e6f7116d3e
+
+  - runs: |
+      cmake -B build -G Ninja \
+      -DCMAKE_BUILD_TYPE=MinSizeRel \
+      -DCMAKE_INSTALL_PREFIX=/usr \
+      -DCMAKE_INSTALL_LIBDIR=lib
+      cmake --build build
+
+  - runs: |
+      DESTDIR="${{targets.destdir}}" cmake --install build
+
+  - uses: strip
+
+subpackages:
+  - name: libid3tag-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - libid3tag
+    description: libid3tag dev
+
+update:
+  enabled: false
+  manual: true # we need to manually update because it does not use GitHub. Release Monitor (id: 21478) is outdated or wrong.

--- a/xauth.yaml
+++ b/xauth.yaml
@@ -1,0 +1,54 @@
+package:
+  name: xauth
+  version: 1.1.2
+  epoch: 0
+  description: X.Org authorization settings program
+  copyright:
+    - license: custom
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libx11-dev
+      - libxau-dev
+      - libxext-dev
+      - libxmu-dev
+      - util-macros
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 78ba6afd19536ced1dddb3276cba6e9555a211b468a06f95f6a97c62ff8ee200
+      uri: https://www.x.org/releases/individual/app/xauth-${{package.version}}.tar.xz
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: xauth-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - xauth
+    description: xauth dev
+
+  - name: xauth-doc
+    pipeline:
+      - uses: split/manpages
+    description: xauth manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5253

--- a/xdpyinfo.yaml
+++ b/xdpyinfo.yaml
@@ -1,0 +1,49 @@
+package:
+  name: xdpyinfo
+  version: 1.3.4
+  epoch: 0
+  description: display information utility for X
+  copyright:
+    - license: custom
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libx11-dev
+      - libxcb-dev
+      - libxext-dev
+      - libxtst-dev
+      - xcb-proto
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: a8ada581dbd7266440d7c3794fa89edf6b99b8857fc2e8c31042684f3af4822b
+      uri: https://www.x.org/releases/individual/app/xdpyinfo-${{package.version}}.tar.xz
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: xdpyinfo-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - xdpyinfo
+    description: xdpyinfo dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 15028


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
