### PR TITLE
add novnc and websockify

### DIFF
--- a/novnc.yaml
+++ b/novnc.yaml
@@ -1,0 +1,58 @@
+package:
+  name: novnc
+  version: 1.4.0
+  epoch: 0
+  description: VNC client using HTML5 (WebSockets, Canvas) with encryption (wss://) support
+  copyright:
+    - license: MPL-2.0
+  dependencies:
+    runtime:
+      - net-tools
+      - websockify
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/novnc/noVNC
+      tag: v${{package.version}}
+      expected-commit: 90455eef0692d2e35276fd31286114d0955016b0
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/webapps/novnc
+      install -Dm644 LICENSE.txt ${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE
+      install -Dm644 vendor/pako/LICENSE ${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENSE.MIT
+      install -Dm644 docs/LICENSE.* ${{targets.destdir}}/usr/share/licenses/${{package.name}}/
+
+      install -Dm644 docs/* -t "${{targets.destdir}}"/usr/share/doc/${{package.name}}
+      install -Dm644 README.md -t "${{targets.destdir}}"/usr/share/doc/${{package.name}}/
+
+      install -D -m 755 utils/novnc_proxy "${{targets.destdir}}"/usr/bin/novnc_server
+
+      for i in app core po vendor vnc.html karma.conf.js package.json vnc_lite.html; do
+        cp -a "$i" ${{targets.destdir}}/usr/share/webapps/novnc
+      done
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-doc
+    pipeline:
+      - uses: split/manpages
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share
+          mv "${{targets.destdir}}"/usr/share/doc/${{package.name}} "${{targets.subpkgdir}}"/usr/share
+
+update:
+  enabled: true
+  github:
+    identifier: novnc/noVNC
+    strip-prefix: v

--- a/py3-jwcrypto.yaml
+++ b/py3-jwcrypto.yaml
@@ -1,0 +1,36 @@
+package:
+  name: py3-jwcrypto
+  version: 1.5.1
+  epoch: 0
+  description: Implementation of JOSE Web standards
+  copyright:
+    - license: LGPL-3.0-or-later
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/latchset/jwcrypto
+      tag: v${{package.version}}
+      expected-commit: 8ae0df6538b8d8aa52e82105ec5132d289ad9ddd
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: latchset/jwcrypto
+    strip-prefix: v

--- a/py3-simplejson.yaml
+++ b/py3-simplejson.yaml
@@ -1,0 +1,36 @@
+package:
+  name: py3-simplejson
+  version: 3.19.2
+  epoch: 0
+  description: Simple, fast, extensible JSON encoder/decoder for Python
+  copyright:
+    - license: MIT License
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/simplejson/simplejson
+      tag: v${{package.version}}
+      expected-commit: 532f41f870f6287ffe73882a313c2cc9c70f3cb6
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: simplejson/simplejson
+    strip-prefix: v

--- a/websockify.yaml
+++ b/websockify.yaml
@@ -1,0 +1,43 @@
+package:
+  name: websockify
+  version: 0.11.0
+  epoch: 0
+  description: WebSockets support for any application/server
+  copyright:
+    - license: LGPL-3.0-or-later
+  dependencies:
+    runtime:
+      - numpy
+      - py3-jwcrypto
+      - py3-requests
+      - py3-simplejson
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-gpep517
+      - py3-setuptools
+      - py3-wheel
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/novnc/websockify
+      tag: v${{package.version}}
+      expected-commit: 06e61fa4cc9d188dd28554ef96e646a2a9506108
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: novnc/websockify
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
