### PR TITLE
argo-cd-2.9/2.9.4-r0: cve remediation

### DIFF
--- a/argo-cd-2.9.yaml
+++ b/argo-cd-2.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.9
   version: 2.9.4
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -22,13 +22,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
+      expected-commit: bb06722d980611a11098bc3eec00c80ea7c2261e
       repository: https://github.com/argoproj/argo-cd
       tag: v${{package.version}}
-      expected-commit: bb06722d980611a11098bc3eec00c80ea7c2261e
 
   - uses: go/bump
     with:
-      deps: github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.1 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0
+      deps: github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.1 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 k8s.io/kubernetes@v1.25.16
       replaces: github.com/whilp/git-urls=github.com/chainguard-dev/git-urls@v0.0.1
 
   - runs: |


### PR DESCRIPTION
argo-cd-2.9/2.9.4-r0: fix GHSA-hq6q-c2x6-hmch/GHSA-f9jg-8p32-2f55/