### PR TITLE
Bump libcap to pick up melange SCA fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ dev-container:
 	    -v "${PWD}:${PWD}" \
 	    -w "${PWD}" \
 	    -e SOURCE_DATE_EPOCH=0 \
-	    ghcr.io/wolfi-dev/sdk@sha256:d4dd58e64afeecc9705a3b4219d25fc17fcd44464674e356a44a04773c3762d9
+	    ghcr.io/wolfi-dev/sdk@sha256:3b44bf9ce249fde260d21f94bbddff12c05ae109a11b485e965ac6d58c5f86c5
 
 PACKAGES_CONTAINER_FOLDER ?= /work/packages
 TMP_REPOSITORIES_DIR := $(shell mktemp -d)
@@ -173,6 +173,6 @@ dev-container-wolfi:
 		--mount type=bind,source="${PWD}/local-melange.rsa.pub",destination="/etc/apk/keys/local-melange.rsa.pub",readonly \
 		--mount type=bind,source="$(TMP_REPOSITORIES_FILE)",destination="/etc/apk/repositories",readonly \
 		-w "$(PACKAGES_CONTAINER_FOLDER)" \
-		ghcr.io/wolfi-dev/sdk@sha256:d4dd58e64afeecc9705a3b4219d25fc17fcd44464674e356a44a04773c3762d9
+		ghcr.io/wolfi-dev/sdk@sha256:3b44bf9ce249fde260d21f94bbddff12c05ae109a11b485e965ac6d58c5f86c5
 	@rm "$(TMP_REPOSITORIES_FILE)"
 	@rmdir "$(TMP_REPOSITORIES_DIR)"

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcap
   version: "2.69"
-  epoch: 1
+  epoch: 2
   description: "POSIX 1003.1e capabilities"
   copyright:
     - license: BSD-3-Clause OR GPL-2.0-only


### PR DESCRIPTION
This fixes an issue with executable shared objects missing provides.

```
[sdk] ❯ tar -Oxf packages/aarch64/libcap-2.69-r2.apk .PKGINFO
# Generated by melange.
pkgname = libcap
pkgver = 2.69-r2
arch = aarch64
size = 176528
origin = libcap
pkgdesc = POSIX 1003.1e capabilities
url =
commit = 6c9e71c6430b068beb67d3cf1ab39e0493f4af7d
license = BSD-3-Clause OR GPL-2.0-only
depend = so:ld-linux-aarch64.so.1
depend = so:libc.so.6
provides = so:libcap.so.2=2
provides = so:libpsx.so.2=2
datahash = feb7e8ece0e359a208990f87cdac2edf18726ae6208f62eafd46c442bff8912f
```

Before:

```
curl -L https://packages.wolfi.dev/os/aarch64/libcap-2.69-r1.apk | tar -Oxz .PKGINFO
# Generated by melange.
pkgname = libcap
pkgver = 2.69-r1
arch = aarch64
size = 176528
origin = libcap
pkgdesc = POSIX 1003.1e capabilities
url = 
commit = c7f4d9b2f9f4f5dcc586ff03253cb040c5bf85c4
builddate = 1705198699
license = BSD-3-Clause OR GPL-2.0-only
depend = so:ld-linux-aarch64.so.1
depend = so:libc.so.6
depend = so:libpsx.so.2
provides = so:libcap.so.2=2
datahash = 5315267fb1fb2e22cea540fa03e6b29b8ea01229eb2e0cf9450c0ea793d68536
```