### PR TITLE
feat(packages): Add ack and perl-file-next

### DIFF
--- a/ack.yaml
+++ b/ack.yaml
@@ -1,0 +1,47 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/ack/APKBUILD
+package:
+  name: ack
+  version: 3.7.0
+  epoch: 0
+  description: A Perl-powered replacement for grep
+  copyright:
+    - license: Artistic-2.0
+  dependencies:
+    runtime:
+      - perl
+      - perl-file-next
+
+environment:
+  contents:
+    packages:
+      - automake
+      - busybox
+      - perl-dev
+      - perl-file-next
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: ea7caa14f757de083310ed2cba298661ddcca5dee06ec8f18043ea625a79df20
+      uri: https://cpan.metacpan.org/authors/id/P/PE/PETDANCE/ack-v${{package.version}}.tar.gz
+
+  - runs: PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: ack-doc
+    pipeline:
+      - uses: split/manpages
+    description: ack manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 15

--- a/perl-file-next.yaml
+++ b/perl-file-next.yaml
@@ -1,0 +1,45 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-file-next/APKBUILD
+package:
+  name: perl-file-next
+  version: "1.18"
+  epoch: 0
+  description: Perl module for taint-safe file-finding
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  dependencies:
+    runtime:
+      - perl
+
+environment:
+  contents:
+    packages:
+      - automake
+      - busybox
+      - perl
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: f900cb39505eb6e168a9ca51a10b73f1bbde1914b923a09ecd72d9c02e6ec2ef
+      uri: https://cpan.metacpan.org/authors/id/P/PE/PETDANCE/File-Next-${{package.version}}.tar.gz
+
+  - runs: PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: find "${{targets.destdir}}" -name perllocal.pod -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-file-next-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-file-next manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2895


### PR DESCRIPTION
ack is a perl-powered replacement for grep

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)