### PR TITLE
xorg-server: switch debian salsa checkout from tag to branch

### DIFF
--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -112,8 +112,8 @@ subpackages:
       - uses: git-checkout
         with:
           repository: https://salsa.debian.org/xorg-team/xserver/xorg-server
-          tag: xorg-server-2_${{package.version}}-1
-          expected-commit: 8db596f78a4cc8dcbb0422d0f833b1c58b9f9f7b
+          branch: debian-unstable
+          expected-commit: b6acc2e6eb9f4bf97e7fc4b4da3ef3d9489267e4
       - working-directory: debian/local
         pipeline:
           - runs: |


### PR DESCRIPTION
xorg-server: switch debian salsa checkout from tag to branch

Last two debian uploads did not push a matching tag. However, only a subtree of debian/local is used to build a small utility which hasn't been changed in years. Update to use `debian-unstable` branch with a fixed expected commit. This is a temporary solution until debian developer pushes matching tags (requested on irc). Possibly we can even drop expected-commit here, as the utility hasn't seen any changes for years now.

Fixes #13535 

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
