### PR TITLE
Update cert-manager-1.13.yaml

### DIFF
--- a/cert-manager-1.13.yaml
+++ b/cert-manager-1.13.yaml
@@ -2,7 +2,7 @@ package:
   name: cert-manager-1.13
   # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
   version: 1.13.3
-  epoch: 2
+  epoch: 3
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -104,16 +104,13 @@ subpackages:
       provides:
         - cert-manager-acmesolver=${{package.full-version}}
 
-  - name: cmctl-1.13
+  - name: ${{package.name}}-cmctl
     pipeline:
       - runs: |
-          make CTR=make _bin/cmctl/cmctl-linux-$(go env GOARCH)
-      - runs: |
-          install -Dm755 _bin/cmctl/cmctl-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/cmctl
-      - uses: strip
+          install -Dm755 ${{targets.destdir}}/usr/bin/cmctl-linux-$(go env GOARCH) ${{targets.subpkgdir}}/usr/bin/cmctl
     dependencies:
       provides:
-        - cmctl=${{package.full-version}}
+        - cert-manager-cmctl=${{package.full-version}}
 
 update:
   enabled: true


### PR DESCRIPTION
Change package delivery to allow cmctl to become an additional image (part of cert-manager) instead of a separate package.
