### PR TITLE
CVE Remediation: GHSA-9763-4f94-gfch: fix CVE for Wolfi package falcoctl

### DIFF
--- a/falcoctl.yaml
+++ b/falcoctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: falcoctl
   version: 0.6.2
-  epoch: 7
+  epoch: 8
   description: Administrative tooling for Falco
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.17.0 github.com/docker/docker@v24.0.7 github.com/go-jose/go-jose/v3@v3.0.1 google.golang.org/grpc@v1.58.3 github.com/sigstore/cosign/v2@v2.2.1 golang.org/x/crypto@v0.17.0
+      deps: golang.org/x/net@v0.17.0 github.com/docker/docker@v24.0.7 github.com/go-jose/go-jose/v3@v3.0.1 google.golang.org/grpc@v1.58.3 github.com/sigstore/cosign/v2@v2.2.1 golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7
       go-version: "1.21"
 
   - runs: |


### PR DESCRIPTION
CVE Remediation: GHSA-9763-4f94-gfch: fix CVE for Wolfi package falcoctl