### PR TITLE
feat(packages): Produce auditable rust binaries

### DIFF
--- a/atuin.yaml
+++ b/atuin.yaml
@@ -1,7 +1,7 @@
 package:
   name: atuin
   version: 18.0.2
-  epoch: 0
+  epoch: 1
   description: Magical shell history
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
 
 pipeline:
@@ -22,7 +23,7 @@ pipeline:
       expected-commit: a78aaa78e487b2499ffd7eed86bac15aa3df0960
 
   - runs: |
-      cargo build --locked --release
+      cargo auditable build --locked --release
       cd target/release
       mkdir -p completions
       for sh in 'bash' 'fish' 'zsh'; do

--- a/bat.yaml
+++ b/bat.yaml
@@ -1,7 +1,7 @@
 package:
   name: bat
   version: 0.24.0
-  epoch: 0
+  epoch: 1
   description: "A cat(1) clone with wings"
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - libgit2-dev
       - rust
       - zlib-dev
@@ -25,7 +26,7 @@ pipeline:
 
   - runs: |
       cargo fetch
-      cargo build --frozen --release
+      cargo auditable build --frozen --release
 
   - runs: |
       install -Dm755 target/release/bat "${{targets.destdir}}"/usr/bin/bat

--- a/berg.yaml
+++ b/berg.yaml
@@ -1,7 +1,7 @@
 package:
   name: berg
   version: 0.3.5
-  epoch: 0
+  epoch: 1
   description: "CLI Tool for Codeberg similar to gh and glab"
   copyright:
     - license: AGPL-3.0-only
@@ -10,6 +10,7 @@ environment:
   contents:
     packages:
       - build-base
+      - cargo-auditable
       - openssl-dev
       - rust
       - wolfi-base
@@ -24,7 +25,7 @@ pipeline:
   - name: Configure and build
     runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin
-      cargo build --all-features --release
+      cargo auditable build --all-features --release
       install -m755 target/release/berg "${{targets.destdir}}"/usr/bin/
 
   - uses: strip

--- a/buck2.yaml
+++ b/buck2.yaml
@@ -2,7 +2,7 @@ package:
   name: buck2
   # When bumping, bump the tag below
   version: 20240102
-  epoch: 0
+  epoch: 1
   description: "Build system, successor to Buck"
   copyright:
     - license: MIT
@@ -13,6 +13,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - libLLVM-16
       - rustup
       - wolfi-base
@@ -43,7 +44,7 @@ pipeline:
       export PATH="$HOME/.rustup/toolchains/${{vars.rust-version}}-${{host.triplet.rust}}/bin:$PATH"
       mkdir -p ${{targets.destdir}}/usr/bin/
       cd app/buck2
-      cargo build --release
+      cargo auditable build --release
       mv ../../target/release/buck2 ${{targets.destdir}}/usr/bin/
 
   - uses: strip

--- a/cbindgen.yaml
+++ b/cbindgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: cbindgen
   version: 0.26.0
-  epoch: 0
+  epoch: 1
   description: Tool to generate C bindings from Rust code
   copyright:
     - license: MPL-2.0
@@ -11,6 +11,7 @@ environment:
     packages:
       - build-base
       - busybox
+      - cargo-auditable
       - rust
 
 pipeline:
@@ -21,7 +22,7 @@ pipeline:
       expected-commit: 703b53c06f9fe2dbc0193d67626558cfa84a0f62
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
       mkdir -p ${{targets.destdir}}/usr/bin
       cp target/release/cbindgen ${{targets.destdir}}/usr/bin/
 

--- a/cedar.yaml
+++ b/cedar.yaml
@@ -1,7 +1,7 @@
 package:
   name: cedar
   version: 3.1.0
-  epoch: 0
+  epoch: 1
   description: "Core implementation of the Cedar language"
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
       - wolfi-base
 
@@ -24,7 +25,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release -vv
+      cargo auditable build --release -vv
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/cedar ${{targets.destdir}}/usr/bin/
 

--- a/delta.yaml
+++ b/delta.yaml
@@ -1,7 +1,7 @@
 package:
   name: delta
   version: 0.16.5
-  epoch: 0
+  epoch: 1
   description: Syntax-highlighting pager for git and diff output
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
 
 pipeline:
@@ -22,7 +23,7 @@ pipeline:
       expected-commit: 03f1569a9aff964e9291371d9928d0584327eae2
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
       install -Dm755 target/release/delta "${{targets.destdir}}"/usr/bin/delta
 
   - uses: strip

