### PR TITLE
chore(avahi): Rebuild with libssp

### DIFF
--- a/avahi.yaml
+++ b/avahi.yaml
@@ -1,7 +1,7 @@
 package:
   name: avahi
   version: 0.9_rc1
-  epoch: 0
+  epoch: 1
   description: A multicast/unicast DNS-SD framework
   copyright:
     - license: LGPL-2.0-or-later


### PR DESCRIPTION
Fixes: Previously avahi brought in all of gcc when it only needed libssp