### PR TITLE
Bundle Envoy into the cilium (version streamed) package

### DIFF
--- a/cilium-1.14.yaml
+++ b/cilium-1.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-1.14
   version: 1.14.6
-  epoch: 0
+  epoch: 1
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -23,16 +23,36 @@ package:
 environment:
   contents:
     packages:
+      - bash
+      - bazel-6
+      - binutils
       - build-base
       - busybox
-      - clang
+      - ca-certificates-bundle
+      - clang~15
+      - cmake
       - coreutils # for GNU install
+      # We need to stick to gcc 12 for now, envoy doesn't build with gcc >= 13
+      - gcc-12-default
       - git
       - go
       - grep
       - iptables # for cilium-iptables
+      - libtool
+      - llvm-lld-15
       - llvm15
+      - llvm15-cmake-default
+      - llvm15-dev
       - llvm15-tools
+      - openjdk-11
+      - patch
+      - python3-dev
+      - samurai
+      - wolfi-baselayout
+
+vars:
+  # https://github.com/cilium/cilium/blob/v1.14.6/images/cilium/Dockerfile
+  CILIUM_PROXY_COMMIT: "ad82c7c56e88989992fd25d8d67747de865c823b"
 
 pipeline:
   - uses: git-checkout
@@ -52,6 +72,62 @@ pipeline:
 
       DESTDIR=${{targets.destdir}} DISABLE_ENVOY_INSTALLATION=1 make build-container
       DESTDIR=${{targets.destdir}} DISABLE_ENVOY_INSTALLATION=1 make install-container
+
+  - runs: |
+      # Check the Dockerfile for a SHA and match against the proxy SHA
+      ENVOY_SHA=$(grep 'FROM.*cilium-envoy' ./images/cilium/Dockerfile \
+        | sed "s/^FROM.*:v[0-9.]\+-//g" | cut -d@ -f1)
+
+      if [ "$ENVOY_SHA" != "${{vars.CILIUM_PROXY_COMMIT}}" ]; then
+        echo "Expected vars.CILIUM_PROXY_COMMIT to be $ENVOY_SHA. Please update" 1>&2
+        exit 1
+      fi
+
+  - runs: |
+      # TODO: Replace with git-checkout when `commit` parameter
+      #       is supported.
+      tmpdir=$(mktemp -d)
+      git config --global --add safe.directory $tmpdir
+      git config --global --add safe.directory /home/build
+      git clone https://github.com/cilium/proxy $tmpdir
+      cd $tmpdir
+      git reset --hard ${{vars.CILIUM_PROXY_COMMIT}}
+
+      mkdir -p /home/build/envoy
+      tar -c . | (cd /home/build/envoy && tar -x)
+      rm -rf $tmpdir
+
+  - uses: patch
+    with:
+      patches: toolchains-paths.patch
+
+  - uses: go/bump
+    with:
+      modroot: /home/build/envoy
+      deps: golang.org/x/net@v0.17.0
+
+  - runs: |
+      cd /home/build/envoy/proxylib
+      make
+      mkdir -p ${{targets.destdir}}/usr/lib
+      cp -v libcilium.so ${{targets.destdir}}/usr/lib/libcilium.so
+
+      cd /home/build/envoy
+
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+      mkdir -p .cache/bazel/_bazel_root
+
+      ./bazel/setup_clang.sh /usr
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      bazel build --fission=no --config=clang \
+        --discard_analysis_cache \
+        --nokeep_state_after_build \
+        --notrack_incremental_state \
+        --conlyopt="-Wno-strict-prototypes" \
+        --verbose_failures -c opt //:cilium-envoy
+
+      cp -v bazel-bin/cilium-envoy ${{targets.destdir}}/usr/bin/cilium-envoy
 
   - uses: strip
 

