### PR TITLE
bump sqllite to 3.45

### DIFF
--- a/sqlite.yaml
+++ b/sqlite.yaml
@@ -82,3 +82,12 @@ update:
   manual: true # fetch URL contains non version string
   release-monitor:
     identifier: 4877
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        sqlite3 --version

--- a/sqlite.yaml
+++ b/sqlite.yaml
@@ -1,6 +1,6 @@
 package:
   name: sqlite
-  version: 3.44.0
+  version: 3.45.0
   epoch: 0
   description: "C library which implements an SQL database engine"
   copyright:
@@ -21,8 +21,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://www.sqlite.org/2023/sqlite-autoconf-3440000.tar.gz
-      expected-sha256: b9cd386e7cd22af6e0d2a0f06d0404951e1bef109e42ea06cc0450e10cd15550
+      uri: https://www.sqlite.org/2024/sqlite-autoconf-3450000.tar.gz
+      expected-sha256: 72887d57a1d8f89f52be38ef84a6353ce8c3ed55ada7864eb944abd9a495e436
   - name: Configure
     runs: |
       _amalgamation="-DSQLITE_ENABLE_FTS4 \


### PR DESCRIPTION
fixes #11195

```
v.conf --unshare-pid --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv HOME /home/build --setenv GOPATH /home/build/.cache/go --setenv GOMODCACHE /var/cache/melange/gomodcache /bin/sh -c [ -x /sbin/ldconfig ] && /sbin/ldconfig /lib || true
ℹ️  x86_64    | running the main test pipeline
❕ x86_64    |     ${{targets.package.sqlite-libs}}: /home/build/melange-out/sqlite-libs
❕ x86_64    |     ${{package.epoch}}: 0
❕ x86_64    |     ${{targets.contextdir}}: /home/build/melange-out/sqlite
❕ x86_64    |     ${{targets.package.sqlite-dev}}: /home/build/melange-out/sqlite-dev
❕ x86_64    |     ${{targets.package.sqlite-doc}}: /home/build/melange-out/sqlite-doc
❕ x86_64    |     ${{targets.package.sqlite}}: /home/build/melange-out/sqlite
❕ x86_64    |     ${{package.name}}: sqlite
❕ x86_64    |     ${{package.version}}: 3.45.0
❕ x86_64    |     ${{package.full-version}}: 3.45.0-r0
❕ x86_64    |     ${{targets.destdir}}: /home/build/melange-out/sqlite
ℹ️  x86_64    | executing: bwrap --bind /tmp/melange-guest-1266609123 / --bind /tmp/melange-workspace-732210151 /home/build --bind /etc/resolv.conf /etc/resolv.conf --unshare-pid --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv HOME /home/build --setenv GOPATH /home/build/.cache/go --setenv GOMODCACHE /var/cache/melange/gomodcache /bin/sh -c set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
sqlite3 --version

exit 0
ℹ️  x86_64    | 3.45.0 2024-01-15 17:01:13 1066602b2b1976fe58b5150777cced894af17c803e068f5918390d6915b46e1d (64-bit)
```