### PR TITLE
Bump the gcc epoch to fix melange SBOMs.

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 13.2.0
-  epoch: 3
+  epoch: 4
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
I've seeing legs failing NTIA checks on `libgcc` and `libstdc++`

ref: https://github.com/chainguard-images/images/pull/2039

