### PR TITLE
GHSA-45x7-px36-x8w8 : fix CVE for Wolfi package weaviate

### DIFF
--- a/weaviate.yaml
+++ b/weaviate.yaml
@@ -1,7 +1,7 @@
 package:
   name: weaviate
   version: 1.23.0
-  epoch: 0
+  epoch: 1
   description: Weaviate is an open source vector database that stores both objects and vectors, allowing for combining vector search with structured filtering with the fault-tolerance and scalability of a cloud-native database, all accessible through GraphQL, REST, and various language clients.
   copyright:
     - license: BSD-3-Clause
@@ -16,9 +16,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: bbf8c87e9b5d7218098aa329bcc81443ea431cb3
       repository: https://github.com/weaviate/weaviate
       tag: v${{package.version}}
-      expected-commit: bbf8c87e9b5d7218098aa329bcc81443ea431cb3
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
 
   - runs: |
       mkdir -p ${{targets.destdir}}/bin
@@ -31,6 +35,7 @@ pipeline:
 
 update:
   enabled: true
+  manual: false
   github:
     identifier: weaviate/weaviate
     strip-prefix: v


### PR DESCRIPTION
Add support for adding `go/bump` whenever we find a `go build` and `go mod tidy` command on a raw pipeline IF we didn't find any other go specific pipelines.