### PR TITLE
kubeflow-pipelines-visualization-server: Fix CVE-2023-50447

### DIFF
--- a/kubeflow-pipelines-visualization-server.yaml
+++ b/kubeflow-pipelines-visualization-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines-visualization-server
   version: 2.0.5
-  epoch: 1
+  epoch: 2
   description: Machine Learning Pipelines for Kubeflow
   copyright:
     - license: Apache-2.0
@@ -32,7 +32,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: bump.patch
+      patches: 0001-Bump-dependencies.patch
 
   - runs: |
       ln -sf /usr/bin/python3.10 /usr/bin/python3

--- a/kubeflow-pipelines-visualization-server/0001-Bump-dependencies.patch
+++ b/kubeflow-pipelines-visualization-server/0001-Bump-dependencies.patch
@@ -1,3 +1,14 @@
+From 2f25db1035998e0a6a3c86a8cb0815611928b71a Mon Sep 17 00:00:00 2001
+From: Philippe Deslauriers <philde@chainguard.dev>
+Date: Tue, 20 Feb 2024 16:25:26 -0800
+Subject: [PATCH] Bump dependencies
+
+Signed-off-by: Philippe Deslauriers <philde@chainguard.dev>
+---
+ .../apiserver/visualization/requirements.in   |  16 +-
+ .../apiserver/visualization/requirements.txt  | 369 +++++++++++-------
+ 2 files changed, 229 insertions(+), 156 deletions(-)
+
 diff --git a/backend/src/apiserver/visualization/requirements.in b/backend/src/apiserver/visualization/requirements.in
 index 61ebd737b..7c75a8809 100644
 --- a/backend/src/apiserver/visualization/requirements.in
@@ -28,7 +39,7 @@ index 61ebd737b..7c75a8809 100644
  mistune<2.0.0
 \ No newline at end of file
 diff --git a/backend/src/apiserver/visualization/requirements.txt b/backend/src/apiserver/visualization/requirements.txt
-index bd95a0191..1f926ceeb 100644
+index bd95a0191..2355efd6c 100644
 --- a/backend/src/apiserver/visualization/requirements.txt
 +++ b/backend/src/apiserver/visualization/requirements.txt
 @@ -1,8 +1,8 @@
@@ -469,7 +480,7 @@ index bd95a0191..1f926ceeb 100644
 -pkgutil-resolve-name==1.3.10
 -    # via jsonschema
 -platformdirs==3.10.0
-+pillow==10.1.0
++pillow==10.2.0
 +    # via
 +    #   bokeh
 +    #   tensorflow-model-analysis
@@ -768,5 +779,8 @@ index bd95a0191..1f926ceeb 100644
 -zstandard==0.21.0
 +zstandard==0.22.0
      # via apache-beam
-
+ 
  # The following packages are considered to be unsafe in a requirements file:
+-- 
+2.43.0
+


### PR DESCRIPTION
Fix CVE-2023-50447 by updating the patch file to upgrade `pillow`