### PR TITLE
opensearch: package internal and external plugins as subpackages (generate 41 packages)

### DIFF
--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -24,6 +24,7 @@ environment:
       - gradle
       - openjdk-11
       - openjdk-11-default-jvm
+      - patch
       - unzip
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
@@ -68,15 +69,15 @@ data:
       index-management: ""
       job-scheduler: ""
       k-nn: ""
-      ml-commons: ""
-      neural-search: ""
+      ml-commons: "CVE-2023-51074.patch"
+      neural-search: "CVE-2023-5072.patch"
       notifications: ""
       observability: ""
       performance-analyzer: ""
       reporting: ""
-      security: ""
+      security: "CVE-2023-44483.patch"
       security-analytics: ""
-      sql: ""
+      sql: "CVE-2023-5072-sql.patch"
 
 pipeline:
   - uses: git-checkout
@@ -89,6 +90,14 @@ pipeline:
     with:
       # Patch from: https://patch-diff.githubusercontent.com/raw/opensearch-project/OpenSearch/pull/10297.patch
       patches: CVE-2022-45146.patch
+
+  - uses: patch
+    with:
+      patches: CVE-2023-46749.patch
+
+  - uses: patch
+    with:
+      patches: CVE-2023-34054.patch
 
   - runs: |
       echo "org.gradle.daemon=false" >> gradle.properties
@@ -154,6 +163,11 @@ subpackages:
           destination: ./plugins/${{range.key}}
       - runs: |
           cd ./plugins/${{range.key}}
+
+          # apply any CVE patches
+          if [ -n "${{range.value}}" ]; then
+              patch -p1 < "../../${{range.value}}"
+          fi
 
           # notifications source live in a subfolder
           if [ "${{range.key}}" = "notifications" ]; then

--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -1,26 +1,82 @@
 package:
   name: opensearch-2
   version: 2.11.1
-  epoch: 3 # Remove CVE-2022-45146 patch when bumping to 2.12 or later
+  epoch: 4 # Remove CVE-2022-45146 patch when bumping to 2.12 or later
   description: Open source distributed and RESTful search engine.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - bash # some helper scripts use bash
+      - busybox # some helper scripts use busybox
       - openjdk-11-jre
+
+vars:
+  plugin_version_qualifier: "0"
 
 environment:
   contents:
     packages:
+      - bash
       - busybox
       - ca-certificates-bundle
       - curl
       - gradle
       - openjdk-11
+      - openjdk-11-default-jvm
+      - unzip
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
     LANG: "en_US.UTF-8"
+
+data:
+  - name: internal-plugins
+    items:
+      # plugin_name: cve patch list
+      analysis-icu: ""
+      analysis-kuromoji: ""
+      analysis-nori: ""
+      analysis-phonetic: ""
+      analysis-smartcn: ""
+      analysis-stempel: ""
+      analysis-ukrainian: ""
+      crypto-kms: ""
+      discovery-azure-classic: ""
+      discovery-ec2: ""
+      discovery-gce: ""
+      identity-shiro: ""
+      ingest-attachment: ""
+      mapper-annotated-text: ""
+      mapper-murmur3: ""
+      mapper-size: ""
+      repository-azure: ""
+      repository-gcs: ""
+      repository-s3: ""
+      store-smb: ""
+      telemetry-otel: ""
+      transport-nio: ""
+
+  - name: external-plugins
+    items:
+      # plugin_name: cve patch list
+      alerting: ""
+      anomaly-detection: ""
+      asynchronous-search: ""
+      cross-cluster-replication: ""
+      custom-codecs: ""
+      geospatial: ""
+      index-management: ""
+      job-scheduler: ""
+      k-nn: ""
+      ml-commons: ""
+      neural-search: ""
+      notifications: ""
+      observability: ""
+      performance-analyzer: ""
+      reporting: ""
+      security: ""
+      security-analytics: ""
+      sql: ""
 
 pipeline:
   - uses: git-checkout
@@ -62,6 +118,105 @@ pipeline:
 
       # Manually set this to docker: https://github.com/opensearch-project/OpenSearch/blob/5f8193021215cd6979fde66474ec8d74d32ac91a/distribution/docker/src/docker/Dockerfile#LL49C90-L49C129
       sed -i -e 's/OPENSEARCH_DISTRIBUTION_TYPE=tar/OPENSEARCH_DISTRIBUTION_TYPE=docker/'  ${{targets.destdir}}/usr/share/opensearch/bin/opensearch-env
