### PR TITLE
argo-cd-2.10: tag moved to new commit

### DIFF
--- a/argo-cd-2.10.yaml
+++ b/argo-cd-2.10.yaml
@@ -24,7 +24,7 @@ pipeline:
     with:
       repository: https://github.com/argoproj/argo-cd
       tag: v${{package.version}}
-      expected-commit: 2268f08819545aef163434ce3c7a02cdca998960
+      expected-commit: a79e0eaca415461dc36615470cecc25d6d38cefb
 
   - uses: go/bump
     with:


### PR DESCRIPTION
https://github.com/argoproj/argo-cd/releases/tag/v2.10.1