### PR TITLE
tigera-operator-1.33

### DIFF
--- a/tigera-operator.yaml
+++ b/tigera-operator.yaml
@@ -5,9 +5,6 @@ package:
   description: Kubernetes operator for installing Calico and Calico Enterprise
   copyright:
     - license: Apache-2.0
-  dependencies:
-    provides:
-      - tigera-operator=${{package.full-version}}
 
 environment:
   contents:

--- a/tigera-operator.yaml
+++ b/tigera-operator.yaml
@@ -1,0 +1,57 @@
+package:
+  name: tigera-operator
+  version: 1.33.0
+  epoch: 0
+  description: Kubernetes operator for installing Calico and Calico Enterprise
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - tigera-operator=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tigera/operator
+      tag: v${{package.version}}
+      expected-commit: 950ca1ea7803d550f64ec6b4f2c486619f3edcc4
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/net@v0.17.0
+
+  - runs: |
+      PACKAGE_NAME=github.com/tigera/operator
+      ARCH=$(go env GOARCH)
+      BINDIR=build/_output/bin
+      GIT_VERSION=$(git describe --tags --dirty --always --abbrev=12)
+      if [ "${ARCH}" = "amd64" ]; then
+        CGO_ENABLED=1
+        GOEXPERIMENT=boringcrypto
+        TAGS="osusergo,netgo"
+      else
+        CGO_ENABLED=0
+      fi
+
+      echo "Building operator for ${ARCH} with CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=${GOEXPERIMENT} TAGS=${TAGS}"
+      GOEXPERIMENT=${GOEXPERIMENT} GO111MODULE=on CGO_ENABLED=${CGO_ENABLED} go build -buildvcs=false -v -o ${BINDIR}/operator-${ARCH} -tags "${TAGS}" -ldflags "-X ${PACKAGE_NAME}/version.VERSION=${GIT_VERSION} -w" ./main.go
+      install -Dm755 build/_output/bin/operator-$(go env GOARCH) "${{targets.destdir}}"/usr/bin/operator
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: tigera/operator
+    use-tag: true
+    strip-prefix: v
+    tag-filter: v1.33.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
