### PR TITLE
feat(packages): Add topgrade and cargo-auditable

### DIFF
--- a/cargo-auditable.yaml
+++ b/cargo-auditable.yaml
@@ -22,7 +22,7 @@ pipeline:
 
   - runs: |
       # Build cargo-auditable
-      cargo fetch --target="${{host.triplet.gnu}}" --locked
+      cargo fetch --locked
       cargo build --release --frozen
 
       # Rebuild cargo-auditable with cargo-auditable

--- a/cargo-auditable.yaml
+++ b/cargo-auditable.yaml
@@ -1,0 +1,51 @@
+package:
+  name: cargo-auditable
+  version: 0.6.2
+  epoch: 0
+  description: Cargo wrapper for embedding auditing data
+  copyright:
+    - license: MIT OR Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rust-secure-code/cargo-auditable
+      tag: v${{package.version}}
+      expected-commit: f56bb45509a8447dbb62331aa868e4a3b83806c2
+
+  - runs: |
+      # Build cargo-auditable
+      cargo fetch --target="${{host.triplet.gnu}}" --locked
+      cargo build --release --frozen
+
+      # Rebuild cargo-auditable with cargo-auditable
+      PATH="$PATH:$PWD/target/release" \
+      cargo auditable build --release --frozen
+
+      # Install cargo-auditable
+      install -Dm755 target/release/cargo-auditable -t "${{targets.destdir}}"/usr/bin/
+      install -Dm644 cargo-auditable/cargo-auditable.1 -t "${{targets.destdir}}"/usr/share/man/man1/
+
+  - uses: strip
+
+subpackages:
+  - name: cargo-auditable-doc
+    pipeline:
+      - uses: split/manpages
+    description: cargo-auditable manpages
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - '.*rust.*'
+  github:
+    identifier: rust-secure-code/cargo-auditable
+    use-tag: true
+    strip-prefix: v

--- a/topgrade.yaml
+++ b/topgrade.yaml
@@ -1,0 +1,91 @@
+package:
+  name: topgrade
+  version: 14.0.1
+  epoch: 0
+  description: Detects which tools you use and runs the appropriate commands to update them
+  copyright:
+    - license: GPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/topgrade-rs/topgrade
+      tag: v${{package.version}}
+      expected-commit: ea13c51b7d74299a7a073a38a3d5f74f88f4fd65
+
+  - runs: |
+      # Build topgrade
+      cargo fetch --target="${{host.triplet.gnu}}" --locked
+      cargo auditable build --release --frozen
+
+      # Generate shell completions
+      target/release/topgrade --gen-completion bash > topgrade.bash
+      target/release/topgrade --gen-completion fish > topgrade.fish
+      target/release/topgrade --gen-completion zsh > _topgrade
+
+      # Generate manpages
+      target/release/topgrade --gen-manpage > topgrade.8
+
+      # Install topgrade
+      install -Dm755 target/release/topgrade "${{targets.destdir}}"/usr/bin/topgrade
+
+      # License
+      install -Dm644 LICENSE "${{targets.destdir}}"/usr/share/license/topgrade/LICENSE
+
+      # Shell completions
+      install -Dm644 topgrade.bash "${{targets.destdir}}"/usr/share/bash-completion/completions/topgrade
+      install -Dm644 topgrade.fish "${{targets.destdir}}"/usr/share/fish/vendor_completions.d/topgrade.fish
+      install -Dm644 _topgrade "${{targets.destdir}}"/usr/share/zsh/site-functions/_topgrade
+
+      # Documentation
+      install -Dm644 config.example.toml "${{targets.destdir}}"/usr/share/doc/topgrade/config.example.toml
+      install -Dm644 topgrade.8 "${{targets.destdir}}"/usr/share/man/man8/topgrade.8
+
+  - uses: strip
+
+subpackages:
+  - name: topgrade-bash-completion
+    description: bash completion for topgrade
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/share/bash-completion/completions"
+          mv "${{targets.destdir}}/usr/share/bash-completion/completions/topgrade" \
+            "${{targets.subpkgdir}}/usr/share/bash-completion/completions/topgrade"
+          rm -rf "${{targets.destdir}}/usr/share/bash-completion"
+
+  - name: topgrade-zsh-completion
+    description: zsh completion for topgrade
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/share/zsh/site-functions"
+          mv "${{targets.destdir}}/usr/share/zsh/site-functions/_topgrade" \
+            "${{targets.subpkgdir}}/usr/share/zsh/site-functions/_topgrade"
+          rm -rf "${{targets.destdir}}/usr/share/zsh"
+
+  - name: topgrade-fish-completion
+    description: fish completion for topgrade
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/share/fish/vendor_completions.d"
+          mv "${{targets.destdir}}/usr/share/fish/vendor_completions.d/" \
+            "${{targets.subpkgdir}}/usr/share/fish/vendor_completions.d"
+          rm -rf "${{targets.destdir}}/usr/share/fish"
+
+  - name: topgrade-doc
+    pipeline:
+      - uses: split/manpages
+    description: topgrade manpages
+
+update:
+  enabled: true
+  github:
+    identifier: topgrade-rs/topgrade
+    use-tag: true
+    strip-prefix: v

--- a/topgrade.yaml
+++ b/topgrade.yaml
@@ -11,6 +11,7 @@ environment:
     packages:
       - build-base
       - busybox
+      - cargo-auditable
       - rust
 
 pipeline:

--- a/topgrade.yaml
+++ b/topgrade.yaml
@@ -23,7 +23,7 @@ pipeline:
 
   - runs: |
       # Build topgrade
-      cargo fetch --target="${{host.triplet.gnu}}" --locked
+      cargo fetch --locked
       cargo auditable build --release --frozen
 
       # Generate shell completions


### PR DESCRIPTION
Adds topgrade, a utility that automatically detects installed update tools and runs them. Also introduces cargo-auditable for producing auditable rust binaries.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)