### PR TITLE
Make python-3.10 co-installable with other python and add .pyc files.

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: 3.10.13
-  epoch: 5
+  epoch: 6
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -72,8 +72,6 @@ pipeline:
       opts: altinstall DESTDIR="${{targets.destdir}}"
 
   - runs: |
-      find ${{targets.destdir}}/usr/lib -type f -name '*.pyc' -exec rm -rf '{}' +
-      find ${{targets.destdir}}/usr/lib -type f -name '*.pyo' -exec rm -rf '{}' +
       find ${{targets.destdir}}/usr/lib -type f -name 'libpython*.a' -exec rm -rf '{}' +
       find ${{targets.destdir}}/usr/lib -type d -name 'test' -exec rm -rf '{}' +
       find ${{targets.destdir}}/usr/lib -type d -name 'tests' -exec rm -rf '{}' +
@@ -82,6 +80,14 @@ pipeline:
       cd ${{targets.destdir}}/usr/bin
       rm -f python3 pydoc3 idle3* 2to3*
       rm ${{targets.destdir}}/usr/lib/libpython3.so
+
+  - runs: |
+      find ${{targets.destdir}}/usr/lib -type f -name '*.pyc' -exec rm -rf '{}' +
+      find ${{targets.destdir}}/usr/lib -type f -name '*.pyo' -exec rm -rf '{}' +
+
+      export LD_LIBRARY_PATH="${{targets.destdir}}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+      ${{targets.destdir}}/usr/bin/python3.10 -m compileall --invalidation-mode=unchecked-hash \
+          -r100 ${{targets.destdir}}/usr/lib
 
   - uses: strip
 

--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -5,10 +5,6 @@ package:
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
-  dependencies:
-    provides:
-      - python3=${{package.full-version}}
-      - python-3=${{package.full-version}}
 
 environment:
   contents:
@@ -83,14 +79,28 @@ pipeline:
       find ${{targets.destdir}}/usr/lib -type d -name 'tests' -exec rm -rf '{}' +
       find ${{targets.destdir}}/usr/lib -type d -name 'idle_test' -exec rm -rf '{}' +
 
-  - name: Install python symlink
-    runs: |
-      ln -s python3.10 "${{targets.destdir}}"/usr/bin/python
-      ln -s python3.10 "${{targets.destdir}}"/usr/bin/python3
+      cd ${{targets.destdir}}/usr/bin
+      rm -f python3 pydoc3 idle3* 2to3*
+      rm ${{targets.destdir}}/usr/lib/libpython3.so
 
   - uses: strip
 
 subpackages:
+  - name: "python-3.10-default"
+    description: "python-3.10 as /usr/bin/python3"
+    dependencies:
+      provides:
+        - python3=${{package.full-version}}
+        - python-3=${{package.full-version}}
+      runtime:
+        - python-3.10
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          ln -sf python3.10 "${{targets.subpkgdir}}"/usr/bin/python3
+          ln -sf pydoc3.10 "${{targets.subpkgdir}}"/usr/bin/pydoc3
+          ln -sf python3 "${{targets.subpkgdir}}"/usr/bin/python
+
   - name: "python-3.10-doc"
     description: "python3.10 documentation"
     pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
