### PR TITLE
Add ruby3.2-logstash-core

### DIFF
--- a/ruby3.2-logstash-core.yaml
+++ b/ruby3.2-logstash-core.yaml
@@ -1,0 +1,68 @@
+# Generated from http://www.elastic.co/guide/en/logstash/current/index.html
+package:
+  name: ruby3.2-logstash-core
+  version: 8.11.3
+  epoch: 0
+  description: The core components of logstash, the scalable log and event management tool
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ruby3.2-chronic_duration
+      - ruby3.2-clamp
+      - ruby3.2-concurrent-ruby
+      - ruby3.2-elasticsearch
+      - ruby3.2-filesize
+      - ruby3.2-gems
+      - ruby3.2-i18n
+      - ruby3.2-jrjackson
+      - ruby3.2-jruby-openssl
+      - ruby3.2-manticore
+      - ruby3.2-minitar
+      - ruby3.2-pry
+      - ruby3.2-puma
+      - ruby3.2-rack
+      - ruby3.2-rubyzip
+      - ruby3.2-sinatra
+      - ruby3.2-stud
+      - ruby3.2-thread_safe
+      - ruby3.2-treetop
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - jruby-9.4
+      - openjdk-11
+      - openjdk-11-default-jvm
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/elastic/logstash
+      tag: v${{package.version}}
+      expected-commit: 45f6dce3e8aa9919e6daa0043a882e12ba3ca97a
+
+  - working-directory: logstash-core
+    pipeline:
+      - runs: |
+          jruby -S gem build ${{vars.gem}}.gemspec
+      - uses: ruby/install
+        with:
+          # Output file name has `java` suffix.
+          gem-file: ${{vars.gem}}-${{package.version}}-java.gem
+          version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: logstash-core
+
+update:
+  enabled: true
+  github:
+    identifier: elastic/logstash
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
