### PR TITLE
python3.12: missing epoch bump

### DIFF
--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: 3.12.2
-  epoch: 5
+  epoch: 6
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0


### PR DESCRIPTION
Fixes: https://github.com/wolfi-dev/os/pull/14921/files
Fixes: https://github.com/wolfi-dev/os/issues/14880
