### PR TITLE
Add logstash-output-opensearch and deps

### DIFF
--- a/ruby3.2-logstash-core-plugin-api.yaml
+++ b/ruby3.2-logstash-core-plugin-api.yaml
@@ -1,0 +1,64 @@
+# Generated from http://www.elastic.co/guide/en/logstash/current/index.html
+package:
+  name: ruby3.2-logstash-core-plugin-api
+  version: 8.11.3
+  epoch: 0
+  description: Logstash plugin API
+  copyright:
+    - license: Apache License 2.0
+  dependencies:
+    runtime:
+      - ruby3.2-logstash-core
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - jruby-9.4
+      - openjdk-11
+      - openjdk-11-default-jvm
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-11-openjdk
+    # TODO: Ideally, we should read the version from the ../versions.yml file. But
+    # melange pipeline does not support evaluating expressions in the `uses/with`.
+    # We also cannot pass environment variables between steps. So, until we
+    # figure out a better way, set a hardcoded version here.
+    LOGSTASH_CORE_PLUGIN_API_VERSION: 2.1.16
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/elastic/logstash
+      tag: v${{package.version}}
+      expected-commit: 45f6dce3e8aa9919e6daa0043a882e12ba3ca97a
+
+  - working-directory: logstash-core-plugin-api
+    pipeline:
+      # We will be adding the runtime dependency in the all the other projects
+      # anyway. So, remove the runtime dependency from the gemspec file to
+      # skip the dependency-check during the build.
+      - runs: sed -i '/add_runtime_dependency "logstash-core"/d' ${{vars.gem}}.gemspec
+      - runs: jruby -S gem build ${{vars.gem}}.gemspec
+      # Ideally, we should read the version from the ../versions.yml file since
+      # output file named like `logstash-core-plugin-api-2.1.16-java.gem`.
+      # But melange pipeline does not support evaluating expressions in
+      # the `uses/with` section. So, rename the gem file to exclude the version.
+      - runs: mv ${{vars.gem}}-*.gem ${{vars.gem}}.gem
+      - uses: ruby/install
+        with:
+          gem-file: ${{vars.gem}}.gem
+          version: ${LOGSTASH_CORE_PLUGIN_API_VERSION}
+
+  - uses: ruby/clean
+
+vars:
+  gem: logstash-core-plugin-api
+
+update:
+  enabled: true
+  github:
+    identifier: elastic/logstash
+    strip-prefix: v

--- a/ruby3.2-logstash-mixin-ecs_compatibility_support.yaml
+++ b/ruby3.2-logstash-mixin-ecs_compatibility_support.yaml
@@ -1,0 +1,56 @@
+package:
+  name: ruby3.2-logstash-mixin-ecs_compatibility_support
+  version: 1.3.0
+  epoch: 0
+  description: Support for the ECS-Compatibility mode targeting Logstash 7.7, for plugins wishing to use this API on older Logstashes
+  copyright:
+    - license: Apache License 2.0
+  dependencies:
+    runtime:
+      - ruby3.2-logstash-core
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/logstash-plugins/logstash-mixin-ecs_compatibility_support
+      tag: v${{package.version}}
+      expected-commit: 24426f92ff4606d97a973abf2dbee1e34dcc9515
+
+  # We will be adding the runtime dependency in the all the other projects
+  # anyway. So, remove the runtime dependency from the gemspec file to
+  # skip the dependency-check during the build.
+  - runs: sed -i "/add_runtime_dependency 'logstash-core'/d" ${{vars.gem}}.gemspec
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  # Get rid of the `-VERSION-ARCH-OS` suffix from the gem file name.
+  - runs: mv ${{vars.gem}}-*.gem ${{vars.gem}}.gem
+
+  - uses: ruby/install
+    with:
+      gem-file: ${{vars.gem}}.gem
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: logstash-mixin-ecs_compatibility_support
+
+update:
+  enabled: true
+  github:
+    identifier: logstash-plugins/logstash-mixin-ecs_compatibility_support
+    strip-prefix: v
+    use-tag: true

--- a/ruby3.2-logstash-output-opensearch.yaml
+++ b/ruby3.2-logstash-output-opensearch.yaml
@@ -1,0 +1,60 @@
+package:
+  name: ruby3.2-logstash-output-opensearch
+  version: 2.0.2
+  epoch: 0
+  description: Logstash - transport and process your logs, events, or other data
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ruby3.2-aws-sdk-core
+      - ruby3.2-json
+      - ruby3.2-logstash-core-plugin-api
+      - ruby3.2-manticore
+      - ruby3.2-stud
+
+environment:
+  contents:
+    packages:
+      - bash
+      - busybox
+      - ca-certificates-bundle
+      - jruby-9.4
+      - openjdk-11
+      - openjdk-11-default-jvm
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-11-openjdk
+
+vars:
+  gem: logstash-output-opensearch
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/opensearch-project/logstash-output-opensearch
+      tag: ${{package.version}}
+      expected-commit: 844fb28d9e148e4042563d277b8e4c8a63392f81
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/share/logstash/config
+      cp release/docker/logstash-opensearch-sample.conf "${{targets.destdir}}"/usr/share/logstash/config/
+
+  - runs: gem install bundler
+
+  - runs: jruby -S gem build ${{vars.gem}}.gemspec
+
+  # Get rid of the `-VERSION-ARCH-OS` suffix from the gem file name.
+  - runs: mv ${{vars.gem}}-*.gem ${{vars.gem}}.gem
+
+  - uses: ruby/install
+    with:
+      gem-file: ${{vars.gem}}.gem
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+update:
+  enabled: true
+  github:
+    identifier: opensearch-project/logstash-output-opensearch
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
