### PR TITLE
Make syft and grype consistent

### DIFF
--- a/grype.yaml
+++ b/grype.yaml
@@ -7,19 +7,15 @@ package:
     - license: Apache-2.0
 
 environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
   environment:
     CGO_ENABLED: "0"
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha512: b90270cf6cbefefeccd89e3a12633d2db6fb920e14f19bc994208393e31bf8b88d45d2ce6add20589e97ed4f0ad8ca6dd6f84b624083935def366fd191478788
-      uri: https://github.com/anchore/grype/archive/v${{package.version}}/grype-${{package.version}}.tar.gz
+      repository: https://github.com/anchore/grype
+      tag: v${{package.version}}
+      expected-commit: 0ae7130bc04c89ddeebb9d85811be352afdc4d51
 
   - uses: go/bump
     with:

--- a/syft.yaml
+++ b/syft.yaml
@@ -6,13 +6,36 @@ package:
   copyright:
     - license: Apache-2.0
 
+environment:
+  environment:
+    CGO_ENABLED: "0"
+
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/anchore/syft/cmd/syft@v${{package.version}}
+      repository: https://github.com/anchore/syft
+      tag: v${{package.version}}
+      expected-commit: f11ce305e25746d5ab601f79e5592f434461bd75
+
+  - uses: go/build
+    with:
+      ldflags: -w -X main.version=${{package.version}}
+      output: syft
+      packages: ./cmd/syft
+
+  - uses: strip
 
 update:
   enabled: true
   github:
     identifier: anchore/syft
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        syft --version


### PR DESCRIPTION
Syft and Grype's Wolfi build definitions were substantially different from one another,  neither were using our latest best practices of avoiding `go/install` and favoring `git-checkout` over `fetch`, Syft didn't have a package test, and Grype had extra build environment packages specified.

This PR polishes both packages and gets them in sync with each other. 😃 