### PR TITLE
fix: bump nginx dependencies to fix build errors

### DIFF
--- a/ingress-nginx-controller.yaml
+++ b/ingress-nginx-controller.yaml
@@ -2,7 +2,7 @@
 package:
   name: ingress-nginx-controller
   version: 1.9.5
-  epoch: 1
+  epoch: 2
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -126,9 +126,9 @@ vars:
   NGINX_SUBSTITUTIONS: "e12e965ac1837ca709709f9a26f572a54d83430e"
   MODSECURITY_NGINX_VERSION: "1.0.3"
   OWASP_MODSECURITY_CRS_VERSION: "v3.3.5"
-  LUA_NGX_VERSION: "0.10.25"
-  LUA_STREAM_NGX_VERSION: "0.0.13"
-  LUA_UPSTREAM_VERSION: "dba0beaaeb0eaed758af3f4dc0c0464adeaedb1c"
+  LUA_NGX_VERSION: "0.10.26"
+  LUA_STREAM_NGX_VERSION: "0.0.14"
+  LUA_UPSTREAM_VERSION: "542be0893543a4e42d89f6dd85372972f5ff2a36"
   GEOIP2_VERSION: "a607a41a8115fecfc05b5c283c81532a3d605425"
   NGX_BROTLI_SHA: a71f9312c2deb28875acc7bacfdd5695a111aa53
 
@@ -208,19 +208,19 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/openresty/lua-nginx-module/archive/v${{vars.LUA_NGX_VERSION}}.tar.gz
-      expected-sha256: bc764db42830aeaf74755754b900253c233ad57498debe7a441cee2c6f4b07c2
+      expected-sha256: a75983287a2bdc5e964ace56a51b215dc2ec996639d4916cd393d6ebba94b565
       strip-components: 0
 
   - uses: fetch
     with:
       uri: https://github.com/openresty/stream-lua-nginx-module/archive/v${{vars.LUA_STREAM_NGX_VERSION}}.tar.gz
-      expected-sha256: 01b715754a8248cc7228e0c8f97f7488ae429d90208de0481394e35d24cef32f
+      expected-sha256: 8e2ff6ad5f91127da3c01757e7e654f1addf9769450d9159601d2cc153953c47
       strip-components: 0
 
   - uses: fetch
     with:
       uri: https://github.com/openresty/lua-upstream-nginx-module/archive/${{vars.LUA_UPSTREAM_VERSION}}.tar.gz
-      expected-sha256: e0baff472e1e8820d355701890f0c075ea0f0ba4ba6ca975f896912ae3b815c2
+      expected-sha256: 41fd8c0edcd53e61ed5694ac8460043cc58fbc367acd7bb73e9c1a44c470168e
       strip-components: 0
 
   - uses: fetch


### PR DESCRIPTION
Bump `lua-nginx-module`, `stream-lua-nginx-module`, and `lua-upstream-nginx-module` versions to fix a build breakage caused by `lua-resty-core`.

Fixes: a build breakage for our `ingress-nginx-controller` image
