### PR TITLE
buildkitd/0.12.4-r3: cve remediation

### DIFF
--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -2,7 +2,7 @@ package:
   name: buildkitd
   version: 0.12.4
   description: "concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
-  epoch: 3
+  epoch: 4
   copyright:
     - license: Apache-2.0
 
@@ -24,7 +24,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.17.0
+      deps: golang.org/x/net@v0.17.0 golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 google.golang.org/grpc@v1.56.3
 
   - runs: |
       PKG=github.com/moby/buildkit


### PR DESCRIPTION
buildkitd/0.12.4-r3: fix GHSA-qppj-fm5r-hxr3/GHSA-8pgv-569h-w5rw/GHSA-7ww5-4wqc-m92c/GHSA-45x7-px36-x8w8/