### PR TITLE
Add package test for redis.

### DIFF
--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -162,7 +162,8 @@ test:
         EOF
 
         redis-server /tmp/redis.conf &
-        sleep 2 # wait for redist to start
+        sleep 2 # wait for redis to start
         redis-cli SET bike:1 "Process 134" || exit 1
         redis-cli GET bike:1 | grep 'Process 134' || exit 1
-        kill `cat /tmp/redis_6379.pid`
+        redis-cli exists bike:1 | grep 1 || exit 1
+        redis-cli exists bike:2 | grep 0 || exit 1

--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -146,3 +146,23 @@ update:
   enabled: true
   github:
     identifier: redis/redis
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+        - redis-cli
+  pipeline:
+    - runs: |
+        cat <<EOF >> /tmp/redis.conf
+        dbfilename dump.rdb
+        pidfile /tmp/redis_6379.pid
+        dir /tmp/
+        EOF
+
+        redis-server /tmp/redis.conf &
+        sleep 2 # wait for redist to start
+        redis-cli SET bike:1 "Process 134" || exit 1
+        redis-cli GET bike:1 | grep 'Process 134' || exit 1
+        kill `cat /tmp/redis_6379.pid`


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
