### PR TITLE
Fix latest mariadb version stream

### DIFF
--- a/mariadb-11.2.yaml
+++ b/mariadb-11.2.yaml
@@ -1,13 +1,15 @@
 package:
   name: mariadb-11.2
   version: 11.2.3
-  epoch: 0
+  epoch: 1
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
   dependencies:
     runtime:
       - pwgen
+    provides:
+      - mariadb=${{package.full-version}}
 
 environment:
   contents:
@@ -147,16 +149,23 @@ pipeline:
 subpackages:
   - name: "${{package.name}}-dev"
     description: "headers for mariadb"
+    dependencies:
+      provides:
+        - mariadb-dev=${{package.full-version}}
     pipeline:
       - uses: split/dev
-    dependencies:
 
   - name: "${{package.name}}-doc"
+    dependencies:
+      provides:
+        - mariadb-doc=${{package.full-version}}
     pipeline:
       - uses: split/manpages
 
   - name: "${{package.name}}-bench"
     dependencies:
+      provides:
+        - mariadb-bench=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/
@@ -164,6 +173,8 @@ subpackages:
 
   - name: "${{package.name}}-backup"
     dependencies:
+      provides:
+        - mariadb-backup=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
@@ -175,6 +186,8 @@ subpackages:
   - name: "${{package.name}}-oci-entrypoint"
     description: Entrypoint for using HAProxy in OCI containers
     dependencies:
+      provides:
+        - mariadb-oci-entrypoint=${{package.full-version}}
       runtime:
         - bash
         - busybox
@@ -187,6 +200,8 @@ subpackages:
   - name: "${{package.name}}-embedded"
     description: Emedded library for mariadb
     dependencies:
+      provides:
+        - mariadb-embedded=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin/


### PR DESCRIPTION
This wasn't providing any of the right virtuals.

This needs to have `provides = mariadb-dev=...` for things to work.

```
$ curl -sL https://packages.wolfi.dev/os/aarch64/mariadb-11.2-dev-11.2.3-r0.apk | tar -Oxz .PKGINFO
# Generated by melange v0.5.9
pkgname = mariadb-11.2-dev
pkgver = 11.2.3-r0
arch = aarch64
size = 62528196
origin = mariadb-11.2
pkgdesc = headers for mariadb
url = 
commit = 715b390bd0610805111f37ed5a98c6a1225c2e4e
builddate = 1707283461
license = GPL-3.0-or-later
depend = so:libmariadbd.so.19
provides = pc:mariadb=11.2.3
datahash = e4e535cf0ba38a927bf62ad19a4cf6cdee0aaa9b88d1d4bb3ee181f974662e06
```