### PR TITLE
Libxcrypt transition again part ii

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.38
-  epoch: 14
+  epoch: 15
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later
@@ -109,7 +109,7 @@ pipeline:
         --host=${{host.triplet.gnu}} \
         --build=${{host.triplet.gnu}} \
         --disable-werror \
-        --enable-crypt \
+        --disable-crypt \
         --enable-kernel=4.9
 
   - runs: |
@@ -379,6 +379,7 @@ subpackages:
     dependencies:
       runtime:
         - linux-headers
+        - libxcrypt-dev
 
   - name: "glibc-iconv"
     description: "GLIBC iconv tables"
@@ -499,10 +500,10 @@ subpackages:
     description: "Password hashing library included with glibc"
     dependencies:
       provider-priority: 10
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/lib
-          mv "${{targets.destdir}}"/lib/libcrypt.so* "${{targets.subpkgdir}}"/lib/
+      provides:
+        - so:libcrypt.so.1=1
+      runtime:
+        - libxcrypt
 
   - name: "glibc-locale-posix"
     description: "POSIX locale data for glibc"


### PR DESCRIPTION
glibc: replace selfbuilt libcrypt.so.1 with dependency on libxcrypt

libcrypt1 package from glibc will always be prefered by origin. Keep building this subpackage, and keep so:libcrypt.so.1 provides on it. Replace compiling libcrypt with a dependency on libxcrypt, which in turn has SCA provides disabled.

This update requires for https://github.com/wolfi-dev/os/pull/15068 to land first

I have verified that after libxcrypt is built; and this glibc update is built that everything works correctly for creating apko based build environments; apko based sdk images; as well as apk-utils based upgrade:

