### PR TITLE
Do not have kubectl versions provide kubectl

### DIFF
--- a/kubernetes-1.25.yaml
+++ b/kubernetes-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.25
   version: 1.25.16
-  epoch: 3
+  epoch: 4
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -80,18 +80,12 @@ pipeline:
 subpackages:
   - name: kubectl-1.25
     description: A command line tool for communicating with a Kubernetes API server
-    dependencies:
-      provides:
-        - kubectl=1.25
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           install -m755 _output/bin/kubectl ${{targets.subpkgdir}}/usr/bin/kubectl-1.25
 
   - name: kubectl-bash-completion-1.25
-    dependencies:
-      runtime:
-        - kubectl-1.25
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion/completions
@@ -106,8 +100,6 @@ subpackages:
         - ethtool
         - conntrack-tools
         - crictl
-      provides:
-        - kubeadm=1.25
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -121,8 +113,6 @@ subpackages:
     dependencies:
       runtime:
         - ip6tables
-      provides:
-        - kubelet=1.25
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -133,9 +123,6 @@ subpackages:
 
   - name: kube-scheduler-1.25
     description: Kubernetes control plane component watching over pods on nodes
-    dependencies:
-      provides:
-        - kube-scheduler=1.25
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -145,9 +132,6 @@ subpackages:
 
   - name: kube-proxy-1.25
     description: Kubernetes network proxy that runs on each node
-    dependencies:
-      provides:
-        - kube-proxy=1.25
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -158,9 +142,6 @@ subpackages:
 
   - name: kube-controller-manager-1.25
     description: Kubernetes control plane component that runs controller processes
-    dependencies:
-      provides:
-        - kube-controller-manager=1.25
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -170,9 +151,6 @@ subpackages:
 
   - name: kube-apiserver-1.25
     description: Kubernetes control plane component exposing the Kubernetes API
-    dependencies:
-      provides:
-        - kube-apiserver=1.25
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -200,6 +178,7 @@ subpackages:
         - ${{range.key}}-1.25
       provides:
         - ${{range.key}}-default=1.25
+        - ${{range.key}}=1.25
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin

--- a/kubernetes-1.26.yaml
+++ b/kubernetes-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.26
   version: 1.26.13
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -75,9 +75,6 @@ pipeline:
 subpackages:
   - name: kubectl-1.26
     description: A command line tool for communicating with a Kubernetes API server
-    dependencies:
-      provides:
-        - kubectl=1.26
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -101,8 +98,6 @@ subpackages:
         - ethtool
         - conntrack-tools
         - crictl
-      provides:
-        - kubeadm=1.26
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -116,8 +111,6 @@ subpackages:
     dependencies:
       runtime:
         - ip6tables
-      provides:
-        - kubelet=1.26
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -128,9 +121,6 @@ subpackages:
 
   - name: kube-scheduler-1.26
     description: Kubernetes control plane component watching over pods on nodes
-    dependencies:
-      provides:
-        - kube-scheduler=1.26
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -140,9 +130,6 @@ subpackages:
 
   - name: kube-proxy-1.26
     description: Kubernetes network proxy that runs on each node
-    dependencies:
-      provides:
-        - kube-proxy=1.26
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -153,9 +140,6 @@ subpackages:
 
   - name: kube-controller-manager-1.26
     description: Kubernetes control plane component that runs controller processes
-    dependencies:
-      provides:
-        - kube-controller-manager=1.26
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -165,9 +149,6 @@ subpackages:
 
   - name: kube-apiserver-1.26
     description: Kubernetes control plane component exposing the Kubernetes API
-    dependencies:
-      provides:
-        - kube-apiserver=1.26
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -195,6 +176,7 @@ subpackages:
         - ${{range.key}}-1.26
       provides:
         - ${{range.key}}-default=1.26
+        - ${{range.key}}=1.26
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin

--- a/kubernetes-1.27.yaml
+++ b/kubernetes-1.27.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.27
   version: 1.27.10
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -76,9 +76,6 @@ pipeline:
 subpackages:
   - name: kubectl-1.27
     description: A command line tool for communicating with a Kubernetes API server
-    dependencies:
-      provides:
-        - kubectl=1.27
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -102,8 +99,6 @@ subpackages:
         - ethtool
         - conntrack-tools
         - crictl
-      provides:
-        - kubeadm=1.27
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -117,8 +112,6 @@ subpackages:
     dependencies:
       runtime:
         - ip6tables
-      provides:
-        - kubelet=1.27
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -129,9 +122,6 @@ subpackages:
 
   - name: kube-scheduler-1.27
     description: Kubernetes control plane component watching over pods on nodes
