### PR TITLE
downgrade  gobject-introspection

### DIFF
--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -1,6 +1,6 @@
 package:
   name: gobject-introspection
-  version: 1.79.1
+  version: 1.78.1
   epoch: 0
   description: Introspection system for GObject-based libraries
   copyright:
@@ -47,7 +47,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: f80ea33ee05ca48fb997952bb46131cfbdd3751f7f5da068888739cbeb2d5443
+      expected-sha256: bd7babd99af7258e76819e45ba4a6bc399608fe762d83fde3cac033c50841bb4
       uri: https://download.gnome.org/sources/gobject-introspection/${{vars.mangled-package-version}}/gobject-introspection-${{package.version}}.tar.xz
 
   - uses: meson/configure

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -2,3 +2,6 @@ gobject-introspection-dev-1.79.0-r0.apk
 gcc-6-6.5.0-r0.apk
 ruby3.3-bundler-2.5.3-r0.apk
 ruby3.3-bundler-doc-2.5.3-r0.apk
+gobject-introspection-1.79.1-r0.apk
+gobject-introspection-dev-1.79.1-r0.apk
+gobject-introspection-doc-1.79.1-r0.apk


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

⚠️ we are downgrading the `gobject-introspection` due to following error:

```
⚠️  x86_64    | Couldn't find include 'GObject-2.0.gir' (search path: '['/home/build/.local/share/gir-1.0', 'gir-1.0', '/usr/local/share/gir-1.0', '/usr/share/gir-1.0', '/usr/share/gir-1.0', '/usr/share/gir-1.0', '/usr/share/gir-1.0']')
```

we made some research about the issue little bit with @Dentrax and found this:

```
# they have removed that file at 1.79 version:
https://gitlab.gnome.org/GNOME/gobject-introspection/-/compare/1.78.1...1.79.1?from_project_id=659&straight=false
```

and both alpine and arch are using the older version of `gobject-introspection`, 1.78.1 to be precise:

- https://git.alpinelinux.org/aports/tree/main/gobject-introspection/APKBUILD#n4
- https://gitlab.archlinux.org/archlinux/packaging/packages/gobject-introspection/-/blob/main/PKGBUILD?ref_type=heads#L10

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
