### PR TITLE
Add .install to gcloud installation root

### DIFF
--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: google-cloud-sdk
   version: 460.0.0
-  epoch: 0
+  epoch: 1
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0
@@ -68,6 +68,10 @@ pipeline:
       # Running gcloud adds a bunch of pyc files, remove those
       find google-cloud-sdk/ -name "*.pyc" -exec rm -rf '{}' +
       rm -rf google-cloud-sdk/.install
+
+      # gcloud expects to find a directory called ".install" in its "Installation Root" (as reported by "gcloud info").
+      # Without this, "gcloud components" doesn't work.
+      mkdir google-cloud-sdk/.install
 
       mv google-cloud-sdk ${{targets.destdir}}/usr/share/
 


### PR DESCRIPTION
This fixes the "gcloud components" subcommand.

```
[sdk] ❯ apk add --allow-untrusted packages/aarch64/google-cloud-sdk-460.0.0-r1.apk
WARNING: opening ./../../packages: No such file or directory
(1/10) Installing libbz2-1 (1.0.8-r6)
(2/10) Installing libffi (3.4.6-r0)
(3/10) Installing gdbm (1.23-r4)
(4/10) Installing xz (5.6.0-r0)
(5/10) Installing mpdecimal (4.0.0-r0)
(6/10) Installing readline (8.2-r3)
(7/10) Installing sqlite-libs (3.45.1-r0)
(8/10) Installing python-3.12 (3.12.2-r0)
(9/10) Installing py3-crcmod (1.7-r2)
(10/10) Installing google-cloud-sdk (460.0.0-r1)
OK: 1216 MiB in 66 packages
[sdk] ❯ gcloud info | grep Install
Installation Root: [/usr/share/google-cloud-sdk]