### PR TITLE
php-imagick: init at 3.7.0

### DIFF
--- a/php-8.1-imagick.yaml
+++ b/php-8.1-imagick.yaml
@@ -1,0 +1,59 @@
+package:
+  name: php-8.1-imagick
+  version: 3.7.0
+  epoch: 0
+  description: "PHP extension for ImageMagick"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - imagemagick
+      - php-8.1
+    provides:
+      - php-imagick=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - imagemagick-dev
+      - php-8.1
+      - php-8.1-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Imagick/imagick
+      tag: "${{package.version}}"
+      expected-commit: 52ec37ff633de0e5cca159a6437b8c340afe7831
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-imagick-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=imagick.so" > "${{targets.subpkgdir}}/etc/php/conf.d/imagick.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: Imagick/imagick
+    use-tag: true

--- a/php-8.2-imagick.yaml
+++ b/php-8.2-imagick.yaml
@@ -1,0 +1,59 @@
+package:
+  name: php-8.2-imagick
+  version: 3.7.0
+  epoch: 0
+  description: "PHP extension for ImageMagick"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - imagemagick
+      - php-8.2
+    provides:
+      - php-imagick=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - imagemagick-dev
+      - php-8.2
+      - php-8.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Imagick/imagick
+      tag: "${{package.version}}"
+      expected-commit: 52ec37ff633de0e5cca159a6437b8c340afe7831
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-imagick-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=imagick.so" > "${{targets.subpkgdir}}/etc/php/conf.d/imagick.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: Imagick/imagick
+    use-tag: true

--- a/php-8.3-imagick.yaml
+++ b/php-8.3-imagick.yaml
@@ -1,0 +1,59 @@
+package:
+  name: php-8.3-imagick
+  version: 3.7.0
+  epoch: 0
+  description: "PHP extension for ImageMagick"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - imagemagick
+      - php-8.3
+    provides:
+      - php-imagick=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - imagemagick-dev
+      - php-8.3
+      - php-8.3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/Imagick/imagick
+      tag: "${{package.version}}"
+      expected-commit: 52ec37ff633de0e5cca159a6437b8c340afe7831
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: |
+      set -x
+      ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-imagick-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=imagick.so" > "${{targets.subpkgdir}}/etc/php/conf.d/imagick.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: Imagick/imagick
+    use-tag: true


### PR DESCRIPTION
Imagick is a popular PHP extension that adds imagemagick into PHP.

https://www.php.net/manual/en/book.imagick.php

The file is kinda the same for all PHP versions. Tested it with the PHP versions.


Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