--- a/deno.yaml
+++ b/deno.yaml
@@ -1,7 +1,7 @@
 package:
   name: deno
   version: 1.41.2
-  epoch: 0
+  epoch: 1
   description: "A modern runtime for JavaScript and TypeScript."
   copyright:
     - license: MIT
@@ -13,6 +13,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - cmake
       - glibc-dev
       - libLLVM-16
@@ -31,7 +32,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release -vv
+      cargo auditable build --release -vv
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/deno ${{targets.destdir}}/usr/bin/
 

--- a/difftastic.yaml
+++ b/difftastic.yaml
@@ -1,7 +1,7 @@
 package:
   name: difftastic
   version: 0.56.1
-  epoch: 0
+  epoch: 1
   description: "a structural diff that understands syntax"
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
 
 pipeline:
@@ -22,7 +23,7 @@ pipeline:
       expected-commit: d9d6401c45d8f1094eec2fb35c0401dc5a589de5
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
       install -Dm755 target/release/difft "${{targets.destdir}}"/usr/bin/difft
 
   - uses: strip

--- a/dua.yaml
+++ b/dua.yaml
@@ -1,7 +1,7 @@
 package:
   name: dua
   version: 2.28.0
-  epoch: 0
+  epoch: 1
   description: "View disk space usage and delete unwanted data, fast."
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
       - wolfi-base
 
@@ -24,7 +25,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release --no-default-features --features tui-crossplatform
+      cargo auditable build --release --no-default-features --features tui-crossplatform
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/dua ${{targets.destdir}}/usr/bin/dua
 

--- a/exa.yaml
+++ b/exa.yaml
@@ -1,7 +1,7 @@
 package:
   name: exa
   version: 0.10.1
-  epoch: 0
+  epoch: 1
   description: "ls replacement written in Rust"
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - libgit2-dev
       - rust
       - zlib-dev
@@ -25,7 +26,7 @@ pipeline:
 
   - runs: |
       cargo fetch
-      cargo build --frozen --release
+      cargo auditable build --frozen --release
 
   - runs: |
       install -Dm755 target/release/exa "${{targets.destdir}}"/usr/bin/exa

--- a/eza.yaml
+++ b/eza.yaml
@@ -1,7 +1,7 @@
 package:
   name: eza
   version: 0.18.6
-  epoch: 0
+  epoch: 1
   description: "A modern, maintained replacement for ls"
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - libgit2-dev
       - rust
       - zlib-dev
@@ -25,7 +26,7 @@ pipeline:
 
   - runs: |
       cargo fetch
-      cargo build --frozen --release
+      cargo auditable build --frozen --release
 
   - runs: |
       install -Dm755 target/release/eza "${{targets.destdir}}"/usr/bin/eza

--- a/fd.yaml
+++ b/fd.yaml
@@ -1,7 +1,7 @@
 package:
   name: fd
   version: 9.0.0
-  epoch: 0
+  epoch: 1
   description: "A simple, fast and user-friendly alternative to 'find'"
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
 
 pipeline:
@@ -22,7 +23,7 @@ pipeline:
       expected-commit: d9c4e6239fc1807bce1bb6aca4426f3880230a84
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
       install -Dm755 target/release/fd "${{targets.destdir}}"/usr/bin/fd
 
   - uses: strip

--- a/hickory-dns.yaml
+++ b/hickory-dns.yaml
@@ -1,7 +1,7 @@
 package:
   name: hickory-dns
   version: 0.24.0
-  epoch: 0
+  epoch: 1
   description: "A Rust based DNS client, server, and resolver"
   copyright:
     - license: MIT
@@ -13,6 +13,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - libLLVM-15
       - openssl-dev
       - rust
@@ -27,7 +28,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release -p hickory-dns --all-features
+      cargo auditable build --release -p hickory-dns --all-features
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/hickory-dns ${{targets.destdir}}/usr/bin/
 

--- a/just.yaml
+++ b/just.yaml
@@ -1,7 +1,7 @@
 package:
   name: just
   version: 1.25.1
-  epoch: 0
+  epoch: 1
   description: "just is a handy way to save and run project-specific commands."
   copyright:
     - license: CC0-1.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
       - wolfi-base
 
@@ -24,7 +25,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release
+      cargo auditable build --release
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/just ${{targets.destdir}}/usr/bin/
 

