### PR TITLE
fix(cassandra-reaper): Don't RAT out dotfiles and patchfiles

### DIFF
--- a/cassandra-reaper.yaml
+++ b/cassandra-reaper.yaml
@@ -46,7 +46,7 @@ pipeline:
       source /usr/share/nvm/nvm.sh
       nvm install v12
       nvm use v12
-      MAVEN_OPTS="-Xmx384m" mvn -B install -DskipTests -Drat.skip=true
+      MAVEN_OPTS="-Xmx384m" mvn -B install -DskipTests -Drat.excludesFile=rat-exclusions.txt
 
       mkdir -p "${{targets.destdir}}"//usr/local/bin
       mkdir -p "${{targets.destdir}}"//usr/local/lib

--- a/cassandra-reaper/rat-exclusions.txt
+++ b/cassandra-reaper/rat-exclusions.txt
@@ -1,0 +1,5 @@
+# Exclude dotfiles
+.*
+
+# Exclude patches
+*.patch


### PR DESCRIPTION
This prevents RAT from flagging top level dotfiles and patchfiles that don't contain licenses, halting the build process

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: The build for x86-64 cassandra-reaper packages due to RAT flagging dotfiles and patchfiles

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)