### PR TITLE
CVE Remediation: GHSA-9763-4f94-gfch: fix CVE for Wolfi package grafana

### DIFF
--- a/grafana.yaml
+++ b/grafana.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana
   version: 10.2.3
-  epoch: 1
+  epoch: 2
   description: The open and composable observability and data visualization platform.
   copyright:
     - license: AGPL-3.0-or-later
@@ -25,13 +25,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 1e84fede543acc892d2a2515187e545eb047f237
       repository: https://github.com/grafana/grafana
       tag: v${{package.version}}
-      expected-commit: 1e84fede543acc892d2a2515187e545eb047f237
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0
+      deps: golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7
       go-version: "1.21"
 
   - runs: |


### PR DESCRIPTION
CVE Remediation: GHSA-9763-4f94-gfch: fix CVE for Wolfi package grafana