### PR TITLE
Unpin provides from a specific version in glib-dev

### DIFF
--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,7 +1,7 @@
 package:
   name: busybox
   version: 1.36.1
-  epoch: 6
+  epoch: 7
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -67,7 +67,7 @@ subpackages:
   - name: busybox-full
     dependencies:
       provides:
-        - busybox=1.36.0-r4
+        - busybox=${{package.full-version}}
       provider-priority: 5
     options:
       no-commands: true

--- a/glib.yaml
+++ b/glib.yaml
@@ -1,7 +1,7 @@
 package:
   name: glib
   version: 2.80.0
-  epoch: 0
+  epoch: 1
   description: Common C routines used by Gtk+ and other libs
   copyright:
     - license: LGPL-2.1-or-later

--- a/glib.yaml
+++ b/glib.yaml
@@ -96,10 +96,9 @@ subpackages:
         - util-linux-dev # needed by gio-2.0 when building gobject-introspection
         - docbook-xml
       provides:
-        - gio-2.0
-        - glib-2.0
-        - gobject-2.0
-        - gthread-2.0
+        - gio=${{package.full-version}}
+        - gobject=${{package.full-version}}
+        - gthread=${{package.full-version}}
     description: glib dev
 
   - name: glib-lang


### PR DESCRIPTION
In glib-dev provides dependencies we were specifying a specific version that results in that we can not install them by those names as more that one version of that package provides the same name package.
for example gio-2.0 is provided by all glib-dev-2.74 till glib-dev-2.80
```
/ # apk add gio-2.0
ERROR: unable to select packages:
  gio-2.0 (virtual):
    note: please select one of the 'provided by' packages explicitly
    provided by: glib-dev-2.74.3-r1 glib-dev-2.74.3-r2 glib-dev-2.76.1-r0
                 glib-dev-2.76.4-r0 glib-dev-2.76.5-r0 glib-dev-2.78.0-r0
                 glib-dev-2.78.1-r0 glib-dev-2.78.2-r0 glib-dev-2.78.3-r0
                 glib-dev-2.79.0-r0 glib-dev-2.79.1-r0 glib-dev-2.80.0-r0
    required by: world[gio-2.0]
```