### PR TITLE
fix jbig2dec download path

### DIFF
--- a/jbig2dec.yaml
+++ b/jbig2dec.yaml
@@ -19,10 +19,11 @@ environment:
       - pkgconf-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 7b63ff6470289547e7a3a0f145cb8ea6c2afffdd65645b7d87d3b7febc96fb3a
-      uri: https://github.com/ArtifexSoftware/jbig2dec/releases/download/${{package.version}}/jbig2dec-${{package.version}}.tar.gz
+      repository: https://github.com/ArtifexSoftware/jbig2dec.git
+      expected-commit: 1d1347e38a55e657dcc4c8f1c77bb3a26bfc9ff3
+      tag: ${{package.version}}
 
   - runs: |
       autoreconf -vif
@@ -58,5 +59,5 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 1431
+  github:
+    identifier: ArtifexSoftware/jbig2dec

--- a/jbig2dec.yaml
+++ b/jbig2dec.yaml
@@ -26,6 +26,7 @@ pipeline:
       tag: ${{package.version}}
 
   - runs: |
+      ./autogen.sh
       autoreconf -vif
       ./configure \
         --build=$CBUILD \

--- a/jbig2dec.yaml
+++ b/jbig2dec.yaml
@@ -1,7 +1,7 @@
 # Generated from https://git.alpinelinux.org/aports/plain/main/jbig2dec/APKBUILD
 package:
   name: jbig2dec
-  version: "0.19"
+  version: 0.20
   epoch: 0
   description: JBIG2 image compression format decoder
   copyright:
@@ -21,8 +21,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 279476695b38f04939aa59d041be56f6bade3422003a406a85e9792c27118a37
-      uri: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9531/jbig2dec-${{package.version}}.tar.gz
+      expected-sha256: 7b63ff6470289547e7a3a0f145cb8ea6c2afffdd65645b7d87d3b7febc96fb3a
+      uri: https://github.com/ArtifexSoftware/jbig2dec/releases/download/${{package.version}}/jbig2dec-${{package.version}}.tar.gz
 
   - runs: |
       autoreconf -vif


### PR DESCRIPTION
Fixes https://github.com/wolfi-dev/os/issues/11680

Looks like the download path changed.