### PR TITLE
Use wolfictl build for postsubmit builds

### DIFF
--- a/.github/workflows/build-old.yaml
+++ b/.github/workflows/build-old.yaml
@@ -1,4 +1,4 @@
-name: Build Wolfi OS
+name: Build Wolfi OS with make all
 
 on:
   push:
@@ -72,22 +72,14 @@ jobs:
           # Make a copy of the APKINDEX.* since we'll need to write to it on package builds
           cp /gcsfuse/wolfi-registry/${{ matrix.arch }}/APKINDEX.* ./packages/${{ matrix.arch }}/
 
-      # TODO: Remove the previous and next steps by folding the logic into wolfictl.
+      # TODO: Replace this with wolfictl build, since the current make build
+      # method doesn't trigger new builds for dependent updates.
       - name: 'Build Wolfi'
         run: |
-          wolfictl build \
-            --runner bubblewrap \
-            --keyring-append=/gcsfuse/wolfi-registry/wolfi-signing.rsa.pub \
-            --repository-append ./packages \
-            --keyring-append local-melange.rsa.pub \
-            --repository-append https://packages.wolfi.dev/os \
-            --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
-            --signing-key local-melange.rsa \
-            --arch ${{ matrix.arch }} \
-            --namespace wolfi \
-            --generate-index false \
-            --pipeline-dir ./pipelines/ \
-            --trace ./packages/${{ matrix.arch }}/trace.json
+          make \
+            ARCH=${{ matrix.arch }} \
+            MELANGE_EXTRA_OPTS="--keyring-append=/gcsfuse/wolfi-registry/wolfi-signing.rsa.pub" \
+            all -j1
 
       # Always run this step for https://github.com/wolfi-dev/os/issues/8698
       - if: ${{ always() }}

--- a/.github/workflows/build-old.yaml
+++ b/.github/workflows/build-old.yaml
@@ -1,13 +1,13 @@
 name: Build Wolfi OS with make all
 
-on:
-  push:
-    branches: ['main']
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
-
-  workflow_dispatch:
+# on:
+#   push:
+#     branches: ['main']
+#     paths-ignore:
+#       - '**.md'
+#       - '**.txt'
+# 
+#   workflow_dispatch:
 
 # Only run one build at a time to prevent out of sync signatures.
 concurrency: build


### PR DESCRIPTION
This gives us concurrent package builds, which speeds things up a bit.

We can revert this if things don't work as expected, but I've also moved the current definition to build-old.yaml in case we want to manually invoke it down the line. We may want to remove that once we've decided this will stick.