### PR TITLE
Add more comprehensive recursive support

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -24,7 +24,10 @@ jobs:
         id: changes
         uses: tj-actions/changed-files@716b1e13042866565e00e85fd4ec490e186c4a2f #tj-actions/changed-files@v41.0.1
         with:
-          files: ./*.yaml
+          files_yaml: |
+            melange:
+              - ./*.yaml # Only top level files without structure
+              - ./*/*/*.melange.yaml # Support recursive melange files with the new naming convention.
 
       - name: "Install wolfictl onto PATH"
         run: |
@@ -44,8 +47,14 @@ jobs:
               -r https://packages.wolfi.dev/bootstrap/stage3 \
               -k https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub > packages-list
           while read pkg; do
-            for file in ${{ steps.changes.outputs.all_changed_files }}; do
-              [ "${file%.yaml}" = "$pkg" ] && printf "%s " ${file%.yaml} >> $GITHUB_OUTPUT
+            for file in ${{ steps.changes.outputs.melange_all_changed_files }}; do
+              # Since the file is a path, we need to strip out only the file
+              # name from it.
+              base_file=$(basename $file)
+              base_file="${base_file%.melange.yaml}"
+              base_file="${base_file%.yaml}"
+              printf "base_file: $base_file"
+              [ "${base_file}" = "$pkg" ] && printf "%s " ${base_file} >> $GITHUB_OUTPUT
             done
           done < packages-list
 

--- a/Makefile
+++ b/Makefile
@@ -86,22 +86,79 @@ list-yaml:
 	$(info $(addsuffix .yaml,$(shell $(PKGLISTCMD))))
 	@printf ''
 
+# This function parses the path from the package file. It's used to figure out
+# what to mount to the container image as supporting files (patches, tests,
+# etc.)
+# Returns the directory of the package in the first variable passed in. In
+# example below this would be ret-variable-in-calling-function. You do not need
+# to explicitly declare this variable in the calling function, just add to
+# argument list and it will be populated and usable.
+#
+# $(call get-package-dir,ret-variable-in-calling-function,package-file)
+define get-package-dir
+	$(info getting package dir for $(2))
+	$(eval pkgdir := $(shell dirname $(2)))
+	$(info For package $(1) found dir: $(pkgdir))
+	$(1) := ${pkgdir}
+endef
+
+# This function tries to figure out what the 'source-dir' is for the package.
+# It's complicated by the fact that it can either be './<package-name>' for
+# packages before the refactoring, or it can be a relative path
+# './<module>/package/', and in some cases it may not exist.
+# To make it easier on the caller, it returns the entire:
+# `--source-dir ./<package-name>`, or `--source-dir ./<module>/package/`, or ""
+# as the first variable passed in, and this is meant to be directly passed
+# to the melange build/test command.
+#
+#$(call get-source-dir,ret-variable-for-source-dir,package-dir,package-name)
+define get-source-dir
+	$(info getting source dir for package $(3) with dir $(2))
+	$(1) := $(shell if [[ "." == "$(2)" ]]; then \
+		if [[ -d "./$(3)" ]]; then \
+			echo "--source-dir ./$(3)"; \
+		fi \
+	else \
+		if [[ -d "$(2)" ]]; then \
+			echo "--source-dir $(2)"; \
+		fi \
+	fi)
+endef
+
 package/%:
 	$(eval yamlfile := $(shell find . -type f \( -name "$*.yaml" -o -path "*/$*/$*.melange.yaml" \) | head -n 1))
+	@if [ -z "$(yamlfile)" ]; then \
+		echo "Error: could not find yaml file for $*"; exit 1; \
+	else \
+		echo "yamlfile is $(yamlfile)"; \
+	fi
+	$(eval $(call get-package-dir,pkgdir,$(yamlfile)))
+	$(info found package dir as $(pkgdir))
+	$(eval $(call get-source-dir,sourcedir,$(pkgdir),$*))
+	$(info found source dir as $(sourcedir))
 	$(eval pkgver := $(shell $(MELANGE) package-version $(yamlfile)))
 	@printf "Building package $* with version $(pkgver) from file $(yamlfile)\n"
-	$(MAKE) yamlfile=$(yamlfile) pkgname=$* packages/$(ARCH)/$(pkgver).apk
-
-test/%:
-	$(eval yamlfile := $(shell find . -type f \( -name "$*.yaml" -o -path "*/$*/$*.melange.yaml" \) | head -n 1))
-	$(eval pkgver := $(shell $(MELANGE) package-version $(yamlfile)))
-	@printf "Testing package $* with version $(pkgver) from file $(yamlfile)\n"
-	$(MELANGE) test $(yamlfile) --source-dir ./$*/ $(MELANGE_TEST_OPTS) --log-policy builtin:stderr
+	$(MAKE) yamlfile=$(yamlfile) srcdirflag="$(sourcedir)" pkgname=$* packages/$(ARCH)/$(pkgver).apk
 
 packages/$(ARCH)/%.apk: $(KEY)
 	@mkdir -p ./$(pkgname)/
 	$(eval SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct --follow $(yamlfile)))
-	@SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) --source-dir ./$(pkgname)/ --log-policy builtin:stderr,$(TARGETDIR)/buildlogs/$*.log
+	@SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) $(srcdirflag) --log-policy builtin:stderr,$(TARGETDIR)/buildlogs/$*.log
+
+test/%:
+	$(eval yamlfile := $(shell find . -type f \( -name "$*.yaml" -o -path "*/$*/$*.melange.yaml" \) | head -n 1))
+	@if [ -z "$(yamlfile)" ]; then \
+		echo "Error: could not find yaml file for $*"; exit 1; \
+	else \
+		echo "yamlfile is $(yamlfile)"; \
+	fi
+	$(eval $(call get-package-dir,pkgdir,$(yamlfile)))
+	$(info found package dir as $(pkgdir))
+	$(eval $(call get-source-dir,sourcedir,$(pkgdir),$*))
+	$(info found source dir as $(sourcedir))
+	$(eval pkgver := $(shell $(MELANGE) package-version $(yamlfile)))
+	@printf "Testing package $* with version $(pkgver) from file $(yamlfile)\n"
+	$(MELANGE) test $(yamlfile) $(sourcedir) $(MELANGE_TEST_OPTS) --log-policy builtin:stderr
 
 dev-container:
 	docker run --privileged --rm -it \


### PR DESCRIPTION
Add support for the planned recursive repo. Wires through source-dir so that things like patches
get properly processed.

This is broken into two commits, one to demonstrate changes to the Makefile, and the second that shows how
moving a trino to subdirectory will be processed correctly with the patches applied.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
