### PR TITLE
CVE Remediation: GHSA-xwh9-gc39-5298: fix CVE for Wolfi package prometheus

### DIFF
--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus
   version: 2.49.0
-  epoch: 0
+  epoch: 1
   description: The Prometheus monitoring system and time series database.
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0 github.com/docker/docker@v24.0.7
+      deps: golang.org/x/crypto@v0.17.0 github.com/docker/docker@v24.0.7 github.com/go-resty/resty/v2@v2.11.0
 
   - runs: |
       GOLDFLAGS="-s -w -X github.com/prometheus/common/version.Version=${{package.version}}


### PR DESCRIPTION
CVE Remediation: GHSA-xwh9-gc39-5298: fix CVE for Wolfi package prometheus