### PR TITLE
new package: less

### DIFF
--- a/less.yaml
+++ b/less.yaml
@@ -1,0 +1,80 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/less/APKBUILD
+package:
+  name: less
+  version: "650"
+  epoch: 0
+  description: File pager
+  copyright:
+    - license: GPL-3.0-or-later OR BSD-2-Clause
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - groff
+      - ncurses-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 898774b20b00eebac04e5f6db66c0c90532822ba
+      repository: https://github.com/gwsw/less
+      tag: v${{package.version}}
+
+  - runs: make -f Makefile.aut distfiles
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - name: Validate that lessecho runs
+      runs: |
+        # lessecho is really just internal help for less binary
+        # but this will show it can be executed and provides expected output.
+        expected='a\:b'
+        found=$(lessecho -m: a:b) || exit
+        [ "$expected" = "$found" ]
+    - name: Less shows --version
+      runs: |
+        out=$(less --version) || exit
+        expected="^less ${{package.version}} "
+        echo "$out" | grep -q "$expected" || {
+          echo "less --version did not contain '$expected'"
+          echo "$out"
+          exit 1
+        }
+    - name: Less --help exits 0
+      runs: |
+        less --help >stdout 2>stderr || exit 1
+        # stdout should be size > 0
+        [ -s stdout ] || exit 1
+        # stderr should be empty
+        [ -s stderr ] && exit 1
+
+subpackages:
+  - name: less-doc
+    pipeline:
+      - uses: split/manpages
+    description: less manpages
+
+update:
+  enabled: true
+  github:
+    identifier: gwsw/less
+    use-tag: true
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
