### PR TITLE
default to running tests on the docker runner

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -73,6 +73,15 @@ jobs:
       image: ghcr.io/wolfi-dev/sdk:latest@sha256:9bc0db73ea7d4b55b0aa73308c4525965ddd591cb6278475eba14463244ca635
       options: |
         --cap-add NET_ADMIN --cap-add SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor:unconfined
+      volumes:
+        # GHA assumes we mount /var/run/docker.sock for dind, which means we're
+        # working with host bind mounts, so we need a volume on the host that
+        # we can leverage for other bind mounts created by melange commands
+        # using the docker runner.
+        #
+        # This is named `temp` on purpose so we don't interfere with the host's
+        # /tmp or the inner containers /tmp.
+        - "/temp:/temp"
     outputs:
       packages_were_built: ${{ steps.file_check.outputs.exists }}
 
@@ -87,7 +96,6 @@ jobs:
           rm -rf /usr/share/dotnet
           rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v4
-
       - name: 'Trust the github workspace'
         run: |
           # This is to avoid fatal errors about "dubious ownership" because we are
@@ -104,10 +112,10 @@ jobs:
           mkdir ../.melangecache
           for package in ${{needs.changes.outputs.packages}}; do
             make MELANGE_EXTRA_OPTS="--create-build-log --cache-dir=$(pwd)/../.melangecache" REPO="$GITHUB_WORKSPACE/packages" package/$package -j1
-            make REPO="$GITHUB_WORKSPACE/packages" test/$package -j1
+            TMPDIR="/temp" make REPO="$GITHUB_WORKSPACE/packages" MELANGE_EXTRA_OPTS="--runner docker" test/$package -j1
           done
 
-      - name: "Check that packages can be installed with apk add"
+      - name: 'Check that packages can be installed with apk add'
         run: |
           # Create a fake linux fs under /tmp/emptyroot to pass to `apk --root`.
           mkdir -p /tmp/emptyroot/etc/apk

--- a/postgresql-12.yaml
+++ b/postgresql-12.yaml
@@ -156,3 +156,37 @@ update:
     strip-prefix: REL_
     tag-filter: REL_12
     use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - postgresql-12-client
+        - wolfi-base
+        - shadow
+        - sudo-rs
+        - glibc-locales
+    environment:
+      PGDATA: /tmp/test_db
+      PGUSER: wolfi
+  pipeline:
+    - name: "Test if PostgreSQL binaries are present and runnable"
+      runs: |
+        command -v initdb
+        command -v pg_ctl
+        command -v psql
+    - name: "Test database creation"
+      runs: |
+        useradd $PGUSER
+        sudo -u $PGUSER initdb -D /tmp/test_db
+        sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start
+        createdb testdb
+        psql -lqt | cut -d \| -f 1 | grep -qw testdb
+    - name: "Test basic read/write operations"
+      runs: |
+        psql -d testdb -c "CREATE TABLE test_table (id SERIAL PRIMARY KEY, test_value VARCHAR(50));"
+        psql -d testdb -c "INSERT INTO test_table (test_value) VALUES ('Hello, PostgreSQL!');"
+        psql -d testdb -t -A -c "SELECT test_value FROM test_table WHERE id=1;"
+    - name: "Test server can run and respond to requests"
+      runs: |
+        psql -d testdb -c "\conninfo"

--- a/postgresql-13.yaml
+++ b/postgresql-13.yaml
@@ -156,3 +156,37 @@ update:
     strip-prefix: REL_
     tag-filter: REL_13
     use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - postgresql-13-client
+        - wolfi-base
+        - shadow
+        - sudo-rs
+        - glibc-locales
+    environment:
+      PGDATA: /tmp/test_db
+      PGUSER: wolfi
+  pipeline:
+    - name: "Test if PostgreSQL binaries are present and runnable"
+      runs: |
+        command -v initdb
+        command -v pg_ctl
+        command -v psql
+    - name: "Test database creation"
+      runs: |
+        useradd $PGUSER
+        sudo -u $PGUSER initdb -D /tmp/test_db
+        sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start
+        createdb testdb
+        psql -lqt | cut -d \| -f 1 | grep -qw testdb
+    - name: "Test basic read/write operations"
+      runs: |
+        psql -d testdb -c "CREATE TABLE test_table (id SERIAL PRIMARY KEY, test_value VARCHAR(50));"
+        psql -d testdb -c "INSERT INTO test_table (test_value) VALUES ('Hello, PostgreSQL!');"
+        psql -d testdb -t -A -c "SELECT test_value FROM test_table WHERE id=1;"
+    - name: "Test server can run and respond to requests"
+      runs: |
+        psql -d testdb -c "\conninfo"

