### PR TITLE
build: remove non-existent noexecheap ld flag

### DIFF
--- a/build-aarch64.env
+++ b/build-aarch64.env
@@ -2,6 +2,6 @@
 export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv8-a+crc+crypto -mtune=neoverse-n1"
 export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
+export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack"
 export GOFLAGS=""
 export GOTOOLCHAIN=local

--- a/build-armv7l.env
+++ b/build-armv7l.env
@@ -2,6 +2,6 @@
 export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv7-a+simd -mtune=cortex-a7"
 export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
+export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack"
 export GOFLAGS=""
 export GOTOOLCHAIN=local

--- a/build-x86_64.env
+++ b/build-x86_64.env
@@ -1,6 +1,6 @@
 export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell"
 export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack,-z,noexecheap"
+export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack"
 export GOFLAGS=""
 export GOTOOLCHAIN=local

--- a/grafana.yaml
+++ b/grafana.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana
   version: 10.4.0
-  epoch: 1
+  epoch: 2
   description: The open and composable observability and data visualization platform.
   copyright:
     - license: AGPL-3.0-or-later

--- a/grafana.yaml
+++ b/grafana.yaml
@@ -38,10 +38,6 @@ pipeline:
       yarn run build
       yarn run plugins:build-bundled
 
-      # Our default LDFLAGS cause an issue with grafana. We need to remove '-z, noexecheap' from LDFLAGS
-      # Ref https://github.com/wolfi-dev/os/issues/7419
-      LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"
-
       # Bump the version of wire used, the old version panics with new Go
       # https://github.com/google/wire/issues/400
       sed -i "s/v0.5.0/v0.6.0/g" .bingo/wire.mod

--- a/gst-plugins-base.yaml
+++ b/gst-plugins-base.yaml
@@ -1,7 +1,7 @@
 package:
   name: gst-plugins-base
   version: 1.24.0
-  epoch: 0
+  epoch: 1
   description: GStreamer streaming media framework base plug-ins
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.0-or-later

--- a/gst-plugins-base.yaml
+++ b/gst-plugins-base.yaml
@@ -43,10 +43,6 @@ pipeline:
       uri: https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${{package.version}}.tar.xz
 
   - runs: |
-      # This breaks the build on aarc64 builds
-      if [ "${{build.arch}}" = "aarch64" ]; then
-        export LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"
-      fi
       meson \
         --prefix=/usr \
       	-Dalsa=enabled \

--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -43,9 +43,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      # Our default LDFLAGS cause an issue with ruby. We need to remove '-z, noexecheap' from LDFLAGS
-      LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"
-
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.0
   version: 3.0.6
-  epoch: 3
+  epoch: 4
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.4
-  epoch: 4
+  epoch: 5
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -44,9 +44,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      # Our default LDFLAGS cause an issue with ruby. We need to remove '-z, noexecheap' from LDFLAGS
-      LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"
-
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -40,9 +40,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      # Our default LDFLAGS cause an issue with ruby. We need to remove '-z, noexecheap' from LDFLAGS
-      LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"
-
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: 3.2.3
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -40,9 +40,6 @@ pipeline:
 
   - name: Configure
     runs: |
-      # Our default LDFLAGS cause an issue with ruby. We need to remove '-z, noexecheap' from LDFLAGS
-      LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"
-
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.3
   version: 3.3.0
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/wayland-protocols.yaml
+++ b/wayland-protocols.yaml
@@ -22,8 +22,6 @@ pipeline:
       uri: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/${{package.version}}/downloads/wayland-protocols-${{package.version}}.tar.xz
 
   - runs: |
-      # This flag doesn't work on the new version
-      export LDFLAGS="$(echo $LDFLAGS | sed 's/,-z,noexecheap//g')"
       env
       meson . output --prefix=/usr
       meson compile -j $(nproc) -C output

--- a/wayland-protocols.yaml
+++ b/wayland-protocols.yaml
@@ -1,7 +1,7 @@
 package:
   name: wayland-protocols
   version: "1.33"
-  epoch: 0
+  epoch: 1
   description: Protocols and protocol extensions complementing the Wayland core protocol
   copyright:
     - license: MIT


### PR DESCRIPTION
The LD flag -noexecheap was a gentoo/pax forked bintuils flag supported in versions 2.15..2.25. In addition to forked toolchain it also required forked/patched kernel. This option has been dropped from Hardened Gentoo binutils in approximately 2016. Yet many guides and tutorials online recommend setting it, when it is ignored by GNU LD and generates stderr warning only.

2024/03/11 12:46:58 WARN /usr/lib/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: warning: -z noexecheap ignored

Same behaviour is observed on modern Gentoo as well. Clearly many packages do ensure that calls to ld are warning-free. Thus stop specifying this flag to unbreak building packages that are strict about it.

Fixes: https://github.com/wolfi-dev/os/issues/7419

Testing:
* Rebuilt all affected packages, they all build cleanly now.
