### PR TITLE
cass-config-builder: Fix CVE-2024-22871

### DIFF
--- a/cass-config-builder.yaml
+++ b/cass-config-builder.yaml
@@ -1,7 +1,7 @@
 package:
   name: cass-config-builder
   version: 1.0.8
-  epoch: 2
+  epoch: 3
   description: |
     Configuration builder for Apache Cassandra based on definitions at datastax/cass-config-definitions
   copyright:

--- a/cass-config-builder/deps.patch
+++ b/cass-config-builder/deps.patch
@@ -1,18 +1,23 @@
-From 8808bf6f304a1ecac0f13e51aabcddf864189426 Mon Sep 17 00:00:00 2001
-From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
-Date: Tue, 28 Nov 2023 21:09:34 +0300
-Subject: [PATCH] upgrade snakeyaml and jackson-dataformat-cbor deps
+From f4e055b0665564f048ab052817d87582fbca9c1f Mon Sep 17 00:00:00 2001
+From: Philippe Deslauriers <philde@chainguard.dev>
+Date: Thu, 14 Mar 2024 16:13:43 -0700
+Subject: [PATCH] Fix CVE
 
-Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Signed-off-by: Philippe Deslauriers <philde@chainguard.dev>
 ---
- build.gradle | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
+ build.gradle | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/build.gradle b/build.gradle
-index 3948c51..9125dad 100644
+index 3948c51..824b28b 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -92,7 +92,8 @@ dependencies {
+@@ -88,11 +88,12 @@ configurations {
+ }
+
+ dependencies {
+-    implementation "org.clojure:clojure:1.10.1"
++    implementation "org.clojure:clojure:1.11.2"
      implementation "org.clojure:core.match:0.3.0-alpha5"
      implementation "org.clojure:core.memoize:0.5.9"
      implementation "slingshot:slingshot:0.12.2"
@@ -22,6 +27,6 @@ index 3948c51..9125dad 100644
      implementation "cheshire:cheshire:5.8.0"
      implementation ("selmer:selmer:1.12.27") { // templating lib
          exclude module: 'hiccups'
--- 
-2.39.3 (Apple Git-145)
+--
+2.43.0
 


### PR DESCRIPTION
Bumps `clojure` to 1.11.2