### PR TITLE
chore(packages): Split libssp from gcc

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 13.2.0
-  epoch: 4
+  epoch: 5
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later
@@ -185,6 +185,13 @@ subpackages:
 
           mv "${{targets.destdir}}"/usr/lib/libgccjit.so "${{targets.subpkgdir}}"/usr/lib/
           mv "${{targets.destdir}}"/usr/include/libgccjit*.h "${{targets.subpkgdir}}"/usr/include/
+
+  - name: "libssp"
+    description: "GCC stack protection library"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
+          mv "${{targets.destdir}}"/usr/lib64/libssp* "${{targets.subpkgdir}}"/usr/lib64
 
   - name: "libgomp"
     description: "GNU parallel programming library"


### PR DESCRIPTION
Fixes: This library functions standalone

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)