### PR TITLE
remove libcrypt1-4.4.36-r2.apk

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -221,3 +221,4 @@ glibc-locale-zh-2.38-r12.apk
 glibc-locale-zu-2.38-r12.apk
 glibc-locales-2.38-r12.apk
 glibc-tracing-2.38-r12.apk
+libcrypt1-4.4.36-r2.apk


### PR DESCRIPTION
removes the left over package from previous withdraw https://github.com/wolfi-dev/os/pull/14313