### PR TITLE
Print complete melange command for make package target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ package/%:
 packages/$(ARCH)/%.apk: $(KEY)
 	@mkdir -p ./$(pkgname)/
 	$(eval SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct --follow $(yamlfile)))
+	$(info @SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) $(srcdirflag) --log-policy builtin:stderr,$(TARGETDIR)/buildlogs/$*.log)
 	@SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) $(srcdirflag) --log-policy builtin:stderr,$(TARGETDIR)/buildlogs/$*.log
 
 test/%:


### PR DESCRIPTION
Sometimes it is quicker to debug a package build using melange directly. This PR just adds an $(info ...) line to spit out the complete command, e.g.:

```
make package/jq
```

Adds this extra line:
```
Building package jq with version jq-1.7.1-r0 from file ./jq.yaml
@SOURCE_DATE_EPOCH=1702498319 /usr/bin/melange build ./jq.yaml --repository-append /work/packages --keyring-append local-melange.rsa.pub --signing-key local-melange.rsa --arch aarch64 --env-file build-aarch64.env --namespace wolfi --generate-index false --pipeline-dir ./pipelines/  -k https://packages.wolfi.dev/os/wolfi-signing.rsa.pub -r https://packages.wolfi.dev/os --source-dir ./jq --log-policy builtin:stderr,packages/aarch64/buildlogs/jq-1.7.1-r0.log
```