### PR TITLE
Refactor kubeflow-katib for python subpackages to utilize venv

### DIFF
--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -67,18 +67,18 @@ subpackages:
     description: Kubeflow Katib earlystopping
     dependencies:
       runtime:
-        - py3-grpcio
-        - py3-protobuf
-        - py3-googleapis-common-protos
-        - py3-kubernetes
-        - cython
+        - python-3.11-dev
+        - py3.11-pip
     pipeline:
       - runs: |
+          python -m venv .venv-earlystopping --system-site-packages
           export SUGGESTION_DIR="cmd/earlystopping/medianstop/v1beta1"
+          .venv-earlystopping/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib
           mkdir -p ${{targets.subpkgdir}}/opt/katib/pkg
           mkdir -p ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
+          mv .venv-earlystopping/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
 
   - name: katib-tfevent-metricscollector
@@ -97,64 +97,55 @@ subpackages:
     description: Kubeflow Katib suggestion-hyperband
     dependencies:
       runtime:
-        - py3-grpcio
-        - py3-cloudpickle
-        - numpy
-        - py3-scikit-learn
-        - py3-scipy
-        - py3-forestci
-        - py3-protobuf
-        - py3-googleapis-common-protos
-        - cython
+        - python-3.11-dev
+        - py3.11-pip
         - libgomp
     pipeline:
       - runs: |
+          python -m venv .venv-hyperband --system-site-packages
           export SUGGESTION_DIR="cmd/suggestion/hyperband/v1beta1"
+          .venv-hyperband/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib
           mkdir -p ${{targets.subpkgdir}}/opt/katib/pkg
           mkdir -p ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
+          mv .venv-hyperband/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
 
   - name: katib-suggestion-hyperopt
     description: Kubeflow Katib suggestion-hyperopt
     dependencies:
       runtime:
-        - py3-grpcio
-        - py3-cloudpickle
-        - numpy
-        - py3-scikit-learn
-        - py3-scipy
-        - py3-forestci
-        - py3-protobuf
-        - py3-googleapis-common-protos
-        - cython
-        - py3-hyperopt
-        - py3-setuptools
+        - python-3.11-dev
+        - py3.11-pip
     pipeline:
       - runs: |
+          python -m venv .venv-hyperopt --system-site-packages
           export SUGGESTION_DIR="cmd/suggestion/hyperopt/v1beta1"
+          .venv-hyperopt/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib
           mkdir -p ${{targets.subpkgdir}}/opt/katib/pkg
           mkdir -p ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
+          mv .venv-hyperopt/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
 
   - name: katib-suggestion-nas-darts
     description: Kubeflow Katib suggestion-nas-darts
     dependencies:
       runtime:
-        - py3-grpcio
-        - py3-protobuf
-        - py3-googleapis-common-protos
-        - cython
+        - python-3.11-dev
+        - py3.11-pip
     pipeline:
       - runs: |
+          python -m venv .venv-darts --system-site-packages
           export SUGGESTION_DIR="cmd/suggestion/nas/darts/v1beta1"
+          .venv-darts/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib
           mkdir -p ${{targets.subpkgdir}}/opt/katib/pkg
           mkdir -p ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
+          mv .venv-darts/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
 
   - name: katib-suggestion-nas-enas
@@ -173,59 +164,54 @@ subpackages:
     description: Kubeflow Katib suggestion-optuna-enas
     dependencies:
       runtime:
-        - py3-grpcio
-        - py3-protobuf
-        - py3-googleapis-common-protos
-        - py3-optuna
-        - py3-typing-extensions
+        - python-3.11-dev
+        - py3.11-pip
     pipeline:
       - runs: |
+          python -m venv .venv-optuna --system-site-packages
           export SUGGESTION_DIR="cmd/suggestion/optuna/v1beta1"
+          .venv-optuna/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib
           mkdir -p ${{targets.subpkgdir}}/opt/katib/pkg
           mkdir -p ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
+          mv .venv-optuna/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
 
   - name: katib-suggestion-pbt-enas
     description: Kubeflow Katib suggestion-pbt-enas
     dependencies:
       runtime:
-        - py3-grpcio
-        - py3-protobuf
-        - py3-googleapis-common-protos
-        - numpy
+        - python-3.11-dev
+        - py3.11-pip
     pipeline:
       - runs: |
+          python -m venv .venv-pbt --system-site-packages
           export SUGGESTION_DIR="cmd/suggestion/pbt/v1beta1"
+          .venv-pbt/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib
           mkdir -p ${{targets.subpkgdir}}/opt/katib/pkg
           mkdir -p ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
+          mv .venv-pbt/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
 
   - name: katib-suggestion-skopt-enas
     description: Kubeflow Katib suggestion-skopt-enas
     dependencies:
       runtime:
-        - py3-grpcio
-        - py3-cloudpickle
-        - numpy
-        - py3-scikit-learn
-        - py3-scikit-optimize
-        - py3-scipy
-        - py3-forestci
-        - py3-protobuf
-        - py3-googleapis-common-protos
-        - cython
+        - python-3.11-dev
+        - py3.11-pip
         - libgomp
     pipeline:
       - runs: |
+          python -m venv .venv-skopt --system-site-packages
           export SUGGESTION_DIR="cmd/suggestion/skopt/v1beta1"
+          .venv-skopt/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib
           mkdir -p ${{targets.subpkgdir}}/opt/katib/pkg
           mkdir -p ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
-          tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
+          mv .venv-skopt/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
 
 update:

--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -1,6 +1,6 @@
 package:
   name: kubeflow-katib
