### PR TITLE
zot/2.0.1-r0: cve remediation

### DIFF
--- a/zot.yaml
+++ b/zot.yaml
@@ -1,7 +1,7 @@
 package:
   name: zot
   version: 2.0.1
-  epoch: 0
+  epoch: 1
   description: A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification)
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
+      deps: golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7 github.com/opencontainers/runc@v1.1.12 github.com/moby/buildkit@v0.12.5
       go-version: "1.20"
 
   - runs: |


### PR DESCRIPTION
zot/2.0.1-r0: fix GHSA-wr6v-9f75-vh2g/GHSA-xr7r-f8xq-vfvv/