### PR TITLE
dotnet-6: Build NuGet packages in RTM mode

### DIFF
--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-6
   version: 6.0.125
-  epoch: 0
+  epoch: 1
   description: ".NET SDK, version 6"
   target-architecture:
     - all
@@ -51,6 +51,11 @@ pipeline:
       ./build.sh /p:ArcadeBuildTarball=true /p:TarballDir=/home/build/src
 
   - working-directory: /home/build/src
+    environment:
+      # Build NuGet packages in RTM mode.
+      BuildRTM: true
+      # Prevents prerelease dependency errors.
+      NoWarn: NU5104
     pipeline:
       - runs: |
           sed -i -E 's|( /p:BuildDebPackage=false)|\1 /p:EnablePackageValidation=false|' src/runtime/eng/SourceBuild.props


### PR DESCRIPTION
Same as https://github.com/wolfi-dev/os/pull/10515, but for `dotnet-6`