### PR TITLE
optimising hugo-extended to use already available hugo

### DIFF
--- a/hugo-extended.yaml
+++ b/hugo-extended.yaml
@@ -1,32 +1,25 @@
 package:
   name: hugo-extended
   version: 0.123.7
-  epoch: 0
-  description: The world's fastest framework for building websites.
+  epoch: 1
+  description: The world's fastest framework for building websites (with extended SASS libraries).
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - hugo
       - libstdc++
 
 environment:
   contents:
     packages:
       - busybox
-      - ca-certificates-bundle
-      - git
+      - wolfi-baselayout
 
 pipeline:
-  - uses: go/install
-    with:
-      package: github.com/gohugoio/hugo
-      version: v${{package.version}}
-      tags: extended
-
-  - uses: strip
+  - name: Install
+    runs: |
+      mkdir -p "${{targets.destdir}}"
 
 update:
-  enabled: true
-  github:
-    identifier: gohugoio/hugo
-    strip-prefix: v
+  enabled: false


### PR DESCRIPTION

Previously in hugo-extended, we were installing hugo directly from GitHub.
As we are already building and have hugo in the repository it was repetitive. 