### PR TITLE
CVE Remediation: GHSA-rcjv-mgp8-qvmr/GHSA-m425-mq94-257g/GHSA-45x7-px36-x8w8/: fix CVE for Wolfi package ipfs

### DIFF
--- a/ipfs.yaml
+++ b/ipfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: ipfs
   version: 0.25.0
-  epoch: 0
+  epoch: 1
   description: An IPFS implementation in Go
   copyright:
     - license: Apache-2.0
@@ -22,9 +22,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 413a52d0eed8582e4c1511e210d7e3f36fe2fe3a
       repository: https://github.com/ipfs/kubo
       tag: v${{package.version}}
-      expected-commit: 413a52d0eed8582e4c1511e210d7e3f36fe2fe3a
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0 google.golang.org/grpc@v1.56.3 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
 
   - runs: |
       CGO_ENABLED=1 GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) GOFLAGS=-buildvcs=false make build GOTAGS=openssl


### PR DESCRIPTION
CVE Remediation: GHSA-rcjv-mgp8-qvmr/GHSA-m425-mq94-257g/GHSA-45x7-px36-x8w8/: fix CVE for Wolfi package ipfs