### PR TITLE
GHSA-9763-4f94-gfch: fix CVE for Wolfi package pulumi-kubernetes-operator

### DIFF
--- a/pulumi-kubernetes-operator.yaml
+++ b/pulumi-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-kubernetes-operator
   version: 1.14.0
-  epoch: 4
+  epoch: 5
   description: A Kubernetes Operator that automates the deployment of Pulumi Stacks
   copyright:
     - license: Apache-2.0
@@ -17,13 +17,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 7d9e693bc6e27f1e3881ce350cdf7fbde71b26be
       repository: https://github.com/pulumi/pulumi-kubernetes-operator.git
       tag: v${{package.version}}
-      expected-commit: 7d9e693bc6e27f1e3881ce350cdf7fbde71b26be
 
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3 golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0
+      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3 golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
 
   - runs: |
       # GHSA-3f2q-6294-fmq5 CVE-2023-46402


### PR DESCRIPTION
GHSA-9763-4f94-gfch: fix CVE for Wolfi package pulumi-kubernetes-operator