### PR TITLE
remediate cves in terraform-docs and kind

### DIFF
--- a/kind.yaml
+++ b/kind.yaml
@@ -1,7 +1,7 @@
 package:
   name: kind
   version: 0.22.0
-  epoch: 0
+  epoch: 1
   description: Kubernetes IN Docker - local clusters for testing Kubernetes
   copyright:
     - license: Apache-2.0
@@ -15,10 +15,15 @@ environment:
       - go
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/kubernetes-sigs/kind/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: e3e21c8d1c4566d0d255e16e65bbc39297c8f5db41e7ec38d9d62a1ac9e51980
+      repository: https://github.com/kubernetes-sigs/kind
+      tag: v${{package.version}}
+      expected-commit: 2b248e7df157d4f1a44ecea114be3d58c9232930
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/sys@v0.0.0-20220412211240-33da011f77ad
 
   - runs: |
       make build

--- a/terraform-docs.yaml
+++ b/terraform-docs.yaml
@@ -1,16 +1,26 @@
 package:
   name: terraform-docs
   version: 0.17.0
-  epoch: 0
+  epoch: 1
   description: Generate documentation from Terraform modules in various output formats
   copyright:
     - license: MIT
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/terraform-docs/terraform-docs
-      version: v${{package.version}}
+      repository: https://github.com/terraform-docs/terraform-docs
+      tag: v${{package.version}}
+      expected-commit: 795d369fdcfbadef3cfca311be03135f794998c5
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+
+  - uses: go/build
+    with:
+      packages: ./cmd
+      output: terraform-docs
 
 test:
   pipeline:

--- a/terraform-docs.yaml
+++ b/terraform-docs.yaml
@@ -19,12 +19,12 @@ pipeline:
 
   - uses: go/build
     with:
-      packages: ./cmd
+      packages: .
       output: terraform-docs
 
 test:
   pipeline:
-    - runs: terraform-docs --help
+    - runs: ls -lh /usr/bin && terraform-docs --help
 
 update:
   enabled: true


### PR DESCRIPTION
```
$ wolfictl scan packages/x86_64/kind-0.22.0-r1.apk 
🔎 Scanning "packages/x86_64/kind-0.22.0-r1.apk"
✅ No vulnerabilities found
```

```
$ wolfictl scan packages/x86_64/terraform-docs-0.17.0-r1.apk 
🔎 Scanning "packages/x86_64/terraform-docs-0.17.0-r1.apk"
✅ No vulnerabilities found
```