### PR TITLE
busybox-full: fix installation

### DIFF
--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,7 +1,7 @@
 package:
   name: busybox
   version: 1.36.1
-  epoch: 6
+  epoch: 7
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only
@@ -67,7 +67,7 @@ subpackages:
   - name: busybox-full
     dependencies:
       provides:
-        - busybox=1.36.0-r4
+        - busybox=1.36.1-r7
       provider-priority: 5
     options:
       no-commands: true


### PR DESCRIPTION
It's right now not possible to install Busybox full as it throws this error:

```
apk add --no-cache busybox-full
fetch https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
ERROR: unable to select packages:
  busybox-full-1.36.1-r6:
    breaks: world[busybox=1.36.1-r6]
    satisfies: world[busybox-full] wolfi-base-1-r4[busybox
```

With this change, it can be installed again:

```
apk add --no-cache --allow-untrusted /packages/x86_64/busybox-full-1.36.1-r7.apk 
fetch https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
(1/2) Purging busybox (1.36.1-r7)
(2/2) Installing busybox-full (1.36.1-r7)
Executing busybox-full-1.36.1-r7.trigger
OK: 15 MiB in 14 packages
```

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
