### PR TITLE
Withdraw gcc-6-6.5.0-r0

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -3,3 +3,4 @@ ruby-3.3-doc-3.3.0_p3-r0.apk
 gobject-introspection-1.79.0-r0.apk
 gobject-introspection-doc-1.79.0-r0.apk
 gobject-introspection-dev-1.79.0-r0.apk
+gcc-6-6.5.0-r0.apk


### PR DESCRIPTION
This package contains libgomp.so, and prior to https://github.com/wolfi-dev/os/commit/1c371c7abfe63b7c0209d358fafc606a35554fd0 claims to provide that, which confuses solving in some cases where `libgomp` should be selected instead.

Withdrawing r0 should fix this. [r1](https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/gcc-6-6.5.0-r1.apk@sha1:c694263313fe738a185e8ab69941a24ef3ec2ec4) and [r2](https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/gcc-6-6.5.0-r2.apk@sha1:eb8d968c8d4759a4be33c1e776372694bd90c54b/.PKGINFO) don't provide libgomp

For posterity, `r0`'s `.PKGINFO`:
<details>

```
# Generated by melange.
pkgname = gcc-6
pkgver = 6.5.0-r0
arch = x86_64
size = 107608478
origin = gcc-6
pkgdesc = the GNU compiler collection
url = 
commit = d86bc0f1b132f7acb4580d7d710d743aef0fbc02
license = GPL-3.0-or-later
depend = binutils
depend = libstdc++-6-dev
depend = so:ld-linux-x86-64.so.2
depend = so:libc.so.6
depend = so:libgcc_s.so.1
depend = so:libgcj-tools.so.17
depend = so:libgcj.so.17
depend = so:libgmp.so.10
depend = so:libisl.so.23
depend = so:libm.so.6
depend = so:libmpc.so.3
depend = so:libmpfr.so.6
depend = so:libstdc++.so.6
depend = so:libz.so.1
provides = cmd:c++-6.5=6.5.0-r0
provides = cmd:cpp-6.5=6.5.0-r0
provides = cmd:g++-6.5=6.5.0-r0
provides = cmd:gcc-6.5=6.5.0-r0
provides = cmd:gcc-ar-6.5=6.5.0-r0
provides = cmd:gcc-nm-6.5=6.5.0-r0
provides = cmd:gcc-ranlib-6.5=6.5.0-r0
provides = cmd:gcov-6.5=6.5.0-r0
provides = cmd:gcov-dump-6.5=6.5.0-r0
provides = cmd:gcov-tool-6.5=6.5.0-r0
provides = cmd:x86_64-pc-linux-gnu-c++-6.5=6.5.0-r0
provides = cmd:x86_64-pc-linux-gnu-g++-6.5=6.5.0-r0
provides = cmd:x86_64-pc-linux-gnu-gcc-6.5.0=6.5.0-r0
provides = cmd:x86_64-pc-linux-gnu-gcc-6.5=6.5.0-r0
provides = cmd:x86_64-pc-linux-gnu-gcc-ar-6.5=6.5.0-r0
provides = cmd:x86_64-pc-linux-gnu-gcc-nm-6.5=6.5.0-r0
provides = cmd:x86_64-pc-linux-gnu-gcc-ranlib-6.5=6.5.0-r0
provides = cmd:x86_64-pc-linux-gnu-gcj-6.5=6.5.0-r0
provides = so:libcc1.so.0=0
provides = so:libcc1plugin.so.0=0
provides = so:libcilkrts.so.5=5
provides = so:libgomp.so.1=1
provides = so:libitm.so.1=1
provides = so:liblto_plugin.so.0=0
provides = so:libmpx.so.2=2
provides = so:libmpxwrappers.so.2=2
provides = so:libquadmath.so.0=0
provides = so:libssp.so.0=0
datahash = 210f6057f761ae9c5be9a87c03172e7146cceed43ea2ef4b2a207a7fe5c9f077
```

</details>