### PR TITLE
`GHSA-45x7-px36-x8w8` and `GHSA-2c7c-3mj9-8fqh`: fix CVE for Wolfi package policy-controller.

### DIFF
--- a/policy-controller.yaml
+++ b/policy-controller.yaml
@@ -1,8 +1,8 @@
 package:
   name: policy-controller
   version: 0.8.3
-  epoch: 2
-  description: "The policy admission controller used to enforce policy on a cluster on verifiable supply-chain metadata from cosign."
+  epoch: 3
+  description: The policy admission controller used to enforce policy on a cluster on verifiable supply-chain metadata from cosign.
   copyright:
     - license: Apache-2.0
   dependencies:
@@ -18,17 +18,16 @@ environment:
       - make
 
 pipeline:
-  # Use git-checkout so that vcs.revision is properly set
   - uses: git-checkout
     with:
+      expected-commit: 64f222cbf5b0be6bc04dcdd050b91cdc91803025
       repository: https://github.com/sigstore/policy-controller
       tag: v${{package.version}}
-      expected-commit: 64f222cbf5b0be6bc04dcdd050b91cdc91803025
 
   - uses: go/bump
     with:
-      deps: github.com/sigstore/cosign/v2@v2.2.1
-      go-version: 1.21
+      deps: github.com/sigstore/cosign/v2@v2.2.1 github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0
+      go-version: "1.21"
 
   - runs: |
       mkdir -p "${{targets.destdir}}/usr/bin"
@@ -38,18 +37,19 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "policy-controller-tester"
-    description: "CLI for testing ClusterImagePolicy resources"
-    dependencies:
-      runtime:
-        - ca-certificates-bundle
+  - name: policy-controller-tester
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"
           mv "${{targets.destdir}}/usr/bin/policy-tester" "${{targets.subpkgdir}}/usr/bin/policy-tester"
+    dependencies:
+      runtime:
+        - ca-certificates-bundle
+    description: CLI for testing ClusterImagePolicy resources
 
 update:
   enabled: true
+  manual: false
   github:
     identifier: sigstore/policy-controller
     strip-prefix: v


### PR DESCRIPTION
`GHSA-45x7-px36-x8w8` and `GHSA-2c7c-3mj9-8fqh`: fix CVE for Wolfi package policy-controller.