### PR TITLE
chore: change ruby3.2-jrjackson to build using rake

### DIFF
--- a/ruby3.2-jrjackson.yaml
+++ b/ruby3.2-jrjackson.yaml
@@ -1,30 +1,20 @@
 package:
   name: ruby3.2-jrjackson
   version: 0.4.18
-  epoch: 2
+  epoch: 3
   description: A mostly native JRuby wrapper for the java jackson json processor jar
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - openjdk-11-default-jvm
 
 environment:
   contents:
     packages:
-      - bash
       - build-base
-      - busybox
-      - ca-certificates-bundle
-      - git
       - jruby-9.4
       - jruby-9.4-default-ruby
-      - maven
-      - openjdk-11
-      - openjdk-11-default-jvm
-      - openjdk-11-jre
+      - openjdk-8-default-jdk # build with JDK 8 since this is the declared version in the upstream Mavenfile
   environment:
-    JAVA_HOME: /usr/lib/jvm/java-11-openjdk
+    JAVA_HOME: /usr/lib/jvm/java-1.8-openjdk
 
 pipeline:
   - uses: git-checkout
@@ -33,32 +23,14 @@ pipeline:
       repository: https://github.com/guyboertje/jrjackson
       tag: v${{package.version}}
 
-  - uses: maven/configure-mirror
+  - uses: patch
+    with:
+      patches: mavenfile.patch
 
   - runs: |
-      gem install bundler
-      gem install ruby-maven
-      gem install maven-tools
-      gem install jar-dependencies
-
-  - runs: sed -i "s/3\.1/3.12.1/g; s/1\.8/11/g" Mavenfile
-
-  - runs: mvn clean install -Dmaven.test.skip
-
-  - runs: |
-      # Extract the jackson_version to use in the maven dependency:copy commands
-      export JACKSON_VERSION=$(grep -A 1 'def self.jackson_version' ./lib/jrjackson/build_info.rb | tail -n 1 | awk -F "'" '{print $2}')
-
-      mkdir -p ./lib/com/fasterxml/jackson/core/jackson-annotations/${JACKSON_VERSION}
-      mkdir -p ./lib/com/fasterxml/jackson/core/jackson-core/${JACKSON_VERSION}
-      mkdir -p ./lib/com/fasterxml/jackson/core/jackson-databind/${JACKSON_VERSION}
-      mkdir -p ./lib/com/fasterxml/jackson/module/jackson-module-afterburner/${JACKSON_VERSION}
-      mkdir -p ./lib/jrjackson/jars
-
-      mvn dependency:copy -Dartifact=com.fasterxml.jackson.core:jackson-annotations:${JACKSON_VERSION} -DoutputDirectory=lib/com/fasterxml/jackson/core/jackson-annotations/${JACKSON_VERSION}
-      mvn dependency:copy -Dartifact=com.fasterxml.jackson.core:jackson-core:${JACKSON_VERSION} -DoutputDirectory=lib/com/fasterxml/jackson/core/jackson-core/${JACKSON_VERSION}
-      mvn dependency:copy -Dartifact=com.fasterxml.jackson.core:jackson-databind:${JACKSON_VERSION} -DoutputDirectory=lib/com/fasterxml/jackson/core/jackson-databind/${JACKSON_VERSION}
-      mvn dependency:copy -Dartifact=com.fasterxml.jackson.module:jackson-module-afterburner:${JACKSON_VERSION} -DoutputDirectory=lib/com/fasterxml/jackson/module/jackson-module-afterburner/${JACKSON_VERSION}
+      bundle install
+      rake
+      rake test
 
   - runs: |
       jruby -S gem build ${{vars.gem}}.gemspec
@@ -80,3 +52,27 @@ update:
     identifier: guyboertje/jrjackson
     strip-prefix: v
     use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+        - jruby-9.4
+        - jruby-9.4-default-ruby
+        - openjdk-11-default-jvm
+  pipeline:
+    - runs: |
+        cat <<EOF > /tmp/test.rb
+        require 'jrjackson'
+
+        obj = {:key1 => "value1"}
+        puts obj
+
+        result = JrJackson::Json.dump(obj)
+        puts result
+
+        puts JrJackson::Json.parse(result)
+        EOF
+
+        jruby /tmp/test.rb

--- a/ruby3.2-jrjackson.yaml
+++ b/ruby3.2-jrjackson.yaml
@@ -29,7 +29,7 @@ pipeline:
 
   - runs: |
       bundle install
-      rake
+      bundle exec rake
       rake test
 
   - runs: |

--- a/ruby3.2-jrjackson.yaml
+++ b/ruby3.2-jrjackson.yaml
@@ -59,7 +59,6 @@ test:
       packages:
         - busybox
         - jruby-9.4
-        - jruby-9.4-default-ruby
         - openjdk-11-default-jvm
   pipeline:
     - runs: |

--- a/ruby3.2-jrjackson/mavenfile.patch
+++ b/ruby3.2-jrjackson/mavenfile.patch
@@ -1,0 +1,17 @@
+diff --git a/Mavenfile b/Mavenfile
+index 80c88b0..f42101f 100644
+--- a/Mavenfile
++++ b/Mavenfile
+@@ -12,11 +12,11 @@ properties 'project.build.sourceEncoding' => 'UTF-8',
+            # create a pom.xml from this here
+            'polyglot.dump.pom' => 'pom.xml'
+
+-jar 'junit:junit', '4.11', :scope => :test
++jar 'junit:junit', '4.13.1', :scope => :test
+
+ jar 'org.jruby:jruby', '9.2.13.0', :scope => :provided
+
+ plugin :compiler, '3.1', :source => '1.8', :target => '1.8',
+        :showDeprecation => false,
+        :showWarnings => false,
+        :executable => '${JAVA_HOME}/bin/javac',


### PR DESCRIPTION
* Change the package to build using `rake` instead of `mvn`, which is the recommended way by upstream, and update the dependency on JUnit to mitigate a CVE.

* Add a basic test to ensure the gem works.