### PR TITLE
keda-2.11/2.11.2-r11: cve remediation

### DIFF
--- a/keda-2.11.yaml
+++ b/keda-2.11.yaml
@@ -3,7 +3,7 @@
 package:
   name: keda-2.11
   version: 2.11.2
-  epoch: 12
+  epoch: 13
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -32,7 +32,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 github.com/cloudflare/circl@v1.3.7
+      deps: golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 github.com/cloudflare/circl@v1.3.7 keda-2.11-adapter@v2.11.2-r12
 
   - runs: |
       # CVE-2023-39325


### PR DESCRIPTION
keda-2.11/2.11.2-r11: fix GHSA-9763-4f94-gfch/GHSA-2c7c-3mj9-8fqh/