### PR TITLE
dockerd: remove redundant runtime dep on ctr

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: 25.0.0
-  epoch: 0
+  epoch: 1
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0

--- a/docker.yaml
+++ b/docker.yaml
@@ -95,7 +95,6 @@ subpackages:
         - pigz
         - zfs
         - containerd
-        - ctr
         - tini-static
     pipeline:
       - runs: |


### PR DESCRIPTION
`ctr` is a subpackage of `containerd` that just splits out the `ctr` binary, which is also provided by `containerd`.

Depending on both `ctr` and `containerd` seems to be confusing our solver, and apk's. At least that's the theory. In any case it's a redundant dependency, since depending on `containerd` will bring in `ctr` regardless.

https://github.com/wolfi-dev/os/blob/ac9f4551e540ae6a198aea0414b6ba1cc521736f/containerd.yaml#L48