### PR TITLE
Fix jruby and add concurrent-ruby java extensions/tests

### DIFF
--- a/jruby-9.4.yaml
+++ b/jruby-9.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: jruby-9.4
   version: 9.4.5.0
-  epoch: 0
+  epoch: 1
   description: JRuby, an implementation of Ruby on the JVM
   copyright:
     - license: Apache-2.0
@@ -26,10 +26,10 @@ pipeline:
   - runs: |
       export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
       mvn install
-      mkdir -p ${{targets.destdir}}/usr/bin
-      mkdir -p ${{targets.destdir}}/usr/share/jruby
+      mkdir -p ${{targets.contextdir}}/usr/bin
+      mkdir -p ${{targets.contextdir}}/usr/share/jruby
 
-      mkdir -p ${{targets.destdir}}/usr/share/jruby/bin
+      mkdir -p ${{targets.contextdir}}/usr/share/jruby/bin
       rm -rf bin/*.bat
       rm -rf bin/*.dll
       rm -rf bin/*.exe
@@ -39,14 +39,23 @@ pipeline:
       rm -rf lib/jni/*-Windows*
       rm -rf lib/jni/*-AIX*
       rm -rf lib/jni/*-*BSD*
-      mv bin/* "${{targets.destdir}}"/usr/share/jruby/bin/
+      mv bin/* "${{targets.contextdir}}"/usr/share/jruby/bin/
       rm -rf lib/target
-      mv lib "${{targets.destdir}}"/usr/share/jruby
-      for f in "${{targets.destdir}}"/usr/share/jruby/bin/*; do
-        filename=$(basename "$f")
-        ln -sf  /usr/share/jruby/bin/"$filename" "${{targets.destdir}}"/usr/bin/"$filename"
+      mv lib "${{targets.contextdir}}"/usr/share/jruby
+      for binary in jgem jirb jruby jrubyc; do
+        ln -sf "/usr/share/jruby/bin/${binary}" "${{targets.contextdir}}/usr/bin/${binary}"
       done
 
+subpackages:
+  - name: ${{package.name}}-default-ruby
+    description: Set the ruby interpreter to jruby implementation
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/bin
+          mkdir -p ${{targets.contextdir}}/usr/share/jruby/bin
+          for binary in gem irb ruby rake bundle bundler; do
+            ln -sf "/usr/share/jruby/bin/${binary}" "${{targets.contextdir}}/usr/bin/${binary}"
+          done
 update:
   enabled: true
   github:

--- a/jruby-9.4.yaml
+++ b/jruby-9.4.yaml
@@ -56,6 +56,7 @@ subpackages:
           for binary in gem irb ruby rake bundle bundler; do
             ln -sf "/usr/share/jruby/bin/${binary}" "${{targets.contextdir}}/usr/bin/${binary}"
           done
+
 update:
   enabled: true
   github:

--- a/jruby-9.4.yaml
+++ b/jruby-9.4.yaml
@@ -27,7 +27,7 @@ pipeline:
       export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
 
       # upgrade uri gem in stdlib
-      sed -i "s/'uri', '0.12.1'/'uri', '0.12.3'/" lib/pom.rb
+      sed -i "s/'uri', '0.12.1'/'uri', '0.12.2'/" lib/pom.rb
 
       mvn install
 

--- a/jruby-9.4.yaml
+++ b/jruby-9.4.yaml
@@ -25,23 +25,29 @@ pipeline:
 
   - runs: |
       export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
+
+      # upgrade uri gem in stdlib
+      sed -i "s/'uri', '0.12.1'/'uri', '0.12.3'/" lib/pom.rb
+
       mvn install
+
       mkdir -p ${{targets.contextdir}}/usr/bin
       mkdir -p ${{targets.contextdir}}/usr/share/jruby
-
       mkdir -p ${{targets.contextdir}}/usr/share/jruby/bin
-      rm -rf bin/*.bat
-      rm -rf bin/*.dll
-      rm -rf bin/*.exe
 
       rm -rf lib/jni/*Darwin*
       rm -rf lib/jni/*-SunOS*
       rm -rf lib/jni/*-Windows*
       rm -rf lib/jni/*-AIX*
       rm -rf lib/jni/*-*BSD*
-      mv bin/* "${{targets.contextdir}}"/usr/share/jruby/bin/
       rm -rf lib/target
       mv lib "${{targets.contextdir}}"/usr/share/jruby
+
+      rm -rf bin/*.bat
+      rm -rf bin/*.dll
+      rm -rf bin/*.exe
+      mv bin/* "${{targets.contextdir}}"/usr/share/jruby/bin/
+
       for binary in jgem jirb jruby jrubyc; do
         ln -sf "/usr/share/jruby/bin/${binary}" "${{targets.contextdir}}/usr/bin/${binary}"
       done

--- a/ruby3.2-concurrent-ruby.yaml
+++ b/ruby3.2-concurrent-ruby.yaml
@@ -95,9 +95,6 @@ test:
         # Install the subpackages for testing
         - ruby3.2-concurrent-ruby-ext
         - ruby3.2-concurrent-ruby-edge
-    environment:
-      JRUBY_HOME: /usr/share/jruby/
-      NO_PATH: true
   pipeline:
     - uses: git-checkout
       with:
@@ -105,7 +102,10 @@ test:
         repository: https://github.com/ruby-concurrency/concurrent-ruby.git
         tag: v${{package.version}}
     - runs: |
+        export JRUBY_HOME=/usr/share/jruby/
         bundle install
+
+        export NO_PATH=true
         bundle exec rake spec:ci
 
 update:

--- a/ruby3.2-concurrent-ruby.yaml
+++ b/ruby3.2-concurrent-ruby.yaml
@@ -16,12 +16,12 @@ environment:
       - busybox
       - ca-certificates-bundle
       - git
-      - ruby-3.2
-      - ruby-3.2-dev
-      - ruby3.2-bundler
       - jruby-9.4
       - openjdk-11
       - openjdk-11-default-jvm
+      - ruby-3.2
+      - ruby-3.2-dev
+      - ruby3.2-bundler
   environment:
     JRUBY_HOME: /usr/share/jruby/
 

--- a/ruby3.2-concurrent-ruby.yaml
+++ b/ruby3.2-concurrent-ruby.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-concurrent-ruby
   version: 1.2.3
-  epoch: 0
+  epoch: 1
   description: Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more. Inspired by Erlang, Clojure, Go, JavaScript, actors, and classic concurrency patterns.
   copyright:
     - license: MIT
@@ -18,6 +18,12 @@ environment:
       - git
       - ruby-3.2
       - ruby-3.2-dev
+      - ruby3.2-bundler
+      - jruby-9.4
+      - openjdk-11
+      - openjdk-11-default-jvm
+  environment:
+    JRUBY_HOME: /usr/share/jruby/
 
 vars:
   gem: concurrent-ruby
@@ -27,26 +33,80 @@ pipeline:
   # must be checked out in order for the gem to build with all files.
   - uses: git-checkout
     with:
-      destination: ${{vars.gem}}
       expected-commit: da6320d22518501abef917f3ac19e9ee9496bffc
       repository: https://github.com/ruby-concurrency/concurrent-ruby.git
       tag: v${{package.version}}
 
-  - working-directory: ${{vars.gem}}
+  - runs: |
+      bundle install
+      bundle exec rake compile
+      bundle exec rake package
+
+  - uses: ruby/install
+    with:
+      dir: ./pkg
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+subpackages:
+  - name: ${{package.name}}-ext
+    description: Concurrent ruby C extensions
     pipeline:
-      - uses: patch
-        with:
-          # Since we're inside the working-directory, the patch will be
-          # in the previous directory
-          patches: ../001-disable-java.patch
-      - uses: ruby/build
-        with:
-          gem: ${{vars.gem}}
       - uses: ruby/install
         with:
-          gem: ${{vars.gem}}
+          dir: ./pkg
+          gem: ${{vars.gem}}-ext
           version: ${{package.version}}
       - uses: ruby/clean
+
+  - name: ${{package.name}}-edge
+    description: Concurrent ruby edge functionality
+    pipeline:
+      # This is ugly but concurrent-ruby publishes an edge gem at a different
+      # version than the main gem and melange does not support setting cross
+      # pipeline variables
+      - runs: |
+          EDGE_VERSION=$(ruby -e "require './lib/concurrent-ruby-edge/concurrent/edge/version'; puts Concurrent::EDGE_VERSION")
+          TARGET_DIR_BIN="${{targets.contextdir}}/usr/bin"
+          TARGET_DIR_INSTALL="${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/"
+
+          mkdir -p "${TARGET_DIR_BIN}"
+          mkdir -p "${TARGET_DIR_INSTALL}"
+
+          GEM="./pkg/${{vars.gem}}-edge-${EDGE_VERSION}.gem"
+          gem install ${GEM} \
+            --install-dir ${TARGET_DIR_INSTALL}  \
+            --bindir ${TARGET_DIR_BIN} \
+            --version ${EDGE_VERSION} \
+            --ignore-dependencies \
+            --no-document \
+            --verbose \
+            --local
+      - uses: ruby/clean
+
+test:
+  environment:
+    contents:
+      packages:
+        - ruby3.2-bundler
+        - wolfi-base
+        # Install the subpackages for testing
+        - ruby3.2-concurrent-ruby-ext
+        - ruby3.2-concurrent-ruby-edge
+    environment:
+      JRUBY_HOME: /usr/share/jruby/
+      NO_PATH: true
+  pipeline:
+    - uses: git-checkout
+      with:
+        expected-commit: da6320d22518501abef917f3ac19e9ee9496bffc
+        repository: https://github.com/ruby-concurrency/concurrent-ruby.git
+        tag: v${{package.version}}
+    - runs: |
+        bundle install
+        bundle exec rake spec:ci
 
 update:
   enabled: true

--- a/ruby3.2-jrjackson.yaml
+++ b/ruby3.2-jrjackson.yaml
@@ -18,6 +18,7 @@ environment:
       - ca-certificates-bundle
       - git
       - jruby-9.4
+      - jruby-9.4-default-ruby
       - maven
       - openjdk-11
       - openjdk-11-default-jvm

--- a/ruby3.2-jrjackson.yaml
+++ b/ruby3.2-jrjackson.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-jrjackson
   version: 0.4.18
-  epoch: 1
+  epoch: 2
   description: A mostly native JRuby wrapper for the java jackson json processor jar
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-logstash-core-plugin-api.yaml
+++ b/ruby3.2-logstash-core-plugin-api.yaml
@@ -18,6 +18,7 @@ environment:
       - ca-certificates-bundle
       - git
       - jruby-9.4
+      - jruby-9.4-default-ruby
       - openjdk-11
       - openjdk-11-default-jvm
   environment:

--- a/ruby3.2-logstash-core-plugin-api.yaml
+++ b/ruby3.2-logstash-core-plugin-api.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-logstash-core-plugin-api
   version: 8.12.0
-  epoch: 1
+  epoch: 2
   description: Logstash plugin API
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-logstash-core.yaml
+++ b/ruby3.2-logstash-core.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-logstash-core
   version: 8.12.0
-  epoch: 0
+  epoch: 1
   description: The core components of logstash, the scalable log and event management tool
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-logstash-core.yaml
+++ b/ruby3.2-logstash-core.yaml
@@ -36,6 +36,7 @@ environment:
       - ca-certificates-bundle
       - git
       - jruby-9.4
+      - jruby-9.4-default-ruby
       - openjdk-11
       - openjdk-11-default-jvm
 

--- a/ruby3.2-logstash-output-opensearch.yaml
+++ b/ruby3.2-logstash-output-opensearch.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-logstash-output-opensearch
   version: 2.0.2
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-logstash-output-opensearch.yaml
+++ b/ruby3.2-logstash-output-opensearch.yaml
@@ -20,6 +20,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - jruby-9.4
+      - jruby-9.4-default-ruby
       - openjdk-11
       - openjdk-11-default-jvm
   environment:


### PR DESCRIPTION
We weren't actually building the concurrent-ruby java extensions to work with jruby. I went to add tests to concurrent-ruby and realized we needed to make jruby installable alongside ruby to get all the functionality of concurrent-ruby. The logstash-core gem also makes use of the java functionality of concurrent-ruby, so this is required for that gem to work.

Ideally we use rbenv or rvm to make virtual machines rather than installing a system ruby alongside system jruby, but this is a workaround for now.