### PR TITLE
chore(chromium): Symlink chromedriver to the executable path

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -2,7 +2,7 @@
 package:
   name: chromium
   version: 122.0.6261.99
-  epoch: 1
+  epoch: 2
   description: "Open souce version of Google's chrome web browser"
   copyright:
     - license: BSD-3-Clause
@@ -179,6 +179,7 @@ pipeline:
       mv locales ${{targets.destdir}}/usr/lib/${{package.name}}
       # links
       ln -sf /usr/lib/${{package.name}}/chrome ${{targets.destdir}}/usr/bin/chromium-browser
+      ln -sf /usr/lib/${{package.name}}/chromedriver ${{targets.destdir}}/usr/bin/chromedriver
       ln -sf chromium-browser ${{targets.destdir}}/usr/bin/chromium
       mkdir -p ${{targets.destdir}}/etc/chromium
 


### PR DESCRIPTION
Given chromedriver is an executable, it should be available in the execution path.