### PR TITLE
Go FIPS v1.22.0

### DIFF
--- a/go-fips-1.22.yaml
+++ b/go-fips-1.22.yaml
@@ -1,0 +1,89 @@
+package:
+  name: go-fips
+  version: 1.22.0
+  epoch: 0
+  description: "the Go programming language with OpenSSL cryptography"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - bash
+      - binutils-gold # Needed for cgo linking due to upstream issue #15696 which forces use of the gold linker.
+      - build-base
+      - openssl-dev # Needed for building against cryptographic packages.
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      # We always use the equivalent non-FIPS branch of Go to build this.
+      - go~1.22
+      - openssl-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://go.dev/dl/go${{package.version}}.src.tar.gz
+      expected-sha256: 4d196c3d41a0d6c1dfc64d04e3cc1f608b0c436bd87b7060ce3e23234e1f4d5c
+      strip-components: 0
+
+  - working-directory: /home/build/go
+
+  - runs: |
+      cd go/src
+      ./make.bash -v
+
+  - runs: |
+      cd go
+
+      mkdir -p "${{targets.destdir}}"/usr/bin "${{targets.destdir}}"/usr/lib/go/bin "${{targets.destdir}}"/usr/share/doc/go
+
+      for bin in go gofmt; do
+        install -Dm755 bin/$bin "${{targets.destdir}}"/usr/lib/go/bin/$bin
+        ln -s /usr/lib/go/bin/$bin "${{targets.destdir}}"/usr/bin/
+      done
+
+      cp -a pkg lib "${{targets.destdir}}"/usr/lib/go/
+      cp -r doc misc "${{targets.destdir}}"/usr/share/doc/go
+      cp -a src "${{targets.destdir}}"/usr/lib/go/
+      cp -p go.env "${{targets.destdir}}"/usr/lib/go/go.env
+
+      rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/obj
+      rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/bootstrap
+      rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/tool/*/api
+      rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/*/cmd
+      rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/tool/*/api
+      rm -rf "${{targets.destdir}}"/usr/lib/go/pkg/tool/*/go_bootstrap
+      rm -rf "${{targets.destdir}}"/usr/lib/go/src/cmd/dist/dist
+
+      # Remove tests from /usr/lib/go/src, not needed at runtime
+      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*_test.go" \) \
+        -exec rm -rf \{\} \+
+      find "${{targets.destdir}}"/usr/lib/go/src \( -type d -a -name "testdata" \) \
+        -exec rm -rf \{\} \+
+      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*.rc" \) \
+        -exec rm -rf \{\} \+
+      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*.bat" \) \
+        -exec rm -rf \{\} \+
+
+  - uses: strip
+
+subpackages:
+  - name: "go-fips-doc"
+    description: "go documentation"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/share
+          mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
+
+update:
+  enabled: true
+  shared: true
+  github:
+    identifier: golang/go
+    strip-prefix: go
+    tag-filter: go1.22
+    use-tag: true

--- a/go-fips-1.22.yaml
+++ b/go-fips-1.22.yaml
@@ -1,12 +1,15 @@
 package:
-  name: go-fips
+  name: go-fips-1.22
   version: 1.22.0
   epoch: 0
   description: "the Go programming language with OpenSSL cryptography"
   copyright:
     - license: BSD-3-Clause
   dependencies:
+    provides:
+      - go-fips=${{package.full-version}}
     runtime:
+      - '!go-1.22'
       - bash
       - binutils-gold # Needed for cgo linking due to upstream issue #15696 which forces use of the gold linker.
       - build-base
@@ -72,7 +75,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "go-fips-doc"
+  - name: "go-fips-1.22-doc"
     description: "go documentation"
     pipeline:
       - runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ X] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
