### PR TITLE
Add version test to grafana-agent-operator

### DIFF
--- a/grafana-agent-operator.yaml
+++ b/grafana-agent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-agent-operator
   version: 0.40.0
-  epoch: 1
+  epoch: 0
   description: Grafana Agent Operator is a Kubernetes operator for the static mode of Grafana Agent. It makes it easier to deploy and configure static mode to collect telemetry data from Kubernetes resources.
   copyright:
     - license: Apache-2.0

--- a/grafana-agent-operator.yaml
+++ b/grafana-agent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-agent-operator
   version: 0.40.0
-  epoch: 0
+  epoch: 1
   description: Grafana Agent Operator is a Kubernetes operator for the static mode of Grafana Agent. It makes it easier to deploy and configure static mode to collect telemetry data from Kubernetes resources.
   copyright:
     - license: Apache-2.0

--- a/grafana-agent-operator.yaml
+++ b/grafana-agent-operator.yaml
@@ -30,6 +30,10 @@ pipeline:
 
   - uses: strip
 
+test:
+  pipeline:
+    - runs: /usr/bin/grafana-agent-operator -version
+
 update:
   enabled: true
   ignore-regex-patterns:


### PR DESCRIPTION
Related: #13440

Adds a test to check `grafana-agent-operator` version info.