### PR TITLE
Don't use [[ in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,12 +114,12 @@ endef
 #$(call get-source-dir,ret-variable-for-source-dir,package-dir,package-name)
 define get-source-dir
 	$(info getting source dir for package $(3) with dir $(2))
-	$(1) := $(shell if [[ "." == "$(2)" ]]; then \
-		if [[ -d "./$(3)" ]]; then \
+	$(1) := $(shell if [ "." == "$(2)" ]; then \
+		if [ -d "./$(3)" ]; then \
 			echo "--source-dir ./$(3)"; \
 		fi \
 	else \
-		if [[ -d "$(2)" ]]; then \
+		if [ -d "$(2)" ]; then \
 			echo "--source-dir $(2)"; \
 		fi \
 	fi)


### PR DESCRIPTION
The melange presubmit runs in an ubuntu container which doesn't seem to contain the [[ binary but does contain the [ binary. This is all very silly but I think this makes the Makefile slightly more portable. I don't understand how computers work.

Failed presubmit: https://github.com/chainguard-dev/melange/actions/runs/7563217425/job/20595293572?pr=935

Relevant logs:

```
getting source dir for package glibc with dir .
/bin/sh: 1: [[: not found
/bin/sh: 1: [[: not found
```