### PR TITLE
fix(chromium): Move wrapper instead of using a hardlink

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -2,7 +2,7 @@
 package:
   name: chromium
   version: 122.0.6261.99
-  epoch: 3
+  epoch: 4
   description: "Open souce version of Google's chrome web browser"
   copyright:
     - license: BSD-3-Clause
@@ -179,10 +179,12 @@ pipeline:
       mv vk_swiftshader_icd.json ${{targets.destdir}}/usr/lib/${{package.name}}
       mv *.pak ${{targets.destdir}}/usr/lib/${{package.name}}
       mv locales ${{targets.destdir}}/usr/lib/${{package.name}}
+      # wrapper
+      cd /home/build
+      mv chromium-launcher.sh ${{targets.destdir}}/usr/bin/chromium-browser
       # links
       ln -sf /usr/lib/${{package.name}}/chrome ${{targets.destdir}}/usr/bin/chromium
       ln -sf /usr/lib/${{package.name}}/chromedriver ${{targets.destdir}}/usr/bin/chromedriver
-      ln -sf chromium-launcher.sh ${{targets.destdir}}/usr/bin/chromium-browser
       mkdir -p ${{targets.destdir}}/etc/chromium
 
   - uses: strip
@@ -240,6 +242,9 @@ test:
 
         # Check status
         chromium --no-sandbox --headless --disable-gpu --dump-dom https://www.chromestatus.com
+
+        # Test wrapper
+        CHROMIUM_USER_FLAGS="--no-sandbox --headless --disable-gpu --dump-dom" chromium-browser https://www.chromestatus.com
 
         # Test ChromeDriver functionality
         pip3 install selenium


### PR DESCRIPTION
Move the wrapper to /usr/bin/chromium-browser instead of using a hardlink. Also add a test for the wrapper