### PR TITLE
opentofu/1.6.0_rc1-r0: cve remediation

### DIFF
--- a/opentofu.yaml
+++ b/opentofu.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentofu
   version: 1.6.0
-  epoch: 2
+  epoch: 3
   copyright:
     - license: MPL-2.0
 


### PR DESCRIPTION
opentofu/1.6.0_rc1-r0: fix GHSA-9763-4f94-gfch