### PR TITLE
cilium: depend only on loopback

### DIFF
--- a/cilium.yaml
+++ b/cilium.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium
   version: 1.14.5
-  epoch: 1
+  epoch: 2
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,7 @@ package:
       - bpftool
       # cilium does compilations at runtime on the node.
       - clang
-      - cni-plugins-main
+      - cni-plugins-loopback
       - iproute2
       - ipset
       - iptables


### PR DESCRIPTION
This was still failing because cni-plugins-main conflicted with iproute2.

X-ref: https://github.com/wolfi-dev/os/issues/11323