### PR TITLE
ipfs: use latest go to build

### DIFF
--- a/ipfs.yaml
+++ b/ipfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: ipfs
   version: 0.26.0
-  epoch: 0
+  epoch: 1
   description: An IPFS implementation in Go
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - fuse3
-      - go-1.20
+      - go
       - openssl # significantly reduces background CPU usage, but requires CGO and gcc
 
 pipeline:


### PR DESCRIPTION
At some point since https://github.com/wolfi-dev/os/commit/548d25bff46be316ae0f5b224b8c73a212f02c32 ipfs no longer needs to be built with 1.20.