### PR TITLE
gotenborg fonts

### DIFF
--- a/font-abyssinica.yaml
+++ b/font-abyssinica.yaml
@@ -1,0 +1,34 @@
+package:
+  name: font-abyssinica
+  version: 2.201
+  epoch: 0
+  description: A font for the Ethiopic script
+  copyright:
+    - license: OFL-1.0
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/silnrsi/font-abyssinica
+      expected-commit: 7f131e8bd54befb412caa9e4874e05fcfa8cde7c
+      tag: v${{package.version}}
+
+  - runs: |
+      pkgname=${{package.name}}
+      mkdir -p "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
+      install -D -m644 ./references/*.ttf "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
+
+update:
+  enabled: true
+  github:
+    identifier: silnrsi/font-abyssinica
+    strip-prefix: v

--- a/font-amiri.yaml
+++ b/font-amiri.yaml
@@ -1,0 +1,33 @@
+package:
+  name: font-amiri
+  version: 1.000
+  epoch: 0
+  description: Amiri (أميري) is a body text Naskh typeface
+  copyright:
+    - license: OFL-1.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/aliftype/amiri
+      expected-commit: 45969ca9131d4c4200be89b1b71b9ec5d897264a
+      tag: ${{package.version}}
+
+  - runs: |
+      pkgname=${{package.name}}
+      mkdir -p "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
+      install -D -m644 ./fonts/*.ttf "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
+
+update:
+  enabled: true
+  github:
+    identifier: aliftype/amiri

--- a/font-lklug.yaml
+++ b/font-lklug.yaml
@@ -1,0 +1,35 @@
+package:
+  name: font-lklug
+  version: 0.6.4
+  epoch: 0
+  description: fonts-lklug
+  copyright:
+    - license: GPL-2.0-or-later
+
+var-transforms:
+  - from: ${{package.version}}
+    match: \.(\d+)$
+    replace: -$1
+    to: mangled-package-version
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 2ad19b51ad8246d7fb94efaba58077744d7a1cc445146cbe95fb2abd1505d331
+      uri: https://salsa.debian.org/fonts-team/fonts-lklug-sinhala/-/archive/debian/${{vars.mangled-package-version}}/fonts-lklug-sinhala-debian-${{vars.mangled-package-version}}.tar.gz
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/share/fonts/
+      install -D -m644 lklug.ttf "${{targets.destdir}}"/usr/share/fonts/
+
+update:
+  enabled: false # No source to watch for the new versions

--- a/font-lohit-guru.yaml
+++ b/font-lohit-guru.yaml
@@ -1,0 +1,38 @@
+package:
+  name: font-lohit-guru
+  version: 2.91.2.3
+  epoch: 0
+  description: font-lohit-guru
+  copyright:
+    - license: OFL-1.1
+
+var-transforms:
+  - from: ${{package.version}}
+    match: \.(\d+)$
+    replace: -$1
+    to: mangled-package-version
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - fontforge
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 736062a41fb2650583b9886f71c2060540606223d3777c07a18ce116643aa6ed
+      uri: https://salsa.debian.org/fonts-team/fonts-lohit-pa/-/archive/debian/${{vars.mangled-package-version}}/fonts-lohit-pa-debian-${{vars.mangled-package-version}}.tar.gz
+
+  - runs: |
+      pkgname=${{package.name}}
+      mkdir -p "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
+      make ttf
+      install -D -m644 *.ttf "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
+
+update:
+  enabled: false # No source to watch for the new versions

--- a/font-lohit-knda.yaml
+++ b/font-lohit-knda.yaml
@@ -1,0 +1,38 @@
+package:
+  name: font-lohit-knda
+  version: 2.5.4.3
+  epoch: 0
+  description: font-lohit-knda
+  copyright:
+    - license: OFL-1.1
+
+var-transforms:
+  - from: ${{package.version}}
+    match: \.(\d+)$
+    replace: -$1
+    to: mangled-package-version
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - fontforge
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 55a96f2743f87d80e5319e7d39a4bc02d1a62f12498cec122be3b312347aa15b
+      uri: https://salsa.debian.org/fonts-team/fonts-lohit-kn/-/archive/debian/${{vars.mangled-package-version}}/fonts-lohit-kn-debian-${{vars.mangled-package-version}}.tar.gz
+
+  - runs: |
+      pkgname=${{package.name}}
+      mkdir -p "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
+      make ttf
+      install -D -m644 *.ttf "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
+
+update:
+  enabled: false # No source to watch for the new versions

--- a/font-padauk.yaml
+++ b/font-padauk.yaml
@@ -1,0 +1,40 @@
+package:
+  name: font-padauk
+  version: 5.001
+  epoch: 0
+  description: Padauk pan Myanmar font
+  copyright:
+    - license: OFL-1.0
+
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d+)\.\d+
+    replace: $1
+    to: mangled-package-version
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/silnrsi/font-padauk
+      expected-commit: 278b8efb03c0ca0d7f29fb3edc1f52489ebb384f
+      tag: v${{package.version}}
+
+  - runs: |
+      pkgname=${{package.name}}
+      mkdir -p "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
+      install -D -m644 ./references/v${{vars.mangled-package-version}}/*.ttf "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
+
+update:
+  enabled: true
+  github:
+    identifier: silnrsi/font-padauk
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
