### PR TITLE
CVE Remediation: GHSA-hq6q-c2x6-hmch/CVE Remediation: GHSA-f9jg-8p32-2f55/CVE Remediation: GHSA-9763-4f94-gfch/: fix CVE for Wolfi package argo-cd-2.7

### DIFF
--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -28,7 +28,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/docker/distribution@v2.8.2 k8s.io/kubernetes@v1.25.16 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
+      deps: github.com/docker/distribution@v2.8.2 k8s.io/kubernetes@v1.24.17 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
       replaces: github.com/whilp/git-urls=github.com/chainguard-dev/git-urls@v0.0.1
 
   - runs: |

--- a/argo-cd-2.7.yaml
+++ b/argo-cd-2.7.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.7
   version: 2.7.15
-  epoch: 7
+  epoch: 8
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -22,13 +22,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 66a8905181ad49a4cd0982644815fb8ee626fdfe
       repository: https://github.com/argoproj/argo-cd
       tag: v${{package.version}}
-      expected-commit: 66a8905181ad49a4cd0982644815fb8ee626fdfe
 
   - uses: go/bump
     with:
-      deps: github.com/docker/distribution@v2.8.2 k8s.io/kubernetes@v1.24.17 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0
+      deps: github.com/docker/distribution@v2.8.2 k8s.io/kubernetes@v1.25.16 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
       replaces: github.com/whilp/git-urls=github.com/chainguard-dev/git-urls@v0.0.1
 
   - runs: |


### PR DESCRIPTION
CVE Remediation: GHSA-hq6q-c2x6-hmch/CVE Remediation: GHSA-f9jg-8p32-2f55/CVE Remediation: GHSA-9763-4f94-gfch/: fix CVE for Wolfi package argo-cd-2.7