### PR TITLE
fix: remove dependency bumps breaking buildkitd

### DIFF
--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -70,10 +70,10 @@ test:
         - busybox
         - runc
   pipeline:
-  - runs: |
-      /usr/bin/buildkitd > /tmp/logs.txt 2>&1 &
-      PID=$!
+    - runs: |
+        /usr/bin/buildkitd > /tmp/logs.txt 2>&1 &
+        PID=$!
 
-      sleep 5 # ensure that enough time is given for the logs to get written
-      cat /tmp/logs.txt | grep -i 'running server'
-      kill $PID
+        sleep 5 # ensure that enough time is given for the logs to get written
+        cat /tmp/logs.txt | grep -i 'running server'
+        kill $PID

--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -2,7 +2,7 @@ package:
   name: buildkitd
   version: 0.12.5
   description: "concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
 
@@ -24,8 +24,8 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.17.0 go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace@v0.44.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.44.0 golang.org/x/crypto@v0.17.0 go.opentelemetry.io/otel/sdk@v1.21.0 github.com/opencontainers/runc@v1.1.12
-      replaces: google.golang.org/grpc=google.golang.org/grpc@v1.56.3 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc=go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 github.com/containerd/containerd=github.com/containerd/containerd@v1.7.11 github.com/docker/docker=github.com/docker/docker@v24.0.0-rc.2.0.20230718135204-8e51b8b59cb8+incompatible
+      deps: golang.org/x/net@v0.17.0 golang.org/x/crypto@v0.17.0 github.com/opencontainers/runc@v1.1.12
+      replaces: google.golang.org/grpc=google.golang.org/grpc@v1.56.3
 
   - runs: |
       PKG=github.com/moby/buildkit
@@ -61,5 +61,19 @@ update:
   github:
     identifier: moby/buildkit
     strip-prefix: v
-    use-tag: true
     tag-filter: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+        - runc
+  pipeline:
+  - runs: |
+      /usr/bin/buildkitd > /tmp/logs.txt 2>&1 &
+      PID=$!
+
+      sleep 5 # ensure that enough time is given for the logs to get written
+      cat /tmp/logs.txt | grep -i 'running server'
+      kill $PID


### PR DESCRIPTION
Some of the dependency bumps break the API compatibility for buildkitd. Remove those, so that buildkitd can run successfully again.

There are CVEs back as a result, will create advisories for that.

Also removes `use-tag: true` because `buildkitd` uses releases.