### PR TITLE
dotnet-6: Fix CVE-2024-0057

### DIFF
--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-6
-  version: 6.0.127
-  epoch: 0
+  version: 6.0.127 # We'll likely be able to remove the fix for CVE-2024-0057 at the next version.
+  epoch: 1
   description: ".NET SDK, version 6"
   copyright:
     - license: MIT
@@ -46,7 +46,7 @@ pipeline:
 
   - working-directory: /home/build/installer
     runs: |
-      ./build.sh /p:ArcadeBuildTarball=true /p:TarballDir=/home/build/src
+      ./build.sh --configuration Release /p:ArcadeBuildTarball=true /p:TarballDir=/home/build/src
 
   - working-directory: /home/build/src
     environment:

--- a/dotnet-6/installer/src/SourceBuild/tarball/patches/installer/0001-Bump-NuGet-client.patch
+++ b/dotnet-6/installer/src/SourceBuild/tarball/patches/installer/0001-Bump-NuGet-client.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Philippe Deslauriers <philde@chainguard.dev>
+Date: Tue, 20 Feb 2024 15:44:33 -0800
+Subject: [PATCH] Bump NuGet client
+
+Signed-off-by: Philippe Deslauriers <philde@chainguard.dev>
+---
+ eng/Version.Details.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/Version.Details.xml b/eng/Version.Details.xml
+index 816b9b949..9e6dbd509 100644
+--- a/eng/Version.Details.xml
++++ b/eng/Version.Details.xml
+@@ -153,7 +153,7 @@
+     </Dependency>
+     <Dependency Name="NuGet.Build.Tasks" Version="6.0.6-rc.4" CoherentParentDependency="Microsoft.NET.Sdk">
+       <Uri>https://dev.azure.com/devdiv/DevDiv/_git/NuGet-NuGet.Client-Trusted</Uri>
+-      <Sha>7fe6b814c901490292f02d8ea12749505fbb959a</Sha>
++      <Sha>71a0d504510294ddc78d989aa1eb8ffea94308ec</Sha>
+       <SourceBuildTarball RepoName="nuget-client" ManagedOnly="true" />
+     </Dependency>
+     <Dependency Name="Microsoft.ApplicationInsights" Version="2.19.0">


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
