### PR TITLE
rust-1.75: continue the rust bootstrap chain

### DIFF
--- a/rust-1.75.yaml
+++ b/rust-1.75.yaml
@@ -1,0 +1,121 @@
+package:
+  name: rust-1.75
+  version: 1.75.0
+  epoch: 0
+  description: "Empowering everyone to build reliable and efficient software."
+  copyright:
+    - license: Apache-2.0 AND MIT
+  dependencies:
+    runtime:
+      - libLLVM-17
+    provides:
+      - rust=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang-17
+      - coreutils
+      - curl-dev
+      - file
+      - libLLVM-17
+      - libgit2-dev
+      - libssh2-dev
+      - llvm17
+      - llvm17-dev
+      - openssl-dev
+      - patch
+      - python3
+      - rust~1.74
+      - wasi-libc
+      - xz-dev
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://static.rust-lang.org/dist/rustc-${{package.version}}-src.tar.xz
+      expected-sha256: 4526f786d673e4859ff2afa0bab2ba13c918b796519a25c1acce06dba9542340
+      extract: false
+
+  - runs: |
+      tar -xJf rustc-${{package.version}}-src.tar.xz
+      rm rustc-${{package.version}}-src.tar.xz
+
+  - runs: |
+      export CFLAGS="$CFLAGS -O2 -I/usr/lib/llvm-17/include"
+      export CXXFLAGS="$CXXFLAGS -O2 -I/usr/lib/llvm-17/include"
+      export OPENSSL_NO_VENDOR=1
+      export RUST_BACKTRACE=1
+      export ARCH=${{host.triplet.rust}}
+      cd rustc-${{package.version}}-src
+
+      ./configure \
+        --host="${ARCH}" \
+        --target="${ARCH}" \
+        --prefix="/usr" \
+        --release-channel="stable" \
+        --enable-local-rust \
+        --local-rust-root="/usr" \
+        --llvm-root="/usr/lib/llvm17" \
+        --llvm-config="/usr/lib/llvm17/bin/llvm-config" \
+        --disable-docs \
+        --enable-extended \
+        --tools="cargo,src" \
+        --enable-llvm-link-shared \
+        --enable-option-checking \
+        --enable-locked-deps \
+        --enable-profiler \
+        --enable-vendor \
+        --dist-compression-formats=gz \
+        --python="python3" \
+        --set="rust.musl-root=/usr" \
+        --set="rust.codegen-units=1" \
+        --set="rust.codegen-units-std=1" \
+        --set="rust.parallel-compiler=false" \
+        --set="target.${ARCH}.musl-root=/usr" \
+        --set="target.${ARCH}.crt-static=false" \
+        --set="target.${ARCH}.musl-root=/usr" \
+        --set="target.${ARCH}.crt-static=false"
+
+  - runs: |
+      cd rustc-${{package.version}}-src
+      sed 's/#deny-warnings = .*/deny-warnings = false/' -i config.toml
+      sed 's|deny(warnings,|deny(|' -i src/bootstrap/src/lib.rs
+      mkdir -p "${{targets.destdir}}/usr"
+      unset CARGO_PROFILE_RELEASE_LTO
+      unset CARGO_PROFILE_RELEASE_OPT_LEVEL
+      unset CARGO_PROFILE_RELEASE_PANIC
+      unset CARGO_PROFILE_RELEASE_CODEGEN_UNITS
+      export CFLAGS="$CFLAGS -O2 -Iusr/include/llvm17"
+      export CXXFLAGS="$CXXFLAGS -O2 -I/usr/include/llvm17"
+      export OPENSSL_NO_VENDOR=1
+      export RUST_BACKTRACE=1
+      DESTDIR=${{targets.destdir}} python3 ./x.py install --jobs $(nproc)
+
+  - uses: strip
+
+  # delete uneeded files eg uninstalltion
+  - runs: |
+      rm ${{targets.destdir}}/usr/lib/rustlib/components
+      rm ${{targets.destdir}}/usr/lib/rustlib/install.log
+      rm ${{targets.destdir}}/usr/lib/rustlib/rust-installer-version
+      rm ${{targets.destdir}}/usr/lib/rustlib/uninstall.sh
+      rm ${{targets.destdir}}/usr/lib/rustlib/manifest-*
+
+  # rustbuild always installs copies of the shared libraries to /usr/lib,
+  # overwrite them with symlinks to the per-architecture versions
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/lib32
+      cd ${{targets.destdir}}
+      ln -srft usr/lib   usr/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.so
+      ln -srft usr/lib32 usr/lib/rustlib/i686-unknown-linux-gnu/lib/*.so
+
+update:
+  enabled: true
+  github:
+    identifier: rust-lang/rust
+    use-tag: true

--- a/rust-1.75.yaml
+++ b/rust-1.75.yaml
@@ -115,7 +115,4 @@ pipeline:
       ln -srft usr/lib32 usr/lib/rustlib/i686-unknown-linux-gnu/lib/*.so
 
 update:
-  enabled: true
-  github:
-    identifier: rust-lang/rust
-    use-tag: true
+  enabled: false


### PR DESCRIPTION
rust 1.76 came out and the `rust` package got updated in https://github.com/wolfi-dev/os/commit/150950c56615c9e52c94dae4a422f5e201e0cd16

This continues our bootstrap chain so that when bootstrapping 1.76 will be built from 1.75, which is built from 1.74.

I think I did this right.