### PR TITLE
cilium-1.15: bump epoch to pick up change in #15227

### DIFF
--- a/cilium-1.15.yaml
+++ b/cilium-1.15.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-1.15
   version: 1.15.2
-  epoch: 0
+  epoch: 1
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Because wolfi-bot update PR https://github.com/wolfi-dev/os/pull/14906 was merged before https://github.com/wolfi-dev/os/pull/15227, the change in #15227 was not rebuilt because it missed an epoch bump.