### PR TITLE
rebuild packages with valid SBOMs

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -123,9 +123,10 @@ jobs:
         env:
           NTIA_IMAGE: cgr.dev/chainguard/ntia-conformance-checker:latest@sha256:bde670cb65228e873ca2a2d674d407f310b11e608465454c668a5285fbaba3ee
         run: |
+          apk add py3-ntia-conformance-checker
           for f in $(find packages -name '*.apk'); do
               tar -tvf $f var/lib/db/sbom/ > sbom.json
-              docker run --rm --user 0 -v $(pwd)/sbom.json:/sbom.json:ro ${NTIA_IMAGE} -v --file /sbom.json
+              ntia-checker -v --file sbom.json
           done
 
       - name: Check for file

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -126,7 +126,7 @@ jobs:
           apk add py3-ntia-conformance-checker
           for f in $(find packages -name '*.apk'); do
               echo ==== Checking SBOM for $f ====
-              tar -tvf $f var/lib/db/sbom/ > sbom.json
+              tar -Oxf $f var/lib/db/sbom/ > sbom.json
               echo ::group::sbom.json
               cat sbom.json
               echo ::endgroup::

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -110,7 +110,7 @@ jobs:
           for f in $(find packages -name '*.apk'); do
               apk_files="$apk_files $f"
           done
-          
+
           # Check if the string is not empty
           if [ -n "$apk_files" ]; then
               # Install all .apk files in one command
@@ -118,6 +118,15 @@ jobs:
           else
               echo "No .apk files found."
           fi
+
+      - name: Check SBOMs
+        env:
+          NTIA_IMAGE: cgr.dev/chainguard/ntia-conformance-checker:latest@sha256:bde670cb65228e873ca2a2d674d407f310b11e608465454c668a5285fbaba3ee
+        run: |
+          for f in $(find packages -name '*.apk'); do
+              tar -tvf $f var/lib/db/sbom/ > sbom.json
+              docker run --rm --user 0 -v $(pwd)/sbom.json:/sbom.json:ro ${NTIA_IMAGE} -v --file /sbom.json
+          done
 
       - name: Check for file
         id: file_check

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -120,8 +120,6 @@ jobs:
           fi
 
       - name: Check SBOMs
-        env:
-          NTIA_IMAGE: cgr.dev/chainguard/ntia-conformance-checker:latest@sha256:bde670cb65228e873ca2a2d674d407f310b11e608465454c668a5285fbaba3ee
         run: |
           apk add py3-ntia-conformance-checker
           for f in $(find packages -name '*.apk'); do

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -125,7 +125,11 @@ jobs:
         run: |
           apk add py3-ntia-conformance-checker
           for f in $(find packages -name '*.apk'); do
+              echo ==== Checking SBOM for $f ====
               tar -tvf $f var/lib/db/sbom/ > sbom.json
+              echo ::group::sbom.json
+              cat sbom.json
+              echo ::endgroup::
               ntia-checker -v --file sbom.json
           done
 

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: binutils
   version: "2.41"
-  epoch: 0
+  epoch: 1
   description: "GNU binutils"
   copyright:
     - license: GPL-3.0-or-later

--- a/build-base.yaml
+++ b/build-base.yaml
@@ -1,7 +1,7 @@
 package:
   name: build-base
   version: 1
-  epoch: 5
+  epoch: 6
   description: "virtual package for builds"
   copyright:
     - license: MIT

--- a/bzip2.yaml
+++ b/bzip2.yaml
@@ -1,7 +1,7 @@
 package:
   name: bzip2
   version: 1.0.8
-  epoch: 5
+  epoch: 6
   description: "a library implementing the bzip2 compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/freetype.yaml
+++ b/freetype.yaml
@@ -1,7 +1,7 @@
 package:
   name: freetype
   version: 2.13.2
-  epoch: 1
+  epoch: 2
   description: TrueType font rendering library
   copyright:
     - license: FTL GPL-2.0-or-later