--- a/kdash.yaml
+++ b/kdash.yaml
@@ -1,7 +1,7 @@
 package:
   name: kdash
   version: 0.6.0
-  epoch: 0
+  epoch: 1
   description: "A simple and fast dashboard for Kubernetes"
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - libgit2-dev
       - libxcb
       - libxcb-dev
@@ -31,7 +32,7 @@ pipeline:
       expected-commit: e31fc1bd37b8c499142abd6a98c2e222521511c4
 
   - runs: |
-      OPENSSL_NO_VENDOR=true cargo build --release
+      OPENSSL_NO_VENDOR=true cargo auditable build --release
       install -Dm755 target/release/kdash "${{targets.destdir}}"/usr/bin/kdash
 
   - uses: strip

--- a/linkerd-await.yaml
+++ b/linkerd-await.yaml
@@ -1,7 +1,7 @@
 package:
   name: linkerd-await
   version: 0.2.8
-  epoch: 0
+  epoch: 1
   description: "A program that blocks on linkerd readiness"
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
 
 pipeline:
@@ -23,7 +24,7 @@ pipeline:
 
   - runs: |
       cargo fetch
-      cargo build --frozen --release
+      cargo auditable build --frozen --release
       mkdir -p ${{targets.destdir}}/usr/bin
       mv target/release/linkerd-await ${{targets.destdir}}/usr/bin
 

--- a/linkerd-network-validator.yaml
+++ b/linkerd-network-validator.yaml
@@ -1,7 +1,7 @@
 package:
   name: linkerd-network-validator
   version: 0.1.2
-  epoch: 0
+  epoch: 1
   description: "A program that validates linkerd networks"
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
 
 pipeline:
@@ -24,7 +25,7 @@ pipeline:
   - runs: |
       cd validator
       cargo fetch
-      cargo build --frozen --release
+      cargo auditable build --frozen --release
 
       cd ..
       mkdir -p ${{targets.destdir}}/usr/bin

--- a/linkerd2-proxy.yaml
+++ b/linkerd2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: linkerd2-proxy
   version: 2.222.0
-  epoch: 0
+  epoch: 1
   description: "A program that validates linkerd networks"
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - clang
       - cmake
       - rust
@@ -25,7 +26,7 @@ pipeline:
 
   - runs: |
       cargo fetch
-      cargo build --frozen --release --package=linkerd2-proxy
+      cargo auditable build --frozen --release --package=linkerd2-proxy
 
       mkdir -p ${{targets.destdir}}/usr/bin
       mv target/release/linkerd2-proxy ${{targets.destdir}}/usr/bin

--- a/lychee.yaml
+++ b/lychee.yaml
@@ -1,7 +1,7 @@
 package:
   name: lychee
   version: 0.14.3
-  epoch: 0
+  epoch: 1
   description: "Fast, async, stream-based link checker written in Rust"
   copyright:
     - license: Apache-2.0 AND MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - openssl-dev
       - rust
 
@@ -23,7 +24,7 @@ pipeline:
       expected-commit: 90ed0e70b727886cf66443d35ccc7a3d321262eb
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
       install -Dm755 target/release/lychee "${{targets.destdir}}"/usr/bin/lychee
 
   - uses: strip

--- a/mdbook.yaml
+++ b/mdbook.yaml
@@ -1,7 +1,7 @@
 package:
   name: mdbook
   version: 0.4.37
-  epoch: 0
+  epoch: 1
   description: "Create book from markdown files. Like Gitbook but implemented in Rust."
   copyright:
     - license: MPL-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - git
       - make
       - openssl-dev
@@ -28,7 +29,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release
+      cargo auditable build --release
       install -d "${{targets.destdir}}"/usr/bin
       install -m755 target/release/mdbook "${{targets.destdir}}"/usr/bin/
 

--- a/meilisearch.yaml
+++ b/meilisearch.yaml
@@ -1,7 +1,7 @@
 package:
   name: meilisearch
   version: 1.6.2
-  epoch: 0
+  epoch: 1
   description: "A lightning-fast search engine that fits effortlessly into your apps, websites, and workflow."
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
       - wolfi-base
 
@@ -23,7 +24,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release --locked -vv
+      cargo auditable build --release --locked -vv
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/meilisearch ${{targets.destdir}}/usr/bin/
 

