### PR TITLE
CVE Remediation: GHSA-v86x-5fm3-5p7j/CVE-2023-48795/: fix CVE for Wolfi package thanos-0.31

### DIFF
--- a/thanos-0.31.yaml
+++ b/thanos-0.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-0.31
   version: 0.31.0
-  epoch: 12
+  epoch: 13
   description: Highly available Prometheus setup with long term storage capabilities.
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0 golang.org/x/crypto@v0.17.0 github.com/prometheus/alertmanager@v0.25.1
+      deps: golang.org/x/crypto@v0.17.0 golang.org/x/crypto@v0.17.0 github.com/prometheus/alertmanager@v0.25.1 thanos-0.31@v0.31.0-r10
 
   - runs: |
       # Fails to build on go1.21 without this. Remove in next release.


### PR DESCRIPTION
CVE Remediation: GHSA-v86x-5fm3-5p7j/CVE-2023-48795/: fix CVE for Wolfi package thanos-0.31