### PR TITLE
nginx: Add with-compat to compile option for nginx

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -79,6 +79,8 @@ pipeline:
           \
           --without-pcre2 \
           \
+          --with-compat \
+          \
           --with-http_ssl_module \
           --with-http_v2_module \
           --with-http_realip_module \

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -82,6 +82,8 @@ pipeline:
           \
           --without-pcre2 \
           \
+          --with-compat \
+          \
           --with-http_ssl_module \
           --with-http_v2_module \
           --with-http_realip_module \


### PR DESCRIPTION
Fixes:
https://github.com/chainguard-images/images/issues/2164

Related:
https://github.com/chainguard-images/images/issues/2164

Tested with https://github.com/openresty/headers-more-nginx-module

Wolfi scan show no vulns

This will enable loading modules with chainguard nginx
