### PR TITLE
tekton-pilelines/0.57.0 package update

### DIFF
--- a/tekton-pipelines.yaml
+++ b/tekton-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: tekton-pipelines
-  version: 0.56.0
-  epoch: 2
+  version: 0.57.0
+  epoch: 0
   description: A cloud-native Pipeline resource.
   copyright:
     - license: Apache-2.0
@@ -15,12 +15,12 @@ pipeline:
     with:
       repository: https://github.com/tektoncd/pipeline
       tag: v${{package.version}}
-      expected-commit: e1c7828e0fad1006b6477a5ce0468a2a3182060b
+      expected-commit: d7145450d6d87d64261abc08798876a41f607f68
       destination: tekton
 
   - uses: go/bump
     with:
-      deps: github.com/docker/docker@v24.0.7 github.com/containerd/containerd@v1.7.11 github.com/go-git/go-git/v5@v5.11.0 github.com/cloudflare/circl@v1.3.7
+      deps: github.com/docker/docker@v24.0.7 github.com/cloudflare/circl@v1.3.7 github.com/go-jose/go-jose/v3@v3.0.3 gopkg.in/go-jose/go-jose.v2@v2.6.3 github.com/cloudevents/sdk-go/v2@v2.15.2
       modroot: tekton
 
   - uses: go/build


### PR DESCRIPTION
issue Fix: #12945

FIX CVE: GHSA-5pf6-2qwx-pxm2 and GHSA-c5q2-7r4c-mv6g

#### For version bump PRs
<!-- remove if unrelated -->
- [0] The `epoch` field is reset to 0