--- a/postgresql-14.yaml
+++ b/postgresql-14.yaml
@@ -158,3 +158,37 @@ update:
     strip-prefix: REL_
     tag-filter: REL_14
     use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - postgresql-14-client
+        - wolfi-base
+        - shadow
+        - sudo-rs
+        - glibc-locales
+    environment:
+      PGDATA: /tmp/test_db
+      PGUSER: wolfi
+  pipeline:
+    - name: "Test if PostgreSQL binaries are present and runnable"
+      runs: |
+        command -v initdb
+        command -v pg_ctl
+        command -v psql
+    - name: "Test database creation"
+      runs: |
+        useradd $PGUSER
+        sudo -u $PGUSER initdb -D /tmp/test_db
+        sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start
+        createdb testdb
+        psql -lqt | cut -d \| -f 1 | grep -qw testdb
+    - name: "Test basic read/write operations"
+      runs: |
+        psql -d testdb -c "CREATE TABLE test_table (id SERIAL PRIMARY KEY, test_value VARCHAR(50));"
+        psql -d testdb -c "INSERT INTO test_table (test_value) VALUES ('Hello, PostgreSQL!');"
+        psql -d testdb -t -A -c "SELECT test_value FROM test_table WHERE id=1;"
+    - name: "Test server can run and respond to requests"
+      runs: |
+        psql -d testdb -c "\conninfo"

--- a/postgresql-15.yaml
+++ b/postgresql-15.yaml
@@ -154,3 +154,37 @@ update:
     strip-prefix: REL_
     tag-filter: REL_15
     use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - postgresql-15-client
+        - wolfi-base
+        - shadow
+        - sudo-rs
+        - glibc-locales
+    environment:
+      PGDATA: /tmp/test_db
+      PGUSER: wolfi
+  pipeline:
+    - name: "Test if PostgreSQL binaries are present and runnable"
+      runs: |
+        command -v initdb
+        command -v pg_ctl
+        command -v psql
+    - name: "Test database creation"
+      runs: |
+        useradd $PGUSER
+        sudo -u $PGUSER initdb -D /tmp/test_db
+        sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start
+        createdb testdb
+        psql -lqt | cut -d \| -f 1 | grep -qw testdb
+    - name: "Test basic read/write operations"
+      runs: |
+        psql -d testdb -c "CREATE TABLE test_table (id SERIAL PRIMARY KEY, test_value VARCHAR(50));"
+        psql -d testdb -c "INSERT INTO test_table (test_value) VALUES ('Hello, PostgreSQL!');"
+        psql -d testdb -t -A -c "SELECT test_value FROM test_table WHERE id=1;"
+    - name: "Test server can run and respond to requests"
+      runs: |
+        psql -d testdb -c "\conninfo"

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -168,3 +168,37 @@ update:
     strip-prefix: REL_
     tag-filter: REL_16
     use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - postgresql-16-client
+        - wolfi-base
+        - shadow
+        - sudo-rs
+        - glibc-locales
+    environment:
+      PGDATA: /tmp/test_db
+      PGUSER: wolfi
+  pipeline:
+    - name: "Test if PostgreSQL binaries are present and runnable"
+      runs: |
+        command -v initdb
+        command -v pg_ctl
+        command -v psql
+    - name: "Test database creation"
+      runs: |
+        useradd $PGUSER
+        sudo -u $PGUSER initdb -D /tmp/test_db
+        sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start
+        createdb testdb
+        psql -lqt | cut -d \| -f 1 | grep -qw testdb
+    - name: "Test basic read/write operations"
+      runs: |
+        psql -d testdb -c "CREATE TABLE test_table (id SERIAL PRIMARY KEY, test_value VARCHAR(50));"
+        psql -d testdb -c "INSERT INTO test_table (test_value) VALUES ('Hello, PostgreSQL!');"
+        psql -d testdb -t -A -c "SELECT test_value FROM test_table WHERE id=1;"
+    - name: "Test server can run and respond to requests"
+      runs: |
+        psql -d testdb -c "\conninfo"


### PR DESCRIPTION
This changes the default `melange test ...` to use the docker runner by default instead of `bwrap`.

We're still relatively greenfield with our tests (compared to our builds), so this seems like the right time if any to make a change like this. Because of what tests are, `docker` feels like a better fit for the runtime, being a full container runtime instead of a light weight sandboxing tool.

I had to plumb through the appropriate bind mount dirs because of how GHA by default mounts the docker socket, so this impl has a bit of nastiness around the `TMPDIR=/temp make test/...`. I left an inline comment to warn future readers.

This only touches `melange test`, but should be similar for `melange build`, but that requires a more complicated migration and validation given the blissful ignorance we've been living in where all runners created workspace is solved and packaged equally.

To prove this works, I migrated the #14496 as part of this PR, which is part of #13623 