### PR TITLE
libpng/1.6.42 package update

### DIFF
--- a/libpng.yaml
+++ b/libpng.yaml
@@ -1,6 +1,6 @@
 package:
   name: libpng
-  version: 1.6.41
+  version: 1.6.42
   epoch: 0
   description: Portable Network Graphics library
   copyright:
@@ -19,10 +19,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: f00a11840f60616bdced9056d0f4cf2e4897697db039f15ce911704f957d3c5d
-      uri: https://downloads.sourceforge.net/libpng/libpng-${{package.version}}.tar.gz
+      repository: https://github.com/pnggroup/libpng
+      tag: v${{package.version}}
+      expected-commit: 35d9f5ea523cb4f9d677af4705e00ddd185ed10e
 
   - runs: autoreconf -vif
 
@@ -62,5 +63,7 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 1705
+  github:
+    identifier: pnggroup/libpng
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
fixes wolfi-dev/os#12062

Switch to github checkout too as 1.6.42 is not available on sourceforge yet.
