### PR TITLE
Make python-3.11 and python-3.12 co-installable.

### DIFF
--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,14 +1,10 @@
 package:
   name: python-3.11
   version: 3.11.8
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
-  dependencies:
-    provides:
-      - python3=3.11.999
-      - python-3=3.11.999
 
 environment:
   contents:
@@ -81,9 +77,9 @@ pipeline:
       find ${{targets.destdir}}/usr/lib -type d -name 'tests' -exec rm -rf '{}' +
       find ${{targets.destdir}}/usr/lib -type d -name 'idle_test' -exec rm -rf '{}' +
 
-  - name: Install python symlink
-    runs: |
-      ln -s python3 "${{targets.destdir}}"/usr/bin/python
+      cd ${{targets.destdir}}/usr/bin
+      rm -f python3 pydoc3 idle3* 2to3*
+      rm ${{targets.destdir}}/usr/lib/libpython3.so
 
   - uses: strip
 
@@ -93,6 +89,21 @@ test:
         python3.11 CVE-2023-27043-unittest.py
 
 subpackages:
+  - name: "python-3.11-default"
+    description: "python-3.11 as /usr/bin/python3"
+    dependencies:
+      provides:
+        - python3=3.11.999
+        - python-3=3.11.999
+      runtime:
+        - python-3.11
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          ln -sf python3.11 "${{targets.subpkgdir}}"/usr/bin/python3
+          ln -sf pydoc3.11 "${{targets.subpkgdir}}"/usr/bin/pydoc3
+          ln -sf python3 "${{targets.subpkgdir}}"/usr/bin/python
+
   - name: "python-3.11-doc"
     description: "python3 documentation"
     pipeline:

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,14 +1,10 @@
 package:
   name: python-3.12
   version: 3.12.2
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
-  dependencies:
-    provides:
-      - python3=${{package.full-version}}
-      - python-3=${{package.full-version}}
 
 environment:
   contents:
@@ -81,9 +77,9 @@ pipeline:
       find ${{targets.destdir}}/usr/lib -type d -name 'tests' -exec rm -rf '{}' +
       find ${{targets.destdir}}/usr/lib -type d -name 'idle_test' -exec rm -rf '{}' +
 
-  - name: Install python symlink
-    runs: |
-      ln -s python3 "${{targets.destdir}}"/usr/bin/python
+      cd ${{targets.destdir}}/usr/bin
+      rm -f python3 pydoc3 idle3* 2to3*
+      rm ${{targets.destdir}}/usr/lib/libpython3.so
 
   - uses: strip
 
@@ -93,7 +89,22 @@ test:
         python3.12 CVE-2023-27043-unittest.py
 
 subpackages:
-  - name: "python-3.12-doc"
+  - name: "python-3.12-default"
+    description: "python-3.12 as /usr/bin/python3"
+    dependencies:
+      provides:
+        - python3=${{package.full-version}}
+        - python-3=${{package.full-version}}
+      runtime:
+        - python-3.12
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          ln -sf python3.12 "${{targets.subpkgdir}}"/usr/bin/python3
+          ln -sf pydoc3.12 "${{targets.subpkgdir}}"/usr/bin/pydoc3
+          ln -sf python3 "${{targets.subpkgdir}}"/usr/bin/python
+
+  - name: "python-3.3.12-doc"
     description: "python3 documentation"
     pipeline:
       - uses: split/manpages


### PR DESCRIPTION
Fixes #2115

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
