### PR TITLE
apk test all the apk at once

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -105,9 +105,19 @@ jobs:
       - name: "Check that packages can be installed with apk add"
         run: |
           apk update
+          apk_files=""
+          # Find .apk files and add them to the string
           for f in $(find packages -name '*.apk'); do
-            apk add --allow-untrusted --simulate $f
+              apk_files="$apk_files $f"
           done
+          
+          # Check if the string is not empty
+          if [ -n "$apk_files" ]; then
+              # Install all .apk files in one command
+              apk add --allow-untrusted --simulate $apk_files
+          else
+              echo "No .apk files found."
+          fi
 
       - name: Check for file
         id: file_check

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,7 +1,7 @@
 package:
   name: goreleaser
   version: 1.23.0
-  epoch: 0
+  epoch: 1
   description: Deliver Go binaries as fast and easily as possible
   copyright:
     - license: Apache-2.0

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.15.1
-  epoch: 3
+  epoch: 4
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
when there are dependency between new packages built together , the app test fails due to the apk defined in the runtime not available on wolfi yet 

https://github.com/wolfi-dev/os/actions/runs/7592501499/job/20681911269

```
WARNING: opening ./../../packages: No such file or directory
fetch https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
 [https://packages.wolfi.dev/os]
OK: 36543 distinct packages available
WARNING: opening ./../../packages: No such file or directory
(1/9) Installing bzip2 (1.0.8-r4)
(2/9) Installing libffi (3.4.4-r2)
(3/9) Installing gdbm (1.23-r3)
(4/9) Installing xz (5.4.5-r0)
(5/9) Installing mpdecimal (2.5.1-r3)
(6/9) Installing readline (8.2-r2)
(7/9) Installing sqlite (3.40.0-r1)
(8/9) Installing python-3.11 (3.11.7-r0)
(9/9) Installing pytorch (2.1.2-r3)
OK: 943 MiB in 51 packages
WARNING: opening ./../../packages: No such file or directory
ERROR: unable to select packages:
  py3-sympy (no such package):
    required by: py3.11-pytorch-2.1.2-r3[py3-sympy]
Error: Process completed with exit code 2.
```

py3-sympy was built in the same PR as PyTorch update , but kept on failing due to the failing dependency 
This should probably work or we can remove simulate and have the package installed 