### PR TITLE
zaproxy-stable

### DIFF
--- a/zaproxy.yaml
+++ b/zaproxy.yaml
@@ -1,0 +1,87 @@
+package:
+  name: zaproxy
+  version: 2.14.0
+  epoch: 0
+  description: The ZAP core project
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - Xvfb
+      - autoconf
+      - automake
+      - aws-cli
+      - bash # some helper scripts use bash
+      - curl
+      - gcc
+      - git
+      - make
+      - net-tools
+      - openbox
+      - openjdk-11-default-jvm
+      - py3-pyyaml
+      - py3-zaproxy
+      - python3
+      - unzip
+      - wget
+      - x11vnc
+      - xmlstarlet
+      - xterm
+
+environment:
+  contents:
+    packages:
+      - bash
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - openjdk-11-default-jvm
+      - wget
+      - xmlstarlet
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/zaproxy/zaproxy
+      tag: v${{package.version}}
+      expected-commit: ebddb3e91eeb52017ced2b080f14e958043f91cf
+
+  - runs: |
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+      wget -qO- https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget --content-disposition -i - -O - | tar zxv && \
+      mv ZAP*/* .
+      ls -latr
+      ./zap.sh -cmd -silent -addonupdate
+      mkdir -p "${{targets.destdir}}"/home/zap
+      mkdir -p "${{targets.destdir}}"/zap/plugin
+      mkdir -p "${{targets.destdir}}"/home/zap/.ZAP/policies
+      mkdir -p "${{targets.destdir}}"/root/.ZAP/policies
+      mkdir -p "${{targets.destdir}}"/home/zap/.ZAP_D/scripts/
+
+      mv /root/.ZAP/plugin/*.zap "${{targets.destdir}}"/zap/plugin/
+
+      WEBSWING_VERSION=23.2.2
+      curl -s -L  "https://dev.webswing.org/files/public/webswing-examples-eval-${WEBSWING_VERSION}-distribution.zip" > webswing.zip
+      unzip webswing.zip
+
+      mkdir -p "${{targets.destdir}}"/zap/webswing
+      mv webswing-* "${{targets.destdir}}"/zap/webswing
+
+      cp ./docker/zap* "${{targets.destdir}}"/zap/
+      cp ./docker/CHANGELOG.md "${{targets.destdir}}"/zap/
+      cp ./docker/webswing.config "${{targets.destdir}}"/zap/webswing/
+      cp ./docker/webswing.properties "${{targets.destdir}}"/zap/webswing/
+      cp -r ./docker/policies "${{targets.destdir}}"/home/zap/.ZAP/policies/
+      cp -r ./docker/policies "${{targets.destdir}}"/root/.ZAP/policies/
+      cp -r ./docker/scripts "${{targets.destdir}}"/home/zap/.ZAP_D/scripts/
+      cp ./docker/.xinitrc "${{targets.destdir}}"/home/zap/
+
+      mkdir -p "${{targets.destdir}}"/zap/.vnc
+      echo "zap2docker-stable" > "${{targets.destdir}}"/zap/container
+      chmod a+x "${{targets.destdir}}"/home/zap/.xinitrc
+
+update:
+  enabled: true
+  github:
+    identifier: zaproxy/zaproxy
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
