### PR TITLE
opensearch-2: Remove SNAPSHOT from built version

### DIFF
--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-2
   version: 2.11.1
-  epoch: 1 # Remove CVE-2022-45146 patch when bumping to 2.12 or later
+  epoch: 2 # Remove CVE-2022-45146 patch when bumping to 2.12 or later
   description:
   target-architecture:
     - all
@@ -40,16 +40,16 @@ pipeline:
       export LANG=en_US.UTF-8
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 
-      gradle localDistro
+      gradle localDistro --parallel -Dbuild.snapshot="false" -Dbuild.version_qualifier=""
 
       mkdir -p ${{targets.destdir}}/usr/share/opensearch/logs
 
       install -dm777 ${{targets.destdir}}/usr/share/opensearch/
-      mv build/distribution/local/opensearch-${{package.version}}-SNAPSHOT/bin/ ${{targets.destdir}}/usr/share/opensearch
-      mv build/distribution/local/opensearch-${{package.version}}-SNAPSHOT/lib/ ${{targets.destdir}}/usr/share/opensearch
-      mv build/distribution/local/opensearch-${{package.version}}-SNAPSHOT/config/ ${{targets.destdir}}/usr/share/opensearch
-      mv build/distribution/local/opensearch-${{package.version}}-SNAPSHOT/modules/ ${{targets.destdir}}/usr/share/opensearch
-      mv build/distribution/local/opensearch-${{package.version}}-SNAPSHOT/plugins/ ${{targets.destdir}}/usr/share/opensearch
+      mv build/distribution/local/opensearch-${{package.version}}/bin/ ${{targets.destdir}}/usr/share/opensearch
+      mv build/distribution/local/opensearch-${{package.version}}/lib/ ${{targets.destdir}}/usr/share/opensearch
+      mv build/distribution/local/opensearch-${{package.version}}/config/ ${{targets.destdir}}/usr/share/opensearch
+      mv build/distribution/local/opensearch-${{package.version}}/modules/ ${{targets.destdir}}/usr/share/opensearch
+      mv build/distribution/local/opensearch-${{package.version}}/plugins/ ${{targets.destdir}}/usr/share/opensearch
 
       # Grab the docker entrypoint from the source tree
       mv ./distribution/docker/src/docker/bin/docker-entrypoint.sh  ${{targets.destdir}}/usr/share/opensearch/bin


### PR DESCRIPTION
This will resolve GHSA-6g3j-p5g6-992f reported on cgr.dev/chainguard/opensearch:latest