### PR TITLE
kubernetes-csi-external-resizer/1.10.0-r0: cve remediation

### DIFF
--- a/kubernetes-csi-external-resizer.yaml
+++ b/kubernetes-csi-external-resizer.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-resizer
   version: 1.10.0
-  epoch: 0
+  epoch: 1
   description: Sidecar container that watches Kubernetes PersistentVolumeClaims objects and triggers controller side expansion operation against a CSI endpoint
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,10 @@ pipeline:
       repository: https://github.com/kubernetes-csi/external-resizer
       tag: v${{package.version}}
       expected-commit: edcf895c8279a22e898e3ecbefd6629c89bf1e49
+
+  - uses: go/bump
+    with:
+      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
 
   - runs: |
       make build


### PR DESCRIPTION
kubernetes-csi-external-resizer/1.10.0-r0: fix GHSA-8pgv-569h-w5rw