### PR TITLE
add helix-editor package to wolfi

### DIFF
--- a/helix.yaml
+++ b/helix.yaml
@@ -1,0 +1,42 @@
+package:
+  name: helix
+  version: 23.10
+  epoch: 0
+  description: "just is a handy way to save and run project-specific commands."
+  copyright:
+    - license: CC0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - rust
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/helix-editor/helix
+      expected-commit: f6021dd0cdd8cf6795f024e396241cb0af2ca368
+      tag: ${{package.version}}
+
+  - uses: patch
+    with:
+      patches: tree-sitter-gemini.patch
+
+  - name: Configure and build
+    runs: |
+      cargo install --path helix-term --locked
+      mkdir -p ${{targets.destdir}}/usr/bin/
+      mv target/release/hx ${{targets.destdir}}/usr/bin/
+      mkdir -p $HOME/.config/helix
+      mv runtime $HOME/.config/helix
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: helix-editor/helix

--- a/helix.yaml
+++ b/helix.yaml
@@ -2,9 +2,9 @@ package:
   name: helix
   version: 23.10
   epoch: 0
-  description: "just is a handy way to save and run project-specific commands."
+  description: "A post-modern modal text editor."
   copyright:
-    - license: CC0
+    - license: MPL-2.0
 
 environment:
   contents:

--- a/helix/tree-sitter-gemini.patch
+++ b/helix/tree-sitter-gemini.patch
@@ -1,0 +1,22 @@
+From 6d168eda275deb23b0c643aecd746af3f4cc9937 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bla=C5=BE=20Hrastnik?= <blaz@mxxn.io>
+Date: Tue, 28 Nov 2023 14:38:15 +0900
+Subject: [PATCH] fix CI: tree-sitter-gemini user renamed
+
+---
+ languages.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/languages.toml b/languages.toml
+index ef4687af8a71..33b27626e720 100644
+--- a/languages.toml
++++ b/languages.toml
+@@ -2916,7 +2916,7 @@ file-types = ["gmi"]
+ 
+ [[grammar]]
+ name = "gemini"
+-source = { git = "https://git.sr.ht/~sfr/tree-sitter-gemini", rev = "3cc5e4bdf572d5df4277fc2e54d6299bd59a54b3" }
++source = { git = "https://git.sr.ht/~nbsp/tree-sitter-gemini", rev = "3cc5e4bdf572d5df4277fc2e54d6299bd59a54b3" }
+ 
+ [[language]]
+ name = "templ"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/11777

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
