### PR TITLE
Add py3.10-google-cloud-sdk

### DIFF
--- a/py3.10-crcmod.yaml
+++ b/py3.10-crcmod.yaml
@@ -1,0 +1,40 @@
+package:
+  name: py3.10-crcmod
+  version: "1.7"
+  epoch: 1
+  description: Cyclic Redundancy Check (CRC) implementation in Python
+  copyright:
+    - license: 'MIT'
+  dependencies:
+    runtime:
+      - python-3.10
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3.10-setuptools
+      - python-3.10
+      - python-3.10-dev
+      - wolfi-base
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://files.pythonhosted.org/packages/source/c/crcmod/crcmod-${{package.version}}.tar.gz
+      expected-sha256: dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e
+
+  - runs: |
+      python setup.py build
+
+  - runs: |
+      python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 12017

--- a/py3.10-google-cloud-sdk.yaml
+++ b/py3.10-google-cloud-sdk.yaml
@@ -1,0 +1,79 @@
+package:
+  name: py3.10-google-cloud-sdk
+  version: 427.0.0
+  epoch: 3
+  description: "Google Cloud Command Line Interface"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      # Required for cyclic redunancy check (gsutil help crcmod)
+      - py3.10-crcmod
+      - python-3.10
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3.10-setuptools
+      - python-3.10
+      - python-3.10-dev
+      - wolfi-base
+
+pipeline:
+  - if: ${{build.arch}} == "x86_64"
+    uses: fetch
+    with:
+      uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-426.0.0-linux-x86_64.tar.gz
+      expected-sha256: c653a8ac1e48889005fd00e2de580a27be5a3cb46ceccc570146982c4ddf4245
+      strip-components: 0
+
+  - if: ${{build.arch}} == "aarch64"
+    uses: fetch
+    with:
+      uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-426.0.0-linux-arm.tar.gz
+      expected-sha256: 8409b8cc00f0ae8089be97d8a565f4072eada890776345bccb988bcd4d4bb27f
+      strip-components: 0
+
+  - runs: |
+      ./google-cloud-sdk/install.sh -q
+      mkdir -p ${{targets.destdir}}/usr/share/
+
+      # Trim some extra stuff
+      rm -rf google-cloud-sdk/platform/bundledpythonunix/
+      rm -rf google-cloud-sdk/deb
+      rm -rf google-cloud-sdk/rpm
+      rm google-cloud-sdk/install.bat
+      rm google-cloud-sdk/data/cli/gcloud.json
+
+      # Remove any third party tests that bloat up the package
+      find google-cloud-sdk -type d \( -name 'tests' -o -name 'test' \) -path '*/third_party/*' -exec rm -rf {} +
+
+      # This is a large binary with vulnerabilities in it, users can add it back later.
+      google-cloud-sdk/bin/gcloud components remove anthoscli
+
+      # This is a large binary with vulnerabilities in it, users can add it back later.
+      google-cloud-sdk/bin/gcloud components remove gcloud-crc32c
+
+      # Running gcloud adds a bunch of pyc files, remove those
+      find google-cloud-sdk/ -name "*.pyc" -exec rm -rf '{}' +
+      rm -rf google-cloud-sdk/.install
+
+      mv google-cloud-sdk ${{targets.destdir}}/usr/share/
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      for f in anthoscli bq docker-credential-gcloud gcloud gcloud-crc32c git-credential-gcloud.sh gsutil java_dev_appserver.sh; do
+        ln -sf /usr/share/google-cloud-sdk/bin/$f ${{targets.destdir}}/usr/bin/$f
+      done
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: GoogleCloudPlatform/cloud-sdk-docker
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
