### PR TITLE
py3-pycparser: add build-time unit tests

### DIFF
--- a/py3-pycparser.yaml
+++ b/py3-pycparser.yaml
@@ -33,6 +33,9 @@ pipeline:
   - name: Python Install
     runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
 
+  - name: Python Unit Test
+    runs: python setup.py test -s tests
+
   - uses: strip
 
 update:


### PR DESCRIPTION
Fixes:
* Execute build time unit-tests, this automatically verifies that new source update is operation beyond just importing the module 

Related:
* Potentially calls like that can be factored out into pipeline that all python packages share

New Output during the build:

```console
...
2024/02/22 11:35:28 INFO running step "Python Unit Test"
2024/02/22 11:35:28 INFO executing: bwrap --bind /tmp/melange-guest-269397680 / --bind /tmp/melange-workspace-2362052663 /home/build --bind /etc/resolv.conf /etc/resolv.conf --unshare-pid --die-with-parent --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv GOMODCACHE /var/cache/melange/gomodcache --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv GOFLAGS  --setenv HOME /home/build --setenv SOURCE_DATE_EPOCH 0 --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell --setenv GOTOOLCHAIN local --setenv GOPATH /home/build/.cache/go --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap /bin/sh -c set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
python setup.py test -s tests
exit 0
2024/02/22 11:35:28 WARN WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
2024/02/22 11:35:28 INFO running test
2024/02/22 11:35:28 WARN /usr/lib/python3.12/site-packages/setuptools/command/test.py:193: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
2024/02/22 11:35:28 WARN !!
2024/02/22 11:35:28 WARN
2024/02/22 11:35:28 WARN         ********************************************************************************
2024/02/22 11:35:28 WARN         Requirements should be satisfied by a PEP 517 installer.
2024/02/22 11:35:28 WARN         If you are using pip, you can try `pip install --use-pep517`.
2024/02/22 11:35:28 WARN         ********************************************************************************
2024/02/22 11:35:28 WARN
2024/02/22 11:35:28 WARN !!
2024/02/22 11:35:28 WARN   ir_d = dist.fetch_build_eggs(dist.install_requires)
2024/02/22 11:35:28 WARN WARNING: The wheel package is not available.
2024/02/22 11:35:28 WARN /usr/lib/python3.12/site-packages/setuptools/command/test.py:194: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
2024/02/22 11:35:28 WARN !!
2024/02/22 11:35:28 WARN
2024/02/22 11:35:28 WARN         ********************************************************************************
2024/02/22 11:35:28 WARN         Requirements should be satisfied by a PEP 517 installer.
2024/02/22 11:35:28 WARN         If you are using pip, you can try `pip install --use-pep517`.
2024/02/22 11:35:28 WARN         ********************************************************************************
2024/02/22 11:35:28 WARN
2024/02/22 11:35:28 WARN !!
2024/02/22 11:35:28 WARN   tr_d = dist.fetch_build_eggs(dist.tests_require or [])
2024/02/22 11:35:28 WARN WARNING: The wheel package is not available.
2024/02/22 11:35:28 INFO running egg_info
2024/02/22 11:35:28 INFO writing pycparser.egg-info/PKG-INFO
2024/02/22 11:35:28 INFO writing dependency_links to pycparser.egg-info/dependency_links.txt
2024/02/22 11:35:28 INFO writing top-level names to pycparser.egg-info/top_level.txt
2024/02/22 11:35:28 WARN /usr/lib/python3.12/site-packages/setuptools/command/test.py:195: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
2024/02/22 11:35:28 WARN !!
2024/02/22 11:35:28 WARN
2024/02/22 11:35:28 WARN         ********************************************************************************
2024/02/22 11:35:28 WARN         Requirements should be satisfied by a PEP 517 installer.
2024/02/22 11:35:28 WARN         If you are using pip, you can try `pip install --use-pep517`.
2024/02/22 11:35:28 WARN         ********************************************************************************
2024/02/22 11:35:28 WARN
2024/02/22 11:35:28 WARN !!
2024/02/22 11:35:28 WARN   er_d = dist.fetch_build_eggs(
2024/02/22 11:35:28 WARN WARNING: The wheel package is not available.
2024/02/22 11:35:28 INFO reading manifest file 'pycparser.egg-info/SOURCES.txt'
2024/02/22 11:35:28 INFO reading manifest template 'MANIFEST.in'
2024/02/22 11:35:28 WARN warning: no previously-included files found matching 'setup.pyc'
2024/02/22 11:35:28 WARN warning: no previously-included files matching 'yacctab.*' found under directory 'tests'
2024/02/22 11:35:28 WARN warning: no previously-included files matching 'lextab.*' found under directory 'tests'
2024/02/22 11:35:28 WARN warning: no previously-included files matching 'yacctab.*' found under directory 'examples'
2024/02/22 11:35:28 INFO adding license file 'LICENSE'
2024/02/22 11:35:28 WARN warning: no previously-included files matching 'lextab.*' found under directory 'examples'
2024/02/22 11:35:28 INFO writing manifest file 'pycparser.egg-info/SOURCES.txt'
2024/02/22 11:35:28 INFO running build_ext
2024/02/22 11:35:28 WARN Generating LALR tables
2024/02/22 11:35:29 WARN WARNING: 79 shift/reduce conflicts
2024/02/22 11:35:29 WARN WARNING: 37 reduce/reduce conflicts
2024/02/22 11:35:29 WARN WARNING: reduce/reduce conflict in state 33 resolved using rule (type_specifier -> atomic_specifier)
2024/02/22 11:35:29 WARN WARNING: rejected rule (empty -> <empty>) in state 33
2024/02/22 11:35:29 WARN WARNING: reduce/reduce conflict in state 70 resolved using rule (type_specifier -> atomic_specifier)
2024/02/22 11:35:29 WARN WARNING: rejected rule (empty -> <empty>) in state 70
2024/02/22 11:35:29 WARN WARNING: reduce/reduce conflict in state 365 resolved using rule (statement -> pppragma_directive)
2024/02/22 11:35:29 WARN WARNING: rejected rule (empty -> <empty>) in state 365
2024/02/22 11:35:29 WARN test_repr (tests.test_c_ast.TestNodeVisitor.test_repr) ... ok
2024/02/22 11:35:29 WARN test_scalar_children (tests.test_c_ast.TestNodeVisitor.test_scalar_children) ... ok
2024/02/22 11:35:29 WARN tests_list_children (tests.test_c_ast.TestNodeVisitor.tests_list_children) ... ok
2024/02/22 11:35:29 WARN test_BinaryOp (tests.test_c_ast.Test_c_ast.test_BinaryOp) ... ok
2024/02/22 11:35:29 WARN test_weakref_works_on_coord (tests.test_c_ast.Test_c_ast.test_weakref_works_on_coord) ... ok
2024/02/22 11:35:29 WARN test_weakref_works_on_nodes (tests.test_c_ast.Test_c_ast.test_weakref_works_on_nodes) ... ok
2024/02/22 11:35:29 WARN test_FileAST (tests.test_c_parser.TestCParser_fundamentals.test_FileAST) ... ok
2024/02/22 11:35:29 WARN test_alignof (tests.test_c_parser.TestCParser_fundamentals.test_alignof) ... ok
2024/02/22 11:35:29 WARN test_anonymous_struct_union (tests.test_c_parser.TestCParser_fundamentals.test_anonymous_struct_union) ... ok
2024/02/22 11:35:29 WARN test_atomic_specifier (tests.test_c_parser.TestCParser_fundamentals.test_atomic_specifier) ... ok
2024/02/22 11:35:29 WARN test_compound_literals (tests.test_c_parser.TestCParser_fundamentals.test_compound_literals) ... ok
2024/02/22 11:35:29 WARN test_compound_statement (tests.test_c_parser.TestCParser_fundamentals.test_compound_statement) ... ok
2024/02/22 11:35:29 WARN test_coords (tests.test_c_parser.TestCParser_fundamentals.test_coords)
2024/02/22 11:35:29 WARN Tests the "coordinates" of parsed elements - file ... ok
2024/02/22 11:35:29 WARN test_decl_inits (tests.test_c_parser.TestCParser_fundamentals.test_decl_inits) ... ok
2024/02/22 11:35:29 WARN test_decl_named_inits (tests.test_c_parser.TestCParser_fundamentals.test_decl_named_inits) ... ok
2024/02/22 11:35:29 WARN test_duplicate_typedef (tests.test_c_parser.TestCParser_fundamentals.test_duplicate_typedef)
2024/02/22 11:35:29 WARN Tests that redeclarations of existing types are parsed correctly. ... ok
2024/02/22 11:35:29 WARN test_empty_toplevel_decl (tests.test_c_parser.TestCParser_fundamentals.test_empty_toplevel_decl) ... ok
2024/02/22 11:35:29 WARN test_enums (tests.test_c_parser.TestCParser_fundamentals.test_enums) ... ok
2024/02/22 11:35:29 WARN test_forloop_coord (tests.test_c_parser.TestCParser_fundamentals.test_forloop_coord) ... ok
2024/02/22 11:35:29 WARN test_func_decls_with_array_dim_qualifiers (tests.test_c_parser.TestCParser_fundamentals.test_func_decls_with_array_dim_qualifiers) ... ok
2024/02/22 11:35:29 WARN test_function_definitions (tests.test_c_parser.TestCParser_fundamentals.test_function_definitions) ... ok
2024/02/22 11:35:29 WARN test_initial_semi (tests.test_c_parser.TestCParser_fundamentals.test_initial_semi) ... ok
2024/02/22 11:35:29 WARN test_inline_specifier (tests.test_c_parser.TestCParser_fundamentals.test_inline_specifier) ... ok
2024/02/22 11:35:29 WARN test_int128 (tests.test_c_parser.TestCParser_fundamentals.test_int128) ... ok
2024/02/22 11:35:29 WARN test_invalid_multiple_types_error (tests.test_c_parser.TestCParser_fundamentals.test_invalid_multiple_types_error) ... ok
2024/02/22 11:35:29 WARN test_invalid_typedef_storage_qual_error (tests.test_c_parser.TestCParser_fundamentals.test_invalid_typedef_storage_qual_error)
2024/02/22 11:35:29 WARN Tests that using typedef as a storage qualifier is correctly flagged ... ok
2024/02/22 11:35:29 WARN test_multi_decls (tests.test_c_parser.TestCParser_fundamentals.test_multi_decls) ... ok
2024/02/22 11:35:29 WARN test_nested_decls (tests.test_c_parser.TestCParser_fundamentals.test_nested_decls) ... ok
2024/02/22 11:35:29 WARN test_noreturn_specifier (tests.test_c_parser.TestCParser_fundamentals.test_noreturn_specifier) ... ok
2024/02/22 11:35:29 WARN test_offsetof (tests.test_c_parser.TestCParser_fundamentals.test_offsetof) ... ok
2024/02/22 11:35:29 WARN test_parenthesized_compounds (tests.test_c_parser.TestCParser_fundamentals.test_parenthesized_compounds) ... ok
2024/02/22 11:35:29 WARN test_pragma (tests.test_c_parser.TestCParser_fundamentals.test_pragma) ... ok
2024/02/22 11:35:29 WARN test_pragmacomp_or_statement (tests.test_c_parser.TestCParser_fundamentals.test_pragmacomp_or_statement) ... ok
2024/02/22 11:35:29 WARN test_qualifiers_storage_specifiers (tests.test_c_parser.TestCParser_fundamentals.test_qualifiers_storage_specifiers) ... ok
2024/02/22 11:35:29 WARN test_simple_decls (tests.test_c_parser.TestCParser_fundamentals.test_simple_decls) ... ok
2024/02/22 11:35:29 WARN test_sizeof (tests.test_c_parser.TestCParser_fundamentals.test_sizeof) ... ok
2024/02/22 11:35:29 WARN test_static_assert (tests.test_c_parser.TestCParser_fundamentals.test_static_assert) ... ok
2024/02/22 11:35:29 WARN test_struct_bitfields (tests.test_c_parser.TestCParser_fundamentals.test_struct_bitfields) ... ok
2024/02/22 11:35:29 WARN test_struct_empty (tests.test_c_parser.TestCParser_fundamentals.test_struct_empty)
2024/02/22 11:35:29 WARN Tests that parsing an empty struct works. ... ok
2024/02/22 11:35:29 WARN test_struct_enum (tests.test_c_parser.TestCParser_fundamentals.test_struct_enum) ... ok
2024/02/22 11:35:29 WARN test_struct_members_namespace (tests.test_c_parser.TestCParser_fundamentals.test_struct_members_namespace)
2024/02/22 11:35:29 WARN Tests that structure/union member names reside in a separate ... ok
2024/02/22 11:35:29 WARN test_struct_union (tests.test_c_parser.TestCParser_fundamentals.test_struct_union) ... ok
2024/02/22 11:35:29 WARN test_struct_with_extra_semis_inside (tests.test_c_parser.TestCParser_fundamentals.test_struct_with_extra_semis_inside) ... ok
2024/02/22 11:35:29 WARN test_struct_with_initial_semi (tests.test_c_parser.TestCParser_fundamentals.test_struct_with_initial_semi) ... ok
2024/02/22 11:35:29 WARN test_tags_namespace (tests.test_c_parser.TestCParser_fundamentals.test_tags_namespace)
2024/02/22 11:35:29 WARN Tests that the tags of structs/unions/enums reside in a separate namespace and ... ok
2024/02/22 11:35:29 WARN test_typedef (tests.test_c_parser.TestCParser_fundamentals.test_typedef) ... ok
2024/02/22 11:35:29 WARN test_unified_string_literals (tests.test_c_parser.TestCParser_fundamentals.test_unified_string_literals) ... ok
2024/02/22 11:35:29 WARN test_unified_wstring_literals (tests.test_c_parser.TestCParser_fundamentals.test_unified_wstring_literals) ... ok
2024/02/22 11:35:29 WARN test_vla (tests.test_c_parser.TestCParser_fundamentals.test_vla) ... ok
2024/02/22 11:35:29 WARN test_ambiguous_parameters (tests.test_c_parser.TestCParser_typenames.test_ambiguous_parameters) ... ok
2024/02/22 11:35:29 WARN test_innerscope_reuse_typedef_name (tests.test_c_parser.TestCParser_typenames.test_innerscope_reuse_typedef_name) ... ok
2024/02/22 11:35:29 WARN test_innerscope_typedef (tests.test_c_parser.TestCParser_typenames.test_innerscope_typedef) ... ok
2024/02/22 11:35:29 WARN test_nested_function_decls (tests.test_c_parser.TestCParser_typenames.test_nested_function_decls) ... ok
2024/02/22 11:35:29 WARN test_parameter_reuse_typedef_name (tests.test_c_parser.TestCParser_typenames.test_parameter_reuse_typedef_name) ... ok
2024/02/22 11:35:29 WARN test_samescope_reuse_name (tests.test_c_parser.TestCParser_typenames.test_samescope_reuse_name) ... ok
2024/02/22 11:35:29 WARN test_empty_statements (tests.test_c_parser.TestCParser_whole_code.test_empty_statements) ... ok
2024/02/22 11:35:29 WARN test_expressions (tests.test_c_parser.TestCParser_whole_code.test_expressions) ... ok
2024/02/22 11:35:29 WARN test_for_statement (tests.test_c_parser.TestCParser_whole_code.test_for_statement) ... ok
2024/02/22 11:35:29 WARN test_statements (tests.test_c_parser.TestCParser_whole_code.test_statements) ... ok
2024/02/22 11:35:29 WARN test_switch_statement (tests.test_c_parser.TestCParser_whole_code.test_switch_statement) ... ok
2024/02/22 11:35:29 WARN test_whole_file (tests.test_c_parser.TestCParser_whole_code.test_whole_file) ... ok
2024/02/22 11:35:29 WARN test_whole_file_with_stdio (tests.test_c_parser.TestCParser_whole_code.test_whole_file_with_stdio) ... ok
2024/02/22 11:35:29 WARN test_char_constants (tests.test_c_lexer.TestCLexerErrors.test_char_constants) ... ok
2024/02/22 11:35:29 WARN test_integer_constants (tests.test_c_lexer.TestCLexerErrors.test_integer_constants) ... ok
2024/02/22 11:35:29 WARN test_preprocessor (tests.test_c_lexer.TestCLexerErrors.test_preprocessor) ... ok
2024/02/22 11:35:29 WARN test_string_literals (tests.test_c_lexer.TestCLexerErrors.test_string_literals) ... ok
2024/02/22 11:35:29 WARN test_trivial_tokens (tests.test_c_lexer.TestCLexerErrors.test_trivial_tokens) ... ok
2024/02/22 11:35:29 WARN test_char_constants (tests.test_c_lexer.TestCLexerNoErrors.test_char_constants) ... ok
2024/02/22 11:35:29 WARN test_exprs (tests.test_c_lexer.TestCLexerNoErrors.test_exprs) ... ok
2024/02/22 11:35:29 WARN test_floating_constants (tests.test_c_lexer.TestCLexerNoErrors.test_floating_constants) ... ok
2024/02/22 11:35:29 WARN test_hexadecimal_floating_constants (tests.test_c_lexer.TestCLexerNoErrors.test_hexadecimal_floating_constants) ... ok
2024/02/22 11:35:29 WARN test_id_typeid (tests.test_c_lexer.TestCLexerNoErrors.test_id_typeid) ... ok
2024/02/22 11:35:29 WARN test_integer_constants (tests.test_c_lexer.TestCLexerNoErrors.test_integer_constants) ... ok
2024/02/22 11:35:29 WARN test_mess (tests.test_c_lexer.TestCLexerNoErrors.test_mess) ... ok
2024/02/22 11:35:29 WARN test_new_keywords (tests.test_c_lexer.TestCLexerNoErrors.test_new_keywords) ... ok
2024/02/22 11:35:29 WARN test_on_rbrace_lbrace (tests.test_c_lexer.TestCLexerNoErrors.test_on_rbrace_lbrace) ... ok
2024/02/22 11:35:29 WARN test_preprocessor_line (tests.test_c_lexer.TestCLexerNoErrors.test_preprocessor_line) ... ok
2024/02/22 11:35:29 WARN test_preprocessor_line_funny (tests.test_c_lexer.TestCLexerNoErrors.test_preprocessor_line_funny) ... ok
2024/02/22 11:35:29 WARN test_preprocessor_pragma (tests.test_c_lexer.TestCLexerNoErrors.test_preprocessor_pragma) ... ok
2024/02/22 11:35:29 WARN test_special_names (tests.test_c_lexer.TestCLexerNoErrors.test_special_names) ... ok
2024/02/22 11:35:29 WARN test_statements (tests.test_c_lexer.TestCLexerNoErrors.test_statements) ... ok
2024/02/22 11:35:29 WARN test_string_literal (tests.test_c_lexer.TestCLexerNoErrors.test_string_literal) ... ok
2024/02/22 11:35:29 WARN test_trivial_tokens (tests.test_c_lexer.TestCLexerNoErrors.test_trivial_tokens) ... ok
2024/02/22 11:35:29 WARN test_nested_else_if_line_breaks (tests.test_c_generator.TestCasttoC.test_nested_else_if_line_breaks) ... ok
2024/02/22 11:35:29 WARN test_to_type (tests.test_c_generator.TestCasttoC.test_to_type) ... ok
2024/02/22 11:35:29 WARN test_to_type_with_cpp (tests.test_c_generator.TestCasttoC.test_to_type_with_cpp) ... ok
2024/02/22 11:35:29 WARN test_alignment (tests.test_c_generator.TestCtoC.test_alignment) ... ok
2024/02/22 11:35:29 WARN test_array_decl (tests.test_c_generator.TestCtoC.test_array_decl) ... ok
2024/02/22 11:35:29 WARN test_atomic_qual (tests.test_c_generator.TestCtoC.test_atomic_qual) ... ok
2024/02/22 11:35:29 WARN test_casts (tests.test_c_generator.TestCtoC.test_casts) ... ok
2024/02/22 11:35:29 WARN test_comma_op_assignment (tests.test_c_generator.TestCtoC.test_comma_op_assignment) ... ok
2024/02/22 11:35:29 WARN test_comma_op_in_ternary (tests.test_c_generator.TestCtoC.test_comma_op_in_ternary) ... ok
2024/02/22 11:35:29 WARN test_comma_operator_funcarg (tests.test_c_generator.TestCtoC.test_comma_operator_funcarg) ... ok
2024/02/22 11:35:29 WARN test_complex_decls (tests.test_c_generator.TestCtoC.test_complex_decls) ... ok
2024/02/22 11:35:29 WARN test_compound_literal (tests.test_c_generator.TestCtoC.test_compound_literal) ... ok
2024/02/22 11:35:29 WARN test_enum (tests.test_c_generator.TestCtoC.test_enum) ... ok
2024/02/22 11:35:29 WARN test_enum_typedef (tests.test_c_generator.TestCtoC.test_enum_typedef) ... ok
2024/02/22 11:35:29 WARN test_expr_list_in_initializer_list (tests.test_c_generator.TestCtoC.test_expr_list_in_initializer_list) ... ok
2024/02/22 11:35:29 WARN test_exprlist_with_semi (tests.test_c_generator.TestCtoC.test_exprlist_with_semi) ... ok
2024/02/22 11:35:29 WARN test_exprlist_with_subexprlist (tests.test_c_generator.TestCtoC.test_exprlist_with_subexprlist) ... ok
2024/02/22 11:35:29 WARN test_exprs (tests.test_c_generator.TestCtoC.test_exprs) ... ok
2024/02/22 11:35:29 WARN test_generate_struct_union_enum_exception (tests.test_c_generator.TestCtoC.test_generate_struct_union_enum_exception) ... ok
2024/02/22 11:35:29 WARN test_initlist (tests.test_c_generator.TestCtoC.test_initlist) ... ok
2024/02/22 11:35:29 WARN test_issue246 (tests.test_c_generator.TestCtoC.test_issue246) ... ok
2024/02/22 11:35:29 WARN test_issue36 (tests.test_c_generator.TestCtoC.test_issue36) ... ok
2024/02/22 11:35:29 WARN test_issue37 (tests.test_c_generator.TestCtoC.test_issue37) ... ok
2024/02/22 11:35:29 WARN test_issue66 (tests.test_c_generator.TestCtoC.test_issue66) ... ok
2024/02/22 11:35:29 WARN test_issue83 (tests.test_c_generator.TestCtoC.test_issue83) ... ok
2024/02/22 11:35:29 WARN test_issue84 (tests.test_c_generator.TestCtoC.test_issue84) ... ok
2024/02/22 11:35:29 WARN test_krstyle (tests.test_c_generator.TestCtoC.test_krstyle) ... ok
2024/02/22 11:35:29 WARN test_nest_initializer_list (tests.test_c_generator.TestCtoC.test_nest_initializer_list) ... ok
2024/02/22 11:35:29 WARN test_nest_named_initializer (tests.test_c_generator.TestCtoC.test_nest_named_initializer) ... ok
2024/02/22 11:35:29 WARN test_nested_sizeof (tests.test_c_generator.TestCtoC.test_nested_sizeof) ... ok
2024/02/22 11:35:29 WARN test_noreturn (tests.test_c_generator.TestCtoC.test_noreturn) ... ok
2024/02/22 11:35:29 WARN test_pragma (tests.test_c_generator.TestCtoC.test_pragma) ... ok
2024/02/22 11:35:29 WARN test_ptr_decl (tests.test_c_generator.TestCtoC.test_ptr_decl) ... ok
2024/02/22 11:35:29 WARN test_reduce_parentheses_binaryops (tests.test_c_generator.TestCtoC.test_reduce_parentheses_binaryops) ... ok
2024/02/22 11:35:29 WARN test_statements (tests.test_c_generator.TestCtoC.test_statements) ... ok
2024/02/22 11:35:29 WARN test_static_assert (tests.test_c_generator.TestCtoC.test_static_assert) ... ok
2024/02/22 11:35:29 WARN test_struct_decl (tests.test_c_generator.TestCtoC.test_struct_decl) ... ok
2024/02/22 11:35:29 WARN test_switchcase (tests.test_c_generator.TestCtoC.test_switchcase) ... ok
2024/02/22 11:35:29 WARN test_ternary (tests.test_c_generator.TestCtoC.test_ternary) ... ok
2024/02/22 11:35:29 WARN test_trivial_decls (tests.test_c_generator.TestCtoC.test_trivial_decls) ... ok
2024/02/22 11:35:29 WARN test_partial_funcdecl_generation (tests.test_c_generator.TestFunctionDeclGeneration.test_partial_funcdecl_generation) ... ok
2024/02/22 11:35:29 WARN test_c11_with_cpp (tests.test_general.TestParsing.test_c11_with_cpp) ... ok
2024/02/22 11:35:29 WARN test_cpp_funkydir (tests.test_general.TestParsing.test_cpp_funkydir) ... ok
2024/02/22 11:35:30 WARN test_no_real_content_after_cpp (tests.test_general.TestParsing.test_no_real_content_after_cpp) ... ok
2024/02/22 11:35:30 WARN test_with_cpp (tests.test_general.TestParsing.test_with_cpp) ... ok
2024/02/22 11:35:30 WARN test_without_cpp (tests.test_general.TestParsing.test_without_cpp) ... ok
2024/02/22 11:35:34 WARN test_all_examples (tests.test_examples.TestExamplesSucceed.test_all_examples) ... ok
2024/02/22 11:35:34 WARN
2024/02/22 11:35:34 WARN ----------------------------------------------------------------------
2024/02/22 11:35:34 WARN Ran 130 tests in 5.015s
2024/02/22 11:35:34 WARN
2024/02/22 11:35:34 WARN OK
2024/02/22 11:35:34 INFO running step "strip"
2024/02/22 11:35:34 INFO running step "Strip binaries"
...
```