### PR TITLE
GHSA-9763-4f94-gfch: fix CVE for Wolfi package pulumi-language-java

### DIFF
--- a/pulumi-language-java.yaml
+++ b/pulumi-language-java.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-java
   version: 0.9.9
-  epoch: 1
+  epoch: 2
   description: Pulumi Language SDK for Java
   copyright:
     - license: Apache-2.0
@@ -17,21 +17,21 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: e40b98d061194998c2ade7a7ec4b726e0f0c2af6
       repository: https://github.com/pulumi/pulumi-java.git
       tag: v${{package.version}}
-      expected-commit: e40b98d061194998c2ade7a7ec4b726e0f0c2af6
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0
+      deps: golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
       modroot: pkg
 
   - uses: go/build
     with:
-      modroot: pkg
-      packages: ./cmd/pulumi-language-java
-      output: pulumi-language-java
       ldflags: -s -w -X github.com/pulumi/pulumi-java/pkg/version.Version=v${{package.version}}
+      modroot: pkg
+      output: pulumi-language-java
+      packages: ./cmd/pulumi-language-java
 
   - uses: strip
 


### PR DESCRIPTION
GHSA-9763-4f94-gfch: fix CVE for Wolfi package pulumi-language-java