### PR TITLE
fix(xkeyboard-config): Fix installation prefix

### DIFF
--- a/xkeyboard-config.yaml
+++ b/xkeyboard-config.yaml
@@ -2,7 +2,7 @@
 package:
   name: xkeyboard-config
   version: "2.40"
-  epoch: 0
+  epoch: 1
   description: X keyboard configuration files
   copyright:
     - license: MIT
@@ -27,7 +27,7 @@ pipeline:
       uri: https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/archive/xkeyboard-config-${{package.version}}/xkeyboard-config-xkeyboard-config-${{package.version}}.tar.gz
 
   - runs: |
-      meson . output
+      meson --prefix=/usr . output
       meson compile -C output
       DESTDIR="${{targets.destdir}}" meson install --no-rebuild -C output
 


### PR DESCRIPTION
Install to /usr instead of /usr/local

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Installation prefix for xkeyboard-config

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)