### PR TITLE
fix(libnspr): Correct symlink path for NSPR config

### DIFF
--- a/libnspr.yaml
+++ b/libnspr.yaml
@@ -48,8 +48,8 @@ pipeline:
   # Link the NSPR package config file into the right place.
   - working-directory: nspr
     runs: |
-      mkdir -p "${{target.destdir}}/usr/lib/pkgconfig/"
-      ln -s nspr.pc "${{target.destdir}}/usr/lib/pkgconfig/mozilla-nspr.pc"
+      mkdir -p "${{targets.destdir}}/usr/lib/pkgconfig/"
+      ln -s nspr.pc "${{targets.destdir}}/usr/lib/pkgconfig/mozilla-nspr.pc"
 
   - uses: strip
 


### PR DESCRIPTION
${{target.destdir}} is not a valid, change this to ${{targets.destdir}}

Fixes: Addresses config not being shipped in the package

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)