### PR TITLE
trurl: init at 0.10

### DIFF
--- a/trurl.yaml
+++ b/trurl.yaml
@@ -1,0 +1,45 @@
+package:
+  name: trurl
+  version: '0.10'
+  epoch: 0
+  description: 'trurl is a command line tool for URL parsing and manipulation.'
+  copyright:
+    - license: curl
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - curl-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/curl/trurl/archive/refs/tags/trurl-0.10.tar.gz
+      expected-sha256: e54ee05a1a39f2547fbb39225f9cf5e2608eeaf07ad3f7dbff0a069d060d3c46
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: "trurl-doc"
+    description: "documentation for trurl"
+    pipeline:
+      - uses: split/manpages
+
+update:
+  enabled: true
+  version-separator: _
+  github:
+    identifier: curl/trurl
+    strip-prefix: trurl-
+
+test:
+  pipeline:
+    - runs: |
+        trurl --version
+        trurl --url https://curl.se/we/are.html --get '{port}'


### PR DESCRIPTION
This packages https://github.com/curl/trurl to wolfi. trurl is kinda like `jq` but for urls.

The license of trurl is `curl license`. Is that a problem to get it into the repo?


### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
