### PR TITLE
google-cloud-sdk: update and build with python 3.12

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -104,6 +104,7 @@ jobs:
 
       - name: "Check that packages can be installed with apk add"
         run: |
+          apk update
           for f in $(find packages -name '*.apk'); do
             apk add --allow-untrusted --simulate $f
           done

--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: google-cloud-sdk
   version: 427.0.0
-  epoch: 3
+  epoch: 4
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0
@@ -9,7 +9,7 @@ package:
     runtime:
       # Required for cyclic redunancy check (gsutil help crcmod)
       - py3-crcmod
-      - python-3.11
+      - python-3.12
 
 environment:
   contents:
@@ -18,8 +18,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - python-3.11
-      - python-3.11-dev
+      - python-3.12
+      - python-3.12-dev
       - wolfi-base
 
 pipeline:
@@ -69,6 +69,14 @@ pipeline:
       done
 
   - uses: strip
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: gcloud --version
 
 update:
   enabled: true

--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: google-cloud-sdk
   version: 452.0.0
-  epoch: 4
+  epoch: 0
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0

--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,6 +1,6 @@
 package:
   name: google-cloud-sdk
-  version: 427.0.0
+  version: 452.0.0
   epoch: 4
   description: "Google Cloud Command Line Interface"
   copyright:
@@ -23,18 +23,26 @@ environment:
       - wolfi-base
 
 pipeline:
+  - runs: |
+      # This step is just here to make it easier to grab SHAs of the files, for adding to the steps below.
+      echo "SHA256 of google-cloud-sdk-${{package.version}}-linux-x86_64.tar.gz"
+      curl -sL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-x86_64.tar.gz | sha256sum -
+
+      echo "SHA256 of google-cloud-sdk-${{package.version}}-linux-arm.tar.gz"
+      curl -sL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-arm.tar.gz | sha256sum -
+
   - if: ${{build.arch}} == "x86_64"
     uses: fetch
     with:
-      uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-426.0.0-linux-x86_64.tar.gz
-      expected-sha256: c653a8ac1e48889005fd00e2de580a27be5a3cb46ceccc570146982c4ddf4245
+      uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-x86_64.tar.gz
+      expected-sha256: 59a3cb9797aff0bfcbc5bc6c7a8219530aca2e2060a411c6c989a5e34fd9aa87
       strip-components: 0
 
   - if: ${{build.arch}} == "aarch64"
     uses: fetch
     with:
-      uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-426.0.0-linux-arm.tar.gz
-      expected-sha256: 8409b8cc00f0ae8089be97d8a565f4072eada890776345bccb988bcd4d4bb27f
+      uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-arm.tar.gz
+      expected-sha256: e5641dc717dc49f4a951455055006bc72dc679de0a7f088a2af2d3e91c76a137
       strip-components: 0
 
   - runs: |


### PR DESCRIPTION
https://issuetracker.google.com/issues/303280713 and https://cloud.google.com/sdk/docs/install#supported_python_versions indicate that latest version of gcloud should be compatible with Python 3.12

Let's find out!

Editor's note: It turns out gcloud updates are basically manual, since we require a human to update the expected SHA each time. I did this, and to make this easier for auto-update triagers in the future, I added a pre-step that prints the observed SHA.