### PR TITLE
culmus

### DIFF
--- a/culmus.yaml
+++ b/culmus.yaml
@@ -26,9 +26,9 @@ pipeline:
       #  # install Type1 fonts
        install -Dm755 -d "${{targets.destdir}}"/usr/share/fonts/Type1
        install -Dm644 ./*.afm \
-            "${{targets.destdir}}"/usr/share/fonts/Type1     
+            "${{targets.destdir}}"/usr/share/fonts/Type1
       install -Dm644 ./*.pfa \
-            "${{targets.destdir}}"/usr/share/fonts/Type1 
+            "${{targets.destdir}}"/usr/share/fonts/Type1
        # install ttf fonts
        install -Dm755 -d "${{targets.destdir}}"/usr/share/fonts/TTF
        install -Dm644 ./*.ttf \
@@ -36,11 +36,11 @@ pipeline:
        # install otf fonts
        install -Dm755 -d "${{targets.destdir}}"/usr/share/fonts/OTF
        install -Dm644 ./*.otf \
-         "${{targets.destdir}}"/usr/share/fonts/OTF        
+         "${{targets.destdir}}"/usr/share/fonts/OTF
        # install provided config file with priority 61
        install -Dm755 -d "${{targets.destdir}}"/etc/fonts/conf.avail/
        install -Dm644 ./culmus.conf \
-         "${{targets.destdir}}/etc/fonts/conf.avail/61-culmus.conf"         
+         "${{targets.destdir}}/etc/fonts/conf.avail/61-culmus.conf"
        # symlink for the abovementioned config file
        install -Dm755 -d "${{targets.destdir}}"/etc/fonts/conf.d
        ln -fs "../conf.avail/61-culmus.conf" "${{targets.destdir}}"/etc/fonts/conf.d/

--- a/culmus.yaml
+++ b/culmus.yaml
@@ -1,0 +1,51 @@
+package:
+  name: culmus
+  version: 0.133
+  epoch: 0
+  description: A collection of Type1 and TrueType Hebrew fonts
+  copyright:
+    - license: GPL-2.0-only
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: c0c6873742d07544f6bacf2ad52eb9cb392974d56427938dc1dfbc8399c64d05
+      uri: http://downloads.sourceforge.net/${{package.name}}/${{package.name}}-${{package.version}}.tar.gz
+
+  - runs: |
+      ls -latr
+      #  # install Type1 fonts
+       install -Dm755 -d "${{targets.destdir}}"/usr/share/fonts/Type1
+       install -Dm644 ./*.afm \
+            "${{targets.destdir}}"/usr/share/fonts/Type1     
+      install -Dm644 ./*.pfa \
+            "${{targets.destdir}}"/usr/share/fonts/Type1 
+       # install ttf fonts
+       install -Dm755 -d "${{targets.destdir}}"/usr/share/fonts/TTF
+       install -Dm644 ./*.ttf \
+         "${{targets.destdir}}"/usr/share/fonts/TTF
+       # install otf fonts
+       install -Dm755 -d "${{targets.destdir}}"/usr/share/fonts/OTF
+       install -Dm644 ./*.otf \
+         "${{targets.destdir}}"/usr/share/fonts/OTF        
+       # install provided config file with priority 61
+       install -Dm755 -d "${{targets.destdir}}"/etc/fonts/conf.avail/
+       install -Dm644 ./culmus.conf \
+         "${{targets.destdir}}/etc/fonts/conf.avail/61-culmus.conf"         
+       # symlink for the abovementioned config file
+       install -Dm755 -d "${{targets.destdir}}"/etc/fonts/conf.d
+       ln -fs "../conf.avail/61-culmus.conf" "${{targets.destdir}}"/etc/fonts/conf.d/
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10067


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
