### PR TITLE
disable mysql from collectd

### DIFF
--- a/collectd.yaml
+++ b/collectd.yaml
@@ -1,7 +1,12 @@
+# This package is required for the metric-collector-for-apache-cassandra.
+# There are bunch of plugins are disabled to trim down the size of the final package and to avoid unnecessary dependencies.
+# But in case you need a collectd package with a plugin we already disabled we could do that by separating the collectd into subpackages
+# for each package that uses collectd. For example, if you need the collectd package with the write_riemann plugin enabled, you could
+# create a subpackage for it and enable the plugin in the subpackage. The subpackage will be built and installed alongside the main package.
 package:
   name: collectd
   version: 5.12.0
-  epoch: 0
+  epoch: 1
   description: "The system statistics collection daemon."
   copyright:
     - license: MIT
@@ -41,8 +46,6 @@ environment:
       - libtool
       - libxml2-dev
       - lm-sensors-dev
-      - mariadb-connector-c-dev
-      - mariadb-dev
       - mosquitto-dev
       - net-snmp-dev
       - openipmi-dev
@@ -132,7 +135,8 @@ pipeline:
         --disable-ping \
         --disable-zone \
         --disable-python \
-        --disable-lua
+        --disable-lua \
+        --disable-mysql
 
         make
         make DESTDIR="${{targets.destdir}}" install


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
