### PR TITLE
CVE Remediation: GHSA-ppxx-5m9h-6vxf/CVE Remediation: GHSA-jq35-85cj-fj4p/: fix CVE for Wolfi package traefik

### DIFF
--- a/traefik.yaml
+++ b/traefik.yaml
@@ -1,7 +1,7 @@
 package:
   name: traefik
   version: 2.10.7
-  epoch: 2
+  epoch: 3
   description: The Cloud Native Application Proxy
   copyright:
     - license: MIT
@@ -18,13 +18,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/traefik/traefik
       expected-commit: 0a7964300166d167f68d5502bc245b3b9c8842b4
+      repository: https://github.com/traefik/traefik
       tag: v${{package.version}}
 
   - uses: go/bump
     with:
-      deps: github.com/docker/docker@v20.10.24 github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0
+      deps: github.com/docker/docker@v20.10.27 github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/quic-go/quic-go@v0.39.4
 
   - runs: |
       go mod edit -replace github.com/hashicorp/consul=github.com/hashicorp/consul@v1.14.7


### PR DESCRIPTION
CVE Remediation: GHSA-ppxx-5m9h-6vxf/CVE Remediation: GHSA-jq35-85cj-fj4p/: fix CVE for Wolfi package traefik