### PR TITLE
libxcrypt: prepare for transition

### DIFF
--- a/libxcrypt.yaml
+++ b/libxcrypt.yaml
@@ -1,10 +1,17 @@
 package:
   name: libxcrypt
   version: 4.4.36
-  epoch: 3
+  epoch: 4
   description: "Modern library for one-way hashing of passwords"
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later
+  options:
+    # For apko same-origin resolution
+    no-provides: true
+  dependencies:
+    # For apk upgrades
+    replaces:
+      - libcrypt1<2.38-r15
 
 environment:
   contents:
@@ -17,6 +24,7 @@ environment:
       - gettext
       - libtool
       - pkgconf
+      - pkgconf-dev
       - wolfi-base
 
 pipeline:
@@ -34,9 +42,9 @@ pipeline:
     with:
       opts: |
         --prefix=/usr \
-        --disable-static \
         --enable-hashes=strong,glibc \
-        --enable-obsolete-api=yes \
+        --enable-obsolete-api=glibc \
+        --disable-xcrypt-compat-files \
         --disable-failure-tokens
 
   - uses: autoconf/make
@@ -55,6 +63,16 @@ subpackages:
     pipeline:
       - uses: split/dev
     description: libxcrypt dev
+    options:
+      # libxcrypt is exact match
+      # versus so:libcrypt.so.1 which prefers obsolete glibc origin
+      no-depends: true
+    dependencies:
+      runtime:
+        - libxcrypt=${{package.full-version}}
+      replaces:
+        # For apk upgrades
+        - glibc-dev<2.38-r15
 
 update:
   enabled: true


### PR DESCRIPTION
apko prefers same-origin libcrypt1 from glibc. Even if it is no longer built, and only obsolete versions available.

Until libcrypt1 are withdrawn from glibc, keep so:libcrypt.so.1 provides in glibc.

This means libxcrypt will not provide so:libcrypt.so.1, and glibc will choose to depend on it for the actual implementation.

Update configuration options, to match against libcrypt1 - specifically keep static library build, and do not provide OpenSUSE / xcrypt.h symlinks which were never used in wolfi.

Update packaging metadata to ensure that libxcrypt-dev and libxcrypt can be unpacked by apk-tools with documented file replacements.

Once this lands, glibc can be upgraded to stop building crypt library and instead depend on libxcrypt from libcrypt1 package.

Glibc is blocked until this lands first - see https://github.com/wolfi-dev/os/pull/15069