### PR TITLE
fix(xterm): Correct destination path for package

### DIFF
--- a/xterm.yaml
+++ b/xterm.yaml
@@ -69,12 +69,12 @@ pipeline:
   - uses: autoconf/make
 
   - runs: |
-      mkdir -p "${{target.destdir}}"/usr/bin
-      make DESTDIR="${{target.destdir}}" install
+      mkdir -p "${{targets.destdir}}"/usr/bin
+      make DESTDIR="${{targets.destdir}}" install
       builddir=$(pwd)
-      install -m755 -d "${{target.destdir}}"/usr/share/applications
-      install -m644 "$builddir"/xterm.desktop "${{target.destdir}}"/usr/share/applications/
-      install -m644 "$builddir"/uxterm.desktop "${{target.destdir}}"/usr/share/applications/
+      install -m755 -d "${{targets.destdir}}"/usr/share/applications
+      install -m644 "$builddir"/xterm.desktop "${{targets.destdir}}"/usr/share/applications/
+      install -m644 "$builddir"/uxterm.desktop "${{targets.destdir}}"/usr/share/applications/
 
   - uses: strip
 


### PR DESCRIPTION
${{target.destdir}} is not valid, use ${{targets.destdir}}

Fixes: Addresses xterm being an empty package

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)