### PR TITLE
first run of auto-test for python packages

### DIFF
--- a/py3-absl-py.yaml
+++ b/py3-absl-py.yaml
@@ -39,3 +39,21 @@ update:
   github:
     identifier: abseil/abseil-py
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="absl-py"
+        OUTPUT=$(python -c "import $LIBRARY" 2>&1)
+
+        if echo "$OUTPUT" | grep -q "No module named"; then
+            echo "Failed to import library '$LIBRARY'. Please check if it is installed."
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3-absl-py.yaml
+++ b/py3-absl-py.yaml
@@ -47,8 +47,8 @@ test:
         - busybox
   pipeline:
     - runs: |
-        LIBRARY="absl-py"
-        OUTPUT=$(python -c "import $LIBRARY" 2>&1)
+        LIBRARY="absl"
+        OUTPUT=$(python -c "from $LIBRARY import app" 2>&1)
 
         if echo "$OUTPUT" | grep -q "No module named"; then
             echo "Failed to import library '$LIBRARY'. Please check if it is installed."

--- a/py3-agate.yaml
+++ b/py3-agate.yaml
@@ -44,3 +44,21 @@ update:
   github:
     use-tag: true
     identifier: wireservice/agate
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="agate"
+        OUTPUT=$(python -c "import $LIBRARY" 2>&1)
+
+        if echo "$OUTPUT" | grep -q "No module named"; then
+            echo "Failed to import library '$LIBRARY'. Please check if it is installed."
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3-aiofiles.yaml
+++ b/py3-aiofiles.yaml
@@ -33,3 +33,21 @@ update:
   enabled: true
   release-monitor:
     identifier: 12743
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="aiofiles"
+        OUTPUT=$(python -c "import $LIBRARY" 2>&1)
+
+        if echo "$OUTPUT" | grep -q "No module named"; then
+            echo "Failed to import library '$LIBRARY'. Please check if it is installed."
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3-aiohttp.yaml
+++ b/py3-aiohttp.yaml
@@ -72,3 +72,21 @@ update:
   enabled: true
   release-monitor:
     identifier: 6713
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="aiohttp"
+        OUTPUT=$(python -c "import $LIBRARY" 2>&1)
+
+        if echo "$OUTPUT" | grep -q "No module named"; then
+            echo "Failed to import library '$LIBRARY'. Please check if it is installed."
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3-aiosignal.yaml
+++ b/py3-aiosignal.yaml
@@ -39,3 +39,21 @@ update:
   enabled: true
   release-monitor:
     identifier: 41889
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="aiosignal"
+        OUTPUT=$(python -c "import $LIBRARY" 2>&1)
+
+        if echo "$OUTPUT" | grep -q "No module named"; then
+            echo "Failed to import library '$LIBRARY'. Please check if it is installed."
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi


### PR DESCRIPTION
I wrote a short script to automatically add a simple/standard test to our Python packages.  I ran it across 5 python packages to start.  If everyone is cool with this I'll run it in batches on the remaining 500+ python packages.

```
: python3 auto-package.py --help
usage: auto-package.py [-h] -d DIRECTORY -n NUMBER

Append a test block to YAML files based on the file name and format with yam.

options:
  -h, --help            show this help message and exit
  -d DIRECTORY, --directory DIRECTORY
                        Directory containing YAML files
  -n NUMBER, --number NUMBER
                        Number of files to process
```

Script: https://github.com/chainguard-dev/quality-squad/tree/main/scripts/auto-package-test

