### PR TITLE
Make sure vendored deps have right permissions

### DIFF
--- a/metric-collector-for-apache-cassandra.yaml
+++ b/metric-collector-for-apache-cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: metric-collector-for-apache-cassandra
   version: 0.3.5
-  epoch: 0
+  epoch: 1
   description: Drop-in metrics collection and dashboards for Apache Cassandra
   copyright:
     - license: Apache-2.0
@@ -34,7 +34,7 @@ pipeline:
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
       mvn -q -ff package -DskipTests
       cp ./target/datastax-mcac-agent-*.jar "${{targets.destdir}}"/opt/metrics-collector
-      cp -r ./target/collectd "${{targets.destdir}}"/opt/metrics-collector/lib
+      find ./target/collectd -type f -exec install -Dm 755 "{}" "${{targets.destdir}}/opt/metrics-collector/lib/{}" \;
       cp ./config/collectd.conf.tmpl "${{targets.destdir}}"/opt/metrics-collector/config
       cp ./config/metric-collector.yaml "${{targets.destdir}}"/opt/metrics-collector/config
       cp -r ./scripts "${{targets.destdir}}"/opt/metrics-collector


### PR DESCRIPTION
This package vendors collectd but has the wrong permissions for its shared objects. We use install instead of cp to fix that.

