### PR TITLE
Withdraw some old sqlite versions

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -16,3 +16,6 @@ openjdk-17-doc-17.0.10.1-r0.apk
 openjdk-17-jmods-17.0.10.1-r0.apk
 openjdk-17-jre-17.0.10.1-r0.apk
 openjdk-17-jre-base-17.0.10.1-r0.apk
+sqlite-3.39.2-r1.apk
+sqlite-3.39.4-r1.apk
+sqlite-3.40.0-r0.apk


### PR DESCRIPTION
These break apk's solver logic because they provide libsqlite.

```
curl -L https://packages.wolfi.dev/os/x86_64/sqlite-3.40.0-r0.apk | tar -Oxz .PKGINFO
# Generated by melange.
pkgname = sqlite
pkgver = 3.40.0-r0
arch = x86_64
size = 3015612
origin = sqlite
pkgdesc = C library which implements an SQL database engine
license = blessing
depend = so:libc.so.6
depend = so:libm.so.6
provides = cmd:sqlite3=3.40.0-r0
provides = so:libsqlite3.so.0=0
datahash = e296c8314279949d2e448733d21498f8ce3e51529bb6a34486c2a6e24a585cbd
```

