### PR TITLE
Add a small version check test to python-3.12.

### DIFF
--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -114,11 +114,6 @@ pipeline:
 
   - uses: strip
 
-test:
-  pipeline:
-    - runs: |
-        ${{vars.python}} CVE-2023-27043-unittest.py
-
 subpackages:
   - name: "${{package.name}}-base"
     description: "${{package.name}} as /usr/bin/python3"
@@ -144,6 +139,11 @@ subpackages:
           mkdir -p "${{targets.destdir}}/$d"
           mv -v "${{targets.subpkgdir}}/$d"/config-${{vars.pyversion}}* \
               "${{targets.destdir}}/$d"
+    test:
+      pipeline:
+        - runs: |
+            ${{vars.python}} CVE-2023-27043-unittest.py
+            ${{vars.python}} version-check.py ${{package.version}}
 
   - name: "${{package.name}}-doc"
     description: "python3 documentation"
@@ -184,6 +184,13 @@ subpackages:
           mv -v "${{targets.destdir}}"/$d/config-${{vars.pyversion}}* \
              "${{targets.subpkgdir}}"/$d
       - uses: split/dev
+
+test:
+  pipeline:
+    - runs: |
+        # main package should provide 'python' and 'python3'.
+        python version-check.py ${{package.version}}
+        python3 version-check.py ${{package.version}}
 
 update:
   enabled: true

--- a/python-3.12/version-check.py
+++ b/python-3.12/version-check.py
@@ -1,0 +1,12 @@
+import sys
+
+info = sys.version_info
+found = "%s.%s.%s" % (info.major, info.minor, info.micro)
+
+if len(sys.argv) > 1:
+    expected = sys.argv[1]
+    if found != expected:
+        print("ERROR: expected version '%s' found '%s'" % (expected, found))
+        sys.exit(1)
+
+print("python version: " + found)


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
