### PR TITLE
migrate to arm runners round 2

### DIFF
--- a/.github/actions/docker-run/action.yaml
+++ b/.github/actions/docker-run/action.yaml
@@ -36,5 +36,6 @@ runs:
           -i \
           ${{ inputs.opts }} \
           ${{ inputs.image }} <<EOF
+        set -e
         ${{ inputs.run }}
         EOF

--- a/acme.sh.yaml
+++ b/acme.sh.yaml
@@ -1,7 +1,7 @@
 package:
   name: acme.sh
   version: 3.0.7
-  epoch: 0
+  epoch: 1
   description: ACME Shell script, an acme client alternative to certbot
   copyright:
     - license: GPL-3.0-only

--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis-7.2
   version: 7.2.4
-  epoch: 2
+  epoch: 3
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause

--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -166,3 +166,5 @@ test:
         redis-cli GET bike:1 | grep 'Process 134' || exit 1
         redis-cli exists bike:1 | grep 1 || exit 1
         redis-cli exists bike:2 | grep 0 || exit 1
+
+        exit 1

--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis-7.2
   version: 7.2.4
-  epoch: 3
+  epoch: 2
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
@@ -166,5 +166,3 @@ test:
         redis-cli GET bike:1 | grep 'Process 134' || exit 1
         redis-cli exists bike:1 | grep 1 || exit 1
         redis-cli exists bike:2 | grep 0 || exit 1
-
-        exit 1


### PR DESCRIPTION
the `docker-run` action was missing a `set -e` in the subshell spawned by `docker run ... /bin/sh`.

this meant errors occurring during the individual `runs:` blocks were failing but not exiting.