### PR TITLE
fix(uutils): Remove utilities provided by procps

### DIFF
--- a/uutils.yaml
+++ b/uutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: uutils
   version: 0.0.24
-  epoch: 1
+  epoch: 2
   description: "Cross-platform Rust rewrite of the GNU coreutils."
   copyright:
     - license: MIT
@@ -29,6 +29,10 @@ pipeline:
       cargo build --release --features unix
       mkdir -p ${{targets.destdir}}/usr
       make PREFIX=${{targets.destdir}}/usr MULTICALL=y install
+
+      # Remove utilities provided by procps
+      rm ${{targets.destdir}}/usr/bin/kill
+      rm ${{targets.destdir}}/usr/bin/uptime
 
 subpackages:
   - name: uutils-bash-completion


### PR DESCRIPTION
Fixes: Currently, uutils is in the process of rewriting utilities available via procps. Both kill and uptime have found their way into uutils, but their procps implementation isn't finished yet. Installing uutils with procps installed will lead to a conflict for this reason so exclude these until their procps implementation is complete