### PR TITLE
CVE Remediation: GHSA-9763-4f94-gfch: fix CVE for Wolfi package opentofu

### DIFF
--- a/opentofu.yaml
+++ b/opentofu.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentofu
   version: 1.6.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MPL-2.0
 
@@ -18,20 +18,20 @@ var-transforms:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 4ac1af3fbc818b458c71a17ad6b31025ad7cba3f
       repository: https://github.com/opentofu/opentofu
       tag: v${{vars.mangled-package-version}}
-      expected-commit: 4ac1af3fbc818b458c71a17ad6b31025ad7cba3f
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0
+      deps: golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7
 
   - uses: go/build
     with:
-      modroot: .
-      packages: ./cmd/tofu
-      output: tofu
       ldflags: -s -w
+      modroot: .
+      output: tofu
+      packages: ./cmd/tofu
 
   - uses: strip
 


### PR DESCRIPTION
CVE Remediation: GHSA-9763-4f94-gfch: fix CVE for Wolfi package opentofu