### PR TITLE
add codespell package

### DIFF
--- a/py3-codespell.yaml
+++ b/py3-codespell.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: "checker for common misspellings "
   copyright:
-    - license: GPL-2.0-only
+    - license: GPL-2.0-or-later
 
 environment:
   contents:

--- a/py3-codespell.yaml
+++ b/py3-codespell.yaml
@@ -4,18 +4,19 @@ package:
   epoch: 0
   description: "checker for common misspellings "
   copyright:
-    - license: GPL v2
+    - license: GPL-2.0-only
 
 environment:
   contents:
     packages:
       - build-base
       - busybox
+      - ca-certificates-bundle
       - py3-pip
       - py3-setuptools
       - python3
-      - ca-certificates-bundle
       - wolfi-base
+
 pipeline:
   - uses: git-checkout
     with:
@@ -25,6 +26,7 @@ pipeline:
 
   - name: Python Build
     uses: python/build-wheel
+
   - uses: strip
 
 update:

--- a/py3-codespell.yaml
+++ b/py3-codespell.yaml
@@ -1,0 +1,35 @@
+package:
+  name: py3-codespell
+  version: 2.2.6
+  epoch: 0
+  description: "checker for common misspellings "
+  copyright:
+    - license: GPL v2
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - py3-pip
+      - py3-setuptools
+      - python3
+      - ca-certificates-bundle
+      - wolfi-base
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/codespell-project/codespell
+      tag: v${{package.version}}
+      expected-commit: 6e41aba91fb32e9feb741a6258eefeb9c6e4a482
+
+  - name: Python Build
+    uses: python/build-wheel
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: codespell-project/codespell
+    use-tag: true
+    strip-prefix: v

--- a/py3-codespell.yaml
+++ b/py3-codespell.yaml
@@ -33,5 +33,4 @@ update:
   enabled: true
   github:
     identifier: codespell-project/codespell
-    use-tag: true
     strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
- adds https://github.com/codespell-project/codespell package

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
