### PR TITLE
add some fonts for selenium

### DIFF
--- a/font-alias.yaml
+++ b/font-alias.yaml
@@ -1,0 +1,42 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/font-alias/APKBUILD
+package:
+  name: font-alias
+  version: 1.0.5
+  epoch: 0
+  description: X.org font alias files
+  copyright:
+    - license: custom
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 9f89e217bb73e0e3636a0a493fbf8b7c995156e0c53d9a0476d201b67c2d6b6e
+      uri: https://www.x.org/releases/individual/font/font-alias-${{package.version}}.tar.xz
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: font-alias-doc
+    pipeline:
+      - uses: split/manpages
+    description: font-alias manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 15059

--- a/font-ipa.yaml
+++ b/font-ipa.yaml
@@ -1,0 +1,35 @@
+# Generated from https://git.alpinelinux.org/aports/plain/community/font-ipa/APKBUILD
+package:
+  name: font-ipa
+  version: 00303
+  epoch: 0
+  description: Japanese outline fonts by Information-technology Promotion Agency, Japan (IPA)
+  copyright:
+    - license: IPA
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - fontconfig
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: f755ed79a4b8e715bed2f05a189172138aedf93db0f465b4e20c344a02766fe5
+      uri: https://data.wolfsden.cz/mirror/IPAfont${{package.version}}.zip
+      extract: false
+
+  - runs: |
+      unzip -o IPAfont${{package.version}}.zip
+      cd IPAfont${{package.version}}
+      install -Dm644 -t ${{targets.destdir}}/usr/share/fonts/ipafont *.ttf
+
+  - uses: strip
+
+update:
+  enabled: false # Non-semanic versioning and 3rd party hosting

