### PR TITLE
Sync changes from python-3.12 to python-3.11 and python-3.10

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,10 +1,16 @@
 package:
   name: python-3.10
   version: 3.10.13
-  epoch: 6
+  epoch: 7
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
+  dependencies:
+    provides:
+      - python3=3.10.999
+      - python-3=3.10.999
+    runtime:
+      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -24,6 +30,17 @@ environment:
       - sqlite-dev
       - xz-dev
       - zlib-dev
+
+# creates helpfull python3.M and 3.M variables
+var-transforms:
+  - from: ${{package.name}}
+    match: '-'
+    replace: ''
+    to: python
+  - from: ${{package.version}}
+    match: (\d).(\d+).(\d+)
+    replace: '$1.$2'
+    to: pyversion
 
 pipeline:
   - uses: fetch
@@ -67,9 +84,7 @@ pipeline:
 
   - uses: autoconf/make
 
-  - uses: autoconf/make
-    with:
-      opts: altinstall DESTDIR="${{targets.destdir}}"
+  - uses: autoconf/make-install
 
   - runs: |
       find ${{targets.destdir}}/usr/lib -type f -name 'libpython*.a' -exec rm -rf '{}' +
@@ -78,51 +93,104 @@ pipeline:
       find ${{targets.destdir}}/usr/lib -type d -name 'idle_test' -exec rm -rf '{}' +
 
       cd ${{targets.destdir}}/usr/bin
-      rm -f python3 pydoc3 idle3* 2to3*
+      rm -f idle3* 2to3*
       rm ${{targets.destdir}}/usr/lib/libpython3.so
+
+      # add dubious python -> python3 link
+      ln -s python3 ${{targets.destdir}}/usr/bin/python
+
+      # Drop site-packages README.txt to avoid SCA dep on python3~3.M
+      cd ${{targets.destdir}}/usr/lib/${{vars.python}}
+      rm site-packages/README.txt
+      rmdir site-packages
 
   - runs: |
       find ${{targets.destdir}}/usr/lib -type f -name '*.pyc' -exec rm -rf '{}' +
       find ${{targets.destdir}}/usr/lib -type f -name '*.pyo' -exec rm -rf '{}' +
 
       export LD_LIBRARY_PATH="${{targets.destdir}}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-      ${{targets.destdir}}/usr/bin/python3.10 -m compileall --invalidation-mode=unchecked-hash \
-          -r100 ${{targets.destdir}}/usr/lib
+      ${{targets.destdir}}/usr/bin/${{vars.python}} -m compileall --invalidation-mode=unchecked-hash \
+          -r100 ${{targets.destdir}}/usr/lib/
 
   - uses: strip
 
 subpackages:
-  - name: "python-3.10-default"
-    description: "python-3.10 as /usr/bin/python3"
-    dependencies:
-      provides:
-        - python3=${{package.full-version}}
-        - python-3=${{package.full-version}}
-      runtime:
-        - python-3.10
+  - name: "${{package.name}}-base"
+    description: "${{package.name}} as /usr/bin/python3"
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -sf python3.10 "${{targets.subpkgdir}}"/usr/bin/python3
-          ln -sf pydoc3.10 "${{targets.subpkgdir}}"/usr/bin/pydoc3
-          ln -sf python3 "${{targets.subpkgdir}}"/usr/bin/python
+          mkdir -p ${{targets.subpkgdir}}/usr/bin ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/bin/${{vars.python}} \
+              ${{targets.destdir}}/usr/bin/pydoc${{vars.pyversion}} \
+              ${{targets.subpkgdir}}/usr/bin
+          mv -v ${{targets.destdir}}/usr/lib/${{vars.python}} \
+             ${{targets.subpkgdir}}/usr/lib
+          mv -v ${{targets.destdir}}/usr/lib/libpython${{vars.pyversion}}.so.* \
+             ${{targets.subpkgdir}}/usr/lib
 
