### PR TITLE
GHSA-8pgv-569h-w5rw: fix CVE for Wolfi package temporal

### DIFF
--- a/temporal.yaml
+++ b/temporal.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal
   version: 0.10.7
-  epoch: 3
+  epoch: 4
   description: Command-line interface for running Temporal Server and interacting with Workflows, Activities, Namespaces, and other parts of Temporal
   copyright:
     - license: MIT License
@@ -20,19 +20,19 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 5a42bcc792e8dd907fd93a20c61943872772c15e
       repository: https://github.com/temporalio/cli
       tag: v${{package.version}}
-      expected-commit: 5a42bcc792e8dd907fd93a20c61943872772c15e
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0
+      deps: golang.org/x/crypto@v0.17.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
 
   - uses: go/build
     with:
-      packages: ./cmd/temporal
-      output: temporal
       ldflags: -s -w
+      output: temporal
+      packages: ./cmd/temporal
 
   - uses: strip
 


### PR DESCRIPTION
GHSA-8pgv-569h-w5rw: fix CVE for Wolfi package temporal