### PR TITLE
Make python3-dev depend on python3

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: 3.10.13
-  epoch: 7
+  epoch: 8
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -157,6 +157,7 @@ subpackages:
         - python3-dev=${{package.full-version}}
         - python-3-dev=${{package.full-version}}
       runtime:
+        - ${{package.name}}=${{package.full-version}}
         - ${{package.name}}-base-dev=${{package.full-version}}
     pipeline:
       - runs: |

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: 3.11.8
-  epoch: 4
+  epoch: 5
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -157,6 +157,7 @@ subpackages:
         - python3-dev=${{package.full-version}}
         - python-3-dev=${{package.full-version}}
       runtime:
+        - ${{package.name}}=${{package.full-version}}
         - ${{package.name}}-base-dev=${{package.full-version}}
     pipeline:
       - runs: |

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: 3.12.2
-  epoch: 7
+  epoch: 8
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -157,6 +157,7 @@ subpackages:
         - python3-dev=${{package.full-version}}
         - python-3-dev=${{package.full-version}}
       runtime:
+        - ${{package.name}}=${{package.full-version}}
         - ${{package.name}}-base-dev=${{package.full-version}}
     pipeline:
       - runs: |


### PR DESCRIPTION
There are some packages that specify 'python3-dev' in their build-depends.  Those are being broken because they expected that python3-dev would depend on python3 which is expected to provide a /usr/bin/python3.  That seems reasonable.

So, make it so.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
