### PR TITLE
octo-sts: allow update bot to create issues, used for failure scenari…

### DIFF
--- a/.github/chainguard/github-updates.sts.yaml
+++ b/.github/chainguard/github-updates.sts.yaml
@@ -7,3 +7,4 @@ permissions:
   contents: write
   pull_requests: write
   workflows: write
+  issues: write


### PR DESCRIPTION
…os during updates

This should fix the bot GHA failures we are seeing
```
2024/01/29 09:13:50 error during command execution: creating updates: POST https://api.github.com/repos/wolfi-dev/os/issues/11895/comments: 403 Resource not accessible by integration []
```
https://github.com/wolfi-dev/os/actions/runs/7693546234/job/20962519474