### PR TITLE
Do full checkout in withdraw-packages workflow

### DIFF
--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          fetch-depth: 0 # We want the full history for uploading withdrawn-packages.txt to GCS. If this takes too long, we look at merging both files.
 
       - name: "Install wolfictl onto PATH"
         run: |


### PR DESCRIPTION
We need the full history.