### PR TITLE
no CGO for clusterctl package

### DIFF
--- a/clusterctl.yaml
+++ b/clusterctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: clusterctl
   version: 1.6.2
-  epoch: 0
+  epoch: 1
   description: A command line tool to manage clusters created by cluster API
   copyright:
     - license: Apache-2.0
@@ -15,6 +15,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
+  environment:
+    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Ref: https://github.com/kubernetes-sigs/cluster-api/blob/0f47a19e038ee6b0d3b1e7675a62cdaf84face8c/Makefile#L1113 

```bash
# docker run --rm -it cgr.dev/chainguard/wolfi-base:latest sh
/ # apk add clusterctl libc-bin
fetch https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
(1/8) Installing clusterctl (1.6.2-r0)
(2/8) Installing localedef (2.38-r11)
(3/8) Installing ncurses-terminfo-base (6.4_p20231125-r1)
(4/8) Installing ncurses (6.4_p20231125-r1)
(5/8) Installing bash (5.2.21-r1)
(6/8) Installing posix-libc-utils (2.38-r11)
(7/8) Installing tzutils (2.38-r11)
(8/8) Installing libc-bin (2.38-r11)
OK: 111 MiB in 22 packages
/ # ls
bin    dev    etc    home   lib    lib64  opt    proc   root   run    sbin   sys    tmp    usr    var
/ # ldd $(command -v clusterctl)
	linux-vdso.so.1 (0x00007ffd1d9ec000)
	libresolv.so.2 => /lib/libresolv.so.2 (0x00007fb9e2ba9000)
	libc.so.6 => /lib/libc.so.6 (0x00007fb9e2972000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fb9e2bbd000)
```


<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
