### PR TITLE
go: drop test private key and cert

### DIFF
--- a/go-1.21.yaml
+++ b/go-1.21.yaml
@@ -73,7 +73,8 @@ pipeline:
         -exec rm -rf \{\} \+
       find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*.bat" \) \
         -exec rm -rf \{\} \+
-
+      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*.pem" \) \
+        -exec rm -rf \{\} \+
   - uses: strip
 
 subpackages:

--- a/go-1.21.yaml
+++ b/go-1.21.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.21
   version: 1.21.8
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause

--- a/go-1.21.yaml
+++ b/go-1.21.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.21
   version: 1.21.8
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -66,6 +66,8 @@ pipeline:
 
       # Remove tests from /usr/lib/go/src, not needed at runtime
       find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*_test.go" \) \
+        -exec rm -rf \{\} \+
+      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "platform_*.pem" \) \
         -exec rm -rf \{\} \+
       find "${{targets.destdir}}"/usr/lib/go/src \( -type d -a -name "testdata" \) \
         -exec rm -rf \{\} \+

--- a/go-1.22.yaml
+++ b/go-1.22.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.22
   version: 1.22.1
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -66,6 +66,8 @@ pipeline:
 
       # Remove tests from /usr/lib/go/src, not needed at runtime
       find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*_test.go" \) \
+        -exec rm -rf \{\} \+
+      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "platform_*.pem" \) \
         -exec rm -rf \{\} \+
       find "${{targets.destdir}}"/usr/lib/go/src \( -type d -a -name "testdata" \) \
         -exec rm -rf \{\} \+

--- a/go-fips-1.21.yaml
+++ b/go-fips-1.21.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-fips-1.21
   version: 1.21.8
-  epoch: 0
+  epoch: 1
   description: "the Go programming language with OpenSSL cryptography"
   copyright:
     - license: BSD-3-Clause
@@ -77,6 +77,8 @@ pipeline:
 
       # Remove tests from /usr/lib/go/src, not needed at runtime
       find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "*_test.go" \) \
+        -exec rm -rf \{\} \+
+      find "${{targets.destdir}}"/usr/lib/go/src \( -type f -a -name "platform_*.pem" \) \
         -exec rm -rf \{\} \+
       find "${{targets.destdir}}"/usr/lib/go/src \( -type d -a -name "testdata" \) \
         -exec rm -rf \{\} \+


### PR DESCRIPTION
Resolves having private keys shipped in packages and images.