### PR TITLE
Bump protobuf-c to fix abseil deps

### DIFF
--- a/protobuf-c.yaml
+++ b/protobuf-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf-c
   version: 1.5.0
-  epoch: 2
+  epoch: 3
   description: Protocol Buffers implementation in C
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
Live:
```
curl -sL https://packages.wolfi.dev/os/aarch64/protobuf-c-compiler-1.5.0-r2.apk | tar -Oxz .PKGINFO | grep check_op
depend = so:libabsl_log_internal_check_op.so.2308.0.0
```

Rebuilt:
```
tar -Oxf packages/aarch64/protobuf-c-compiler-1.5.0-r3.apk .PKGINFO | grep check_op
depend = so:libabsl_log_internal_check_op.so.2401.0.0
```