### PR TITLE
new package xset/1.2.5

### DIFF
--- a/xset.yaml
+++ b/xset.yaml
@@ -1,0 +1,44 @@
+package:
+  name: xset
+  version: 1.2.5
+  epoch: 0
+  description: X.Org xset application
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - libx11-dev
+      - libxext-dev
+      - libxmu-dev
+      - util-macros
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 9f692d55635b3862cd63633b1222a87680ec283c7a8e8ed6dd698a3147f75e2f
+      uri: https://www.x.org/releases/individual/app/xset-${{package.version}}.tar.xz
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: xset-doc
+    description: xset documentation
+    pipeline:
+      - uses: split/manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 14954


### PR DESCRIPTION
- new package xset/1.2.5


Related: https://github.com/chainguard-dev/image-requests/issues/524

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
