### PR TITLE
bump more epochs, fix some licenses

### DIFF
--- a/aom.yaml
+++ b/aom.yaml
@@ -5,7 +5,7 @@
 package:
   name: aom
   version: 3.8.1
-  epoch: 0
+  epoch: 1
   description: Alliance for Open Media (AOM) AV1 codec SDK
   copyright:
     - license: BSD-2-Clause

--- a/findutils.yaml
+++ b/findutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: findutils
   version: 4.9.0
-  epoch: 1
+  epoch: 3
   description: "GNU find utilities"
   copyright:
     - license: GPL-3.0-or-later

--- a/geoip.yaml
+++ b/geoip.yaml
@@ -1,10 +1,10 @@
 package:
   name: geoip
   version: 1.6.12
-  epoch: 0
+  epoch: 1
   description: Lookup countries by IP addresses
   copyright:
-    - license: GPL
+    - license: GPL-2.0-or-later
 
 environment:
   contents:

--- a/grafana-grafonnet.yaml
+++ b/grafana-grafonnet.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-grafonnet
   version: 0.0_git20231114
-  epoch: 1
+  epoch: 2
   description: Jsonnet library for generating Grafana dashboards
   copyright:
     - license: Apache-2.0

--- a/gsm.yaml
+++ b/gsm.yaml
@@ -1,7 +1,7 @@
 package:
   name: gsm
   version: 1.0.22
-  epoch: 1
+  epoch: 2
   description: Shared libraries for GSM speech compressor
   copyright:
     - license: TU-Berlin-2.0

--- a/http-echo.yaml
+++ b/http-echo.yaml
@@ -1,7 +1,7 @@
 package:
   name: http-echo
   version: 1.0.0
-  epoch: 2
+  epoch: 3
   description: A tiny go web server that echos what you start it with!
   copyright:
     - license: MPL-2.0
@@ -39,7 +39,7 @@ pipeline:
 
       go build \
         -ldflags="$LDFLAGS" \
-        -o ${{targets.destdir}}/http-echo \
+        -o ${{targets.destdir}}/usr/bin/http-echo \
         .
 
   - uses: strip

--- a/libapr.yaml
+++ b/libapr.yaml
@@ -1,7 +1,7 @@
 package:
   name: libapr
   version: 1.7.4
-  epoch: 1
+  epoch: 2
   description: "Apache Portable Runtime Library (APR)"
   copyright:
     - license: Apache-2.0

--- a/libxinerama.yaml
+++ b/libxinerama.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxinerama
   version: 1.1.5
-  epoch: 0
+  epoch: 1
   description: X11 Xinerama extension library
   copyright:
     - license: MIT

--- a/libxkb.yaml
+++ b/libxkb.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxkb
   version: 1.1.2
-  epoch: 1
+  epoch: 2
   description: "X11 keyboard file manipulation library"
   copyright:
     - license: MIT

--- a/lua-json4.yaml
+++ b/lua-json4.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-json4
   version: 1.0.0
-  epoch: 0
+  epoch: 1
   description: JSON module for Lua
   copyright:
     - license: MIT

--- a/nmap.yaml
+++ b/nmap.yaml
@@ -1,7 +1,7 @@
 package:
   name: nmap
   version: 7.94
-  epoch: 0
+  epoch: 1
   description: "network discovery and security auditing tool"
   copyright:
     - license: GPL-2.0-or-later

--- a/pgbouncer.yaml
+++ b/pgbouncer.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgbouncer
   version: 1.21.0
-  epoch: 0
+  epoch: 1
   description: lightweight connection pooler for PostgreSQL
   copyright:
     - license: ISC

--- a/pulseaudio.yaml
+++ b/pulseaudio.yaml
@@ -2,7 +2,7 @@
 package:
   name: pulseaudio
   version: "16.1"
-  epoch: 0
+  epoch: 1
   description: featureful, general-purpose sound server
   copyright:
     - license: LGPL-2.1-or-later

--- a/pulseaudio.yaml
+++ b/pulseaudio.yaml
@@ -2,7 +2,7 @@
 package:
   name: pulseaudio
   version: "16.1"
-  epoch: 1
+  epoch: 0
   description: featureful, general-purpose sound server
   copyright:
     - license: LGPL-2.1-or-later

--- a/py3-ipaddress.yaml
+++ b/py3-ipaddress.yaml
@@ -1,10 +1,10 @@
 package:
   name: py3-ipaddress
   version: 1.0.23
-  epoch: 1
+  epoch: 2
   description: IPv4/IPv6 manipulation library
   copyright:
-    - license: Python Software Foundation License
+    - license: PSF-2.0
   dependencies:
     runtime:
       - python3

--- a/py3-lru-dict.yaml
+++ b/py3-lru-dict.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-lru-dict
   version: 1.3.0
-  epoch: 0
+  epoch: 1
   description: An Dict like LRU container.
   copyright:
     - license: MIT

--- a/py3-typing-extensions.yaml
+++ b/py3-typing-extensions.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-typing-extensions
   version: 4.9.0
-  epoch: 0
+  epoch: 1
   description: Backported and Experimental Type Hints for Python 3.7+
   copyright:
-    - license: Python Software Foundation
+    - license: PSF-2.0
   dependencies:
     runtime:
       - python3

--- a/py3-websocket-client.yaml
+++ b/py3-websocket-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-websocket-client
   version: 1.7.0
-  epoch: 0
+  epoch: 1
   description: WebSocket client for Python with low level API options
   copyright:
     - license: Apache-2.0

--- a/ssdeep.yaml
+++ b/ssdeep.yaml
@@ -1,7 +1,7 @@
 package:
   name: ssdeep
   version: 2.14.1
-  epoch: 0
+  epoch: 1
   description: "Fuzzy hashing API and fuzzy hashing tool"
   copyright:
     - license: GPL-2.0-or-later

--- a/tomcat-native.yaml
+++ b/tomcat-native.yaml
@@ -1,7 +1,7 @@
 package:
   name: tomcat-native
   version: 2.0.6
-  epoch: 0
+  epoch: 1
   description: OpenSSL extension for Tomcat
   copyright:
     - license: Apache-2.0

--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: wavefront-proxy
   version: "13.4" # When version is bumped, check if patches are still needed to address CVE-2023-1428
-  epoch: 1
+  epoch: 2
   description: Wavefront Proxy Project
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/11919 mistakenly un-bumped the epoch for `findutils` from 2 -> 1, when it should have bumped to 3. That's why this change bumps 1 -> 3.

The rest are normal bumps and license tweaks.