### PR TITLE
kubeflow-pipelines/2.0.5-r2: cve remediation

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,13 +1,13 @@
 package:
   name: kubeflow-pipelines
   version: 2.0.5
-  epoch: 2
+  epoch: 3
   description: Machine Learning Pipelines for Kubeflow
+  copyright:
+    - license: Apache-2.0
   checks:
     disabled:
       - empty
-  copyright:
-    - license: Apache-2.0
 
 environment:
   contents:
@@ -42,9 +42,13 @@ data:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: c5658f09ec38e82730a8eca0a1aabf0876087eec
       repository: https://github.com/kubeflow/pipelines
       tag: ${{package.version}}
-      expected-commit: c5658f09ec38e82730a8eca0a1aabf0876087eec
+
+  - uses: go/bump
+    with:
+      deps: k8s.io/kubernetes@v1.11.9 k8s.io/kubernetes@v1.21 k8s.io/kubernetes@v1.24.17 k8s.io/kubernetes@v1.20.0-alpha.1 k8s.io/kubernetes@v1.24.15 k8s.io/kubernetes@v1.19.15 k8s.io/kubernetes@v1.26.0-alpha.3 k8s.io/kubernetes@v1.18.18 k8s.io/kubernetes@v1.25.16 k8s.io/kubernetes@v1.16.0-beta.1 k8s.io/kubernetes@v1.13.12 k8s.io/kubernetes@v1.11.8 k8s.io/kubernetes@v1.18.19 k8s.io/kubernetes@v1.16.11 k8s.io/kubernetes@v1.11.2 k8s.io/kubernetes@v1.15.12 k8s.io/kubernetes@v1.24.14
 
   - uses: patch
     with:
@@ -54,7 +58,6 @@ pipeline:
     with:
       patches: add-samples.patch
 
-  # ERROR: No matching distribution found for kfp==2.0.1
   - uses: patch
     with:
       patches: kfp.patch


### PR DESCRIPTION
kubeflow-pipelines/2.0.5-r2: fix GHSA-xc8m-28vv-4pjc/GHSA-x6mj-w4jf-jmgw/GHSA-wqwf-x5cj-rg56/GHSA-wqv3-8cm6-h6wg/GHSA-qh36-44jv-c8xj/GHSA-q4rr-64r9-fwgf/GHSA-pmqp-h87c-mr78/GHSA-jmrx-5g74-6v2f/GHSA-hq6q-c2x6-hmch/GHSA-g42g-737j-qx6j/GHSA-f9jg-8p32-2f55/GHSA-f5f7-6478-qm6p/GHSA-cgcv-5272-97pr/GHSA-8mjg-8c8g-6h85/GHSA-7fxm-f474-hf8w/GHSA-35c7-w35f-xwgh/GHSA-34jx-wx69-9x8v/