### PR TITLE
Switch node to use system libuv.

### DIFF
--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-21
   version: 21.6.1
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     runtime:
@@ -18,6 +18,7 @@ environment:
       - c-ares-dev
       - ca-certificates-bundle
       - icu-dev
+      - libuv-dev
       - linux-headers
       - nghttp2-dev
       - openssl-dev
@@ -52,6 +53,7 @@ pipeline:
         --shared-openssl \
         --shared-cares \
         --shared-nghttp2 \
+        --shared-libuv \
         --ninja \
         --openssl-use-def-ca-store \
         --with-icu-default-data-dir=$(icu-config --icudatadir) \
@@ -83,3 +85,12 @@ update:
     strip-prefix: v
     use-tag: true
     tag-filter: v21.
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        node --version | grep ${{package.version}}


### PR DESCRIPTION
We were previously using bundled libuv, this changes node to use the system one.

Fixes:

Related:

### Pre-review Checklist
