### PR TITLE
Disable update for librdkafka

### DIFF
--- a/librdkafka.yaml
+++ b/librdkafka.yaml
@@ -51,7 +51,7 @@ subpackages:
     description: librdkafka dev
 
 update:
-  enabled: true
+  enabled: false
   ignore-regex-patterns:
     - full-integration-tests
   github:


### PR DESCRIPTION
GitHub updates are broken due to confluentinc has ip allow list 
GH updates has been broken for almost 21 hours 
```
Error: creating updates: failed to get package updates: failed getting github releases: error response from github Although you appear to have the correct authorization credentials, the `confluentinc` organization has an IP allow list enabled, and your IP address is not permitted to access this resource.
time="2024-01-26T02:16:40Z" level=fatal msg="error during command execution: creating updates: failed to get package updates: failed getting github releases: error response from github Although you appear to have the correct authorization credentials, the `confluentinc` organization has an IP allow list enabled, and your IP address is not permitted to access this resource."
```