### PR TITLE
add font-ipafont and font-unfonts-core

### DIFF
--- a/font-ipafont.yaml
+++ b/font-ipafont.yaml
@@ -1,0 +1,40 @@
+package:
+  name: font-ipafont
+  version: 0_git20240221
+  epoch: 0
+  description: IPA Fonts are JIS X 0213:2004 compliant OpenType fonts based on TrueType outlines.
+  copyright:
+    - license: IPA
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 14659e87866e5bfefd4a007dfb2263df814f9285e937df75d831ae45e2404643
+      uri: https://salsa.debian.org/fonts-team/fonts-ipafont/-/archive/207ccc6c3e920b22108c167e5e9e0769f07f60be/fonts-ipafont-master.tar.gz
+
+data:
+  - name: fonts
+    items:
+      gothic: ipag
+      mincho: ipam
+
+subpackages:
+  - range: fonts
+    name: ${{package.name}}-${{range.key}}
+    description: "${{package.name}}-${{range.key}} font"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/fonts/${{package.name}}
+          install -D -m644 ${{range.value}}*.ttf -t "${{targets.subpkgdir}}"/usr/share/fonts/${{package.name}}
+
+update:
+  enabled: false # No releases or tags

--- a/font-unfonts-core.yaml
+++ b/font-unfonts-core.yaml
@@ -1,0 +1,32 @@
+package:
+  name: font-unfonts-core
+  version: 0_git20240220
+  epoch: 0
+  description: Un-fonts is comes from the HLaTeX as type1 fonts in 1998 by Koaunghi Un
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: fc027dee883ba28cb49cc7a93ab8d03bb52a09b52a74fdc1d66aef6d7bcdede2
+      uri: https://salsa.debian.org/fonts-team/fonts-unfonts-core/-/archive/3074e56086ecfc806bd618da0ab917f4f3335f1f/fonts-unfonts-core-master.tar.gz
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/fonts/${{package.name}}
+
+      install -Dm644 ./*.ttf -t ${{targets.destdir}}/usr/share/fonts/${{package.name}}
+
+  - uses: strip
+
+update:
+  enabled: false # No releases or tags


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
