### PR TITLE
remove jenkins from runtime dependencies for -compat package

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins
   version: "2.448"
-  epoch: 1
+  epoch: 2
   description: Open-source CI/CD application.
   copyright:
     - license: MIT
@@ -65,9 +65,6 @@ subpackages:
   # The Jenkins entrypoint script expects directories to exist, and the .war file
   # under a different location.
   - name: "jenkins-compat"
-    dependencies:
-      runtime:
-        - jenkins
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/var/jenkins_home


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

This avoids us to use the same -compat package for older versions of the same package, so, let's remove the jenkins from the runtime dependencies of the compat package to allow that.

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
