### PR TITLE
build: Use --destination-repository flag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
           wolfictl build \
             --runner bubblewrap \
-            --keyring-append=/gcsfuse/wolfi-registry/wolfi-signing.rsa.pub \
+            --keyring-append /gcsfuse/wolfi-registry/wolfi-signing.rsa.pub \
             --repository-append ./packages \
             --keyring-append local-melange.rsa.pub \
             --repository-append https://packages.wolfi.dev/os \
@@ -86,6 +86,7 @@ jobs:
             --arch ${{ matrix.arch }} \
             --namespace wolfi \
             --pipeline-dir ./pipelines/ \
+            --destination-repository https://packages.wolfi.dev/os \
             --trace ./packages/${{ matrix.arch }}/trace.json
 
       # Always run this step for https://github.com/wolfi-dev/os/issues/8698


### PR DESCRIPTION
This skips statting any APKs that are already present in the index.