### PR TITLE
kubernetes-event-exporter: bump logrus

### DIFF
--- a/kubernetes-event-exporter.yaml
+++ b/kubernetes-event-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-event-exporter
   version: 1.6.1
-  epoch: 3
+  epoch: 4
   description: Export Kubernetes events to multiple destinations with routing and filtering
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: google.golang.org/grpc@v1.56.3 golang.org/x/crypto@v0.17.0
+      deps: google.golang.org/grpc@v1.56.3 golang.org/x/crypto@v0.17.0 github.com/sirupsen/logrus@v1.9.3
       modroot: .
 
   - uses: go/build


### PR DESCRIPTION
This incorporates a fix to https://github.com/sirupsen/logrus/issues/1370 (with no identifiable CVE at this time).
