### PR TITLE
Fix BSD license -> BSD-3-Clause

### DIFF
--- a/crfsuite.yaml
+++ b/crfsuite.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: An implementation of Conditional Random Fields (CRFs) for labeling sequential data
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/crfsuite.yaml
+++ b/crfsuite.yaml
@@ -1,7 +1,7 @@
 package:
   name: crfsuite
   version: 0.12
-  epoch: 0
+  epoch: 1
   description: An implementation of Conditional Random Fields (CRFs) for labeling sequential data
   copyright:
     - license: BSD-3-Clause

--- a/imlib2.yaml
+++ b/imlib2.yaml
@@ -1,7 +1,7 @@
 package:
   name: imlib2
   version: 1.12.1
-  epoch: 0
+  epoch: 1
   description: Image manipulation library
   copyright:
     - license: BSD-3-Clause

--- a/imlib2.yaml
+++ b/imlib2.yaml
@@ -1,10 +1,10 @@
 package:
   name: imlib2
   version: 1.12.1
-  epoch: 1
+  epoch: 0
   description: Image manipulation library
   copyright:
-    - license: BSD-3-Clause
+    - license: BSD
 
 environment:
   contents:

--- a/imlib2.yaml
+++ b/imlib2.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: Image manipulation library
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/libssh2.yaml
+++ b/libssh2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libssh2
   version: 1.11.0 # Remove CVE-2023-48795.patch when upgrading to 1.11.1
-  epoch: 2
+  epoch: 3
   description: "A library implementing the SSH2 protocol as defined by Internet Drafts"
   copyright:
     - license: BSD-3-Clause

--- a/libssh2.yaml
+++ b/libssh2.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 2
   description: "A library implementing the SSH2 protocol as defined by Internet Drafts"
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/lua-resty-balancer.yaml
+++ b/lua-resty-balancer.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-balancer
   version: 0.05
-  epoch: 1
+  epoch: 2
   description: "A generic consistent hash implementation for OpenResty/Lua"
   copyright:
     - license: BSD-3-Clause

--- a/lua-resty-balancer.yaml
+++ b/lua-resty-balancer.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: "A generic consistent hash implementation for OpenResty/Lua"
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/lua-resty-cache.yaml
+++ b/lua-resty-cache.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-cache
   version: 0.13
-  epoch: 1
+  epoch: 2
   description: "lua-resty-lrucache - Lua-land LRU cache based on the LuaJIT FFI."
   copyright:
     - license: BSD-3-Clause

--- a/lua-resty-cache.yaml
+++ b/lua-resty-cache.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: "lua-resty-lrucache - Lua-land LRU cache based on the LuaJIT FFI."
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/lua-resty-cookie.yaml
+++ b/lua-resty-cookie.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: "lua-resty-lrucache - Lua-land LRU cache based on the LuaJIT FFI."
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/lua-resty-cookie.yaml
+++ b/lua-resty-cookie.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-cookie
   version: 0.1.0
-  epoch: 1
+  epoch: 2
   description: "lua-resty-lrucache - Lua-land LRU cache based on the LuaJIT FFI."
   copyright:
     - license: BSD-3-Clause

--- a/lua-resty-core.yaml
+++ b/lua-resty-core.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: "lua-resty-core - New FFI-based Lua API for ngx_http_lua_module and/or ngx_stream_lua_module"
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/lua-resty-core.yaml
+++ b/lua-resty-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-core
   version: 0.1.28
-  epoch: 0
+  epoch: 1
   description: "lua-resty-core - New FFI-based Lua API for ngx_http_lua_module and/or ngx_stream_lua_module"
   copyright:
     - license: BSD-3-Clause

--- a/lua-resty-dns.yaml
+++ b/lua-resty-dns.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: "lua-resty-lrucache - Lua-land LRU cache based on the LuaJIT FFI."
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/lua-resty-dns.yaml
+++ b/lua-resty-dns.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-dns
   version: "0.23"
