### PR TITLE
Update cilium to 1.14.7

### DIFF
--- a/cilium-1.14.yaml
+++ b/cilium-1.14.yaml
@@ -59,7 +59,7 @@ pipeline:
     with:
       repository: https://github.com/cilium/cilium
       tag: v${{package.version}}
-      expected-commit: 4a4fa0587d1beb6abce883780957f9848dc50b60
+      expected-commit: 91b461c78160ff5c96cad23a85e4287093753c22
 
   - uses: patch
     with:

--- a/cilium-1.14.yaml
+++ b/cilium-1.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-1.14
-  version: 1.14.6
-  epoch: 2
+  version: 1.14.7
+  epoch: 0
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -51,8 +51,8 @@ environment:
       - wolfi-baselayout
 
 vars:
-  # https://github.com/cilium/cilium/blob/v1.14.6/images/cilium/Dockerfile
-  CILIUM_PROXY_COMMIT: "ad82c7c56e88989992fd25d8d67747de865c823b"
+  # https://github.com/cilium/cilium/blob/v1.14.7/images/cilium/Dockerfile
+  CILIUM_PROXY_COMMIT: "39dc41f86c465d2a2d16386339dc0bf4d425babc"
 
 pipeline:
   - uses: git-checkout
@@ -100,11 +100,6 @@ pipeline:
   - uses: patch
     with:
       patches: toolchains-paths.patch
-
-  - uses: go/bump
-    with:
-      modroot: /home/build/envoy
-      deps: golang.org/x/net@v0.17.0
 
   - runs: |
       cd /home/build/envoy/proxylib

--- a/cilium-1.14.yaml
+++ b/cilium-1.14.yaml
@@ -63,7 +63,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: loopback-location.patch
+      patches: loopback-location.patch,go.mod.patch
 
   - runs: |
       # Remove groupadd from Makefile: it's not doing anything useful in

--- a/cilium-1.14.yaml
+++ b/cilium-1.14.yaml
@@ -63,7 +63,11 @@ pipeline:
 
   - uses: patch
     with:
-      patches: loopback-location.patch,go.mod.patch
+      patches: loopback-location.patch
+
+  - uses: patch
+    with:
+      patches: go.mod.patch
 
   - runs: |
       # Remove groupadd from Makefile: it's not doing anything useful in

--- a/cilium-1.14/go.mod.patch
+++ b/cilium-1.14/go.mod.patch
@@ -1,0 +1,13 @@
+diff --git a/go.mod b/go.mod
+index f590dc1a11..95ef440a9e 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,7 +1,7 @@
+ module github.com/cilium/cilium
+ 
+ // renovate: datasource=golang-version depName=go
+-go 1.21.0
++go 1.21
+ 
+ require (
+ 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1


### PR DESCRIPTION
cilium-1.14: update to 1.14.7

### Pre-review Checklist

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
