### PR TITLE
github: drop kaniini from assignees on new package requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-wolfi-package-request.yml
+++ b/.github/ISSUE_TEMPLATE/new-wolfi-package-request.yml
@@ -2,8 +2,6 @@ name: New Wolfi Package Request
 description: Use this form to request the inclusion of wolfi OS.
 title: "[Wolfi Package Request]: $PACKAGE_NAME"
 labels: [ "wolfi-package-request", "needs-triage" ]
-assignees:
-  - kaniini
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
No longer the right assignee, thus its better to keep it empty for now.