### PR TITLE
Add `permissions:` to our pre/post-submit jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,8 +25,8 @@ jobs:
     runs-on:
       group: wolfi-os-builder-${{ matrix.arch }}
 
-    # Ensure this is deprivileged, isolated job
-    # permissions:
+    permissions:
+      contents: read
 
     container:
       image: ghcr.io/wolfi-dev/sdk:latest@sha256:05c92bc51cf3c81f484a06111c4c499bf8a8fe0ddda68c46ae3b31f4802f24fc
@@ -198,6 +198,10 @@ jobs:
               melange sign --signing-key ./wolfi-signing.rsa ./packages/${arch}/*.apk
             fi
           done
+
+      # Clean up the signing key before uploading to storage out
+      # of an abundance of caution.
+      - run: rm ./wolfi-signing.rsa
 
       - name: 'Upload packages to GCS'
         run: |

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   changes:
+    permissions:
+      contents: read
+
     name: Determine packages to test building
     runs-on: ubuntu-latest
     outputs:
@@ -65,7 +68,6 @@ jobs:
       packages_were_built: ${{ steps.file_check.outputs.exists }}
 
     permissions:
-      packages: write
       contents: read
       pull-requests: write # so we have permission to comment on pull requests
 
@@ -141,6 +143,9 @@ jobs:
           if-no-files-found: warn
 
   scan:
+    permissions:
+      contents: read
+
     name: "Scan packages for CVEs"
     runs-on: ubuntu-latest
     container:

--- a/crane.yaml
+++ b/crane.yaml
@@ -1,7 +1,7 @@
 package:
   name: crane
   version: 0.17.0
-  epoch: 2
+  epoch: 3
   description: Tool for interacting with remote images and registries.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Attempt to drop the `packages: write` on the actual CI job.

This touches `crane` as a canary to exercise this presubmit