### PR TITLE
python-3.12: move python3-dev provides to something that will pull in both default python and -dev

### DIFF
--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: 3.12.2
-  epoch: 4
+  epoch: 5
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -139,7 +139,13 @@ subpackages:
           # pyconfig.h is needed at runtime... ugh.
           mkdir -p "${{targets.destdir}}"/usr/include/${{vars.python}}
           mv "${{targets.subpkgdir}}"/usr/include/${{vars.python}}/pyconfig.h "${{targets.destdir}}"/usr/include/${{vars.python}}
+
+  - name: "${{package.name}}-dev-default"
+    description: "python3 by default with development headers"
     dependencies:
+      runtime:
+        - ${{package.name}}-dev
+        - ${{package.name}}-default
       provides:
         - python3-dev=${{package.full-version}}
         - python-3-dev=${{package.full-version}}


### PR DESCRIPTION
Previous dis-entaglement left default python3-dev provider without usr/bin/python3 pointing at the matching python, breaking packages that depend on `python3-dev` alone (and just want whatever)

With this change, that use-case remains supported correctly:

```
# apk add python3-dev
(1/16) Installing libbz2-1 (1.0.8-r6)
(2/16) Installing libexpat1 (2.6.1-r0)
(3/16) Installing libffi (3.4.6-r0)
(4/16) Installing gdbm (1.23-r4)
(5/16) Installing xz (5.6.1-r0)
(6/16) Installing libgcc (13.2.0-r5)
(7/16) Installing libstdc++ (13.2.0-r5)
(8/16) Installing mpdecimal (4.0.0-r0)
(9/16) Installing ncurses-terminfo-base (6.4_p20231125-r1)
(10/16) Installing ncurses (6.4_p20231125-r1)
(11/16) Installing readline (8.2-r3)
(12/16) Installing sqlite-libs (3.45.1-r0)
(13/16) Installing python-3.12 (3.12.2-r5)
(14/16) Installing python-3.12-default (3.12.2-r5)
(15/16) Installing python-3.12-dev (3.12.2-r5)
(16/16) Installing python-3.12-dev-default (3.12.2-r5)
OK: 68 MiB in 30 packages
```