### PR TITLE
Fix get-source-dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,13 +115,9 @@ endef
 define get-source-dir
 	$(info getting source dir for package $(3) with dir $(2))
 	$(1) := $(shell set -x; if [[ "." == "$(2)" ]]; then \
-		if [[ -d "./$(3)" ]]; then \
-			echo "--source-dir ./$(3)"; \
-		fi \
+		echo "--source-dir ./$(3)"; \
 	else \
-		if [[ -d "$(2)" ]]; then \
-			echo "--source-dir $(2)"; \
-		fi \
+		echo "--source-dir $(2)"; \
 	fi)
 endef
 


### PR DESCRIPTION
We should always pass the package name as source-dir even if the directory doesn't exist (to match previous behavior).