### PR TITLE
refactor gpsd and scons to use python 3.11

### DIFF
--- a/gpsd.yaml
+++ b/gpsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: gpsd
   version: "3.25"
-  epoch: 0
+  epoch: 1
   description: GPS daemon
   copyright:
     - license: BSD-2-Clause
@@ -17,10 +17,10 @@ environment:
       - ca-certificates-bundle
       - libcap-dev
       - ncurses-dev
-      - py3.12-setuptools
-      - python3
-      - python3-dev
-      - scons
+      - py3.11-setuptools
+      - python-3.11
+      - python-3.11-dev
+      - scons=4.6.0-r2
 
 pipeline:
   - uses: fetch
@@ -34,6 +34,7 @@ pipeline:
 
   - runs: |
       CPPFLAGS="$CPPFLAGS -I./pps-tools/ -DHAVE_SYS_TIMEPPS_H"
+      export PATH=/usr/share/scons/.venv/bin:$PATH
       scons -j${JOBS:-1} \
       	prefix=/usr \
       	target_python=python3 \
@@ -42,6 +43,7 @@ pipeline:
       	systemd=no
 
   - runs: |
+      export PATH=/usr/share/scons/.venv/bin:$PATH
       mkdir -p "${{targets.destdir}}"/etc/init.d
       mkdir -p "${{targets.destdir}}"/etc/conf.d
       DESTDIR="${{targets.destdir}}" scons install

--- a/scons.yaml
+++ b/scons.yaml
@@ -1,7 +1,7 @@
 package:
   name: scons
   version: 4.6.0
-  epoch: 0
+  epoch: 2
   description: Software construction system
   copyright:
     - license: MIT
@@ -15,10 +15,9 @@ environment:
       - busybox
       - ca-certificates-bundle
       - curl
-      - py3-gpep517
-      - py3-setuptools
-      - py3-wheel
-      - python3
+      - py3.11-setuptools
+      - py3.11-pip
+      - python-3.11
 
 pipeline:
   - uses: git-checkout
@@ -39,22 +38,15 @@ pipeline:
       patches: dont-install-manpages.patch
 
   - runs: |
-      tar -xzf SCons-${{package.version}}.tar.gz
+      python -m venv .venv
+      .venv/bin/pip install scons
 
-      python3 -m gpep517 build-wheel --wheel-dir .dist --output-fd 3 3>&1 >&2
-      install -vDm 644 ./SCons-${{package.version}}/*.1 -t "${{targets.destdir}}/usr/share/man/man1/"
 
-      python3 -m installer -d "${{targets.destdir}}" .dist/*.whl
-      # remove docbook dirs
-      find "${{targets.destdir}}" -name 'docbook' -type d -exec rm -rf {} +
+      mkdir -p ${{targets.destdir}}/usr/share/scons
+      mv .venv ${{targets.destdir}}/usr/share/scons
 
-  - uses: strip
-
-subpackages:
-  - name: scons-doc
-    pipeline:
-      - uses: split/manpages
-    description: scons manpages
+      # edit the venv paths
+      sed -i "s|/home/build|/usr/share/scons|g" ${{targets.destdir}}/usr/share/scons/.venv/bin/*
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
