### PR TITLE
tekton-pipelines :: fix: cve GHSA-9763-4f94-gfch

### DIFF
--- a/tekton-pipelines.yaml
+++ b/tekton-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: tekton-pipelines
   version: 0.55.0
-  epoch: 2
+  epoch: 3
   description: A cloud-native Pipeline resource.
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/docker/docker@v24.0.7 golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0
+      deps: github.com/docker/docker@v24.0.7 golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
       go-version: 1.21
       modroot: tekton
 


### PR DESCRIPTION
On our dashboard, tekton-pipelines reported a CVE GHSA-9763-4f94-gfch, if you look at the source code you can see how they use an old version of circl. 

However when I scan the remote package,  I get no vulnerabilities 🤔 

```
wolfictl scan tekton-pipelines --remote
📡 Finding remote packages
🔎 Scanning "/var/folders/5z/z12256p10mv1flm169vbp5w40000gn/T/x86_64-tekton-pipelines-0.55.0-r2-535680142.apk"
✅ No vulnerabilities found
🔎 Scanning "/var/folders/5z/z12256p10mv1flm169vbp5w40000gn/T/aarch64-tekton-pipelines-0.55.0-r2-3931490237.apk"
✅ No vulnerabilities found
```
I checked the logs from the cve-remediation service for this package, but I didn't get anything. I assume we didn't get any vulnerability results for this one.