### PR TITLE
chore: cleanup go-version from gobump

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,7 +1,7 @@
 package:
   name: atlantis
   version: 0.27.1
-  epoch: 0
+  epoch: 1
   description: Terraform Pull Request Automation
   copyright:
     - license: Apache-2.0
@@ -29,7 +29,6 @@ pipeline:
   - uses: go/bump
     with:
       deps: golang.org/x/crypto@v0.17.0
-      go-version: "1.21"
 
   - uses: go/build
     with:

--- a/certificate-transparency.yaml
+++ b/certificate-transparency.yaml
@@ -1,7 +1,7 @@
 package:
   name: certificate-transparency
   version: 1.1.7
-  epoch: 2
+  epoch: 3
   description: Auditing for TLS certificates
   copyright:
     - license: Apache-2.0
@@ -40,7 +40,6 @@ subpackages:
       - uses: go/bump
         with:
           deps: golang.org/x/crypto@v0.17.0
-          go-version: "1.21"
       - runs: |
           CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o "${{range.key}}" ${{range.value}}
       - runs: |

--- a/cloudflared.yaml
+++ b/cloudflared.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudflared
   version: 2024.1.0
-  epoch: 1
+  epoch: 2
   description: Cloudflare Tunnel client
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,6 @@ pipeline:
   - uses: go/bump
     with:
       deps: golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1
-      go-version: "1.21"
 
   - uses: go/build
     with:

--- a/cri-tools.yaml
+++ b/cri-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: cri-tools
   version: 1.29.0
-  epoch: 2
+  epoch: 3
   description: CLI and validation tools for Kubelet Container Runtime Interface (CRI) .
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,6 @@ pipeline:
   - uses: go/bump
     with:
       deps: google.golang.org/grpc@v1.58.3 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel/sdk@v1.20.0
-      go-version: "1.21"
 
   - uses: go/build
     with:

--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-aws
   version: 0.47.1
-  epoch: 2
+  epoch: 3
   description: Official AWS Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -32,7 +32,6 @@ pipeline:
   - uses: go/bump
     with:
       deps: golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7
-      go-version: "1.21"
 
   - runs: |
       # `make` downloads `up`, unless we move our prebuilt `up` to where it expects it.

--- a/istio-cni-1.20.yaml
+++ b/istio-cni-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-cni-1.20
   version: 1.20.2
-  epoch: 2
+  epoch: 3
   description: Istio Container Network Interface
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,6 @@ pipeline:
   - uses: go/bump
     with:
       deps: golang.org/x/crypto@v0.17.0 github.com/lestrrat-go/jwx@v1.2.28
-      go-version: "1.21"
 
   - uses: go/build
     with:

--- a/istio-operator-1.20.yaml
+++ b/istio-operator-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-operator-1.20
   version: 1.20.2
-  epoch: 2
+  epoch: 3
   description: Istio operator provides user friendly options to operate the Istio service mesh
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,6 @@ pipeline:
   - uses: go/bump
     with:
       deps: golang.org/x/crypto@v0.17.0 github.com/lestrrat-go/jwx@v1.2.28
-      go-version: "1.21"
 
   - uses: go/build
     with:

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.15.1
-  epoch: 4
+  epoch: 5
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,6 @@ pipeline:
   - uses: go/bump
     with:
       deps: golang.org/x/crypto@v0.17.0
-      go-version: "1.21"
       modroot: ko
 
   - uses: go/build

--- a/pulumi.yaml
+++ b/pulumi.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi
   version: 3.103.1
-  epoch: 0
+  epoch: 1
   description: Infrastructure as Code in any programming language
   copyright:
     - license: Apache-2.0
@@ -33,7 +33,6 @@ pipeline:
   - uses: go/bump
     with:
       deps: google.golang.org/grpc@v1.58.3 golang.org/x/crypto@v0.17.0 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
-      go-version: "1.21"
       modroot: ${{package.name}}/pkg
 
   - pipeline:

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,7 +1,7 @@
 package:
   name: trivy
   version: 0.48.3
-  epoch: 0
+  epoch: 1
   description: Simple and comprehensive vulnerability scanner for containers
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,6 @@ pipeline:
   - uses: go/bump
     with:
       deps: github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
-      go-version: "1.21"
 
   - runs: |
       CGO_ENABLED=0 go build \


### PR DESCRIPTION
gobump go-version is now autodetected by gobump source code.