### PR TITLE
add confluent-kafka-images

### DIFF
--- a/confluent-kafka-images.yaml
+++ b/confluent-kafka-images.yaml
@@ -1,0 +1,62 @@
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: confluent-kafka-images
+  version: 7.6.1.15
+  epoch: 0
+  description: Provides build files for Apache Kafka and Confluent Docker images
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+
+var-transforms:
+  - from: ${{package.version}}
+    match: '\.(\d+)$'
+    replace: '-$1'
+    to: mangled-package-version
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 81a72376a8d70bc82429eb069b7732cfc2f9c910
+      repository: https://github.com/confluentinc/kafka-images
+      tag: v${{vars.mangled-package-version}}
+
+data:
+  - name: files
+    items:
+      # https://github.com/confluentinc/kafka-images/tree/master/ce-kafka
+      ce-kafka: Files for for deploying and running the Enterprise Version of Kafka.
+      # https://github.com/confluentinc/kafka-images/tree/master/kafka
+      kafka: Files for deploying and running the Community Version of Kafka.
+      # https://github.com/confluentinc/kafka-images/tree/master/kafka-connect-base
+      kafka-connect-base: Files for for deploying and running Kafka Connect.
+      # https://github.com/confluentinc/kafka-images/tree/master/local
+      local: Files for quickly start Apache Kafka® in KRaft mode with zero configuration setup.
+      # https://github.com/confluentinc/kafka-images/tree/master/server-connect-base
+      server-connect-base: Files for deploying and running Kafka Connect.
+      # https://github.com/confluentinc/kafka-images/tree/master/server
+      server: Files for deploying and running Confluent Server.
+      # https://github.com/confluentinc/kafka-images/tree/master/zookeeper
+      zookeeper: Files for deploying and running Zookeeper.
+
+subpackages:
+  - range: files
+    name: ${{package.name}}-${{range.key}}
+    description: ${{range.value}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/etc/confluent/docker
+          install -Dm644 ${{range.key}}/include/etc/confluent/docker/* "${{targets.subpkgdir}}"/etc/confluent/docker/
+
+update:
+  enabled: true
+  version-transform:
+    - match: "-"
+      replace: "."
+  release-monitor:
+    identifier: 371736


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
