### PR TITLE
postgresql-client: add additional utilities

### DIFF
--- a/postgresql-12.yaml
+++ b/postgresql-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-12
   version: "12.18"
-  epoch: 3
+  epoch: 4
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -71,7 +71,21 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/clusterdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/createdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/createuser ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/dropdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/dropuser ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_basebackup ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_dump ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_dumpall ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_isready ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_receivewal ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_recvlogical ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_restore ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/bin/psql ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/reindexdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/vacuumdb ${{targets.subpkgdir}}/usr/bin/
 
   - name: postgresql-12-contrib
     pipeline:

--- a/postgresql-13.yaml
+++ b/postgresql-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-13
   version: "13.14"
-  epoch: 3
+  epoch: 4
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -70,7 +70,22 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/clusterdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/createdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/createuser ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/dropdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/dropuser ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_basebackup ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_dump ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_dumpall ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_isready ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_receivewal ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_recvlogical ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_restore ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_verifybackup ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/bin/psql ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/reindexdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/vacuumdb ${{targets.subpkgdir}}/usr/bin/
 
   - name: postgresql-13-contrib
     pipeline:

--- a/postgresql-14.yaml
+++ b/postgresql-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-14
   version: "14.11"
-  epoch: 4
+  epoch: 5
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -71,7 +71,23 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/clusterdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/createdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/createuser ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/dropdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/dropuser ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_amcheck ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_basebackup ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_dump ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_dumpall ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_isready ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_receivewal ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_recvlogical ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_restore ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_verifybackup ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/bin/psql ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/reindexdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/vacuumdb ${{targets.subpkgdir}}/usr/bin/
 
   - name: postgresql-14-contrib
     pipeline:

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-15
   version: "15.6"
-  epoch: 3
+  epoch: 4
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -67,7 +67,23 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/clusterdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/createdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/createuser ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/dropdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/dropuser ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_amcheck ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_basebackup ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_dump ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_dumpall ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_isready ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_receivewal ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_recvlogical ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_restore ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_verifybackup ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/bin/psql ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/reindexdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/vacuumdb ${{targets.subpkgdir}}/usr/bin/
 
   - name: postgresql-15-contrib
     pipeline:

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.2"
-  epoch: 3
+  epoch: 4
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -76,7 +76,23 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/clusterdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/createdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/createuser ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/dropdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/dropuser ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_amcheck ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_basebackup ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_dump ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_dumpall ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_isready ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_receivewal ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_recvlogical ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_restore ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/pg_verifybackup ${{targets.subpkgdir}}/usr/bin/
           mv ${{targets.destdir}}/usr/bin/psql ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/reindexdb ${{targets.subpkgdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/vacuumdb ${{targets.subpkgdir}}/usr/bin/
 
   - name: postgresql-16-contrib
     dependencies:


### PR DESCRIPTION
First contribution, so let me know if I'm missing anything...

I'm migrating several of my container images to use apko/melange (which are fantastic tools by the way -- kudos!). One issue I ran into this morning is that the `postgresql-client` package normally includes a lot more than just `psql`... it normally has a whole bunch of useful helper utilities like `pg_isready`.

Each distribution has slightly different contents for this package, so I made a best effort to put together a list of binaries that's similar to these:
- Ubuntu: https://packages.ubuntu.com/noble/amd64/postgresql-client-16/filelist
- Alpine: https://pkgs.alpinelinux.org/contents?branch=v3.13&name=postgresql%2dclient&arch=x86_64&repo=main

Note: Differences between the PG versions in this PR: PG 12 and 13 do not include `pg_amcheck`, and PG 12 does not include `pg_verifybackup` either.

Note 2: Although it may seem cleaner to wildcard some of these `cp` commands so that there aren't so many, `pg_*` actually matches on several other utilities that do not appear to be traditionally included in postgresql-client.