### PR TITLE
zellij: new package

### DIFF
--- a/zellij.yaml
+++ b/zellij.yaml
@@ -1,0 +1,77 @@
+package:
+  name: zellij
+  version: 0.39.2
+  epoch: 0
+  description: A terminal workspace with batteries included
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - openssl-dev
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/zellij-org/zellij
+      tag: v${{package.version}}
+      expected-commit: d9b956bc40cd1b526b683291d3d55673a191b5a2
+
+  - runs: |
+      cargo build --release
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv target/release/zellij ${{targets.destdir}}/usr/bin/
+      install -Dm 644 "target/completions/${{package.name}}.bash" "${{targets.destdir}}/usr/share/bash-completion/completions"
+      install -Dm 644 "target/completions/${{package.name}}.fish" -t "${{targets.destdir}}/usr/share/fish/vendor_completions.d"
+      install -Dm 644 "target/completions/_${{package.name}}" -t "${{targets.destdir}}/usr/share/zsh/site-functions"
+
+  - uses: strip
+
+subpackages:
+  - name: zellij-bash-completion
+    description: bash completion for zellij
+    pipeline:
+      - runs: |
+          set -x
+          mkdir -p "${{targets.subpkgdir}}/usr/share/bash-completion"
+          mv "${{targets.destdir}}/usr/share/bash-completion/completions" \
+            "${{targets.subpkgdir}}/usr/share/bash-completion/completions"
+    dependencies:
+      runtime:
+        - zellij
+
+  - name: zellij-zsh-completion
+    description: zsh completion for zellij
+    pipeline:
+      - runs: |
+          set -x
+          mkdir -p "${{targets.subpkgdir}}/usr/share/zsh"
+          mv "${{targets.destdir}}/usr/share/zsh/site-functions" \
+            "${{targets.subpkgdir}}/usr/share/zsh/site-functions"
+    dependencies:
+      runtime:
+        - zellij
+
+  - name: zellij-fish-completion
+    description: fish completion for zellij
+    pipeline:
+      - runs: |
+          set -x
+          mkdir -p "${{targets.subpkgdir}}/usr/share/fish"
+          mv "${{targets.destdir}}/usr/share/fish/vendor_completions.d" \
+            "${{targets.subpkgdir}}/usr/share/fish/vendor_completions.d"
+    dependencies:
+      runtime:
+        - zellij
+
+update:
+  enabled: true
+  github:
+    identifier: zellij-org/zellij
+    strip-prefix: v

--- a/zellij.yaml
+++ b/zellij.yaml
@@ -24,12 +24,21 @@ pipeline:
       expected-commit: d9b956bc40cd1b526b683291d3d55673a191b5a2
 
   - runs: |
+      # use system openssl
+      export OPENSSL_NO_VENDOR=1
       cargo build --release
       mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p target/completions
+      for sh in bash fish zsh; do
+        target/release/${{package.name}} setup --generate-completion $sh \
+          > target/completions/${{package.name}}.$sh
+      done
+
       mv target/release/zellij ${{targets.destdir}}/usr/bin/
+
       install -Dm 644 "target/completions/${{package.name}}.bash" "${{targets.destdir}}/usr/share/bash-completion/completions"
       install -Dm 644 "target/completions/${{package.name}}.fish" -t "${{targets.destdir}}/usr/share/fish/vendor_completions.d"
-      install -Dm 644 "target/completions/_${{package.name}}" -t "${{targets.destdir}}/usr/share/zsh/site-functions"
+      install -Dm 644 "target/completions/${{package.name}}.zsh" -t "${{targets.destdir}}/usr/share/zsh/site-functions/_${{package.name}}"
 
   - uses: strip
 
@@ -75,3 +84,12 @@ update:
   github:
     identifier: zellij-org/zellij
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        zellij --version


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #11779 

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
