### PR TITLE
kubernetes-1.27/1.27.10-r1: cve remediation

### DIFF
--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.27
   version: 1.27.10
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -42,6 +42,10 @@ pipeline:
       expected-commit: 0fa26aea1d5c21516b0d96fea95a77d8d429912e
       repository: https://github.com/kubernetes/kubernetes
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0
 
   - runs: |
       # Mitigate GHSA-hqxw-f8mx-cpmw / CVE-2023-2253


### PR DESCRIPTION
kubernetes-1.27/1.27.10-r1: fix GHSA-rcjv-mgp8-qvmr/GHSA-8pgv-569h-w5rw/