--- a/ntpd-rs.yaml
+++ b/ntpd-rs.yaml
@@ -1,7 +1,7 @@
 package:
   name: ntpd-rs
   version: 1.1.2
-  epoch: 0
+  epoch: 1
   description: "An NTP implementation in Rust."
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
       - wolfi-base
 
@@ -24,7 +25,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release -vv
+      cargo auditable build --release -vv
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/ntp-daemon ${{targets.destdir}}/usr/bin/
 

--- a/oranda.yaml
+++ b/oranda.yaml
@@ -1,7 +1,7 @@
 package:
   name: oranda
   version: 0.6.2
-  epoch: 0
+  epoch: 1
   description: generate beautiful landing pages for your developer tools
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - openssl-dev
       - rust
 
@@ -23,7 +24,7 @@ pipeline:
       expected-commit: 03d7d2de61f3e56986c875c3b413f2800da78eda
 
   - runs: |
-      cargo build --locked --profile=dist
+      cargo auditable build --locked --profile=dist
       mkdir -p ${{targets.destdir}}/usr/bin
       mv target/dist/oranda ${{targets.destdir}}/usr/bin/
 

--- a/parseable.yaml
+++ b/parseable.yaml
@@ -1,7 +1,7 @@
 package:
   name: parseable
   version: 0.9.0
-  epoch: 0
+  epoch: 1
   description: "Parseable is a log analytics system built for high throughput log ingestion cases."
   copyright:
     - license: AGPL-3.0-or-later
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
 
 pipeline:
@@ -22,7 +23,7 @@ pipeline:
       expected-commit: b8e310dd8ae28931d62d97ad087515b2130f9c95
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
       install -Dm755 target/release/parseable "${{targets.destdir}}"/usr/bin/parseable
 
   - uses: strip

--- a/pgcat.yaml
+++ b/pgcat.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgcat
   version: 1.1.1
-  epoch: 1
+  epoch: 2
   description: "PostgreSQL pooler with sharding, load balancing and failover support."
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
       - wolfi-base
 
@@ -24,7 +25,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release -vv
+      cargo auditable build --release -vv
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/pgcat ${{targets.destdir}}/usr/bin/
 

--- a/pixi.yaml
+++ b/pixi.yaml
@@ -1,7 +1,7 @@
 package:
   name: pixi
   version: 0.15.2
-  epoch: 0
+  epoch: 1
   description: "Package management made easy"
   copyright:
     - license: BSD-3-Clause
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - openssl-dev
       - rust
       - wolfi-base
@@ -25,7 +26,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release
+      cargo auditable build --release
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/pixi ${{targets.destdir}}/usr/bin/
 

--- a/pulumi-watch.yaml
+++ b/pulumi-watch.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-watch
   version: 0.1.5
-  epoch: 2
+  epoch: 3
   description: Supports the functionality of the pulumi watch command
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
       - wolfi-base
 
@@ -27,7 +28,7 @@ pipeline:
     pipeline:
       - runs: |
           set -x
-          cargo build --release -vv
+          cargo auditable build --release -vv
           mkdir -p "${{targets.destdir}}/usr/bin/"
           mv target/release/pulumi-watch "${{targets.destdir}}/usr/bin/"
       - uses: strip

--- a/qdrant.yaml
+++ b/qdrant.yaml
@@ -1,7 +1,7 @@
 package:
   name: qdrant
   version: 1.8.1
-  epoch: 0
+  epoch: 1
   description: "High-performance, massive-scale Vector Database for the next generation of AI"
   copyright:
     - license: Apache-2.0
@@ -13,6 +13,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - clang-16-dev
       - curl
       - jq
@@ -40,7 +41,7 @@ pipeline:
 
   - name: build-qdrant-binary
     runs: |
-      cargo build --release --bin qdrant
+      cargo auditable build --release --bin qdrant
 
   - runs: |
       _qdrant_home="usr/lib/qdrant"

--- a/ripgrep.yaml
+++ b/ripgrep.yaml
@@ -1,7 +1,7 @@
 package:
   name: ripgrep
   version: 14.1.0
-  epoch: 0
+  epoch: 1
   description: "ripgrep recursively searches directories for a regex pattern while respecting your gitignore"
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
       - wolfi-base
 
@@ -24,7 +25,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release --features 'pcre2'
+      cargo auditable build --release --features 'pcre2'
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/rg ${{targets.destdir}}/usr/bin/
 

--- a/ruff.yaml
+++ b/ruff.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruff
   version: 0.3.2
