### PR TITLE
buildkitd/0.12.4-r2: cve remediation

### DIFF
--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -2,7 +2,7 @@ package:
   name: buildkitd
   version: 0.12.4
   description: "concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
-  epoch: 2
+  epoch: 3
   copyright:
     - license: Apache-2.0
 
@@ -21,6 +21,10 @@ pipeline:
       repository: https://github.com/moby/buildkit
       tag: v${{package.version}}
       expected-commit: 833949d0f7908608b00ab6b93b8f92bdb147fcca
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/net@v0.17.0
 
   - runs: |
       PKG=github.com/moby/buildkit


### PR DESCRIPTION
buildkitd/0.12.4-r2: fix GHSA-4374-p667-p6c8