### PR TITLE
gh: fix path issues for gh and add tests

### DIFF
--- a/gh.yaml
+++ b/gh.yaml
@@ -1,7 +1,7 @@
 package:
   name: gh
   version: 2.40.1
-  epoch: 0
+  epoch: 1
   description: GitHub's official command line tool
   copyright:
     - license: MIT
@@ -22,7 +22,7 @@ pipeline:
       repository: https://github.com/cli/cli
       tag: v${{package.version}}
 
-  - runs: make install prefix=${{targets.destdir}}/usr/bin
+  - runs: make install prefix=${{targets.destdir}}/usr
 
   - uses: strip
 
@@ -31,3 +31,12 @@ update:
   github:
     identifier: cli/cli
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        gh --version


### PR DESCRIPTION
gh package had a wrong prefix in the install 

```
# apk info -L gh 
WARNING: opening ./../../packages: No such file or directory
gh-2.40.1-r0 contains:
usr/bin/bin/gh
usr/bin/share/bash-completion/completions/gh
usr/bin/share/fish/vendor_completions.d/gh.fish
usr/bin/share/man/man1/gh-alias-delete.1

```