### PR TITLE
go: convert packaging to better go pipelines

### DIFF
--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: caddy
   version: 2.7.6
-  epoch: 3
+  epoch: 4
   description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
   copyright:
     - license: Apache-2.0
@@ -11,8 +11,6 @@ environment:
     packages:
       - busybox
       - ca-certificates-bundle
-  environment:
-    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout
@@ -31,7 +29,6 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w
       output: caddy
       packages: ./cmd/caddy
 

--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.27.2
-  epoch: 2
+  epoch: 3
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0
@@ -355,14 +355,14 @@ subpackages:
           packages: ./apiserver/cmd/apiserver
           output: calico-apiserver
           subpackage: "true"
-          ldflags: "-s -w -X github.com/projectcalico/calico/cmd/apiserver/server.VERSION=${{package.version}}) -X github.com/projectcalico/calico/cmd/apiserver/server.BUILD_DATE=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_DESCRIPTION=$(git describe --tags) -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_REVISION=$(git rev-parse --short HEAD)"
+          ldflags: "-X github.com/projectcalico/calico/cmd/apiserver/server.VERSION=${{package.version}}) -X github.com/projectcalico/calico/cmd/apiserver/server.BUILD_DATE=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_DESCRIPTION=$(git describe --tags) -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_REVISION=$(git rev-parse --short HEAD)"
       - uses: go/build
         with:
           modroot: .
           packages: ./apiserver/cmd/filecheck
           output: calico-filecheck
           subpackage: "true"
-          ldflags: "-s -w -X github.com/projectcalico/calico/cmd/apiserver/server.VERSION=${{package.version}}) -X github.com/projectcalico/calico/cmd/apiserver/server.BUILD_DATE=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_DESCRIPTION=$(git describe --tags) -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_REVISION=$(git rev-parse --short HEAD)"
+          ldflags: "-X github.com/projectcalico/calico/cmd/apiserver/server.VERSION=${{package.version}}) -X github.com/projectcalico/calico/cmd/apiserver/server.BUILD_DATE=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_DESCRIPTION=$(git describe --tags) -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_REVISION=$(git rev-parse --short HEAD)"
 
   - name: "calico-app-policy"
     dependencies:
@@ -375,7 +375,7 @@ subpackages:
           packages: ./app-policy/cmd/dikastes
           output: calico-dikastes
           subpackage: "true"
-          ldflags: "-s -w -X github.com/projectcalico/calico/app-policy/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>') -X github.com/projectcalico/calico/app-policy/buildinfo.BuildDate=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/app-policy/GitRevision=$(git rev-parse HEAD || echo '<unknown>') -B 0x$(git rev-parse HEAD || uuidgen | sed 's/-//g')"
+          ldflags: "-X github.com/projectcalico/calico/app-policy/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>') -X github.com/projectcalico/calico/app-policy/buildinfo.BuildDate=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/app-policy/GitRevision=$(git rev-parse HEAD || echo '<unknown>') -B 0x$(git rev-parse HEAD || uuidgen | sed 's/-//g')"
       - uses: go/build
         with:
           modroot: .
@@ -394,14 +394,14 @@ subpackages:
           packages: ./kube-controllers/cmd/kube-controllers
           output: calico-kube-controllers
           subpackage: "true"
-          ldflags: "-s -w -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
+          ldflags: "-X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
       - uses: go/build
         with:
           modroot: .
           packages: ./kube-controllers/cmd/check-status
           output: check-status # keep naming convention as "check-status" is usually harded to /usr/bin/check-status
           subpackage: "true"
-          ldflags: "-s -w -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
+          ldflags: "-X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
 
   - name: "calico-pod2daemon"
     description: "The calico pod2daemon components"
@@ -415,21 +415,18 @@ subpackages:
           packages: ./pod2daemon/flexvol
           output: calico-pod2daemon-flexvol
           subpackage: "true"
-          ldflags: "-s -w"
       - uses: go/build
         with:
           modroot: .
           packages: ./pod2daemon/csidriver
           output: calico-pod2daemon-csidriver
           subpackage: "true"
-          ldflags: "-s -w"
       - uses: go/build
         with:
           modroot: .
           packages: ./pod2daemon/nodeagent
           output: calico-pod2daemon-nodeagent
           subpackage: "true"
-          ldflags: "-s -w"
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           install -m755 ./pod2daemon/flexvol/docker/flexvol.sh "${{targets.subpkgdir}}"/usr/bin/flexvol.sh
@@ -449,28 +446,20 @@ subpackages:
           packages: ./calicoctl/calicoctl
           output: calicoctl
           subpackage: "true"
