### PR TITLE
zoxide: new package

### DIFF
--- a/zoxide.yaml
+++ b/zoxide.yaml
@@ -1,0 +1,70 @@
+package:
+  name: zoxide
+  version: 0.9.2
+  epoch: 0
+  description: "A smarter cd command. Supports all major shells."
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - fzf
+      - rust
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ajeetdsouza/zoxide
+      tag: v${{package.version}}
+      expected-commit: 1bfcdfacf22fe22ff05ad2813aac7c0d14dfba36
+
+  - runs: |
+      cargo build --release
+      install -Dm755 target/release/zoxide "${{targets.destdir}}"/usr/bin/zoxide
+      cd contrib/completions
+      install -Dm644 zoxide.bash "${{targets.destdir}}"/usr/share/bash-completion/completions/zoxide
+      install -Dm644 zoxide.fish -t "${{targets.destdir}}"/usr/share/fish/vendor_completions.d/
+      install -Dm644 _zoxide -t "${{targets.destdir}}"/usr/share/zsh/site-functions/
+
+  - uses: strip
+
+subpackages:
+  - name: zoxide-bash-completion
+    description: bash completion for zoxide
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/share/bash-completion/completions"
+          mv "${{targets.destdir}}/usr/share/bash-completion/completions/zoxide" \
+            "${{targets.subpkgdir}}/usr/share/bash-completion/completions/zoxide"
+          rm -rf "${{targets.destdir}}/usr/share/bash-completion"
+
+  - name: zoxide-zsh-completion
+    description: zsh completion for zoxide
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/share/zsh/site-functions"
+          mv "${{targets.destdir}}/usr/share/zsh/site-functions/_zoxide" \
+            "${{targets.subpkgdir}}/usr/share/zsh/site-functions/_zoxide"
+          rm -rf "${{targets.destdir}}/usr/share/zsh"
+
+  - name: zoxide-fish-completion
+    description: fish completion for zoxide
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/share/fish/vendor_completions.d"
+          mv "${{targets.destdir}}/usr/share/fish/vendor_completions.d/" \
+            "${{targets.subpkgdir}}/usr/share/fish/vendor_completions.d"
+          rm -rf "${{targets.destdir}}/usr/share/fish"
+
+update:
+  enabled: true
+  github:
+    identifier: ajeetdsouza/zoxide
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #12453 

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
