### PR TITLE
DNM: make file exclude .melangecache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,11 +102,17 @@ list-yaml:
 # argument list and it will be populated and usable.
 #
 # $(call get-package-dir,ret-variable-in-calling-function,package-file)
+# $(call get-package-dir,ret-variable-in-calling-function,package-file)
 define get-package-dir
-	$(info getting package dir for $(2))
-	$(eval pkgdir := $(shell dirname $(2)))
-	$(info For package $(1) found dir: $(pkgdir))
-	$(1) := ${pkgdir}
+        $(@info Getting package dir for $(2))
+        $(@eval temp_dir := $(shell dirname $(2)))
+        $(@eval is_excluded := $(findstring /.melangecache/,$(temp_dir)))
+        $(if $(is_excluded),\
+            $(@info Skipping $(2) due to /.melangecache/ in path),\
+            $(@eval pkgdir := $(temp_dir))\
+            $(@info For package $(1) found dir: $(pkgdir))\
+            $(1) := $(pkgdir)\
+        )
 endef
 
 # This function tries to figure out what the 'source-dir' is for the package.

--- a/Makefile
+++ b/Makefile
@@ -103,12 +103,13 @@ list-yaml:
 #
 # $(call get-package-dir,ret-variable-in-calling-function,package-file)
 # $(call get-package-dir,ret-variable-in-calling-function,package-file)
+# $(call get-package-dir,ret-variable-in-calling-function,package-file)
 define get-package-dir
         $(@info Getting package dir for $(2))
         $(@eval temp_dir := $(shell dirname $(2)))
         $(@eval is_excluded := $(findstring /.melangecache/,$(temp_dir)))
         $(if $(is_excluded),\
-            $(@info Skipping $(2) due to /.melangecache/ in path),\
+            $(@info Skipping directory $(temp_dir) due to /.melangecache/ in path),\
             $(@eval pkgdir := $(temp_dir))\
             $(@info For package $(1) found dir: $(pkgdir))\
             $(1) := $(pkgdir)\

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent
   version: 7.51.1
-  epoch: 1
+  epoch: 2
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0

--- a/hello-wolfi.yaml
+++ b/hello-wolfi.yaml
@@ -1,7 +1,7 @@
 package:
   name: hello-wolfi
   version: 2.12.1
-  epoch: 5
+  epoch: 6
   description: "the GNU hello world program"
   copyright:
     - paths:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
