### PR TITLE
dotnet-7: Build NuGet packages in RTM mode

### DIFF
--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-7
   version: 7.0.114
-  epoch: 1
+  epoch: 2
   description: ".NET SDK"
   copyright:
     - license: MIT
@@ -49,6 +49,11 @@ pipeline:
       ./build.sh /p:ArcadeBuildTarball=true /p:TarballDir=/home/build/src
 
   - working-directory: /home/build/src
+    environment:
+      # Build NuGet packages in RTM mode.
+      BuildRTM: true
+      # Prevents prerelease dependency error caused by Microsoft.Web.Xdt imported at version 7.0.0-preview.22423.2
+      NoWarn: NU5104
     pipeline:
       - runs: |
           sed -i -E 's|( /p:BuildDebPackage=false)|\1 /p:EnablePackageValidation=false|' src/runtime/eng/SourceBuild.props


### PR DESCRIPTION
Update our `dotnet-7` package to attempt building NuGet packages in release mode (RTM). The goal is to have a clean version in the package so that scanners can pickup the accurate version.

Before:
```
wolfictl scan packages/x86_64/dotnet-7-sdk-7.0.114-r1.apk
🔎 Scanning "packages/x86_64/dotnet-7-sdk-7.0.114-r1.apk"
├── 📄 /usr/share/dotnet/sdk/7.0.114/NuGet.Commands.dll
│       📦 NuGet.Commands 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
│           High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
│
├── 📄 /usr/share/dotnet/sdk/7.0.114/NuGet.Common.dll
│       📦 NuGet.Common 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
│           High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
│
├── 📄 /usr/share/dotnet/sdk/7.0.114/NuGet.Protocol.dll
│       📦 NuGet.Protocol 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
│           High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
│
├── 📄 /usr/share/dotnet/sdk/7.0.114/Sdks/Microsoft.NET.Sdk/tools/net472/NuGet.Common.dll
│       📦 NuGet.Common 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
│           High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
│
├── 📄 /usr/share/dotnet/sdk/7.0.114/Sdks/Microsoft.NET.Sdk/tools/net472/NuGet.Protocol.dll
│       📦 NuGet.Protocol 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
│           High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
│
├── 📄 /usr/share/dotnet/sdk/7.0.114/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.Commands.dll
│       📦 NuGet.Commands 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
│           High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
│
├── 📄 /usr/share/dotnet/sdk/7.0.114/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.Common.dll
│       📦 NuGet.Common 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
│           High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
│
├── 📄 /usr/share/dotnet/sdk/7.0.114/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.Protocol.dll
│       📦 NuGet.Protocol 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
│           High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
│
├── 📄 /usr/share/dotnet/sdk/7.0.114/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.Commands.dll
│       📦 NuGet.Commands 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
│           High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
│
├── 📄 /usr/share/dotnet/sdk/7.0.114/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.Common.dll
│       📦 NuGet.Common 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
│           High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
│
├── 📄 /usr/share/dotnet/sdk/7.0.114/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.Protocol.dll
│       📦 NuGet.Protocol 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
│           High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
│
├── 📄 /usr/share/dotnet/sdk/7.0.114/Sdks/NuGet.Build.Tasks.Pack/NuGet.Commands.dll
│       📦 NuGet.Commands 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
│           High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
│
├── 📄 /usr/share/dotnet/sdk/7.0.114/Sdks/NuGet.Build.Tasks.Pack/NuGet.Common.dll
│       📦 NuGet.Common 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
│           High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
│
└── 📄 /usr/share/dotnet/sdk/7.0.114/Sdks/NuGet.Build.Tasks.Pack/NuGet.Protocol.dll
        📦 NuGet.Protocol 6.4.2-rc.32767+24f8150c97f9d26a7b5d77e983938e18d48e7d9f (dotnet)
            High CVE-2023-29337 GHSA-6qmf-mmc7-6c2p fixed in 6.4.2
```

After
```
wolfictl scan packages/x86_64/dotnet-7-sdk-7.0.114-r2.apk
🔎 Scanning "packages/x86_64/dotnet-7-sdk-7.0.114-r2.apk"
✅ No vulnerabilities found
```