### PR TITLE
cassandra with jdk11

### DIFF
--- a/cassandra.yaml
+++ b/cassandra.yaml
@@ -1,14 +1,10 @@
 package:
   name: cassandra
   version: 4.1.3
-  epoch: 7
+  epoch: 8
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - openjdk-8-default-jvm
-      - openjdk-8-jre
 
 environment:
   contents:
@@ -18,8 +14,11 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - openjdk-8
+      - openjdk-11-default-jvm
       - python3
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-11-openjdk
+    CASSANDRA_USE_JDK11: true
 
 pipeline:
   - uses: git-checkout
@@ -34,8 +33,6 @@ pipeline:
       patches: bumpdeps.patch CVE-2023-43642.patch CVE-2023-6378.patch
 
   - runs: |
-      export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
-
       ant artifacts -Dversion=${{package.version}}
 
       # Install cassandra from the tarball in build/dist into the destdir in /usr/share/java/cassandra


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