-  epoch: 0
+  epoch: 1
   description: "lua-resty-lrucache - Lua-land LRU cache based on the LuaJIT FFI."
   copyright:
     - license: BSD-3-Clause

--- a/lua-resty-global-throttle.yaml
+++ b/lua-resty-global-throttle.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: "lua-resty-dns - Lua DNS resolver for the ngx_lua based on the cosocket API"
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/lua-resty-global-throttle.yaml
+++ b/lua-resty-global-throttle.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-global-throttle
   version: 0.2.0
-  epoch: 1
+  epoch: 2
   description: "lua-resty-dns - Lua DNS resolver for the ngx_lua based on the cosocket API"
   copyright:
     - license: BSD-3-Clause

--- a/lua-resty-http.yaml
+++ b/lua-resty-http.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: "Lua HTTP client cosocket driver for OpenResty / ngx_lua."
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/lua-resty-http.yaml
+++ b/lua-resty-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-http
   version: 0.0_git20210806
-  epoch: 1
+  epoch: 2
   description: "Lua HTTP client cosocket driver for OpenResty / ngx_lua."
   copyright:
     - license: BSD-3-Clause

--- a/lua-resty-lock.yaml
+++ b/lua-resty-lock.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-lock
   version: 0.09
-  epoch: 1
+  epoch: 2
   description: "Simple nonblocking lock API for ngx_lua based on shared memory dictionaries"
   copyright:
     - license: BSD-3-Clause

--- a/lua-resty-lock.yaml
+++ b/lua-resty-lock.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: "Simple nonblocking lock API for ngx_lua based on shared memory dictionaries"
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/lua-resty-memcached.yaml
+++ b/lua-resty-memcached.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: "Lua memcached client driver for the ngx_lua based on the cosocket API"
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/lua-resty-memcached.yaml
+++ b/lua-resty-memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-memcached
   version: 0.17
-  epoch: 1
+  epoch: 2
   description: "Lua memcached client driver for the ngx_lua based on the cosocket API"
   copyright:
     - license: BSD-3-Clause

--- a/lua-resty-redis.yaml
+++ b/lua-resty-redis.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-redis
   version: 0.30
-  epoch: 1
+  epoch: 2
   description: "Lua redis client driver for the ngx_lua based on the cosocket API"
   copyright:
     - license: BSD-3-Clause

--- a/lua-resty-redis.yaml
+++ b/lua-resty-redis.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: "Lua redis client driver for the ngx_lua based on the cosocket API"
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/lua-resty-string.yaml
+++ b/lua-resty-string.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-string
   version: 0.15
-  epoch: 1
+  epoch: 2
   description: "String utilities and common hash functions for ngx_lua and LuaJIT"
   copyright:
     - license: BSD-3-Clause

--- a/lua-resty-string.yaml
+++ b/lua-resty-string.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: "String utilities and common hash functions for ngx_lua and LuaJIT"
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/lua-resty-upload.yaml
+++ b/lua-resty-upload.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: "Streaming reader and parser for http file uploading based on ngx_lua cosocket"
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/lua-resty-upload.yaml
+++ b/lua-resty-upload.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-upload
   version: 0.10
-  epoch: 1
+  epoch: 2
   description: "Streaming reader and parser for http file uploading based on ngx_lua cosocket"
   copyright:
     - license: BSD-3-Clause

--- a/pgaudit-12.yaml
+++ b/pgaudit-12.yaml
@@ -6,7 +6,7 @@ package:
   epoch: 0
   description: PostgreSQL Audit Extension
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/pgaudit-12.yaml
+++ b/pgaudit-12.yaml
@@ -3,7 +3,7 @@
 package:
   name: pgaudit-12
   version: 1.4.3
-  epoch: 0
+  epoch: 1
   description: PostgreSQL Audit Extension
   copyright:
     - license: BSD-3-Clause

