### PR TITLE
chore(chromium): Add Chromium Docker Selenium compat package

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -2,7 +2,7 @@
 package:
   name: chromium
   version: 122.0.6261.99
-  epoch: 0
+  epoch: 1
   description: "Open souce version of Google's chrome web browser"
   copyright:
     - license: BSD-3-Clause
@@ -200,6 +200,18 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib/${{package.name}}
           mv ${{targets.destdir}}/usr/lib/${{package.name}}/locales ${{targets.subpkgdir}}/usr/lib/${{package.name}}
+
+  # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/NodeChrome/Dockerfile
+  - name: chromium-docker-selenium-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/opt/selenium
+
+          ln -sf /usr/lib/chromium/chromedriver ${{targets.subpkgdir}}/opt/selenium/chromedriver-${{package.version}}
+
+          echo "chrome" > ${{targets.subpkgdir}}/opt/selenium/browser_name
+          echo ${{package.version}} > ${{targets.subpkgdir}}/opt/selenium/browser_version
+          echo "\"goog:chromeOptions\": {\"binary\": \"/usr/bin/chromium\"}" > ${{targets.subpkgdir}}/opt/selenium/browser_binary_location
 
 update:
   enabled: true

--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -5,7 +5,7 @@ package:
   # 'package format error' when trying to install the package. The workaround is
   # to replace '-' with '.', then mangling the version to replace back.
   version: 4.18.1.20240224
-  epoch: 0
+  epoch: 1
   description: Provides a simple way to run Selenium Grid with Chrome, Firefox, and Edge using Docker, making it easier to perform browser automation
   copyright:
     - license: Apache-2.0
@@ -19,6 +19,7 @@ package:
       - bash
       - busybox
       - chromium
+      - chromium-docker-selenium-compat
       - coreutils
       - fluxbox
       - font-ipa
@@ -62,7 +63,6 @@ environment:
       - busybox
       - bzip2
       - ca-certificates-bundle
-      - chromium
       - curl
       - git
       - gnupg
@@ -150,14 +150,6 @@ pipeline:
     pipeline:
       - runs: |
           install -Dm755 wrap_chrome_binary ${{targets.destdir}}/opt/bin/wrap_chrome_binary
-
-          export CHROMEDRIVER_VERSION=$(/usr/lib/chromium/chromedriver --version | awk '{print $2}')
-          ln -sf /usr/lib/chromium/chromedriver ${{targets.destdir}}/opt/selenium/chromedriver-$CHROMEDRIVER_VERSION
-
-          export CHROMIUM_VERSION=$(/usr/bin/chromium-browser --product-version)
-          echo "chrome" > ${{targets.destdir}}/opt/selenium/browser_name
-          echo $CHROMIUM_VERSION > ${{targets.destdir}}/opt/selenium/browser_version
-          echo "\"goog:chromeOptions\": {\"binary\": \"/usr/bin/chromium\"}" > ${{targets.destdir}}/opt/selenium/browser_binary_location
 
   # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/Standalone/Dockerfile
   - working-directory: Standalone


### PR DESCRIPTION
Since these files are tied to the Chromium version, it's best we create them while packaging Chromium instead of incrementing Docker Selenium's epoch for a rebuild

