### PR TITLE
adding clickhouse-23

### DIFF
--- a/clickhouse-23.yaml
+++ b/clickhouse-23.yaml
@@ -1,0 +1,96 @@
+package:
+  name: clickhouse-23
+  version: 23.8.10.43
+  epoch: 0
+  description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - clickhouse-=${{package.full-version}}-lts
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang-17
+      - clang-17-dev
+      - cmake
+      - coreutils
+      - findutils
+      - git
+      - grep
+      - llvm-libcxx-17
+      - llvm-libcxx-17-dev
+      - llvm-lld-17
+      - llvm-lld-17-dev
+      - nasm
+      - ninja
+      - perl
+      - python3
+      - yasm
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ClickHouse/ClickHouse
+      tag: v${{package.version}}-lts
+      expected-commit: a278225bba98c092a9b8101e6c02836bbc4d030b
+
+  # The default build script is defensive and tries to protect against defining cflags.
+  - uses: patch
+    with:
+      patches: allow_cflags.patch
+
+  - runs: |
+      git submodule update --init
+      mkdir build
+      cd build
+      cmake \
+        -DCOMPILER_CACHE=disabled \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        ..
+
+  - runs: |
+      cd build
+      ninja -j $(nproc)
+      mkdir -p  ${{targets.destdir}}/var/lib/clickhouse
+      mkdir -p  ${{targets.destdir}}/var/log/clickhouse-server
+      DESTDIR=${{targets.destdir}} ninja install
+      rm -rf ${{targets.destdir}}/usr/lib/debug
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-dev"
+    description: "headers for clickhouse"
+    pipeline:
+      - uses: split/dev
+
+  - name: "${{package.name}}-bash-completion"
+    description: "bash completion for clickhouse"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share/bash-completion/completions
+          mv ${{targets.destdir}}/usr/share/bash-completion/completions/clickhouse ${{targets.subpkgdir}}/usr/share/bash-completion/completions
+
+  - name: "${{package.name}}-compat"
+    description: "docker compat for clickhouse"
+    pipeline:
+      - runs: |
+          cd build
+          install -Dm755 ../docker/server/entrypoint.sh ${{targets.subpkgdir}}/entrypoint.sh
+          mkdir -p ${{targets.subpkgdir}}/etc/clickhouse-server/config.d/
+          cp  ../docker/server/docker_related_config.xml ${{targets.subpkgdir}}/etc/clickhouse-server/config.d/docker_related_config.xml
+
+update:
+  enabled: true
+  github:
+    identifier: ClickHouse/ClickHouse
+    strip-prefix: v23.
+    strip-suffix: -lts

--- a/clickhouse-23.yaml
+++ b/clickhouse-23.yaml
@@ -16,17 +16,17 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang-17
-      - clang-17-dev
+      - clang-16
+      - clang-16-dev
       - cmake
       - coreutils
       - findutils
       - git
       - grep
-      - llvm-libcxx-17
-      - llvm-libcxx-17-dev
-      - llvm-lld-17
-      - llvm-lld-17-dev
+      - llvm-libcxx-16
+      - llvm-libcxx-16-dev
+      - llvm-lld-16
+      - llvm-lld-16-dev
       - nasm
       - ninja
       - perl

--- a/clickhouse-23/allow_cflags.patch
+++ b/clickhouse-23/allow_cflags.patch
@@ -1,0 +1,44 @@
+--- a/PreLoad.cmake
++++ b/PreLoad.cmake
+@@ -15,41 +15,6 @@ if (NOT DEFINED ENV{XCODE_IDE})
+     endif ()
+ endif()
+ 
+-# Check if environment is polluted.
+-if (NOT "$ENV{CFLAGS}" STREQUAL ""
+-    OR NOT "$ENV{CXXFLAGS}" STREQUAL ""
+-    OR NOT "$ENV{LDFLAGS}" STREQUAL ""
+-    OR CMAKE_C_FLAGS OR CMAKE_CXX_FLAGS OR CMAKE_EXE_LINKER_FLAGS OR CMAKE_MODULE_LINKER_FLAGS
+-    OR CMAKE_C_FLAGS_INIT OR CMAKE_CXX_FLAGS_INIT OR CMAKE_EXE_LINKER_FLAGS_INIT OR CMAKE_MODULE_LINKER_FLAGS_INIT)
+-
+-    # if $ENV
+-    message("CFLAGS: $ENV{CFLAGS}")
+-    message("CXXFLAGS: $ENV{CXXFLAGS}")
+-    message("LDFLAGS: $ENV{LDFLAGS}")
+-    # if *_FLAGS
+-    message("CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}")
+-    message("CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+-    message("CMAKE_EXE_LINKER_FLAGS: ${CMAKE_EXE_LINKER_FLAGS}")
+-    message("CMAKE_SHARED_LINKER_FLAGS: ${CMAKE_SHARED_LINKER_FLAGS}")
+-    message("CMAKE_MODULE_LINKER_FLAGS: ${CMAKE_MODULE_LINKER_FLAGS}")
+-    # if *_FLAGS_INIT
+-    message("CMAKE_C_FLAGS_INIT: ${CMAKE_C_FLAGS_INIT}")
+-    message("CMAKE_CXX_FLAGS_INIT: ${CMAKE_CXX_FLAGS_INIT}")
+-    message("CMAKE_EXE_LINKER_FLAGS_INIT: ${CMAKE_EXE_LINKER_FLAGS_INIT}")
+-    message("CMAKE_MODULE_LINKER_FLAGS_INIT: ${CMAKE_MODULE_LINKER_FLAGS_INIT}")
+-
+-    message(FATAL_ERROR "
+-        Some of the variables like CFLAGS, CXXFLAGS, LDFLAGS are not empty.
+-        It is not possible to build ClickHouse with custom flags.
+-        These variables can be set up by previous invocation of some other build tools.
+-        You should cleanup these variables and start over again.
+-
+-        Run the `env` command to check the details.
+-        You will also need to remove the contents of the build directory.
+-
+-        Note: if you don't like this behavior, you can manually edit the cmake files, but please don't complain to developers.")
+-endif()
+-
+ # Default toolchain - this is needed to avoid dependency on OS files.
+ execute_process(COMMAND uname -s OUTPUT_VARIABLE OS)
+ execute_process(COMMAND uname -m OUTPUT_VARIABLE ARCH)


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
