### PR TITLE
ci: Always log packages.log and diff.log

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -105,6 +105,7 @@ jobs:
         id: file_check
         run: |
           if test -f "packages.log"; then
+            cat packages.log
             echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "exists=false" >> $GITHUB_OUTPUT
@@ -121,6 +122,7 @@ jobs:
         id: diff_file_check
         run: |
           if test -f "diff.log"; then
+            cat diff.log
             echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "exists=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
These only show up in GitHub PR comments when opened by the robots, but I always want to see this information. I don't know how to fix the permission situation, so as a compromise, let's at least make them visible in the CI logs.