--- a/font-liberation.yaml
+++ b/font-liberation.yaml
@@ -1,0 +1,43 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/font-liberation/APKBUILD
+package:
+  name: font-liberation
+  version: 2.1.5
+  epoch: 0
+  description: Fonts to replace commonly used Microsoft Windows fonts
+  copyright:
+    - license: OFL-1.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - fontconfig
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 7191c669bf38899f73a2094ed00f7b800553364f90e2637010a69c0e268f25d0
+      uri: https://github.com/liberationfonts/liberation-fonts/files/7261482/liberation-fonts-ttf-${{package.version}}.tar.gz
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/fonts/${{package.name}} \
+        ${{targets.destdir}}/etc/fonts/conf.avail \
+        ${{targets.destdir}}/etc/fonts/conf.d
+
+      install -D -m644 ./*.ttf -t ${{targets.destdir}}/usr/share/fonts/${{package.name}}/
+
+      for i in $(find . -name '*.conf'); do
+        install -D -m644 "$i" -t ${{targets.destdir}}/etc/fonts/conf.avail/
+        ln -sf /etc/fonts/conf.avail/$i ${{targets.destdir}}/etc/fonts/conf.d/$i
+      done
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 16833

--- a/font-liberation/30-liberation-mono.conf
+++ b/font-liberation/30-liberation-mono.conf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "../fonts.dtd">
+<fontconfig>
+
+  <!-- Microsoft -->
+  <alias binding="same">
+    <family>Courier New</family>
+    <accept>
+      <family>Liberation Mono</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>Liberation Mono</family>
+    <default>
+      <family>Courier New</family>
+    </default>
+  </alias>
+
+</fontconfig>

--- a/font-liberation/30-liberation-sans.conf
+++ b/font-liberation/30-liberation-sans.conf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "../fonts.dtd">
+<fontconfig>
+
+  <!-- Microsoft -->
+  <alias binding="same">
+    <family>Arial</family>
+    <accept>
+      <family>Liberation Sans</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>Liberation Sans</family>
+    <default>
+      <family>Arial</family>
+    </default>
+  </alias>
+
+</fontconfig>

--- a/font-liberation/30-liberation-serif.conf
+++ b/font-liberation/30-liberation-serif.conf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "../fonts.dtd">
+<fontconfig>
+
+  <!-- Microsoft -->
+  <alias binding="same">
+    <family>Times New Roman</family>
+    <accept>
+      <family>Liberation Serif</family>
+    </accept>
+  </alias>
+  <alias binding="same">
+    <family>Liberation Serif</family>
+    <default>
+      <family>Times New Roman</family>
+    </default>
+  </alias>
+
+</fontconfig>

--- a/font-liberation/45-liberation.conf
+++ b/font-liberation/45-liberation.conf
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+
+  <alias>
+    <family>Liberation Mono</family>
+    <default>
+      <family>monospace</family>
+    </default>
+  </alias>
+
+  <alias>
+    <family>Liberation Sans</family>
+    <default>
+      <family>sans-serif</family>
+    </default>
+  </alias>
+
+  <alias>
+    <family>Liberation Serif</family>
+    <default>
+      <family>serif</family>
+    </default>
+  </alias>
+
+</fontconfig>

--- a/font-liberation/90-liberation.conf
+++ b/font-liberation/90-liberation.conf
@@ -1,0 +1,191 @@
+<?xml version='1.0'?>
+<!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+<fontconfig>
+
+  <!-- Liberation Mono -->
+  <match target="font">
+    <test name="force_autohint">
+      <bool>false</bool>
+    </test>
+    <test name="family">
+      <string>Liberation Mono</string>
+    </test>
+    <edit name="antialias" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hinting" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hintstyle" mode="assign">
+      <const>hintslight</const>
+    </edit>
+    <edit name="autohint" mode="assign">
+      <bool>false</bool>
+    </edit>
+  </match>
+
+  <match target="font">
+    <test name="force_autohint">
+      <bool>false</bool>
+    </test>
+    <test name="family">
+      <string>Liberation Mono</string>
+    </test>
+    <test name="pixelsize" compare="more">
+      <double>10.5</double>
+    </test>
+    <test name="pixelsize" compare="less">
+      <double>13.5</double>
+    </test>
+    <edit name="autohint" mode="assign">
+      <bool>false</bool>
+    </edit>
+    <edit name="antialias" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hinting" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hintstyle" mode="assign">
+      <const>hintfull</const>
+    </edit>
+  </match>
+
+  <match target="font">
+    <test name="force_autohint">
+      <bool>false</bool>
+    </test>
+    <test name="family">
+      <string>Liberation Mono</string>
+    </test>
+    <test name="pixelsize" compare="more">
+      <double>15.5</double>
+    </test>
+    <test name="pixelsize" compare="less">
+      <double>17.5</double>
+    </test>
+    <edit name="autohint" mode="assign">
+      <bool>false</bool>
+    </edit>
+    <edit name="antialias" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hinting" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hintstyle" mode="assign">
+      <const>hintfull</const>
+    </edit>
+  </match>
+
+  <match target="font">
+    <test name="force_autohint">
+      <bool>false</bool>
+    </test>
+    <test name="family">
+      <string>Liberation Mono</string>
+    </test>
+    <test name="pixelsize" compare="more">
+      <double>19.5</double>
+    </test>
+    <test name="pixelsize" compare="less">
+      <double>22.5</double>
+    </test>
+    <edit name="autohint" mode="assign">
+      <bool>false</bool>
+    </edit>
+    <edit name="antialias" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hinting" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hintstyle" mode="assign">
+      <const>hintfull</const>
+    </edit>
+  </match>
+
+  <match target="font">
+    <test name="family">
+      <string>Liberation Mono</string>
+    </test>
+    <test name="pixelsize" compare="less_eq">
+      <double>12.0</double>
+    </test>
+    <edit name="lcd_filter" mode="assign">
+      <const>lcdlegacy</const>
+    </edit>
+  </match>
+
+  <!-- Liberation Sans -->
+  <match target="font">
+    <test name="force_autohint">
+      <bool>false</bool>
+    </test>
+    <test name="family">
+      <string>Liberation Sans</string>
+    </test>
+    <edit name="antialias" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hinting" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hintstyle" mode="assign">
+      <const>hintslight</const>
+    </edit>
+    <edit name="autohint" mode="assign">
+      <bool>false</bool>
+    </edit>
+  </match>
+
+  <match target="font">
+    <test name="force_autohint">
+      <bool>false</bool>
+    </test>
+    <test name="family">
+      <string>Liberation Sans</string>
+    </test>
+    <test name="pixelsize" compare="less">
+      <double>12.5</double>
+    </test>
+    <edit name="autohint" mode="assign">
+      <bool>false</bool>
+    </edit>
+    <edit name="antialias" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hinting" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hintstyle" mode="assign">
+      <const>hintfull</const>
+    </edit>
+    <edit name="lcd_filter" mode="assign">
+      <const>lcdlegacy</const>
+    </edit>
+  </match>
+
+  <!-- Liberation Serif -->
+  <match target="font">
+    <test name="force_autohint">
+      <bool>false</bool>
+    </test>
+    <test name="family">
+      <string>Liberation Serif</string>
+    </test>
+    <edit name="antialias" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hinting" mode="assign">
+      <bool>true</bool>
+    </edit>
+    <edit name="hintstyle" mode="assign">
+      <const>hintslight</const>
+    </edit>
+    <edit name="autohint" mode="assign">
+      <bool>false</bool>
+    </edit>
+  </match>
+
+</fontconfig>

--- a/font-noto-emoji.yaml
+++ b/font-noto-emoji.yaml
@@ -1,0 +1,39 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/font-liberation/APKBUILD
+package:
+  name: font-noto-emoji
+  version: 2.042
+  epoch: 0
+  description: Google Noto emoji fonts
+  copyright:
+    - license: OFL-1.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - fontconfig
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: d79d23e6822e0f6e5731b114cbfb26b2a4e380da
+      repository: https://github.com/googlefonts/noto-emoji
+      tag: v${{package.version}}
+
+  - runs: install -Dm644 -t ${{targets.destdir}}/usr/share/fonts/${{package.name}} fonts/NotoColorEmoji.ttf
+
+  - uses: strip
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - '.*-unicode*'
+    - '.*-color-emoji-binary'
+    - '.*-license-apache'
+  github:
+    identifier: googlefonts/noto-emoji
+    strip-prefix: v

--- a/font-ubuntu.yaml
+++ b/font-ubuntu.yaml
@@ -1,0 +1,37 @@
+# Generated from https://git.alpinelinux.org/aports/plain/community/font-ubuntu/APKBUILD
+package:
+  name: font-ubuntu
+  version: 0.869
+  epoch: 0
+  description: Ubuntu font family
+  copyright:
+    - license: custom:Ubuntu Font License 1.0
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 34243d0aebd962c746abe7f31337c50a866bc8ddd55470f5716d638f8a8945d6
+      uri: https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/fonts-ubuntu/${{package.version}}-0ubuntu1/fonts-ubuntu_${{package.version}}.orig.tar.gz
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/fonts/${{package.name}} \
+        ${{targets.destdir}}/etc/fonts/conf.avail \
+        ${{targets.destdir}}/etc/fonts/conf.d
+
+      install -Dm644 ./*.ttf -t ${{targets.destdir}}/usr/share/fonts/ubuntu
+      install -Dm644 81-ubuntu.conf -t ${{targets.destdir}}/usr/share/fontconfig/conf.avail/
+      install -Dm644 LICENCE.txt ${{targets.destdir}}/usr/share/licenses/${{package.name}}/LICENCE
+
+  - uses: strip
+
+update:
+  enabled: false # No source to watch for the new versions

--- a/font-ubuntu/81-ubuntu.conf
+++ b/font-ubuntu/81-ubuntu.conf
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+
+<!-- Fixes for Ubuntu family:
+     - Medium variant is used instead of Regular on Qt apps:
+       https://bugs.launchpad.net/ubuntu-font-family/+bug/744812
+     - Medium and Bold looks the same in certain applications:
+       https://bugs.launchpad.net/ubuntu/+source/gnome-specimen/+bug/813373
+-->
+
+<match target="scan">
+	<test name="fullname" compare="eq">
+		<string>Ubuntu Light</string>
+	</test>
+	<edit name="family" mode="assign">
+		<string>Ubuntu</string>
+	</edit>
+	<edit name="style" mode="assign">
+		<string>Light</string>
+	</edit>
+</match>
+
+<match target="scan">
+	<test name="fullname" compare="eq">
+		<string>Ubuntu Light Italic</string>
+	</test>
+	<edit name="family" mode="assign">
+		<string>Ubuntu</string>
+	</edit>
+	<edit name="style" mode="assign">
+		<string>Light Italic</string>
+	</edit>
+</match>
+
+<match target="scan">
+	<test name="fullname" compare="eq">
+		<string>Ubuntu Medium</string>
+	</test>
+	<edit name="family" mode="assign">
+		<string>Ubuntu</string>
+	</edit>
+	<edit name="style" mode="assign">
+		<string>Medium</string>
+	</edit>
+	<edit name="weight" mode="assign">
+		<const>demibold</const>
+	</edit>
+</match>
+
+<match target="scan">
+	<test name="fullname" compare="eq">
+		<string>Ubuntu Medium Italic</string>
+	</test>
+	<edit name="family" mode="assign">
+		<string>Ubuntu</string>
+	</edit>
+	<edit name="style" mode="assign">
+		<string>Medium Italic</string>
+	</edit>
+	<edit name="weight" mode="assign">
+		<const>demibold</const>
+	</edit>
+</match>
+
+</fontconfig>

--- a/font-wqy-zenhei.yaml
+++ b/font-wqy-zenhei.yaml
@@ -1,0 +1,42 @@
+# Generated from https://git.alpinelinux.org/aports/plain/community/font-wqy-zenhei/APKBUILD
+package:
+  name: font-wqy-zenhei
+  version: 0.9.45
+  epoch: 0
+  description: Hei-Ti style (sans-serif) Chinese outline font
+  copyright:
+    - license: GPL-2.0
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - fontconfig
+      - mkfontscale
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: e4b7e306475bf9427d1757578f0e4528930c84c44eaa3f167d4c42f110ee75d6
+      uri: https://downloads.sourceforge.net/wqy/wqy-zenhei-${{package.version}}.tar.gz
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/fonts/${{package.name}} \
+        ${{targets.destdir}}/etc/fonts/conf.avail \
+        ${{targets.destdir}}/etc/fonts/conf.d
+
+      install -Dm644 wqy-zenhei.ttc -t ${{targets.destdir}}/usr/share/fonts/${{package.name}}
+
+      for i in $(find . -name '*.conf'); do
+        install -D -m644 "$i" -t ${{targets.destdir}}/etc/fonts/conf.avail/
+        ln -sf /etc/fonts/conf.avail/$i ${{targets.destdir}}/etc/fonts/conf.d/$i
+      done
+
+  - uses: strip
+
+update:
+  enabled: false # No source to watch for the new versions


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
