### PR TITLE
npm: add node-gyp references only so it can refer to system path of n…

### DIFF
--- a/npm.yaml
+++ b/npm.yaml
@@ -1,7 +1,7 @@
 package:
   name: npm
   version: 10.2.5
-  epoch: 1
+  epoch: 2
   description: "the npm package manager for javascript, mainline"
   copyright:
     - license: Artistic-2.0
@@ -50,7 +50,6 @@ pipeline:
              -name 'readme.markdown' \) -delete
 
       rm -rf ./*/.git* ./*/doc ./*/docs ./*/examples ./*/scripts ./*/test
-      rm -rf ./node-gyp/
       rm -rf node_modules/node-gyp
 
       find . -type f -executable  -exec chmod -x {} \;
@@ -68,10 +67,7 @@ pipeline:
 
   - runs: |
       destdir="${{targets.destdir}}"/usr/lib/node_modules/npm
-
       install -dDm755 "$destdir"
-      rm -rf node_modules/@npmcli/node-gyp/
-
       rsync -av --exclude melange-out /home/build/ "$destdir"
       chmod 755 "$destdir"
 


### PR DESCRIPTION
with recent npm changes  https://github.com/wolfi-dev/os/pull/10605 few npm based builds are exhibiting the following node not found build failures 
```
exit 0
⚠️  x86_64    | npm ERR! code MODULE_NOT_FOUND
⚠️  x86_64    | npm ERR! Cannot find module 'node-gyp/bin/node-gyp.js'
⚠️  x86_64    | npm ERR! Require stack:

```

This just keeps lib references of node-gyp from npm which can be overridden by system node-gyp 


the tests here confirms this fix works for both system provide node-gyp and previous node-gyp conflicted packages https://github.com/wolfi-dev/os/pull/10609
