### PR TITLE
postgis deps

### DIFF
--- a/cgal.yaml
+++ b/cgal.yaml
@@ -1,0 +1,79 @@
+package:
+  name: cgal
+  version: "5.6.1"
+  epoch: 0
+  description: Efficient and reliable geometric algorithms as C++ library
+  copyright:
+    - license: GPL-3.0-or-later custom
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - boost-dev
+      - build-base
+      - busybox
+      - bzip2-dev
+      - ca-certificates-bundle
+      - cmake
+      - gcc-12
+      - gcc-12-default
+      - glu-dev
+      - gmp-dev
+      - icu-dev
+      - libuv-dev
+      - mesa-dev
+      - mpfr-dev
+      - ninja
+      - xz-dev
+      - zlib-dev
+      - zstd-dev
+  environment:
+    CC: gcc
+    CXX: g++
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/CGAL/cgal
+      tag: v${{package.version}}
+      expected-commit: 188e51bad36ffc30e49dbabda29620b71a84664c
+
+  - runs: |
+      cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=MinSizeRel \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=/usr/lib
+      cmake --build build
+
+  - runs: |
+      DESTDIR="${{targets.destdir}}" cmake --install build
+      mkdir -p "${{targets.destdir}}"/usr/share/licenses/${{package.name}}
+      install -t "${{targets.destdir}}"/usr/share/licenses/${{package.name}} -Dm644 LICENSE*
+
+  - uses: strip
+
+subpackages:
+  - name: cgal-dev
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          cp ./MacOSX/scripts/cgal_make_macosx_app ${{targets.subpkgdir}}/usr/bin/cgal_make_macosx_app
+          cp ./Scripts/scripts/cgal_create_cmake_script ${{targets.subpkgdir}}/usr/bin/cgal_create_cmake_script
+          cp ./Scripts/scripts/cgal_create_CMakeLists ${{targets.subpkgdir}}/usr/bin/cgal_create_CMakeLists
+    dependencies:
+      runtime:
+        - cgal
+    description: cgal dev
+
+  - name: cgal-doc
+    pipeline:
+      - uses: split/manpages
+    description: cgal manpages
+
+update:
+  enabled: true
+  github:
+    identifier: CGAL/cgal
+    strip-prefix: v

--- a/glu.yaml
+++ b/glu.yaml
@@ -1,0 +1,53 @@
+package:
+  name: glu
+  version: 9.0.3
+  epoch: 0
+  description: Mesa OpenGL Utility library
+  copyright:
+    - license: SGI-B-1.1 AND SGI-B-2.0
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - mesa-dev
+      - mesa-osmesa
+      - meson
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: bd43fe12f374b1192eb15fe20e45ff456b9bc26ab57f0eee919f96ca0f8a330f
+      uri: https://mesa.freedesktop.org/archive/glu/glu-${{package.version}}.tar.xz
+
+  - uses: meson/configure
+    with:
+      opts: |
+        -Db_lto=true \
+        -Ddefault_library=shared \
+        -Dgl_provider=osmesa
+
+  - uses: meson/compile
+
+  - uses: meson/install
+
+  - uses: strip
+
+subpackages:
+  - name: glu-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - glu
+        - mesa-dev
+    description: glu dev
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 13518

--- a/sfcgal.yaml
+++ b/sfcgal.yaml
@@ -1,0 +1,66 @@
+# source is gitlab so we can't use github updates to get expected commit
+#nolint:git-checkout-must-use-github-updates
+package:
+  name: sfcgal
+  version: 1.5.1
+  epoch: 0
+  description: Library for ISO 19107:2013 and OGC SFA 1.2 for 3D operations
+  copyright:
+    - license: LGPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - boost-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cgal-dev
+      - cmake
+      - gmp-dev
+      - mpfr-dev
+      - samurai
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/sfcgal/SFCGAL
+      tag: v${{package.version}}
+      expected-commit: 61f3b08ade49493b56c6bafa98c7c1f84addbc10
+
+  - runs: |
+      mkdir -p build && cd build
+      cmake -Wno-dev \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DSFCGAL_BUILD_EXAMPLES=1 \
+        -DSFCGAL_BUILD_TESTS=0 \
+        ..
+      make
+
+  - runs: |
+      cd build
+      make DESTDIR="${{targets.destdir}}" install
+      # installs tests
+      rm -rf "${{targets.destdir}}"/usr/bin/*test*
+      # Remove conflict with cgal package
+      rm -rf "${{targets.destdir}}"/usr/include/CGAL
+
+  - uses: strip
+
+subpackages:
+  - name: sfcgal-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - sfcgal
+    description: sfcgal dev
+
+# failed to create a latestVersion from package sfcgal: list.  Error: Malformed version: list
+# https://release-monitoring.org/project/236494/
+update:
+  enabled: false


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
