### PR TITLE
add new gitlab-exporter dependency

### DIFF
--- a/gitlab-exporter.yaml
+++ b/gitlab-exporter.yaml
@@ -5,7 +5,7 @@
 package:
   name: gitlab-exporter
   version: 14.2.0
-  epoch: 0
+  epoch: 1
   description: GitLab Exporter is a Prometheus Web exporter.
   copyright:
     - license: MIT
@@ -22,6 +22,7 @@ package:
       - ruby3.2-faraday-excon
       - ruby3.2-mustermann
       - ruby3.2-bundler
+      - ruby3.2-deep_merge
       - ruby3.2-redis
       - ruby3.2-redis-namespace
       - ruby3.2-sinatra

--- a/ruby3.2-deep_merge.yaml
+++ b/ruby3.2-deep_merge.yaml
@@ -1,0 +1,45 @@
+# Generated from https://github.com/danielsdeleo/deep_merge
+package:
+  name: ruby3.2-deep_merge
+  version: 1.2.2
+  epoch: 0
+  description: Recursively merge hashes.
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/danielsdeleo/deep_merge
+      tag: ${{package.version}}
+      expected-commit: aab0f7fed5c1e22226efec5d4adaa3e95d198b83
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: deep_merge
+
+update:
+  enabled: true
+  github:
+    identifier: danielsdeleo/deep_merge
+    use-tag: true


### PR DESCRIPTION
adds new dep added in 14.2.0 release:

related: https://github.com/chainguard-images/images/pull/2111

recent failing build: https://github.com/chainguard-images/images/actions/runs/7632775316