### PR TITLE
Adds consul latest 1.17 version

### DIFF
--- a/consul.yaml
+++ b/consul.yaml
@@ -1,0 +1,66 @@
+package:
+  name: consul
+  version: 1.17.1
+  epoch: 0
+  description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
+  copyright:
+    - license: MPL-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hashicorp/consul
+      tag: v${{package.version}}
+      expected-commit: 9bcafa2495399acb52c65fc5759d1981dca633ce
+      destination: ${{package.name}}
+
+  - working-directory: ${{package.name}}
+    pipeline:
+      - uses: go/bump
+        with:
+          deps: golang.org/x/crypto@v0.17.0
+      - runs: |
+          make linux
+      - runs: |
+          mkdir -p ${{targets.destdir}}/bin
+
+          # The docker-entrypoint.sh expects the binary to be in /bin so put it there
+          mv ./pkg/bin/linux_*/consul ${{targets.destdir}}/bin/consul
+      - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-oci-entrypoint
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{package.name}}/.release/docker/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/"
+    dependencies:
+      runtime:
+        - consul
+        - busybox
+        - dumb-init
+        - su-exec
+        - libcap-utils
+
+  - name: ${{package.name}}-oci-entrypoint-compat
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
+          ln -s /usr/bin/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/local/bin/"
+    dependencies:
+      runtime:
+        - consul-1.16-oci-entrypoint
+
+update:
+  enabled: true
+  github:
+    identifier: hashicorp/consul
+    strip-prefix: v
+    tag-filter: v1.17.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