--- a/freetype.yaml
+++ b/freetype.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 2
   description: TrueType font rendering library
   copyright:
-    - license: FTL GPL-2.0-or-later
+    - license: FTL OR GPL-2.0-or-later
 
 environment:
   contents:

--- a/gdbm.yaml
+++ b/gdbm.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdbm
   version: 1.23
-  epoch: 3
+  epoch: 4
   description: "GNU dbm is a set of database routines which use extensible hashing"
   copyright:
     - license: GPL-3.0-or-later

--- a/gmp.yaml
+++ b/gmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: gmp
   version: 6.3.0
-  epoch: 0
+  epoch: 1
   description: "a library for arbitrary precision arithmetic"
   copyright:
     - license: LGPL-3.0-or-later OR GPL-2.0-or-later

--- a/isl.yaml
+++ b/isl.yaml
@@ -1,7 +1,7 @@
 package:
   name: isl
   version: 0.26
-  epoch: 0
+  epoch: 1
   description: "an integer set library for the polyhedral model"
   copyright:
     - license: MIT

--- a/java-cacerts.yaml
+++ b/java-cacerts.yaml
@@ -2,7 +2,7 @@ package:
   name: java-cacerts
   # Update this when ca-certificates is updated.
   version: 20230106
-  epoch: 2
+  epoch: 3
   description: "default certificate authorities for Java"
   copyright:
     - license: MIT

--- a/java-common.yaml
+++ b/java-common.yaml
@@ -1,7 +1,7 @@
 package:
   name: java-common
   version: 0.1
-  epoch: 0
+  epoch: 1
   description: "Compatibility infrastructure for JVM runtimes"
   copyright:
     - license: GPL-2.0-or-later

--- a/libffi.yaml
+++ b/libffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libffi
   version: 3.4.4
-  epoch: 2
+  epoch: 3
   description: "portable foreign function interface library"
   copyright:
     - license: MIT

--- a/libidn.yaml
+++ b/libidn.yaml
@@ -1,7 +1,7 @@
 package:
   name: libidn
   version: "1.42"
-  epoch: 1
+  epoch: 0
   description: Encode/Decode library for internationalized domain names
   copyright:
     - license: LGPL-2.1-or-later

--- a/libidn.yaml
+++ b/libidn.yaml
@@ -1,7 +1,7 @@
 package:
   name: libidn
   version: "1.42"
-  epoch: 0
+  epoch: 1
   description: Encode/Decode library for internationalized domain names
   copyright:
     - license: LGPL-2.1-or-later

--- a/libidn2.yaml
+++ b/libidn2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libidn2
   version: 2.3.4
-  epoch: 0
+  epoch: 1
   description: Encode/Decode library for internationalized domain names
   copyright:
     - license: GPL-2.0-or-later AND LGPL-3.0-or-later

--- a/libpng.yaml
+++ b/libpng.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpng
   version: 1.6.40
-  epoch: 0
+  epoch: 1
   description: Portable Network Graphics library
   copyright:
     - license: Libpng

--- a/libtasn1.yaml
+++ b/libtasn1.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtasn1
   version: 4.19.0
-  epoch: 0
+  epoch: 1
   description: The ASN.1 library used in GNUTLS
   copyright:
     - license: LGPL-2.1-or-later

--- a/libunistring.yaml
+++ b/libunistring.yaml
@@ -1,7 +1,7 @@
 package:
   name: libunistring
   version: "1.1"
-  epoch: 1
+  epoch: 2
   description: Library for manipulating Unicode strings and C strings
   copyright:
     - license: GPL-2.0-or-later OR LGPL-3.0-or-later

--- a/make.yaml
+++ b/make.yaml
@@ -1,7 +1,7 @@
 package:
   name: make
   version: 4.4.1
-  epoch: 0
+  epoch: 1
   description: "GNU make"
   copyright:
     - license: GPL-3.0-or-later

--- a/mpc.yaml
+++ b/mpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: mpc
   version: 1.3.1
