### PR TITLE
fix(uutils): Mark as providing coreutils

### DIFF
--- a/uutils.yaml
+++ b/uutils.yaml
@@ -1,10 +1,13 @@
 package:
   name: uutils
   version: 0.0.24
-  epoch: 0
+  epoch: 1
   description: "Cross-platform Rust rewrite of the GNU coreutils."
   copyright:
     - license: MIT
+  dependencies:
+    provides:
+      - coreutils
 
 environment:
   contents:


### PR DESCRIPTION
uutils is intended to be a drop in replacement for coreutils. Currently, many packages depend on coreutils and coreutils conflicts with uutils.

Fixes: This marks uutils as providing coreutils so that it may be installed in its place

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)