### PR TITLE
npm: Fix vulnerability

### DIFF
--- a/npm.yaml
+++ b/npm.yaml
@@ -1,7 +1,7 @@
 package:
   name: npm
   version: 10.4.0
-  epoch: 0
+  epoch: 1
   description: "the npm package manager for javascript, mainline"
   copyright:
     - license: Artistic-2.0
@@ -18,15 +18,29 @@ pipeline:
     with:
       uri: https://registry.npmjs.org/npm/-/npm-${{package.version}}.tgz
       expected-sha512: 452eccc743957d794e7102d178fb8321874509504f08d6a9587a650cafa687b18374ffd3be8af8a1cbb26d144f4af7dc45bdaf8d126dd5f1c2ab0ddcafca8009
+      delete: true
 
   - uses: patch
     with:
       patches: dont-check-for-last-version.patch
 
+  # Delete the ip package from the npm package to prepare for replacement.
+  - working-directory: /home/build/node_modules
+    runs: |
+      rm -rf ip
+
+  # Replace the ip package with the seal-security fork, which is a drop-in replacement
+  # that resolves a CVE.
+  - uses: fetch
+    working-directory: /home/build/node_modules/ip
+    with:
+      uri: https://registry.npmjs.org/@seal-security/ip/-/ip-2.0.0-sp-1.tgz
+      expected-sha512: 652901950df430b0d6f484fc12be69ca6e88b0c3223ad3a97441c510a438437a7858c959c85cc4d03d98ab920c4919401114497fe7436b8e5942392582e7ab4f
+      delete: true
+
   - runs: |
       # Wrapper scripts written in Bash and CMD.
       rm bin/npm bin/npx bin/*.cmd
-      #rm -rf bin/node-gyp-bin
       rm README.md
 
       # HTML docs
@@ -103,6 +117,10 @@ test:
       packages:
         - wolfi-base
         - nodejs
+    environment:
+      HOME: /home/build
   pipeline:
     - runs: |
         npm --version
+        npm install -g cowsay
+        cowsay Yay! It works!


### PR DESCRIPTION
- Fix CVE-2023-42282
- Remove extra `.tar.gz` in the package
- Fix test