### PR TITLE
octo-sts: allow release monitoring update bot to create issues, used for failure scenari…

### DIFF
--- a/.github/chainguard/release-monitoring-updates.sts.yaml
+++ b/.github/chainguard/release-monitoring-updates.sts.yaml
@@ -7,3 +7,4 @@ permissions:
   contents: write
   pull_requests: write
   workflows: write
+  issues: write


### PR DESCRIPTION
…os during updates
