### PR TITLE
kube-state-metrics: Bump emicklei/go-restful

### DIFF
--- a/kube-state-metrics.yaml
+++ b/kube-state-metrics.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-state-metrics
   version: 2.10.1
-  epoch: 3
+  epoch: 4
   description: Add-on agent to generate and expose cluster-level metrics.
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0
+      deps: golang.org/x/crypto@v0.17.0 github.com/emicklei/go-restful/v3@v3.11.3
       modroot: .
 
   - runs: |
@@ -39,3 +39,8 @@ update:
     identifier: kubernetes/kube-state-metrics
     strip-prefix: v
     tag-filter: v
+
+test:
+  pipeline:
+    - runs: |
+        kube-state-metrics version


### PR DESCRIPTION
PRISMA is reporting a finding - and we can bump this package easily: PRISMA-2022-0227