### PR TITLE
chore(supervisor): Clean up dependencies

### DIFF
--- a/supervisor.yaml
+++ b/supervisor.yaml
@@ -1,28 +1,20 @@
 package:
   name: supervisor
   version: 4.2.5
-  epoch: 3
+  epoch: 4
   description: Supervisor process control system for Unix (supervisord)
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
-      - py3-pip
-      - py3-pkgconfig
-      - python3
+      - py3-setuptools
       - supervisor-config
 
 environment:
   contents:
     packages:
-      - bash
-      - build-base
       - busybox
-      - ca-certificates-bundle
-      - gcc
       - py3-pip
-      - python3-dev
-      - wolfi-base
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Fixes: Supervisor is dependent on py3-setuptools and python3. It does not need py3-pip.

Additionally, supervisor only needs py3-pip and busybox during the build process.