### PR TITLE
GHSA-9763-4f94-gfch: fix CVE for Wolfi package cosign

### DIFF
--- a/cosign.yaml
+++ b/cosign.yaml
@@ -1,7 +1,7 @@
 package:
   name: cosign
   version: 2.2.2
-  epoch: 1
+  epoch: 2
   description: Container Signing
   copyright:
     - license: Apache-2.0
@@ -21,19 +21,19 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://github.com/sigstore/cosign/archive/v${{package.version}}/cosign-v${{package.version}}.tar.gz
       expected-sha256: a1a9231d3768989b89f2b031b6d72adac0b0eb1e1276313efa0afdc9ed56398b
+      uri: https://github.com/sigstore/cosign/archive/v${{package.version}}/cosign-v${{package.version}}.tar.gz
 
   - uses: go/bump
     with:
-      deps: github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0
+      deps: github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7
       go-version: "1.21"
 
   - uses: go/build
     with:
-      packages: ./cmd/cosign
-      output: cosign
       ldflags: -s -w -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}}
+      output: cosign
+      packages: ./cmd/cosign
 
   - uses: strip
 


### PR DESCRIPTION
GHSA-9763-4f94-gfch: fix CVE for Wolfi package cosign