+
+  - runs: |
+      cd plugins
+      gradle assemble -Dbuild.snapshot="false" -Dbuild.version_qualifier="" --stacktrace
+
+      # useful for finding generated zip file we use to extract into the final apk
+      find . -name "*.zip"
+
+  - runs: |
+      # Remove files so they don't conflict with subpackages
+      echo "Removing files that conflict with subpackages"
+      rm -rf /home/build/settings.gradle
+
+  - uses: strip
+
+subpackages:
+  - range: internal-plugins
+    name: ${{package.name}}-${{range.key}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/share/opensearch/plugins/opensearch-${{range.key}}
+          unzip "./plugins/${{range.key}}/build/distributions/${{range.key}}-${{package.version}}.zip" -d "${{targets.contextdir}}/usr/share/opensearch/plugins/opensearch-${{range.key}}"
+
+  - range: external-plugins
+    name: ${{package.name}}-${{range.key}}
+    pipeline:
+      # Delete other plugins. Opensearch can only build one at a time, otherwise we run into conflicting dependencies version issues with yarn.
+      - runs: |
+          rm -r plugins/* || true
+      - uses: git-checkout
+        with:
+          repository: https://github.com/opensearch-project/${{range.key}}.git
+          tag: ${{package.version}}.${{vars.plugin_version_qualifier}}
+          destination: ./plugins/${{range.key}}
+      - runs: |
+          cd ./plugins/${{range.key}}
+
+          # notifications source live in a subfolder
+          if [ "${{range.key}}" = "notifications" ]; then
+            cd ./notifications
+          fi
+
+          # skip check task, using -x doesn't append to an existing list
+          # job scheduler requires a test cluster to connect to so skip verification checks
+          if [ "${{range.key}}" = "job-scheduler" ]; then
+            sed -i '/startParameter.excludedTaskNames=\[/ s/]/, "check"]/g' settings.gradle
+          fi
+
+          echo "org.gradle.daemon=false" >> gradle.properties
+          ./gradlew clean assemble -Dbuild.snapshot="false" -Dbuild.version_qualifier="" -x check -x integTest -x javadoc -PfailOnJavadocWarning=false --stacktrace
+
+          # useful for finding generated zip file we use to extract into the final apk
+          find . -name "*.zip"
+
+          mkdir -p "${{targets.contextdir}}/usr/share/opensearch/plugins"
+
+          # Define the base path for the unzip destination
+          destination_base="${{targets.contextdir}}/usr/share/opensearch/plugins"
+
+          # Extract the value of rootProject.name, this is because the key is not always the same as the plugin name
+          # note: not all plugins have a settings.gradle file
+          plugin_name=$(grep "^rootProject.name" settings.gradle 2>/dev/null | awk -F" = " '{print $2}' | tr -d "'" | tr -d '"')
+
+          # Check if plugin_name is empty and assign default if it is
+          if [ -z "$plugin_name" ]; then
+              plugin_name=${{range.key}}
+          fi
+
+          echo "Plugin name: $plugin_name"
+
+          # Remove any existing "opensearch-" prefix before adding it to ensure it's not duplicated
+          plugin_name=$(echo $plugin_name | sed 's/^opensearch-//')
+
+          # Ensure the plugin_name has the "opensearch-" prefix
+          plugin_name="opensearch-$plugin_name"
+
+          echo "Final plugin name: $plugin_name"
+
+          # Determine the source directory based on the plugin key
+          case "${{range.key}}" in
+              "alerting")
+                  zip_dir="./alerting"
+                  ;;
+              "ml-commons"|"sql")
+                  zip_dir="./plugin"
+                  ;;
+              "notifications")
+                  zip_dir="./notifications"
+                  # Special handling for notifications core
+                  unzip "./core/build/distributions/${plugin_name}-core-${{package.version}}.${{vars.plugin_version_qualifier}}.zip" -d "${destination_base}/${plugin_name}-core"
+                  ;;
+              *)
+                  zip_dir="."
+                  ;;
+          esac
+
+          # Unzip the main plugin distribution
+          unzip "${zip_dir}/build/distributions/${plugin_name}-${{package.version}}.${{vars.plugin_version_qualifier}}.zip" -d "${destination_base}/${plugin_name}"
+      - uses: strip
 
 update:
   enabled: true

--- a/opensearch-2/CVE-2023-34054.patch
+++ b/opensearch-2/CVE-2023-34054.patch
@@ -1,0 +1,13 @@
+diff --git a/plugins/repository-azure/build.gradle b/plugins/repository-azure/build.gradle
+index 2695d3f..f53c944 100644
+--- a/plugins/repository-azure/build.gradle
++++ b/plugins/repository-azure/build.gradle
+@@ -60,7 +60,7 @@ dependencies {
+   api 'io.projectreactor:reactor-core:3.5.6'
+   api 'io.projectreactor.netty:reactor-netty:1.1.8'
+   api 'io.projectreactor.netty:reactor-netty-core:1.1.8'
+-  api 'io.projectreactor.netty:reactor-netty-http:1.1.9'
++  api 'io.projectreactor.netty:reactor-netty-http:1.1.13'
+   api "org.slf4j:slf4j-api:${versions.slf4j}"
+   api "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+   api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"

--- a/opensearch-2/CVE-2023-44483.patch
+++ b/opensearch-2/CVE-2023-44483.patch
@@ -1,0 +1,13 @@
+diff --git a/build.gradle b/build.gradle
+index 67d5c6d..34cf14b 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -587,7 +587,7 @@ dependencies {
+     runtimeOnly "org.glassfish.jaxb:txw2:${jaxb_version}"
+     runtimeOnly 'com.fasterxml.woodstox:woodstox-core:6.5.1'
+     runtimeOnly 'org.apache.ws.xmlschema:xmlschema-core:2.3.1'
+-    runtimeOnly 'org.apache.santuario:xmlsec:2.3.3'
++    runtimeOnly 'org.apache.santuario:xmlsec:2.3.4'
+     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
+     runtimeOnly 'org.checkerframework:checker-qual:3.38.0'
+     runtimeOnly "org.bouncycastle:bcpkix-jdk15to18:${versions.bouncycastle}"

--- a/opensearch-2/CVE-2023-46749.patch
+++ b/opensearch-2/CVE-2023-46749.patch
@@ -1,0 +1,13 @@
+diff --git a/plugins/identity-shiro/build.gradle b/plugins/identity-shiro/build.gradle
+index baa3464..1548780 100644
+--- a/plugins/identity-shiro/build.gradle
++++ b/plugins/identity-shiro/build.gradle
+@@ -17,7 +17,7 @@ opensearchplugin {
+ }
+
+ dependencies {
+-  implementation 'org.apache.shiro:shiro-core:1.11.0'
++  implementation 'org.apache.shiro:shiro-core:1.13.0'
+
+   // Needed for shiro
+   implementation "org.slf4j:slf4j-api:${versions.slf4j}"

--- a/opensearch-2/CVE-2023-5072-sql.patch
+++ b/opensearch-2/CVE-2023-5072-sql.patch
@@ -1,0 +1,78 @@
+diff --git a/legacy/build.gradle b/legacy/build.gradle
+index d89f7af..7eb5489 100644
+--- a/legacy/build.gradle
++++ b/legacy/build.gradle
+@@ -89,7 +89,7 @@ dependencies {
+         }
+     }
+     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
+-    implementation group: 'org.json', name: 'json', version:'20230227'
++    implementation group: 'org.json', name: 'json', version:'20231013'
+     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
+     // add geo module as dependency. https://github.com/opensearch-project/OpenSearch/pull/4180/.
+diff --git a/opensearch/build.gradle b/opensearch/build.gradle
+index 11f4a9b..2261a1b 100644
+--- a/opensearch/build.gradle
++++ b/opensearch/build.gradle
+@@ -35,7 +35,7 @@ dependencies {
+     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
+     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
+     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"
+-    implementation group: 'org.json', name: 'json', version:'20230227'
++    implementation group: 'org.json', name: 'json', version:'20231013'
+     compileOnly group: 'org.opensearch.client', name: 'opensearch-rest-high-level-client', version: "${opensearch_version}"
+     implementation group: 'org.opensearch', name:'opensearch-ml-client', version: "${opensearch_build}"
+
+diff --git a/ppl/build.gradle b/ppl/build.gradle
+index 484934d..7408d7a 100644
+--- a/ppl/build.gradle
++++ b/ppl/build.gradle
+@@ -48,7 +48,7 @@ dependencies {
+
+     implementation "org.antlr:antlr4-runtime:4.7.1"
+     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
+-    api group: 'org.json', name: 'json', version: '20230227'
++    api group: 'org.json', name: 'json', version: '20231013'
+     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.20.0'
+     api project(':common')
+     api project(':core')
+diff --git a/prometheus/build.gradle b/prometheus/build.gradle
+index f8c10c7..c2878ab 100644
+--- a/prometheus/build.gradle
++++ b/prometheus/build.gradle
+@@ -22,7 +22,7 @@ dependencies {
+     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${versions.jackson}"
+     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${versions.jackson_databind}"
+     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: "${versions.jackson}"
+-    implementation group: 'org.json', name: 'json', version: '20230227'
++    implementation group: 'org.json', name: 'json', version: '20231013'
+
+     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
+     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
+diff --git a/spark/build.gradle b/spark/build.gradle
+index c06b5b6..99a4472 100644
+--- a/spark/build.gradle
++++ b/spark/build.gradle
+@@ -47,7 +47,7 @@ dependencies {
+     implementation project(':datasources')
+
+     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
+-    implementation group: 'org.json', name: 'json', version: '20230227'
++    implementation group: 'org.json', name: 'json', version: '20231013'
+     api group: 'com.amazonaws', name: 'aws-java-sdk-emr', version: '1.12.545'
+     api group: 'com.amazonaws', name: 'aws-java-sdk-emrserverless', version: '1.12.545'
+     implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
+diff --git a/sql/build.gradle b/sql/build.gradle
+index 44dc37c..a9e1787 100644
+--- a/sql/build.gradle
++++ b/sql/build.gradle
+@@ -46,7 +46,7 @@ dependencies {
+
+     implementation "org.antlr:antlr4-runtime:4.7.1"
+     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
+-    implementation group: 'org.json', name: 'json', version:'20230227'
++    implementation group: 'org.json', name: 'json', version:'20231013'
+     implementation project(':common')
+     implementation project(':core')
+     api project(':protocol')

--- a/opensearch-2/CVE-2023-5072.patch
+++ b/opensearch-2/CVE-2023-5072.patch
@@ -1,0 +1,13 @@
+diff --git a/build.gradle b/build.gradle
+index ae67657..1f13f7d 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -153,7 +153,7 @@ dependencies {
+     runtimeOnly group: 'org.opensearch', name: 'common-utils', version: "${opensearch_build}"
+     runtimeOnly group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
+     runtimeOnly group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
+-    runtimeOnly group: 'org.json', name: 'json', version: '20230227'
++    runtimeOnly group: 'org.json', name: 'json', version: '20231013'
+ }
+
+ // In order to add the jar to the classpath, we need to unzip the

--- a/opensearch-2/CVE-2023-51074.patch
+++ b/opensearch-2/CVE-2023-51074.patch
@@ -1,0 +1,12 @@
+diff --git a/ml-algorithms/build.gradle b/ml-algorithms/build.gradle
+index 3561472..050ea67 100644
+--- a/ml-algorithms/build.gradle
++++ b/ml-algorithms/build.gradle
+@@ -62,7 +62,7 @@ dependencies {
+     implementation 'software.amazon.awssdk:auth'
+     implementation 'software.amazon.awssdk:apache-client'
+     implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
+-    implementation 'com.jayway.jsonpath:json-path:2.8.0'
++    implementation 'com.jayway.jsonpath:json-path:2.9.0'
+     implementation group: 'org.json', name: 'json', version: '20231013'
+ }


### PR DESCRIPTION
The main motivation for putting all the plugins in one package is they all share the same tag version, even though 19 of the plugins are in different repos, but the same org.

If we had separate YAMLs for them then we’d update then automatically at different times, which would then break any downstream consumers of these packages.

So having them all in a single yaml means we build and publish opensearch + the main 41 related plugins together