### PR TITLE
kots/1.105.4-r0: cve remediation

### DIFF
--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
   version: 1.105.4
-  epoch: 0
+  epoch: 1
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0
@@ -20,13 +20,13 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://github.com/replicatedhq/kots/archive/refs/tags/v${{package.version}}.tar.gz
       expected-sha256: ea7cd49e176523f254a01586fb837f87cec825df63cb78b6bc334b495f614af1
+      uri: https://github.com/replicatedhq/kots/archive/refs/tags/v${{package.version}}.tar.gz
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0
-      go-version: "1.21.0"
+      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0 github.com/dexidp/dex@v2.35.0
+      go-version: 1.21.0
 
   - runs: |
       set -x


### PR DESCRIPTION
kots/1.105.4-r0: fix GHSA-vh7g-p26c-j2cw/GHSA-2x32-jm95-2cpx/