### PR TITLE
fix(calico): use the correct binary for cni-plugin-install

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.27.2
-  epoch: 0
+  epoch: 1
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0
@@ -170,6 +170,7 @@ subpackages:
                 -ldflags "$LDFLAGS" \
                 -o "${{targets.subpkgdir}}"/bin/calico-node \
                 ./node/cmd/calico-node
+
           # Equivalent to target: "$(TOOLS_MOUNTNS_BINARY)"
           - runs: |
               _arch=$(uname -m); case $_arch in aarch64) _arch="arm64" ;; x86_64) _arch="amd64" ;; esac
@@ -301,6 +302,7 @@ subpackages:
         - cni-plugins-bandwidth
     pipeline:
       # NOTE: cni is a multicall binary: https://github.com/projectcalico/calico/blob/master/cni-plugin/cmd/calico/calico.go
+      # install is not a part of that multicall binary anymore (as of calico 3.27.1)
       - runs: |
           # On boot (of calico-node) the CNI is installed/copied onto the host
           # node and run when pod network sandboxes are created. Since it runs on
@@ -314,10 +316,18 @@ subpackages:
             -ldflags "$LDFLAGS" \
             -o cni-plugin/out/calico \
             ./cni-plugin/cmd/calico
+
+          CGO_ENABLED=0 \
+            go build -v -buildvcs=false \
+            -ldflags "$LDFLAGS" \
+            -o cni-plugin/out/install \
+            ./cni-plugin/cmd/install
+
       - runs: |
           install -Dm755 cni-plugin/out/calico "${{targets.subpkgdir}}"/usr/bin/calico
           ln -sf /usr/bin/calico "${{targets.subpkgdir}}"/usr/bin/calico-ipam
-          ln -sf /usr/bin/calico "${{targets.subpkgdir}}"/usr/bin/install
+
+          install -Dm755 cni-plugin/out/install "${{targets.subpkgdir}}"/usr/bin/calico-cni-install
 
   - name: "calico-cni-compat"
     dependencies:
@@ -334,7 +344,7 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/opt/cni/bin
           ln -s /usr/bin/calico "${{targets.subpkgdir}}"/opt/cni/bin/calico
           ln -s /usr/bin/calico "${{targets.subpkgdir}}"/opt/cni/bin/calico-ipam
-          ln -s /usr/bin/calico "${{targets.subpkgdir}}"/opt/cni/bin/install
+          ln -s /usr/bin/calico-cni-install "${{targets.subpkgdir}}"/opt/cni/bin/install
 
   - name: "calico-apiserver"
     dependencies:

--- a/calico.yaml
+++ b/calico.yaml
@@ -170,7 +170,6 @@ subpackages:
                 -ldflags "$LDFLAGS" \
                 -o "${{targets.subpkgdir}}"/bin/calico-node \
                 ./node/cmd/calico-node
-
           # Equivalent to target: "$(TOOLS_MOUNTNS_BINARY)"
           - runs: |
               _arch=$(uname -m); case $_arch in aarch64) _arch="arm64" ;; x86_64) _arch="amd64" ;; esac
@@ -322,7 +321,6 @@ subpackages:
             -ldflags "$LDFLAGS" \
             -o cni-plugin/out/install \
             ./cni-plugin/cmd/install
-
       - runs: |
           install -Dm755 cni-plugin/out/calico "${{targets.subpkgdir}}"/usr/bin/calico
           ln -sf /usr/bin/calico "${{targets.subpkgdir}}"/usr/bin/calico-ipam


### PR DESCRIPTION
As of calico v3.27.1, the install binary for cni-plugin is not a part of the main calico binary any longer, but instead is its own binary. Update our package to reflect this change, so that images using this package can successfully install the CNI.