### PR TITLE
new pkg: libgdiplus

### DIFF
--- a/libgdiplus.yaml
+++ b/libgdiplus.yaml
@@ -1,0 +1,52 @@
+package:
+  name: libgdiplus
+  version: 6.1
+  epoch: 0
+  description: "Open Source Implementation of the GDI+ API"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cairo-dev
+      - cmake
+      - giflib-dev
+      - glib-dev
+      - libexif-dev
+      - pango-dev
+      - tiff-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 97d5a83d6d6d8f96c27fb7626f4ae11d3b38bc88a1726b4466aeb91451f3255b
+      uri: https://github.com/mono/libgdiplus/archive/refs/tags/${{package.version}}.tar.gz
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: libgdiplus-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - libgdiplus
+    description: libgdiplus dev
+
+update:
+  enabled: true
+  github:
+    identifier: mono/libgdiplus
+    use-tag: true

--- a/libgdiplus.yaml
+++ b/libgdiplus.yaml
@@ -16,19 +16,34 @@ environment:
       - ca-certificates-bundle
       - cairo-dev
       - cmake
+      - expat-dev
+      - fribidi-dev
       - giflib-dev
       - glib-dev
+      - glib-static
+      - harfbuzz-dev
       - libexif-dev
+      - libtool
+      - libxft-dev
       - pango-dev
       - tiff-dev
 
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 97d5a83d6d6d8f96c27fb7626f4ae11d3b38bc88a1726b4466aeb91451f3255b
-      uri: https://github.com/mono/libgdiplus/archive/refs/tags/${{package.version}}.tar.gz
+      expected-sha512: 7f176d38024d5bde4a825ad00b907006f7dd3ff174e12aba6e91df0b624431cc9b536f1bcf206998bad11f6d03e6fe5122710591f58877de0f2c08e8cb4e46cd
+      uri: https://download.mono-project.com/sources/libgdiplus/libgdiplus-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
+    with:
+      opts: |
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --infodir=/usr/share/info \
+        --localstatedir=/var \
+        --disable-dependency-tracking \
+        --with-pango
 
   - uses: autoconf/make
 

--- a/libgdiplus.yaml
+++ b/libgdiplus.yaml
@@ -65,3 +65,4 @@ update:
   github:
     identifier: mono/libgdiplus
     use-tag: true
+    tag-filter: 6.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #11428 

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