--- a/pgaudit-13.yaml
+++ b/pgaudit-13.yaml
@@ -6,7 +6,7 @@ package:
   epoch: 0
   description: PostgreSQL Audit Extension
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/pgaudit-13.yaml
+++ b/pgaudit-13.yaml
@@ -3,7 +3,7 @@
 package:
   name: pgaudit-13
   version: 1.5.2
-  epoch: 0
+  epoch: 1
   description: PostgreSQL Audit Extension
   copyright:
     - license: BSD-3-Clause

--- a/pgaudit-14.yaml
+++ b/pgaudit-14.yaml
@@ -6,7 +6,7 @@ package:
   epoch: 0
   description: PostgreSQL Audit Extension
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/pgaudit-14.yaml
+++ b/pgaudit-14.yaml
@@ -3,7 +3,7 @@
 package:
   name: pgaudit-14
   version: 1.6.2
-  epoch: 0
+  epoch: 1
   description: PostgreSQL Audit Extension
   copyright:
     - license: BSD-3-Clause

--- a/pgaudit-15.yaml
+++ b/pgaudit-15.yaml
@@ -6,7 +6,7 @@ package:
   epoch: 0
   description: PostgreSQL Audit Extension
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/pgaudit-15.yaml
+++ b/pgaudit-15.yaml
@@ -3,7 +3,7 @@
 package:
   name: pgaudit-15
   version: 1.7.0
-  epoch: 0
+  epoch: 1
   description: PostgreSQL Audit Extension
   copyright:
     - license: BSD-3-Clause

--- a/pgaudit-16.yaml
+++ b/pgaudit-16.yaml
@@ -6,7 +6,7 @@ package:
   epoch: 0
   description: PostgreSQL Audit Extension
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/pgaudit-16.yaml
+++ b/pgaudit-16.yaml
@@ -3,7 +3,7 @@
 package:
   name: pgaudit-16
   version: 16.0
-  epoch: 0
+  epoch: 1
   description: PostgreSQL Audit Extension
   copyright:
     - license: BSD-3-Clause

--- a/postgresql-12.yaml
+++ b/postgresql-12.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 7
   description: A sophisticated object-relational DBMS
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/postgresql-12.yaml
+++ b/postgresql-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-12
   version: "12.17"
-  epoch: 7
+  epoch: 8
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/postgresql-13.yaml
+++ b/postgresql-13.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 7
   description: A sophisticated object-relational DBMS
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/postgresql-13.yaml
+++ b/postgresql-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-13
   version: "13.13"
-  epoch: 7
+  epoch: 8
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/postgresql-14.yaml
+++ b/postgresql-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-14
   version: "14.10"
-  epoch: 7
+  epoch: 8
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/postgresql-14.yaml
+++ b/postgresql-14.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 7
   description: A sophisticated object-relational DBMS
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 7
   description: A sophisticated object-relational DBMS
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-15
   version: "15.5"
-  epoch: 7
+  epoch: 8
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.1"
-  epoch: 8
+  epoch: 9
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 8
   description: A sophisticated object-relational DBMS
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     provides:
       - postgresql=${{package.full-version}}

--- a/py3-appnope.yaml
+++ b/py3-appnope.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 1
   description: Disable App Nap on macOS >= 10.9
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-appnope.yaml
+++ b/py3-appnope.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-appnope
   version: 0.1.3
-  epoch: 1
+  epoch: 2
   description: Disable App Nap on macOS >= 10.9
   copyright:
     - license: BSD-3-Clause

--- a/py3-asn1-modules.yaml
+++ b/py3-asn1-modules.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 2
   description: A collection of ASN.1-based protocols modules
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-asn1

--- a/py3-asn1-modules.yaml
+++ b/py3-asn1-modules.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-asn1-modules
   version: 0.3.0
-  epoch: 2
+  epoch: 3
   description: A collection of ASN.1-based protocols modules
   copyright:
     - license: BSD-3-Clause

