### PR TITLE
fix(openblas): fix update block

### DIFF
--- a/openblas.yaml
+++ b/openblas.yaml
@@ -94,5 +94,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/liblapacke.so* "${{targets.subpkgdir}}"/usr/lib
 
 update:
+  enabled: true
   github:
     identifier: xianyi/OpenBLAS
+    strip-prefix: v


### PR DESCRIPTION
This package was missing an `enabled: true` and a `strip-prefix: v` to be able to correctly auto-update.