### PR TITLE
Fix broken apache-arrow dep graph

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -109,16 +109,8 @@ jobs:
           # Find .apk files and add them to the string
           for f in $(find packages -name '*.apk'); do
               tar -Oxf $f .PKGINFO
-              apk_files="$apk_files $f"
+              apk add --repository "$GITHUB_WORKSPACE/packages" --allow-untrusted --simulate $f
           done
-
-          # Check if the string is not empty
-          if [ -n "$apk_files" ]; then
-              # Install all .apk files in one command
-              apk add --allow-untrusted --simulate $apk_files
-          else
-              echo "No .apk files found."
-          fi
 
       - name: Check SBOMs
         run: |

--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-arrow
   version: 14.0.2
-  epoch: 4
+  epoch: 5
   description: "multi-language toolbox for accelerated data interchange and in-memory processing"
   copyright:
     - license: Apache-2.0
@@ -116,7 +116,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
-          cp ${{targets.destdir}}/usr/lib/libarrow_dataset.so.* ${{targets.subpkgdir}}/usr/lib
+          cp -a ${{targets.destdir}}/usr/lib/libarrow.so.* ${{targets.subpkgdir}}/usr/lib
     dependencies:
       runtime:
         - libarrow
@@ -126,7 +126,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
-          cp ${{targets.destdir}}/usr/lib/libarrow_acero.so.* ${{targets.subpkgdir}}/usr/lib
+          cp -a ${{targets.destdir}}/usr/lib/libarrow_acero.so.* ${{targets.subpkgdir}}/usr/lib
     dependencies:
       runtime:
         - libarrow
@@ -136,7 +136,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
-          cp ${{targets.destdir}}/usr/lib/libarrow_dataset.so.* ${{targets.subpkgdir}}/usr/lib
+          cp -a ${{targets.destdir}}/usr/lib/libarrow_dataset.so.* ${{targets.subpkgdir}}/usr/lib
     dependencies:
       runtime:
         - libarrow
@@ -146,7 +146,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
-          cp ${{targets.destdir}}/usr/lib/libarrow_flight.so.* ${{targets.subpkgdir}}/usr/lib
+          cp -a ${{targets.destdir}}/usr/lib/libarrow_flight.so.* ${{targets.subpkgdir}}/usr/lib
     dependencies:
       runtime:
         - libarrow
@@ -156,7 +156,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib
-          cp ${{targets.destdir}}/usr/lib/libparquet.so.* ${{targets.subpkgdir}}/usr/lib
+          cp -a ${{targets.destdir}}/usr/lib/libparquet.so.* ${{targets.subpkgdir}}/usr/lib
     dependencies:
       runtime:
         - libarrow


### PR DESCRIPTION
One of these was a typo that made libarrow uninstallable.

The rest just preserve symlinks and makes the packages 50% smaller.

X-ref: https://github.com/wolfi-dev/os/issues/11323