### PR TITLE
kubernetes-1.27/1.27.10-r0: cve remediation

### DIFF
--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.27
   version: 1.27.10
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -39,9 +39,13 @@ vars:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 0fa26aea1d5c21516b0d96fea95a77d8d429912e
       repository: https://github.com/kubernetes/kubernetes
       tag: v${{package.version}}
-      expected-commit: 0fa26aea1d5c21516b0d96fea95a77d8d429912e
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
 
   - runs: |
       # Mitigate GHSA-hqxw-f8mx-cpmw / CVE-2023-2253

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -43,13 +43,10 @@ pipeline:
       repository: https://github.com/kubernetes/kubernetes
       tag: v${{package.version}}
 
-  - uses: go/bump
-    with:
-      deps: golang.org/x/crypto@v0.17.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
-
   - runs: |
       # Mitigate GHSA-hqxw-f8mx-cpmw / CVE-2023-2253
       ./hack/pin-dependency.sh github.com/docker/distribution v2.8.2
+      ./hack/pin-dependency.sh golang.org/x/crypto v0.17.0
       ./hack/update-vendor.sh
       ./hack/lint-dependencies.sh
 


### PR DESCRIPTION
kubernetes-1.27/1.27.10-r0: fix GHSA-rcjv-mgp8-qvmr/GHSA-8pgv-569h-w5rw/GHSA-45x7-px36-x8w8/