### PR TITLE
soname CI check: split into it's own job so it's easier to see when t…

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -101,11 +101,6 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Check sonames
-        if: steps.file_check.outputs.exists == 'true'
-        run: |
-          wolfictl check so-name
-
       - name: Check diff
         if: steps.file_check.outputs.exists == 'true'
         # Let's not fail the whole job if this step fails as it is for improved UX rather than an enforced check
@@ -141,6 +136,44 @@ jobs:
           name: packages-${{ matrix.arch }}
           retention-days: 1
           if-no-files-found: warn
+
+  so_check:
+    permissions:
+      contents: read
+
+    name: "ABI Compatibility check"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/wolfi-dev/sdk:latest@sha256:05c92bc51cf3c81f484a06111c4c499bf8a8fe0ddda68c46ae3b31f4802f24fc
+    needs: build
+    if: needs.build.outputs.packages_were_built == 'true'
+
+    steps:
+      - name: 'Retrieve x86_64 packages'
+        uses: actions/download-artifact@v3
+        with:
+          name: packages-x86_64
+          path: /tmp/artifacts-1/
+
+      - name: 'Retrieve aarch64 packages'
+        uses: actions/download-artifact@v3
+        with:
+          name: packages-aarch64
+          path: /tmp/artifacts-2/
+
+      - name: 'Collect packages from all architectures into one place'
+        run: |
+          cd /tmp/artifacts-1
+
+          # Put the packages into one place
+          mv /tmp/artifacts-2/packages/* ./packages/
+
+          # Merge the build log ("packages.log") files
+          cat /tmp/artifacts-2/packages.log >> ./packages.log
+
+      - name: Soname check
+        run: |
+          wolfictl check so-name --packages-dir /tmp/artifacts-1/packages --package-list-file /tmp/artifacts-1/packages.log
 
   scan:
     permissions:

--- a/hello-wolfi.yaml
+++ b/hello-wolfi.yaml
@@ -1,7 +1,7 @@
 package:
   name: hello-wolfi
   version: 2.12.1
-  epoch: 1
+  epoch: 2
   description: "the GNU hello world program"
   copyright:
     - paths:


### PR DESCRIPTION
…he check fails + we continue to run other jobs like scan.

__Once we're ready to merge we should make the soname check a GitHub required check__ so we don't accidentally merge PRs.  The failed check should still require admin override due to the importance of ABI compatability.

