### PR TITLE
new package: statsd

### DIFF
--- a/statsd.yaml
+++ b/statsd.yaml
@@ -35,4 +35,5 @@ update:
   enabled: true
   github:
     identifier: statsd/statsd
+    use-tag: true
     strip-prefix: v

--- a/statsd.yaml
+++ b/statsd.yaml
@@ -1,0 +1,38 @@
+package:
+  name: statsd
+  version: 0.10.2
+  epoch: 0
+  description: Daemon for easy but powerful stats aggregation
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 0e20be57d4918dadf5b5fad61b5c61ef382f8860
+      repository: https://github.com/statsd/statsd
+      tag: v${{package.version}}
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/src/app
+      cp *.js ${{targets.destdir}}/usr/src/app
+      cp *.json ${{targets.destdir}}/usr/src/app
+      for d in backends bin lib servers test utils; do
+        cp -r $d ${{targets.destdir}}/usr/src/app
+      done
+
+  - runs: |
+      # Set graphite hostname to "graphite"
+      sed -i 's/graphite.example.com/graphite/' exampleConfig.js
+      mv exampleConfig.js ${{targets.destdir}}/usr/src/app/config.js
+
+update:
+  enabled: true
+  github:
+    identifier: statsd/statsd
+    strip-prefix: v


### PR DESCRIPTION
Based on https://github.com/statsd/statsd/blob/master/Dockerfile and browsing around the [statsd docker image](https://oci.dag.dev/size/statsd/statsd@sha256:4d4bfc2925dff838caa998d7fa764135c2322237671ee1793ca08b89942408da?mt=application/vnd.oci.image.layer.v1.tar+gzip&size=99830)

The upstream seems to intend to exclude some unnecessary files from the final image using `.dockerignore`, but this doesn't seem to work, or the image wasn't built from that source. https://github.com/statsd/statsd/issues/710 also mentions this.