### PR TITLE
gotenborg fonts part 2

### DIFF
--- a/font-tlwg.yaml
+++ b/font-tlwg.yaml
@@ -1,0 +1,53 @@
+package:
+  name: font-tlwg
+  version: 0.7.3
+  epoch: 0
+  description: font-tlwg
+  copyright:
+    - license: GPL
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - fontforge
+      - libtool
+      - m4
+      - pkgconf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tlwg/fonts-tlwg
+      expected-commit: a2d3f66b3004276232eb279c3392758c05bcc279
+      tag: v${{package.version}}
+
+  - runs: ./autogen.sh
+
+  - runs: |
+      ./configure \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --enable-ttf \
+        --disable-otf \
+        --with-ttfdir=/usr/share/fonts/TTF
+
+      make
+
+      mkdir -p "${{targets.destdir}}"/usr/share/fontconfig
+      mkdir -p "${{targets.destdir}}"/usr/share/licenses/${{package.name}}
+      make DESTDIR="${{targets.destdir}}" install
+      mkdir -p "${{targets.destdir}}"/etc/fonts
+      mv "${{targets.destdir}}"/usr/share/fontconfig/conf.avail "${{targets.destdir}}"/etc/fonts
+      rm -r "${{targets.destdir}}"/usr/share/fontconfig
+      install -Dm644 COPYING "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/COPYING
+
+update:
+  enabled: true
+  github:
+    identifier: tlwg/fonts-tlwg
+    strip-prefix: v

--- a/font-tlwg.yaml
+++ b/font-tlwg.yaml
@@ -10,6 +10,7 @@ environment:
   contents:
     packages:
       - autoconf
+      - autoconf-archive
       - automake
       - build-base
       - busybox
@@ -18,6 +19,7 @@ environment:
       - libtool
       - m4
       - pkgconf-dev
+      - py3-fontforge
 
 pipeline:
   - uses: git-checkout

--- a/ttf-arphic-ukai.yaml
+++ b/ttf-arphic-ukai.yaml
@@ -1,0 +1,33 @@
+package:
+  name: ttf-arphic-ukai
+  version: 0.2.20080216.2
+  epoch: 0
+  description: CJK Unicode font Kaiti style
+  copyright:
+    - license: Arphic-1999
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: 7f341556e4d70f3c8ce894ef06d99d2261ecf1e0983c32ae5883adf767995e8cbf40a1eaec48f6ee7a7fb57535443e4c35d6dec2e1493b9521b7a6544705f4cf
+      uri: https://deb.debian.org/debian/pool/main/f/fonts-arphic-ukai/fonts-arphic-ukai_${{package.version}}.orig.tar.bz2
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/share/fonts/TTF
+      mkdir -p "${{targets.destdir}}"/usr/share/licenses/${{package.name}}
+      install -Dm644 ukai.ttc "${{targets.destdir}}"/usr/share/fonts/TTF/ukai.ttc
+      install -Dm644 license/english/ARPHICPL.TXT "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/COPYING
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 288

--- a/ttf-arphic-ukai.yaml
+++ b/ttf-arphic-ukai.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: CJK Unicode font Kaiti style
   copyright:
-    - license: Arphic-1999
+    - license: Arphic Public License
 
 environment:
   contents:

--- a/ttf-arphic-uming.yaml
+++ b/ttf-arphic-uming.yaml
@@ -1,0 +1,33 @@
+package:
+  name: ttf-arphic-uming
+  version: 0.2.20080216.2
+  epoch: 0
+  description: CJK Unicode font Ming style
+  copyright:
+    - license: Arphic-1999
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha512: c60dfaed26b59f437cd77d3ce841b0647fe4de96d9d512c6e400e1a409c1bbc9186f51acf7437cf7367856a5f32490834886e88f0d9191be4cbcfb2253ffa51c
+      uri: https://deb.debian.org/debian/pool/main/f/fonts-arphic-uming/fonts-arphic-uming_${{package.version}}.orig.tar.bz2
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/share/fonts/TTF
+      mkdir -p "${{targets.destdir}}"/usr/share/licenses/${{package.name}}
+      install -Dm644 uming.ttc "${{targets.destdir}}"/usr/share/fonts/TTF/uming.ttc
+      install -Dm644 license/english/ARPHICPL.TXT "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/COPYING
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 289

--- a/ttf-arphic-uming.yaml
+++ b/ttf-arphic-uming.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: CJK Unicode font Ming style
   copyright:
-    - license: Arphic-1999
+    - license: Arphic Public License
 
 environment:
   contents:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
