### PR TITLE
fix: remove unnecessary 'go mod vendor' cmd

### DIFF
--- a/containerd.yaml
+++ b/containerd.yaml
@@ -1,7 +1,7 @@
 package:
   name: containerd
   version: 1.7.12
-  epoch: 1
+  epoch: 2
   description: An open and reliable container runtime
   copyright:
     - license: Apache-2.0
@@ -30,8 +30,6 @@ pipeline:
       deps: golang.org/x/crypto@v0.17.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel/sdk@v1.20.0
 
   - runs: |
-      go mod vendor
-
       make VERSION="v${{package.version}}"
 
   - runs: |

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,7 +1,7 @@
 package:
   name: skaffold
   version: 2.10.0
-  epoch: 2
+  epoch: 3
   description: Easy and Repeatable Kubernetes Development
   copyright:
     - license: Apache-2.0
@@ -29,7 +29,6 @@ pipeline:
       go-version: "1.21"
 
   - runs: |
-      go mod vendor
       make
       install -m755 -D ./out/skaffold "${{targets.destdir}}"/usr/bin/skaffold
 


### PR DESCRIPTION
I've added `go mod vendor` when gobump should be handling that.