### PR TITLE
Remove redundant provides in keda

### DIFF
--- a/keda.yaml
+++ b/keda.yaml
@@ -2,15 +2,13 @@
 package:
   name: keda
   version: 2.13.0
-  epoch: 0
+  epoch: 1
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - tzdata
-    provides:
-      - keda=${{package.full-version}}
 
 environment:
   contents:
@@ -46,8 +44,6 @@ subpackages:
     dependencies:
       runtime:
         - tzdata
-      provides:
-        - keda-adapter=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"
@@ -59,8 +55,6 @@ subpackages:
     dependencies:
       runtime:
         - tzdata
-      provides:
-        - keda-admission-webhooks=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"
@@ -69,9 +63,6 @@ subpackages:
 
   - name: "${{package.name}}-compat"
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"
-    dependencies:
-      provides:
-        - keda-compat=${{package.full-version}}
     pipeline:
       - runs: |
           # The helm chart expects the keda binaries to be in / instead of /usr/bin


### PR DESCRIPTION
These break apk's ability to install the package.

X-ref: https://github.com/wolfi-dev/os/issues/11323

```
[sdk] ❯ apk add keda=2.13.0-r0
WARNING: opening ./../../packages: No such file or directory
ERROR: unable to select packages:
  keda-2.13.0-r0:
    conflicts: keda-2.13.0-r0[keda=2.13.0-r0]
    satisfies: world[keda=2.13.0-r0]
```