### PR TITLE
management-api-for-apache-cassandra

### DIFF
--- a/management-api-for-apache-cassandra.yaml
+++ b/management-api-for-apache-cassandra.yaml
@@ -1,0 +1,52 @@
+package:
+  name: management-api-for-apache-cassandra
+  version: 0.1.72
+  epoch: 0
+  description: RESTful / Secure Management Sidecar for Apache Cassandra
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - maven
+      - openjdk-11
+      - openjdk-11-default-jvm
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/k8ssandra/management-api-for-apache-cassandra
+      expected-commit: fc0ec73f57aa06bb9108d76c6c01dd750f1a5095
+      tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      patches: upgrade-deps.patch
+
+  - runs: |
+      MAAC_PATH="${{targets.destdir}}"/opt/management-api
+      mkdir -p "${{targets.destdir}}"/usr/local/bin
+      mkdir -p "${{targets.destdir}}"/opt/management-api
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+      mvn -q -ff package -DskipTests -DskipOpenApi
+
+      cp ./scripts/docker-entrypoint.sh "${{targets.destdir}}"/usr/local/bin/
+      find . -type f -name "datastax-*.jar" -exec mv -t $MAAC_PATH -i '{}' +
+      chmod +x "${{targets.destdir}}"/usr/local/bin/docker-entrypoint.sh
+
+subpackages:
+  - name: management-api-for-apache-cassandra-compat
+    pipeline:
+      - runs: |
+          ln -s "${{targets.destdir}}"/opt/management-api/datastax-mgmtapi-agent-4.1.x-0.1.0-SNAPSHOT.jar "${{targets.destdir}}"/opt/management-api/datastax-mgmtapi-agent.jar
+          ln -s "${{targets.destdir}}"/opt/management-api/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar "${{targets.destdir}}"/opt/management-api/datastax-mgmtapi-server.jar
+          ln -sf "${{targets.destdir}}"/usr/local/bin/docker-entrypoint.sh "${{targets.destdir}}"/docker-entrypoint.sh
+
+update:
+  enabled: true
+  github:
+    identifier: k8ssandra/management-api-for-apache-cassandra
+    strip-prefix: v

--- a/management-api-for-apache-cassandra/upgrade-deps.patch
+++ b/management-api-for-apache-cassandra/upgrade-deps.patch
@@ -1,0 +1,55 @@
+From ced3dc07c8a3cfa3277b4088b102fc05c2a343f4 Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Sun, 14 Jan 2024 20:08:54 +0300
+Subject: [PATCH] upgrade deps
+
+Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+---
+ management-api-server/pom.xml | 4 ++--
+ pom.xml                       | 6 +++---
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/management-api-server/pom.xml b/management-api-server/pom.xml
+index f2b9659..f638e0d 100644
+--- a/management-api-server/pom.xml
++++ b/management-api-server/pom.xml
+@@ -17,10 +17,10 @@
+   <artifactId>datastax-mgmtapi-server</artifactId>
+   <properties>
+     <rsapi.version>2.1.1</rsapi.version>
+-    <guava.version>30.1.1-jre</guava.version>
++    <guava.version>32.0.0-android</guava.version>
+     <airline.version>2.7.0</airline.version>
+     <jaxrs.version>2.1.6</jaxrs.version>
+-    <resteasy.version>4.5.9.Final</resteasy.version>
++    <resteasy.version>4.6.1.Final</resteasy.version>
+     <awaitility.version>4.0.3</awaitility.version>
+     <assertj.version>3.17.2</assertj.version>
+     <servelet.version>3.1.0</servelet.version>
+diff --git a/pom.xml b/pom.xml
+index 00cd64f..8803b67 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -16,7 +16,7 @@
+   <properties>
+     <build.version.file>build_version.sh</build.version.file>
+     <revision>0.1.0-SNAPSHOT</revision>
+-    <driver.version>4.15.0</driver.version>
++    <driver.version>4.17.0</driver.version>
+     <cassandra3.version>3.11.16</cassandra3.version>
+     <cassandra4.version>4.0.11</cassandra4.version>
+     <docker.java.version>3.2.13</docker.java.version>
+@@ -25,8 +25,8 @@
+     <bytebuddy.version>1.12.19</bytebuddy.version>
+     <build.version.file>build_version.sh</build.version.file>
+     <slf4j.version>1.7.25</slf4j.version>
+-    <logback.version>1.2.9</logback.version>
+-    <netty.version>4.1.78.Final</netty.version>
++    <logback.version>1.2.13</logback.version>
++    <netty.version>4.1.100.Final</netty.version>
+     <mockito.version>3.5.13</mockito.version>
+     <prometheus.version>0.16.0</prometheus.version>
+     <!-- This old version is used by Cassandra 4.x -->
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: https://github.com/wolfi-dev/advisories/pull/848

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
