### PR TITLE
Unpin the go version from go-1.20  in cadvisor 

### DIFF
--- a/cadvisor.yaml
+++ b/cadvisor.yaml
@@ -1,7 +1,7 @@
 package:
   name: cadvisor
   version: 0.49.1
-  epoch: 2
+  epoch: 3
   description: Analyzes resource usage and performance characteristics of running containers.
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - go-1.20 # Pinned to 1.20 due to upstream issues with 1.21
+      - go
 
 pipeline:
   - uses: git-checkout
@@ -25,12 +25,10 @@ pipeline:
   - uses: go/bump
     with:
       deps: google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4
-      go-version: 1.20
 
   - uses: go/bump
     with:
       deps: google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4
-      go-version: 1.20
       modroot: cmd
 
   - runs: |


### PR DESCRIPTION
so that it can build with the latest go-1.22.x

there was an issue with the version go-1.21 but it is not persisted for go-1.22 
