### PR TITLE
gobject-introspection: ignore dev versions identified by an odd minor…

### DIFF
--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -81,5 +81,7 @@ subpackages:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - (\d+)\.(\d*[13579])\.(\d+)$ # ignore "odd" numbered minor versions as these are development releases
   release-monitor:
     identifier: 1223


### PR DESCRIPTION
… version

see wolfi-dev/os#10782

No epoch bump needed as just the update config is changed for future updates

