### PR TITLE
Mitigate CVE GHSA-7ww5-4wqc-m92c, GHSA-mw99-9chc-xw7r & GHSA-45x7-px36-x8w8 for zot

### DIFF
--- a/zot.yaml
+++ b/zot.yaml
@@ -1,7 +1,7 @@
 package:
   name: zot
   version: 2.0.0
-  epoch: 0
+  epoch: 1
   description: A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification)
   copyright:
     - license: Apache-2.0
@@ -24,13 +24,18 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: c2196e3ae1625b87b9bdd3ed002466b71c51fc20
 
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0
+      go-version: "1.20"
+
   - runs: |
       GOARCH=$(go env GOARCH)
 
-      make OS=linux ARCH=${GOARCH} binary
+      make -o modcheck OS=linux ARCH=${GOARCH} modtidy binary
       install -m755 -D ./bin/zot-linux-${GOARCH} "${{targets.destdir}}"/usr/bin/zot
 
-      make OS=linux ARCH=${GOARCH} cli
+      make -o modcheck OS=linux ARCH=${GOARCH} modtidy cli
       install -m755 -D ./bin/zli-linux-${GOARCH} "${{targets.destdir}}"/usr/bin/zli
 
   - uses: strip


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
Ignoring `modcheck` target as we are changing the `go.mod` file.
https://github.com/project-zot/zot/blob/59f41ac17dbb723effe5760388e96a7c9230443e/Makefile#L92-L99

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

