### PR TITLE
crossplane-provider-aws/0.47.1-r0: cve remediation

### DIFF
--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-aws
   version: 0.47.1
-  epoch: 0
+  epoch: 1
   description: Official AWS Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -25,14 +25,14 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 384bfc6c8c320db7ecd80b060e95abd8e4206619
       repository: https://github.com/upbound/provider-aws
       tag: v${{package.version}}
-      expected-commit: 384bfc6c8c320db7ecd80b060e95abd8e4206619
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0
-      go-version: 1.21
+      deps: golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7
+      go-version: "1.21"
 
   - runs: |
       # `make` downloads `up`, unless we move our prebuilt `up` to where it expects it.


### PR DESCRIPTION
crossplane-provider-aws/0.47.1-r0: fix GHSA-9763-4f94-gfch