### PR TITLE
run postunpack.sh for postgres

### DIFF
--- a/postgresql-12.yaml
+++ b/postgresql-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-12
   version: "12.18"
-  epoch: 1
+  epoch: 2
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -11,6 +11,7 @@ environment:
     packages:
       - autoconf
       - automake
+      - bash
       - bison
       - build-base
       - busybox
@@ -118,6 +119,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin
+          ${{targets.subpkgdir}}/opt/bitnami/scripts/postgresql/postunpack.sh
           ln -sf /usr/share/postgresql/pg_hba.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf/pg_hba.conf
           ln -sf /usr/share/postgresql/postgresql.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf/postgresql.conf
           ln -sf /usr/bin/initdb ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/initdb

--- a/postgresql-13.yaml
+++ b/postgresql-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-13
   version: "13.14"
-  epoch: 1
+  epoch: 2
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -11,6 +11,7 @@ environment:
     packages:
       - autoconf
       - automake
+      - bash
       - bison
       - build-base
       - busybox
@@ -117,6 +118,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin
+          ${{targets.subpkgdir}}/opt/bitnami/scripts/postgresql/postunpack.sh
           ln -s /usr/share/postgresql/pg_hba.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf/pg_hba.conf
           ln -s /usr/share/postgresql/postgresql.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf/postgresql.conf
           ln -sf /usr/bin/initdb ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/initdb

--- a/postgresql-14.yaml
+++ b/postgresql-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-14
   version: "14.11"
-  epoch: 1
+  epoch: 3
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -11,6 +11,7 @@ environment:
     packages:
       - autoconf
       - automake
+      - bash
       - bison
       - build-base
       - busybox
@@ -118,6 +119,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin
+          ${{targets.subpkgdir}}/opt/bitnami/scripts/postgresql/postunpack.sh
           ln -s /usr/share/postgresql/pg_hba.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf/pg_hba.conf
           ln -s /usr/share/postgresql/postgresql.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf/postgresql.conf
           ln -sf /usr/bin/initdb ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/initdb

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-15
   version: "15.6"
-  epoch: 1
+  epoch: 2
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -11,6 +11,7 @@ environment:
     packages:
       - autoconf
       - automake
+      - bash
       - bison
       - build-base
       - busybox
@@ -114,6 +115,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin
+          ${{targets.subpkgdir}}/opt/bitnami/scripts/postgresql/postunpack.sh
           ln -s /usr/share/postgresql/pg_hba.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf/pg_hba.conf
           ln -s /usr/share/postgresql/postgresql.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf/postgresql.conf
           ln -sf /usr/bin/initdb ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/initdb

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.2"
-  epoch: 1
+  epoch: 2
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -14,6 +14,7 @@ environment:
     packages:
       - autoconf
       - automake
+      - bash
       - bison
       - build-base
       - busybox
@@ -128,6 +129,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin
+          ${{targets.subpkgdir}}/opt/bitnami/scripts/postgresql/postunpack.sh
           ln -s /usr/share/postgresql/pg_hba.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf/pg_hba.conf
           ln -s /usr/share/postgresql/postgresql.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf/postgresql.conf
           ln -sf /usr/bin/initdb ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/initdb


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

We (w/@dentrax) realized that our postgres bitnami image is having an issue like this during the start up:

```
cp: can't stat '/opt/bitnami/postgresql/conf.default/.': No such file or directory
```

We found the following line in their Dockerfile that creates the necessary files for us:

> https://github.com/bitnami/containers/blob/50f700046dc1cd8043f81103ef1fef11ea736cf4/bitnami/postgresql/15/debian-12/Dockerfile#L53

So, this PR aims to fix this issue.

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
