### PR TITLE
GHSA-45x7-px36-x8w8 : fix CVE for Wolfi package caddy

### DIFF
--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: caddy
   version: 2.7.6
-  epoch: 0
+  epoch: 1
   description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
   copyright:
     - license: Apache-2.0
@@ -12,40 +12,40 @@ environment:
       - busybox
       - ca-certificates-bundle
   environment:
-    CGO_ENABLED: 0
+    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 6d9a83376b5e19b3c0368541ee46044ab284038b
       repository: https://github.com/caddyserver/caddy
       tag: v${{package.version}}
-      expected-commit: 6d9a83376b5e19b3c0368541ee46044ab284038b
 
   - runs: |
       install -m644 -D "./Caddyfile" "${{targets.destdir}}/etc/caddy/Caddyfile"
       install -m755 -D "./index.html" "${{targets.destdir}}/usr/share/caddy/index.html"
 
-  # TODO: Add support for plugins
   - uses: go/build
     with:
-      packages: ./cmd/caddy
-      output: caddy
       ldflags: -s -w
+      output: caddy
+      packages: ./cmd/caddy
 
   - uses: strip
 
 subpackages:
   - name: caddy-man
-    description: caddy manpages
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share
           "${{targets.destdir}}"/usr/bin/caddy manpage --directory "${{targets.subpkgdir}}"/usr/share/
+    description: caddy manpages
 
 update:
   enabled: true
+  manual: false
   github:
     identifier: caddyserver/caddy
     strip-prefix: v
-    use-tag: true
     tag-filter: v
+    use-tag: true


### PR DESCRIPTION
Fix for GHSA-45x7-px36-x8w8 using wolfi-bump.