### PR TITLE
adds cassandra patch to upgrade py3openssl

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: 0.17.1
-  epoch: 3
+  epoch: 4
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0

--- a/py3-cassandra-medusa/bump.patch
+++ b/py3-cassandra-medusa/bump.patch
@@ -1,12 +1,14 @@
 diff --git a/setup.py b/setup.py
-index 9727ac2..a7a0f7b 100644
+index 9727ac2..014d17a 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -50,13 +50,13 @@ setuptools.setup(
+@@ -49,14 +49,14 @@ setuptools.setup(
+         'psutil>=5.4.7',
          'ffwd>=0.0.2',
          'lockfile>=0.12.2',
-         'pyOpenSSL==22.0.0',
+-        'pyOpenSSL==22.0.0',
 -        'cryptography<=35.0,>=2.5',
++        'pyOpenSSL==24.0.0',
 +        'cryptography<=41.0.6,>=2.5',
          'pycryptodome>=3.9.9',
          'retrying>=1.3.3',


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
