### PR TITLE
php-grpc: init at 1.62.1

### DIFF
--- a/php-8.1-grpc.yaml
+++ b/php-8.1-grpc.yaml
@@ -1,0 +1,59 @@
+package:
+  name: php-8.1-grpc
+  version: 1.62.1
+  epoch: 0
+  description: "A PHP extension for gRPC"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - grpc
+      - php-8.1
+    provides:
+      - php-grpc=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - grpc-dev
+      - php-8.1
+      - php-8.1-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/grpc/grpc
+      tag: "v${{package.version}}"
+      expected-commit: 6d7a55890e076a3a8abc8185b6bf0153fcf9d179
+
+  - name: Prepare build
+    runs: cd src/php/ext/grpc && phpize
+
+  - name: Configure
+    runs: cd src/php/ext/grpc && ./configure
+
+  - name: Make install
+    runs: |
+      cd src/php/ext/grpc
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-grpc-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=grpc.so" > "${{targets.subpkgdir}}/etc/php/conf.d/grpc.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: grpc/grpc
+    strip-prefix: v
+    tag-filter: v

--- a/php-8.2-grpc.yaml
+++ b/php-8.2-grpc.yaml
@@ -1,0 +1,59 @@
+package:
+  name: php-8.2-grpc
+  version: 1.62.1
+  epoch: 0
+  description: "A PHP extension for gRPC"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - grpc
+      - php-8.2
+    provides:
+      - php-grpc=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - grpc-dev
+      - php-8.2
+      - php-8.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/grpc/grpc
+      tag: "v${{package.version}}"
+      expected-commit: 6d7a55890e076a3a8abc8185b6bf0153fcf9d179
+
+  - name: Prepare build
+    runs: cd src/php/ext/grpc && phpize
+
+  - name: Configure
+    runs: cd src/php/ext/grpc && ./configure
+
+  - name: Make install
+    runs: |
+      cd src/php/ext/grpc
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-grpc-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=grpc.so" > "${{targets.subpkgdir}}/etc/php/conf.d/grpc.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: grpc/grpc
+    strip-prefix: v
+    tag-filter: v

--- a/php-8.3-grpc.yaml
+++ b/php-8.3-grpc.yaml
@@ -1,0 +1,59 @@
+package:
+  name: php-8.3-grpc
+  version: 1.62.1
+  epoch: 0
+  description: "A PHP extension for gRPC"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - grpc
+      - php-8.3
+    provides:
+      - php-grpc=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - grpc-dev
+      - php-8.3
+      - php-8.3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/grpc/grpc
+      tag: "v${{package.version}}"
+      expected-commit: 6d7a55890e076a3a8abc8185b6bf0153fcf9d179
+
+  - name: Prepare build
+    runs: cd src/php/ext/grpc && phpize
+
+  - name: Configure
+    runs: cd src/php/ext/grpc && ./configure
+
+  - name: Make install
+    runs: |
+      cd src/php/ext/grpc
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-grpc-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=grpc.so" > "${{targets.subpkgdir}}/etc/php/conf.d/grpc.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: grpc/grpc
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
Adds gRPC for PHP. This is needed for general gRPC stuff, or as an OpenTelemetry endpoint (optional, you can output also to console).

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
