### PR TITLE
GHSA-ppxx-5m9h-6vxf: fix CVE for Wolfi package caddy

### DIFF
--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: caddy
   version: 2.7.6
-  epoch: 1
+  epoch: 2
   description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
   copyright:
     - license: Apache-2.0
@@ -27,9 +27,8 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0
+      deps: golang.org/x/crypto@v0.17.0 github.com/quic-go/quic-go@v0.40.1
 
-  # TODO: Add support for plugins
   - uses: go/build
     with:
       ldflags: -s -w


### PR DESCRIPTION
GHSA-ppxx-5m9h-6vxf: fix CVE for Wolfi package caddy