### PR TITLE
telegraf-1.26/1.26.3-r9: cve remediation

### DIFF
--- a/telegraf-1.26.yaml
+++ b/telegraf-1.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: telegraf-1.26
   version: 1.26.3
-  epoch: 9
+  epoch: 10
   copyright:
     - license: MIT
   dependencies:
@@ -26,7 +26,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.17.0 github.com/nats-io/nats-server/v2@v2.9.23 google.golang.org/grpc@v1.56.3 github.com/nats-io/nkeys@v0.4.6 golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.6.26 github.com/dvsekhvalnov/jose2go@v1.5.1-0.20231206184617-48ba0b76bc88
+      deps: golang.org/x/net@v0.17.0 github.com/nats-io/nats-server/v2@v2.9.23 google.golang.org/grpc@v1.56.3 github.com/nats-io/nkeys@v0.4.6 golang.org/x/crypto@v0.17.0 github.com/containerd/containerd@v1.6.26 github.com/dvsekhvalnov/jose2go@v1.5.1-0.20231206184617-48ba0b76bc88 github.com/opencontainers/runc@v1.1.12
 
   - if: ${{build.arch}} == 'x86_64'
     runs: |


### PR DESCRIPTION
telegraf-1.26/1.26.3-r9: fix GHSA-xr7r-f8xq-vfvv