### PR TITLE
kots/1.106.0-r0: cve remediation

### DIFF
--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
   version: 1.106.0
-  epoch: 0
+  epoch: 1
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0
+      deps: github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0 github.com/dexidp/dex@v2.35.0
       go-version: "1.21.0"
 
   - runs: |


### PR DESCRIPTION
kots/1.106.0-r0: fix GHSA-vh7g-p26c-j2cw