### PR TITLE
py3-sqlalchemy-cockroachdb: fix correct url so it can update

### DIFF
--- a/py3-sqlalchemy-cockroachdb.yaml
+++ b/py3-sqlalchemy-cockroachdb.yaml
@@ -25,7 +25,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: ddb46e2da53d812bf7b8ef21c3cafb918004747f815a283f374796bf57a9497a
-      uri: https://files.pythonhosted.org/packages/72/74/7157d36dee9175864f803fdbc931913dac17b0d4eee24727dbdac1244543/sqlalchemy-cockroachdb-${{package.version}}.tar.gz
+      uri: https://files.pythonhosted.org/packages/source/s/sqlalchemy-cockroachdb/sqlalchemy-cockroachdb-${{package.version}}.tar.gz
 
   - name: Python Build
     uses: python/build-wheel


### PR DESCRIPTION
fixes #10961 