### PR TITLE
trivy/0.49.0-r0: cve remediation

### DIFF
--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,7 +1,7 @@
 package:
   name: trivy
   version: 0.49.0
-  epoch: 0
+  epoch: 1
   description: Simple and comprehensive vulnerability scanner for containers
   copyright:
     - license: Apache-2.0
@@ -19,6 +19,10 @@ pipeline:
       expected-commit: 729a0512abb633a29b6eaa49d224c1fedf389c05
       repository: https://github.com/aquasecurity/trivy
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: github.com/moby/buildkit@v0.12.5
 
   - runs: |
       CGO_ENABLED=0 go build \

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -22,7 +22,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/moby/buildkit@v0.12.5
+      deps: github.com/moby/buildkit@v0.12.5 github.com/docker/docker@v25.0.1+incompatible oras.land/oras-go@v1.2.5
 
   - runs: |
       CGO_ENABLED=0 go build \


### PR DESCRIPTION
trivy/0.49.0-r0: fix GHSA-wr6v-9f75-vh2g