### PR TITLE
Fix cassandra 4.1 update checks

### DIFF
--- a/cassandra-4.1.yaml
+++ b/cassandra-4.1.yaml
@@ -74,7 +74,7 @@ update:
   github:
     identifier: apache/cassandra
     use-tag: true
-    tag-filter-prefix: cassandra-4
+    tag-filter-prefix: cassandra-4.1
     strip-prefix: cassandra-
 
 test:


### PR DESCRIPTION
Noticed that Cassandra v4.1 stream was not fltering for 4.1 tags in Git. As a result when 4.2 dropped, it'd have picked it up 