### PR TITLE
ci: handle single arch builds more good

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -177,11 +177,12 @@ jobs:
         run: |
           cd /tmp/artifacts-1
 
-          # Put the packages into one place
-          mv /tmp/artifacts-2/packages/* ./packages/
-
-          # Merge the build log ("packages.log") files
-          cat /tmp/artifacts-2/packages.log >> ./packages.log
+          # Put the packages into one place (if aarch64 logs exist)
+          if test -f "/tmp/artifacts-2/packages"; then
+            mv /tmp/artifacts-2/packages/* ./packages/
+            # Merge the build log ("packages.log") files
+            cat /tmp/artifacts-2/packages.log >> ./packages.log
+          fi
 
       - name: Soname check
         run: |
@@ -215,11 +216,12 @@ jobs:
         run: |
           cd /tmp/artifacts-1
 
-          # Put the packages into one place
-          mv /tmp/artifacts-2/packages/* ./packages/
-
-          # Merge the build log ("packages.log") files
-          cat /tmp/artifacts-2/packages.log >> ./packages.log
+          # Put the packages into one place (if aarch64 logs exist)
+          if test -f "/tmp/artifacts-2/packages"; then
+            mv /tmp/artifacts-2/packages/* ./packages/
+            # Merge the build log ("packages.log") files
+            cat /tmp/artifacts-2/packages.log >> ./packages.log
+          fi
 
       - name: 'Retrieve Wolfi advisory data'
         uses: actions/checkout@v4

--- a/calico.yaml
+++ b/calico.yaml
@@ -3,7 +3,6 @@ package:
   version: 3.27.0
   epoch: 0
   description: "Cloud native networking and network security"
-
   copyright:
     - license: Apache-2.0
   checks:

--- a/calico.yaml
+++ b/calico.yaml
@@ -3,9 +3,7 @@ package:
   version: 3.27.0
   epoch: 0
   description: "Cloud native networking and network security"
-  target-architecture:
-    - x86_64
-    - aarch64
+
   copyright:
     - license: Apache-2.0
   checks:

--- a/certificate-transparency.yaml
+++ b/certificate-transparency.yaml
@@ -3,8 +3,6 @@ package:
   version: 1.1.7
   epoch: 2
   description: Auditing for TLS certificates
-  target-architecture:
-    - all
   copyright:
     - license: Apache-2.0
       paths:

--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -3,8 +3,6 @@ package:
   version: 6.0.126
   epoch: 0
   description: ".NET SDK, version 6"
-  target-architecture:
-    - all
   copyright:
     - license: MIT
   dependencies:

--- a/kube-rbac-proxy.yaml
+++ b/kube-rbac-proxy.yaml
@@ -1,9 +1,6 @@
 package:
   name: kube-rbac-proxy
   version: 0.15.0
-  target-architecture:
-    - x86_64
-    - aarch64
   epoch: 1
   description: Kubernetes RBAC authorizing HTTP proxy for a single upstream.
   copyright:

--- a/libdaemon.yaml
+++ b/libdaemon.yaml
@@ -3,8 +3,6 @@ package:
   version: 0.14
   epoch: 0
   description: A lightweight C library which eases the writing of UNIX daemons
-  target-architecture:
-    - all
   copyright:
     - license: LGPL-2.1-or-later
 

--- a/newrelic-prometheus-configurator.yaml
+++ b/newrelic-prometheus-configurator.yaml
@@ -3,8 +3,6 @@ package:
   version: 1.12.0
   epoch: 0
   description: New Relic Prometheus Configurator
-  target-architecture:
-    - all
   copyright:
     - license: Apache-2.0
 

--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -3,8 +3,6 @@ package:
   version: 2.11.1
   epoch: 2 # Remove CVE-2022-45146 patch when bumping to 2.12 or later
   description:
-  target-architecture:
-    - all
   copyright:
     - paths:
         - "*"

--- a/php-8.1-pdo_snowflake.yaml
+++ b/php-8.1-pdo_snowflake.yaml
@@ -70,7 +70,3 @@ update:
   github:
     identifier: snowflakedb/pdo_snowflake
     strip-prefix: v
-
-
-
-# TODO touch this file

--- a/php-8.1-pdo_snowflake.yaml
+++ b/php-8.1-pdo_snowflake.yaml
@@ -70,3 +70,7 @@ update:
   github:
     identifier: snowflakedb/pdo_snowflake
     strip-prefix: v
+
+
+
+# TODO touch this file

--- a/rekor.yaml
+++ b/rekor.yaml
@@ -3,8 +3,6 @@ package:
   version: 1.3.4
   epoch: 2
   description: Software Supply Chain Transparency Log
-  target-architecture:
-    - all
   copyright:
     - license: Apache-2.0
   checks:

--- a/task.yaml
+++ b/task.yaml
@@ -3,8 +3,6 @@ package:
   version: 3.33.1
   epoch: 0
   description: A task runner / simpler Make alternative written in Go
-  target-architecture:
-    - all
   copyright:
     - license: MIT
       paths:

--- a/timestamp-authority.yaml
+++ b/timestamp-authority.yaml
@@ -3,8 +3,6 @@ package:
   version: 1.2.1
   epoch: 0
   description: RFC3161 Timestamp Authority
-  target-architecture:
-    - all
   copyright:
     - license: Apache-2.0
       paths:


### PR DESCRIPTION
Also remove some places where we were setting `target-architecture` unnecessarily.

This should make CI pass when a single-arch build is requested in CI

Fixes https://github.com/wolfi-dev/os/issues/11461