### PR TITLE
CVE Remediation: GHSA-rcjv-mgp8-qvmr/GHSA-8pgv-569h-w5rw/GHSA-45x7-px36-x8w8/: fix CVE for Wolfi package kubernetes-1.29

### DIFF
--- a/kubernetes-1.29.yaml
+++ b/kubernetes-1.29.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.29
   version: 1.29.0
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -39,9 +39,13 @@ vars:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 3f7a50f38688eb332e2a1b013678c6435d539ae6
       repository: https://github.com/kubernetes/kubernetes
       tag: v${{package.version}}
-      expected-commit: 3f7a50f38688eb332e2a1b013678c6435d539ae6
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful@v0.44.0
 
   - runs: |
       # Use our Go version instead of downloading another one


### PR DESCRIPTION
CVE Remediation: GHSA-rcjv-mgp8-qvmr/GHSA-8pgv-569h-w5rw/GHSA-45x7-px36-x8w8/: fix CVE for Wolfi package kubernetes-1.29