### PR TITLE
kargo: fix grpc-health-probe symlink path

### DIFF
--- a/kargo.yaml
+++ b/kargo.yaml
@@ -1,7 +1,7 @@
 package:
   name: kargo
   version: 0.3.2
-  epoch: 0
+  epoch: 1
   description: Application lifecycle orchestration
   copyright:
     - license: Apache-2.0

--- a/kargo.yaml
+++ b/kargo.yaml
@@ -59,7 +59,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin
           ln -sf /usr/bin/kargo ${{targets.subpkgdir}}/usr/local/bin/kargo
           ln -sf /usr/share/kargo/ui ${{targets.subpkgdir}}/
-          ln -sf /usr/bin/grpc_health_probe ${{targets.subpkgdir}}/usr/local/bin/grpc_health_probe
+          ln -sf /usr/bin/grpc-health-probe ${{targets.subpkgdir}}/usr/local/bin/grpc_health_probe
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: grpc_health_probe symlink in "kargo-oci-compat" should link to "/usr/bin/grpc-health-probe" with dashes, since that is what is installed using the apk package "grpc-health-probe".

The problem is reproducable with this simple setup:
```bash
docker run -it --rm cgr.dev/chainguard/wolfi-base

7131c87ae581:/# apk update && apk add kargo kargo-oci-compat
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
 [https://packages.wolfi.dev/os]
OK: 38382 distinct packages available
(1/3) Installing kargo (0.3.2-r0)
(2/3) Installing grpc-health-probe (0.4.24-r1)
(3/3) Installing kargo-oci-compat (0.3.2-r0)
OK: 84 MiB in 16 packages
7131c87ae581:/# grpc_health_probe
/bin/sh: grpc_health_probe: not found
7131c87ae581:/# which grpc_health_probe
7131c87ae581:/# echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
7131c87ae581:/# ls /usr/local/bin
grpc_health_probe  kargo
7131c87ae581:/# ls -lash /usr/local/bin
total 8K
   4.0K drwxr-xr-x    2 root     root        4.0K Jan 31 09:41 .
   4.0K drwxr-xr-x    1 root     root        4.0K Jan 31 09:41 ..
      0 lrwxrwxrwx    1 root     root          26 Jan 31 09:41 grpc_health_probe -> /usr/bin/grpc_health_probe
      0 lrwxrwxrwx    1 root     root          14 Jan 31 09:41 kargo -> /usr/bin/kargo
7131c87ae581:/# ls -lash /usr/bin/grpc_health_probe
ls: /usr/bin/grpc_health_probe: No such file or directory
7131c87ae581:/# ls -lash /usr/bin/grpc*
  10.6M -rwxr-xr-x    1 root     root       10.6M Dec 20 03:28 /usr/bin/grpc-health-probe
```

Related: