### PR TITLE
fix(zot): last CVE fixes missed epoch bump

### DIFF
--- a/zot.yaml
+++ b/zot.yaml
@@ -1,7 +1,7 @@
 package:
   name: zot
   version: 2.0.1
-  epoch: 1
+  epoch: 2
   description: A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification)
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
See https://github.com/wolfi-dev/os/commit/050498e7fc6d4a566e3cdac5da7b9542c6b8cc6b.
