### PR TITLE
bump ko to 0.15.2

### DIFF
--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
-  version: 0.15.1
-  epoch: 5
+  version: 0.15.2
+  epoch: 0
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0
@@ -19,14 +19,9 @@ pipeline:
   - uses: git-checkout
     with:
       destination: ko
-      expected-commit: 2e9e58b187e1092534fbfc9889a04725da4a403d
+      expected-commit: 348ca2d9731d3c19da9c785f06aac590954a7e27
       repository: https://github.com/ko-build/ko
       tag: v${{package.version}}
-
-  - uses: go/bump
-    with:
-      deps: golang.org/x/crypto@v0.17.0
-      modroot: ko
 
   - uses: go/build
     with:


### PR DESCRIPTION
Fixes: https://github.com/wolfi-dev/os/issues/13421

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
