### PR TITLE
fix(volumes-webapp): Remove urllib3 as a buildtime dependency

### DIFF
--- a/kubeflow-volumes-web-app.yaml
+++ b/kubeflow-volumes-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-volumes-web-app
   version: 1.8.0
-  epoch: 2
+  epoch: 3
   description: Kubeflow volumes web app component
   copyright:
     - license: Apache-2.0
@@ -22,7 +22,6 @@ environment:
       - openssl
       - py3-pip
       - py3-setuptools
-      - py3-urllib3
       - py3-wheel
       - python3
       - python3-dev

--- a/kubeflow-volumes-web-app.yaml
+++ b/kubeflow-volumes-web-app.yaml
@@ -74,3 +74,13 @@ update:
     # There were some malformed early tags
     tag-filter: v1
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        python3 -c "import urllib3"
+        python3 -c "import werkzeug"


### PR DESCRIPTION
Fixes: When installed as a buildtime dependency, urllib3 doesn't get installed to the virtual environment, leaving the volumes webapp unable to find the urllib3 module

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)