### PR TITLE
add dua package

### DIFF
--- a/dua.yaml
+++ b/dua.yaml
@@ -1,0 +1,45 @@
+package:
+  name: dua
+  version: 2.28.0
+  epoch: 0
+  description: "View disk space usage and delete unwanted data, fast."
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - rust
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Byron/dua-cli
+      expected-commit: 984fd979e18ffaa20ba35bca3b85dc47c404328c
+      tag: v${{package.version}}
+
+  - name: Configure and build
+    runs: |
+      cargo build --release --no-default-features --features tui-crossplatform
+      mkdir -p ${{targets.destdir}}/usr/bin/
+      mv target/release/dua ${{targets.destdir}}/usr/bin/dua
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: Byron/dua-cli
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        dua -V

--- a/dua.yaml
+++ b/dua.yaml
@@ -34,6 +34,7 @@ update:
   enabled: true
   github:
     identifier: Byron/dua-cli
+    strip-prefix: v
 
 test:
   environment:


### PR DESCRIPTION
_this commit adds [dua](https://github.com/byron/dua-cli) package_
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
