### PR TITLE
Withdraw alpha python packages

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -22,3 +22,14 @@ openjdk-21-jre-base-21.35-r0.apk
 openjdk-21-jre-21.35-r1.apk
 openjdk-21-jre-base-21.35-r1.apk
 nspr-dev-4.35-r0.apk
+python-3.12-3.12.0_alpha5-r2.apk
+python-3.12-3.12.0_alpha6-r0.apk
+python-3.12-3.12.0_alpha7-r0.apk
+python-3.12-dev-3.12.0_alpha5-r2.apk
+python-3.12-dev-3.12.0_alpha6-r0.apk
+python-3.12-dev-3.12.0_alpha7-r0.apk
+python-3.12-doc-3.12.0_alpha5-r0.apk
+python-3.12-doc-3.12.0_alpha5-r1.apk
+python-3.12-doc-3.12.0_alpha5-r2.apk
+python-3.12-doc-3.12.0_alpha6-r0.apk
+python-3.12-doc-3.12.0_alpha7-r0.apk


### PR DESCRIPTION
These are missing some provides/depends metadata that breaks "apk add".