### PR TITLE
cassandra-4.1: move cassandra to version stream

### DIFF
--- a/cassandra-4.1.yaml
+++ b/cassandra-4.1.yaml
@@ -1,0 +1,84 @@
+package:
+  name: cassandra-4.1
+  version: 4.1.4
+  epoch: 0
+  description: Open Source NoSQL Database
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - python-3.11 # needed for cqlsh
+    provides:
+      - cassandra=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - ant
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - openjdk-11-default-jvm
+      - python-3.11
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-11-openjdk
+    CASSANDRA_USE_JDK11: true
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/cassandra
+      expected-commit: 99d9faeef57c9cf5240d11eac9db5b283e45a4f9
+      tag: cassandra-${{package.version}}
+
+  - uses: patch
+    with:
+      # Bumps snakeyaml and jackson-databind to mitigate a bunch of CVEs
+      patches: bumpdeps.patch
+
+  - runs: |
+      ant artifacts -Dversion=${{package.version}}
+
+      # Install cassandra from the tarball in build/dist into the destdir in /usr/share/java/cassandra
+      mkdir -p "${{targets.destdir}}"/usr/share/java/cassandra
+      tar --strip-components 1 -C "${{targets.destdir}}"/usr/share/java/cassandra -xzf build/apache-cassandra-${{package.version}}-bin.tar.gz
+
+      # Symlink everything in the cassandra bin directory into /usr/bin
+      mkdir -p "${{targets.destdir}}"/usr/bin/
+
+      for f in /home/build/build/dist/bin/*; do
+        filename=$(basename "$f")
+        ln -sf  /usr/share/java/cassandra/bin/"$filename" "${{targets.destdir}}"/usr/bin/"$filename"
+      done
+
+      mkdir -p ${{targets.destdir}}/var/lib/cassandra
+      mkdir -p ${{targets.destdir}}/var/log/cassandra
+
+      ln -sT /var/lib/cassandra/ "${{targets.destdir}}"/usr/share/java/cassandra/data
+      ln -sT /var/log/cassandra/ "${{targets.destdir}}"/usr/share/java/cassandra/logs
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          install -d ${{targets.subpkgdir}}/etc/cassandra
+          mkdir -p ${{targets.subpkgdir}}/opt
+          ln -sf /usr/share/java/cassandra ${{targets.subpkgdir}}/opt/cassandra
+
+update:
+  enabled: true
+  github:
+    identifier: apache/cassandra
+    use-tag: true
+    tag-filter-prefix: cassandra-4
+    strip-prefix: cassandra-
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+  pipeline:
+    - runs: |
+        cqlsh --version

--- a/cassandra-4.1/build.properties
+++ b/cassandra-4.1/build.properties
@@ -1,0 +1,1 @@
+artifact.remoteRepository.central=https://maven-central.storage-download.googleapis.com/repos/central/data/

--- a/cassandra-4.1/bumpdeps.patch
+++ b/cassandra-4.1/bumpdeps.patch
@@ -1,0 +1,22 @@
+diff --git a/build.xml b/build.xml
+index d2d5974cd6..34778edc10 100644
+--- a/build.xml
++++ b/build.xml
+@@ -555,7 +555,7 @@
+           <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.2.9"/>
+           <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.2.9"/>
+           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.13.2"/>
+-          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.13.2.2"/>
++          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.13.4.2"/>
+           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.13.2"/>
+           <dependency groupId="com.fasterxml.jackson.datatype" artifactId="jackson-datatype-jsr310" version="2.13.2"/>
+           <dependency groupId="com.fasterxml.jackson.dataformat" artifactId="jackson-dataformat-yaml" version="2.13.2"  scope="test">
+@@ -564,7 +564,7 @@
+           <dependency groupId="com.googlecode.json-simple" artifactId="json-simple" version="1.1"/>
+           <dependency groupId="com.boundary" artifactId="high-scale-lib" version="1.0.6"/>
+           <dependency groupId="com.github.jbellis" artifactId="jamm" version="${jamm.version}"/>
+-          <dependency groupId="org.yaml" artifactId="snakeyaml" version="1.26"/>
++          <dependency groupId="org.yaml" artifactId="snakeyaml" version="1.32"/>
+           <dependency groupId="junit" artifactId="junit" version="4.12" scope="test">
+             <exclusion groupId="org.hamcrest" artifactId="hamcrest-core"/>
+           </dependency>


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
