### PR TITLE
Fix wasm-tools versioning scheme and bump versions.

### DIFF
--- a/wasm-tools.yaml
+++ b/wasm-tools.yaml
@@ -1,6 +1,6 @@
 package:
   name: wasm-tools
-  version: 1.0.60
+  version: 1.200.0
   epoch: 0
   description: "Low level tooling for WebAssembly in Rust"
   copyright:
@@ -20,8 +20,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/bytecodealliance/wasm-tools
-      tag: wasm-tools-${{package.version}}
-      expected-commit: 2573bb28cc897d64ce33739e3b46ac63c9588267
+      tag: v${{package.version}}
+      expected-commit: 69a397f99a3775c0a20a4ad68aaf193b85e23213
 
   - name: Configure and build
     runs: |
@@ -35,4 +35,5 @@ update:
   enabled: true
   github:
     identifier: bytecodealliance/wasm-tools
-    strip-prefix: wasm-tools-
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
Old version tags looked like `wasm-tools-1.0.60`, it changed to `v1.200.0`