-    dependencies:
-      provides:
-        - kube-scheduler=1.27
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -141,9 +131,6 @@ subpackages:
 
   - name: kube-proxy-1.27
     description: Kubernetes network proxy that runs on each node
-    dependencies:
-      provides:
-        - kube-proxy=1.27
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -154,9 +141,6 @@ subpackages:
 
   - name: kube-controller-manager-1.27
     description: Kubernetes control plane component that runs controller processes
-    dependencies:
-      provides:
-        - kube-controller-manager=1.27
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -166,9 +150,6 @@ subpackages:
 
   - name: kube-apiserver-1.27
     description: Kubernetes control plane component exposing the Kubernetes API
-    dependencies:
-      provides:
-        - kube-apiserver=1.27
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -196,6 +177,7 @@ subpackages:
         - ${{range.key}}-1.27
       provides:
         - ${{range.key}}-default=1.27
+        - ${{range.key}}=1.27
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin

--- a/kubernetes-1.28.yaml
+++ b/kubernetes-1.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.28
   version: 1.28.6
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -69,9 +69,6 @@ pipeline:
 subpackages:
   - name: kubectl-1.28
     description: A command line tool for communicating with a Kubernetes API server
-    dependencies:
-      provides:
-        - kubectl=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -95,8 +92,6 @@ subpackages:
         - ethtool
         - conntrack-tools
         - crictl
-      provides:
-        - kubeadm=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -110,8 +105,6 @@ subpackages:
     dependencies:
       runtime:
         - ip6tables
-      provides:
-        - kubelet=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -122,9 +115,6 @@ subpackages:
 
   - name: kube-scheduler-1.28
     description: Kubernetes control plane component watching over pods on nodes
-    dependencies:
-      provides:
-        - kube-scheduler=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -134,9 +124,6 @@ subpackages:
 
   - name: kube-proxy-1.28
     description: Kubernetes network proxy that runs on each node
-    dependencies:
-      provides:
-        - kube-proxy=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -147,9 +134,6 @@ subpackages:
 
   - name: kube-controller-manager-1.28
     description: Kubernetes control plane component that runs controller processes
-    dependencies:
-      provides:
-        - kube-controller-manager=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -159,9 +143,6 @@ subpackages:
 
   - name: kube-apiserver-1.28
     description: Kubernetes control plane component exposing the Kubernetes API
-    dependencies:
-      provides:
-        - kube-apiserver=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -189,6 +170,7 @@ subpackages:
         - ${{range.key}}-1.28
       provides:
         - ${{range.key}}-default=1.28
+        - ${{range.key}}=1.28
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin

--- a/kubernetes-1.29.yaml
+++ b/kubernetes-1.29.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.29
   version: 1.29.1
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -69,9 +69,6 @@ pipeline:
 subpackages:
   - name: kubectl-1.29
     description: A command line tool for communicating with a Kubernetes API server
-    dependencies:
-      provides:
-        - kubectl=1.29
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -95,8 +92,6 @@ subpackages:
         - ethtool
         - conntrack-tools
         - crictl
-      provides:
-        - kubeadm=1.29
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -110,8 +105,6 @@ subpackages:
     dependencies:
       runtime:
         - ip6tables
-      provides:
-        - kubelet=1.29
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -122,9 +115,6 @@ subpackages:
 
   - name: kube-scheduler-1.29
     description: Kubernetes control plane component watching over pods on nodes
-    dependencies:
-      provides:
-        - kube-scheduler=1.29
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -134,9 +124,6 @@ subpackages:
 
   - name: kube-proxy-1.29
     description: Kubernetes network proxy that runs on each node
-    dependencies:
-      provides:
-        - kube-proxy=1.29
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -147,9 +134,6 @@ subpackages:
 
   - name: kube-controller-manager-1.29
     description: Kubernetes control plane component that runs controller processes
-    dependencies:
-      provides:
-        - kube-controller-manager=1.29
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -159,9 +143,6 @@ subpackages:
 
   - name: kube-apiserver-1.29
     description: Kubernetes control plane component exposing the Kubernetes API
-    dependencies:
-      provides:
-        - kube-apiserver=1.29
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -189,6 +170,7 @@ subpackages:
         - ${{range.key}}-1.29
       provides:
         - ${{range.key}}-default=1.29
+        - ${{range.key}}=1.29
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin


### PR DESCRIPTION
We want to be able to install multiple versions of kubectl, but it's impossible because they have conflicting provides. The -default packages for each kubectl version set up a symlink for the default kubectl.