### PR TITLE
pgvectors for each postgres version

### DIFF
--- a/pgvector-14.yaml
+++ b/pgvector-14.yaml
@@ -1,5 +1,7 @@
+# pgvector-14 is intended to support PostgreSQL 14.
+# https://github.com/pgvector/pgvector#installation-notes
 package:
-  name: pgvector
+  name: pgvector-14
   version: 0.6.1
   epoch: 0
   description: Open-source vector similarity search for PostgreSQL
@@ -13,7 +15,7 @@ environment:
       - automake
       - build-base
       - busybox
-      - postgresql-dev
+      - postgresql-14-dev
 
 pipeline:
   - uses: git-checkout

--- a/pgvector-15.yaml
+++ b/pgvector-15.yaml
@@ -1,0 +1,38 @@
+# pgvector-15 is intended to support PostgreSQL 15.
+# https://github.com/pgvector/pgvector#installation-notes
+package:
+  name: pgvector-15
+  version: 0.6.1
+  epoch: 0
+  description: Open-source vector similarity search for PostgreSQL
+  copyright:
+    - license: PostgreSQL
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - postgresql-15-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pgvector/pgvector
+      expected-commit: c6ddf62a29f4790d386a60f9826583d2a228ef68
+      tag: v${{package.version}}
+
+  - runs: |
+      make OPTFLAGS=""
+      make USE_PGXS=1 DESTDIR="${{targets.destdir}}" PG_CONFIG=/usr/bin/pg_config install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pgvector/pgvector
+    strip-prefix: v
+    use-tag: true

--- a/pgvector-16.yaml
+++ b/pgvector-16.yaml
@@ -1,0 +1,38 @@
+# pgvector-16 is intended to support PostgreSQL 16.
+# https://github.com/pgvector/pgvector#installation-notes
+package:
+  name: pgvector-16
+  version: 0.6.1
+  epoch: 0
+  description: Open-source vector similarity search for PostgreSQL
+  copyright:
+    - license: PostgreSQL
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - postgresql-16-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pgvector/pgvector
+      expected-commit: c6ddf62a29f4790d386a60f9826583d2a228ef68
+      tag: v${{package.version}}
+
+  - runs: |
+      make OPTFLAGS=""
+      make USE_PGXS=1 DESTDIR="${{targets.destdir}}" PG_CONFIG=/usr/bin/pg_config install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: pgvector/pgvector
+    strip-prefix: v
+    use-tag: true

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -222,3 +222,5 @@ glibc-locale-zu-2.38-r12.apk
 glibc-locales-2.38-r12.apk
 glibc-tracing-2.38-r12.apk
 libcrypt1-4.4.36-r2.apk
+pgvector-0.6.0-r0.apk
+pgvector-0.6.0-r1.apk


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

I noticed that according to [here](https://github.com/pgvector/pgvector#postgres-location) we should compile pgvector for each postgres version, also I confirmed that during the tests of the pgvector extension with postgres and saw the following errors:

```bash
Server is version 15, library is version 16.
```

This PR aims to fix this issue.

I couldn't test it in the image side because docker gave the this error:

``` 
 docker: failed to register layer: lsetxattr com.docker.grpcfuse.ownership
│ /usr/include/postgresql/server/extension/vector: operation not supported.
```

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
