### PR TITLE
Drop invalid vars from openjdk packages

### DIFF
--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -69,7 +69,7 @@ pipeline:
         --with-libjpeg=system \
         --with-giflib=system \
         --with-lcms=system \
-        --with-version-string="${{vars.mangled-package-version}}"
+        --with-version-string=""
 
   - runs: make jdk-image
 

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -81,7 +81,7 @@ pipeline:
         --with-giflib=system \
         --with-lcms=system \
         --with-gtest="/home/build/googletest" \
-        --with-version-string="${{vars.mangled-package-version}}"
+        --with-version-string=""
 
   - runs: make jdk-image
 

--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -1,10 +1,10 @@
 package:
   name: openjdk-18
   version: 18.0.2.1.0
-  epoch: 2
+  epoch: 3
   description:
   copyright:
-    - license: GPL-2.0-with-classpath-exception
+    - license: GPL-2.0-or-later
   dependencies:
     runtime:
       - openjdk-18-jre

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -1,10 +1,10 @@
 package:
   name: openjdk-19
   version: 19.0.2.7
-  epoch: 2
+  epoch: 3
   description:
   copyright:
-    - license: GPL-2.0-with-classpath-exception
+    - license: GPL-2.0-or-later
   dependencies:
     runtime:
       - openjdk-19-jre

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -1,10 +1,10 @@
 package:
   name: openjdk-20
   version: 20.0.2.9
-  epoch: 1
+  epoch: 2
   description:
   copyright:
-    - license: GPL-2.0-with-classpath-exception
+    - license: GPL-2.0-or-later
   dependencies:
     runtime:
       - openjdk-20-jre

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -1,10 +1,10 @@
 package:
   name: openjdk-21
   version: 21.0.2
-  epoch: 0
+  epoch: 1
   description:
   copyright:
-    - license: GPL-2.0-with-classpath-exception
+    - license: GPL-2.0-or-later
   dependencies:
     runtime:
       - openjdk-21-jre
@@ -77,7 +77,7 @@ pipeline:
         --with-giflib=system \
         --with-lcms=system \
         --with-gtest="/home/build/googletest" \
-        --with-version-string="${{vars.mangled-package-version}}"
+        --with-version-string=""
 
   - runs: make jdk-image
 


### PR DESCRIPTION
I'm not sure if we should keep these and fix it or what.

Also not sure if we care to bump the epoch because this mostly just affects melange, not sure if it affects the package.