-  epoch: 0
+  epoch: 1
   description: An extremely fast Python linter, written in Rust.
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
 
 pipeline:
@@ -22,7 +23,7 @@ pipeline:
       expected-commit: a892fc755d6d4342c2f5a768aa50a401d704ae2c
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
       mkdir -p ${{targets.destdir}}/usr/bin
       mv target/release/ruff ${{targets.destdir}}/usr/bin/
 

--- a/rust-analyzer.yaml
+++ b/rust-analyzer.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-analyzer
   version: 20240122
-  epoch: 0
+  epoch: 1
   description: A Rust compiler front-end for IDEs
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - git
       - openssl-dev
       - rust
@@ -30,7 +31,7 @@ pipeline:
       expected-commit: d410d4a2baf9e99b37b03dd42f06238b14374bf7
 
   - runs: |
-      CFG_RELEASE=1 cargo build --release
+      CFG_RELEASE=1 cargo auditable build --release
       mkdir -p ${{targets.destdir}}/usr/bin
       mv target/release/rust-analyzer ${{targets.destdir}}/usr/bin/
 

--- a/rustup.yaml
+++ b/rustup.yaml
@@ -1,7 +1,7 @@
 package:
   name: rustup
   version: 1.26.0
-  epoch: 0
+  epoch: 1
   description: "rustup is an installer for the systems programming language Rust"
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - git
       - libLLVM-15
       - make
@@ -30,7 +31,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release --features no-self-update --bin rustup-init
+      cargo auditable build --release --features no-self-update --bin rustup-init
       install -d "${{targets.destdir}}"/usr/bin
       install -m755 target/release/rustup-init "${{targets.destdir}}"/usr/bin/
       ln -s /usr/bin/rustup-init "${{targets.destdir}}"/usr/bin/rustup

--- a/rye.yaml
+++ b/rye.yaml
@@ -1,7 +1,7 @@
 package:
   name: rye
   version: 0.28.0
-  epoch: 0
+  epoch: 1
   description: "An Experimental Package Management Solution for Python"
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - openssl-dev
       - perl
       - rust
@@ -26,7 +27,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release
+      cargo auditable build --release
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/${{package.name}} ${{targets.destdir}}/usr/bin/
 

--- a/sccache.yaml
+++ b/sccache.yaml
@@ -1,7 +1,7 @@
 package:
   name: sccache
   version: 0.7.7
-  epoch: 0
+  epoch: 1
   description: sccache is ccache with cloud storage
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - openssl-dev
       - rust
 
@@ -23,7 +24,7 @@ pipeline:
       expected-commit: e976c42c2141969915bdd39dd3177db6f27405a8
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
       mkdir -p ${{targets.destdir}}/usr/bin
       mv target/release/sccache ${{targets.destdir}}/usr/bin/
 

--- a/sdp-k8s-injector.yaml
+++ b/sdp-k8s-injector.yaml
@@ -1,7 +1,7 @@
 package:
   name: sdp-k8s-injector
   version: 1.2.5
-  epoch: 0
+  epoch: 1
   description: "SDP Client for Kubernetes"
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - openssl-dev
       - rust
       - wolfi-base
@@ -30,7 +31,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release
+      cargo auditable build --release
       mkdir -p ${{targets.destdir}}/usr/bin
 
       # move the executable binaries to the destdir

--- a/spin.yaml
+++ b/spin.yaml
@@ -1,7 +1,7 @@
 package:
   name: spin
   version: 2.3.1
-  epoch: 0
+  epoch: 1
   description: "Spin is the open source developer tool for building and running serverless applications powered by WebAssembly."
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - cmake
       - openssl-dev
       - rustup
@@ -43,7 +44,7 @@ pipeline:
           echo 'rustflags = ["-Ctarget-feature=+fp16"]' >> .cargo/config
       fi
 
-      cargo build --release
+      cargo auditable build --release
 
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/spin ${{targets.destdir}}/usr/bin/

--- a/starship.yaml
+++ b/starship.yaml
@@ -1,7 +1,7 @@
 package:
   name: starship
   version: 1.17.1
-  epoch: 0
+  epoch: 1
   description: "The minimal, blazing-fast, and infinitely customizable prompt for any shell!"
   copyright:
     - license: ISC
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - cmake
       - rust
 
