### PR TITLE
jupyterhub-k8s-hub: Fix incorrect provides

### DIFF
--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -64,7 +64,7 @@ subpackages:
           ln -sf /etc/jupyterhub/jupyterhub_config.py ${{targets.subpkgdir}}/usr/local/etc/jupyterhub/jupyterhub_config.py
           ln -sf /etc/jupyterhub/z2jh.py ${{targets.subpkgdir}}/usr/local/etc/jupyterhub/z2jh.py
     dependencies:
-      provides:
+      runtime:
         - jupyterhub-k8s-hub
 
 update:


### PR DESCRIPTION
This compat package incorrectly provides jupyterhub-k8s-hub when it should depend on it. This made the apk solver skip over the main package because the compat package already provided it and it wasn't needed.