### PR TITLE
rebuild some packages to generate valid SBOMs

### DIFF
--- a/libedit.yaml
+++ b/libedit.yaml
@@ -1,7 +1,7 @@
 package:
   name: libedit
   version: 3.1
-  epoch: 2
+  epoch: 3
   description: "the NetBSD editline library"
   copyright:
     - license: BSD-3-Clause

--- a/libev.yaml
+++ b/libev.yaml
@@ -1,7 +1,7 @@
 package:
   name: libev
   version: 4.33
-  epoch: 3
+  epoch: 4
   description: "event dispatch library"
   copyright:
     - license: BSD-2-Clause OR GPL-2.0-or-later

--- a/maven.yaml
+++ b/maven.yaml
@@ -1,7 +1,7 @@
 package:
   name: maven
   version: 3.9.6
-  epoch: 0
+  epoch: 1
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
These packages' SBOMs don't have an `originator`, which was implemented in melange in the last month.