### PR TITLE
gobump: set empty go-version

### DIFF
--- a/pipelines/go/bump.yaml
+++ b/pipelines/go/bump.yaml
@@ -15,7 +15,7 @@ inputs:
     default: .
   go-version:
     description: "The go version to set the go.mod syntax to"
-    default: 1.20
+    default: ""
   replaces:
     description: "The replaces to add to the go.mod file"
 


### PR DESCRIPTION
gobump now detects the go-version so we should default to an empty value