### PR TITLE
GHSA-8pgv-569h-w5rw: fix CVE for Wolfi package temporal-server

### DIFF
--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -30,7 +30,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.58.3 golang.org/x/crypto@v0.17.0
+      deps: google.golang.org/grpc@v1.58.3 golang.org/x/crypto@v0.17.0
 
   - runs: |
       make bins


### PR DESCRIPTION
GHSA-8pgv-569h-w5rw: fix CVE for Wolfi package temporal-server