### PR TITLE
numpy with `--skip-build` missing some generated files.

### DIFF
--- a/numpy.yaml
+++ b/numpy.yaml
@@ -1,7 +1,7 @@
 package:
   name: numpy
   version: 1.26.4
-  epoch: 1
+  epoch: 2
   description: "The fundamental package for scientific computing with Python."
   copyright:
     - license: BSD-3-Clause
@@ -32,15 +32,10 @@ pipeline:
       repository: https://github.com/numpy/numpy
       tag: v${{package.version}}
       expected-commit: 9815c16f449e12915ef35a8255329ba26dacd5c0
+      recurse-submodules: true
 
   - runs: |
-      git submodule update --init
-
-  - runs: |
-      python3 setup.py build
-
-  - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
 
   - uses: strip
 


### PR DESCRIPTION
Needed for https://github.com/wolfi-dev/os/pull/13420#issuecomment-1960804263

Not sure why but some missing files when we use --skip-build

- now Building and installing in the same step.

After some digging locally I found that the files are getting generated in the build process but in the next step, they are not getting installed.
logs:
```
INFO: numpy.core - nothing done with h_files = ['build/src.linux-x86_64-3.12/numpy/core/src/multiarray/arraytypes.h', 'build/src.linux-x86_64-3.12/numpy/core/include/numpy/_numpyconfig.h', 'build/src.linux-x86_64-3.12/numpy/core/include/numpy/__multiarray_api.h', 'build/src.linux-x86_64-3.12/numpy/core/include/numpy/__ufunc_api.h' ...
```
Upstream conversation: https://github.com/numpy/numpy/issues/16005#issuecomment-1043899552

