### PR TITLE
new package xprop/1.2.6

### DIFF
--- a/xprop.yaml
+++ b/xprop.yaml
@@ -1,0 +1,42 @@
+package:
+  name: xprop
+  version: 1.2.6
+  epoch: 0
+  description: Property displayer for X
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - libx11-dev
+      - util-macros
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 580b8525b12ecc0144aa16c88b0aafa76d2e799b44c8c6c50f9ce92788b5586e
+      uri: https://www.x.org/archive/individual/app/xprop-${{package.version}}.tar.xz
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: xprop-doc
+    description: xprop documentation
+    pipeline:
+      - uses: split/manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 14958


### PR DESCRIPTION
- new package xprop/1.2.6

Related: https://github.com/chainguard-dev/image-requests/issues/524

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
