### PR TITLE
workaround/remove runtime version check

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -22,7 +22,7 @@ environment:
       - ca-certificates-bundle
       - crane
       - curl
-      - go~1.21
+      - go
       - libseccomp-dev
       - sqlite-dev
       - yq
@@ -107,6 +107,11 @@ pipeline:
       go get golang.org/x/crypto@v0.17.0
 
       go mod tidy
+
+      # Override the go version check at runtime to always match the go version at build time
+      # Ref: https://github.com/k3s-io/k3s/pull/9054
+      GOVERSION=$(go env GOVERSION)
+      sed -i "s/\${VERSION_GOLANG}/$GOVERSION/g" scripts/build
 
       ./scripts/build
   # k3s embedds a lot of useful components (containerd, kubectl, etc...) in a
@@ -209,3 +214,13 @@ update:
     identifier: k3s-io/k3s
     strip-prefix: v
     strip-suffix: "+k3s1" # NOTE: Update k3s# if upstream ships a >k3s1 revision
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - name: Basic version smoketest
+      runs: |
+        k3s --version

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.29.2
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: Apache-2.0
@@ -22,7 +22,7 @@ environment:
       - ca-certificates-bundle
       - crane
       - curl
-      - go
+      - go~1.21
       - libseccomp-dev
       - sqlite-dev
       - yq


### PR DESCRIPTION
without this, we fail on boot with:

```
failed to validate golang version: incorrect golang build version - kubernetes v1.29.2 should be built with go1.21.7, runtime version is go1.22.1
```

https://github.com/k3s-io/k3s/pull/9054