### PR TITLE
grype: Fix package version

### DIFF
--- a/grype.yaml
+++ b/grype.yaml
@@ -1,7 +1,7 @@
 package:
   name: grype
   version: 0.74.0
-  epoch: 0
+  epoch: 1
   description: Vulnerability scanner for container images, filesystems, and SBOMs
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
+  environment:
+    CGO_ENABLED: "0"
 
 pipeline:
   - uses: fetch
@@ -19,10 +21,11 @@ pipeline:
       uri: https://github.com/anchore/grype/archive/v${{package.version}}/grype-${{package.version}}.tar.gz
       expected-sha512: b90270cf6cbefefeccd89e3a12633d2db6fb920e14f19bc994208393e31bf8b88d45d2ce6add20589e97ed4f0ad8ca6dd6f84b624083935def366fd191478788
 
-  - runs: |
-      CGO_ENABLED=0 go build \
-        -ldflags "-w -X github.com/anchore/grype/internal/version.version=${{package.version}}" \
-        -o "${{targets.destdir}}/usr/bin/grype" ./cmd/grype
+  - uses: go/build
+    with:
+      packages: ./cmd/grype
+      ldflags: -w -X main.version=${{package.version}}
+      output: grype
 
   - uses: strip
 
@@ -31,3 +34,12 @@ update:
   github:
     identifier: anchore/grype
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        grype --version


### PR DESCRIPTION
The grype package was previously reporting: `grype [not provided]`. With this change, it reports `grype 0.74.0`