### PR TITLE
Revert pull request that moves libcrypt1

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.38
-  epoch: 11
+  epoch: 13
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.38
-  epoch: 12
+  epoch: 11
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later
@@ -108,7 +108,7 @@ pipeline:
         --host=${{host.triplet.gnu}} \
         --build=${{host.triplet.gnu}} \
         --disable-werror \
-        --disable-crypt \
+        --enable-crypt \
         --enable-kernel=4.9
 
   - runs: |
@@ -378,7 +378,6 @@ subpackages:
     dependencies:
       runtime:
         - linux-headers
-        - libxcrypt-dev
 
   - name: "glibc-iconv"
     description: "GLIBC iconv tables"
@@ -494,6 +493,15 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/sbin
           mv "${{targets.destdir}}"/sbin/sln "${{targets.subpkgdir}}"/sbin
+
+  - name: "libcrypt1"
+    description: "Password hashing library included with glibc"
+    dependencies:
+      provider-priority: 10
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/lib
+          mv "${{targets.destdir}}"/lib/libcrypt.so* "${{targets.subpkgdir}}"/lib/
 
   - name: "glibc-locale-posix"
     description: "POSIX locale data for glibc"

--- a/libxcrypt.yaml
+++ b/libxcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcrypt
   version: 4.4.36
-  epoch: 1
+  epoch: 3
   description: "Modern library for one-way hashing of passwords"
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/libxcrypt.yaml
+++ b/libxcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcrypt
   version: 4.4.36
-  epoch: 2
+  epoch: 1
   description: "Modern library for one-way hashing of passwords"
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later
@@ -17,7 +17,6 @@ environment:
       - gettext
       - libtool
       - pkgconf
-      - pkgconf-dev
       - wolfi-base
 
 pipeline:
@@ -56,15 +55,6 @@ subpackages:
     pipeline:
       - uses: split/dev
     description: libxcrypt dev
-
-  - name: "libcrypt1"
-    description: "Password hashing library compatible with glibc"
-    dependencies:
-      provider-priority: 20
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib
-          mv "${{targets.destdir}}"/usr/lib/libcrypt.so.* "${{targets.subpkgdir}}"/usr/lib/
 
 update:
   enabled: true


### PR DESCRIPTION
As apk refuses to upgrade libcrypt1 (glibc) to libcrypt1 (libxcrypt).

Partially reverts https://github.com/wolfi-dev/os/pull/14133
With higher epoch

(however i do not revert the fixup of confusing duplicate calls to configure)