### PR TITLE
fix(cassandra-medusa): Add python-3.11-base as a runtime dep

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -108,8 +108,5 @@ test:
         fail() { echo "$@" 1>&2; exit 1; }
         out=$(/usr/share/medusa/.venv/bin/python3 -m medusa.service.grpc.server 2>&1)
         status=$?
-        if [ $status -ne 0 ]; then
-          fail "medusa.service.grpc.server exited $status: $out"
-        fi
-        echo "$out" | grep -q '/etc/medusa/medusa.ini' || fail "medusa.service.grpc.server output did not contain expected 'medusa.ini' message!"
-        echo "medusa.service.grpc.server started successfully."
+        echo "$out" | grep -q '/etc/medusa/medusa.ini' || fail "medusa.service.grpc.server output did not contain expected 'medusa.ini' message. Exit status $status: $out"
+        echo "medusa.service.grpc.server exited with expected error message"

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -104,4 +104,8 @@ test:
         - python-3.11-dev
   pipeline:
     - runs: medusa --version
-    - runs: /usr/share/medusa/.venv/bin/python3 -m medusa.service.grpc.server server.py 2>&1 | grep "/etc/medusa/medusa.ini"
+    - runs: |
+        fail() { echo "$@" 1>&2; exit 1; }
+        out=$(/usr/share/medusa/.venv/bin/python3 -m medusa.service.grpc.server 2>&1) ||
+            fail "medusa.service.grpc.server exited $?: $out"
+        echo "$out" | grep -q /etc/medusa/medusa.ini || fail "medusa.service.grpc.server output did not contain expected 'medusa.ini' message!"

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -104,4 +104,4 @@ test:
         - python-3.11-dev
   pipeline:
     - runs: medusa --version
-    - runs: python3 -m medusa.service.grpc.server server.py | grep "/etc/medusa/medusa.ini"
+    - runs: /usr/share/medusa/.venv/bin/python3 -m medusa.service.grpc.server server.py | grep "/etc/medusa/medusa.ini"

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -106,6 +106,10 @@ test:
     - runs: medusa --version
     - runs: |
         fail() { echo "$@" 1>&2; exit 1; }
-        out=$(/usr/share/medusa/.venv/bin/python3 -m medusa.service.grpc.server 2>&1) ||
-            fail "medusa.service.grpc.server exited $?: $out"
-        echo "$out" | grep -q /etc/medusa/medusa.ini || fail "medusa.service.grpc.server output did not contain expected 'medusa.ini' message!"
+        out=$(/usr/share/medusa/.venv/bin/python3 -m medusa.service.grpc.server 2>&1)
+        status=$?
+        if [ $status -ne 0 ]; then
+          fail "medusa.service.grpc.server exited $status: $out"
+        fi
+        echo "$out" | grep -q '/etc/medusa/medusa.ini' || fail "medusa.service.grpc.server output did not contain expected 'medusa.ini' message!"
+        echo "medusa.service.grpc.server started successfully."

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -53,6 +53,10 @@ pipeline:
       .venv/bin/pip install -I --no-compile dist/*.whl
 
   - runs: |
+      # python-snappy is required to run medusa using $MEDUSA_MODE=GRPC.
+      .venv/bin/pip install -I python-snappy --no-compile
+
+  - runs: |
       mkdir -p ${{targets.destdir}}/usr/share/medusa
       mv .venv ${{targets.destdir}}/usr/share/medusa/
 
@@ -99,5 +103,5 @@ test:
       packages:
         - python-3.11-dev
   pipeline:
-    - runs: |
-        medusa --version
+    - runs: medusa --version
+    - runs: python3 -m medusa.service.grpc.server server.py | grep "/etc/medusa/medusa.ini"

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,13 +2,16 @@
 package:
   name: py3-cassandra-medusa
   version: 0.19.1
-  epoch: 1
+  epoch: 2
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
   options:
     no-provides: true
     no-depends: true
+  dependencies:
+    runtime:
+      - python-3.11-base
 
 environment:
   contents:

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -104,4 +104,4 @@ test:
         - python-3.11-dev
   pipeline:
     - runs: medusa --version
-    - runs: /usr/share/medusa/.venv/bin/python3 -m medusa.service.grpc.server server.py | grep "/etc/medusa/medusa.ini"
+    - runs: /usr/share/medusa/.venv/bin/python3 -m medusa.service.grpc.server server.py 2>&1 | grep "/etc/medusa/medusa.ini"

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -105,6 +105,7 @@ test:
   pipeline:
     - runs: medusa --version
     - runs: |
+        set +e
         fail() { echo "$@" 1>&2; exit 1; }
         out=$(/usr/share/medusa/.venv/bin/python3 -m medusa.service.grpc.server 2>&1)
         status=$?


### PR DESCRIPTION
Fixes: no-depends was blocking python-3.11-base from being installed as an implicit dependency