--- a/py3-astunparse.yaml
+++ b/py3-astunparse.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-astunparse
   version: 1.6.3
-  epoch: 1
+  epoch: 2
   description: An AST unparser for Python
   copyright:
     - license: BSD-3-Clause

--- a/py3-astunparse.yaml
+++ b/py3-astunparse.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: An AST unparser for Python
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-six

--- a/py3-cached-property.yaml
+++ b/py3-cached-property.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 1
   description: A decorator for caching properties in classes.
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-cached-property.yaml
+++ b/py3-cached-property.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cached-property
   version: 1.5.2
-  epoch: 1
+  epoch: 2
   description: A decorator for caching properties in classes.
   copyright:
     - license: BSD-3-Clause

--- a/py3-certipy.yaml
+++ b/py3-certipy.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 0
   description: Utility to create and sign CAs and certificates
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-pyopenssl

--- a/py3-certipy.yaml
+++ b/py3-certipy.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-certipy
   version: 0.1.3
-  epoch: 0
+  epoch: 1
   description: Utility to create and sign CAs and certificates
   copyright:
     - license: BSD-3-Clause

--- a/py3-fabric.yaml
+++ b/py3-fabric.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 0
   description: High level SSH command execution
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-invoke

--- a/py3-fabric.yaml
+++ b/py3-fabric.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-fabric
   version: 3.2.2
-  epoch: 0
+  epoch: 1
   description: High level SSH command execution
   copyright:
     - license: BSD-3-Clause

--- a/py3-fastjsonschema.yaml
+++ b/py3-fastjsonschema.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 0
   description: Fastest Python implementation of JSON schema
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-fastjsonschema.yaml
+++ b/py3-fastjsonschema.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-fastjsonschema
   version: 2.19.1
-  epoch: 0
+  epoch: 1
   description: Fastest Python implementation of JSON schema
   copyright:
     - license: BSD-3-Clause

--- a/py3-flask-opentracing.yaml
+++ b/py3-flask-opentracing.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 2
   description: OpenTracing support for Flask applications
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python3

--- a/py3-flask-opentracing.yaml
+++ b/py3-flask-opentracing.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-flask-opentracing
   version: 1.1.0
-  epoch: 2
+  epoch: 3
   description: OpenTracing support for Flask applications
   copyright:
     - license: BSD-3-Clause

--- a/py3-flask.yaml
+++ b/py3-flask.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-flask
   version: 3.0.1
-  epoch: 0
+  epoch: 1
   description: A simple framework for building complex web applications.
   copyright:
     - license: BSD-3-Clause

--- a/py3-flask.yaml
+++ b/py3-flask.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 0
   description: A simple framework for building complex web applications.
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-werkzeug

--- a/py3-fsspec.yaml
+++ b/py3-fsspec.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-fsspec
   version: 2023.9.1
-  epoch: 1
+  epoch: 2
   description: File-system specification
   copyright:
     - license: BSD-3-Clause

--- a/py3-fsspec.yaml
+++ b/py3-fsspec.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 1
   description: File-system specification
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-gcsfs.yaml
+++ b/py3-gcsfs.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-gcsfs
   version: 2023.9.2
-  epoch: 1
+  epoch: 2
   description: Convenient Filesystem interface over GCS
   copyright:
     - license: BSD-3-Clause

--- a/py3-gcsfs.yaml
+++ b/py3-gcsfs.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 1
   description: Convenient Filesystem interface over GCS
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-aiohttp

--- a/py3-httpcore.yaml
+++ b/py3-httpcore.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 0
   description: A minimal low-level HTTP client.
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-h11

--- a/py3-httpcore.yaml
+++ b/py3-httpcore.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-httpcore
   version: 1.0.2
-  epoch: 0
+  epoch: 1
   description: A minimal low-level HTTP client.
   copyright:
     - license: BSD-3-Clause

--- a/py3-hyperopt.yaml
+++ b/py3-hyperopt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-hyperopt
   version: 0.2.7
