### PR TITLE
fix(memcached-bitnami-compat): add required folder for package

### DIFF
--- a/memcached.yaml
+++ b/memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached
   version: 1.6.25
-  epoch: 0
+  epoch: 1
   description: "Distributed memory object caching system"
   copyright:
     - license: BSD-3-Clause
@@ -64,6 +64,7 @@ subpackages:
           version-path: 1/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/memcached/conf/sasl2
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/memcached/conf.default
 
 update:
   enabled: true
@@ -71,3 +72,23 @@ update:
     identifier: memcached/memcached
     use-tag: true
     tag-filter: 1.
+
+test:
+  environment:
+    contents:
+      packages:
+        - memcached-bitnami-compat
+  pipeline:
+    # Check command can at least show version
+    - runs: |
+        /usr/bin/memcached --version
+    # Check that command starts up and listens
+    - runs: |
+        # TODO(mauren): implement a real test when the option to switch to a nonroot user is available
+        if /usr/bin/memcached -vvv 2>&1 | grep -qi "run as root without the -u switch"; then
+          exit 0
+        fi
+        exit 1
+    # Check folder exists
+    - runs: |
+        stat /opt/bitnami/memcached/conf.default


### PR DESCRIPTION
`memcached-bitnami-compat` now requires folder `/opt/bitnami/memcached/conf.default` to exist.

Extra: add test coverage to this package.