### PR TITLE
Remove JRE runtime dep - we pass in at image level so we can replace

### DIFF
--- a/cloudwatch-exporter.yaml
+++ b/cloudwatch-exporter.yaml
@@ -5,10 +5,9 @@ package:
   description: Metrics exporter for Amazon AWS CloudWatch
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - openjdk-17-jre
 
+# NOTE: JRE runtime dependency required. This is defined in the image which
+# allows us to switch out the JDK version.
 environment:
   contents:
     packages:


### PR DESCRIPTION
Remove JRE runtime dep - we pass in at image level so we can replace with different versions.