### PR TITLE
CVE Remediation: GHSA-vh7g-p26c-j2cw/GHSA-m9hp-7r99-94h5/ GHSA-2x32-jm95-2cpx/: fix CVE for Wolfi package kots

### DIFF
--- a/kots.yaml
+++ b/kots.yaml
@@ -18,14 +18,15 @@ environment:
       - yarn
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: dca2ad702d78ac78ef5071b30dfbc2ed2497c1f84045309a5be3412e73a42e03
-      uri: https://github.com/replicatedhq/kots/archive/refs/tags/v${{package.version}}.tar.gz
+      repository: https://github.com/replicatedhq/kots
+      tag: v${{package.version}}
+      expected-commit: 4ff9cfe0a7aca05a31a6983d40ae6eabd86c94b1
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0 github.com/dexidp/dex@v2.35.0
+      deps: github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0 github.com/dexidp/dex@v2.13.0+incompatible
       go-version: 1.21.0
 
   - runs: |

--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
   version: 1.105.3
-  epoch: 0
+  epoch: 1
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0
@@ -20,13 +20,13 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://github.com/replicatedhq/kots/archive/refs/tags/v${{package.version}}.tar.gz
       expected-sha256: dca2ad702d78ac78ef5071b30dfbc2ed2497c1f84045309a5be3412e73a42e03
+      uri: https://github.com/replicatedhq/kots/archive/refs/tags/v${{package.version}}.tar.gz
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0
-      go-version: "1.21.0"
+      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0 github.com/dexidp/dex@v2.35.0
+      go-version: 1.21.0
 
   - runs: |
       set -x


### PR DESCRIPTION
CVE Remediation: GHSA-vh7g-p26c-j2cw/CVE Remediation: GHSA-vh7g-p26c-j2cw/CVE Remediation: GHSA-m9hp-7r99-94h5/CVE Remediation: GHSA-m9hp-7r99-94h5/CVE Remediation: GHSA-2x32-jm95-2cpx/CVE Remediation: GHSA-2x32-jm95-2cpx/: fix CVE for Wolfi package kots