### PR TITLE
php-apcu: init at 5.1.23

### DIFF
--- a/php-8.1-apcu.yaml
+++ b/php-8.1-apcu.yaml
@@ -1,0 +1,59 @@
+package:
+  name: php-8.1-apcu
+  version: 5.1.23
+  epoch: 0
+  description: "PHP extension for User Cache"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.1
+    provides:
+      - php-apcu=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.1
+      - php-8.1-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/krakjoe/apcu
+      tag: "v${{package.version}}"
+      expected-commit: 1b725692b80b4856e8d705a7eda3ac416951aa1f
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: |
+      set -x
+      ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-apcu-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=apcu.so" > "${{targets.subpkgdir}}/etc/php/conf.d/apcu.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: krakjoe/apcu
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/php-8.2-apcu.yaml
+++ b/php-8.2-apcu.yaml
@@ -1,0 +1,59 @@
+package:
+  name: php-8.2-apcu
+  version: 5.1.23
+  epoch: 0
+  description: "PHP extension for User Cache"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.2
+    provides:
+      - php-apcu=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.2
+      - php-8.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/krakjoe/apcu
+      tag: "v${{package.version}}"
+      expected-commit: 1b725692b80b4856e8d705a7eda3ac416951aa1f
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: |
+      set -x
+      ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-apcu-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=apcu.so" > "${{targets.subpkgdir}}/etc/php/conf.d/apcu.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: krakjoe/apcu
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/php-8.3-apcu.yaml
+++ b/php-8.3-apcu.yaml
@@ -1,0 +1,59 @@
+package:
+  name: php-8.3-apcu
+  version: 5.1.23
+  epoch: 0
+  description: "PHP extension for User Cache"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.3
+    provides:
+      - php-apcu=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.3
+      - php-8.3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/krakjoe/apcu
+      tag: "v${{package.version}}"
+      expected-commit: 1b725692b80b4856e8d705a7eda3ac416951aa1f
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: |
+      set -x
+      ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-apcu-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=apcu.so" > "${{targets.subpkgdir}}/etc/php/conf.d/apcu.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: krakjoe/apcu
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true


### PR DESCRIPTION
PHP APCu is an extension to a cache results in memory. It's the lazy peoples way to cache, without thinking about Redis and so on.

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
