### PR TITLE
use vendored-openssl feature with lychee package

### DIFF
--- a/lychee.yaml
+++ b/lychee.yaml
@@ -1,7 +1,7 @@
 package:
   name: lychee
   version: 0.14.3
-  epoch: 0
+  epoch: 1
   description: "Fast, async, stream-based link checker written in Rust"
   copyright:
     - license: Apache-2.0 AND MIT
@@ -23,7 +23,7 @@ pipeline:
       expected-commit: 90ed0e70b727886cf66443d35ccc7a3d321262eb
 
   - runs: |
-      cargo build --release
+      cargo build --release --features vendored-openssl
       install -Dm755 target/release/lychee "${{targets.destdir}}"/usr/bin/lychee
 
   - uses: strip


### PR DESCRIPTION
_vendored-openssl compiles and statically links a copy of OpenSSL._ (from lychee docs)
Ref: https://github.com/lycheeverse/lychee/blob/13f4339710d76831d9daf961584d796cee4847d2/.github/workflows/release.yml#L70 

For static linking. I copied the lychee binary in a multistage pipeline and got the following error. 
```bash
lychee: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```
this commit updates the package so that we get a statically linked binary. 

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
