### PR TITLE
Add openmpi v5.0.2

### DIFF
--- a/openmpi.yaml
+++ b/openmpi.yaml
@@ -1,6 +1,6 @@
 package:
   name: openmpi
-  version: 5.0.2
+  version: 4.1.6
   epoch: 0
   description: Message passing library for high-performance computing
   target-architecture:
@@ -25,8 +25,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: ee46ad8eeee2c3ff70772160bff877cbf38c330a0bc3b3ddc811648b3396698f
-      uri: https://www.open-mpi.org/software/ompi/v5.0/downloads/openmpi-${{package.version}}.tar.bz2
+      expected-sha256: f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415
+      uri: https://www.open-mpi.org/software/ompi/v4.1/downloads/openmpi-${{package.version}}.tar.bz2
 
   - uses: autoconf/configure
 
@@ -51,7 +51,7 @@ subpackages:
     description: openmpi manpages
 
 update:
-  enabled: true
+  enabled: false
   github:
     identifier: open-mpi/ompi
     strip-prefix: v

--- a/openmpi.yaml
+++ b/openmpi.yaml
@@ -5,7 +5,7 @@ package:
   description: Message passing library for high-performance computing
   copyright:
     - license: BSD-3-Clause
-        
+
 environment:
   contents:
     packages:

--- a/openmpi.yaml
+++ b/openmpi.yaml
@@ -3,6 +3,8 @@ package:
   version: 5.0.2
   epoch: 0
   description: Message passing library for high-performance computing
+  target-architecture:
+    - x86_64
   copyright:
     - license: BSD-3-Clause
 

--- a/openmpi.yaml
+++ b/openmpi.yaml
@@ -1,0 +1,57 @@
+package:
+  name: openmpi
+  version: 5.0.2
+  epoch: 0
+  description: Message passing library for high-performance computing
+  copyright:
+    - license: BSD-3-Clause
+        
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gfortran
+      - hwloc-dev
+      - libevent-dev
+      - libgomp
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: ee46ad8eeee2c3ff70772160bff877cbf38c330a0bc3b3ddc811648b3396698f
+      uri: https://www.open-mpi.org/software/ompi/v5.0/downloads/openmpi-${{package.version}}.tar.bz2
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: openmpi-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - openmpi
+    description: openmpi dev
+
+  - name: openmpi-doc
+    pipeline:
+      - uses: split/manpages
+    description: openmpi manpages
+
+update:
+  enabled: true
+  github:
+    identifier: open-mpi/ompi
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
