### PR TITLE
Revert "ensure the default shell is /bin/bash"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ ifeq (${ARCH}, arm64)
 	ARCH = aarch64
 endif
 TARGETDIR = packages/${ARCH}
-SHELL := /bin/bash
 
 MELANGE ?= $(shell which melange)
 WOLFICTL ?= $(shell which wolfictl)


### PR DESCRIPTION
Reverts wolfi-dev/os#11390