### PR TITLE
tctl/1.18.0-r10: cve remediation

### DIFF
--- a/tctl.yaml
+++ b/tctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tctl
   version: 1.18.0
-  epoch: 11
+  epoch: 12
   description: Temporal CLI
   copyright:
     - license: MIT
@@ -23,7 +23,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: go.temporal.io/server@v1.20.0 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3
+      deps: go.temporal.io/server@v1.20.0 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
 
   - runs: |
       make build


### PR DESCRIPTION
tctl/1.18.0-r10: fix GHSA-8pgv-569h-w5rw