### PR TITLE
adds a patch to use sha256 instead of md5

### DIFF
--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -55,6 +55,10 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 989d8f41f37cca3275bf3fedc5c2057a717d1d64
 
+  - uses: patch
+    with:
+      patches: use-sha256.patch
+
   - runs: |
       # Workaround for "OpenSearch Dashboards should not be run as root.  Use --allow-root to continue."
       # This change will add the --allow-root when running the build_ts_refs and register_git_hook scripts

--- a/opensearch-dashboards-2/use-sha256.patch
+++ b/opensearch-dashboards-2/use-sha256.patch
@@ -1,0 +1,105 @@
+diff --git a/packages/osd-opensearch/src/install/source.js b/packages/osd-opensearch/src/install/source.js
+index 00e93b0e5b..ad07642430 100644
+--- a/packages/osd-opensearch/src/install/source.js
++++ b/packages/osd-opensearch/src/install/source.js
+@@ -106,7 +106,7 @@ async function sourceInfo(cwd, license, log = defaultLog) {
+   log.info('on %s at %s', chalk.bold(branch), chalk.bold(sha));
+   log.info('%s locally modified file(s)', chalk.bold(status.modified.length));
+ 
+-  const etag = crypto.createHash('md5').update(branch);
++  const etag = crypto.createHash('sha256').update(branch);
+   etag.update(sha);
+ 
+   // for changed files, use last modified times in hash calculation
+@@ -114,7 +114,7 @@ async function sourceInfo(cwd, license, log = defaultLog) {
+     etag.update(fs.statSync(path.join(cwd, file.path)).mtime.toString());
+   });
+ 
+-  const cwdHash = crypto.createHash('md5').update(cwd).digest('hex').substr(0, 8);
++  const cwdHash = crypto.createHash('sha256').update(cwd).digest('hex').substr(0, 8);
+ 
+   const basename = `${branch}-${task}-${cwdHash}`;
+   const filename = `${basename}.${ext}`;
+diff --git a/src/core/TESTING.md b/src/core/TESTING.md
+index 02e6c38850..070227d61f 100644
+--- a/src/core/TESTING.md
++++ b/src/core/TESTING.md
+@@ -617,7 +617,7 @@ import { SavedObjectsClientContract } from 'opensearch-dashboards/server';
+ 
+ export const shortUrlLookup = {
+   generateUrlId(url: string, savedObjectsClient: SavedObjectsClientContract) {
+-    const id = crypto.createHash('md5').update(url).digest('hex');
++    const id = crypto.createHash('sha256').update(url).digest('hex');
+ 
+     return savedObjectsClient
+       .create(
+diff --git a/src/core/server/saved_objects/mappings/types.ts b/src/core/server/saved_objects/mappings/types.ts
+index d3d41fe53e..bf452ae04a 100644
+--- a/src/core/server/saved_objects/mappings/types.ts
++++ b/src/core/server/saved_objects/mappings/types.ts
+@@ -138,8 +138,8 @@ export interface IndexMapping {
+ 
+ /** @internal */
+ export interface IndexMappingMeta {
+-  // A dictionary of key -> md5 hash (e.g. 'dashboard': '24234qdfa3aefa3wa')
++  // A dictionary of key -> sha256 hash (e.g. 'dashboard': '24234qdfa3aefa3wa')
+   // with each key being a root-level mapping property, and each value being
+-  // the md5 hash of that mapping's value when the index was created.
++  // the sha256 hash of that mapping's value when the index was created.
+   migrationMappingPropertyHashes?: { [k: string]: string };
+ }
+diff --git a/src/core/server/saved_objects/migrations/core/build_active_mappings.ts b/src/core/server/saved_objects/migrations/core/build_active_mappings.ts
+index 01a7ba11b7..f5cf8c0202 100644
+--- a/src/core/server/saved_objects/migrations/core/build_active_mappings.ts
++++ b/src/core/server/saved_objects/migrations/core/build_active_mappings.ts
+@@ -95,9 +95,9 @@ export function diffMappings(actual: IndexMapping, expected: IndexMapping) {
+   return changedProp ? { changedProp: `properties.${changedProp}` } : undefined;
+ }
+ 
+-// Convert an object to an md5 hash string, using a stable serialization (canonicalStringify)
+-function md5Object(obj: any) {
+-  return crypto.createHash('md5').update(canonicalStringify(obj)).digest('hex');
++// Convert an object to a SHA-256 hash string, using a stable serialization (canonicalStringify)
++function sha256Object(obj: any) {
++  return crypto.createHash('sha256').update(canonicalStringify(obj)).digest('hex');
+ }
+ 
+ // JSON.stringify is non-canonical, meaning the same object may produce slightly
+@@ -129,9 +129,9 @@ function canonicalStringify(obj: any): string {
+   return `{${sortedObj}}`;
+ }
+ 
+-// Convert an object's values to md5 hash strings
++// Convert an object's values to sha256 hash strings
+ function md5Values(obj: any) {
+-  return mapValues(obj, md5Object);
++  return mapValues(obj, sha256Object);
+ }
+ 
+ // If something exists in actual, but is missing in expected, we don't
+diff --git a/src/legacy/server/i18n/localization/file_integrity.ts b/src/legacy/server/i18n/localization/file_integrity.ts
+index dbacd74f25..7d0ab133fe 100644
+--- a/src/legacy/server/i18n/localization/file_integrity.ts
++++ b/src/legacy/server/i18n/localization/file_integrity.ts
+@@ -49,7 +49,7 @@ export async function getIntegrityHashes(filepaths: string[]): Promise<Integriti
+ 
+ export async function getIntegrityHash(filepath: string): Promise<Hash | null> {
+   try {
+-    const output = createHash('md5');
++    const output = createHash('sha256');
+ 
+     await pipeline(fs.createReadStream(filepath), output);
+     const data = output.read();
+diff --git a/src/plugins/share/server/routes/lib/short_url_lookup.ts b/src/plugins/share/server/routes/lib/short_url_lookup.ts
+index f9ff2dd7ba..e64f70cbff 100644
+--- a/src/plugins/share/server/routes/lib/short_url_lookup.ts
++++ b/src/plugins/share/server/routes/lib/short_url_lookup.ts
+@@ -64,7 +64,7 @@ export function shortUrlLookupProvider({ logger }: { logger: Logger }): ShortUrl
+ 
+   return {
+     async generateUrlId(url, { savedObjects }) {
+-      const id = crypto.createHash('md5').update(url).digest('hex');
++      const id = crypto.createHash('sha256').update(url).digest('hex');
+       const { isConflictError } = savedObjects.errors;
+ 
+       try {


### PR DESCRIPTION
The existing upstream of opensearch-dashboard uses md5, this PR adds a patch to use more secure sha256 instead