### PR TITLE
CVE Remediation: GHSA-jq35-85cj-fj4p/GHSA-fwv2-65wh-2w8c/GHSA-2w8w-qhg4-f78j/: fix CVE for Wolfi package telegraf-1.26

### DIFF
--- a/telegraf-1.26.yaml
+++ b/telegraf-1.26.yaml
@@ -1,12 +1,12 @@
 package:
   name: telegraf-1.26
   version: 1.26.3
-  epoch: 9
+  epoch: 10
   copyright:
     - license: MIT
   dependencies:
     provides:
-      - telegraf=1.26.999 # This is because we had a 1.26.0 telegraf package, remove in 1.28+
+      - telegraf=1.26.999
 
 environment:
   contents:
@@ -26,15 +26,15 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.17.0 github.com/nats-io/nats-server/v2@v2.9.23 google.golang.org/grpc@v1.56.3 github.com/nats-io/nkeys@v0.4.6 golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.6.26 github.com/dvsekhvalnov/jose2go@v1.5.1-0.20231206184617-48ba0b76bc88
+      deps: golang.org/x/net@v0.17.0 github.com/nats-io/nats-server/v2@v2.9.23 google.golang.org/grpc@v1.56.3 github.com/nats-io/nkeys@v0.4.6 golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.6.26 github.com/dvsekhvalnov/jose2go@v1.5.1-0.20231206184617-48ba0b76bc88 github.com/jaegertracing/jaeger@v1.47.0 github.com/snowflakedb/gosnowflake@v1.6.19 github.com/docker/docker@v23.0.8
 
-  - if: ${{build.arch}} == 'x86_64'
-    runs: |
+  - runs: |
       make package include_packages="linux_amd64.tar.gz"
+    if: ${{build.arch}} == 'x86_64'
 
-  - if: ${{build.arch}} == 'aarch64'
-    runs: |
+  - runs: |
       make package include_packages="linux_arm64.tar.gz"
+    if: ${{build.arch}} == 'aarch64'
 
   - runs: |
       tar -xf build/dist/telegraf-${{package.version}}*.tar.gz


### PR DESCRIPTION
CVE Remediation: GHSA-jq35-85cj-fj4p/GHSA-fwv2-65wh-2w8c/GHSA-2w8w-qhg4-f78j/: fix CVE for Wolfi package telegraf-1.26