### PR TITLE
temporal-server/1.22.4-r0: cve remediation

### DIFF
--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal-server
   version: 1.22.4
-  epoch: 0
+  epoch: 1
   description: Temporal server executes units of application logic, Workflows, in a resilient manner that automatically handles intermittent failures, and retries failed operations
   copyright:
     - license: MIT License
@@ -24,13 +24,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: fb617040c84afe4c787645a33816fda2b6fe775b
       repository: https://github.com/temporalio/temporal
       tag: v${{package.version}}
-      expected-commit: fb617040c84afe4c787645a33816fda2b6fe775b
 
   - uses: go/bump
     with:
-      deps: google.golang.org/grpc@v1.58.3 golang.org/x/crypto@v0.17.0
+      deps: google.golang.org/grpc@v1.58.3 golang.org/x/crypto@v0.17.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
 
   - runs: |
       make bins


### PR DESCRIPTION
temporal-server/1.22.4-r0: fix GHSA-8pgv-569h-w5rw