### PR TITLE
fix(fluxbox): Change installation prefix from /usr/local to /usr

### DIFF
--- a/fluxbox.yaml
+++ b/fluxbox.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluxbox
   version: 1.3.7
-  epoch: 0
+  epoch: 1
   description: Fluxbox Window Manager
   copyright:
     - license: GPL-2.0-or-later
@@ -41,6 +41,7 @@ pipeline:
   - name: 'Configure binutils'
     runs: |
       ./configure \
+        --prefix=/usr \
         --enable-imlib2 \
         --disable-nls
 


### PR DESCRIPTION
Installs fluxbox to /usr instead of /usr/local

Fixes: Fluxbox's installation prefix