### PR TITLE
Add wdiff as part of chromium dependency

### DIFF
--- a/wdiff.yaml
+++ b/wdiff.yaml
@@ -12,8 +12,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - wolfi-base
       - texinfo
+      - wolfi-base
 
 pipeline:
   - uses: fetch

--- a/wdiff.yaml
+++ b/wdiff.yaml
@@ -1,0 +1,50 @@
+package:
+  name: wdiff
+  version: "1.2.2"
+  epoch: 0
+  description: "GNU diff utilities"
+  copyright:
+    - license: GPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+      - texinfo
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://ftp.gnu.org/gnu/wdiff/wdiff-${{package.version}}.tar.gz
+      expected-sha256: 34ff698c870c87e6e47a838eeaaae729fa73349139fc8db12211d2a22b78af6b
+
+  - runs: |
+      ./configure \
+         --prefix=/usr \
+         --libdir=/lib \
+         --libexecdir=/usr/libexec \
+         --sysconfdir=/etc \
+         --mandir=/usr/share/man \
+         --infodir=/usr/share/info \
+         --disable-nls
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: "wdiff-doc"
+    description: "documentation for GNU wdiff"
+    pipeline:
+      - uses: split/manpages
+      - uses: split/infodir
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5112


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