@@ -23,7 +24,7 @@ pipeline:
       expected-commit: 1082afce0a27c5459d25998ea137067eb44dadab
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
       install -Dm755 target/release/starship "${{targets.destdir}}"/usr/bin/starship
 
   - uses: strip

--- a/sudo-rs.yaml
+++ b/sudo-rs.yaml
@@ -1,7 +1,7 @@
 package:
   name: sudo-rs
   version: 0.2.2
-  epoch: 0
+  epoch: 1
   description: A memory safe implementation of sudo and su.
   copyright:
     - license: MIT
@@ -15,6 +15,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - linux-pam-dev
       - openssl-dev
       - rust
@@ -27,7 +28,7 @@ pipeline:
       expected-commit: f3171451e551cedee60bffb91e910fa5346bdb94
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
       mkdir -p ${{targets.destdir}}/usr/bin
       mv target/release/sudo ${{targets.destdir}}/usr/bin/
       mv target/release/su ${{targets.destdir}}/usr/bin/

--- a/thin-provisioning-tools.yaml
+++ b/thin-provisioning-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: thin-provisioning-tools
   version: 1.0.12
-  epoch: 0
+  epoch: 1
   description: "suite of tools for manipulating the metadata of the dm-thin device-mapper target"
   copyright:
     - license: GPL-3.0-or-later
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - coreutils
       - gawk
       - rust
@@ -25,7 +26,7 @@ pipeline:
       tag: v${{package.version}}
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
       make install DESTDIR="${{targets.destdir}}"
 
   - uses: strip

--- a/trust-dns.yaml
+++ b/trust-dns.yaml
@@ -1,7 +1,7 @@
 package:
   name: trust-dns
   version: 0.23.1
-  epoch: 0
+  epoch: 1
   description: ""
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - libLLVM-15
       - openssl-dev
       - rust
@@ -26,7 +27,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release -p trust-dns --all-features
+      cargo auditable build --release -p trust-dns --all-features
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/trust-dns ${{targets.destdir}}/usr/bin/
 

--- a/uutils.yaml
+++ b/uutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: uutils
   version: 0.0.24
-  epoch: 2
+  epoch: 3
   description: "Cross-platform Rust rewrite of the GNU coreutils."
   copyright:
     - license: MIT
@@ -15,6 +15,7 @@ environment:
       - bash
       - build-base
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
       - wolfi-base
 
@@ -26,7 +27,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release --features unix
+      cargo auditable build --release --features unix
       mkdir -p ${{targets.destdir}}/usr
       make PREFIX=${{targets.destdir}}/usr MULTICALL=y install
 

--- a/uv.yaml
+++ b/uv.yaml
@@ -1,7 +1,7 @@
 package:
   name: uv
   version: 0.1.16
-  epoch: 0
+  epoch: 1
   description: An extremely fast Python package installer and resolver, written in Rust.
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - cmake
       - openssl-dev
       - perl
@@ -25,7 +26,7 @@ pipeline:
       expected-commit: 9f1452cb72e1da912f0653e398ac4ecb81244a82
 
   - runs: |
-      cargo build --locked --release
+      cargo auditable build --locked --release
       install -Dm755 target/release/uv "${{targets.destdir}}"/usr/bin/uv
 
   - uses: strip

--- a/wasker.yaml
+++ b/wasker.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasker
   version: 0.1.1
-  epoch: 0
+  epoch: 1
   description: "Wasm compiler for running Wasm on your favorite kernel"
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - cmake
       - libxml2-dev
       - llvm-tools
@@ -28,7 +29,7 @@ pipeline:
       expected-commit: 5947507d2529fb33af75b61aa6b824d3a46480d0
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin/

--- a/wasm-tools.yaml
+++ b/wasm-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasm-tools
   version: 1.201.0
-  epoch: 0
+  epoch: 1
   description: "Low level tooling for WebAssembly in Rust"
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - libLLVM-15
       - rust
       - wolfi-base
@@ -25,7 +26,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release -vv
+      cargo auditable build --release -vv
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/wasm-tools ${{targets.destdir}}/usr/bin/
 

--- a/wasmtime.yaml
+++ b/wasmtime.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasmtime
   version: 18.0.2
-  epoch: 0
+  epoch: 1
   description: "A fast and secure runtime for WebAssembly"
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - libLLVM-15
       - rust
       - wolfi-base
@@ -26,7 +27,7 @@ pipeline:
   - name: Configure and build
     runs: |
       git submodule update --init
