### PR TITLE
Fix zstd pkgconfig data.

### DIFF
--- a/zstd.yaml
+++ b/zstd.yaml
@@ -1,7 +1,7 @@
 package:
   name: zstd
   version: 1.5.5
-  epoch: 1
+  epoch: 2
   description: "the Zstandard compression algorithm"
   copyright:
     - license: BSD-2-Clause AND GPL-2.0-only
@@ -22,7 +22,7 @@ pipeline:
       expected-sha256: 98e9c3d949d1b924e28e01eccb7deed865eefebf25c2f21c702e5cd5b63b85e1
 
   - runs: |
-      make -j$(nproc) CC=${{host.triplet.gnu}}-gcc
+      make -j$(nproc) CC=${{host.triplet.gnu}}-gcc PREFIX="/usr"
 
   - runs: |
       make install PREFIX="/usr" DESTDIR="${{targets.destdir}}"
@@ -57,3 +57,14 @@ update:
   enabled: true
   release-monitor:
     identifier: 12083
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+        - pkgconf
+        - zstd-dev
+  pipeline:
+    - runs: |
+        pkg-config --libs libzstd | grep /usr/lib


### PR DESCRIPTION
Without this we were getting /usr/local templated in instead of usr because the variable is needed at make time.
