### PR TITLE
pdftk and qpdf

### DIFF
--- a/pdftk.yaml
+++ b/pdftk.yaml
@@ -1,0 +1,53 @@
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: pdftk
+  version: 3.3.3
+  epoch: 0
+  description: Command-line tool for working with PDFs
+  copyright:
+    - license: GPL-2.0-or-later
+  dependencies:
+    runtime:
+      - busybox
+      - findutils
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - gradle-8
+      - openjdk-8-default-jvm
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-1.8-openjdk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/pdftk-java/pdftk
+      tag: v${{package.version}}
+      expected-commit: e4292c8f1bd2580a44d3cbf3570a4505bd3a74b6
+
+  - name: Build
+    runs: |
+      gradle -Dorg.gradle.daemon=false build
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/usr/share/java/${{package.name}}
+      install -Dm644 ./build/libs/pdftk.jar -t "${{targets.destdir}}/usr/share/java/${{package.name}}"
+      install -Dm644 pdftk.1 -t "${{targets.destdir}}/usr/share/man/man1"
+      install -Dm755 "pdftk.sh" "${{targets.destdir}}/usr/bin/pdftk"
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 21275
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+        - openjdk-8-default-jvm
+  pipeline:
+    - runs: |
+        pdftk -version

--- a/pdftk/pdftk.sh
+++ b/pdftk/pdftk.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+CP='/usr/share/java/bcprov/bcprov.jar:/usr/share/java/commons-lang/commons-lang.jar:/usr/share/java/pdftk/pdftk.jar'
+exec /usr/bin/java -cp "$CP" com.gitlab.pdftk_java.pdftk "$@"

--- a/qpdf.yaml
+++ b/qpdf.yaml
@@ -1,0 +1,83 @@
+package:
+  name: qpdf
+  version: 11.8.0
+  epoch: 0
+  description: Command-line tools and library for transforming PDF files
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gnutls-dev
+      - libjpeg-turbo-dev
+      - openssl-dev
+      - samurai
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/qpdf/qpdf
+      tag: v${{package.version}}
+      expected-commit: 452e1f5c20ec6adf62cd296cb9dddacbc06e6ffa
+
+  - name: Build
+    runs: |
+      cmake -B build -G Ninja \
+      	-DCMAKE_INSTALL_PREFIX=/usr \
+      	-DCMAKE_BUILD_TYPE=MinSizeRel \
+      	-DBUILD_STATIC_LIBS=OFF \
+      	-DBUILD_DOC_PDF=OFF \
+      	-DBUILD_DOC_HTML=OFF \
+      	-DINSTALL_EXAMPLES=OFF
+      cmake --build build
+
+  - name: Package
+    runs: DESTDIR="${{targets.destdir}}" cmake --install build
+
+  - uses: strip
+
+subpackages:
+  - name: qpdf-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - qpdf
+    description: qpdf dev
+
+  - name: qpdf-doc
+    pipeline:
+      - uses: split/manpages
+    description: qpdf manpages
+
+  - name: qpdf-fix-qdf
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/fix-qdf "${{targets.subpkgdir}}"/usr/bin/
+    description: Repair PDF files in QDF form after editing
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        qpdf -version
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - "release-qpdf*"
+  github:
+    identifier: qpdf/qpdf
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
