### PR TITLE
withdraw argo-cd replaced by argo-cd-2.8

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -4,3 +4,7 @@ expat-dev-2.4.8-r2.apk
 expat-2.4.9-r0.apk
 expat-dev-2.4.9-r0.apk
 rustls-ffi-0.12.0-r0.apk
+argo-cd-2.8.0-r0.apk
+argo-cd-2.8.0-r1.apk
+argo-cd-2.8.1-r0.apk
+argo-cd-2.8.2-r0.apk

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,9 +1,3 @@
-tigera-operator-1.33.0-r0.apk
-expat-2.4.8-r2.apk
-expat-dev-2.4.8-r2.apk
-expat-2.4.9-r0.apk
-expat-dev-2.4.9-r0.apk
-rustls-ffi-0.12.0-r0.apk
 argo-cd-2.8.0-r0.apk
 argo-cd-2.8.0-r1.apk
 argo-cd-2.8.1-r0.apk


### PR DESCRIPTION
- withdraw argo-cd replaced by argo-cd-2.8


slack thread: https://chainguard-dev.slack.com/archives/C0636FTRFED/p1707910963696699


related to https://github.com/wolfi-dev/advisories/pull/1215 and https://github.com/wolfi-dev/advisories/pull/1393