--- a/cilium-1.14/toolchains-paths.patch
+++ b/cilium-1.14/toolchains-paths.patch
@@ -1,0 +1,87 @@
+diff --git a/envoy/bazel/toolchains/BUILD b/envoy/bazel/toolchains/BUILD
+index b806112b6..024d8882e 100644
+--- a/envoy/bazel/toolchains/BUILD
++++ b/envoy/bazel/toolchains/BUILD
+@@ -48,6 +48,11 @@ cc_toolchain_config(
+     coverage_link_flags = ["--coverage"],
+     cpu = "aarch64",
+     cxx_builtin_include_directories = [
++        # These aren't how we configure where to look, but which files
++        # Bazel allows us to use in the build. So we don't have to be
++        # super exact and specify the version in the path.
++        "/usr/lib64/gcc/aarch64-unknown-linux-gnu",
++        "/usr/lib/clang",
+         "/usr/lib/llvm-15",
+         "/usr/aarch64-linux-gnu/include",
+         "/usr/include",
+@@ -76,18 +81,18 @@ cc_toolchain_config(
+     target_libc = "glibc",
+     target_system_name = "aarch64-linux-gnu",
+     tool_paths = {
+-        "ar": "/usr/bin/llvm-ar-15",
+-        "compat-ld": "/usr/bin/lld-15",
+-        "ld": "/usr/bin/lld-15",
+-        "gold": "/usr/bin/lld-15",
++        "ar": "/usr/bin/llvm-ar",
++        "compat-ld": "/usr/bin/lld",
++        "ld": "/usr/bin/lld",
++        "gold": "/usr/bin/lld",
+         "cpp": "/usr/bin/clang-cpp-15",
+         "gcc": "/usr/bin/clang-15",
+-        "dwp": "/usr/bin/llvm-dwp-15",
+-        "gcov": "/usr/bin/llvmcov-15",
+-        "nm": "/usr/bin/llvm-nm-15",
+-        "objcopy": "/usr/bin/llvm-objcopy-15",
+-        "objdump": "/usr/bin/llvm-objdump-15",
+-        "strip": "/usr/bin/llvm-strip-15",
++        "dwp": "/usr/bin/llvm-dwp",
++        "gcov": "/usr/bin/llvmcov",
++        "nm": "/usr/bin/llvm-nm",
++        "objcopy": "/usr/bin/llvm-objcopy",
++        "objdump": "/usr/bin/llvm-objdump",
++        "strip": "/usr/bin/llvm-strip",
+     },
+     toolchain_identifier = "linux_aarch64",
+     unfiltered_compile_flags = [
+@@ -146,6 +151,11 @@ cc_toolchain_config(
+     coverage_link_flags = ["--coverage"],
+     cpu = "k8",
+     cxx_builtin_include_directories = [
++        # These aren't how we configure where to look, but which files
++        # Bazel allows us to use in the build. So we don't have to be
++        # super exact and specify the version in the path.
++        "/usr/lib64/gcc/x86_64-pc-linux-gnu",
++        "/usr/lib/clang",
+         "/usr/lib/llvm-15",
+         "/usr/x86_64-linux-gnu/include",
+         "/usr/include",
+@@ -174,18 +184,18 @@ cc_toolchain_config(
+     target_libc = "unknown",
+     target_system_name = "unknown",
+     tool_paths = {
+-        "ar": "/usr/bin/llvm-ar-15",
+-        "compat-ld": "/usr/bin/lld-15",
+-        "ld": "/usr/bin/lld-15",
+-        "gold": "/usr/bin/lld-15",
+-        "cpp": "/usr/bin/clang-cpp-15",
++        "ar": "/usr/bin/llvm-ar",
++        "compat-ld": "/usr/bin/lld",
++        "ld": "/usr/bin/lld",
++        "gold": "/usr/bin/lld",
++        "cpp": "/usr/bin/clang-cpp",
+         "gcc": "/usr/bin/clang-15",
+-        "dwp": "/usr/bin/llvm-dwp-15",
+-        "gcov": "/usr/bin/llvmcov-15",
+-        "nm": "/usr/bin/llvm-nm-15",
+-        "objcopy": "/usr/bin/llvm-objcopy-15",
+-        "objdump": "/usr/bin/llvm-objdump-15",
+-        "strip": "/usr/bin/llvm-strip-15",
++        "dwp": "/usr/bin/llvm-dwp",
++        "gcov": "/usr/bin/llvmcov",
++        "nm": "/usr/bin/llvm-nm",
++        "objcopy": "/usr/bin/llvm-objcopy",
++        "objdump": "/usr/bin/llvm-objdump",
++        "strip": "/usr/bin/llvm-strip",
+     },
+     toolchain_identifier = "linux_x86_64",
+     unfiltered_compile_flags = [


### PR DESCRIPTION
Since 1.14.7 and 1.15, the agent expects the exact commit for cilium/proxy so we need to bundle them together.

Also add a check to remind reviewers to bump the SHA for Wolfi-bot PRs.