### PR TITLE
fix the compat package for management-api-for-apache-cassandra

### DIFF
--- a/management-api-for-apache-cassandra.yaml
+++ b/management-api-for-apache-cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: management-api-for-apache-cassandra
   version: 0.1.72
-  epoch: 1
+  epoch: 2
   description: RESTful / Secure Management Sidecar for Apache Cassandra
   copyright:
     - license: Apache-2.0
@@ -41,9 +41,9 @@ subpackages:
   - name: management-api-for-apache-cassandra-compat
     pipeline:
       - runs: |
-          ln -s "${{targets.destdir}}"/opt/management-api/datastax-mgmtapi-agent-4.1.x-0.1.0-SNAPSHOT.jar "${{targets.destdir}}"/opt/management-api/datastax-mgmtapi-agent.jar
-          ln -s "${{targets.destdir}}"/opt/management-api/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar "${{targets.destdir}}"/opt/management-api/datastax-mgmtapi-server.jar
-          ln -sf "${{targets.destdir}}"/usr/local/bin/docker-entrypoint.sh "${{targets.destdir}}"/docker-entrypoint.sh
+          ln -s /opt/management-api/datastax-mgmtapi-agent-4.1.x-0.1.0-SNAPSHOT.jar "${{targets.destdir}}"/opt/management-api/datastax-mgmtapi-agent.jar
+          ln -s /opt/management-api/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar "${{targets.destdir}}"/opt/management-api/datastax-mgmtapi-server.jar
+          ln -sf /usr/local/bin/docker-entrypoint.sh "${{targets.destdir}}"/docker-entrypoint.sh
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
