### PR TITLE
py3-cassandra-medusa: fix CVE-2024-23334 CVE-2024-23829 CVE-2023-50782

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: 0.17.2
-  epoch: 0
+  epoch: 1
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0

--- a/py3-cassandra-medusa/bump.patch
+++ b/py3-cassandra-medusa/bump.patch
@@ -1,5 +1,5 @@
 diff --git a/setup.py b/setup.py
-index 9727ac2..014d17a 100644
+index 9727ac2..057cba8 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -49,14 +49,14 @@ setuptools.setup(
@@ -9,7 +9,7 @@ index 9727ac2..014d17a 100644
 -        'pyOpenSSL==22.0.0',
 -        'cryptography<=35.0,>=2.5',
 +        'pyOpenSSL==24.0.0',
-+        'cryptography<=41.0.6,>=2.5',
++        'cryptography==42.0.2',
          'pycryptodome>=3.9.9',
          'retrying>=1.3.3',
          'parallel-ssh==2.2.0',
@@ -20,12 +20,15 @@ index 9727ac2..014d17a 100644
          'protobuf==4.24.3',
          'grpcio==1.58.0',
          'grpcio-health-checking==1.58.0',
-@@ -68,7 +68,7 @@ setuptools.setup(
+@@ -68,9 +68,9 @@ setuptools.setup(
          'botocore>=1.13.27',
          'dnspython>=2.2.1',
          'asyncio==3.4.3',
 -        'aiohttp==3.8.5',
-+        'aiohttp==3.9.0',
++        'aiohttp==3.9.2',
          'boto3>=1.28.38',
-         'gcloud-aio-storage==8.3.0',
+-        'gcloud-aio-storage==8.3.0',
++        'gcloud-aio-storage==9.1.0',
          'azure-core==1.29.4',
+         'azure-identity==1.14.0',
+         'azure-storage-blob==12.17.0'


### PR DESCRIPTION
Fixing:
$ wolfictl scan packages/aarch64/py3-cassandra-medusa-0.17.2-r0.apk
🔎 Scanning "packages/aarch64/py3-cassandra-medusa-0.17.2-r0.apk"
├── 📄 /usr/share/medusa/.venv/lib/python3.11/site-packages/aiohttp-3.9.0.dist-info/METADATA, /usr/share/medusa/.venv/lib/python3.11/site-packages/aiohttp-3.9.0.dist-info/RECORD, /usr/share/medusa/.venv/lib/python3.11/site-packages/aiohttp-3.9.0.dist-info/top_level.txt
│       📦 aiohttp 3.9.0 (python)
│           Medium CVE-2024-23334 GHSA-5h86-8mv2-jq9f fixed in 3.9.2
│           Medium CVE-2024-23829 GHSA-8qpw-xqxj-h4r2 fixed in 3.9.2
│
└── 📄 /usr/share/medusa/.venv/lib/python3.11/site-packages/cryptography-41.0.6.dist-info/METADATA, /usr/share/medusa/.venv/lib/python3.11/site-packages/cryptography-41.0.6.dist-info/RECORD, /usr/share/medusa/.venv/lib/python3.11/site-packages/cryptography-41.0.6.dist-info/top_level.txt
        📦 cryptography 41.0.6 (python)
            Medium CVE-2023-50782 GHSA-3ww4-gg4f-jr7f fixed in 42.0.0