### PR TITLE
`ghaudit`: new package experimenting with github policy checking.

### DIFF
--- a/ghaudit.yaml
+++ b/ghaudit.yaml
@@ -1,0 +1,51 @@
+package:
+  name: ghaudit
+  version: 0.1.0
+  epoch: 0
+  description: Experimental tool for evaluating Chainguard's GitHub policies.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/chainguard-dev/ghaudit/archive/v${{package.version}}/v${{package.version}}.tar.gz
+      expected-sha256: 9711351039ac42182fabaa47ed104717037b9692ec7ca828188bf5b055c3a53a
+
+  - uses: go/build
+    with:
+      packages: .
+      ldflags: -s -w
+      output: ghaudit
+
+  - uses: strip
+
+test:
+  pipeline:
+    - runs: |
+        # This expects GH_TOKEN to be set and will error.
+        if ghaudit --help; then
+          echo "This should error without GH_TOKEN set."
+          exit 1
+        fi
+
+        # This should print usage.
+        GH_TOKEN=foo ghaudit --help
+
+update:
+  enabled: true
+  github:
+    identifier: chainguard-dev/ghaudit
+    strip-prefix: v


### PR DESCRIPTION
### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
