### PR TITLE
Upload full withdrawn-packages.txt list to GCS

### DIFF
--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -66,6 +66,14 @@ jobs:
             gsutil -h "Cache-Control:no-store" cp $arch/APKINDEX.tar.gz gs://wolfi-production-registry-destination/os/$arch/APKINDEX.tar.gz || true
           done
 
+      - name: Upload full withdrawn packages list
+        run: |
+          set -euxo pipefail
+          git log -p -- withdrawn-packages.txt | grep "^+" | grep ".apk$" | cut -c2- | sort | uniq > all-withdrawn-packages.txt
+          gsutil cp \
+            all-withdrawn-packages.txt \
+            gs://wolfi-production-registry-destination/os/withdrawn-packages.txt
+
       - uses: rtCamp/action-slack-notify@v2.2.1
         if: failure()
         env:


### PR DESCRIPTION
This is useful for vulnerability data integrity checks because we don't want information that references invalid packages, but we also want the ability to withdraw packages. With this list and APKINDEX, wolfictl will be able to know all packages that ever existed, not just the packages that currently exist.

X-ref: https://github.com/wolfi-dev/wolfictl/issues/576