### PR TITLE
Adding 10 Python package tests - #2

### DIFF
--- a/py3-click.yaml
+++ b/py3-click.yaml
@@ -41,3 +41,22 @@ update:
   enabled: true
   github:
     identifier: pallets/click
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="click"
+        IMPORT_STATEMENT="import click"
+
+        if ! python -c "$IMPORT_STATEMENT"; then
+            echo "Failed to import library '$LIBRARY'."
+            python -c "$IMPORT_STATEMENT" 2>&1
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3-cloudpickle.yaml
+++ b/py3-cloudpickle.yaml
@@ -41,3 +41,22 @@ update:
     strip-prefix: v
     use-tag: true
     tag-filter: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="cloudpickle"
+        IMPORT_STATEMENT="import cloudpickle"
+
+        if ! python -c "$IMPORT_STATEMENT"; then
+            echo "Failed to import library '$LIBRARY'."
+            python -c "$IMPORT_STATEMENT" 2>&1
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3-cmaes.yaml
+++ b/py3-cmaes.yaml
@@ -41,3 +41,22 @@ update:
   github:
     identifier: CyberAgentAILab/cmaes
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="cmaes"
+        IMPORT_STATEMENT="from cmaes import CMA,"
+
+        if ! python -c "$IMPORT_STATEMENT"; then
+            echo "Failed to import library '$LIBRARY'."
+            python -c "$IMPORT_STATEMENT" 2>&1
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3-cmaes.yaml
+++ b/py3-cmaes.yaml
@@ -50,7 +50,7 @@ test:
   pipeline:
     - runs: |
         LIBRARY="cmaes"
-        IMPORT_STATEMENT="from cmaes import CMA,"
+        IMPORT_STATEMENT="from cmaes import CMA"
 
         if ! python -c "$IMPORT_STATEMENT"; then
             echo "Failed to import library '$LIBRARY'."

--- a/py3-codeowners.yaml
+++ b/py3-codeowners.yaml
@@ -36,3 +36,22 @@ update:
   manual: true
   github:
     identifier: sbdchd/codeowners
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="codeowners"
+        IMPORT_STATEMENT="from codeowners import CodeOwners"
+
+        if ! python -c "$IMPORT_STATEMENT"; then
+            echo "Failed to import library '$LIBRARY'."
+            python -c "$IMPORT_STATEMENT" 2>&1
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3-codespell.yaml
+++ b/py3-codespell.yaml
@@ -2,7 +2,7 @@ package:
   name: py3-codespell
   version: 2.2.6
   epoch: 0
-  description: "checker for common misspellings "
+  description: 'checker for common misspellings '
   copyright:
     - license: GPL-2.0-or-later
 
@@ -34,3 +34,22 @@ update:
   github:
     identifier: codespell-project/codespell
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="codespell"
+        IMPORT_STATEMENT="import codespell"
+
+        if ! python -c "$IMPORT_STATEMENT"; then
+            echo "Failed to import library '$LIBRARY'."
+            python -c "$IMPORT_STATEMENT" 2>&1
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3-codespell.yaml
+++ b/py3-codespell.yaml
@@ -34,22 +34,3 @@ update:
   github:
     identifier: codespell-project/codespell
     strip-prefix: v
-
-test:
-  environment:
-    contents:
-      packages:
-        - busybox
-  pipeline:
-    - runs: |
-        LIBRARY="codespell"
-        IMPORT_STATEMENT="import codespell"
-
-        if ! python -c "$IMPORT_STATEMENT"; then
-            echo "Failed to import library '$LIBRARY'."
-            python -c "$IMPORT_STATEMENT" 2>&1
-            exit 1
-        else
-            echo "Library '$LIBRARY' is installed and can be imported successfully."
-            exit 0
-        fi

--- a/py3-colorama.yaml
+++ b/py3-colorama.yaml
@@ -2,7 +2,7 @@ package:
   name: py3-colorama
   version: 0.4.6
   epoch: 3
-  description: "Simple cross-platform colored terminal text"
+  description: Simple cross-platform colored terminal text
   copyright:
     - license: BSD-3-Clause
   dependencies:
@@ -49,3 +49,22 @@ update:
   github:
     identifier: tartley/colorama
     use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="colorama"
+        IMPORT_STATEMENT="import colorama"
+
+        if ! python -c "$IMPORT_STATEMENT"; then
+            echo "Failed to import library '$LIBRARY'."
+            python -c "$IMPORT_STATEMENT" 2>&1
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3-colorlog.yaml
+++ b/py3-colorlog.yaml
@@ -40,3 +40,22 @@ update:
   github:
     identifier: borntyping/python-colorlog
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="colorlog"
+        IMPORT_STATEMENT="import colorlog"
+
+        if ! python -c "$IMPORT_STATEMENT"; then
+            echo "Failed to import library '$LIBRARY'."
+            python -c "$IMPORT_STATEMENT" 2>&1
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3-configobj.yaml
+++ b/py3-configobj.yaml
@@ -5,7 +5,7 @@ package:
   epoch: 1
   description: Config file reading, writing and validation.
   copyright:
-    - license: BSD (2 clause)
+    - license: BSD-2-Clause
   dependencies:
     runtime:
       - py3-six

--- a/py3-configobj.yaml
+++ b/py3-configobj.yaml
@@ -42,3 +42,22 @@ update:
     identifier: DiffSK/configobj
     strip-prefix: v
     use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="configobj"
+        IMPORT_STATEMENT="from configobj import ConfigObj"
+
+        if ! python -c "$IMPORT_STATEMENT"; then
+            echo "Failed to import library '$LIBRARY'."
+            python -c "$IMPORT_STATEMENT" 2>&1
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3-contextlib2.yaml
+++ b/py3-contextlib2.yaml
@@ -2,7 +2,7 @@ package:
   name: py3-contextlib2
   version: 21.6.0
   epoch: 4
-  description: "backports of the contextlib module from newer versions of python"
+  description: backports of the contextlib module from newer versions of python
   copyright:
     - license: PSF-2.0 AND Apache-2.0
   dependencies:
@@ -37,3 +37,22 @@ update:
   enabled: true
   release-monitor:
     identifier: 6215
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="contextlib2"
+        IMPORT_STATEMENT="import contextlib2"
+
+        if ! python -c "$IMPORT_STATEMENT"; then
+            echo "Failed to import library '$LIBRARY'."
+            python -c "$IMPORT_STATEMENT" 2>&1
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3-contourpy.yaml
+++ b/py3-contourpy.yaml
@@ -46,3 +46,22 @@ update:
   github:
     identifier: contourpy/contourpy
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        LIBRARY="contourpy"
+        IMPORT_STATEMENT="import contourpy"
+
+        if ! python -c "$IMPORT_STATEMENT"; then
+            echo "Failed to import library '$LIBRARY'."
+            python -c "$IMPORT_STATEMENT" 2>&1
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi


### PR DESCRIPTION
Automated Python package tests created by [auto-package-test](https://github.com/chainguard-dev/quality-squad/tree/main/scripts/auto-package-test).

Note:

1. These will eventually be cleaned up and moved to a dedicated pipeline once bubblewrap and the pipeline is reliable.
2. We also looked at creating these as a script some packages don't have a directory.

The top priority is to improve our coverage and we can come back through with automation to clean these up.