```
tar -Oxf packages/aarch64/metric-collector-for-apache-cassandra-0.3.5-r1.apk .PKGINFO
# Generated by melange.
pkgname = metric-collector-for-apache-cassandra
pkgver = 0.3.5-r1
arch = aarch64
size = 117613138
origin = metric-collector-for-apache-cassandra
pkgdesc = Drop-in metrics collection and dashboards for Apache Cassandra
url = 
commit = 9f54473b41f3e8cdf85433f2759f2dd0f7655dbb
license = Apache-2.0
provides = pc:libcollectdclient=0.1.7
# vendored = so:libdevmapper-event-lvm2mirror.so.2.02=2.02
# vendored = so:libdevmapper-event-lvm2raid.so.2.02=2.02
# vendored = so:libdevmapper-event-lvm2snapshot.so.2.02=2.02
# vendored = so:libdevmapper-event-lvm2thin.so.2.02=2.02
# vendored = so:ld-linux-x86-64.so.2=2
# vendored = so:ld-linux-x86-64.so.2=2
# vendored = so:libBrokenLocale.so.1=1
# vendored = so:libBrokenLocale.so.1=1
# vendored = so:libSegFault.so=0
# vendored = so:libacl.so.1=1
# vendored = so:libacl.so.1=1
# vendored = so:libanl.so.1=1
# vendored = so:libanl.so.1=1
# vendored = so:libapparmor.so.1=1
# vendored = so:libapparmor.so.1=1
# vendored = so:libatasmart.so.4=4
# vendored = so:libatasmart.so.4=4
# vendored = so:libattr.so.1=1
# vendored = so:libattr.so.1=1
# vendored = so:libaudit.so.1=1
# vendored = so:libaudit.so.1=1
# vendored = so:libblkid.so.1=1
# vendored = so:libblkid.so.1=1
# vendored = so:libbsd.so.0=0
# vendored = so:libbsd.so.0=0
# vendored = so:libbz2.so.1.0=1.0
# vendored = so:libbz2.so.1.0=1.0
# vendored = so:libbz2.so.1.0=1.0
# vendored = so:libc.so.6=6
# vendored = so:libcap-ng.so.0=0
# vendored = so:libcap-ng.so.0=0
# vendored = so:libcidn.so.1=1
# vendored = so:libcidn.so.1=1
# vendored = so:libcom_err.so.2=2
# vendored = so:libcom_err.so.2=2
# vendored = so:libcrypt.so.1=1
# vendored = so:libcrypt.so.1=1
# vendored = so:libdbus-1.so.3=3
# vendored = so:libdbus-1.so.3=3
# vendored = so:libdevmapper-event-lvm2.so.2.02=2.02
# vendored = so:libdevmapper-event-lvm2mirror.so.2.02=2.02
# vendored = so:libdevmapper-event-lvm2raid.so.2.02=2.02
# vendored = so:libdevmapper-event-lvm2snapshot.so.2.02=2.02
# vendored = so:libdevmapper-event-lvm2thin.so.2.02=2.02
# vendored = so:libdevmapper-event.so.1.02.1=1.02.1
# vendored = so:libdevmapper.so.1.02.1=1.02.1
# vendored = so:libdl.so.2=2
# vendored = so:libdl.so.2=2
# vendored = so:libe2p.so.2=2
# vendored = so:libe2p.so.2=2
# vendored = so:libexpat.so.1=1
# vendored = so:libexpat.so.1=1
# vendored = so:libext2fs.so.2=2
# vendored = so:libext2fs.so.2=2
# vendored = so:libfdisk.so.1=1
# vendored = so:libfdisk.so.1=1
# vendored = so:libgcc_s.so.1=1
# vendored = so:libgcrypt.so.20=20
# vendored = so:libgcrypt.so.20=20
# vendored = so:libgpg-error.so.0=0
# vendored = so:libgpg-error.so.0=0
# vendored = so:libhistory.so.5=5
# vendored = so:libhistory.so.5=5
# vendored = so:libhistory.so.7=7
# vendored = so:libhistory.so.7=7
# vendored = so:libkeyutils.so.1=1
# vendored = so:libkeyutils.so.1=1
# vendored = so:liblvm2app.so.2.2=2.2
# vendored = so:liblvm2cmd.so.2.02=2.02
# vendored = so:liblzma.so.5=5
# vendored = so:liblzma.so.5=5
# vendored = so:libm.so.6=6
# vendored = so:libm.so.6=6
# vendored = so:libmemusage.so=0
# vendored = so:libmnl.so.0=0
# vendored = so:libmnl.so.0=0
# vendored = so:libmount.so.1=1
# vendored = so:libmount.so.1=1
# vendored = so:libmvec.so.1=1
# vendored = so:libmvec.so.1=1
# vendored = so:libncurses.so.5=5
# vendored = so:libncurses.so.5=5
# vendored = so:libncursesw.so.5=5
# vendored = so:libncursesw.so.5=5
# vendored = so:libnl-3.so.200=200
# vendored = so:libnl-3.so.200=200
# vendored = so:libnsl.so.1=1
# vendored = so:libnsl.so.1=1
# vendored = so:libnss_compat.so.2=2
# vendored = so:libnss_compat.so.2=2
# vendored = so:libnss_dns.so.2=2
# vendored = so:libnss_dns.so.2=2
# vendored = so:libnss_files.so.2=2
# vendored = so:libnss_files.so.2=2
# vendored = so:libnss_hesiod.so.2=2
# vendored = so:libnss_hesiod.so.2=2
# vendored = so:libnss_nis.so.2=2
# vendored = so:libnss_nis.so.2=2
# vendored = so:libnss_nisplus.so.2=2
# vendored = so:libnss_nisplus.so.2=2
# vendored = so:libpam.so.0=0
# vendored = so:libpam.so.0=0
# vendored = so:libpam_misc.so.0=0
# vendored = so:libpam_misc.so.0=0
# vendored = so:libpamc.so.0=0
# vendored = so:libpamc.so.0=0
# vendored = so:libpci.so.3=3
# vendored = so:libpci.so.3=3
# vendored = so:libpcprofile.so=0
# vendored = so:libpcre.so.3=3
# vendored = so:libpcre.so.3=3
# vendored = so:libprocps.so.6=6
# vendored = so:libprocps.so.6=6
# vendored = so:libpthread.so.0=0
# vendored = so:libreadline.so.5=5
# vendored = so:libreadline.so.5=5
# vendored = so:libreadline.so.7=7
# vendored = so:libreadline.so.7=7
# vendored = so:libresolv.so.2=2
# vendored = so:libresolv.so.2=2
# vendored = so:librt.so.1=1
# vendored = so:librt.so.1=1
# vendored = so:libseccomp.so.2=2
# vendored = so:libseccomp.so.2=2
# vendored = so:libselinux.so.1=1
# vendored = so:libsepol.so.1=1
# vendored = so:libsmartcols.so.1=1
# vendored = so:libsmartcols.so.1=1
# vendored = so:libss.so.2=2
# vendored = so:libss.so.2=2
# vendored = so:libsystemd.so.0=0
# vendored = so:libsystemd.so.0=0
# vendored = so:libthread_db.so.1=1
# vendored = so:libthread_db.so.1=1
# vendored = so:libtinfo.so.5=5
# vendored = so:libtinfo.so.5=5
# vendored = so:libudev.so.1=1
# vendored = so:libudev.so.1=1
# vendored = so:libudev.so.1=1
# vendored = so:libupsclient.so.4=4
# vendored = so:libupsclient.so.4=4
# vendored = so:libusb-1.0.so.0=0
# vendored = so:libusb-1.0.so.0=0
# vendored = so:libutil.so.1=1
# vendored = so:libutil.so.1=1
# vendored = so:libuuid.so.1=1
# vendored = so:libuuid.so.1=1
# vendored = so:libwrap.so.0=0
# vendored = so:libwrap.so.0=0
# vendored = so:libz.so.1=1
# vendored = so:libz.so.1=1
# vendored = so:pam_access.so=0
# vendored = so:pam_debug.so=0
# vendored = so:pam_deny.so=0
# vendored = so:pam_echo.so=0
# vendored = so:pam_env.so=0
# vendored = so:pam_exec.so=0
# vendored = so:pam_extrausers.so=0
# vendored = so:pam_faildelay.so=0
# vendored = so:pam_faillock.so=0
# vendored = so:pam_filter.so=0
# vendored = so:pam_ftp.so=0
# vendored = so:pam_group.so=0
# vendored = so:pam_issue.so=0
# vendored = so:pam_keyinit.so=0
# vendored = so:pam_lastlog.so=0
# vendored = so:pam_limits.so=0
# vendored = so:pam_listfile.so=0
# vendored = so:pam_localuser.so=0
# vendored = so:pam_loginuid.so=0
# vendored = so:pam_mail.so=0
# vendored = so:pam_mkhomedir.so=0
# vendored = so:pam_motd.so=0
# vendored = so:pam_namespace.so=0
# vendored = so:pam_nologin.so=0
# vendored = so:pam_permit.so=0
# vendored = so:pam_pwhistory.so=0
# vendored = so:pam_rhosts.so=0
# vendored = so:pam_rootok.so=0
# vendored = so:pam_securetty.so=0
# vendored = so:pam_selinux.so=0
# vendored = so:pam_sepermit.so=0
# vendored = so:pam_shells.so=0
# vendored = so:pam_stress.so=0
# vendored = so:pam_succeed_if.so=0
# vendored = so:pam_tally.so=0
# vendored = so:pam_tally2.so=0
# vendored = so:pam_time.so=0
# vendored = so:pam_timestamp.so=0
# vendored = so:pam_tty_audit.so=0
# vendored = so:pam_umask.so=0
# vendored = so:pam_unix.so=0
# vendored = so:pam_userdb.so=0
# vendored = so:pam_warn.so=0
# vendored = so:pam_wheel.so=0
# vendored = so:pam_xauth.so=0
# vendored = so:aggregation.so=0
# vendored = so:amqp.so=0
# vendored = so:apache.so=0
# vendored = so:apcups.so=0
# vendored = so:battery.so=0
# vendored = so:bind.so=0
# vendored = so:ceph.so=0
# vendored = so:cgroups.so=0
# vendored = so:chrony.so=0
# vendored = so:conntrack.so=0
# vendored = so:contextswitch.so=0
# vendored = so:cpu.so=0
# vendored = so:cpufreq.so=0
# vendored = so:cpusleep.so=0
# vendored = so:csv.so=0
# vendored = so:curl.so=0
# vendored = so:curl_json.so=0
# vendored = so:dbi.so=0
# vendored = so:df.so=0
# vendored = so:disk.so=0
# vendored = so:dns.so=0
# vendored = so:drbd.so=0
# vendored = so:email.so=0
# vendored = so:entropy.so=0
# vendored = so:ethstat.so=0
# vendored = so:exec.so=0
# vendored = so:fhcount.so=0
# vendored = so:filecount.so=0
# vendored = so:fscache.so=0
# vendored = so:gmond.so=0
# vendored = so:hddtemp.so=0
# vendored = so:hugepages.so=0
# vendored = so:interface.so=0
# vendored = so:ipc.so=0
# vendored = so:iptables.so=0
# vendored = so:ipvs.so=0
# vendored = so:irq.so=0
# vendored = so:java.so=0
# vendored = so:load.so=0
# vendored = so:log_logstash.so=0
# vendored = so:logfile.so=0
# vendored = so:madwifi.so=0
# vendored = so:match_empty_counter.so=0
# vendored = so:match_hashed.so=0
# vendored = so:match_regex.so=0
# vendored = so:match_timediff.so=0
# vendored = so:match_value.so=0
# vendored = so:mbmon.so=0
# vendored = so:mcelog.so=0
# vendored = so:md.so=0
# vendored = so:memcachec.so=0
# vendored = so:memcached.so=0
# vendored = so:memory.so=0
# vendored = so:multimeter.so=0
# vendored = so:mysql.so=0
# vendored = so:netlink.so=0
# vendored = so:network.so=0
# vendored = so:nfs.so=0
# vendored = so:nginx.so=0
# vendored = so:notify_desktop.so=0
# vendored = so:notify_email.so=0
# vendored = so:notify_nagios.so=0
# vendored = so:ntpd.so=0
# vendored = so:numa.so=0
# vendored = so:nut.so=0
# vendored = so:olsrd.so=0
# vendored = so:openldap.so=0
# vendored = so:openvpn.so=0
# vendored = so:ovs_events.so=0
# vendored = so:ovs_stats.so=0
# vendored = so:perl.so=0
# vendored = so:pinba.so=0
# vendored = so:ping.so=0
# vendored = so:postgresql.so=0
# vendored = so:powerdns.so=0
# vendored = so:processes.so=0
# vendored = so:protocols.so=0
# vendored = so:serial.so=0
# vendored = so:smart.so=0
# vendored = so:snmp.so=0
# vendored = so:snmp_agent.so=0
# vendored = so:statsd.so=0
# vendored = so:swap.so=0
# vendored = so:synproxy.so=0
# vendored = so:syslog.so=0
# vendored = so:table.so=0
# vendored = so:tail.so=0
# vendored = so:tail_csv.so=0
# vendored = so:target_notification.so=0
# vendored = so:target_replace.so=0
# vendored = so:target_scale.so=0
# vendored = so:target_set.so=0
# vendored = so:target_v5upgrade.so=0
# vendored = so:tcpconns.so=0
# vendored = so:teamspeak2.so=0
# vendored = so:ted.so=0
# vendored = so:thermal.so=0
# vendored = so:threshold.so=0
# vendored = so:turbostat.so=0
# vendored = so:uptime.so=0
# vendored = so:users.so=0
# vendored = so:uuid.so=0
# vendored = so:varnish.so=0
# vendored = so:virt.so=0
# vendored = so:vmem.so=0
# vendored = so:vserver.so=0
# vendored = so:wireless.so=0
# vendored = so:write_graphite.so=0
# vendored = so:write_http.so=0
# vendored = so:write_log.so=0
# vendored = so:write_prometheus.so=0
# vendored = so:write_scribe.so=0
# vendored = so:write_tsdb.so=0
# vendored = so:xencpu.so=0
# vendored = so:zookeeper.so=0
# vendored = so:libcollectdclient.so.1=1
# vendored = so:libganglia-3.6.0.so.0=0
# vendored = so:libmicrohttpd.so.12=12
# vendored = so:libthrift-0.10.0.so=0
# vendored = so:libapr-1.so.0=0
# vendored = so:libasn1.so.8=8
# vendored = so:libavahi-client.so.3=3
# vendored = so:libavahi-common.so.3=3
# vendored = so:libboost_filesystem.so.1.65.1=1.65.1
# vendored = so:libboost_iostreams.so.1.65.1=1.65.1
# vendored = so:libboost_system.so.1.65.1=1.65.1
# vendored = so:libconfuse.so.2=2
# vendored = so:libcrypto.so.1.1=1.1
# vendored = so:libcurl-gnutls.so.4=4
# vendored = so:libdbi.so.1=1
# vendored = so:libesmtp.so.6=6
# vendored = so:libffi.so.6=6
# vendored = so:libgdk_pixbuf-2.0.so.0=0
# vendored = so:libgio-2.0.so.0=0
# vendored = so:libglib-2.0.so.0=0
# vendored = so:libgmodule-2.0.so.0=0
# vendored = so:libgmp.so.10=10
# vendored = so:libgnutls.so.30=30
# vendored = so:libgobject-2.0.so.0=0
# vendored = so:libgssapi.so.3=3
# vendored = so:libgssapi_krb5.so.2=2
# vendored = so:libhcrypto.so.4=4
# vendored = so:libheimbase.so.1=1
# vendored = so:libheimntlm.so.0=0
# vendored = so:libhogweed.so.4=4
# vendored = so:libhx509.so.5=5
# vendored = so:libicudata.so.60=60
# vendored = so:libicuuc.so.60=60
# vendored = so:libidn2.so.0=0
# vendored = so:libip4tc.so.0=0
# vendored = so:libip6tc.so.0=0
# vendored = so:libk5crypto.so.3=3
# vendored = so:libkrb5.so.26=26
# vendored = so:libkrb5.so.3=3
# vendored = so:libkrb5support.so.0=0
# vendored = so:liblber-2.4.so.2=2
# vendored = so:libldap_r-2.4.so.2=2
# vendored = so:liblz4.so.1=1
# vendored = so:libmemcached.so.11=11
# vendored = so:libmysqlclient.so.20=20
# vendored = so:libnetsnmp.so.30=30
# vendored = so:libnetsnmpagent.so.30=30
# vendored = so:libnettle.so.6=6
# vendored = so:libnghttp2.so.14=14
# vendored = so:libnotify.so.4=4
# vendored = so:libnspr4.so=0
# vendored = so:libnss3.so=0
# vendored = so:libnssutil3.so=0
# vendored = so:libnuma.so.1=1
# vendored = so:liboping.so.0=0
# vendored = so:libp11-kit.so.0=0
# vendored = so:libpcap.so.0.8=0.8
# vendored = so:libperl.so.5.26=5.26
# vendored = so:libplc4.so=0
# vendored = so:libplds4.so=0
# vendored = so:libpq.so.5=5
# vendored = so:libprotobuf-c.so.1=1
# vendored = so:libpsl.so.5=5
# vendored = so:librabbitmq.so.4=4
# vendored = so:libroken.so.18=18
# vendored = so:librtmp.so.1=1
# vendored = so:libsasl2.so.2=2
# vendored = so:libsqlite3.so.0=0
# vendored = so:libssl.so.1.1=1.1
# vendored = so:libssl3.so=0
# vendored = so:libstdc++.so.6=6
# vendored = so:libtasn1.so.6=6
# vendored = so:libunistring.so.2=2
# vendored = so:libvarnishapi.so.1=1
# vendored = so:libvirt.so.0=0
# vendored = so:libwind.so.0=0
# vendored = so:libxencall-4.9.so.1=1
# vendored = so:libxenctrl-4.9.so=0
# vendored = so:libxendevicemodel-4.9.so.1=1
# vendored = so:libxenevtchn-4.9.so.1=1
# vendored = so:libxenforeignmemory-4.9.so.1=1
# vendored = so:libxengnttab-4.9.so.1=1
# vendored = so:libxentoollog-4.9.so.1=1
# vendored = so:libxml2.so.2=2
# vendored = so:libyajl.so.2=2
datahash = a76af63a4f772375e36d16a6339988721353ba6c1e4ddcfc6eb1f56995f1ab87
```

There are some duplicates here in the comments, which is harmless, but I'm going to fix that separately.