### PR TITLE
Automatically package-append apk-tools to debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ MELANGE_OPTS += ${MELANGE_EXTRA_OPTS}
 
 # Enter interactive mode on failure for debug
 MELANGE_DEBUG_OPTS += --interactive
+MELANGE_DEBUG_OPTS += --package-append apk-tools
 MELANGE_DEBUG_OPTS += ${MELANGE_OPTS}
 
 # These are separate from MELANGE_OPTS because for building we need additional
@@ -184,7 +185,7 @@ dev-container:
 	    -v "${PWD}:${PWD}" \
 	    -w "${PWD}" \
 	    -e SOURCE_DATE_EPOCH=0 \
-	    ghcr.io/wolfi-dev/sdk:latest@sha256:110c4bc0a8941606034ee7af12f1197b4a6b6f6434fd4b4bbf61de501e18ffd1
+	    ghcr.io/wolfi-dev/sdk:latest@sha256:fad3eed9b19dc66976a553f29d1eccde3f32873e795aa1625b915947a3063e0e
 
 PACKAGES_CONTAINER_FOLDER ?= /work/packages
 TMP_REPOSITORIES_DIR := $(shell mktemp -d)
@@ -249,6 +250,6 @@ dev-container-wolfi:
 		--mount type=bind,source="${PWD}/local-melange.rsa.pub",destination="/etc/apk/keys/local-melange.rsa.pub",readonly \
 		--mount type=bind,source="$(TMP_REPOSITORIES_FILE)",destination="/etc/apk/repositories",readonly \
 		-w "$(PACKAGES_CONTAINER_FOLDER)" \
-		ghcr.io/wolfi-dev/sdk:latest@sha256:110c4bc0a8941606034ee7af12f1197b4a6b6f6434fd4b4bbf61de501e18ffd1
+		ghcr.io/wolfi-dev/sdk:latest@sha256:fad3eed9b19dc66976a553f29d1eccde3f32873e795aa1625b915947a3063e0e
 	@rm "$(TMP_REPOSITORIES_FILE)"
 	@rmdir "$(TMP_REPOSITORIES_DIR)"


### PR DESCRIPTION
This makes it possible to install any tools you would need when debugging a failure.