### PR TITLE
rebuild without werkzeug build dependency

### DIFF
--- a/kubeflow-volumes-web-app.yaml
+++ b/kubeflow-volumes-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-volumes-web-app
   version: 1.8.0
-  epoch: 1
+  epoch: 2
   description: Kubeflow volumes web app component
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,6 @@ environment:
       - py3-pip
       - py3-setuptools
       - py3-urllib3
-      - py3-werkzeug
       - py3-wheel
       - python3
       - python3-dev


### PR DESCRIPTION
including `werkzeug` as a buildtime dependency prevents the setup.py from placing this in site-packages. removing it to prevent this behavior