### PR TITLE
add timeout for scan ci step

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -236,6 +236,8 @@ jobs:
     needs: build
     if: needs.build.outputs.packages_were_built == 'true'
 
+    timeout-minutes: 30
+
     steps:
       - name: 'Retrieve x86_64 packages'
         uses: actions/download-artifact@21e5c25de9cf2ee24742cd3e822327f3be6dd2a3 # v4.1.1


### PR DESCRIPTION
the job should run pretty fast even for bigger batches

adding a timeout of 1 hour in case the job get stuck