### PR TITLE
fix(xorg-server): Use correct xkb path

### DIFF
--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: xorg-server
   version: 21.1.10
-  epoch: 3
+  epoch: 4
   description: "X Server"
   copyright:
     - license: SGI-B-2.0
@@ -63,7 +63,7 @@ pipeline:
       opts: |
         --prefix=/usr \
         --with-default-font-path=/usr/share/fonts/misc \
-        --with-xkb-path=/usr/local/share/X11/xkb \
+        --with-xkb-path=/usr/share/X11/xkb \
         --enable-xorg \
         --enable-glamor \
         --enable-xnest \


### PR DESCRIPTION
Fixes: Use /usr/share/... instead of /usr/local/share/...

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)