### PR TITLE
Uploads logs and trace as separate artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,10 +123,30 @@ jobs:
             <(cat /gcsfuse/wolfi-registry/${{ matrix.arch }}/APKINDEX.tar.gz | tar -Oxz APKINDEX) \
             <(cat ./packages/${{ matrix.arch }}/APKINDEX.tar.gz | tar -Oxz APKINDEX) || true
 
+          # Move logs so we can upload them separately.
+          mv ./packages/${{ matrix.arch }}/buildlogs /tmp/buildlogs
+
+          # Move trace so we can upload it separately.
+          mv ./packages/${{ matrix.arch }}/trace.json /tmp/trace.json
+
           # Create an archive for uploading
           tar -cvzf /tmp/packages-${{ matrix.arch }}.tar.gz ./packages/${{ matrix.arch }}
 
-      # Always run this step for https://github.com/wolfi-dev/os/issues/8698
+      # Always run these steps for https://github.com/wolfi-dev/os/issues/8698
+      - if: ${{ always() }}
+        name: 'Upload logs archive to GitHub Artifacts'
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: logs-${{ matrix.arch }}
+          path: /tmp/buildlogs/
+          if-no-files-found: warn
+      - if: ${{ always() }}
+        name: 'Upload trace to GitHub Artifacts'
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: trace-${{ matrix.arch }}
+          path: /tmp/trace.json
+          if-no-files-found: warn
       - if: ${{ always() }}
         name: 'Upload built packages archive to GitHub Artifacts'
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1


### PR DESCRIPTION
So you don't have to download all the APKs just to look at logs or traces.