-          ldflags: "-s -w -X github.com/projectcalico/calico/calicoctl/commands.VERSION=$(git describe --tags --dirty --always --abbrev=12) -X github.com/projectcalico/calico/calicoctl/commands.GIT_REVISION=$(git rev-parse --short HEAD) -X github.com/projectcalico/calico/calicoctl/commands/common.VERSION=$(git describe --tags --dirty --always --abbrev=12) -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
+          ldflags: "-X github.com/projectcalico/calico/calicoctl/commands.VERSION=$(git describe --tags --dirty --always --abbrev=12) -X github.com/projectcalico/calico/calicoctl/commands.GIT_REVISION=$(git rev-parse --short HEAD) -X github.com/projectcalico/calico/calicoctl/commands/common.VERSION=$(git describe --tags --dirty --always --abbrev=12) -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
 
   - name: "calico-typhad"
     description: "The calico typha daemon"
-    dependencies:
-      runtime:
-        - glibc
     pipeline:
-      # TODO: I'm not sure yet if this actually needs CGO, or is just enabled upstream because of go-fips
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./typha/cmd/calico-typha
+          output: calico-typha
+          subpackage: "true"
+          ldflags: "-X github.com/projectcalico/calico/typha/pkg/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>') -X github.com/projectcalico/calico/typha/pkg/buildinfo.BuildDate=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/typha/pkg/buildinfo.GitRevision=$(git rev-parse HEAD || echo '<unknown>') -B 0x$(git rev-parse HEAD || uuidgen | sed 's/-//g')"
+
       - runs: |
-          LDFLAGS="-s -w"
-          LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/typha/pkg/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>')"
-          LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/typha/pkg/buildinfo.BuildDate=$(date -u +'%FT%T%z')"
-          LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/typha/pkg/buildinfo.GitRevision=$(git rev-parse HEAD || echo '<unknown>')"
-          LDFLAGS="$LDFLAGS -B 0x$(git rev-parse HEAD || uuidgen | sed 's/-//g')"
-
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin/
-          CGO_ENABLED=1 \
-            go build -v -tags cgo -v -buildvcs=false \
-            -o "${{targets.subpkgdir}}"/usr/bin/calico-typha \
-            ./typha/cmd/calico-typha
-
           mkdir -p "${{targets.subpkgdir}}"/etc/calico
           cp ./typha/docker-image/typha.cfg "${{targets.subpkgdir}}"/etc/calico/typha.cfg
 
@@ -480,21 +469,14 @@ subpackages:
   - name: "calico-typha-client"
     description: "The calico typha client"
     dependencies:
-      runtime:
-        - glibc
     pipeline:
-      # TODO: I'm not sure yet if this actually needs CGO, or is just enabled upstream because of go-fips
-      - runs: |
-          LDFLAGS="-s -w"
-          LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/typha/pkg/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>')"
-          LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/typha/pkg/buildinfo.BuildDate=$(date -u +'%FT%T%z')"
-          LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/typha/pkg/buildinfo.GitRevision=$(git rev-parse HEAD || echo '<unknown>')"
-          LDFLAGS="$LDFLAGS -B 0x$(git rev-parse HEAD || uuidgen | sed 's/-//g')"
-
-          CGO_ENABLED=1 \
-            go build -v -tags cgo -v -buildvcs=false \
-            -o "${{targets.subpkgdir}}"/usr/bin/typha-client \
-            ./typha/cmd/typha-client
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./typha/cmd/typha-client
+          output: typha-client
+          subpackage: "true"
+          ldflags: "-X github.com/projectcalico/calico/typha/pkg/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>') -X github.com/projectcalico/calico/typha/pkg/buildinfo.BuildDate=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/typha/pkg/buildinfo.GitRevision=$(git rev-parse HEAD || echo '<unknown>') -B 0x$(git rev-parse HEAD || uuidgen | sed 's/-//g')"
 
 update:
   enabled: true

--- a/cert-exporter.yaml
+++ b/cert-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: cert-exporter
   version: 2.12.0
-  epoch: 1
+  epoch: 2
   description: A Prometheus exporter that publishes cert expirations on disk and in Kubernetes secrets
   copyright:
     - license: Apache-2.0
@@ -24,12 +24,9 @@ pipeline:
     with:
       deps: golang.org/x/crypto@v0.17.0
 
-  - runs: |
-      # Original build command referenced from here:
-      # - https://github.com/joe-elliott/cert-exporter/blob/master/Dockerfile#L6
-      CGO_ENABLED=0 go build -a -installsuffix cgo -o "${{targets.destdir}}"/usr/bin/cert-exporter .
-
-  - uses: strip
+  - uses: go/install
+    with:
+      package: .
 
 # Upstream publishes helm charts and application releases separately, example:
 # - cert-exporter-3.4.1 (helm chart)


### PR DESCRIPTION
These are conversions to better go pipelines as implemented by https://github.com/chainguard-dev/melange/pull/1086

Depends on https://github.com/chainguard-dev/melange/pull/1086
