### PR TITLE
create subpackage for collectd for further customizations

### DIFF
--- a/metric-collector-for-apache-cassandra.yaml
+++ b/metric-collector-for-apache-cassandra.yaml
@@ -1,13 +1,13 @@
 package:
   name: metric-collector-for-apache-cassandra
   version: 0.3.5
-  epoch: 2
+  epoch: 3
   description: Drop-in metrics collection and dashboards for Apache Cassandra
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - collectd
+      - collectd-metric-collector-for-apache-cassandra
 
 environment:
   contents:
@@ -15,9 +15,54 @@ environment:
       - bash
       - busybox
       - ca-certificates-bundle
+      - cairo-dev
+      - curl-dev
+      - eudev-dev
+      - flex
+      - gdk-pixbuf-dev
+      - gpsd-dev
+      - harfbuzz-dev
+      - hiredis-dev
+      - i2c-tools-dev
+      - iptables-dev
+      - jansson-dev
+      - libatasmart-dev
+      - libdbi-dev
+      - libgcrypt-dev
+      - libmemcached-dev
+      - libmicrohttpd-dev
+      - libmnl-dev
+      - libmodbus-dev
+      - libnotify-dev
+      - liboping-dev
+      - libpcap-dev
+      - libpq-16
+      - librdkafka-dev
+      - libtool
+      - libxml2-dev
+      - lm-sensors-dev
       - maven
+      - mosquitto-dev
+      - net-snmp-dev
+      - openipmi-dev
       - openjdk-11
       - openjdk-11-default-jvm
+      - openldap-dev
+      - openssl-dev>3
+      - owfs-dev
+      - pango-dev
+      - patchelf
+      - perl-dev
+      - pkgconf
+      - pkgconf-dev
+      - postgresql-16-dev
+      - rabbitmq-c
+      - rabbitmq-c-dev
+      - riemann-c-client-dev
+      - rrdtool-dev
+      - varnish
+      - yajl-dev
+      - zlib-dev
 
 pipeline:
   - uses: git-checkout
@@ -40,6 +85,109 @@ pipeline:
       cp ./config/collectd.conf.tmpl "${{targets.destdir}}"/opt/metrics-collector/config
       cp ./config/metric-collector.yaml "${{targets.destdir}}"/opt/metrics-collector/config
       cp -r ./scripts "${{targets.destdir}}"/opt/metrics-collector
+
+subpackages:
+  - name: collectd-metric-collector-for-apache-cassandra
+    description: "collectd package for metric collector for Apache Cassandra"
+    pipeline:
+      - uses: git-checkout
+        with:
+          repository: https://github.com/collectd/collectd.git
+          tag: collectd-5.12.0
+          expected-commit: 3f935d017e81b7eaf84c9df421490230845dc5c0
+          destination: collectd
+      - runs: |
+          cd collectd
+          ./build.sh
+
+          CFLAGS="$CFLAGS -fPIC" \
+          CPPFLAGS="$CFLAGS" \
+          CXXFLAGS="$CFLAGS"
+          ./configure \
+            --build=$CBUILD \
+            --host=$CHOST \
+            --prefix=/usr \
+            --sysconfdir=/etc/collectd \
+            --mandir=/usr/share/man \
+            --infodir=/usr/share/info \
+            --localstate=/var \
+            --with-libiptc \
+            --disable-werror \
+            --with-perl-bindings=INSTALLDIRS=vendor \
+            --with-java=/usr/lib/jvm/default-jvm \
+            \
+            --enable-all-plugins \
+            --disable-amqp1 \
+            --disable-apple_sensors \
+            --disable-aquaero \
+            --disable-dcpmm \
+            --disable-dpdkevents \
+            --disable-dpdkstat \
+            --disable-dpdk_telemetry \
+            --disable-gmond \
+            --disable-gpu_nvidia \
+            --disable-grpc \
+            --disable-intel_pmu \
+            --disable-intel_rdt \
+            --disable-ipstats \
+            --disable-lpar \
+            --disable-mic \
+            --disable-netapp \
+            --disable-netlink \
+            --disable-netstat_udp \
+            --disable-notify_email \
+            --disable-nut \
+            --disable-oracle \
+            --disable-pf \
+            --disable-redfish \
+            --disable-routeros \
+            --disable-sigrok \
+            --disable-slurm \
+            --disable-tape \
+            --disable-tokyotyrant \
+            --disable-write_mongodb \
+            --disable-write_prometheus \
+            --disable-xencpu \
+            --disable-xmms \
+            --disable-virt \
+            --disable-pinba \
+            --disable-barometer \
+            --disable-capabilities \
+            --disable-turbostat \
+            --disable-write_riemann \
+            --disable-ping \
+            --disable-zone \
+            --disable-python \
+            --disable-lua \
+            --disable-mysql
+
+            make
+            make DESTDIR="${{targets.subpkgdir}}" install
+            find "${{targets.subpkgdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+            mkdir -p "${{targets.subpkgdir}}"/etc/collectd.d
+            mkdir -p "${{targets.subpkgdir}}"/etc/init.d
+            mkdir -p "${{targets.subpkgdir}}"/usr/include/collectd/core
+            mkdir -p "${{targets.subpkgdir}}"/usr/include/collectd/liboconfig
+
+            install -D -m755 ./${{package.name}}.initd "${{targets.subpkgdir}}"/etc/init.d/${{package.name}}
+
+             # Install all header files to allow building out-of-tree plugins.
+             # This is based on Debian.
+             for path in $(find src -path src/libcollectdclient -prune \
+             	-o -path src/liboconfig -prune \
+             	-o -name '*.h' -print)
+             do
+             	install -D -m644 "$path" "${{targets.subpkgdir}}"/usr/include/collectd/core/${path#src/}
+             done
+
+            install -D -m644 ./src/liboconfig/oconfig.h -t "${{targets.subpkgdir}}"/usr/include/collectd/liboconfig/
+            cd "${{targets.subpkgdir}}"/usr/include/collectd/
+            # Update include path for collectd core header files.
+            headers=$(find ./core ./liboconfig -type f -name '*.h')
+            for path in $headers; do
+            	sed -r -i "s|(include\s+)\".*\<${path##*/}\"|\1\"collectd/${path#./}\"|" $headers
+            done
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
