### PR TITLE
Swap cilium dep cni-plugins -> cni-plugins-main

### DIFF
--- a/cilium.yaml
+++ b/cilium.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium
   version: 1.14.5
-  epoch: 0
+  epoch: 1
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,7 @@ package:
       - bpftool
       # cilium does compilations at runtime on the node.
       - clang
-      - cni-plugins
+      - cni-plugins-main
       - iproute2
       - ipset
       - iptables


### PR DESCRIPTION
I believe cilium only really needs loopback, but let's start with this plugin subset first because it meshes better with existing image configs.