### PR TITLE
opensearch-dashboards-2: New package

### DIFF
--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -15,6 +15,7 @@ environment:
       - ca-certificates-bundle
       - gcc-12
       - gcc-12-default
+      - git
       - node-gyp
       - nodejs-18
       - py3-setuptools
@@ -33,7 +34,7 @@ pipeline:
       expected-commit: 989d8f41f37cca3275bf3fedc5c2057a717d1d64
 
   - runs: |
-      # Workaround for "OpenSearch Dashboards should not be run as root.  Use --allow-root to continue.""
+      # Workaround for "OpenSearch Dashboards should not be run as root.  Use --allow-root to continue."
       # This change will add the --allow-root when running the build_ts_refs and register_git_hook scripts
       sed -i 's/\("osd:bootstrap": "scripts\/use_node scripts\/build_ts_refs\)\( && scripts\/use_node scripts\/register_git_hook\)/\1 --allow-root\2 --allow-root/' package.json
 
@@ -41,16 +42,20 @@ pipeline:
       # Our commond LDFLAGS cause some issues when building for aarch64. We
       # unset our global flags to allow the build to succeed.
       unset LDFLAGS
-      yarn osd bootstrap
-      ./scripts/use_node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers 5
+      yarn osd bootstrap --allow-root
+      yarn build-platform --linux-arm --skip-os-packages --release --allow-root
 
-      install -Dm755 assets "${{targets.destdir}}"/usr/share/opensearch-dashboards/assets
-      install -Dm755 config "${{targets.destdir}}"/usr/share/opensearch-dashboards/config
-      install -Dm755 data "${{targets.destdir}}"/usr/share/opensearch-dashboards/data
-      install -Dm755 node_modules "${{targets.destdir}}"/usr/share/opensearch-dashboards/node_modules
-      install -Dm755 plugins "${{targets.destdir}}"/usr/share/opensearch-dashboards/plugins
+      install -dm755 build/opensearch-dashboards-${{package.version}}-linux-arm64 "${{targets.destdir}}/usr/share/opensearch-dashboards"
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: Compatibility package to place Docker startup scripts.
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}/usr/local/bin"
+          install -m755 src/dev/build/tasks/os_packages/docker_generator/resources/bin/opensearch-dashboards-docker "${{targets.contextdir}}/usr/local/bin/opensearch-dashboards-docker"
 
 update:
   enabled: true

--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -5,6 +5,9 @@ package:
   description: Open source visualization dashboards for OpenSearch
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - nodejs-18
 
 environment:
   contents:
@@ -39,13 +42,19 @@ pipeline:
       sed -i 's/\("osd:bootstrap": "scripts\/use_node scripts\/build_ts_refs\)\( && scripts\/use_node scripts\/register_git_hook\)/\1 --allow-root\2 --allow-root/' package.json
 
   - runs: |
+      set -x
+
       # Our commond LDFLAGS cause some issues when building for aarch64. We
       # unset our global flags to allow the build to succeed.
       unset LDFLAGS
       yarn osd bootstrap --allow-root
       yarn build-platform --linux-arm --skip-os-packages --release --allow-root
 
-      install -dm755 build/opensearch-dashboards-${{package.version}}-linux-arm64 "${{targets.destdir}}/usr/share/opensearch-dashboards"
+      # Delete the node directory to ensure we use the system node.
+      rm -r build/opensearch-dashboards-${{package.version}}-linux-arm64/node
+
+      mkdir -p "${{targets.destdir}}/usr/share"
+      cp -r build/opensearch-dashboards-${{package.version}}-linux-arm64 "${{targets.destdir}}/usr/share/opensearch-dashboards"
 
   - uses: strip
 
@@ -54,11 +63,21 @@ subpackages:
     description: Compatibility package to place Docker startup scripts.
     pipeline:
       - runs: |
-          mkdir -p "${{targets.contextdir}}/usr/local/bin"
-          install -m755 src/dev/build/tasks/os_packages/docker_generator/resources/bin/opensearch-dashboards-docker "${{targets.contextdir}}/usr/local/bin/opensearch-dashboards-docker"
+          install -Dm755 src/dev/build/tasks/os_packages/docker_generator/resources/bin/opensearch-dashboards-docker "${{targets.contextdir}}/usr/local/bin/opensearch-dashboards-docker"
 
 update:
   enabled: true
   github:
     identifier: opensearch-project/OpenSearch-Dashboards
     tag-filter: 2.
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+    environment:
+      OSD_NODE_HOME: /usr
+  pipeline:
+    - runs: |
+        /usr/share/opensearch-dashboards/bin/opensearch-dashboards --version --allow-root

--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -48,13 +48,13 @@ pipeline:
       # unset our global flags to allow the build to succeed.
       unset LDFLAGS
       yarn osd bootstrap --allow-root
-      yarn build-platform --linux-arm --skip-os-packages --release --allow-root
+      yarn build-platform --skip-os-packages --release --allow-root
 
       # Delete the node directory to ensure we use the system node.
-      rm -r build/opensearch-dashboards-${{package.version}}-linux-arm64/node
+      rm -r build/opensearch-dashboards-${{package.version}}-linux-*/node
 
       mkdir -p "${{targets.destdir}}/usr/share"
-      cp -r build/opensearch-dashboards-${{package.version}}-linux-arm64 "${{targets.destdir}}/usr/share/opensearch-dashboards"
+      cp -r build/opensearch-dashboards-${{package.version}}-linux-* "${{targets.destdir}}/usr/share/opensearch-dashboards"
 
   - uses: strip
 

--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -1,0 +1,59 @@
+package:
+  name: opensearch-dashboards-2
+  version: 2.11.1
+  epoch: 0
+  description: Open source visualization dashboards for OpenSearch
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - apk-tools
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gcc-12
+      - gcc-12-default
+      - node-gyp
+      - nodejs-18
+      - py3-setuptools
+      - python3
+      - xorg-server
+      - yarn
+  environment:
+    CC: gcc
+    CXX: g++
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
+      tag: ${{package.version}}
+      expected-commit: 989d8f41f37cca3275bf3fedc5c2057a717d1d64
+
+  - runs: |
+      # Workaround for "OpenSearch Dashboards should not be run as root.  Use --allow-root to continue.""
+      # This change will add the --allow-root when running the build_ts_refs and register_git_hook scripts
+      sed -i 's/\("osd:bootstrap": "scripts\/use_node scripts\/build_ts_refs\)\( && scripts\/use_node scripts\/register_git_hook\)/\1 --allow-root\2 --allow-root/' package.json
+
+  - runs: |
+      # Our commond LDFLAGS cause some issues when building for aarch64. We
+      # unset our global flags to allow the build to succeed.
+      unset LDFLAGS
+      yarn osd bootstrap
+      ./scripts/use_node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers 5
+
+      install -Dm755 assets "${{targets.destdir}}"/usr/share/opensearch-dashboards/assets
+      install -Dm755 config "${{targets.destdir}}"/usr/share/opensearch-dashboards/config
+      install -Dm755 data "${{targets.destdir}}"/usr/share/opensearch-dashboards/data
+      install -Dm755 node_modules "${{targets.destdir}}"/usr/share/opensearch-dashboards/node_modules
+      install -Dm755 plugins "${{targets.destdir}}"/usr/share/opensearch-dashboards/plugins
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: opensearch-project/OpenSearch-Dashboards
+    tag-filter: 2.


### PR DESCRIPTION
There are 3 known CVEs on the package - we'll follow up with advisories.

Version's policy: https://endoflife.date/opensearch

- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] This PR links to the upstream project's support policy (e.g. `endoflife.date`)