### PR TITLE
Run cache update every 6h instead of on push

### DIFF
--- a/.github/workflows/update-cache.yaml
+++ b/.github/workflows/update-cache.yaml
@@ -1,8 +1,10 @@
 name: Update prod cache of build materials
 
 on:
-  push:
-    branches: ['main']
+  workflow_dispatch:
+  # Triggers the workflow every six hours
+  schedule:
+    - cron: "0 */6 * * *"
 
 env:
   PROJECT: prod-images-c6e5


### PR DESCRIPTION
Also add a manual invocation option

This blocks/preempts the Build Wolfi OS workflow, which means we're not releasing packages as efficiently as we could be.