### PR TITLE
Fix the curl-rustls build by pinning rustls-ffi

### DIFF
--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl-rustls
   version: 8.5.0
-  epoch: 0
+  epoch: 1
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -21,7 +21,8 @@ environment:
       - ca-certificates-bundle
       - nghttp2-dev
       - openssl-dev
-      - rustls-ffi
+      # This doesn't build with 0.12 yet: https://github.com/curl/curl/issues/12737
+      - rustls-ffi~0.11
       - wolfi-base
       - zlib-dev
 


### PR DESCRIPTION
curl doesn't build with rustls-ffi 0.12 yet:
https://github.com/curl/curl/issues/12737
