### PR TITLE
bun/1.0.28 package version update

### DIFF
--- a/bun-bootstrap.yaml
+++ b/bun-bootstrap.yaml
@@ -1,6 +1,6 @@
 package:
   name: bun-bootstrap
-  version: 1.0.20
+  version: 1.0.23
   epoch: 0
   description: "Bun requires itself to bootstrap."
   copyright:

--- a/bun-bootstrap.yaml
+++ b/bun-bootstrap.yaml
@@ -17,7 +17,7 @@ environment:
 
 pipeline:
   - runs: |
-      curl -fsSL https://bun.sh/install | bash
+      curl -fsSL https://bun.sh/install | bash -s "bun-v${{package.version}}"
       mkdir -p ${{targets.destdir}}/usr/bin
       mv $HOME/.bun/bin/* ${{targets.destdir}}/usr/bin/
 

--- a/bun.yaml
+++ b/bun.yaml
@@ -1,6 +1,6 @@
 package:
   name: bun
-  version: 1.0.27
+  version: 1.0.28
   epoch: 0
   description: "Incredibly fast JavaScript runtime, bundler, test runner, and package manager - all in one"
   copyright:
@@ -40,7 +40,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/oven-sh/bun
-      expected-commit: c34bbb2e3fcaaadd8dfb5e75d545acee1c3cfd1b
+      expected-commit: 7056384702231f634e4e5d0f7c65965041314fc6
       tag: bun-v${{package.version}}
 
   # bun requires a specific zig to build


### PR DESCRIPTION
Fixes: #13319 

This issue was fixed in bun version `1.0.23` [upstream info](https://github.com/oven-sh/bun/issues/7617#issuecomment-1900013158). Here in the bun-bootstrap we are using the old version.

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

