### PR TITLE
chore(supervisor): Split supervisor config into subpackage

### DIFF
--- a/supervisor.yaml
+++ b/supervisor.yaml
@@ -10,6 +10,7 @@ package:
       - py3-pip
       - py3-pkgconfig
       - python3
+      - supervisor-config
 
 environment:
   contents:
@@ -82,6 +83,13 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: supervisor-config
+    description: Supervisor configuration
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc
+          mv ${{targets.destdir}}/etc/supervisord.conf ${{targets.subpkgdir}}/etc/
+
   - name: supervisor-pyc
     description: Precompiled Python bytecode for supervisor
     pipeline:


### PR DESCRIPTION
Fixes: Allows packages that depend on supervisor to provide their own supervisor configurations

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)