### PR TITLE
cilium-envoy: Sync with upstream

### DIFF
--- a/cilium-envoy.yaml
+++ b/cilium-envoy.yaml
@@ -38,8 +38,8 @@ environment:
 
 vars:
   # From latest cilium/cilium release:
-  #   https://github.com/cilium/cilium/blob/v1.14.3/images/cilium/Dockerfile
-  CILIUM_PROXY_COMMIT: "f71a313bd0daee41470af31ce6ea20c750fe35dd"
+  #   https://github.com/cilium/cilium/blob/v1.14.7/images/cilium/Dockerfile
+  CILIUM_PROXY_COMMIT: "39dc41f86c465d2a2d16386339dc0bf4d425babc"
 
 pipeline:
   - runs: |
@@ -58,9 +58,9 @@ pipeline:
     with:
       patches: toolchains-paths.patch
 
-  - uses: go/bump
-    with:
-      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3
+#  - uses: go/bump
+#    with:
+#      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3
 
   - runs: |
       cd /home/build/proxylib


### PR DESCRIPTION
This commit is to sync with the upstream hash and to remove outdated go/bump

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
