### PR TITLE
add shfmt package

### DIFF
--- a/shfmt.yaml
+++ b/shfmt.yaml
@@ -7,11 +7,6 @@ package:
     - license: BSD-3-Clause
 
 environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
   environment:
     CGO_ENABLED: "0"
 

--- a/shfmt.yaml
+++ b/shfmt.yaml
@@ -1,0 +1,47 @@
+package:
+  name: shfmt
+  version: 3.7.0
+  epoch: 0
+  description: A shell formatter
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/mvdan/sh
+      tag: v${{package.version}}
+      expected-commit: d3fa14772d78bd15e242a5d7bd1f5c3899191cd2
+
+  - uses: go/build
+    with:
+      packages: ./cmd/shfmt
+      repository: https://github.com/mvdan/sh
+      ldflags: -s -w -X main.version=v${{package.version}}
+      output: shfmt
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: mvdan/sh
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        shfmt --version


### PR DESCRIPTION
For linting shell scripts. 

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
