### PR TITLE
opam: add 'support' for wolfi

### DIFF
--- a/opam.yaml
+++ b/opam.yaml
@@ -1,7 +1,7 @@
 package:
   name: opam
   version: 2.1.5
-  epoch: 0
+  epoch: 1
   description: "opam is a source-based package manager. It supports multiple simultaneous compiler installations, flexible package constraints, and a Git-friendly development workflow."
   copyright:
     - license: LGPL-2.1-or-later-WITH-linking-exception
@@ -26,6 +26,10 @@ pipeline:
       repository: https://github.com/ocaml/opam
       tag: ${{package.version}}
       expected-commit: 93f47ec3140f6299182254fbe7eeae68f9ca7abd
+
+  - uses: patch
+    with:
+      patches: 0001-opam-Let-wolfi-be-treated-like-alpine.patch
 
   - runs: |
       ./configure \

--- a/opam/0001-opam-Let-wolfi-be-treated-like-alpine.patch
+++ b/opam/0001-opam-Let-wolfi-be-treated-like-alpine.patch
@@ -1,0 +1,26 @@
+From 5fd51f6e361fd03b06e2e5dca8bb0a18c5495d92 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
+Date: Mon, 11 Mar 2024 23:54:58 +0000
+Subject: [PATCH] opam: Let wolfi be treated like alpine
+
+Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
+---
+ src/state/opamSysInteract.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/state/opamSysInteract.ml b/src/state/opamSysInteract.ml
+index 7b6374c71..1110cb9ff 100644
+--- a/src/state/opamSysInteract.ml
++++ b/src/state/opamSysInteract.ml
+@@ -105,7 +105,7 @@ let family =
+         "External dependency unusable, OS family not detected."
+     | Some family ->
+       match family with
+-      | "alpine" -> Alpine
++      | "alpine" | "wolfi" -> Alpine
+       | "amzn" | "centos" | "fedora" | "mageia" | "oraclelinux" | "ol"
+       | "rhel" -> Centos
+       | "archlinux" | "arch" -> Arch
+-- 
+2.43.0
+

--- a/opam/0001-opam-Let-wolfi-be-treated-like-alpine.patch
+++ b/opam/0001-opam-Let-wolfi-be-treated-like-alpine.patch
@@ -5,6 +5,9 @@ Subject: [PATCH] opam: Let wolfi be treated like alpine
 
 Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
 ---
+
+ Backport from https://github.com/ocaml/opam/pull/5878/files
+
  src/state/opamSysInteract.ml | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 


### PR DESCRIPTION
opam: add 'support' for wolfi

This gets rid of red-herring warnings that opam doesn't know how to query system packages on wolfi, by quering things using apk just like it does for Alpine.

This removes a warning from build logs. And this seems to be about it.

Related: https://github.com/ocaml/opam/pull/5878