### PR TITLE
dotnet-7: Bump epoch

### DIFF
--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-7
   version: 7.0.114
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT


### PR DESCRIPTION
Bumping the epoch resolves GHSA-6qmf-mmc7-6c2p  by getting the non-RC version of NuGet packages (at least that's my guess)