-  - name: "python-3.10-doc"
-    description: "python3.10 documentation"
+          # pyconfig.h is needed at runtime... ugh.
+          d=usr/include/${{vars.python}}
+          mkdir -p "${{targets.subpkgdir}}"/$d
+          mv "${{targets.destdir}}"/$d/pyconfig.h "${{targets.subpkgdir}}"/$d/
+
+          # move usr/lib/python3.X/config-3.X-x86_64-linux-gnu
+          # back into main package so the -base-dev can take it below.
+          d="usr/lib/${{vars.python}}"
+          mkdir -p "${{targets.destdir}}/$d"
+          mv -v "${{targets.subpkgdir}}/$d"/config-${{vars.pyversion}}* \
+              "${{targets.destdir}}/$d"
+    test:
+      pipeline:
+        - runs: |
+            ${{vars.python}} CVE-2023-27043-unittest.py
+            ${{vars.python}} version-check.py ${{package.version}}
+
+  - name: "${{package.name}}-doc"
+    description: "python3 documentation"
     pipeline:
       - uses: split/manpages
 
-  - name: "python-3.10-dev"
-    description: "python3.10 development headers"
-    pipeline:
-      - uses: split/dev
-      - runs: |
-          mkdir -p "${{targets.destdir}}"/usr/include/python3.10
-          mv "${{targets.subpkgdir}}"/usr/include/python3.10/pyconfig.h "${{targets.destdir}}"/usr/include/python3.10
+  - name: "${{package.name}}-dev"
+    description: "python3 development headers"
     dependencies:
       provides:
         - python3-dev=${{package.full-version}}
         - python-3-dev=${{package.full-version}}
+      runtime:
+        - ${{package.name}}-base-dev=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv -v ${{targets.destdir}}/usr/bin/python3-config ${{targets.subpkgdir}}/usr/bin
+
+          d="usr/lib/pkgconfig"
+          mkdir -p "${{targets.subpkgdir}}/$d"
+          mv -v \
+             "${{targets.destdir}}"/$d/python3-embed.pc \
+             "${{targets.destdir}}"/$d/python3.pc \
+             "${{targets.subpkgdir}}/$d/"
+
+  - name: "${{package.name}}-base-dev"
+    description: "python3 development headers"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
+    pipeline:
+      - runs: |
+          # usr/lib/pytyon3.X/config-3.X-x86_64-linux-gnu
+          # split/dev will only move 2 files from it, but we want all of it.
+          d="usr/lib/${{vars.python}}"
+          mkdir -p "${{targets.subpkgdir}}/$d"
+          mv -v "${{targets.destdir}}"/$d/config-${{vars.pyversion}}* \
+             "${{targets.subpkgdir}}"/$d
+      - uses: split/dev
+
+test:
+  pipeline:
+    - runs: |
+        # main package should provide 'python' and 'python3'.
+        python version-check.py ${{package.version}}
+        python3 version-check.py ${{package.version}}
 
 update:
   enabled: true
@@ -132,10 +200,3 @@ update:
     strip-prefix: v
     tag-filter: v3.10
     use-tag: true
-
-test:
-  pipeline:
-    - runs: |
-        python3 --version
-    - runs: |
-        python3.10 CVE-2023-27043-unittest.py

--- a/python-3.10/version-check.py
+++ b/python-3.10/version-check.py
@@ -1,0 +1,12 @@
+import sys
+
+info = sys.version_info
+found = "%s.%s.%s" % (info.major, info.minor, info.micro)
+
+if len(sys.argv) > 1:
+    expected = sys.argv[1]
+    if found != expected:
+        print("ERROR: expected version '%s' found '%s'" % (expected, found))
+        sys.exit(1)
+
+print("python version: " + found)

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -7,8 +7,8 @@ package:
     - license: PSF-2.0
   dependencies:
     provides:
