### PR TITLE
chore: remove redundant manual=false

### DIFF
--- a/chartmuseum.yaml
+++ b/chartmuseum.yaml
@@ -1,7 +1,7 @@
 package:
   name: chartmuseum
   version: 0.16.1
-  epoch: 0
+  epoch: 1
   description: helm chart repository server
   copyright:
     - license: Apache-2.0
@@ -40,7 +40,6 @@ pipeline:
 
 update:
   enabled: true
-  manual: false
   github:
     identifier: helm/chartmuseum
     strip-prefix: v

--- a/external-dns.yaml
+++ b/external-dns.yaml
@@ -1,7 +1,7 @@
 package:
   name: external-dns
   version: 0.14.0
-  epoch: 4
+  epoch: 5
   description: Configure external DNS servers (AWS Route53, Google CloudDNS and others) for Kubernetes Ingresses and Services.
   copyright:
     - paths:
@@ -38,7 +38,6 @@ pipeline:
 
 update:
   enabled: true
-  manual: false
   github:
     identifier: kubernetes-sigs/external-dns
     strip-prefix: v

--- a/fluent-plugin-record-modifier.yaml
+++ b/fluent-plugin-record-modifier.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-record-modifier
   version: 2.2.0
-  epoch: 0
+  epoch: 1
   description: Filter plugin for modifying event record
   copyright:
     - license: MIT
@@ -41,7 +41,6 @@ pipeline:
 
 update:
   enabled: true
-  manual: false
   github:
     identifier: repeatedly/fluent-plugin-record-modifier
     strip-prefix: v

--- a/flux-notification-controller.yaml
+++ b/flux-notification-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-notification-controller
   version: 1.2.3
-  epoch: 1
+  epoch: 2
   description: The GitOps Toolkit event forwarded and notification dispatcher
   copyright:
     - license: Apache-2.0
@@ -34,7 +34,6 @@ pipeline:
 
 update:
   enabled: true
-  manual: false
   github:
     identifier: fluxcd/notification-controller
     strip-prefix: v

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.15.1
-  epoch: 2
+  epoch: 3
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0
@@ -41,7 +41,6 @@ pipeline:
 
 update:
   enabled: true
-  manual: false
   github:
     identifier: ko-build/ko
     strip-prefix: v

--- a/kubernetes-csi-node-driver-registrar-2.9.yaml
+++ b/kubernetes-csi-node-driver-registrar-2.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-node-driver-registrar-2.9
   version: 2.9.3
-  epoch: 0
+  epoch: 1
   description: Sidecar container that registers a CSI driver with the kubelet using the kubelet plugin registration mechanism.
   copyright:
     - license: Apache-2.0
@@ -46,7 +46,6 @@ subpackages:
 
 update:
   enabled: true
-  manual: false
   github:
     identifier: kubernetes-csi/node-driver-registrar
     strip-prefix: v

--- a/nvidia-device-plugin.yaml
+++ b/nvidia-device-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: nvidia-device-plugin
   version: 0.14.3
-  epoch: 1
+  epoch: 2
   description: NVIDIA device plugin for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -33,7 +33,6 @@ pipeline:
 
 update:
   enabled: true
-  manual: false
   github:
     identifier: NVIDIA/k8s-device-plugin
     strip-prefix: v

--- a/thanos-0.31.yaml
+++ b/thanos-0.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-0.31
   version: 0.31.0
-  epoch: 10
+  epoch: 11
   description: Highly available Prometheus setup with long term storage capabilities.
   copyright:
     - license: Apache-2.0
@@ -57,7 +57,6 @@ pipeline:
 
 update:
   enabled: true
-  manual: false
   github:
     identifier: thanos-io/thanos
     strip-prefix: v


### PR DESCRIPTION
This removes a redundant field that got added when serializing/deserializing the yaml configuration.