### PR TITLE
GHSA-9763-4f94-gfch: fix CVE for Wolfi package rclone

### DIFF
--- a/rclone.yaml
+++ b/rclone.yaml
@@ -1,8 +1,8 @@
 package:
   name: rclone
   version: 1.65.1
-  epoch: 1
-  description: "rsync for cloud storage - Google Drive, S3, Dropbox, Backblaze B2, One Drive, Swift, Hubic, Wasabi, Google Cloud Storage, Yandex Files"
+  epoch: 2
+  description: rsync for cloud storage - Google Drive, S3, Dropbox, Backblaze B2, One Drive, Swift, Hubic, Wasabi, Google Cloud Storage, Yandex Files
   copyright:
     - license: MIT
   dependencies:
@@ -20,13 +20,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 863b4125c3ef994094b1821e87518a0619f4b484
       repository: https://github.com/rclone/rclone
       tag: v${{package.version}}
-      expected-commit: 863b4125c3ef994094b1821e87518a0619f4b484
 
   - uses: go/bump
     with:
-      deps: github.com/go-resty/resty/v2@v2.11.0
+      deps: github.com/go-resty/resty/v2@v2.11.0 github.com/cloudflare/circl@v1.3.7
 
   - runs: |
       CGO_ENABLED=0 make


### PR DESCRIPTION
GHSA-9763-4f94-gfch: fix CVE for Wolfi package rclone