-      - python3=${{package.full-version}}
-      - python-3=${{package.full-version}}
+      - python3=3.11.999
+      - python-3=3.11.999
     runtime:
       - ${{package.name}}-base=${{package.full-version}}
 

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,10 +1,16 @@
 package:
   name: python-3.11
   version: 3.11.8
-  epoch: 3
+  epoch: 4
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
+  dependencies:
+    provides:
+      - python3=${{package.full-version}}
+      - python-3=${{package.full-version}}
+    runtime:
+      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -24,6 +30,17 @@ environment:
       - sqlite-dev
       - xz-dev
       - zlib-dev
+
+# creates helpfull python3.M and 3.M variables
+var-transforms:
+  - from: ${{package.name}}
+    match: '-'
+    replace: ''
+    to: python
+  - from: ${{package.version}}
+    match: (\d).(\d+).(\d+)
+    replace: '$1.$2'
+    to: pyversion
 
 pipeline:
   - uses: fetch
@@ -76,57 +93,104 @@ pipeline:
       find ${{targets.destdir}}/usr/lib -type d -name 'idle_test' -exec rm -rf '{}' +
 
       cd ${{targets.destdir}}/usr/bin
-      rm -f python3 pydoc3 idle3* 2to3*
+      rm -f idle3* 2to3*
       rm ${{targets.destdir}}/usr/lib/libpython3.so
+
+      # add dubious python -> python3 link
+      ln -s python3 ${{targets.destdir}}/usr/bin/python
+
+      # Drop site-packages README.txt to avoid SCA dep on python3~3.M
+      cd ${{targets.destdir}}/usr/lib/${{vars.python}}
+      rm site-packages/README.txt
+      rmdir site-packages
 
   - runs: |
       find ${{targets.destdir}}/usr/lib -type f -name '*.pyc' -exec rm -rf '{}' +
       find ${{targets.destdir}}/usr/lib -type f -name '*.pyo' -exec rm -rf '{}' +
 
       export LD_LIBRARY_PATH="${{targets.destdir}}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-      ${{targets.destdir}}/usr/bin/python3.11 -m compileall --invalidation-mode=unchecked-hash \
-          -r100 ${{targets.destdir}}/usr/lib
+      ${{targets.destdir}}/usr/bin/${{vars.python}} -m compileall --invalidation-mode=unchecked-hash \
+          -r100 ${{targets.destdir}}/usr/lib/
 
   - uses: strip
 
-test:
-  pipeline:
-    - runs: |
-        python3.11 CVE-2023-27043-unittest.py
-
 subpackages:
-  - name: "python-3.11-default"
-    description: "python-3.11 as /usr/bin/python3"
-    dependencies:
-      provides:
-        - python3=3.11.999
-        - python-3=3.11.999
-      runtime:
-        - python-3.11
+  - name: "${{package.name}}-base"
+    description: "${{package.name}} as /usr/bin/python3"
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -sf python3.11 "${{targets.subpkgdir}}"/usr/bin/python3
-          ln -sf pydoc3.11 "${{targets.subpkgdir}}"/usr/bin/pydoc3
-          ln -sf python3 "${{targets.subpkgdir}}"/usr/bin/python
+          mkdir -p ${{targets.subpkgdir}}/usr/bin ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/bin/${{vars.python}} \
+              ${{targets.destdir}}/usr/bin/pydoc${{vars.pyversion}} \
+              ${{targets.subpkgdir}}/usr/bin
+          mv -v ${{targets.destdir}}/usr/lib/${{vars.python}} \
+             ${{targets.subpkgdir}}/usr/lib
+          mv -v ${{targets.destdir}}/usr/lib/libpython${{vars.pyversion}}.so.* \
+             ${{targets.subpkgdir}}/usr/lib
 
