### PR TITLE
fix: broken openjdk-11 build

### DIFF
--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -38,12 +38,6 @@ environment:
       - openjdk-10-default-jvm
       - zip
 
-var-transforms:
-  - from: ${{package.version}}
-    match: \.(\d+)$
-    replace: +$1
-    to: mangled-package-version
-
 pipeline:
   - uses: git-checkout
     with:
@@ -75,7 +69,7 @@ pipeline:
         --with-libjpeg=system \
         --with-giflib=system \
         --with-lcms=system \
-        --with-version-string="${{vars.mangled-package-version}}"
+        --with-version-string="${{package.version}}"
 
   - runs: make jdk-image
 

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -38,6 +38,12 @@ environment:
       - openjdk-10-default-jvm
       - zip
 
+var-transforms:
+  - from: ${{package.version}}
+    match: \.(\d+)$
+    replace: +$1
+    to: mangled-package-version
+
 pipeline:
   - uses: git-checkout
     with:


### PR DESCRIPTION
We had removed the vars needed to build `openjdk-11` in https://github.com/wolfi-dev/os/pull/7958. This PR adds the vars section back to fix the build.

Noticed this because of failing CI on https://github.com/wolfi-dev/wolfictl/pull/569.