### PR TITLE
fix: bunx broken symlink in Bun Package

### DIFF
--- a/bun.yaml
+++ b/bun.yaml
@@ -76,3 +76,4 @@ test:
   pipeline:
     - runs: |
         bun --version
+        bunx --version

--- a/bun.yaml
+++ b/bun.yaml
@@ -57,7 +57,7 @@ pipeline:
       mv ./build-release/bun ${{targets.destdir}}/usr/bin
 
       # symlink bunx as bun: https://github.com/oven-sh/bun/blob/main/dockerhub/distroless/Dockerfile#L70
-      ln -s /usr/bin/bunn ${{targets.destdir}}/usr/bin/bunx
+      ln -s /usr/bin/bun ${{targets.destdir}}/usr/bin/bunx
 
   - uses: strip
 


### PR DESCRIPTION
there is a typo.
Ref: https://github.com/oven-sh/bun/blob/main/dockerhub/distroless/Dockerfile#L70