### PR TITLE
tekton-chains/0.19.0-r5: cve remediation

### DIFF
--- a/tekton-chains.yaml
+++ b/tekton-chains.yaml
@@ -1,7 +1,7 @@
 package:
   name: tekton-chains
   version: 0.19.0
-  epoch: 5
+  epoch: 6
   description: Supply Chain Security in Tekton Pipelines
   copyright:
     - license: Apache-2.0
@@ -19,7 +19,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.17.0 github.com/sigstore/cosign/v2@v2.2.1 github.com/docker/docker@v24.0.7 github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7
+      deps: golang.org/x/net@v0.17.0 github.com/sigstore/cosign/v2@v2.2.1 github.com/docker/docker@v24.0.7 github.com/go-jose/go-jose/v3@v3.0.1 golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7 github.com/lestrrat-go/jwx/v2@v2.0.19
       go-version: "1.21"
 
   - uses: go/build


### PR DESCRIPTION
tekton-chains/0.19.0-r5: fix GHSA-pvcr-v8j8-j5q3/GHSA-7f9x-gw85-8grf/