```console
f2671a8fff10:/work/packages# sed 's/=.*//' -i /etc/apk/world
f2671a8fff10:/work/packages# apk upgrade --all --latest
(1/5) Upgrading ld-linux (2.38-r13 -> 2.38-r15)
(2/5) Upgrading glibc-locale-posix (2.38-r13 -> 2.38-r15)
(3/5) Upgrading glibc (2.38-r13 -> 2.38-r15)
(4/5) Installing libxcrypt (4.4.36-r4)
(5/5) Upgrading libcrypt1 (2.38-r13 -> 2.38-r15)
Executing glibc-2.38-r15.trigger
OK: 15 MiB in 15 packages

[sdk] ❯ sed 's/=.*//' -i /etc/apk/world
[sdk] ❯ apk upgrade --all --latest
(1/10) Upgrading ld-linux (2.38-r13 -> 2.38-r15)
(2/10) Upgrading glibc-locale-posix (2.38-r13 -> 2.38-r15)
(3/10) Upgrading glibc (2.38-r13 -> 2.38-r15)
(4/10) Installing libxcrypt (4.4.36-r4)
(5/10) Installing libxcrypt-dev (4.4.36-r4)
(6/10) Upgrading nss-db (2.38-r13 -> 2.38-r15)
(7/10) Upgrading nss-hesiod (2.38-r13 -> 2.38-r15)
(8/10) Upgrading glibc-dev (2.38-r13 -> 2.38-r15)
(9/10) Upgrading libcrypt1 (2.38-r13 -> 2.38-r15)
(10/10) Upgrading libexpat1 (2.6.1-r0 -> 2.6.2-r0)
Executing glibc-2.38-r15.trigger
OK: 969 MiB in 61 packages

$ make package/guile
getting package dir for ./guile.yaml
For package pkgdir found dir: .
found package dir as .
getting source dir for package guile with dir .
found source dir as --source-dir ./guile
yamlfile is ./guile.yaml
Building package guile with version guile-3.0.9-r0 from file ./guile.yaml
make yamlfile=./guile.yaml srcdirflag="--source-dir ./guile" pkgname=guile packages/x86_64/guile-3.0.9-r0.apk
make[1]: Entering directory '/home/xnox/wolfi-dev/os'
@SOURCE_DATE_EPOCH=1701733156 /home/xnox/go/bin/melange build ./guile.yaml --repository-append /home/xnox/wolfi-dev/os/packages --keyring-append local-melange.rsa.pub --signing-key local-melange.rsa --arch x86_64 --env-file build-x86_64.env --namespace wolfi --generate-index false  --pipeline-dir ./pipelines/  -k https://packages.wolfi.dev/os/wolfi-signing.rsa.pub -r https://packages.wolfi.dev/os --source-dir ./guile --log-policy builtin:stderr,packages/x86_64/buildlogs/guile-3.0.9-r0.log
2024/03/14 11:45:28 INFO melange is building:
2024/03/14 11:45:28 INFO   configuration file: ./guile.yaml
2024/03/14 11:45:28 INFO   workspace dir: /tmp/melange-workspace-1290287648
2024/03/14 11:45:28 INFO evaluating pipelines for package requirements
2024/03/14 11:45:28 INFO   adding packages [wget] for pipeline "Fetch and extract external object into workspace"
2024/03/14 11:45:28 INFO   adding packages [make] for pipeline "Run autoconf make"
2024/03/14 11:45:28 INFO   adding packages [make] for pipeline "Run autoconf make install"
2024/03/14 11:45:28 INFO   adding packages [binutils scanelf] for pipeline "Strip binaries"
2024/03/14 11:45:28 INFO populating workspace /tmp/melange-workspace-1290287648 from ./guile
2024/03/14 11:45:28 INFO building workspace in '/tmp/melange-guest-413807576' with apko
2024/03/14 11:45:28 INFO image configuration:
2024/03/14 11:45:28 INFO   contents:
2024/03/14 11:45:28 INFO     repositories: []
2024/03/14 11:45:28 INFO     keyring:      []
2024/03/14 11:45:28 INFO     packages:     [autoconf automake binutils build-base busybox ca-certificates-bundle gc-dev glibc-iconv gmp-dev libffi-dev libtool libunistring-dev make ncurses-dev posix-libc-utils readline-dev scanelf texinfo wget]
2024/03/14 11:45:28 INFO   accounts:
2024/03/14 11:45:28 INFO     runas:  
2024/03/14 11:45:28 INFO     users:
2024/03/14 11:45:28 INFO       - uid=1000(build) gid=1000
2024/03/14 11:45:28 INFO     groups:
2024/03/14 11:45:28 INFO       - gid=1000(build) members=[build]
2024/03/14 11:45:29 INFO installing ca-certificates-bundle (20240226-r0)
2024/03/14 11:45:29 INFO installing wolfi-baselayout (20230201-r7)
2024/03/14 11:45:29 INFO installing ld-linux (2.38-r15)
2024/03/14 11:45:29 INFO installing glibc-locale-posix (2.38-r15)
2024/03/14 11:45:29 INFO installing glibc (2.38-r15)
2024/03/14 11:45:29 INFO installing m4 (1.4.19-r4)
2024/03/14 11:45:29 INFO installing libbz2-1 (1.0.8-r6)
2024/03/14 11:45:29 INFO installing zlib (1.3.1-r0)
2024/03/14 11:45:29 INFO installing libxcrypt (4.4.36-r4)
2024/03/14 11:45:29 INFO installing libcrypt1 (2.38-r15)
2024/03/14 11:45:29 INFO installing perl (5.38.2-r1)
2024/03/14 11:45:29 INFO installing autoconf (2.72-r0)
2024/03/14 11:45:29 INFO installing automake (1.16.5-r2)
2024/03/14 11:45:29 INFO installing libgcc (13.2.0-r5)
2024/03/14 11:45:29 INFO installing libstdc++ (13.2.0-r5)
2024/03/14 11:45:29 INFO installing binutils (2.42-r0)
2024/03/14 11:45:29 INFO installing make (4.4.1-r1)
2024/03/14 11:45:29 INFO installing pkgconf (2.1.1-r0)
2024/03/14 11:45:29 INFO installing posix-cc-wrappers (1-r1)
2024/03/14 11:45:29 INFO installing libgo (13.2.0-r5)
2024/03/14 11:45:29 INFO installing gmp (6.3.0-r1)
2024/03/14 11:45:29 INFO installing mpfr (4.2.1-r1)
2024/03/14 11:45:29 INFO installing mpc (1.3.1-r1)
2024/03/14 11:45:29 INFO installing isl (0.26-r1)
2024/03/14 11:45:29 INFO installing libstdc++-dev (13.2.0-r5)
2024/03/14 11:45:29 INFO installing libatomic (13.2.0-r5)
2024/03/14 11:45:29 INFO installing libgomp (13.2.0-r5)
2024/03/14 11:45:29 INFO installing gcc (13.2.0-r5)
2024/03/14 11:45:29 INFO installing libxcrypt-dev (4.4.36-r4)
2024/03/14 11:45:29 INFO installing linux-headers (6.6.11-r0)
2024/03/14 11:45:29 INFO installing nss-hesiod (2.38-r15)
2024/03/14 11:45:29 INFO installing nss-db (2.38-r15)
2024/03/14 11:45:29 INFO installing glibc-dev (2.38-r15)
2024/03/14 11:45:29 INFO installing build-base (1-r6)
2024/03/14 11:45:29 INFO installing busybox (1.36.1-r6)
2024/03/14 11:45:29 INFO installing gc (8.2.6-r0)
2024/03/14 11:45:29 INFO installing libgc++ (8.2.6-r0)
2024/03/14 11:45:29 INFO installing gc-dev (8.2.6-r0)
2024/03/14 11:45:29 INFO installing glibc-iconv (2.38-r15)
2024/03/14 11:45:29 INFO installing gmp-dev (6.3.0-r1)
2024/03/14 11:45:29 INFO installing libffi (3.4.6-r0)
2024/03/14 11:45:29 INFO installing libffi-dev (3.4.6-r0)
2024/03/14 11:45:29 INFO installing libltdl (2.4.7-r3)
2024/03/14 11:45:29 INFO installing libtool (2.4.7-r3)
2024/03/14 11:45:29 INFO installing libunistring (1.2-r0)
2024/03/14 11:45:29 INFO installing libunistring-dev (1.2-r0)
2024/03/14 11:45:29 INFO installing ncurses-terminfo-base (6.4_p20231125-r1)
2024/03/14 11:45:29 INFO installing ncurses (6.4_p20231125-r1)
2024/03/14 11:45:29 INFO installing ncurses-dev (6.4_p20231125-r1)
2024/03/14 11:45:29 INFO installing bash (5.2.21-r1)
2024/03/14 11:45:29 INFO installing posix-libc-utils (2.38-r15)
2024/03/14 11:45:29 INFO installing readline (8.2-r3)
2024/03/14 11:45:29 INFO installing readline-dev (8.2-r3)
2024/03/14 11:45:29 INFO installing scanelf (1.3.7-r1)
2024/03/14 11:45:29 INFO installing texinfo (7.1-r0)
2024/03/14 11:45:29 INFO installing openssl-config (3.2.1-r0)
2024/03/14 11:45:29 INFO installing libcrypto3 (3.2.1-r0)
2024/03/14 11:45:29 INFO installing libssl3 (3.2.1-r0)
2024/03/14 11:45:29 INFO installing wget (1.24.5-r0)
2024/03/14 11:45:31 INFO built image layer tarball as /tmp/apko-temp-894654468/apko-x86_64.tar.gz
2024/03/14 11:45:31 INFO using /tmp/apko-temp-894654468/apko-x86_64.tar.gz for image layer
2024/03/14 11:45:33 INFO ImgRef = /tmp/melange-guest-520982091
```