-  epoch: 1
+  epoch: 2
   description: Distributed Asynchronous Hyperparameter Optimization
   copyright:
     - license: BSD-3-Clause

--- a/py3-hyperopt.yaml
+++ b/py3-hyperopt.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: Distributed Asynchronous Hyperparameter Optimization
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - numpy

--- a/py3-ipython-genutils.yaml
+++ b/py3-ipython-genutils.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-ipython-genutils
   version: 0.2.0
-  epoch: 1
+  epoch: 2
   description: Vestigial utilities from IPython
   copyright:
     - license: BSD-3-Clause

--- a/py3-ipython-genutils.yaml
+++ b/py3-ipython-genutils.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 1
   description: Vestigial utilities from IPython
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-isodate.yaml
+++ b/py3-isodate.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 1
   description: An ISO 8601 date/time/duration parser and formatter
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-six

--- a/py3-isodate.yaml
+++ b/py3-isodate.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-isodate
   version: 0.6.1
-  epoch: 1
+  epoch: 2
   description: An ISO 8601 date/time/duration parser and formatter
   copyright:
     - license: BSD-3-Clause

--- a/py3-jupyterlab-pygments.yaml
+++ b/py3-jupyterlab-pygments.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 1
   description: Pygments theme using JupyterLab CSS variables
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-jupyterlab-pygments.yaml
+++ b/py3-jupyterlab-pygments.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-jupyterlab-pygments
   version: 0.2.2
-  epoch: 1
+  epoch: 2
   description: Pygments theme using JupyterLab CSS variables
   copyright:
     - license: BSD-3-Clause

--- a/py3-nest-asyncio.yaml
+++ b/py3-nest-asyncio.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-nest-asyncio
   version: 1.6.0
-  epoch: 0
+  epoch: 1
   description: Patch asyncio to allow nested event loops
   copyright:
     - license: BSD-3-Clause

--- a/py3-nest-asyncio.yaml
+++ b/py3-nest-asyncio.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 0
   description: Patch asyncio to allow nested event loops
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-nltk.yaml
+++ b/py3-nltk.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-nltk
   version: 3.8.1
-  epoch: 0
+  epoch: 1
   description: Natural Language Toolkit
   copyright:
     - license: BSD-3-Clause

--- a/py3-nltk.yaml
+++ b/py3-nltk.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: Natural Language Toolkit
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - numpy

--- a/py3-oauthlib.yaml
+++ b/py3-oauthlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-oauthlib
   version: 3.2.2
-  epoch: 2
+  epoch: 3
   description: A generic, spec-compliant, thorough implementation of the OAuth request-signing logic
   copyright:
     - license: BSD-3-Clause

--- a/py3-oauthlib.yaml
+++ b/py3-oauthlib.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 2
   description: A generic, spec-compliant, thorough implementation of the OAuth request-signing logic
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python3

--- a/py3-pgcli.yaml
+++ b/py3-pgcli.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: CLI for Postgres Database. With auto-completion and syntax highlighting.
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-cli-helpers

--- a/py3-pgcli.yaml
+++ b/py3-pgcli.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pgcli
   version: 4.0.1
-  epoch: 0
+  epoch: 1
   description: CLI for Postgres Database. With auto-completion and syntax highlighting.
   copyright:
     - license: BSD-3-Clause

--- a/py3-ply.yaml
+++ b/py3-ply.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 2
   description: Python Lex & Yacc
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python3

--- a/py3-ply.yaml
+++ b/py3-ply.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ply
   version: 3.11_git20180215
-  epoch: 2
+  epoch: 3
   description: Python Lex & Yacc
   copyright:
     - license: BSD-3-Clause

--- a/py3-pybind11.yaml
+++ b/py3-pybind11.yaml
@@ -62,6 +62,7 @@ subpackages:
       - uses: split/dev
       - runs: |
           mv "${{targets.destdir}}"/usr/share "${{targets.contextdir}}"/usr/share
