### PR TITLE
flatbuffers: update tag commit

### DIFF
--- a/flatbuffers.yaml
+++ b/flatbuffers.yaml
@@ -26,7 +26,7 @@ pipeline:
     with:
       repository: https://github.com/google/flatbuffers
       tag: v${{package.version}}
-      expected-commit: 7cd216c51e7e921bd687c70f7b673ea71578abe7
+      expected-commit: d1867fb4cf7d64b2d3d23b67e86df6ae5d9f993b
 
   - uses: cmake/configure
 


### PR DESCRIPTION
Upstream seems to have moved the tag.
