### PR TITLE
pgbouncer bitnami compat

### DIFF
--- a/pgbouncer.yaml
+++ b/pgbouncer.yaml
@@ -11,6 +11,7 @@ environment:
     packages:
       - autoconf
       - automake
+      - bash
       - build-base
       - busybox
       - c-ares-dev
@@ -50,6 +51,69 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/share/doc/
           mv "${{targets.destdir}}"/usr/share/doc/pgbouncer "${{targets.subpkgdir}}"/usr/share/doc
     description: pgbouncer manpages
+
+  - name: ${{package.name}}-bitnami-compat
+    description: "compat package with bitnami/pgbouncer image"
+    dependencies:
+      runtime:
+        - libbsd-dev
+        # - libaudit1  #https://pkgs.alpinelinux.org/contents?branch=edge&name=audit-libs&arch=x86&repo=main
+        - libbsd-dev
+        - c-ares-dev
+        - libcap-ng-dev
+        - libedit-dev
+        - libevent-dev
+        - libffi-dev
+        - libgcc
+        - gmp-dev
+        - gnutls-dev
+        - icu-dev
+        - libidn-dev
+        - openldap-dev
+        - xz-dev
+        - libmd-dev
+        - nettle-dev
+        - p11-kit-dev
+        - linux-pam-dev
+        - cyrus-sasl-dev
+        - openssl-dev
+        - libstdc++-dev
+        - libtasn1-dev
+        - ncurses-dev
+        - libunistring-dev
+        - util-linux-dev
+        - libxml2-dev
+        - libxslt-dev
+        - glibc-locale-en
+        - procps
+        - zlib-dev
+        - wait-for-port
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: pgbouncer
+          version-path: 1/debian-12
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/pgbouncer
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/pgbouncer/logs
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/pgbouncer/tmp
+          mkdir -p "${{targets.subpkgdir}}"/bitnami/pgbouncer/conf
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/common/lib
+          mkdir -p ${{targets.subpkgdir}}/docker-entrypoint-initdb.d
+
+          # sed all the scripts to use absolute path in the build environment
+          find . -iname "*.sh" -exec sed 's#/opt/bitnami#${{targets.subpkgdir}}/opt/bitnami#g' -i {} \;
+
+          # this script does some magic with env vars, templates, etc. etc.
+          # it is easier to run it than figure out everything that it touches
+
+          # I don't think that this is necessary, but it is in the original script
+          # it gives an error 'line 46: locale-gen: command not found'
+          # ${{targets.subpkgdir}}/opt/bitnami/scripts/locales/add-extra-locales.sh
+          ${{targets.subpkgdir}}/opt/bitnami/scripts/pgbouncer/postunpack.sh
+
+          # un-sed everything back to absolute /opt/bitnami prefix
+          find ${{targets.subpkgdir}}/opt/bitnami -type f -exec sed 's#${{targets.subpkgdir}}##g' -i {} \;
 
 update:
   # Doesn't work with var transforms


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
