### PR TITLE
Split off libecpg subpackages from postgres.

### DIFF
--- a/postgresql-12.yaml
+++ b/postgresql-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-12
   version: "12.18"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -53,6 +53,40 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: libecpg-12
+    description: PostgreSQL libraries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/libecpg.so* ${{targets.subpkgdir}}/usr/lib/
+    dependencies:
+      provider-priority: 12
+
+  - name: libecpg-12-dev
+    description: PostgreSQL libraries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/ecpg ${{targets.subpkgdir}}/usr/bin/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/include/postgresql
+          mv ${{targets.destdir}}/usr/include/ecpg*.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/postgresql/informix/* ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/pgtypes*.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sql3types.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sqlca.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sqlda*.h ${{targets.subpkgdir}}/usr/include/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.destdir}}/usr/lib/libecpg.* ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.destdir}}/usr/lib/libpgtypes.* ${{targets.subpkgdir}}/usr/lib/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/pkgconfig
+          mv ${{targets.destdir}}/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig
+          mv ${{targets.destdir}}/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig
+    dependencies:
+      provider-priority: 12
+
   - name: postgresql-12-dev
     pipeline:
       - uses: split/dev

--- a/postgresql-13.yaml
+++ b/postgresql-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-13
   version: "13.14"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -52,6 +52,40 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: libecpg-13
+    description: PostgreSQL libraries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/libecpg.so* ${{targets.subpkgdir}}/usr/lib/
+    dependencies:
+      provider-priority: 13
+
+  - name: libecpg-13-dev
+    description: PostgreSQL libraries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/ecpg ${{targets.subpkgdir}}/usr/bin/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/include/postgresql
+          mv ${{targets.destdir}}/usr/include/ecpg*.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/postgresql/informix/* ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/pgtypes*.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sql3types.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sqlca.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sqlda*.h ${{targets.subpkgdir}}/usr/include/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.destdir}}/usr/lib/libecpg.* ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.destdir}}/usr/lib/libpgtypes.* ${{targets.subpkgdir}}/usr/lib/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/pkgconfig
+          mv ${{targets.destdir}}/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig
+          mv ${{targets.destdir}}/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig
+    dependencies:
+      provider-priority: 13
+
   - name: postgresql-13-dev
     pipeline:
       - uses: split/dev

--- a/postgresql-14.yaml
+++ b/postgresql-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-14
   version: "14.11"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -53,6 +53,40 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: libecpg-14
+    description: PostgreSQL libraries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/libecpg.so* ${{targets.subpkgdir}}/usr/lib/
+    dependencies:
+      provider-priority: 14
+
+  - name: libecpg-14-dev
+    description: PostgreSQL libraries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/ecpg ${{targets.subpkgdir}}/usr/bin/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/include/postgresql
+          mv ${{targets.destdir}}/usr/include/ecpg*.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/postgresql/informix/* ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/pgtypes*.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sql3types.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sqlca.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sqlda*.h ${{targets.subpkgdir}}/usr/include/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.destdir}}/usr/lib/libecpg.* ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.destdir}}/usr/lib/libpgtypes.* ${{targets.subpkgdir}}/usr/lib/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/pkgconfig
+          mv ${{targets.destdir}}/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig
+          mv ${{targets.destdir}}/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig
+    dependencies:
+      provider-priority: 14
+
   - name: postgresql-14-dev
     pipeline:
       - uses: split/dev

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-15
   version: "15.6"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -49,6 +49,40 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: libecpg-15
+    description: PostgreSQL libraries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/libecpg.so* ${{targets.subpkgdir}}/usr/lib/
+    dependencies:
+      provider-priority: 15
+
+  - name: libecpg-15-dev
+    description: PostgreSQL libraries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/ecpg ${{targets.subpkgdir}}/usr/bin/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/include/postgresql
+          mv ${{targets.destdir}}/usr/include/ecpg*.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/postgresql/informix/* ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/pgtypes*.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sql3types.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sqlca.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sqlda*.h ${{targets.subpkgdir}}/usr/include/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.destdir}}/usr/lib/libecpg.* ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.destdir}}/usr/lib/libpgtypes.* ${{targets.subpkgdir}}/usr/lib/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/pkgconfig
+          mv ${{targets.destdir}}/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig
+          mv ${{targets.destdir}}/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig
+    dependencies:
+      provider-priority: 15
+
   - name: postgresql-15-dev
     pipeline:
       - uses: split/dev

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.2"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -53,6 +53,40 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: libecpg-16
+    description: PostgreSQL libraries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/libecpg.so* ${{targets.subpkgdir}}/usr/lib/
+    dependencies:
+      provider-priority: 16
+
+  - name: libecpg-16-dev
+    description: PostgreSQL libraries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/ecpg ${{targets.subpkgdir}}/usr/bin/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/include
+          mv ${{targets.destdir}}/usr/include/ecpg*.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/postgresql/informix/* ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/pgtypes*.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sql3types.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sqlca.h ${{targets.subpkgdir}}/usr/include/
+          mv ${{targets.destdir}}/usr/include/sqlda*.h ${{targets.subpkgdir}}/usr/include/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.destdir}}/usr/lib/libecpg.* ${{targets.subpkgdir}}/usr/lib/
+          mv ${{targets.destdir}}/usr/lib/libpgtypes.* ${{targets.subpkgdir}}/usr/lib/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/pkgconfig
+          mv ${{targets.destdir}}/usr/lib/pkgconfig/libecpg.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig
+          mv ${{targets.destdir}}/usr/lib/pkgconfig/libpgtypes.pc ${{targets.subpkgdir}}/usr/lib/pkgconfig
+    dependencies:
+      provider-priority: 16
+
   - name: postgresql-16-dev
     pipeline:
       - uses: split/dev


### PR DESCRIPTION
This is split off in alpine, and some apps depend on it directly: https://github.com/apache/superset/blob/master/Dockerfile#L73C9-L73C16