### PR TITLE
Withdraw packages that have been split to dev

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -33,3 +33,11 @@ python-3.12-doc-3.12.0_alpha5-r1.apk
 python-3.12-doc-3.12.0_alpha5-r2.apk
 python-3.12-doc-3.12.0_alpha6-r0.apk
 python-3.12-doc-3.12.0_alpha7-r0.apk
+sqlite-3.40.0-r1.apk
+bzip2-1.0.8-r2.apk
+bzip2-1.0.8-r3.apk
+bzip2-1.0.8-r4.apk
+expat-2.5.0-r0.apk
+expat-2.5.0-r1.apk
+expat-2.5.0-r2.apk
+expat-2.5.0-r3.apk


### PR DESCRIPTION
These packages are preferred by apk because they have simpler dependency graphs than their later equivalents that have been split into e.g. sqlite and sqlitelibs.

Withdrawing these simplifies a lot of differences between apk and apko solutions.