### PR TITLE
ruby3.2-json-jwt: Fix CVE-2023-51774

### DIFF
--- a/ruby3.2-json-jwt.yaml
+++ b/ruby3.2-json-jwt.yaml
@@ -1,6 +1,6 @@
 package:
   name: ruby3.2-json-jwt
-  version: 1.16.5
+  version: 1.16.6
   epoch: 0
   description: JSON Web Token and its family (JSON Web Signature, JSON Web Encryption and JSON Web Key) in Ruby
   copyright:
@@ -26,7 +26,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 87cb8c8a44cce786d235976e9331d8617c2e9dc1
+      expected-commit: fcc22b0033dff3ec7624dfadcbb4a3deae516573
       repository: https://github.com/nov/json-jwt
       tag: v${{package.version}}
 
@@ -51,3 +51,5 @@ update:
   github:
     identifier: nov/json-jwt
     strip-prefix: v
+    # This project doesn't consistently use GitHub releases.
+    use-tag: true


### PR DESCRIPTION
We didn't pick up the version update since they only released a new tag.