-  epoch: 2
+  epoch: 3
   version: 0.16.0
   description: Kubeflow Katib services
   copyright:

--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -72,6 +72,7 @@ subpackages:
     pipeline:
       - runs: |
           python -m venv .venv-earlystopping --system-site-packages
+          .venv-earlystopping/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
           export SUGGESTION_DIR="cmd/earlystopping/medianstop/v1beta1"
           .venv-earlystopping/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib
@@ -91,6 +92,7 @@ subpackages:
     pipeline:
       - runs: |
           python -m venv .venv-metricscollector --system-site-packages
+          .venv-metricscollector/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
           export SUGGESTION_DIR="cmd/metricscollector/v1beta1/tfevent-metricscollector"
           .venv-metricscollector/bin/pip install -r $SUGGESTION_DIR/requirements.txt
 
@@ -110,6 +112,7 @@ subpackages:
     pipeline:
       - runs: |
           python -m venv .venv-hyperband --system-site-packages
+          .venv-hyperband/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
           export SUGGESTION_DIR="cmd/suggestion/hyperband/v1beta1"
           .venv-hyperband/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib
@@ -128,6 +131,7 @@ subpackages:
     pipeline:
       - runs: |
           python -m venv .venv-hyperopt --system-site-packages
+          .venv-hyperopt/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
           export SUGGESTION_DIR="cmd/suggestion/hyperopt/v1beta1"
           .venv-hyperopt/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib
@@ -146,6 +150,7 @@ subpackages:
     pipeline:
       - runs: |
           python -m venv .venv-darts --system-site-packages
+          .venv-darts/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
           export SUGGESTION_DIR="cmd/suggestion/nas/darts/v1beta1"
           .venv-darts/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib
@@ -165,6 +170,7 @@ subpackages:
     pipeline:
       - runs: |
           python -m venv .venv-enas --system-site-packages
+          .venv-enas/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
           export SUGGESTION_DIR="cmd/suggestion/nas/enas/v1beta1"
           .venv-enas/bin/pip install -r $SUGGESTION_DIR/requirements.txt
 
@@ -183,6 +189,7 @@ subpackages:
     pipeline:
       - runs: |
           python -m venv .venv-optuna --system-site-packages
+          .venv-optuna/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
           export SUGGESTION_DIR="cmd/suggestion/optuna/v1beta1"
           .venv-optuna/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib
@@ -201,6 +208,7 @@ subpackages:
     pipeline:
       - runs: |
           python -m venv .venv-pbt --system-site-packages
+          .venv-pbt/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
           export SUGGESTION_DIR="cmd/suggestion/pbt/v1beta1"
           .venv-pbt/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib
@@ -220,6 +228,7 @@ subpackages:
     pipeline:
       - runs: |
           python -m venv .venv-skopt --system-site-packages
+          .venv-skopt/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
           export SUGGESTION_DIR="cmd/suggestion/skopt/v1beta1"
           .venv-skopt/bin/pip install -r $SUGGESTION_DIR/requirements.txt
           mkdir -p ${{targets.subpkgdir}}/opt/katib

--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -80,18 +80,25 @@ subpackages:
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
           mv .venv-earlystopping/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
-
+  
   - name: katib-tfevent-metricscollector
     description: Kubeflow Katib tfevent-metricscollector
+    dependencies:
+      runtime:
+        - openmp-17
+        - python-3.11-dev
+        - py3.11-pip
     pipeline:
       - runs: |
+          python -m venv .venv-metricscollector --system-site-packages
           export SUGGESTION_DIR="cmd/metricscollector/v1beta1/tfevent-metricscollector"
+          .venv-metricscollector/bin/pip install -r $SUGGESTION_DIR/requirements.txt
+
           mkdir -p ${{targets.subpkgdir}}/opt/katib
           mkdir -p ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           cp -r ./pkg ${{targets.subpkgdir}}/opt/katib/pkg
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           cd ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
-          pip install --prefer-binary -r requirements.txt --prefix=/usr --root=${{targets.subpkgdir}}
 
   - name: katib-suggestion-hyperband
     description: Kubeflow Katib suggestion-hyperband
@@ -150,15 +157,22 @@ subpackages:
 
   - name: katib-suggestion-nas-enas
     description: Kubeflow Katib suggestion-nas-enas
+    dependencies:
+      runtime:
+        - openmp-17
+        - python-3.11-dev
+        - py3.11-pip
     pipeline:
       - runs: |
+          python -m venv .venv-enas --system-site-packages
           export SUGGESTION_DIR="cmd/suggestion/nas/enas/v1beta1"
+          .venv-enas/bin/pip install -r $SUGGESTION_DIR/requirements.txt
+
           mkdir -p ${{targets.subpkgdir}}/opt/katib
           mkdir -p ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           cp -r ./pkg ${{targets.subpkgdir}}/opt/katib/pkg
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           cd ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
-          pip install --prefer-binary -r requirements.txt --prefix=/usr --root=${{targets.subpkgdir}}
 
   - name: katib-suggestion-optuna-enas
     description: Kubeflow Katib suggestion-optuna-enas

--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -80,7 +80,7 @@ subpackages:
           tar c ./pkg | tar xvf - -C ${{targets.subpkgdir}}/opt/katib/
           mv .venv-earlystopping/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
           mv ./$SUGGESTION_DIR/* ${{targets.subpkgdir}}/opt/katib/$SUGGESTION_DIR
-  
+
   - name: katib-tfevent-metricscollector
     description: Kubeflow Katib tfevent-metricscollector
     dependencies:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