-      cargo build --release -vv
+      cargo auditable build --release -vv
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/wasmtime ${{targets.destdir}}/usr/bin/
 
@@ -37,7 +38,7 @@ subpackages:
     description: "c library for wasmtime"
     pipeline:
       - runs: |
-          cargo build --release --manifest-path crates/c-api/artifact/Cargo.toml
+          cargo auditable build --release --manifest-path crates/c-api/artifact/Cargo.toml
           mkdir -p ${{targets.subpkgdir}}/usr/lib/
           mv target/release/libwasmtime.* ${{targets.subpkgdir}}/usr/lib/
       - uses: strip

--- a/wit-bindgen.yaml
+++ b/wit-bindgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: wit-bindgen
   version: 0.21.0
-  epoch: 0
+  epoch: 1
   description: "A language binding generator for WebAssembly interface types"
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - libLLVM-15
       - rust
       - wolfi-base
@@ -25,7 +26,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release -vv
+      cargo auditable build --release -vv
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/wit-bindgen ${{targets.destdir}}/usr/bin/
 

--- a/wizer.yaml
+++ b/wizer.yaml
@@ -1,7 +1,7 @@
 package:
   name: wizer
   version: 4.0.0
-  epoch: 0
+  epoch: 1
   description: "The WebAssembly Pre-Initializer"
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - libLLVM-15
       - rust
       - wolfi-base
@@ -25,7 +26,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release -vv --all-features
+      cargo auditable build --release -vv --all-features
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/wizer ${{targets.destdir}}/usr/bin/
 

--- a/yazi.yaml
+++ b/yazi.yaml
@@ -1,7 +1,7 @@
 package:
   name: yazi
   version: 0.2.4
-  epoch: 0
+  epoch: 1
   description: Blazing fast terminal file manager written in Rust, based on async I/O.
   copyright:
     - license: MIT
@@ -15,6 +15,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
 
 pipeline:
@@ -25,7 +26,7 @@ pipeline:
       expected-commit: b10f2de16d46df3ed7f6efe99ac966fd49d6e919
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
 
       install -Dm755 ./target/release/yazi "${{targets.destdir}}"/usr/bin/yazi
 

--- a/zellij.yaml
+++ b/zellij.yaml
@@ -1,7 +1,7 @@
 package:
   name: zellij
   version: 0.39.2
-  epoch: 0
+  epoch: 1
   description: A terminal workspace with batteries included
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - git
       - openssl-dev
       - rust
@@ -26,7 +27,7 @@ pipeline:
   - runs: |
       # use system openssl
       export OPENSSL_NO_VENDOR=1
-      cargo build --release
+      cargo auditable build --release
       mkdir -p ${{targets.destdir}}/usr/bin
       mkdir -p target/completions
       for sh in bash fish zsh; do

--- a/zola.yaml
+++ b/zola.yaml
@@ -1,7 +1,7 @@
 package:
   name: zola
   version: 0.18.0 # The next time we update, see if the cherry-picked patch can be removed now.
-  epoch: 0
+  epoch: 1
   description: "A fast static site generator in a single binary with everything built-in"
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - rust
       - wolfi-base
 
@@ -24,7 +25,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
-      cargo build --release
+      cargo auditable build --release
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/zola ${{targets.destdir}}/usr/bin/
 

--- a/zoxide.yaml
+++ b/zoxide.yaml
@@ -1,7 +1,7 @@
 package:
   name: zoxide
   version: 0.9.4
-  epoch: 0
+  epoch: 1
   description: "A smarter cd command. Supports all major shells."
   copyright:
     - license: MIT
@@ -13,6 +13,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - fzf
       - rust
       - wolfi-base
@@ -25,7 +26,7 @@ pipeline:
       expected-commit: 418a78d348445ddca0e15b1e95c4f17e4c628b19
 
   - runs: |
-      cargo build --release
+      cargo auditable build --release
       install -Dm755 target/release/zoxide "${{targets.destdir}}"/usr/bin/zoxide
       cd contrib/completions
       install -Dm644 zoxide.bash "${{targets.destdir}}"/usr/share/bash-completion/completions/zoxide


### PR DESCRIPTION
Leverages cargo-auditable to produce rust binaries with an embedded dependency tree in a dedicated linker section of the produced binaries containing crate versions in JSON. Useful for tracking bugs and vulnerabilities impacting crates

NOTE: Increases binary size by less than 4kB