### PR TITLE
temporal-server/1.22.4-r1: cve remediation

### DIFF
--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal-server
   version: 1.22.4
-  epoch: 1
+  epoch: 2
   description: Temporal server executes units of application logic, Workflows, in a resilient manner that automatically handles intermittent failures, and retries failed operations
   copyright:
     - license: MIT
@@ -30,7 +30,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: google.golang.org/grpc@v1.58.3 golang.org/x/crypto@v0.17.0
+      deps: google.golang.org/grpc@v1.58.3 golang.org/x/crypto@v0.17.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
 
   - runs: |
       make bins


### PR DESCRIPTION
temporal-server/1.22.4-r1: fix GHSA-8pgv-569h-w5rw