### PR TITLE
feat(packages): Add mkcert

### DIFF
--- a/mkcert.yaml
+++ b/mkcert.yaml
@@ -1,0 +1,44 @@
+package:
+  name: mkcert
+  version: 1.4.4
+  epoch: 0
+  description: A simple zero-config tool to make locally trusted development certificates with any names you'd like.
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/FiloSottile/mkcert.git
+      tag: v${{package.version}}
+      expected-commit: 2a46726cebac0ff4e1f133d90b4e4c42f1edf44a
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/net@v0.21.0 golang.org/x/text@v0.3.8
+      replaces: golang.org/x/crypto=golang.org/x/crypto@v0.21.0
+
+  - uses: go/build
+    with:
+      packages: .
+      output: mkcert
+      ldflags: -X main.Version=${{package.version}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: FiloSottile/mkcert
+    strip-prefix: v
+    use-tag: true
+
+test:
+  pipeline:
+    - runs: |
+        mkcert -version


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

This adds [mkcert](https://github.com/FiloSottile/mkcert) following the patterns in the `gobump` yaml file.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)