### PR TITLE
trino: Exclude phoenix5 from plugins

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
   version: "439"
-  epoch: 0
+  epoch: 1
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0
@@ -89,7 +89,7 @@ data:
       mysql-event-listener: mysql-event-listener
       oracle: oracle
       password-authenticators: password-authenticators
-      phoenix5: phoenix5
+      # phoenix5: phoenix5 # phoenix5 is riddled with CVEs, so we're not including it.
       pinot: pinot
       postgresql: postgresql
       prometheus: prometheus


### PR DESCRIPTION
This subpackage is riddled with CVEs, and we don't need it!