### PR TITLE
Withdraw old expat versions

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,1 +1,3 @@
 tigera-operator-1.33.0-r0.apk
+expat-2.4.8-r2.apk
+expat-2.4.9-r0.apk


### PR DESCRIPTION
These self-provide `so:libexpat.so.1=1` so they are preferred by apk.

Fixes https://github.com/wolfi-dev/os/issues/12556