### PR TITLE
php-8.3-memcached: init at 3.2.0

### DIFF
--- a/php-8.3-memcached.yaml
+++ b/php-8.3-memcached.yaml
@@ -1,0 +1,69 @@
+package:
+  name: php-8.3-memcached
+  version: 3.2.0
+  epoch: 0
+  description: "A PHP extension for Memcached"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.3
+    provides:
+      - php-memcached=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - libmemcached-dev
+      - php-8.3
+      - php-8.3-dev
+      - php-8.3-igbinary-dev
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-memcached-dev/php-memcached
+      tag: v${{package.version}}
+      expected-commit: d1cb3ae87be5382444322118f87324f4044d13b0
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    dependencies:
+      provides:
+        - php-memcached-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=memcached.so" > "${{targets.subpkgdir}}/etc/php/conf.d/memcached.ini"
+
+  - name: ${{package.name}}-dev
+    description: PHP 8.3 memcached development headers
+    dependencies:
+      provides:
+        - php-memcached-dev=${{package.full-version}}
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: php-memcached-dev/php-memcached
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
Adds missing PHP 8.3 variant of memcached. For 8.1 and 8.2 it's already there

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
