### PR TITLE
new package: scap-security-guide

### DIFF
--- a/scap-security-guide.yaml
+++ b/scap-security-guide.yaml
@@ -1,0 +1,54 @@
+package:
+  name: scap-security-guide
+  version: 0.1.71
+  epoch: 0
+  description: Security automation content in SCAP, Bash, Ansible, and other formats
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - libxml2-dev
+      - openscap
+      - pcre2-dev
+      - py3-jinja2
+      - py3-lxml
+      - py3-pandas
+      - py3-setuptools
+      - py3-sphinx
+      - py3-yaml
+      - python-3
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ComplianceAsCode/content
+      expected-commit: 459f0abf2ac08d36e5fc4a2619bc75cff7000da9
+      tag: v${{package.version}}
+
+  - uses: cmake/configure
+    with:
+      # TODO: RHEL# product suite is not compiling
+      opts: |
+        -DSSG_ANSIBLE_PLAYBOOKS_ENABLED=False \
+        -DSSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED=False \
+        -DSSG_BASH_SCRIPTS_ENABLED=False \
+        -DSSG_BATS_TESTS_ENABLED=False \
+        -DSSG_PRODUCT_RHEL7=False \
+        -DSSG_PRODUCT_RHEL8=False \
+        -DSSG_PRODUCT_RHEL9=False
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: ComplianceAsCode/content
+    strip-prefix: v


### PR DESCRIPTION
new package, used for references for scanning with `openscap`