### PR TITLE
cert-manager-1.11/1.11.5-r9: cve remediation

### DIFF
--- a/cert-manager-1.11.yaml
+++ b/cert-manager-1.11.yaml
@@ -1,14 +1,13 @@
 package:
   name: cert-manager-1.11
-  # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
   version: 1.11.5
-  epoch: 9
+  epoch: 10
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
-      - cert-manager=1.11.999 # This is because we had a 1.11.2 cert-manager package, remove in 1.13+
+      - cert-manager=1.11.999
 
 environment:
   contents:
@@ -23,15 +22,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: b1d501c85d97afd2adde2e86c2b119ac060caece
       repository: https://github.com/cert-manager/cert-manager
       tag: v${{package.version}}
-      expected-commit: b1d501c85d97afd2adde2e86c2b119ac060caece
 
-  # the makefile hardcodes the requirement for some container runtime (CTR), even when we don't need it
-  # to workaround, set CTR to anything $(command -v)able
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.17.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/docker/docker@v24.0.7 oras.land/oras-go@v1.2.4 github.com/cyphar/filepath-securejoin@v0.2.4 golang.org/x/crypto@v0.17.0
+      deps: golang.org/x/net@v0.17.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/docker/docker@v24.0.7 oras.land/oras-go@v1.2.4 github.com/cyphar/filepath-securejoin@v0.2.4 golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11
       replaces: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp=go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
 
   - runs: |


### PR DESCRIPTION
cert-manager-1.11/1.11.5-r9: fix GHSA-7ww5-4wqc-m92c