### PR TITLE
add provides alias for latest postgresql

### DIFF
--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -5,6 +5,9 @@ package:
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD
+  dependencies:
+    provides:
+      - postgresql=${{package.full-version}}
 
 environment:
   contents:
@@ -58,6 +61,8 @@ subpackages:
     pipeline:
       - uses: split/dev
     dependencies:
+      provides:
+        - postgresql-dev=${{package.full-version}}
       runtime:
         - postgresql-16
         - openssl-dev
@@ -67,12 +72,18 @@ subpackages:
 
   - name: postgresql-16-client
     description: PostgreSQL client
+    dependencies:
+      provides:
+        - postgresql-client=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv ${{targets.destdir}}/usr/bin/psql ${{targets.subpkgdir}}/usr/bin/
 
   - name: postgresql-16-contrib
+    dependencies:
+      provides:
+        - postgresql-contrib=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}
@@ -87,6 +98,8 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib/libpq.so* ${{targets.subpkgdir}}/usr/lib/
     dependencies:
       provider-priority: 16
+      provides:
+        - libpq=${{package.full-version}}
 
   - name: postgresql-16-oci-entrypoint
     description: Entrypoint for using PostgreSQL in OCI containers


### PR DESCRIPTION
follow how we do other toolchains/databases and provide a `${{package.name}}` alias for the latest postgresql