### PR TITLE
Point kafka bitnami to an existing directory

### DIFF
--- a/kafka.yaml
+++ b/kafka.yaml
@@ -2,7 +2,7 @@ package:
   name: kafka
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.7.0
-  epoch: 0
+  epoch: 1
   description: Apache Kafka is a distributed event streaming platformm
   copyright:
     - paths:
@@ -54,7 +54,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: kafka
-          version-path: 3.5/debian-11
+          version-path: 3.6/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/kafka/
           ln -s /usr/lib/kafka/bin ${{targets.subpkgdir}}/opt/bitnami/kafka/bin


### PR DESCRIPTION
[Last week the bitnami repo dropped all references to debian-11](https://github.com/bitnami/containers/commit/d624c10ea7e23d8059dc62adb11e1414d8e39123) in favor of debian-12. Our latest kafka package is missing entrypoint scripts which is breaking the kafka image. This PR points the bitnami/compat pipeline to the correct directory