### PR TITLE
Libxcrypt transition

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.38
-  epoch: 11
+  epoch: 12
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later
@@ -108,7 +108,7 @@ pipeline:
         --host=${{host.triplet.gnu}} \
         --build=${{host.triplet.gnu}} \
         --disable-werror \
-        --enable-crypt \
+        --disable-crypt \
         --enable-kernel=4.9
 
   - runs: |
@@ -378,6 +378,7 @@ subpackages:
     dependencies:
       runtime:
         - linux-headers
+        - libxcrypt-dev
 
   - name: "glibc-iconv"
     description: "GLIBC iconv tables"
@@ -493,15 +494,6 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/sbin
           mv "${{targets.destdir}}"/sbin/sln "${{targets.subpkgdir}}"/sbin
-
-  - name: "libcrypt1"
-    description: "Password hashing library included with glibc"
-    dependencies:
-      provider-priority: 10
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/lib
-          mv "${{targets.destdir}}"/lib/libcrypt.so* "${{targets.subpkgdir}}"/lib/
 
   - name: "glibc-locale-posix"
     description: "POSIX locale data for glibc"

--- a/libxcrypt.yaml
+++ b/libxcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcrypt
   version: 4.4.36
-  epoch: 1
+  epoch: 2
   description: "Modern library for one-way hashing of passwords"
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later
@@ -17,6 +17,7 @@ environment:
       - gettext
       - libtool
       - pkgconf
+      - pkgconf-dev
       - wolfi-base
 
 pipeline:
@@ -55,6 +56,15 @@ subpackages:
     pipeline:
       - uses: split/dev
     description: libxcrypt dev
+
+  - name: "libcrypt1"
+    description: "Password hashing library compatible with glibc"
+    dependencies:
+      provider-priority: 20
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libcrypt.so.* "${{targets.subpkgdir}}"/usr/lib/
 
 update:
   enabled: true

--- a/libxcrypt.yaml
+++ b/libxcrypt.yaml
@@ -36,10 +36,8 @@ pipeline:
         --prefix=/usr \
         --disable-static \
         --enable-hashes=strong,glibc \
-        --enable-obsolete-api=no \
+        --enable-obsolete-api=yes \
         --disable-failure-tokens
-
-  - uses: autoconf/configure
 
   - uses: autoconf/make
 


### PR DESCRIPTION
glibc,libxcrypt: move libcrypt1 package from glibc to libxcrypt

This will be required with next glibc release, but was possible to do
for a while now. All other distros have transitioned to using
libxcrypt already. I have double checked the abi compatibility with
abi-compliance-checker. Separately, once this lands, we might want to
bump epoch on all the reverse depends for them to gain stronger crypt
support.

Also note previous yaml for libxcrypt had a mistake and didn't use any custom provided options.

(See
https://apk.dag.dev/https/packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz@etag:2edafbb750de4d6487204c1cd6110c7b/APKINDEX?&depend=so%3Alibcrypt.so.1
for packages to bump).

Fixes:

Unblocks: #12226