### PR TITLE
metric-collector-for-apache-cassandra

### DIFF
--- a/metric-collector-for-apache-cassandra.yaml
+++ b/metric-collector-for-apache-cassandra.yaml
@@ -1,0 +1,46 @@
+package:
+  name: metric-collector-for-apache-cassandra
+  version: 0.3.5
+  epoch: 0
+  description: Drop-in metrics collection and dashboards for Apache Cassandra
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - bash
+      - busybox
+      - ca-certificates-bundle
+      - maven
+      - openjdk-11
+      - openjdk-11-default-jvm
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/datastax/metric-collector-for-apache-cassandra
+      expected-commit: f97a258ea95d055c71f762c3725061f43678ae1f
+      tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      patches: upgrade-deps.patch
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/opt/metrics-collector
+      mkdir -p "${{targets.destdir}}"/opt/metrics-collector/lib
+      mkdir -p "${{targets.destdir}}"/opt/metrics-collector/config
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+      mvn -q -ff package -DskipTests
+      cp ./target/datastax-mcac-agent-*.jar "${{targets.destdir}}"/opt/metrics-collector
+      cp -r ./target/collectd "${{targets.destdir}}"/opt/metrics-collector/lib
+      cp ./config/collectd.conf.tmpl "${{targets.destdir}}"/opt/metrics-collector/config
+      cp ./config/metric-collector.yaml "${{targets.destdir}}"/opt/metrics-collector/config
+      cp -r ./scripts "${{targets.destdir}}"/opt/metrics-collector
+
+update:
+  enabled: true
+  github:
+    identifier: datastax/metric-collector-for-apache-cassandra
+    strip-prefix: v

--- a/metric-collector-for-apache-cassandra/upgrade-deps.patch
+++ b/metric-collector-for-apache-cassandra/upgrade-deps.patch
@@ -1,0 +1,26 @@
+From a4c6a6527daa536a2cf52849ea3ce7113c61592e Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Sat, 13 Jan 2024 00:50:37 +0300
+Subject: [PATCH] upgrade deps
+
+Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+---
+ pom.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pom.xml b/pom.xml
+index 25f2d82..b4f6988 100755
+--- a/pom.xml
++++ b/pom.xml
+@@ -44,7 +44,7 @@
+         <dependency>
+             <groupId>org.yaml</groupId>
+             <artifactId>snakeyaml</artifactId>
+-            <version>1.26</version>
++            <version>1.33</version>
+         </dependency>
+         <dependency>
+             <groupId>com.github.docker-java</groupId>
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
