### PR TITLE
argo-cd-2.9/2.9.3-r5: cve remediation

### DIFF
--- a/argo-cd-2.9.yaml
+++ b/argo-cd-2.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.9
   version: 2.9.3
-  epoch: 5
+  epoch: 6
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -22,13 +22,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: 6eba5be864b7e031871ed7698f5233336dfe75c7
       repository: https://github.com/argoproj/argo-cd
       tag: v${{package.version}}
-      expected-commit: 6eba5be864b7e031871ed7698f5233336dfe75c7
 
   - uses: go/bump
     with:
-      deps: k8s.io/kubernetes@v1.24.17 google.golang.org/grpc@v1.56.3 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.1 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0
+      deps: k8s.io/kubernetes@v1.25.16 google.golang.org/grpc@v1.56.3 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.1 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
       replaces: github.com/whilp/git-urls=github.com/chainguard-dev/git-urls@v0.0.1
 
   - runs: |

--- a/argo-cd-2.9.yaml
+++ b/argo-cd-2.9.yaml
@@ -28,7 +28,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: k8s.io/kubernetes@v1.25.16 google.golang.org/grpc@v1.56.3 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.1 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
+      deps: k8s.io/kubernetes@v1.24.17 google.golang.org/grpc@v1.56.3 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.1 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
       replaces: github.com/whilp/git-urls=github.com/chainguard-dev/git-urls@v0.0.1
 
   - runs: |


### PR DESCRIPTION
argo-cd-2.9/2.9.3-r5: fix GHSA-hq6q-c2x6-hmch/GHSA-f9jg-8p32-2f55/GHSA-9763-4f94-gfch/