### PR TITLE
Replace use of bash-specific shell code with posix equivalent.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ endef
 #$(call get-source-dir,ret-variable-for-source-dir,package-dir,package-name)
 define get-source-dir
 	$(info getting source dir for package $(3) with dir $(2))
-	$(1) := $(shell set -x; if [[ "." == "$(2)" ]]; then \
+	$(1) := $(shell set -x; if [ "." = "$(2)" ]; then \
 		echo "--source-dir ./$(3)"; \
 	else \
 		echo "--source-dir $(2)"; \


### PR DESCRIPTION
This just replaces a "bashism" (`[[ "a" == "b" ]]`) with a posix shell equivalent  (`[ "a" = "b" ]`).

/bin/sh is what is used as 'shell' by default in Make. Another option to avoid the problem would be to set .SHELL := /bin/bash .
