### PR TITLE
add py3-{trio, outcome, sortedcontainers} deps of selenium

### DIFF
--- a/py3-outcome.yaml
+++ b/py3-outcome.yaml
@@ -1,0 +1,43 @@
+# Generated from https://pypi.org/project/outcome/
+package:
+  name: py3-outcome
+  version: 1.3.0
+  epoch: 0
+  description: Capture the outcome of Python function calls.
+  copyright:
+    - license: MIT
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - py3-attrs
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/python-trio/outcome
+      tag: v${{package.version}}
+      expected-commit: 4037dd7fa89b3a26f41594607bc94aaea422d7c3
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - .post0
+    - DEBIAN-0.1.0-2
+  github:
+    identifier: python-trio/outcome
+    use-tag: true
+    strip-prefix: v

--- a/py3-sortedcontainers.yaml
+++ b/py3-sortedcontainers.yaml
@@ -1,0 +1,35 @@
+# Generated from https://pypi.org/project/sortedcontainers/
+package:
+  name: py3-sortedcontainers
+  version: 2.4.0
+  epoch: 0
+  description: Sorted Containers -- Sorted List, Sorted Dict, Sorted Set
+  copyright:
+    - license: Apache 2.0
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88
+      uri: https://files.pythonhosted.org/packages/source/s/sortedcontainers/sortedcontainers-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 15939

--- a/py3-trio.yaml
+++ b/py3-trio.yaml
@@ -1,0 +1,46 @@
+# Generated from https://pypi.org/project/trio/
+package:
+  name: py3-trio
+  version: 0.23.2
+  epoch: 0
+  description: A friendly Python library for async concurrency and I/O
+  copyright:
+    - license: MIT
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - py3-attrs
+      - py3-sortedcontainers
+      - py3-idna
+      - py3-outcome
+      - py3-sniffio
+      - py3-cffi
+      - py3-exceptiongroup
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/python-trio/trio
+      tag: v${{package.version}}
+      expected-commit: 60172de0c37a0d87c341cef3ef13f565ace343e9
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: python-trio/trio
+    use-tag: true
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
