### PR TITLE
opensearch: base modified docker entrypoint script off versioned upst…

### DIFF
--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -5,7 +5,7 @@
 package:
   name: opensearch-2
   version: 2.11.1
-  epoch: 6 # Remove CVE-2022-45146 patch when bumping to 2.12 or later
+  epoch: 7 # Remove CVE-2022-45146 patch when bumping to 2.12 or later
   description: Open source distributed and RESTful search engine.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
…ream script rather than latest

Based the script off 2.11.1 rather than HEAD as the script doesn't work with the versioned set of plugins otherwise https://github.com/opensearch-project/opensearch-build/blob/2.11.1/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
