### PR TITLE
numpy: prototyping with building wheel, and then vendoring it

### DIFF
--- a/numpy.yaml
+++ b/numpy.yaml
@@ -35,7 +35,13 @@ pipeline:
       recurse-submodules: true
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      # Eventually this should become a default pipeline
+      # Use most up to date wheel method for building this thing
+      pip wheel --no-deps .
+      # Install it with better .dist-info data
+      pip install --no-compile --no-deps --prefix=/usr --root="${{targets.destdir}}" ./*.whl
+      # Accelerate startup time with the fastest .pyc cache files
+      python3 -m compileall -f --invalidation-mode=unchecked-hash -r100 "${{targets.destdir}}"
 
   - uses: strip
 
@@ -50,6 +56,27 @@ subpackages:
       runtime:
         - python3-dev
         - numpy
+  - name: numpy-whl
+    pipeline:
+      - runs: |
+          # Eventually this should be split wheels pipeline
+          # ... but should this be a single wheel; or a collection of
+          # wheels that this package needs
+          # also want to build these wheels for all supported python versions
+          # but the pythons are still not co-installable
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/python-wheels
+          cp *.whl "${{targets.subpkgdir}}"/usr/share/python-wheels
+  - name: numpy-static
+    pipeline:
+      - runs: |
+          # ideally generate this for all pythons, but they are still
+          # not co-installable
+          # This version of numpy is preinstalled with all the dependencies
+          # As if it is 'static', with all the deps
+          # .... however this is not a great example as numpy doesn't have any deps
+          pip install --no-compile --prefix=/usr --root="${{targets.subpkgdir}}" ./*.whl
+          # Accelerate startup time with the fastest .pyc cache files
+          python3 -m compileall -f --invalidation-mode=unchecked-hash -r100 "${{targets.subpkgdir}}"
 
 update:
   enabled: true


### PR DESCRIPTION
Trying to build wheel as the first class target.

Then use that to install the wheel to create the python package.

And also ship the built .whl files

And also install the .whl with all the dependencies.... but there aren't any.

As pythons are still not co-installable cannot prototype how it will look like to provide multiples of these for every python version.

This is a draft.