### PR TITLE
Use federation to access signing key.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -153,17 +153,6 @@ jobs:
           # running inside of a container action with the workspace mounted in.
           git config --global --add safe.directory "$(pwd)"
 
-      - id: auth
-        name: 'Authenticate to Google Cloud'
-        uses: google-github-actions/auth@v1
-        with:
-          workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
-          service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
-
-      - uses: google-github-actions/setup-gcloud@v1
-        with:
-          project_id: prod-images-c6e5
-
       - name: 'Download x86_64 package archives'
         uses: actions/download-artifact@v3
         with:
@@ -176,7 +165,23 @@ jobs:
           path: /tmp/artifacts/
           name: packages-aarch64
 
-      - run: echo "${{ secrets.MELANGE_RSA }}" > ./wolfi-signing.rsa
+      - name: 'Authenticate to Google Cloud'
+        id: auth
+        uses: google-github-actions/auth@f6de81663f7788d05bd15bcce18f0e57f23f0846 # v2.0.1
+        with:
+          workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
+          service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
+
+      - uses: google-github-actions/setup-gcloud@5a5f7b85fca43e76e53463acaa9d408a03c98d3a # v2.0.1
+        with:
+          project_id: "prod-images-c6e5"
+
+      - uses: 'google-github-actions/get-secretmanager-secrets@ae0d4054c32840e2ced71207a9df55161ae3debc' # v2.0.0
+        id: secrets
+        with:
+          secrets: |-
+            token:prod-images-c6e5/melange-signing-key
+      - run: echo "${{ steps.secrets.outputs.token }}" > ./wolfi-signing.rsa
       - run: |
           mkdir -p /etc/apk/keys
           cp ./wolfi-signing.rsa.pub /etc/apk/keys/wolfi-signing.rsa.pub

--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -27,16 +27,21 @@ jobs:
 
       - name: 'Authenticate to Google Cloud'
         id: auth
-        uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
+        uses: google-github-actions/auth@f6de81663f7788d05bd15bcce18f0e57f23f0846 # v2.0.1
         with:
           workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
           service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
 
-      - uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
+      - uses: google-github-actions/setup-gcloud@5a5f7b85fca43e76e53463acaa9d408a03c98d3a # v2.0.1
         with:
           project_id: "prod-images-c6e5"
 
-      - run: echo "${{ secrets.MELANGE_RSA }}" > ./wolfi-signing.rsa
+      - uses: 'google-github-actions/get-secretmanager-secrets@ae0d4054c32840e2ced71207a9df55161ae3debc' # v2.0.0
+        id: secrets
+        with:
+          secrets: |-
+            token:prod-images-c6e5/melange-signing-key
+      - run: echo "${{ steps.secrets.outputs.token }}" > ./wolfi-signing.rsa
       - run: |
           sudo mkdir -p /etc/apk/keys
           sudo cp ./wolfi-signing.rsa.pub /etc/apk/keys/wolfi-signing.rsa.pub


### PR DESCRIPTION
These are copied from the enterprise repo where we've been using this mechanism for a week or so.