### PR TITLE
kubescape/3.0.3-r2: cve remediation

### DIFF
--- a/kubescape.yaml
+++ b/kubescape.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubescape
   version: 3.0.3
-  epoch: 2
+  epoch: 3
   description: Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources.
   copyright:
     - license: Apache-2.0 AND MIT
@@ -27,7 +27,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/containerd/containerd@v1.7.11 golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 google.golang.org/grpc@v1.56.3 github.com/docker/docker@v24.0.7 github.com/cloudflare/circl@v1.3.7 github.com/sigstore/cosign/v2@v2.2.1
+      deps: github.com/containerd/containerd@v1.7.11 golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 google.golang.org/grpc@v1.56.3 github.com/docker/docker@v24.0.7 github.com/cloudflare/circl@v1.3.7 github.com/sigstore/cosign/v2@v2.2.1 github.com/lestrrat-go/jwx/v2@v2.0.19
       replaces: sigs.k8s.io/kustomize/kyaml=sigs.k8s.io/kustomize/kyaml@v0.14.1 k8s.io/kube-openapi=k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f github.com/google/gnostic=github.com/google/gnostic@v0.5.7-v3refs k8s.io/client-go=k8s.io/client-go@v0.27.4 k8s.io/api=k8s.io/api@v0.27.4
       go-version: "1.21"
 

--- a/kubescape.yaml
+++ b/kubescape.yaml
@@ -27,7 +27,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/containerd/containerd@v1.7.11 golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 google.golang.org/grpc@v1.56.3 github.com/docker/docker@v24.0.7 github.com/cloudflare/circl@v1.3.7 github.com/sigstore/cosign/v2@v2.2.1 github.com/lestrrat-go/jwx/v2@v2.0.19
+      deps: github.com/containerd/containerd@v1.7.11 golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/docker/docker@v24.0.7 github.com/cloudflare/circl@v1.3.7 github.com/sigstore/cosign/v2@v2.2.1 github.com/lestrrat-go/jwx/v2@v2.0.19
       replaces: sigs.k8s.io/kustomize/kyaml=sigs.k8s.io/kustomize/kyaml@v0.14.1 k8s.io/kube-openapi=k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f github.com/google/gnostic=github.com/google/gnostic@v0.5.7-v3refs k8s.io/client-go=k8s.io/client-go@v0.27.4 k8s.io/api=k8s.io/api@v0.27.4
       go-version: "1.21"
 


### PR DESCRIPTION
kubescape/3.0.3-r2: fix GHSA-pvcr-v8j8-j5q3/GHSA-7f9x-gw85-8grf/