### PR TITLE
temporal-server: include getent

### DIFF
--- a/temporal-docker-builds.yaml
+++ b/temporal-docker-builds.yaml
@@ -9,7 +9,7 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - posix-libc-utils // Required for getent
+      - posix-libc-utils # Required for getent
 
 vars:
   commit: 70f8b8bbda3723fe7c8f822cc8aa379598ac8c86

--- a/temporal-docker-builds.yaml
+++ b/temporal-docker-builds.yaml
@@ -3,10 +3,13 @@ package:
   # This project doesn't do releases and everything is commit based.
   # This corresponds to commit 70f8b8bbda3723fe7c8f822cc8aa379598ac8c86
   version: 0.0_git20231116
-  epoch: 1
+  epoch: 2
   description: Temporal service Docker images build
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      - posix-libc-utils // Required for getent
 
 vars:
   commit: 70f8b8bbda3723fe7c8f822cc8aa379598ac8c86

--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal-server
   version: 1.22.4
-  epoch: 2
+  epoch: 1
   description: Temporal server executes units of application logic, Workflows, in a resilient manner that automatically handles intermittent failures, and retries failed operations
   copyright:
     - license: MIT
@@ -104,7 +104,6 @@ subpackages:
         - bash
         - temporal-docker-builds
         - tctl
-        - posix-libc-utils // Required for getent
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc/temporal/config/dynamicconfig

--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal-server
   version: 1.22.4
-  epoch: 1
+  epoch: 2
   description: Temporal server executes units of application logic, Workflows, in a resilient manner that automatically handles intermittent failures, and retries failed operations
   copyright:
     - license: MIT
@@ -104,6 +104,7 @@ subpackages:
         - bash
         - temporal-docker-builds
         - tctl
+        - posix-libc-utils // Required for getent
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc/temporal/config/dynamicconfig


### PR DESCRIPTION
The entrypoint calls `getent`, which was not present otherwise.

https://oci.dag.dev/layers/cgr.dev/chainguard/temporal-server@sha256:8a290fd0376bbd608b1dc54294a3dbd009ea10a8f43d2a404bb9c3289252ce7e/etc/temporal/entrypoint.sh