### PR TITLE
fix CVE `GHSA-9763-4f94-gfch in both` `keda` & `keda-2.11`

### DIFF
--- a/keda-2.11.yaml
+++ b/keda-2.11.yaml
@@ -33,7 +33,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 github.com/cloudflare/circl@v1.3.7
+      deps: golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7
 
   - runs: |
       # CVE-2023-39325

--- a/keda-2.11.yaml
+++ b/keda-2.11.yaml
@@ -2,9 +2,9 @@
 # Remove after 2.14 or 3.0
 package:
   name: keda-2.11
-  # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
+  # See https://keda.sh/support/ for upstream-supported versions
   version: 2.11.2
-  epoch: 11
+  epoch: 12
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -33,7 +33,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0
+      deps: golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 github.com/cloudflare/circl@v1.3.7
 
   - runs: |
       # CVE-2023-39325

--- a/keda.yaml
+++ b/keda.yaml
@@ -1,8 +1,8 @@
 package:
   name: keda
-  # See https://github.com/kedacore/keda/blob/main/SECURITY.md#supported-versions for upstream-supported versions
+  # See https://keda.sh/support/ for upstream-supported versions
   version: 2.12.1
-  epoch: 4
+  epoch: 5
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0
+      deps: github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7
 
   - runs: |
       ARCH=$(go env GOARCH) make build


### PR DESCRIPTION
Fix CVE GHSA-9763-4f94-gfch in both `keda` & `keda-2.11`

Related:

### Pre-review Checklist



#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
Ref: https://github.com/wolfi-dev/advisories/pull/761
