### PR TITLE
update the bitnami paths to debian 12

### DIFF
--- a/kubernetes-event-exporter.yaml
+++ b/kubernetes-event-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-event-exporter
   version: "1.7"
-  epoch: 0
+  epoch: 1
   description: Export Kubernetes events to multiple destinations with routing and filtering
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: kubernetes-event-exporter
-          version-path: 1/debian-11
+          version-path: 1/debian-12
 
 update:
   enabled: true

--- a/memcached-exporter.yaml
+++ b/memcached-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached-exporter
   version: 0.14.2
-  epoch: 0
+  epoch: 1
   description: Exports metrics from memcached servers for consumption by Prometheus.
   copyright:
     - license: Apache-2.0
@@ -38,7 +38,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: memcached-exporter
-          version-path: 0/debian-11
+          version-path: 0/debian-12
 
 update:
   enabled: true

--- a/memcached.yaml
+++ b/memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached
   version: 1.6.24
-  epoch: 0
+  epoch: 1
   description: "Distributed memory object caching system"
   copyright:
     - license: BSD-3-Clause
@@ -61,7 +61,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: memcached
-          version-path: 1/debian-11
+          version-path: 1/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/memcached/conf/sasl2
 

--- a/pipelines/bitnami/compat.yaml
+++ b/pipelines/bitnami/compat.yaml
@@ -26,6 +26,11 @@ pipeline:
       mkdir -p "${{targets.contextdir}}"/opt/bitnami
       mkdir -p "${{targets.contextdir}}"/bitnami/${{inputs.image}}
 
