### PR TITLE
Add JPEG2000 support and fix gdal version

### DIFF
--- a/gdal.yaml
+++ b/gdal.yaml
@@ -36,6 +36,7 @@ environment:
       - odbc-cpp-wrapper-dev
       - openblas-dev
       - opencl-dev
+      - openjpeg-dev
       - openssl-dev
       - pcre2-dev
       - proj-dev
@@ -50,11 +51,10 @@ environment:
       - zstd-dev
 
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://github.com/OSGeo/gdal
-      tag: v${{package.version}}
-      expected-commit: 654f4907abbbf6bf4226d58a8c067d134eaf3ce9
+      expected-sha256: f7a30387a8239e9da26200f787a02136df2ee6473e86b36d05ad682761a049ea
+      uri: https://github.com/OSGeo/gdal/releases/download/v${{package.version}}/gdal-${{package.version}}.tar.gz
 
   - uses: cmake/configure
 
@@ -85,6 +85,5 @@ subpackages:
 
 update:
   enabled: true
-  github:
-    identifier: OSGeo/gdal
-    strip-prefix: v
+  release-monitor:
+    identifier: 881

--- a/gdal.yaml
+++ b/gdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdal
   version: 3.8.3
-  epoch: 0
+  epoch: 1
   description: GDAL is an open source MIT licensed translator library for raster and vector geospatial data formats.
   copyright:
     - license: MIT


### PR DESCRIPTION
The cmake build system adds support for plugins when it can detect them in the build system. Adding openjpeg-dev will enable JPEG2000 support.

Switching from git-checkout to fetch resolves a separate issue in which the version (check with $gdal-config --version) returns the version with a "dev" suffix appended,, for instance "3.8.3dev" instead of "3.8.3". The gdal build setup adds "dev" even when the build is marked as a release if it detects a hidden git directory. When the .git directory is not present, we see the correct version string. https://github.com/OSGeo/gdal/blob/master/cmake/helpers/GdalVersion.cmake#L43-L47

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
