### PR TITLE
kyverno: Bump notaryproject/notation-go

### DIFF
--- a/kyverno.yaml
+++ b/kyverno.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno
   version: 1.11.4
-  epoch: 3
+  epoch: 4
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/go-jose/go-jose/v3@v3.0.1 github.com/cloudflare/circl@v1.3.7 github.com/lestrrat-go/jwx/v2@v2.0.19
+      deps: github.com/go-jose/go-jose/v3@v3.0.1 github.com/cloudflare/circl@v1.3.7 github.com/lestrrat-go/jwx/v2@v2.0.19 github.com/notaryproject/notation-go@v1.0.1
 
   - runs: |
       make build-all


### PR DESCRIPTION
This removes false negatives for scanner thinking that `v1.0.0` comes before `v1.0.0-rc*`