### PR TITLE
CVE Remediation: GHSA-mhpq-9638-x6pw/CVE Remediation: GHSA-7ww5-4wqc-m92c/CVE Remediation: GHSA-45x7-px36-x8w8/: fix CVE for Wolfi package telegraf-1.28

### DIFF
--- a/telegraf-1.28.yaml
+++ b/telegraf-1.28.yaml
@@ -27,7 +27,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/dvsekhvalnov/jose2go@v1.5.1-0.20231206184617-48ba0b76bc88
+      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/dvsekhvalnov/jose2go@v1.5.1-0.20231206184617-48ba0b76bc88 go.opentelemetry.io/otel/exporters/otlp/internal/retry@v1.17.0 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@v0.44.0
       go-version: "1.21"
 
   - if: ${{build.arch}} == 'x86_64'

--- a/telegraf-1.28.yaml
+++ b/telegraf-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: telegraf-1.28
   version: 1.28.5
-  epoch: 0
+  epoch: 1
   description: Telegraf is an agent for collecting, processing, aggregating, and writing metric
   copyright:
     - license: MIT
@@ -21,17 +21,21 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      tag: v${{package.version}}
       expected-commit: 77e1a498e520faf38ac7ee3daef1481d6f990957
       repository: https://github.com/influxdata/telegraf
+      tag: v${{package.version}}
 
-  - if: ${{build.arch}} == 'x86_64'
-    runs: |
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/dvsekhvalnov/jose2go@v1.5.1-0.20231206184617-48ba0b76bc88
+
+  - runs: |
       make package include_packages="linux_amd64.tar.gz"
+    if: ${{build.arch}} == 'x86_64'
 
-  - if: ${{build.arch}} == 'aarch64'
-    runs: |
+  - runs: |
       make package include_packages="linux_arm64.tar.gz"
+    if: ${{build.arch}} == 'aarch64'
 
   - runs: |
       tar -xf build/dist/telegraf-${{package.version}}*.tar.gz

--- a/telegraf-1.28.yaml
+++ b/telegraf-1.28.yaml
@@ -28,14 +28,15 @@ pipeline:
   - uses: go/bump
     with:
       deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/dvsekhvalnov/jose2go@v1.5.1-0.20231206184617-48ba0b76bc88
+      go-version: "1.21"
 
-  - runs: |
+  - if: ${{build.arch}} == 'x86_64'
+    runs: |
       make package include_packages="linux_amd64.tar.gz"
-    if: ${{build.arch}} == 'x86_64'
 
-  - runs: |
+  - if: ${{build.arch}} == 'aarch64'
+    runs: |
       make package include_packages="linux_arm64.tar.gz"
-    if: ${{build.arch}} == 'aarch64'
 
   - runs: |
       tar -xf build/dist/telegraf-${{package.version}}*.tar.gz


### PR DESCRIPTION
CVE Remediation: GHSA-mhpq-9638-x6pw/CVE Remediation: GHSA-7ww5-4wqc-m92c/CVE Remediation: GHSA-45x7-px36-x8w8/: fix CVE for Wolfi package telegraf-1.28