### PR TITLE
fix the python lib

### DIFF
--- a/gpsd.yaml
+++ b/gpsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: gpsd
   version: "3.25"
-  epoch: 0
+  epoch: 1
   description: GPS daemon
   copyright:
     - license: BSD-2-Clause
@@ -66,6 +66,9 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p  "${{targets.subpkgdir}}"/usr/bin
+          mkdir -p  "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/local/lib/python*  "${{targets.subpkgdir}}"/usr/lib/
+          rm -rf "${{targets.destdir}}"/usr/local
           for n in gpscat gpsfake gpsprof; do
           	mv "${{targets.destdir}}"/usr/bin/$n  "${{targets.subpkgdir}}"/usr/bin/
           done
@@ -82,3 +85,12 @@ update:
   enabled: true
   release-monitor:
     identifier: 6846
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        gpsd --version


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
