### PR TITLE
new package xdg-utils/1.1.3

### DIFF
--- a/xdg-utils.yaml
+++ b/xdg-utils.yaml
@@ -1,0 +1,73 @@
+package:
+  name: xdg-utils
+  version: 1.1.3
+  epoch: 0
+  description: Basic desktop integration functions
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
+      - busybox
+      - libxml2-utils
+      - libxslt
+      - lynx
+      - perl
+      - xmlto
+      - file
+      - xprop
+      - xset
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: d798b08af8a8e2063ddde6c9fa3398ca81484f27dec642c5627ffcaa0d4051d9
+      uri: https://portland.freedesktop.org/download/xdg-utils-${{package.version}}.tar.gz
+
+  # patches from https://git.alpinelinux.org/aports/tree/community/xdg-utils?h=master
+  - uses: patch
+    with:
+      patches: xdg-screensaver-mv-T.patch
+
+  - uses: patch
+    with:
+      patches: deprecated-grep.patch
+
+  # - uses: autoconf/configure
+    # with:
+    #   opts: |
+    #     --prefix=/usr \
+    #     --sysconfdir=/etc \
+    #     --mandir=/usr/share/man \
+    #     --infodir=/usr/share/info
+
+  # - uses: autoconf/make
+
+  - runs: |
+      ./configure \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --mandir=/usr/share/man \
+        --infodir=/usr/share/info
+      make
+      make DESTDIR="${{targets.destdir}}" install
+
+  # - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: "xdg-utils-doc"
+    description: "xdg-utils documentation"
+    pipeline:
+      - uses: split/manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5176

--- a/xdg-utils/deprecated-grep.patch
+++ b/xdg-utils/deprecated-grep.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/xdg-open.in b/scripts/xdg-open.in
+index 630e63e..40cc239 100644
+--- a/scripts/xdg-open.in
++++ b/scripts/xdg-open.in
+@@ -72,7 +72,7 @@ get_key()
+ is_file_url_or_path()
+ {
+     if echo "$1" | grep -q '^file://' \
+-            || ! echo "$1" | egrep -q '^[[:alpha:]+\.\-]+:'; then
++            || ! echo "$1" | grep -E -q '^[[:alpha:]+\.\-]+:'; then
+         return 0
+     else
+         return 1

--- a/xdg-utils/xdg-screensaver-mv-T.patch
+++ b/xdg-utils/xdg-screensaver-mv-T.patch
@@ -1,0 +1,25 @@
+--- ./scripts/xdg-screensaver.in.orig
++++ ./scripts/xdg-screensaver.in
+@@ -26,18 +26,10 @@
+ 
+ #@xdg-utils-common@
+ 
+-# Check if we can use "mv -T"
+-if mv -T ... ... 2>&1 | grep '\.\.\.' > /dev/null ; then
+-   # We can securely move files in /tmp with mv -T
+-   DEBUG 1 "mv -T available"
+-   MV="mv -T"
+-   screensaver_file="/tmp/xdg-screensaver-$USER-"`echo $DISPLAY | sed 's/:/-/g'`
+-else
+-   # No secure moves available, use home dir
+-   DEBUG 1 "mv -T not available"
+-   MV="mv"
+-   screensaver_file="$HOME/.xdg-screensaver-"`echo $(hostname)-$DISPLAY | sed 's/:/-/g'`
+-fi
++# No secure moves available, use home dir
++DEBUG 1 "mv -T not available"
++MV="mv"
++screensaver_file="$HOME/.xdg-screensaver-"`echo $(hostname)-$DISPLAY | sed 's/:/-/g'`
+ lockfile_command=`which lockfile 2> /dev/null`
+ 
+ lockfile()


### PR DESCRIPTION
- new package xdg-utils/1.1.3


Related: https://github.com/chainguard-dev/image-requests/issues/524

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
