### PR TITLE
opensearch-2: Bump `commons-compress`

### DIFF
--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -93,15 +93,7 @@ pipeline:
   - uses: patch
     with:
       # Patch from: https://patch-diff.githubusercontent.com/raw/opensearch-project/OpenSearch/pull/10297.patch
-      patches: CVE-2022-45146.patch
-
-  - uses: patch
-    with:
-      patches: CVE-2023-46749.patch
-
-  - uses: patch
-    with:
-      patches: CVE-2023-34054.patch
+      patches: CVE-2022-45146.patch CVE-2023-46749.patch CVE-2023-34054.patch CVE-2024-26308.patch
 
   - runs: |
       echo "org.gradle.daemon=false" >> gradle.properties

--- a/opensearch-2/CVE-2024-26308.patch
+++ b/opensearch-2/CVE-2024-26308.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Philippe Deslauriers <philde@chainguard.dev>
+Date: Thu, 7 Mar 2024 10:18:58 -0500
+Subject: [PATCH] Bump commonscompress
+
+Signed-off-by: Philippe Deslauriers <philde@chainguard.dev>
+---
+ buildSrc/build.gradle       | 2 +-
+ buildSrc/version.properties | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/buildSrc/build.gradle b/buildSrc/build.gradle
+index 66f99b9..f260a3c 100644
+--- a/buildSrc/build.gradle
++++ b/buildSrc/build.gradle
+@@ -103,7 +103,7 @@ dependencies {
+   api localGroovy()
+
+   api 'commons-codec:commons-codec:1.16.0'
+-  api 'org.apache.commons:commons-compress:1.24.0'
++  api 'org.apache.commons:commons-compress:1.26.0'
+   api 'org.apache.ant:ant:1.10.13'
+   api 'com.netflix.nebula:gradle-extra-configurations-plugin:10.0.0'
+   api 'com.netflix.nebula:nebula-publishing-plugin:20.3.0'
+diff --git a/buildSrc/version.properties b/buildSrc/version.properties
+index 53a0248..14e77c7 100644
+--- a/buildSrc/version.properties
++++ b/buildSrc/version.properties
+@@ -36,7 +36,7 @@ httpasyncclient   = 4.1.5
+ commonslogging    = 1.2
+ commonscodec      = 1.15
+ commonslang       = 3.13.0
+-commonscompress   = 1.24.0
++commonscompress   = 1.26.0
+ # plugin dependencies
+ aws               = 2.20.55
+ reactivestreams   = 1.0.4

--- a/opensearch-2/ml-commons.patch
+++ b/opensearch-2/ml-commons.patch
@@ -1,8 +1,8 @@
 diff --git a/ml-algorithms/build.gradle b/ml-algorithms/build.gradle
-index 3561472..050ea67 100644
+index 3561472..73ec352 100644
 --- a/ml-algorithms/build.gradle
 +++ b/ml-algorithms/build.gradle
-@@ -62,7 +62,7 @@ dependencies {
+@@ -62,12 +62,13 @@ dependencies {
      implementation 'software.amazon.awssdk:auth'
      implementation 'software.amazon.awssdk:apache-client'
      implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
@@ -11,27 +11,21 @@ index 3561472..050ea67 100644
      implementation group: 'org.json', name: 'json', version: '20231013'
  }
 
-diff --git a/ml-algorithms/build.gradle b/ml-algorithms/build.gradle
-index 35614721..74b0acbf 100644
---- a/ml-algorithms/build.gradle
-+++ b/ml-algorithms/build.gradle
-@@ -68,6 +68,7 @@ dependencies {
- 
  configurations.all {
      resolutionStrategy.force 'com.google.protobuf:protobuf-java:3.21.9'
-+    resolutionStrategy.force 'org.apache.commons:commons-compress:1.25.0'
++    resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
  }
- 
+
  jacocoTestReport {
 diff --git a/plugin/build.gradle b/plugin/build.gradle
-index af976e6f..3dc408a8 100644
+index af976e6..ac9af82 100644
 --- a/plugin/build.gradle
 +++ b/plugin/build.gradle
 @@ -330,6 +330,7 @@ configurations.all {
      resolutionStrategy.force 'org.apache.httpcomponents:httpclient:4.5.14'
      resolutionStrategy.force 'commons-codec:commons-codec:1.15'
      resolutionStrategy.force 'org.slf4j:slf4j-api:1.7.36'
-+    resolutionStrategy.force 'org.apache.commons:commons-compress:1.25.0'
++    resolutionStrategy.force 'org.apache.commons:commons-compress:1.26.0'
  }
- 
+
  apply plugin: 'com.netflix.nebula.ospackage'


### PR DESCRIPTION
This PR solves the vulnerability in the `opensearch-2`, but not `opensearch-2-ml-commons`. This is still a step forward!