### PR TITLE
Remove -default package from python-3.12, use -base instead.

### DIFF
--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -5,6 +5,12 @@ package:
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
+  dependencies:
+    provides:
+      - python3=${{package.full-version}}
+      - python-3=${{package.full-version}}
+    runtime:
+      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -87,7 +93,7 @@ pipeline:
       find ${{targets.destdir}}/usr/lib -type d -name 'idle_test' -exec rm -rf '{}' +
 
       cd ${{targets.destdir}}/usr/bin
-      rm -f python3 pydoc3 idle3* 2to3*
+      rm -f idle3* 2to3*
       rm ${{targets.destdir}}/usr/lib/libpython3.so
 
       # Drop site-packages README.txt to avoid SCA dep on python3~3.M
@@ -111,20 +117,29 @@ test:
         ${{vars.python}} CVE-2023-27043-unittest.py
 
 subpackages:
-  - name: "${{package.name}}-default"
+  - name: "${{package.name}}-base"
     description: "${{package.name}} as /usr/bin/python3"
-    dependencies:
-      provides:
-        - python3=${{package.full-version}}
-        - python-3=${{package.full-version}}
-      runtime:
-        - ${{package.name}}
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -sf ${{vars.python}} "${{targets.subpkgdir}}"/usr/bin/python3
-          ln -sf pydoc${{vars.pyversion}} "${{targets.subpkgdir}}"/usr/bin/pydoc3
-          ln -sf python3 "${{targets.subpkgdir}}"/usr/bin/python
+          mkdir -p ${{targets.subpkgdir}}/usr/bin ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/bin/${{vars.python}} \
+              ${{targets.destdir}}/usr/bin/pydoc${{vars.pyversion}} \
+              ${{targets.subpkgdir}}/usr/bin
+          mv -v ${{targets.destdir}}/usr/lib/${{vars.python}} \
+             ${{targets.subpkgdir}}/usr/lib
+          mv -v ${{targets.destdir}}/usr/lib/libpython${{vars.pyversion}}.so.* \
+             ${{targets.subpkgdir}}/usr/lib
+
+          # pyconfig.h is needed at runtime... ugh.
+          d=usr/include/${{vars.python}}
+          mkdir -p "${{targets.subpkgdir}}"/$d
+          mv "${{targets.destdir}}"/$d/pyconfig.h "${{targets.subpkgdir}}"/$d/
+          # this does not belong here. picked up by -base-dev below.
+          # config-3.12-x86_64-linux-gnu
+          d="usr/lib/${{vars.python}}"
+          mkdir -p "${{targets.destdir}}/$d"
+          mv -v "${{targets.subpkgdir}}/$d"/config-${{vars.pyversion}}* \
+              "${{targets.destdir}}/$d"
 
   - name: "${{package.name}}-doc"
     description: "python3 documentation"
@@ -133,22 +148,38 @@ subpackages:
 
   - name: "${{package.name}}-dev"
     description: "python3 development headers"
-    pipeline:
-      - uses: split/dev
-      - runs: |
-          # pyconfig.h is needed at runtime... ugh.
-          mkdir -p "${{targets.destdir}}"/usr/include/${{vars.python}}
-          mv "${{targets.subpkgdir}}"/usr/include/${{vars.python}}/pyconfig.h "${{targets.destdir}}"/usr/include/${{vars.python}}
-
-  - name: "${{package.name}}-dev-default"
-    description: "python3 by default with development headers"
     dependencies:
-      runtime:
-        - ${{package.name}}-dev
-        - ${{package.name}}-default
       provides:
         - python3-dev=${{package.full-version}}
         - python-3-dev=${{package.full-version}}
+      runtime:
+        - ${{package.name}}-base-dev=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv -v ${{targets.destdir}}/usr/bin/python3-config ${{targets.subpkgdir}}/usr/bin
+
+          d="usr/lib/pkgconfig"
+          mkdir -p "${{targets.subpkgdir}}/$d"
+          mv -v \
+             "${{targets.destdir}}"/$d/python3-embed.pc \
+             "${{targets.destdir}}"/$d/python3.pc \
+             "${{targets.subpkgdir}}/$d/"
+
+  - name: "${{package.name}}-base-dev"
+    description: "python3 development headers"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
+    pipeline:
+      - uses: split/dev
+      - runs: |
+          # expect a dir like config-3.12-x86_64-linux-gnu
+          d="usr/lib/${{vars.python}}"
+          mkdir -p "${{targets.subpkgdir}}/$d"
+          mv -v "${{targets.destdir}}"/$d/config-${{vars.pyversion}}* \
+             "${{targets.subpkgdir}}"/$d/config-${{vars.pyversion}}*
+          rmdir "${{targets.destdir}}"/$d/config-${{vars.pyversion}}*
 
 update:
   enabled: true


### PR DESCRIPTION
We tried python-3.12-default to provide symlinks python3 -> python3.12. That caused some problems.

The change here is to instead have
  python-3.12 provide /usr/bin/python3
and depend on
  python-3.12-base for the primary files.

There is also -dev and -base-dev which are similarly focused.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
