### PR TITLE
revert gobject to 1.78.1 on main

### DIFF
--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobject-introspection
-  version: 1.79.0
-  epoch: 0
+  version: 1.78.1
+  epoch: 1
   description: Introspection system for GObject-based libraries
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT
@@ -47,7 +47,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 2aed9cdcfb3d423cc608b122191eda5968a7c27094b15ccf2c00a4866a9cd943
+      expected-sha256: bd7babd99af7258e76819e45ba4a6bc399608fe762d83fde3cac033c50841bb4
       uri: https://download.gnome.org/sources/gobject-introspection/${{vars.mangled-package-version}}/gobject-introspection-${{package.version}}.tar.xz
 
   - uses: meson/configure


### PR DESCRIPTION
update check will fail ignore it and ignore the update until the 1.79.1 is released 

1.79.0-r0 Packages were withdrawn here https://github.com/wolfi-dev/os/pull/10445

Fixes build failure on main
https://github.com/wolfi-dev/os/actions/runs/7342492317