### PR TITLE
py3-pytest-timeout: new package

### DIFF
--- a/py3-pytest-timeout.yaml
+++ b/py3-pytest-timeout.yaml
@@ -1,0 +1,53 @@
+# Generated from https://pypi.org/project/pytest-timeout/
+package:
+  name: py3-pytest-timeout
+  version: 2.2.0
+  epoch: 0
+  description: 'pytest plugin to abort hanging tests'
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - py3-pytest
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 78cc24f0d91ca24a7448779fcf5c2f22470b6ae4
+      repository: https://github.com/pytest-dev/pytest-timeout
+      tag: ${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pytest-dev/pytest-timeout
+    use-tag: true
+    tag-filter: 2.
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        rc=0
+        tname="test_a_slow_test"
+        python3 -m pytest --timeout=5 ./test.py >expected-pass.out 2>&1
+        grep "FAILED.*$tname" expected-pass.out && exit 1
+        python3 -m pytest --timeout=1 ./test.py > expected-timeout.txt 2>&1 || rc=$?
+        grep -q "FAILED.*$tname" expected-timeout.txt || exit 1

--- a/py3-pytest-timeout/test.py
+++ b/py3-pytest-timeout/test.py
@@ -1,0 +1,8 @@
+# test.py
+
+import time
+
+def test_a_slow_test():
+    """This should take 3 seconds to run. An agressive 'pytest --timeout'
+    value will kill it, but forgiving timeout flag will let it go."""
+    time.sleep(3)


### PR DESCRIPTION
Also includes a very simple test verifying some timeout functionality.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