-  epoch: 0
+  epoch: 1
   description: "multiple-precision C library"
   copyright:
     - license: LGPL-3.0-or-later

--- a/mpdecimal.yaml
+++ b/mpdecimal.yaml
@@ -1,7 +1,7 @@
 package:
   name: mpdecimal
   version: 2.5.1
-  epoch: 4
+  epoch: 3
   description: "complete implementation of the general decimal arithmetic specification"
   copyright:
     - license: MIT

--- a/mpdecimal.yaml
+++ b/mpdecimal.yaml
@@ -1,7 +1,7 @@
 package:
   name: mpdecimal
   version: 2.5.1
-  epoch: 3
+  epoch: 4
   description: "complete implementation of the general decimal arithmetic specification"
   copyright:
     - license: MIT

--- a/mpfr.yaml
+++ b/mpfr.yaml
@@ -1,7 +1,7 @@
 package:
   name: mpfr
   version: 4.2.1
-  epoch: 0
+  epoch: 1
   description: "multiple-precision floating-point library"
   copyright:
     - license: LGPL-3.0-or-later

--- a/p11-kit.yaml
+++ b/p11-kit.yaml
@@ -1,7 +1,7 @@
 package:
   name: p11-kit
   version: 0.25.3
-  epoch: 0
+  epoch: 1
   description: Library for loading and sharing PKCS#11 modules
   copyright:
     - license: BSD-3-Clause

--- a/pkgconf.yaml
+++ b/pkgconf.yaml
@@ -1,7 +1,7 @@
 package:
   name: pkgconf
   version: 2.1.0
-  epoch: 0
+  epoch: 1
   description: "An implementation of pkg-config"
   copyright:
     - license: ISC

--- a/posix-cc-wrappers.yaml
+++ b/posix-cc-wrappers.yaml
@@ -1,7 +1,7 @@
 package:
   name: posix-cc-wrappers
   version: 1
-  epoch: 0
+  epoch: 1
   description: "Wrappers around GCC and Clang for POSIX conformance"
   copyright:
     - license: MIT

--- a/pulumi-watch.yaml
+++ b/pulumi-watch.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-watch
   version: 0.1.5
-  epoch: 1
+  epoch: 2
   description: Supports the functionality of the pulumi watch command
   copyright:
     - license: Apache-2.0

--- a/readline.yaml
+++ b/readline.yaml
@@ -1,7 +1,7 @@
 package:
   name: readline
   version: "8.2"
-  epoch: 2
+  epoch: 3
   description: "GNU readline library"
   copyright:
     - license: GPL-3.0-or-later

--- a/xz.yaml
+++ b/xz.yaml
@@ -1,7 +1,7 @@
 package:
   name: xz
   version: 5.4.5
-  epoch: 0
+  epoch: 1
   description: "Library and CLI tools for XZ and LZMA compressed files"
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
These packages haven't been rebuilt in months, sometimes a year+, and their SBOMs are invalid:

```
│ spdx_id must only contain letters, numbers, "." and "-" and must begin with "SPDXRef-", but is: SPDXRef-File-/usr/share/doc/libunistring/libunistring_abt.html
│ spdx_id must only contain letters, numbers, "." and "-" and must begin with "SPDXRef-", but is: SPDXRef-File-/usr/share/doc/libunistring/libunistring_toc.html
│ spdx_id must only contain letters, numbers, "." and "-" and must begin with "SPDXRef-", but is: SPDXRef-File-/usr/share/info/libunistring.info
│ Components missing an supplier: libunistring,libidn2
```

Rebuilding should give them new valid SBOMs.

Also adding a check to CI that the SBOMs we produce are valid. We also [run this check in melange's CI](https://github.com/chainguard-dev/melange/blob/eb44fc3229f8047d17171cf70ed727b13a9a7642/.github/workflows/e2e.yaml#L52), but there are a lot more exotic packages in this repo than there, so we may find more edge cases here.