### PR TITLE
add a smoke test for helm-operator

### DIFF
--- a/helm-operator.yaml
+++ b/helm-operator.yaml
@@ -38,3 +38,31 @@ update:
   github:
     identifier: operator-framework/operator-sdk
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+        - git
+        - curl
+        - kustomize
+  pipeline:
+    - uses: test/kwok/cluster
+    - name: Fetch the testdata from the source repo
+      runs: |
+        git clone --depth=1 https://github.com/operator-framework/operator-sdk.git
+    - name: Run a simple test of the operator against the testdata
+      working-directory: operator-sdk/testdata/helm/memcached-operator
+      runs: |
+        kustomize build config/crd | kubectl apply -f -
+
+        # Start the operator
+        helm-operator run &
+        sleep 5
+
+        # Deploy the CR and check that we reconcile some pods
+        kustomize build config/samples | kubectl apply -f -
+
+        sleep 5
+        kubectl wait --for=condition=Ready pods --all -n default

--- a/pipelines/test/kwok/cluster.yaml
+++ b/pipelines/test/kwok/cluster.yaml
@@ -1,0 +1,24 @@
+name: Kwok Cluster
+
+needs:
+  packages:
+    - busybox
+    - kubectl-default
+    - kwok
+    - kwokctl
+    - kubernetes
+    - etcd
+
+pipeline:
+  - runs: |
+      # ensure we can create a cluster using our own components instead of
+      # fetching from the internet
+      kwokctl create cluster --runtime binary \
+        --kube-apiserver-binary="/usr/bin/kube-apiserver" \
+        --kube-controller-manager-binary="/usr/bin/kube-controller-manager" \
+        --kube-scheduler-binary="/usr/bin/kube-scheduler" \
+        --kwok-controller-binary="/usr/bin/kwok" \
+        --etcd-binary="/usr/bin/etcd"
+      # Create a node
+      kwokctl scale node --replicas 1
+      kubectl wait --for=condition=Ready nodes --all


### PR DESCRIPTION
also re-introduces a `kwok` testing pipeline when mock clusters are useful

#13170 