+          mv "${{targets.destdir}}"/usr/lib/python3.12/site-packages/pybind11/share "${{targets.contextdir}}"/usr/lib/python3.12/site-packages/pybind11/share
 
 update:
   enabled: true

--- a/py3-pybind11.yaml
+++ b/py3-pybind11.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 5
   description: Seamless operability between C++11 and Python
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python3

--- a/py3-pybind11.yaml
+++ b/py3-pybind11.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pybind11
   version: 2.11.1
-  epoch: 5
+  epoch: 6
   description: Seamless operability between C++11 and Python
   copyright:
     - license: BSD-3-Clause

--- a/py3-pycparser.yaml
+++ b/py3-pycparser.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pycparser
   version: 2.21
-  epoch: 2
+  epoch: 3
   description: C parser in Python
   copyright:
     - license: BSD-3-Clause

--- a/py3-pycparser.yaml
+++ b/py3-pycparser.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 2
   description: C parser in Python
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python3

--- a/py3-pycryptodome.yaml
+++ b/py3-pycryptodome.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 0
   description: Cryptographic library for Python
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python3

--- a/py3-pycryptodome.yaml
+++ b/py3-pycryptodome.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pycryptodome
   version: 3.20.0
-  epoch: 0
+  epoch: 1
   description: Cryptographic library for Python
   copyright:
     - license: BSD-3-Clause

--- a/py3-pyperclip.yaml
+++ b/py3-pyperclip.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pyperclip
   version: 1.8.2
-  epoch: 2
+  epoch: 3
   description: A cross-platform clipboard module for Python. (Only handles plain text for now.)
   copyright:
     - license: BSD-3-Clause

--- a/py3-pyperclip.yaml
+++ b/py3-pyperclip.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 2
   description: A cross-platform clipboard module for Python. (Only handles plain text for now.)
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python3

--- a/py3-python-json-logger.yaml
+++ b/py3-python-json-logger.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 2
   description: A python library adding a json log formatter
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-python-json-logger.yaml
+++ b/py3-python-json-logger.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-python-json-logger
   version: 2.0.7
-  epoch: 2
+  epoch: 3
   description: A python library adding a json log formatter
   copyright:
     - license: BSD-3-Clause

--- a/py3-semantic-version.yaml
+++ b/py3-semantic-version.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 2
   description: A library implementing the 'SemVer' scheme.
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python3

--- a/py3-semantic-version.yaml
+++ b/py3-semantic-version.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-semantic-version
   version: 2.10.0
-  epoch: 2
+  epoch: 3
   description: A library implementing the 'SemVer' scheme.
   copyright:
     - license: BSD-3-Clause

