### PR TITLE
build confluent-common-docker and fix permission issues

### DIFF
--- a/confluent-common-docker.yaml
+++ b/confluent-common-docker.yaml
@@ -1,8 +1,7 @@
-#nolint:git-checkout-must-use-github-updates
 package:
   name: confluent-common-docker
-  version: 7.7.0.16
-  epoch: 0
+  version: 7.6.0
+  epoch: 1
   description: Confluent Commons with support for building and testing Docker images.
   copyright:
     - license: Apache-2.0
@@ -13,19 +12,21 @@ environment:
       - busybox
       - ca-certificates-bundle
       - curl
-
-var-transforms:
-  - from: ${{package.version}}
-    match: '\.(\d+)$'
-    replace: '-$1'
-    to: mangled-package-version
+      - maven
+      - openjdk-17
+      - openjdk-17-default-jvm
 
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: b4613e601f1009e59fdba1f4b1b9ccc86d3e6d03
+      expected-commit: 1517960f490072414719d11cdb66e5a183ee45dc
       repository: https://github.com/confluentinc/common-docker
-      tag: v${{vars.mangled-package-version}}
+      tag: v${{package.version}}
+
+  - runs: |
+      # Add missing repository to pom.xml to resolve 'io.confluent:common:pom'.
+      sed -i '/<\/project>/i \  <repositories>\n    <repository>\n      <id>confluent</id>\n      <url>https://packages.confluent.io/maven/</url>\n    </repository>\n  </repositories>' pom.xml
+      mvn clean install -DskipTests -Dmaven.test.skip=true
 
 subpackages:
   # https://github.com/confluentinc/common-docker/tree/master/base
@@ -35,6 +36,7 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/etc/confluent/docker
           cp -r base/include/etc/confluent/docker/* "${{targets.subpkgdir}}"/etc/confluent/docker/
+          chmod -R 755 ${{targets.subpkgdir}}/etc/confluent/docker
 
   # https://github.com/confluentinc/common-docker/tree/master/base-lite/ub
   - name: ${{package.name}}-ub
@@ -50,12 +52,7 @@ subpackages:
       - uses: strip
 
 update:
-  enabled: true
-  version-transform:
-    - match: "-"
-      replace: "."
-  release-monitor:
-    identifier: 371725
+  enabled: false # Upstream repo doesn't provide any jars/poms past 7.6.0: https://packages.confluent.io/maven/io/confluent/common/
 
 test:
   environment:

--- a/confluent-kafka-images.yaml
+++ b/confluent-kafka-images.yaml
@@ -2,7 +2,7 @@
 package:
   name: confluent-kafka-images
   version: 7.6.1.17
-  epoch: 0
+  epoch: 1
   description: Provides build files for Apache Kafka and Confluent Docker images
   copyright:
     - license: Apache-2.0
@@ -52,6 +52,7 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/etc/confluent/docker
           install -Dm644 ${{range.key}}/include/etc/confluent/docker/* "${{targets.subpkgdir}}"/etc/confluent/docker/
+          chmod -R 755 ${{targets.subpkgdir}}/etc/confluent/docker
 
 update:
   enabled: true


### PR DESCRIPTION
Build: https://github.com/confluentinc/common-docker

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
