### PR TITLE
patch the default supported ciphers

### DIFF
--- a/argo-cd-2.10.yaml
+++ b/argo-cd-2.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.10
   version: 2.10.4
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,10 @@ pipeline:
       repository: https://github.com/argoproj/argo-cd
       tag: v${{package.version}}
       expected-commit: f5d63a5c77d2e804e51ef94bee3db441e0789d00
+
+  - uses: patch
+    with:
+      patches: 0001-remove-deprecated-default-cipher.patch
 
   - uses: go/bump
     with:

--- a/argo-cd-2.10/0001-remove-deprecated-default-cipher.patch
+++ b/argo-cd-2.10/0001-remove-deprecated-default-cipher.patch
@@ -1,0 +1,26 @@
+From df23831eb83a9a33a86c8a1530e5e0e17ee5c89a Mon Sep 17 00:00:00 2001
+From: Josh Wolf <josh@wolfs.io>
+Date: Tue, 19 Mar 2024 11:09:08 -0400
+Subject: [PATCH] remove deprecated default cipher
+
+Signed-off-by: Josh Wolf <josh@wolfs.io>
+---
+ util/tls/tls.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/util/tls/tls.go b/util/tls/tls.go
+index 5e18c8eb7..c7925b832 100644
+--- a/util/tls/tls.go
++++ b/util/tls/tls.go
+@@ -28,7 +28,7 @@ const (
+ 	DefaultRSABits = 2048
+ 	// The default TLS cipher suites to provide to clients - see https://cipherlist.eu for updates
+ 	// Note that for TLS v1.3, cipher suites are not configurable and will be chosen automatically.
+-	DefaultTLSCipherSuite = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_RSA_WITH_AES_256_GCM_SHA384"
++	DefaultTLSCipherSuite = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+ 	// The default minimum TLS version to provide to clients
+ 	DefaultTLSMinVersion = "1.2"
+ 	// The default maximum TLS version to provide to clients
+-- 
+2.44.0
+


### PR DESCRIPTION
upstream ref: https://github.com/argoproj/argo-cd/pull/17569