### PR TITLE
Keda-2.11 Fix CVE: GHSA-c5q2-7r4c-mv6g

### DIFF
--- a/keda-2.11.yaml
+++ b/keda-2.11.yaml
@@ -3,7 +3,7 @@
 package:
   name: keda-2.11
   version: 2.11.2
-  epoch: 12
+  epoch: 13
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -30,29 +30,16 @@ pipeline:
       repository: https://github.com/kedacore/keda
       tag: v${{package.version}}
 
+  # CVE-2023-39325 CVE-2023-45142 CVE-2023-47108
   - uses: go/bump
     with:
-      deps: golang.org/x/crypto@v0.17.0 github.com/go-jose/go-jose/v3@v3.0.1 github.com/cloudflare/circl@v1.3.7
+      deps: sigs.k8s.io/custom-metrics-apiserver@v1.28.0 sigs.k8s.io/controller-tools@v0.14.0 golang.org/x/net@v0.17.0 golang.org/x/crypto@v0.19.0 github.com/go-jose/go-jose/v3@v3.0.3 github.com/cloudflare/circl@v1.3.7 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.19.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0 go.opentelemetry.io/otel/sdk@v1.21.0 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
+
+  - uses: patch
+    with:
+      patches: kube-openapi.patch
 
   - runs: |
-      # CVE-2023-39325
-      go mod edit -dropreplace=golang.org/x/net
-      go get golang.org/x/net@v0.17.0
-
-      # google.golang.org/grpc@v1.58.3 changes the required sigs.k8s.io/custom-metrics-apiserver version
-      go mod edit -replace=sigs.k8s.io/custom-metrics-apiserver=sigs.k8s.io/custom-metrics-apiserver@v1.28.0
-
-      # CVE-2023-45142 CVE-2023-47108
-      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.19.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.19.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v0.42.0
-      go get go.opentelemetry.io/otel/sdk@v1.21.0
-      go mod edit -droprequire=go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
-      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0
-
-      go mod tidy
-      go mod vendor
       go clean -cache -modcache
       ARCH=$(go env GOARCH) make build
       mkdir -p "${{targets.destdir}}/usr/bin"

--- a/keda-2.11/kube-openapi.patch
+++ b/keda-2.11/kube-openapi.patch
@@ -1,0 +1,62 @@
+diff --git a/vendor/sigs.k8s.io/custom-metrics-apiserver/pkg/cmd/builder.go b/vendor/sigs.k8s.io/custom-metrics-apiserver/pkg/cmd/builder.go
+index 7b4fb40a..3b871055 100644
+--- a/vendor/sigs.k8s.io/custom-metrics-apiserver/pkg/cmd/builder.go
++++ b/vendor/sigs.k8s.io/custom-metrics-apiserver/pkg/cmd/builder.go
+@@ -264,8 +264,8 @@ func (b *AdapterBase) defaultOpenAPIConfig() *openapicommon.Config {
+ 	return b.openAPIConfig(genericapiserver.DefaultOpenAPIConfig)
+ }
+ 
+-func (b *AdapterBase) defaultOpenAPIV3Config() *openapicommon.Config {
+-	return b.openAPIConfig(genericapiserver.DefaultOpenAPIV3Config)
++func (b *AdapterBase) defaultOpenAPIV3Config() *openapicommon.OpenAPIV3Config {
++	return b.defaultOpenAPIV3Config()
+ }
+ 
+ // Config fetches the configuration used to ultimately create the custom metrics adapter's
+@@ -284,7 +284,7 @@ func (b *AdapterBase) Config() (*apiserver.Config, error) {
+ 			b.OpenAPIConfig = b.defaultOpenAPIConfig()
+ 		}
+ 		b.CustomMetricsAdapterServerOptions.OpenAPIConfig = b.OpenAPIConfig
+-		if b.OpenAPIV3Config == nil && utilfeature.DefaultFeatureGate.Enabled(features.OpenAPIV3) {
++		if b.OpenAPIV3Config == nil && utilfeature.DefaultFeatureGate.Enabled(features.OpenAPIEnums) {
+ 			b.OpenAPIV3Config = b.defaultOpenAPIV3Config()
+ 		}
+ 
+diff --git a/vendor/sigs.k8s.io/custom-metrics-apiserver/pkg/cmd/options/options.go b/vendor/sigs.k8s.io/custom-metrics-apiserver/pkg/cmd/options/options.go
+index 16f943e9..473e8973 100644
+--- a/vendor/sigs.k8s.io/custom-metrics-apiserver/pkg/cmd/options/options.go
++++ b/vendor/sigs.k8s.io/custom-metrics-apiserver/pkg/cmd/options/options.go
+@@ -25,6 +25,8 @@ import (
+ 
+ 	genericapiserver "k8s.io/apiserver/pkg/server"
+ 	genericoptions "k8s.io/apiserver/pkg/server/options"
++	"k8s.io/client-go/informers"
++	"k8s.io/client-go/kubernetes"
+ 	openapicommon "k8s.io/kube-openapi/pkg/common"
+ )
+ 
+@@ -40,7 +42,7 @@ type CustomMetricsAdapterServerOptions struct {
+ 	Features       *genericoptions.FeatureOptions
+ 
+ 	OpenAPIConfig   *openapicommon.Config
+-	OpenAPIV3Config *openapicommon.Config
++	OpenAPIV3Config *openapicommon.OpenAPIV3Config
+ 	EnableMetrics   bool
+ }
+ 
+@@ -99,7 +101,14 @@ func (o *CustomMetricsAdapterServerOptions) ApplyTo(serverConfig *genericapiserv
+ 	if err := o.Audit.ApplyTo(serverConfig); err != nil {
+ 		return err
+ 	}
+-	if err := o.Features.ApplyTo(serverConfig); err != nil {
++	kubernetesClient, err := kubernetes.NewForConfig(serverConfig.LoopbackClientConfig)
++	if err != nil {
++		return err
++	}
++
++	sharedInformers := informers.NewSharedInformerFactory(kubernetesClient, serverConfig.LoopbackClientConfig.Timeout)
++
++	if err := o.Features.ApplyTo(serverConfig, kubernetesClient, sharedInformers); err != nil {
+ 		return err
+ 	}
+ 


### PR DESCRIPTION
Fixes: #14349 #14343 #14458

- Fix CVE: GHSA-c5q2-7r4c-mv6g in keda-2.11
  - sigs.k8s.io/custom-metrics-apiserver@v1.28.0 is incompatible with the projects kube-openapi module, modified it to work with the current version.

> kube-openapi do not do tag release, causes issue with version upgrade https://github.com/kubernetes/kube-openapi/issues/383

