### PR TITLE
adds venv method for cassandra-medusa

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -6,6 +6,9 @@ package:
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
+  options:
+    no-provides: true
+    no-depends: true
   dependencies:
     runtime:
       - python3
@@ -29,6 +32,10 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 4a34c29ea09010420a7139336a2758a7c765e343
 
+  - uses: patch
+    with:
+      patches: bump.patch
+
   - name: Python Build
     runs: |
       pip install wheel
@@ -44,20 +51,18 @@ pipeline:
       .venv/bin/pip install -I --no-compile dist/*.whl
 
   - runs: |
-      mkdir -p ${{targets.destdir}}/usr/share/py3-cassandra-medusa
-      mv .venv ${{targets.destdir}}/usr/share/py3-cassandra-medusa/
+      mkdir -p ${{targets.destdir}}/usr/share/medusa
+      mv .venv ${{targets.destdir}}/usr/share/medusa/
 
       # edit the venv paths
-      sed -i "s|/home/build|/usr/share/py3-cassandra-medusa|g" ${{targets.destdir}}/usr/share/py3-cassandra-medusa/.venv/bin/*
+      sed -i "s|/home/build|/usr/share/medusa|g" ${{targets.destdir}}/usr/share/medusa/.venv/bin/*
 
       # allow site-packages
-      sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/py3-cassandra-medusa/.venv/pyvenv.cfg
+      sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/medusa/.venv/pyvenv.cfg
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
-      ln -s /usr/share/py3-cassandra-medusa/.venv/bin/py3-cassandra-medusa ${{targets.destdir}}/usr/bin/py3-cassandra-medusa
-
-  - uses: strip
+      ln -s /usr/share/medusa/.venv/bin/medusa ${{targets.destdir}}/usr/bin/medusa
 
 subpackages:
   - name: "${{package.name}}-compat"

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,44 +2,12 @@
 package:
   name: py3-cassandra-medusa
   version: 0.17.1
-  epoch: 1
+  epoch: 2
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - py3-python-dateutil
-      - py3-click
-      - py3-click-aliases
-      - py3-pyyaml
-      - py3-cassandra-driver
-      - py3-psutil
-      - py3-ffwd
-      - py3-lockfile
-      - py3-pyopenssl
-      - py3-cryptography
-      - py3-pycryptodome
-      - py3-retrying
-      - py3-parallel-ssh
-      - py3-ssh2-python
-      - py3-ssh-python
-      - py3-requests
-      - py3-protobuf
-      - py3-grpcio
-      - py3-grpcio-health-checking
-      - py3-grpcio-tools
-      - py3-gevent
-      - py3-greenlet
-      - py3-fasteners
-      - py3-datadog
-      - py3-botocore
-      - py3-dnspython
-      - py3-aiohttp
-      - py3-boto3
-      - py3-gcloud-aio-storage
-      - py3-azure-core
-      - py3-azure-identity
-      - py3-azure-storage-blob
       - python3
 
 environment:
@@ -48,6 +16,10 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - py3.11-installer
+      - py3.11-pip
+      - python-3.11
+      - python-3.11-dev
       - wolfi-base
 
 pipeline:
@@ -58,7 +30,32 @@ pipeline:
       expected-commit: 4a34c29ea09010420a7139336a2758a7c765e343
 
   - name: Python Build
-    uses: python/build-wheel
+    runs: |
+      pip install wheel
+      python setup.py bdist_wheel
+
+  - runs: |
+      # Setup the virtualenv
+      python -m venv .venv --system-site-packages
+      # Bump pip to patch a CVE
+      .venv/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
+
+  - runs: |
+      .venv/bin/pip install -I --no-compile dist/*.whl
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/py3-cassandra-medusa
+      mv .venv ${{targets.destdir}}/usr/share/py3-cassandra-medusa/
+
+      # edit the venv paths
+      sed -i "s|/home/build|/usr/share/py3-cassandra-medusa|g" ${{targets.destdir}}/usr/share/py3-cassandra-medusa/.venv/bin/*
+
+      # allow site-packages
+      sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/py3-cassandra-medusa/.venv/pyvenv.cfg
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      ln -s /usr/share/py3-cassandra-medusa/.venv/bin/py3-cassandra-medusa ${{targets.destdir}}/usr/bin/py3-cassandra-medusa
 
   - uses: strip
 

--- a/py3-cassandra-medusa/bump.patch
+++ b/py3-cassandra-medusa/bump.patch
@@ -1,0 +1,29 @@
+diff --git a/setup.py b/setup.py
+index 9727ac2..a7a0f7b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -50,13 +50,13 @@ setuptools.setup(
+         'ffwd>=0.0.2',
+         'lockfile>=0.12.2',
+         'pyOpenSSL==22.0.0',
+-        'cryptography<=35.0,>=2.5',
++        'cryptography<=41.0.6,>=2.5',
+         'pycryptodome>=3.9.9',
+         'retrying>=1.3.3',
+         'parallel-ssh==2.2.0',
+         'ssh2-python==1.0.0',
+         'ssh-python>=0.8.0',
+-        'requests==2.22.0',
++        'requests==2.31.0',
+         'protobuf==4.24.3',
+         'grpcio==1.58.0',
+         'grpcio-health-checking==1.58.0',
+@@ -68,7 +68,7 @@ setuptools.setup(
+         'botocore>=1.13.27',
+         'dnspython>=2.2.1',
+         'asyncio==3.4.3',
+-        'aiohttp==3.8.5',
++        'aiohttp==3.9.0',
+         'boto3>=1.28.38',
+         'gcloud-aio-storage==8.3.0',
+         'azure-core==1.29.4',


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
- [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
