### PR TITLE
Add xcompmgr and libevdev

### DIFF
--- a/libevdev.yaml
+++ b/libevdev.yaml
@@ -1,0 +1,43 @@
+# Generated from https://git.alpinelinux.org/aports/plain/community/libevdev/APKBUILD
+package:
+    name: libevdev
+    version: 1.13.1
+    epoch: 0
+    description: Kernel Evdev Device Wrapper Library
+    copyright:
+        - license: MIT
+environment:
+    contents:
+        packages:
+            - busybox
+            - ca-certificates-bundle
+            - build-base
+            - automake
+            - autoconf
+            - linux-headers
+            - doxygen
+            - meson
+            - python3
+            - linux-headers
+pipeline:
+    - uses: fetch
+      with:
+        expected-sha256: 06a77bf2ac5c993305882bc1641017f5bec1592d6d1b64787bad492ab34f2f36
+        uri: https://freedesktop.org/software/libevdev/libevdev-${{package.version}}.tar.xz
+    - uses: autoconf/configure
+    - uses: autoconf/make
+    - uses: autoconf/make-install
+    - uses: strip
+subpackages:
+    - name: libevdev-dev
+      pipeline:
+        - uses: split/dev
+      dependencies:
+        runtime:
+            - libevdev
+            - linux-headers
+      description: libevdev dev
+    - name: libevdev-doc
+      pipeline:
+        - uses: split/manpages
+      description: libevdev manpages

--- a/xcompmgr.yaml
+++ b/xcompmgr.yaml
@@ -1,0 +1,36 @@
+# Generated from https://git.alpinelinux.org/aports/plain/testing/xcompmgr/APKBUILD
+package:
+    name: xcompmgr
+    version: 1.1.9
+    epoch: 0
+    description: Composite Window-effects manager for X.org
+    copyright:
+        - license: MIT
+environment:
+    contents:
+        packages:
+            - busybox
+            - ca-certificates-bundle
+            - build-base
+            - automake
+            - autoconf
+            - libx11-dev
+            - libxfixes-dev
+            - libxcomposite-dev
+            - libxdamage-dev
+            - libxrender-dev
+            - libxext-dev
+pipeline:
+    - uses: fetch
+      with:
+        expected-sha256: 4875b6698672d01eb3a5080bde6eac9a989d486a82226a2d5e23624f1527a6f0
+        uri: https://xorg.freedesktop.org/releases/individual/app/xcompmgr-${{package.version}}.tar.xz
+    - uses: autoconf/configure
+    - uses: autoconf/make
+    - uses: autoconf/make-install
+    - uses: strip
+subpackages:
+    - name: xcompmgr-doc
+      pipeline:
+        - uses: split/manpages
+      description: xcompmgr manpages


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
