### PR TITLE
use jdk 11

### DIFF
--- a/cass-config-builder.yaml
+++ b/cass-config-builder.yaml
@@ -1,14 +1,11 @@
 package:
   name: cass-config-builder
   version: 1.0.8
-  epoch: 1
+  epoch: 2
   description: |
     Configuration builder for Apache Cassandra based on definitions at datastax/cass-config-definitions
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - openjdk-8-default-jvm
 
 environment:
   contents:
@@ -17,6 +14,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - openjdk-8-default-jvm
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-1.8-openjdk
 
 pipeline:
   - uses: git-checkout
@@ -36,7 +35,6 @@ pipeline:
       git submodule update --init
 
   - runs: |
-      export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
       ./gradlew copyDockerBuildCtx
       mkdir -p "${{targets.destdir}}"/usr/local/bin
       mkdir -p "${{targets.destdir}}"/definitions


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
