### PR TITLE
Make gobump flags configurable

### DIFF
--- a/pipelines/go/bump.yaml
+++ b/pipelines/go/bump.yaml
@@ -18,13 +18,19 @@ inputs:
     default: ""
   replaces:
     description: "The replaces to add to the go.mod file"
+  tidy:
+    default: true
+    description: Run go mod tidy command before and after the bump
+  show-diff:
+    default: false
+    description: Show the difference between the go.mod file before and after the bump
 
 pipeline:
   - runs: |
       cd "${{inputs.modroot}}"
 
       # We use the --tidy flag to run go mod tidy before and after in some cases (if old versions of go are used, we need to update the go.mod format)
-      gobump --packages "${{inputs.deps}}" --replaces "${{inputs.replaces}}" --tidy --go-version=${{inputs.go-version}}
+      gobump --packages "${{inputs.deps}}" --replaces "${{inputs.replaces}}" --tidy=${{inputs.tidy}} --show-diff=${{inputs.show-diff}} --go-version=${{inputs.go-version}}
 
       if [ -d "./vendor" ]; then
         go mod vendor


### PR DESCRIPTION
We need to expose the flags in some scenarios where we cannot run `go mod tidy`, or show the differences between go.mod files on demand while debugging issues only.