### PR TITLE
glibc: add libc-bin virtual

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.38
-  epoch: 8
+  epoch: 9
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later
@@ -508,6 +508,18 @@ subpackages:
             || mv "${{targets.destdir}}"/usr/lib/locale/${{range.key}}_* "${{targets.subpkgdir}}"/usr/lib/locale/
           [ -d "${{targets.destdir}}"/usr/lib/locale/${{range.key}} ] \
             && mv "${{targets.destdir}}"/usr/lib/locale/${{range.key}} "${{targets.subpkgdir}}"/usr/lib/locale/
+
+  # Similar to https://packages.debian.org/bookworm/libc-bin
+  - name: "libc-bin"
+    description: "GNU C Library: Binaries"
+    dependencies:
+      runtime:
+        - posix-libc-utils
+        - tzutils
+        - localedef
+    checks:
+      disabled:
+        - empty
 
 update:
   enabled: true


### PR DESCRIPTION
Debian/Ubuntu have [`libc-bin`](https://packages.debian.org/bookworm/libc-bin) which installs `ldd` and other common glibc binaries (`getconf`, `getent`, `tzselect`, `localedef`, others)

We define these in separate packages, mainly `posix-libc-utils` for `ldd`. For folks with Debian muscle memory we can make it easier to install these common utilities under their more familiar name.

Marking as draft to make sure @kaniini approves before merging.