### PR TITLE
defualt to debug mode for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ MELANGE_TEST_OPTS += --arch ${ARCH}
 MELANGE_TEST_OPTS += --pipeline-dirs ./pipelines/
 MELANGE_TEST_OPTS += --repository-append https://packages.wolfi.dev/os
 MELANGE_TEST_OPTS += --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+MELANGE_TEST_OPTS += --debug
 MELANGE_TEST_OPTS += ${MELANGE_EXTRA_OPTS}
 
 ifeq (${USE_CACHE}, yes)


### PR DESCRIPTION
unlike for builds, running with `-x` is almost always desirable to see whats going on and what steps fail, this will also make debugging any CI failures easier too