### PR TITLE
add imlib2 and x11vnc

### DIFF
--- a/imlib2.yaml
+++ b/imlib2.yaml
@@ -1,0 +1,58 @@
+package:
+  name: imlib2
+  version: 1.12.1
+  epoch: 0
+  description: Image manipulation library
+  copyright:
+    - license: BSD
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - bzip2-dev
+      - ca-certificates-bundle
+      - freetype-dev
+      - giflib-dev
+      - libid3tag-dev
+      - libjpeg-turbo-dev
+      - libpng-dev
+      - libsm-dev
+      - libwebp-dev
+      - libxext-dev
+      - tiff-dev
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: d35d746b245e64cd024833414eef148a8625f1bed720193cd5c2c33730188425
+      uri: https://downloads.sourceforge.net/enlightenment/imlib2-${{package.version}}.tar.gz
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: imlib2-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - imlib2
+        - freetype-dev
+        - libxext-dev
+        - libsm-dev
+    description: imlib2 dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 21676

--- a/x11vnc.yaml
+++ b/x11vnc.yaml
@@ -1,0 +1,81 @@
+package:
+  name: x11vnc
+  version: 0.9.16
+  epoch: 0
+  description: VNC server for real X displays
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - avahi-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libcrypt1
+      - libcrypto3
+      - libjpeg-turbo
+      - libjpeg-turbo-dev
+      - libpthread-stubs
+      - libssl3
+      - libvncserver-dev
+      - libx11-dev
+      - libx11-static
+      - libxdamage-dev
+      - libxext-dev
+      - libxfixes-dev
+      - libxinerama-dev
+      - libxrandr
+      - libxrandr-dev
+      - libxrandr-dev
+      - libxrender
+      - libxrender-dev
+      - libxss-dev
+      - libxtst-dev
+      - linux-headers
+      - m4
+      - openssl-dev
+      - pkgconf
+      - pkgconf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/LibVNC/x11vnc
+      tag: ${{package.version}}
+      expected-commit: 4ca006fed80410bd9b061a1519bd5d9366bb0bc8
+
+  - runs: autoupdate
+
+  - runs: ./autogen.sh
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: x11vnc-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - x11vnc
+    description: x11vnc dev
+
+  - name: x11vnc-doc
+    pipeline:
+      - uses: split/manpages
+    description: x11vnc manpages
+
+update:
+  enabled: true
+  github:
+    identifier: LibVNC/x11vnc
+    use-tag: true

--- a/x11vnc.yaml
+++ b/x11vnc.yaml
@@ -30,7 +30,6 @@ environment:
       - libxinerama-dev
       - libxrandr
       - libxrandr-dev
-      - libxrandr-dev
       - libxrender
       - libxrender-dev
       - libxss-dev

--- a/x11vnc.yaml
+++ b/x11vnc.yaml
@@ -15,30 +15,46 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - libcrypt1
-      - libcrypto3
+      - dbus-dev
+      - glibc-dev
+      - libbsd-dev
+      - libgcrypt-dev
+      - libgpg-error-dev
       - libjpeg-turbo
       - libjpeg-turbo-dev
+      - libmd-dev
+      - libpng
+      - libpng-dev
       - libpthread-stubs
       - libssl3
       - libvncserver-dev
+      - libx11
       - libx11-dev
-      - libx11-static
+      - libxau-dev
+      - libxcb-dev
       - libxdamage-dev
+      - libxdmcp-dev
+      - libxext
       - libxext-dev
       - libxfixes-dev
+      - libxi-dev
       - libxinerama-dev
       - libxrandr
       - libxrandr-dev
       - libxrender
       - libxrender-dev
+      - libxss
       - libxss-dev
+      - libxtst
       - libxtst-dev
       - linux-headers
+      - lzo-dev
       - m4
       - openssl-dev
       - pkgconf
       - pkgconf-dev
+      - zlib
+      - zlib-dev
 
 pipeline:
   - uses: git-checkout
@@ -46,6 +62,10 @@ pipeline:
       repository: https://github.com/LibVNC/x11vnc
       tag: ${{package.version}}
       expected-commit: 4ca006fed80410bd9b061a1519bd5d9366bb0bc8
+
+  - uses: patch
+    with:
+      patches: gcc-10.patch
 
   - runs: autoupdate
 

--- a/x11vnc/gcc-10.patch
+++ b/x11vnc/gcc-10.patch
@@ -1,0 +1,44 @@
+From a48b0b1cd887d7f3ae67f525d7d334bd2feffe60 Mon Sep 17 00:00:00 2001
+From: Alexander Tsoy <alexander@tsoy.me>
+Date: Tue, 28 Jan 2020 22:21:01 +0300
+Subject: [PATCH] Fix build with -fno-common
+
+GCC 10 defaults to -fno-common
+---
+ src/util.c | 3 +++
+ src/util.h | 6 +++---
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/src/util.c b/src/util.c
+index a82a1a4..6a52ebf 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -47,6 +47,9 @@ int hxl = 0;
+ #ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
+ MUTEX(x11Mutex);
+ MUTEX(scrollMutex);
++MUTEX(clientMutex);
++MUTEX(inputMutex);
++MUTEX(pointerMutex);
+ #endif
+ 
+ int nfix(int i, int n);
+diff --git a/src/util.h b/src/util.h
+index 35c1afd..99b5dd1 100644
+--- a/src/util.h
++++ b/src/util.h
+@@ -102,9 +102,9 @@ extern struct timeval _mysleep;
+ #ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
+ extern MUTEX(x11Mutex);
+ extern MUTEX(scrollMutex);
+-MUTEX(clientMutex);
+-MUTEX(inputMutex);
+-MUTEX(pointerMutex);
++extern MUTEX(clientMutex);
++extern MUTEX(inputMutex);
++extern MUTEX(pointerMutex);
+ #endif
+ 
+ #define X_INIT INIT_MUTEX(x11Mutex)
+-- 
+2.24.1


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
