### PR TITLE
CVE Remediation: GHSA-9763-4f94-gfch: fix CVE for Wolfi package tekton-chains

### DIFF
--- a/tekton-chains.yaml
+++ b/tekton-chains.yaml
@@ -1,7 +1,7 @@
 package:
   name: tekton-chains
   version: 0.19.0
-  epoch: 4
+  epoch: 5
   description: Supply Chain Security in Tekton Pipelines
   copyright:
     - license: Apache-2.0
@@ -13,19 +13,19 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 3fe5c46e9a259f3a562f85c115418cb4a1106e00
       repository: https://github.com/tektoncd/chains
       tag: v${{package.version}}
-      expected-commit: 3fe5c46e9a259f3a562f85c115418cb4a1106e00
 
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.17.0 github.com/sigstore/cosign/v2@v2.2.1 github.com/docker/docker@v24.0.7 github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0
-      go-version: 1.21
+      deps: golang.org/x/net@v0.17.0 github.com/sigstore/cosign/v2@v2.2.1 github.com/docker/docker@v24.0.7 github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7
+      go-version: "1.21"
 
   - uses: go/build
     with:
-      packages: ./cmd/controller
       output: tekton-chains
+      packages: ./cmd/controller
 
 update:
   enabled: true


### PR DESCRIPTION
CVE Remediation: GHSA-9763-4f94-gfch: fix CVE for Wolfi package tekton-chains