### PR TITLE
Fix openvpn-dev

### DIFF
--- a/openvpn.yaml
+++ b/openvpn.yaml
@@ -1,7 +1,7 @@
 package:
   name: openvpn
   version: 2.6.8
-  epoch: 0
+  epoch: 1
   description: Robust, and highly configurable VPN (Virtual Private Network)
   copyright:
     - license: GPL-2.0
@@ -88,7 +88,6 @@ subpackages:
       runtime:
         - openvpn
         - openssl-dev
-        - iproute2-minimal
 
   - name: openvpn-openrc
     description: openvpn openrc init


### PR DESCRIPTION
iproute2-minimal does not exist and openvpn-dev already has a dependency on openvpn which depends on iproute, so it seems like whatever dep that was intended to represent is already satisfied.

X-ref: https://github.com/wolfi-dev/os/issues/11323