### PR TITLE
Re-apply creation of python-3.12-base.

### DIFF
--- a/py3.12-pip.yaml
+++ b/py3.12-pip.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.12-pip
   version: "24.0"
-  epoch: 0
+  epoch: 1
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT

--- a/py3.12-setuptools.yaml
+++ b/py3.12-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.12-setuptools
   version: 69.1.1
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,10 +1,16 @@
 package:
   name: python-3.12
   version: 3.12.2
-  epoch: 6
+  epoch: 7
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
+  dependencies:
+    provides:
+      - python3=${{package.full-version}}
+      - python-3=${{package.full-version}}
+    runtime:
+      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -87,8 +93,11 @@ pipeline:
       find ${{targets.destdir}}/usr/lib -type d -name 'idle_test' -exec rm -rf '{}' +
 
       cd ${{targets.destdir}}/usr/bin
-      rm -f python3 pydoc3 idle3* 2to3*
+      rm -f idle3* 2to3*
       rm ${{targets.destdir}}/usr/lib/libpython3.so
+
+      # add dubious python -> python3 link
+      ln -s python3 ${{targets.destdir}}/usr/bin/python
 
       # Drop site-packages README.txt to avoid SCA dep on python3~3.M
       cd ${{targets.destdir}}/usr/lib/${{vars.python}}
@@ -111,20 +120,30 @@ test:
         ${{vars.python}} CVE-2023-27043-unittest.py
 
 subpackages:
-  - name: "${{package.name}}-default"
+  - name: "${{package.name}}-base"
     description: "${{package.name}} as /usr/bin/python3"
-    dependencies:
-      provides:
-        - python3=${{package.full-version}}
-        - python-3=${{package.full-version}}
-      runtime:
-        - ${{package.name}}
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -sf ${{vars.python}} "${{targets.subpkgdir}}"/usr/bin/python3
-          ln -sf pydoc${{vars.pyversion}} "${{targets.subpkgdir}}"/usr/bin/pydoc3
-          ln -sf python3 "${{targets.subpkgdir}}"/usr/bin/python
+          mkdir -p ${{targets.subpkgdir}}/usr/bin ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/bin/${{vars.python}} \
+              ${{targets.destdir}}/usr/bin/pydoc${{vars.pyversion}} \
+              ${{targets.subpkgdir}}/usr/bin
+          mv -v ${{targets.destdir}}/usr/lib/${{vars.python}} \
+             ${{targets.subpkgdir}}/usr/lib
+          mv -v ${{targets.destdir}}/usr/lib/libpython${{vars.pyversion}}.so.* \
+             ${{targets.subpkgdir}}/usr/lib
+
+          # pyconfig.h is needed at runtime... ugh.
+          d=usr/include/${{vars.python}}
+          mkdir -p "${{targets.subpkgdir}}"/$d
+          mv "${{targets.destdir}}"/$d/pyconfig.h "${{targets.subpkgdir}}"/$d/
+
+          # move usr/lib/python3.X/config-3.X-x86_64-linux-gnu
+          # back into main package so the -base-dev can take it below.
+          d="usr/lib/${{vars.python}}"
+          mkdir -p "${{targets.destdir}}/$d"
+          mv -v "${{targets.subpkgdir}}/$d"/config-${{vars.pyversion}}* \
+              "${{targets.destdir}}/$d"
 
   - name: "${{package.name}}-doc"
     description: "python3 documentation"
@@ -133,22 +152,38 @@ subpackages:
 
   - name: "${{package.name}}-dev"
     description: "python3 development headers"
-    pipeline:
-      - uses: split/dev
-      - runs: |
-          # pyconfig.h is needed at runtime... ugh.
-          mkdir -p "${{targets.destdir}}"/usr/include/${{vars.python}}
-          mv "${{targets.subpkgdir}}"/usr/include/${{vars.python}}/pyconfig.h "${{targets.destdir}}"/usr/include/${{vars.python}}
-
-  - name: "${{package.name}}-dev-default"
-    description: "python3 by default with development headers"
     dependencies:
-      runtime:
-        - ${{package.name}}-dev
-        - ${{package.name}}-default
       provides:
         - python3-dev=${{package.full-version}}
         - python-3-dev=${{package.full-version}}
+      runtime:
+        - ${{package.name}}-base-dev=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv -v ${{targets.destdir}}/usr/bin/python3-config ${{targets.subpkgdir}}/usr/bin
+
+          d="usr/lib/pkgconfig"
+          mkdir -p "${{targets.subpkgdir}}/$d"
+          mv -v \
+             "${{targets.destdir}}"/$d/python3-embed.pc \
+             "${{targets.destdir}}"/$d/python3.pc \
+             "${{targets.subpkgdir}}/$d/"
+
+  - name: "${{package.name}}-base-dev"
+    description: "python3 development headers"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
+    pipeline:
+      - runs: |
+          # usr/lib/pytyon3.X/config-3.X-x86_64-linux-gnu
+          # split/dev will only move 2 files from it, but we want all of it.
+          d="usr/lib/${{vars.python}}"
+          mkdir -p "${{targets.subpkgdir}}/$d"
+          mv -v "${{targets.destdir}}"/$d/config-${{vars.pyversion}}* \
+             "${{targets.subpkgdir}}"/$d
+      - uses: split/dev
 
 update:
   enabled: true


### PR DESCRIPTION
We tried python-3.12-default to provide symlinks python3 -> python3.12. That caused some problems as many things expected to get a /usr/bin/python3 (or /usr/bin/python) from installing 'python-3.12'.

The change here is to instead have python-3.12 provide /usr/bin/python3 as it did before, and depend on python-3.12-base for the primary files. python-3.12 and python-3.12-dev contain only symlinks.

The other changes here are a move of some files out of the runtime package and into -dev (usr/lib/python3.X/config-3.X-x86_64-linux-gnu). debian/ubuntu put these files in the -dev package.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
