### PR TITLE
snappy-java: remove unncessary runtime dependencies and compile with …

### DIFF
--- a/snappy-java.yaml
+++ b/snappy-java.yaml
@@ -1,13 +1,10 @@
 package:
   name: snappy-java
   version: 1.1.10.5
-  epoch: 0
+  epoch: 1
   description: Snappy compressor/decompressor for Java
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - openjdk-17-default-jvm
 
 environment:
   contents:
@@ -18,12 +15,12 @@ environment:
       - ca-certificates-bundle
       - cmake
       - curl
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-8
+      - openjdk-8-default-jvm
       - samurai
   environment:
     LANG: en_US.UTF-8
-    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+    JAVA_HOME: /usr/lib/jvm/java-1.8-openjdk
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Enables to use the snappy-java with various JRE versions 