### PR TITLE
new package:atuin

### DIFF
--- a/atuin.yaml
+++ b/atuin.yaml
@@ -1,0 +1,53 @@
+package:
+  name: atuin
+  version: 17.2.1
+  epoch: 0
+  description: Magical shell history
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/atuinsh/atuin
+      tag: v${{package.version}}
+      expected-commit: 9f79a34a9dea207df7184972fa29f4fe5ec41b27
+
+  - runs: |
+      cargo build --locked --release
+      cd target/release
+      mkdir -p completions
+      for sh in 'bash' 'fish' 'zsh'; do
+        "./atuin" gen-completions -s "$sh" -o completions/
+      done
+
+      install -Dm755 atuin "${{targets.destdir}}"/usr/bin/atuin
+
+      install -Dm 644 "completions/${{package.name}}.bash" "${{targets.destdir}}/usr/share/bash-completion/completions/atuin"
+      install -Dm 644 "completions/${{package.name}}.fish" -t "${{targets.destdir}}/usr/share/fish/vendor_completions.d"
+      install -Dm 644 "completions/_${{package.name}}" -t "${{targets.destdir}}/usr/share/zsh/site-functions"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: atuinsh/atuin
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        atuin -V


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