+      if [ ! -d "./bitnami/bitnami/${{inputs.image}}/${{inputs.version-path}}" ]; then
+        echo "./bitnami/bitnami/${{inputs.image}}/${{inputs.version-path}} does not exist"
+        exit 1
+      fi
+
       if [ -d "./bitnami/bitnami/${{inputs.image}}/${{inputs.version-path}}/prebuildfs" ]; then
         cp -rf ./bitnami/bitnami/${{inputs.image}}/${{inputs.version-path}}/prebuildfs/* ${{targets.contextdir}}/
       fi

--- a/postgresql-12.yaml
+++ b/postgresql-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-12
   version: "12.18"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -113,7 +113,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: postgresql
-          version-path: 12/debian-11
+          version-path: 12/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf

--- a/postgresql-13.yaml
+++ b/postgresql-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-13
   version: "13.14"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -112,7 +112,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: postgresql
-          version-path: 13/debian-11
+          version-path: 13/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf

--- a/postgresql-14.yaml
+++ b/postgresql-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-14
   version: "14.11"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -113,7 +113,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: postgresql
-          version-path: 14/debian-11
+          version-path: 14/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-15
   version: "15.6"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -109,7 +109,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: postgresql
-          version-path: 15/debian-11
+          version-path: 15/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.2"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -123,7 +123,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: postgresql
-          version-path: 16/debian-11
+          version-path: 16/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf

--- a/prometheus-elasticsearch-exporter.yaml
+++ b/prometheus-elasticsearch-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-elasticsearch-exporter
   version: 1.7.0
-  epoch: 0
+  epoch: 1
   description: Elasticsearch stats exporter for Prometheus
   copyright:
     - license: Apache-2.0
@@ -42,7 +42,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: elasticsearch-exporter
-          version-path: 1/debian-11
+          version-path: 1/debian-12
       - runs: |
           mkdir -p ${{targets.contextdir}}/opt/bitnami/elasticsearch-exporter/bin
           ln -s /usr/bin/elasticsearch_exporter ${{targets.contextdir}}/opt/bitnami/elasticsearch-exporter/bin/elasticsearch_exporter

--- a/prometheus-postgres-exporter.yaml
+++ b/prometheus-postgres-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-postgres-exporter
   version: 0.15.0
-  epoch: 2
+  epoch: 3
   description: Prometheus Exporter for Postgres server metrics
   copyright:
     - license: Apache-2.0
@@ -41,7 +41,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: postgres-exporter
-          version-path: 0/debian-11
+          version-path: 0/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgres-exporter
           ln -s /usr/bin/postgres_exporter ${{targets.subpkgdir}}/opt/bitnami/postgres-exporter/postgres_exporter

--- a/prometheus-pushgateway.yaml
+++ b/prometheus-pushgateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-pushgateway
   version: 1.7.0
-  epoch: 0
+  epoch: 1
   description: Push acceptor for ephemeral and batch jobs.
   copyright:
     - license: Apache-2.0
@@ -42,7 +42,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: pushgateway
-          version-path: 1/debian-11
+          version-path: 1/debian-12
       - runs: |
           mkdir -p  ${{targets.subpkgdir}}/opt/bitnami/pushgateway/bin/
           chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami

--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus
   version: 2.50.1
-  epoch: 0
+  epoch: 1
   description: The Prometheus monitoring system and time series database.
   copyright:
     - license: Apache-2.0
@@ -83,7 +83,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: prometheus
-          version-path: 2/debian-11
+          version-path: 2/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/prometheus/bin/
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/prometheus/conf

--- a/redis-6.2.yaml
+++ b/redis-6.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis-6.2
   version: 6.2.14
-  epoch: 3
+  epoch: 4
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
@@ -82,7 +82,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: redis
-          version-path: 6.2/debian-11
+          version-path: 6.2/debian-12
       - runs: |
           # Bitnami startup scripts _require_ the redis-default.conf to exist
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc
@@ -110,7 +110,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: redis-sentinel
-          version-path: 6.2/debian-11
+          version-path: 6.2/debian-12
       - runs: |
           # Bitnami startup scripts _require_ the redis-default.conf to exist
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis-sentinel/etc
@@ -135,7 +135,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: redis-cluster
-          version-path: 6.2/debian-11
+          version-path: 6.2/debian-12
       - runs: |
           # Bitnami startup scripts _require_ the redis-default.conf to exist
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis-cluster/etc

--- a/redis-7.0.yaml
+++ b/redis-7.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis-7.0
   version: 7.0.15
-  epoch: 0
+  epoch: 1
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
@@ -80,7 +80,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: redis
-          version-path: 7.0/debian-11
+          version-path: 7.0/debian-12
       - runs: |
           # Bitnami startup scripts _require_ the redis-default.conf to exist
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc
@@ -108,7 +108,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: redis-sentinel
-          version-path: 7.0/debian-11
+          version-path: 7.0/debian-12
       - runs: |
           # Bitnami startup scripts _require_ the redis-default.conf to exist
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis-sentinel/etc
@@ -133,7 +133,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: redis-cluster
-          version-path: 7.0/debian-11
+          version-path: 7.0/debian-12
       - runs: |
           # Bitnami startup scripts _require_ the redis-default.conf to exist
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis-cluster/etc

--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis-7.2
   version: 7.2.4
-  epoch: 0
+  epoch: 1
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
@@ -82,7 +82,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: redis
-          version-path: 7.2/debian-11
+          version-path: 7.2/debian-12
       - runs: |
           # Bitnami startup scripts _require_ the redis-default.conf to exist
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc
@@ -110,7 +110,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: redis-sentinel
-          version-path: 7.2/debian-11
+          version-path: 7.2/debian-12
       - runs: |
           # Bitnami startup scripts _require_ the redis-default.conf to exist
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis-sentinel/etc
@@ -136,7 +136,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: redis-cluster
-          version-path: 7.2/debian-11
+          version-path: 7.2/debian-12
       - runs: |
           # Bitnami startup scripts _require_ the redis-default.conf to exist
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis-cluster/etc

--- a/zookeeper-3.8.yaml
+++ b/zookeeper-3.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.8
   version: 3.8.4.0
-  epoch: 0
+  epoch: 1
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0
@@ -66,7 +66,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: zookeeper
-          version-path: 3.8/debian-11
+          version-path: 3.8/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/zookeeper/
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/scripts/zookeeper/

--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.9
   version: 3.9.2.0
-  epoch: 0
+  epoch: 1
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0
@@ -66,7 +66,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: zookeeper
-          version-path: 3.9/debian-11
+          version-path: 3.9/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/zookeeper/
           ln -s /usr/share/java/zookeeper/bin ${{targets.subpkgdir}}/opt/bitnami/zookeeper/bin


### PR DESCRIPTION
[Last week the bitnami repo dropped all references to debian-11](https://github.com/bitnami/containers/commit/d624c10ea7e23d8059dc62adb11e1414d8e39123) in favor of debian-12. This PR points the bitnami/compat pipeline to the correct directory for all packages pointed towards debian-11.

It also adds a check to the bitnami/compat pipeline to check if the directory exists so this doesn't silently fail again.