### PR TITLE
linuring/2.5 new package added

### DIFF
--- a/liburing.yaml
+++ b/liburing.yaml
@@ -1,0 +1,64 @@
+package:
+  name: liburing
+  version: "2.5"
+  epoch: 0
+  description: Linux kernel io_uring access library.
+  copyright:
+    - license: MIT or LGPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - ca-certificates-bundle
+      - build-base
+      - busybox
+      - linux-headers
+      - glibc-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: f4e42a515cd78c8c9cac2be14222834be5f8df2b
+      repository: https://github.com/axboe/liburing.git
+      tag: liburing-${{package.version}}
+
+  - runs: |
+      ./configure \
+        --prefix=/usr \
+        --use-libc \
+        --libdir=/usr/lib \
+        --mandir=/usr/share/man
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: liburing-ffi
+    description: liburing shared library
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/lib"
+          mv ${{targets.destdir}}/usr/lib/liburing-ffi.so.* ${{targets.subpkgdir}}/usr/lib/
+
+  - name: liburing-dev
+    description: liburing development headers
+    pipeline:
+      - uses: split/dev
+
+  - name: liburing-doc
+    description: liburing documentation
+    pipeline:
+      - uses: split/manpages
+
+update:
+  enabled: true
+  github:
+    identifier: axboe/liburing
+    strip-prefix: liburing-
+    tag-filter: liburing-
+    use-tag: true

--- a/liburing.yaml
+++ b/liburing.yaml
@@ -1,6 +1,6 @@
 package:
   name: liburing
-  version: "2.5"
+  version: 2.5
   epoch: 0
   description: Linux kernel io_uring access library.
   copyright:
@@ -11,11 +11,11 @@ environment:
     packages:
       - autoconf
       - automake
-      - ca-certificates-bundle
       - build-base
       - busybox
-      - linux-headers
+      - ca-certificates-bundle
       - glibc-dev
+      - linux-headers
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
**liburing**: provides helpers to set up and teardown io_uring instances, and also a simplified interface for applications that don't need (or want) to deal with the full kernel side implementation.
https://github.com/axboe/liburing

Version: 2.5


### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
