### PR TITLE
chore: Bump epoch for xterm and libnspr

### DIFF
--- a/libnspr.yaml
+++ b/libnspr.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnspr
   version: "4.35"
-  epoch: 2
+  epoch: 3
   description: "Netscape Portable Runtime (NSPR) provides a platform-neutral API for system level and libc-like functions."
   copyright:
     - license: MPL-2.0

--- a/xterm.yaml
+++ b/xterm.yaml
@@ -1,7 +1,7 @@
 package:
   name: xterm
   version: "389"
-  epoch: 0
+  epoch: 1
   description: X Terminal Emulator
   copyright:
     - license: MIT


### PR DESCRIPTION
## Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)