### PR TITLE
php-8.3: add popular extensions

### DIFF
--- a/php-8.3-amqp.yaml
+++ b/php-8.3-amqp.yaml
@@ -1,0 +1,64 @@
+package:
+  name: php-8.3-amqp
+  version: 2.1.2
+  epoch: 0 # NB intentionally meant to be picked over previous php-amqp
+  description: "PHP extension to communicate with any AMQP compliant server"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.3
+      - rabbitmq-c
+    provides:
+      - php-amqp=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.3
+      - php-8.3-dev
+      - rabbitmq-c-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-amqp/php-amqp
+      tag: "v${{package.version}}"
+      expected-commit: 82424ed50eb10cd97777e2aabf0f2a0887faf447
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      set -x
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-amqp-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=amqp.so" > "${{targets.subpkgdir}}/etc/php/conf.d/amqp.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: php-amqp/php-amqp
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/php-8.3-igbinary.yaml
+++ b/php-8.3-igbinary.yaml
@@ -1,0 +1,67 @@
+package:
+  name: php-8.3-igbinary
+  version: 3.2.15
+  epoch: 0
+  description: "Igbinary is a drop in replacement for the standard php serializer."
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.3
+    provides:
+      - php-igbinary=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.3
+      - php-8.3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/igbinary/igbinary
+      tag: ${{package.version}}
+      expected-commit: cde4f9b98b6aaa10566166865b2142f83301c641
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      ./configure CFLAGS="-O2 -g" --enable-igbinary
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      set -x
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-igbinary-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
+
+  - name: ${{package.name}}-dev
+    description: PHP 8.3 igbinary development headers
+    dependencies:
+      provides:
+        - php-igbinary-dev=${{package.full-version}}
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: igbinary/igbinary

--- a/php-8.3-redis.yaml
+++ b/php-8.3-redis.yaml
@@ -1,0 +1,66 @@
+package:
+  name: php-8.3-redis
+  version: 6.0.2
+  epoch: 0
+  description: "A PHP extension for Redis"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.3
+      - php-8.3-igbinary
+    provides:
+      - php-redis=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.3
+      - php-8.3-dev
+      - php-8.3-igbinary-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/phpredis/phpredis
+      tag: ${{package.version}}
+      expected-commit: 62cf943fecc5182c6329b332df43cf28012cef55
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure --enable-redis-igbinary
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-redis-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
+
+  - name: ${{package.name}}-dev
+    description: PHP 8.3 redis development headers
+    dependencies:
+      provides:
+        - php-redis-dev=${{package.full-version}}
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: phpredis/phpredis


### PR DESCRIPTION
These three extensions are already in this repo, but only for PHP 8.2. I copied them and adjusted for PHP 8.3.

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
