### PR TITLE
Use the wolfi signing key from the new location.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -165,22 +165,21 @@ jobs:
           path: /tmp/artifacts/
           name: packages-aarch64
 
-      - name: 'Authenticate to Google Cloud'
+      # This is managed here: https://github.com/chainguard-dev/secrets/blob/main/wolfi-dev.tf
+      - uses: google-github-actions/auth@a6e2e39c0a0331da29f7fd2c2a20a427e8d3ad1f # v2.1.1
         id: auth
-        uses: google-github-actions/auth@f6de81663f7788d05bd15bcce18f0e57f23f0846 # v2.0.1
         with:
-          workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
-          service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
-
+          workload_identity_provider: "projects/12758742386/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "wolfi-dev@chainguard-github-secrets.iam.gserviceaccount.com"
       - uses: google-github-actions/setup-gcloud@5a5f7b85fca43e76e53463acaa9d408a03c98d3a # v2.0.1
         with:
-          project_id: "prod-images-c6e5"
-
+          project_id: "chainguard-github-secrets"
       - uses: 'google-github-actions/get-secretmanager-secrets@ae0d4054c32840e2ced71207a9df55161ae3debc' # v2.0.0
         id: secrets
         with:
           secrets: |-
-            token:prod-images-c6e5/melange-signing-key
+            token:chainguard-github-secrets/wolfi-dev-signing-key
+
       - run: echo "${{ steps.secrets.outputs.token }}" > ./wolfi-signing.rsa
       - run: |
           mkdir -p /etc/apk/keys
@@ -207,6 +206,15 @@ jobs:
       # Clean up the signing key before uploading to storage out
       # of an abundance of caution.
       - run: rm ./wolfi-signing.rsa
+
+      # We use a different GSA for our interaction with GCS.
+      - uses: google-github-actions/auth@f6de81663f7788d05bd15bcce18f0e57f23f0846 # v2.0.1
+        with:
+          workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
+          service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
+      - uses: google-github-actions/setup-gcloud@5a5f7b85fca43e76e53463acaa9d408a03c98d3a # v2.0.1
+        with:
+          project_id: "prod-images-c6e5"
 
       - name: 'Upload packages to GCS'
         run: |

--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -27,22 +27,21 @@ jobs:
           docker run --rm -i -v $TMP:/out --entrypoint /bin/sh ghcr.io/wolfi-dev/sdk:latest@sha256:110c4bc0a8941606034ee7af12f1197b4a6b6f6434fd4b4bbf61de501e18ffd1 -c "cp /usr/bin/wolfictl /out"
           echo "$TMP" >> $GITHUB_PATH
 
-      - name: 'Authenticate to Google Cloud'
+      # This is managed here: https://github.com/chainguard-dev/secrets/blob/main/wolfi-dev.tf
+      - uses: google-github-actions/auth@a6e2e39c0a0331da29f7fd2c2a20a427e8d3ad1f # v2.1.1
         id: auth
-        uses: google-github-actions/auth@f6de81663f7788d05bd15bcce18f0e57f23f0846 # v2.0.1
         with:
-          workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
-          service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
-
+          workload_identity_provider: "projects/12758742386/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "wolfi-dev@chainguard-github-secrets.iam.gserviceaccount.com"
       - uses: google-github-actions/setup-gcloud@5a5f7b85fca43e76e53463acaa9d408a03c98d3a # v2.0.1
         with:
-          project_id: "prod-images-c6e5"
-
+          project_id: "chainguard-github-secrets"
       - uses: 'google-github-actions/get-secretmanager-secrets@ae0d4054c32840e2ced71207a9df55161ae3debc' # v2.0.0
         id: secrets
         with:
           secrets: |-
-            token:prod-images-c6e5/melange-signing-key
+            token:chainguard-github-secrets/wolfi-dev-signing-key
+
       - run: echo "${{ steps.secrets.outputs.token }}" > ./wolfi-signing.rsa
       - run: |
           sudo mkdir -p /etc/apk/keys
@@ -55,6 +54,15 @@ jobs:
             mkdir -p $arch
             curl https://packages.wolfi.dev/os/$arch/APKINDEX.tar.gz | wolfictl withdraw $(grep -v '\#' withdrawn-packages.txt) --signing-key="${{ github.workspace }}/wolfi-signing.rsa" > $arch/APKINDEX.tar.gz
           done
+
+      # We use a different GSA for our interaction with GCS.
+      - uses: google-github-actions/auth@f6de81663f7788d05bd15bcce18f0e57f23f0846 # v2.0.1
+        with:
+          workload_identity_provider: "projects/618116202522/locations/global/workloadIdentityPools/prod-shared-e350/providers/prod-shared-gha"
+          service_account: "prod-images-ci@prod-images-c6e5.iam.gserviceaccount.com"
+      - uses: google-github-actions/setup-gcloud@5a5f7b85fca43e76e53463acaa9d408a03c98d3a # v2.0.1
+        with:
+          project_id: "prod-images-c6e5"
 
       - name: Delete withdrawn packages
         run: |


### PR DESCRIPTION
ref: https://github.com/chainguard-dev/secrets/blob/main/wolfi-dev.tf
