### PR TITLE
Confluent kafka deps: common-base, ub, cub, dub

### DIFF
--- a/confluent-common-docker.yaml
+++ b/confluent-common-docker.yaml
@@ -1,0 +1,58 @@
+package:
+  name: confluent-common-docker
+  version: 7.7.0.16
+  epoch: 0
+  description: Confluent Commons with support for building and testing Docker images.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+
+var-transforms:
+  - from: ${{package.version}}
+    match: '\.(\d+)$'
+    replace: '-$1'
+    to: mangled-package-version
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: b4613e601f1009e59fdba1f4b1b9ccc86d3e6d03
+      repository: https://github.com/confluentinc/common-docker
+      tag: v${{vars.mangled-package-version}}
+
+subpackages:
+  # https://github.com/confluentinc/common-docker/tree/master/base
+  - name: ${{package.name}}-base
+    description: "This repo provides build files for the Confluent Platform Docker images."
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/etc/confluent/docker
+          cp -r base/include/etc/confluent/docker/* "${{targets.subpkgdir}}"/etc/confluent/docker/
+
+  # https://github.com/confluentinc/common-docker/tree/master/base-lite/ub
+  - name: ${{package.name}}-ub
+    description: "ub tool for base-lite"
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: ./base-lite/ub
+          packages: .
+          output: ub
+          subpackage: "true"
+          ldflags: "-s -w"
+      - uses: strip
+
+update:
+  enabled: true
+  version-transform:
+    - match: "-"
+      replace: "."
+  github:
+    identifier: confluentinc/common-docker
+    use-tag: true

--- a/confluent-common-docker.yaml
+++ b/confluent-common-docker.yaml
@@ -1,3 +1,4 @@
+#nolint:git-checkout-must-use-github-updates
 package:
   name: confluent-common-docker
   version: 7.7.0.16
@@ -53,6 +54,14 @@ update:
   version-transform:
     - match: "-"
       replace: "."
-  github:
-    identifier: confluentinc/common-docker
-    use-tag: true
+  release-monitor:
+    identifier: 371725
+
+test:
+  environment:
+    contents:
+      packages:
+        - confluent-common-docker-ub
+  pipeline:
+    - runs: |
+        ub -h

--- a/confluent-docker-utils.yaml
+++ b/confluent-docker-utils.yaml
@@ -1,0 +1,75 @@
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: confluent-docker-utils
+  version: 0.0.75
+  epoch: 0
+  description: This package provides Docker Utility Belt (dub) and Confluent Platform Utility Belt (cub).
+  copyright:
+    - license: Apache-2.0
+  options:
+    no-depends: true
+  dependencies:
+    runtime:
+      - py3-setuptools # To fix `No module named 'distutils'`
+      - python3
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - py3-gpep517
+      - py3-installer
+      - py3-pip
+      - py3-setuptools
+      - py3-wheel
+      - python-3
+      - python-3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 6fb6b5ad8e980dc0179c336e4cd02b6f24869e80
+      repository: https://github.com/confluentinc/confluent-docker-utils
+      tag: v${{package.version}}
+
+  - runs: |
+      # Workaround to fix `AttributeError: cython_sources` issue
+      # https://github.com/yaml/pyyaml/issues/724#issuecomment-1638587228
+      sed -i 's|PyYAML~=5.4.1|PyYAML==6.0.1|g' requirements.txt
+
+  - runs: |
+      python3 -m gpep517 build-wheel \
+        --wheel-dir dist \
+        --output-fd 3 3>&1 >&2
+      python3 -m installer \
+        -d "${{targets.destdir}}" \
+        dist/*.whl
+      install -Dm644 LICENSE \
+        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+  - runs: |
+      # `--use-deprecated=legacy-resolver` is used force ignore the dependency check.
+      # `docker-compose` was requiring `PyYAML<6` and also `PyYAML==5.4.1` was causing
+      # `AttributeError: cython_sources` issue.
+      pip install --root=${{targets.destdir}} --prefix=/usr --prefer-binary --use-deprecated=legacy-resolver -r requirements.txt
+      pip install --root=${{targets.destdir}} --prefix=/usr setuptools
+      find ${{targets.destdir}} -name "*.pyc" -exec rm -rf '{}' +
+
+  - runs: |
+      _py3ver=$(python3 -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
+      mkdir -p ${{targets.destdir}}/usr/lib/python"$_py3ver"/site-packages/confluent/docker_utils
+      cp -r confluent/docker_utils/* ${{targets.destdir}}/usr/lib/python"$_py3ver"/site-packages/confluent/docker_utils/
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 371723
+
+test:
+  pipeline:
+    - runs: |
+        cub -h
+        dub -h


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
