### PR TITLE
CVE Remediation: GHSA-hq6q-c2x6-hmch/CVE Remediation: GHSA-f9jg-8p32-2f55/: fix CVE for Wolfi package argo-cd-2.8

### DIFF
--- a/argo-cd-2.8.yaml
+++ b/argo-cd-2.8.yaml
@@ -2,13 +2,13 @@
 package:
   name: argo-cd-2.8
   version: 2.8.7
-  epoch: 7
+  epoch: 8
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
-      - argo-cd=2.8.999 # When updating to 2.9, use ${{package.version}} instead of 2.9.999
+      - argo-cd=2.8.999
 
 environment:
   contents:
@@ -29,7 +29,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: k8s.io/kubernetes@v1.24.17 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
+      deps: k8s.io/kubernetes@v1.25.16 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
       replaces: github.com/whilp/git-urls=github.com/chainguard-dev/git-urls@v0.0.1
 
   - runs: |


### PR DESCRIPTION
CVE Remediation: GHSA-hq6q-c2x6-hmch/CVE Remediation: GHSA-f9jg-8p32-2f55/: fix CVE for Wolfi package argo-cd-2.8