### PR TITLE
new package lynx/2.9.0

### DIFF
--- a/lynx.yaml
+++ b/lynx.yaml
@@ -1,0 +1,71 @@
+package:
+  name: lynx
+  version: 2.9.0
+  epoch: 0
+  description: Cross-platform text-based browser
+  copyright:
+    - license: GPL-2.0-only
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
+      - busybox
+      - gettext-dev
+      - glib-dev
+      - ncurses-dev
+      - openssl-dev>3
+      - perl
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 746c926e28d50571a42d2477f9c50784b27fc8cba4c7db7f3e6c9e00dde89070
+      uri: https://invisible-mirror.net/archives/lynx/tarballs/lynx${{package.version}}.tar.gz
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --enable-ipv6 \
+        --with-ssl \
+        --enable-default-colors \
+        --with-screen=ncursesw \
+        --with-zlib \
+        --disable-full-paths \
+        --enable-externs \
+        --enable-nls
+
+  - uses: autoconf/make
+    with:
+      opts: |
+        helpdir=/usr/share/doc/lynx/help
+        docdir=/usr/share/doc/lynx
+
+  - uses: autoconf/make-install
+    with:
+      opts: |
+        DESTDIR=${{targets.destdir}} install install-help install-doc
+
+  - uses: strip
+
+subpackages:
+  - name: lynx-doc
+    description: lynx documentation
+    pipeline:
+      - uses: split/manpages
+
+  - name: lynx-lang
+    description: lynx lang
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share
+          mv ${{targets.destdir}}/usr/share/locale ${{targets.subpkgdir}}/usr/share/
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 1863


### PR DESCRIPTION
- new package lynx/2.9.0



Related: https://github.com/chainguard-dev/image-requests/issues/524

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
