### PR TITLE
solr: Fix GHSA-pfh2-hfmq-phg5

### DIFF
--- a/solr.yaml
+++ b/solr.yaml
@@ -1,7 +1,7 @@
 package:
   name: solr
   version: 9.4.1
-  epoch: 0
+  epoch: 1
   description: Apache Solr open-source search software
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,12 @@ pipeline:
       repository: https://github.com/apache/solr
       expected-commit: 57762a5b52a9d40a6f15441c4adeb76f0b045476
       tag: releases/solr/${{package.version}}
+
+  - runs: |
+      sed -i -e 's|com.jayway.jsonpath:json-path=2.8.0|com.jayway.jsonpath:json-path=2.9.0|g' versions.props
+      ./gradlew --write-locks
+
+      ./gradlew dependencies
 
   - runs: |
       ./gradlew assembleDist


### PR DESCRIPTION
Upstream has a pending PR upstream, so hopefully it'll also get fixed by the next release: https://github.com/apache/solr/pull/2222