### PR TITLE
kubescape/3.0.3-r5: cve remediation

### DIFF
--- a/kubescape.yaml
+++ b/kubescape.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubescape
   version: 3.0.3
-  epoch: 5
+  epoch: 6
   description: Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources.
   copyright:
     - license: Apache-2.0 AND MIT
@@ -27,7 +27,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/containerd/containerd@v1.7.11 golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/docker/docker@v24.0.7 github.com/cloudflare/circl@v1.3.7 github.com/sigstore/cosign/v2@v2.2.1 github.com/lestrrat-go/jwx/v2@v2.0.19
+      deps: github.com/containerd/containerd@v1.7.11 golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/otel@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/docker/docker@v24.0.7 github.com/cloudflare/circl@v1.3.7 github.com/sigstore/cosign/v2@v2.2.1 github.com/lestrrat-go/jwx/v2@v2.0.19 github.com/anchore/stereoscope@v0.0.1 github.com/moby/buildkit@v0.12.5
       replaces: sigs.k8s.io/kustomize/kyaml=sigs.k8s.io/kustomize/kyaml@v0.14.1 k8s.io/kube-openapi=k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f github.com/google/gnostic=github.com/google/gnostic@v0.5.7-v3refs k8s.io/client-go=k8s.io/client-go@v0.27.4 k8s.io/api=k8s.io/api@v0.27.4 google.golang.org/grpc=google.golang.org/grpc@v1.58.3
 
   - runs: |


### PR DESCRIPTION
kubescape/3.0.3-r5: fix GHSA-wr6v-9f75-vh2g/GHSA-hpxr-w9w7-g4gv/