### PR TITLE
containerd: rearrange subpackages

### DIFF
--- a/containerd.yaml
+++ b/containerd.yaml
@@ -1,13 +1,19 @@
 package:
   name: containerd
   version: 1.7.12
-  epoch: 2
+  epoch: 3
   description: An open and reliable container runtime
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - runc
+      # Aggregate all the subpackages into this meta-package.
+      - ctr
+      - containerd-stress
+      - containerd-shim
+      - containerd-shim-runc-v1
+      - containerd-shim-runc-v2
 
 environment:
   contents:
@@ -36,10 +42,6 @@ pipeline:
       mkdir -p "${{targets.destdir}}"/etc/containerd
       ./bin/containerd config default > "${{targets.destdir}}"/etc/containerd/config.toml
 
-  - runs: |
-      mkdir -p "${{targets.destdir}}"/usr/bin
-      install -sm755 ./bin/* "${{targets.destdir}}"/usr/bin/
-
   - uses: strip
 
 data:
@@ -56,8 +58,10 @@ subpackages:
     name: ${{range.key}}
     description: ${{range.value}}
     pipeline:
+      # Move each binary into its own subpackage, which gets runtime-depended-on by the containerd meta-package.
+      # This allows users who only want one of these tools to get it, or get all of them by depending on `containerd` (with its config)
       - runs: |
-          install -Dm755 "${{targets.destdir}}"/usr/bin/${{range.key}} "${{targets.subpkgdir}}"/usr/bin/${{range.key}}
+          install -Dm755 "./bin/${{range.key}}" "${{targets.subpkgdir}}"/usr/bin/${{range.key}}
 
 update:
   enabled: true

--- a/containerd.yaml
+++ b/containerd.yaml
@@ -6,14 +6,14 @@ package:
   copyright:
     - license: Apache-2.0
   dependencies:
+    # Aggregate all the subpackages into this meta-package.
     runtime:
-      - runc
-      # Aggregate all the subpackages into this meta-package.
-      - ctr
-      - containerd-stress
       - containerd-shim
       - containerd-shim-runc-v1
       - containerd-shim-runc-v2
+      - containerd-stress
+      - ctr
+      - runc
 
 environment:
   contents:


### PR DESCRIPTION
Before this change, the `containerd` package contained all its binaries, and each subpackage _also_ contained those binaries, split into separate packages.

This meant that both `containerd` and `ctr` had an SCA-generated `provides=cmd:ctr-<version>`, which caused confusion when solving.

With this change, the `containerd` package itself will contain no binaries -- only a simple config file -- but will have runtime deps on its subpackages that contain all the binaries it had before. The subpackages will have the _only_ copy of their binaries, rather than sharing them with their parent package.

Users should be unaffected by this change -- anybody depending on `containerd` will still get `ctr` etc as a transient dependency. Anybody depending on `ctr` will get only `ctr`, as before.