### PR TITLE
linux-pam: add missing configs to linux-pam package, fix broken su

### DIFF
--- a/util-linux/base-account.pamd
+++ b/util-linux/base-account.pamd
@@ -1,0 +1,4 @@
+# basic PAM configuration for Wolfi.
+
+account required pam_unix.so
+account required pam_nologin.so

--- a/util-linux/base-auth.pamd
+++ b/util-linux/base-auth.pamd
@@ -1,0 +1,5 @@
+# basic PAM configuration for Wolfi.
+
+auth required pam_unix.so nullok
+auth required pam_nologin.so
+auth required pam_env.so

--- a/util-linux/base-password.pamd
+++ b/util-linux/base-password.pamd
@@ -1,0 +1,3 @@
+# basic PAM configuration for Wolfi.
+
+password required pam_unix.so nullok sha512 shadow

--- a/util-linux/base-session-noninteractive.pamd
+++ b/util-linux/base-session-noninteractive.pamd
@@ -1,0 +1,5 @@
+# basic PAM configuration for Wolfi.
+
+session required pam_env.so
+session required pam_limits.so
+session required pam_unix.so

--- a/util-linux/base-session.pamd
+++ b/util-linux/base-session.pamd
@@ -1,0 +1,3 @@
+# basic PAM configuration for Wolfi.
+
+session include base-session-noninteractive

--- a/util-linux/other.pamd
+++ b/util-linux/other.pamd
@@ -1,0 +1,6 @@
+#%PAM-1.0
+# default config for any service don't specified
+auth     include    base-auth
+account  include    base-account
+password include    base-password
+session  include    base-session-noninteractive

--- a/util-linux/su-l.pamd
+++ b/util-linux/su-l.pamd
@@ -1,0 +1,6 @@
+# basic PAM configuration for Wolfi.
+auth     sufficient pam_rootok.so
+auth     include    base-auth
+account  include    base-account
+password include    base-password
+session  include    base-session

--- a/util-linux/su.pamd
+++ b/util-linux/su.pamd
@@ -1,0 +1,6 @@
+# basic PAM configuration for Wolfi.
+auth     sufficient pam_rootok.so
+auth     include    base-auth
+account  include    base-account
+password include    base-password
+session  include    base-session


### PR DESCRIPTION
Fixes:

Right now the `/etc/pam.d/login` file provided by `linux-pam` package, refers to non-existend profiles, this also breaks `su` and `runuser` if you install `linux-pam` with a `Critical error - immediate abort` 

Adding the minimal pam configs to make them work with this PR