### PR TITLE
new package for joe-elliott/cert-exporter

### DIFF
--- a/cert-exporter.yaml
+++ b/cert-exporter.yaml
@@ -40,3 +40,4 @@ update:
   github:
     identifier: joe-elliott/cert-exporter
     strip-prefix: v
+    tag-filter: v

--- a/cert-exporter.yaml
+++ b/cert-exporter.yaml
@@ -1,0 +1,42 @@
+package:
+  name: cert-exporter
+  version: 2.11.0
+  epoch: 0
+  description: A Prometheus exporter that publishes cert expirations on disk and in Kubernetes secrets
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/joe-elliott/cert-exporter.git
+      tag: v${{package.version}}
+      expected-commit: 233f1dd5fe8c5173e0d29b084438c3e72e3cc4ca
+
+  - uses: go/bump
+    with:
+      deps: github.com/aws/aws-sdk-go@v1.34.0 github.com/prometheus/client_golang@v1.18.0 golang.org/x/crypto@v0.17.0
+
+  - runs: |
+      # Original build command referenced from here:
+      # - https://github.com/joe-elliott/cert-exporter/blob/master/Dockerfile#L6
+      CGO_ENABLED=0 go build -a -installsuffix cgo -o "${{targets.destdir}}"/usr/bin/cert-exporter .
+
+  - uses: strip
+
+# Upstream publishes helm charts and application releases separately, example:
+# - cert-exporter-3.4.1 (helm chart)
+# - v2.11.0 (application release)
+# We're only intersted in the latter.
+update:
+  enabled: true
+  github:
+    identifier: joe-elliott/cert-exporter
+    strip-prefix: v


### PR DESCRIPTION
Creating a new wolfi package for cert-explorer (used with prometheus).


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

