### PR TITLE
add xvfb, xvfb-run, xorg-server-dev and make xorg-server alpine compatible

### DIFF
--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: xorg-server
   version: 21.1.10
-  epoch: 0
+  epoch: 1
   description: "X Server"
   copyright:
     - license: SGI-B-2.0
@@ -22,6 +22,8 @@ environment:
       - automake
       - build-base
       - busybox
+      - dbus-dev
+      - eudev-dev
       - freetype-dev
       - libdrm
       - libdrm-dev
@@ -35,12 +37,20 @@ environment:
       - libxfixes-dev
       - libxfont-dev
       - libxkbfile-dev
+      - libxshmfence-dev
       - libxxf86vm-dev
       - mesa-dev
       - mesa-gbm
       - mesa-gl
       - pixman-dev
       - zlib-dev
+
+data:
+  - name: bins
+    items:
+      Xvfb: Virtual Framebuffer 'fake' X server
+      Xnest: A nested Xorg server
+      gtf: Generate mode timings using the GTF Timing Standard
 
 pipeline:
   - uses: fetch
@@ -54,11 +64,56 @@ pipeline:
         --prefix=/usr \
         --with-default-font-path=/usr/share/fonts/misc \
         --with-xkb-path=/usr/local/share/X11/xkb \
+        --enable-xorg \
+        --enable-glamor \
+        --enable-xnest \
+        --enable-xvfb \
+        --enable-xcsecurity \
+        --enable-suid-wrapper \
+        --enable-pciaccess \
+        --enable-config-udev \
+        --disable-config-hal \
+        --enable-systemd-logind \
+        --enable-dri \
+        --enable-dri2 \
+        --enable-dri3 \
         --mandir=/usr/share/man
 
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-dev
+    description: ${{package.name}} dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - xorg-server
+
+  - range: bins
+    name: ${{range.key}}
+    description: ${{range.value}}
+    pipeline:
+      - runs: |
+          install -Dm755 "${{targets.destdir}}"/usr/bin/${{range.key}} "${{targets.subpkgdir}}"/usr/bin/${{range.key}}
+
+  - name: xvfb-run
+    description: imlib2 dev
+    pipeline:
+      - uses: git-checkout
+        with:
+          repository: https://salsa.debian.org/xorg-team/xserver/xorg-server
+          tag: xorg-server-2_${{package.version}}-1
+          expected-commit: 8db596f78a4cc8dcbb0422d0f833b1c58b9f9f7b
+      - working-directory: debian/local
+        pipeline:
+          - runs: |
+              install -Dm755 xvfb-run "${{targets.subpkgdir}}"/usr/bin/xvfb-run
+              install -D xvfb-run.1 "${{targets.subpkgdir}}"/usr/share/man/man1/xvfb-run.1
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
