### PR TITLE
coreutils: use openssl & split legacy tools

### DIFF
--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: coreutils
   version: "9.4"
-  epoch: 4
+  epoch: 5
   description: "GNU core utilities"
   copyright:
     - license: GPL-3.0-or-later
@@ -18,6 +18,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - openssl-dev
       - texinfo
       - wolfi-base
 
@@ -37,6 +38,7 @@ pipeline:
          --infodir=/usr/share/info \
          --disable-nls \
          --enable-no-install-program=hostname,su,kill,uptime,groups \
+         --with-openssl=auto-gpl-compat \
          --enable-single-binary=symlinks
 
   - uses: autoconf/make
@@ -76,6 +78,14 @@ subpackages:
     pipeline:
       - uses: split/manpages
       - uses: split/infodir
+
+  - name: "coreutils-legacy"
+    description: "legacy GNU coreutils"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/md5sum "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/sha1sum "${{targets.subpkgdir}}"/usr/bin
 
 update:
   enabled: true


### PR DESCRIPTION
md5sum & sha1sum are obsolete and should not be used anymore. Split them into separate subpackage.

Enable OpenSSL backend for sha256sum and friends. This gains hardware acceleration, reduces coreutils binary size, and opens the path to FIPS compliant coreutils - when paired with OpenSSl in FIPS mode.