### PR TITLE
cilium-1.15: explicit dep on python-3.12-default

### DIFF
--- a/cilium-1.15.yaml
+++ b/cilium-1.15.yaml
@@ -46,8 +46,8 @@ environment:
       - llvm15-tools
       - openjdk-11
       - patch
-      - python3-dev
       - python-3.12-default
+      - python3-dev
       - samurai
       - wolfi-baselayout
 

--- a/cilium-1.15.yaml
+++ b/cilium-1.15.yaml
@@ -47,6 +47,7 @@ environment:
       - openjdk-11
       - patch
       - python3-dev
+      - python-3.12-default
       - samurai
       - wolfi-baselayout
 


### PR DESCRIPTION
Attempting to fix this package build, if this works we'll probably need to add this elsewhere.