### PR TITLE
new pkg: talloc

### DIFF
--- a/talloc.yaml
+++ b/talloc.yaml
@@ -1,0 +1,65 @@
+package:
+  name: talloc
+  version: 2.4.1
+  epoch: 0
+  description: Memory pool management library
+  copyright:
+    - license: GPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - docbook-xml
+      - libxslt
+      - python3-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 4de3b66d7cd1ff3f53e28e86bf9e89528635465c67868e1262aab6946106c228b2c184e988561361c3194fb260d83e016477254c9dbea7abff40c4dc0d31c76c
+      uri: https://samba.org/ftp/talloc/talloc-${{package.version}}.tar.gz
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --bundled-libraries=NONE \
+        --builtin-libraries=replace \
+        --disable-rpath \
+        --disable-rpath-install \
+        --without-gettext
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: talloc-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - talloc
+
+  - name: "talloc-doc"
+    description: "talloc documentation"
+    pipeline:
+      - uses: split/manpages
+
+  - name: "py3-talloc"
+    description: "Python 3 binding for libtalloc"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libpy* "${{targets.contextdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/python3* "${{targets.contextdir}}"/usr/lib
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 287

--- a/talloc.yaml
+++ b/talloc.yaml
@@ -62,4 +62,4 @@ subpackages:
 update:
   enabled: true
   release-monitor:
-    identifier: 287
+    identifier: 1733


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
