### PR TITLE
ci: change scan filter from "all" to "resolved"

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -110,7 +110,7 @@ jobs:
           for f in $(find packages -name '*.apk'); do
               apk_files="$apk_files $f"
           done
-          
+
           # Check if the string is not empty
           if [ -n "$apk_files" ]; then
               # Install all .apk files in one command
@@ -251,7 +251,7 @@ jobs:
           wolfictl scan \
             --build-log \
             --advisories-repo-dir 'data/wolfi-advisories' \
-            --advisory-filter 'all' \
+            --advisory-filter 'resolved' \
             --require-zero \
             /tmp/artifacts-1 \
             2> /dev/null # The error message renders strangely on GitHub Actions, and the important information is already being sent to stdout.


### PR DESCRIPTION
For more information on how this works, see `wolfictl scan --help`.
