### PR TITLE
logstash-exporter

### DIFF
--- a/logstash-exporter.yaml
+++ b/logstash-exporter.yaml
@@ -1,0 +1,50 @@
+package:
+  name: logstash-exporter
+  version: 1.6.1
+  epoch: 0
+  description: Prometheus exporter for Logstash written in Go
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    GITHUB_REPO: "github.com/kuskoman/logstash-exporter"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 387fb36f814e74e81dd14d82a948e61cefa76f5c
+      repository: https://github.com/kuskoman/logstash-exporter
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      packages: ./cmd/exporter/main.go
+      ldflags: -s -w -X ${GITHUB_REPO}/config.Version="${{package.version}}" -X ${GITHUB_REPO}/config.GitCommit="$(git rev-parse --short HEAD)" -X ${GITHUB_REPO}/config.BuildDate="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      repository: https://github.com/kuskoman/logstash-exporter
+      output: logstash-exporter
+
+  - uses: strip
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - "-pre*"
+  github:
+    identifier: kuskoman/logstash-exporter
+    strip-prefix: v
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        logstash-exporter -version


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
