### PR TITLE
curl: build with libpsl

### DIFF
--- a/curl.yaml
+++ b/curl.yaml
@@ -17,6 +17,7 @@ environment:
       - openssl-dev
       - wolfi-base
       - zlib-dev
+      - libpsl-dev
 
 pipeline:
   - uses: fetch

--- a/curl.yaml
+++ b/curl.yaml
@@ -13,11 +13,11 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libpsl-dev
       - nghttp2-dev
       - openssl-dev
       - wolfi-base
       - zlib-dev
-      - libpsl-dev
 
 pipeline:
   - uses: fetch

--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: 8.5.0
-  epoch: 0
+  epoch: 1
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -26,6 +26,7 @@ pipeline:
 
   - uses: autoconf/configure
     with:
+      # https://everything.curl.dev/build/deps#libpsl
       opts: |
         --enable-ipv6 \
         --enable-unix-sockets \
@@ -34,7 +35,8 @@ pipeline:
         --with-nghttp2 \
         --with-pic \
         --disable-ldap \
-        --without-libssh2
+        --without-libssh2 \
+        --with-libpsl
 
   - uses: autoconf/make
 

--- a/libpsl.yaml
+++ b/libpsl.yaml
@@ -52,3 +52,15 @@ subpackages:
     pipeline:
       - uses: split/manpages
     description: libpsl manpages
+
+  - name: libpsl-utils
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr
+          mv ${{targets.destdir}}/usr/bin ${{targets.subpkgdir}}/usr/
+    description: libpsl utils
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 7305

--- a/libpsl.yaml
+++ b/libpsl.yaml
@@ -1,0 +1,54 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/libpsl/APKBUILD
+package:
+  name: libpsl
+  version: 0.21.2
+  epoch: 0
+  description: C library for the Publix Suffix List
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libidn2-dev
+      - libunistring-dev
+      - meson
+      - python3
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: e35991b6e17001afa2c0ca3b10c357650602b92596209b7492802f3768a6285f
+      uri: https://github.com/rockdaboot/libpsl/releases/download/${{package.version}}/libpsl-${{package.version}}.tar.gz
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: libpsl-static
+    pipeline:
+      - uses: split/static
+    description: libpsl static
+
+  - name: libpsl-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - libpsl
+    description: libpsl dev
+
+  - name: libpsl-doc
+    pipeline:
+      - uses: split/manpages
+    description: libpsl manpages


### PR DESCRIPTION
https://everything.curl.dev/build/deps#libpsl

> ## libpsl
> https://rockdaboot.github.io/libpsl/
> When you build curl with support for libpsl, the cookie parser knows about the Public Suffix List and thus handle such cookies appropriately.