### PR TITLE
GHSA-9763-4f94-gfch: fix CVE for Wolfi package terraform-provider-azurerm

### DIFF
--- a/terraform-provider-azurerm.yaml
+++ b/terraform-provider-azurerm.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-azurerm
   version: 3.86.0
-  epoch: 0
+  epoch: 1
   description: Terraform provider for Azure Resource Manager
   copyright:
     - license: MPL-2.0
@@ -18,21 +18,21 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 52734966f765c12a9537644f72d34cab1e1ab0cf
       repository: https://github.com/hashicorp/terraform-provider-azurerm
       tag: v${{package.version}}
-      expected-commit: 52734966f765c12a9537644f72d34cab1e1ab0cf
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0
+      deps: golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7
       go-version: "1.21"
 
   - uses: go/build
     with:
-      packages: .
-      output: terraform-provider-azurerm
       ldflags: -s -w
-      vendor: true
+      output: terraform-provider-azurerm
+      packages: .
+      vendor: "true"
 
   - runs: |
       GOARCH=$(go env GOARCH)


### PR DESCRIPTION
GHSA-9763-4f94-gfch: fix CVE for Wolfi package terraform-provider-azurerm