### PR TITLE
chore: bump google-cloud-sdk to v460.0.0 to fix Python issue

### DIFF
--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,6 +1,6 @@
 package:
   name: google-cloud-sdk
-  version: 452.0.0
+  version: 460.0.0
   epoch: 0
   description: "Google Cloud Command Line Interface"
   copyright:
@@ -35,14 +35,14 @@ pipeline:
     uses: fetch
     with:
       uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-x86_64.tar.gz
-      expected-sha256: 59a3cb9797aff0bfcbc5bc6c7a8219530aca2e2060a411c6c989a5e34fd9aa87
+      expected-sha256: 93684d9df236ea1207dcf8622eb7f6e4c368777b99b0c77ac848b47a0e5d9c9e
       strip-components: 0
 
   - if: ${{build.arch}} == "aarch64"
     uses: fetch
     with:
       uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-arm.tar.gz
-      expected-sha256: e5641dc717dc49f4a951455055006bc72dc679de0a7f088a2af2d3e91c76a137
+      expected-sha256: 9a6f4f44658ad8f21555b6d51c72400a55adaefa61caadaf5b5f5a1bbe3d485b
       strip-components: 0
 
   - runs: |
@@ -85,6 +85,7 @@ test:
         - wolfi-base
   pipeline:
     - runs: gcloud --version
+    - runs: gsutil --version
 
 update:
   enabled: true


### PR DESCRIPTION
Bump `google-cloud-sdk` version from v452.0.0 to v460.0.0 and add a test to verify `gsutil` runs. This fixes an issue where `gsutil` fails to run due to a dependency on the Python `six` library.