### PR TITLE
Bump libcap epoch

### DIFF
--- a/libcap.yaml
+++ b/libcap.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcap
   version: "2.69"
-  epoch: 0
+  epoch: 1
   description: "POSIX 1003.1e capabilities"
   copyright:
     - license: BSD-3-Clause OR GPL-2.0-only


### PR DESCRIPTION
This hasn't been rebuilt in a while but the provides are broken.

```
[sdk] ❯ apk add libcap
WARNING: opening ./../../packages: No such file or directory
ERROR: unable to select packages:
  libcap-2.68-r0:
    conflicts: libcap-2.69-r0
    satisfies: world[libcap] libcap-2.69-r0[so:libcap.so.2] libcap-2.69-r0[so:libpsx.so.2]
  libcap-2.69-r0:
    conflicts: libcap-2.68-r0
    satisfies: world[libcap]
```