--- a/py3-semver.yaml
+++ b/py3-semver.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 0
   description: Python helper for Semantic Versioning (https://semver.org)
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-semver.yaml
+++ b/py3-semver.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-semver
   version: 3.0.2
-  epoch: 0
+  epoch: 1
   description: Python helper for Semantic Versioning (https://semver.org)
   copyright:
     - license: BSD-3-Clause

--- a/py3-setproctitle.yaml
+++ b/py3-setproctitle.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: A Python module to customize the process title
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python3

--- a/py3-setproctitle.yaml
+++ b/py3-setproctitle.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-setproctitle
   version: 1.3.2
-  epoch: 1
+  epoch: 2
   description: A Python module to customize the process title
   copyright:
     - license: BSD-3-Clause

--- a/py3-sphinxcontrib-jsmath.yaml
+++ b/py3-sphinxcontrib-jsmath.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 3
   description: A sphinx extension which renders display math in HTML via JavaScript
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python3

--- a/py3-sphinxcontrib-jsmath.yaml
+++ b/py3-sphinxcontrib-jsmath.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-jsmath
   version: 1.0.1
-  epoch: 3
+  epoch: 4
   description: A sphinx extension which renders display math in HTML via JavaScript
   copyright:
     - license: BSD-3-Clause

--- a/py3-typogrify.yaml
+++ b/py3-typogrify.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: Filters to enhance web typography, including support for Django & Jinja templates
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/py3-typogrify.yaml
+++ b/py3-typogrify.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-typogrify
   version: 2.0.7
-  epoch: 0
+  epoch: 1
   description: Filters to enhance web typography, including support for Django & Jinja templates
   copyright:
     - license: BSD-3-Clause

--- a/py3-webencodings.yaml
+++ b/py3-webencodings.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-webencodings
   version: 0.5.1
-  epoch: 2
+  epoch: 3
   description: Character encoding aliases for legacy web content
   copyright:
     - license: BSD-3-Clause

--- a/py3-webencodings.yaml
+++ b/py3-webencodings.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 2
   description: Character encoding aliases for legacy web content
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-wrapt.yaml
+++ b/py3-wrapt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wrapt
   version: 1.16.0
-  epoch: 0
+  epoch: 1
   description: Module for decorators, wrappers and monkey patching.
   copyright:
     - license: BSD-3-Clause

--- a/py3-wrapt.yaml
+++ b/py3-wrapt.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: Module for decorators, wrappers and monkey patching.
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-zstandard.yaml
+++ b/py3-zstandard.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 0
   description: Zstandard bindings for Python
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-cffi

--- a/py3-zstandard.yaml
+++ b/py3-zstandard.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-zstandard
   version: 0.22.0
-  epoch: 0
+  epoch: 1
   description: Zstandard bindings for Python
   copyright:
     - license: BSD-3-Clause

--- a/runit.yaml
+++ b/runit.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: UNIX init scheme with service supervision
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/runit.yaml
+++ b/runit.yaml
@@ -1,7 +1,7 @@
 package:
   name: runit
   version: 2.1.2
-  epoch: 0
+  epoch: 1
   description: UNIX init scheme with service supervision
   copyright:
     - license: BSD-3-Clause

--- a/smartypants.yaml
+++ b/smartypants.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: Translate plain ASCII punctuation characters into “smart” typographic punctuation HTML entities
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
 
 environment:
   contents:

--- a/smartypants.yaml
+++ b/smartypants.yaml
@@ -1,7 +1,7 @@
 package:
   name: smartypants
   version: 2.0.1
-  epoch: 0
+  epoch: 1
   description: Translate plain ASCII punctuation characters into “smart” typographic punctuation HTML entities
   copyright:
     - license: BSD-3-Clause

--- a/supervisor.yaml
+++ b/supervisor.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 1
   description: Supervisor process control system for Unix (supervisord)
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-pip

--- a/supervisor.yaml
+++ b/supervisor.yaml
@@ -1,7 +1,7 @@
 package:
   name: supervisor
   version: 4.2.5
-  epoch: 1
+  epoch: 2
   description: Supervisor process control system for Unix (supervisord)
   copyright:
     - license: BSD-3-Clause

--- a/tclx.yaml
+++ b/tclx.yaml
@@ -1,7 +1,7 @@
 package:
   name: tclx
   version: 8.6.2
-  epoch: 0
+  epoch: 1
   description: TclX extension to Tcl
   copyright:
     - license: BSD-3-Clause

--- a/tclx.yaml
+++ b/tclx.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: TclX extension to Tcl
   copyright:
-    - license: BSD
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - tcl


### PR DESCRIPTION
`BSD` is not a valid license identifier, according to https://spdx.org/licenses/

> While the original license is sometimes referred to as the "BSD-old", the resulting 3-clause version is sometimes referred to by "BSD-new." Other names include new BSD, "revised BSD", "BSD-3", or "3-clause BSD". This version has been [vetted](https://en.wikipedia.org/wiki/Vetting) as an Open source license by the OSI as "The BSD License".[[5]](https://en.wikipedia.org/wiki/BSD_licenses#cite_note-osi-5)

- https://en.wikipedia.org/wiki/BSD_licenses