### PR TITLE
chore: Don't rebuild python packages on installation

### DIFF
--- a/aws-cli.yaml
+++ b/aws-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-cli
   version: 1.32.44
-  epoch: 0
+  epoch: 1
   description: "Universal Command Line Interface for Amazon Web Services"
   copyright:
     - license: Apache-2.0
@@ -39,7 +39,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/diffoscope.yaml
+++ b/diffoscope.yaml
@@ -1,7 +1,7 @@
 package:
   name: diffoscope
   version: "257"
-  epoch: 0
+  epoch: 1
   description: "In-depth comparison of files, archives, and directories."
   copyright:
     - license: GPL-3.0-or-later
@@ -34,7 +34,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/httpie.yaml
+++ b/httpie.yaml
@@ -1,7 +1,7 @@
 package:
   name: httpie
   version: 3.2.2
-  epoch: 2
+  epoch: 3
   description: "HTTPie for Terminal — modern, user-friendly command-line HTTP client for the API era. JSON support, colors, sessions, downloads, plugins & more."
   copyright:
     - license: BSD-3-Clause
@@ -31,7 +31,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/meson.yaml
+++ b/meson.yaml
@@ -1,7 +1,7 @@
 package:
   name: meson
   version: 1.3.2
-  epoch: 0
+  epoch: 1
   description: Fast and user friendly build system
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,7 @@ pipeline:
 
   - runs: python3 setup.py build
 
-  - runs: python3 setup.py install --prefix=/usr --root=${{targets.destdir}}
+  - runs: python3 setup.py install --prefix=/usr --root=${{targets.destdir}} --skip-build
 
 subpackages:
   - name: meson-doc

--- a/numpy.yaml
+++ b/numpy.yaml
@@ -1,7 +1,7 @@
 package:
   name: numpy
   version: 1.26.4
-  epoch: 0
+  epoch: 1
   description: "The fundamental package for scientific computing with Python."
   copyright:
     - license: BSD-3-Clause
@@ -40,7 +40,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/py3-appdirs.yaml
+++ b/py3-appdirs.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-appdirs
   version: 1.4.4
-  epoch: 4
+  epoch: 5
   description: "a small python module for appdir support"
   copyright:
     - license: MIT
@@ -29,7 +29,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/py3-asn1.yaml
+++ b/py3-asn1.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-asn1
   version: 0.4.8
-  epoch: 5
+  epoch: 6
   description: "Python3 ASN1 library"
   copyright:
     - license: BSD-2-Clause
@@ -29,7 +29,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/py3-botocore.yaml
+++ b/py3-botocore.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-botocore
   version: 1.34.44
-  epoch: 0
+  epoch: 1
   description: "The low-level, core functionality of Boto3"
   copyright:
     - license: Apache-2.0
@@ -33,7 +33,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/py3-certifi.yaml
+++ b/py3-certifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-certifi
   version: 2024.02.02
-  epoch: 0
+  epoch: 1
   description: "Python3 package for providing Mozilla's CA Bundle"
   copyright:
     - license: MPL-2.0
@@ -47,7 +47,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
       _py3ver=$(python3 -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
       sed -i 's/Version: ${{vars.normalized-package-version}}/Version: ${{package.version}}/' "${{targets.destdir}}"/usr/lib/python"$_py3ver"/site-packages/certifi-${{vars.normalized-package-version}}-py3.12.egg-info/PKG-INFO
 

--- a/py3-charset-normalizer.yaml
+++ b/py3-charset-normalizer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-charset-normalizer
   version: 3.3.2
-  epoch: 1
+  epoch: 2
   description: "offers you an alternative to Universal Charset Encoding Detector, also known as Chardet"
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/py3-contextlib2.yaml
+++ b/py3-contextlib2.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-contextlib2
   version: 21.6.0
-  epoch: 3
+  epoch: 4
   description: "backports of the contextlib module from newer versions of python"
   copyright:
     - license: PSF-2.0 AND Apache-2.0
@@ -29,7 +29,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/py3-jmespath.yaml
+++ b/py3-jmespath.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-jmespath
   version: 1.0.1
-  epoch: 3
+  epoch: 4
   description: "JMESPath is a query language for JSON"
   copyright:
     - license: MIT
@@ -29,7 +29,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/py3-ordered-set.yaml
+++ b/py3-ordered-set.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ordered-set
   version: 4.1.0
-  epoch: 1
+  epoch: 2
   description: "mutableset which remembers its order"
   copyright:
     - license: MIT
@@ -28,7 +28,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/py3-pluggy.yaml
+++ b/py3-pluggy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pluggy
   version: 1.4.0
-  epoch: 0
+  epoch: 1
   description: "Plugin management and hook calling for Python"
   copyright:
     - license: MIT
@@ -30,7 +30,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/py3-retrying.yaml
+++ b/py3-retrying.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-retrying
   version: 1.3.4
-  epoch: 3
+  epoch: 4
   description: "python 2 and 3 compatibility library"
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/py3-rsa.yaml
+++ b/py3-rsa.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rsa
   version: 4.9
-  epoch: 3
+  epoch: 4
   description: "Pure-Python3 RSA implementation"
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/py3-s3transfer.yaml
+++ b/py3-s3transfer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-s3transfer
   version: 0.10.0
-  epoch: 0
+  epoch: 1
   description: "Amazon S3 Transfer Manager for Python"
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/py3-six.yaml
+++ b/py3-six.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-six
   version: 1.16.0
-  epoch: 6
+  epoch: 7
   description: "python 2 and 3 compatibility library"
   copyright:
     - license: MIT
@@ -29,7 +29,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 

--- a/py3.12-setuptools.yaml
+++ b/py3.12-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.12-setuptools
   version: 69.1.0
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"
@@ -30,7 +30,7 @@ pipeline:
     runs: python setup.py build
 
   - name: Python Install
-    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
 update:
   enabled: true

--- a/suricata-update.yaml
+++ b/suricata-update.yaml
@@ -1,7 +1,7 @@
 package:
   name: suricata-update
   version: 1.2.7
-  epoch: 2
+  epoch: 3
   description: "The tool for updating your Suricata rules"
   copyright:
     - license: GPL-2.0-only
@@ -28,7 +28,7 @@ pipeline:
       python3 setup.py build
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
 
   - uses: strip
 


### PR DESCRIPTION
Fixes: All of these are built before installation. Installing these without the --skip-build flag will rebuild them again.

In most cases, this also slightly decreases the size of the package