-  - name: "python-3.11-doc"
+          # pyconfig.h is needed at runtime... ugh.
+          d=usr/include/${{vars.python}}
+          mkdir -p "${{targets.subpkgdir}}"/$d
+          mv "${{targets.destdir}}"/$d/pyconfig.h "${{targets.subpkgdir}}"/$d/
+
+          # move usr/lib/python3.X/config-3.X-x86_64-linux-gnu
+          # back into main package so the -base-dev can take it below.
+          d="usr/lib/${{vars.python}}"
+          mkdir -p "${{targets.destdir}}/$d"
+          mv -v "${{targets.subpkgdir}}/$d"/config-${{vars.pyversion}}* \
+              "${{targets.destdir}}/$d"
+    test:
+      pipeline:
+        - runs: |
+            ${{vars.python}} CVE-2023-27043-unittest.py
+            ${{vars.python}} version-check.py ${{package.version}}
+
+  - name: "${{package.name}}-doc"
     description: "python3 documentation"
     pipeline:
       - uses: split/manpages
 
-  - name: "python-3.11-dev"
+  - name: "${{package.name}}-dev"
     description: "python3 development headers"
-    pipeline:
-      - uses: split/dev
-      - runs: |
-          # pyconfig.h is needed at runtime... ugh.
-          mkdir -p "${{targets.destdir}}"/usr/include/python3.11
-          mv "${{targets.subpkgdir}}"/usr/include/python3.11/pyconfig.h "${{targets.destdir}}"/usr/include/python3.11
     dependencies:
       provides:
-        - python3-dev=3.11.999
-        - python-3-dev=3.11.999
+        - python3-dev=${{package.full-version}}
+        - python-3-dev=${{package.full-version}}
+      runtime:
+        - ${{package.name}}-base-dev=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv -v ${{targets.destdir}}/usr/bin/python3-config ${{targets.subpkgdir}}/usr/bin
+
+          d="usr/lib/pkgconfig"
+          mkdir -p "${{targets.subpkgdir}}/$d"
+          mv -v \
+             "${{targets.destdir}}"/$d/python3-embed.pc \
+             "${{targets.destdir}}"/$d/python3.pc \
+             "${{targets.subpkgdir}}/$d/"
+
+  - name: "${{package.name}}-base-dev"
+    description: "python3 development headers"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
+    pipeline:
+      - runs: |
+          # usr/lib/pytyon3.X/config-3.X-x86_64-linux-gnu
+          # split/dev will only move 2 files from it, but we want all of it.
+          d="usr/lib/${{vars.python}}"
+          mkdir -p "${{targets.subpkgdir}}/$d"
+          mv -v "${{targets.destdir}}"/$d/config-${{vars.pyversion}}* \
+             "${{targets.subpkgdir}}"/$d
+      - uses: split/dev
+
+test:
+  pipeline:
+    - runs: |
+        # main package should provide 'python' and 'python3'.
+        python version-check.py ${{package.version}}
+        python3 version-check.py ${{package.version}}
 
 update:
   enabled: true

--- a/python-3.11/version-check.py
+++ b/python-3.11/version-check.py
@@ -1,0 +1,12 @@
+import sys
+
+info = sys.version_info
+found = "%s.%s.%s" % (info.major, info.minor, info.micro)
+
+if len(sys.argv) > 1:
+    expected = sys.argv[1]
+    if found != expected:
+        print("ERROR: expected version '%s' found '%s'" % (expected, found))
+        sys.exit(1)
+
+print("python version: " + found)


### PR DESCRIPTION
This results in a python-3.11 that is co-installable. Changes include:
 * small test added ('version-check.py')
 * "templatized" more... the content is the same as python-3.12.yaml other than version and hash changes, so we can more easily sync changes to.
 * python-3.11 will (still) lay down python and python3 links to python3.11 in /usr/bin, but does not provide much else.  It depends on python-3.11-base, which does provide python3.11 binary and all the python installation.
 * /usr/lib/python3.X/config-3.X-<arch>-linux-gnu is moved from runtime package to dev package (-base-dev)

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
