### PR TITLE
datadog-agent fix GHSA-xr7r-f8xq-vfvv GHSA-wr6v-9f75-vh2g

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -54,9 +54,6 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 024f4fb4b528f0eabaeeb4114744dd63edbe3553
 
-  - runs: |
-      go mod edit -dropreplace=github.com/moby/buildkit
-
   - uses: go/bump
     with:
       deps: google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4 github.com/moby/buildkit@v0.13.1

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent
   version: 7.51.1
-  epoch: 2
+  epoch: 3
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -19,7 +19,7 @@ environment:
       - cmake
       - coreutils
       - gcc-12
-      - go-1.21
+      - go
       - py3-boto3
       - py3-codeowners
       - py3-docker
@@ -54,9 +54,16 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 024f4fb4b528f0eabaeeb4114744dd63edbe3553
 
+  - runs: |
+      go mod edit -dropreplace=github.com/moby/buildkit
+
   - uses: go/bump
     with:
-      deps: google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4
+      deps: google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4 github.com/moby/buildkit@v0.13.1
+
+  - uses: patch
+    with:
+      patches: local-docker.patch
 
   - runs: |
       export PATH=$PATH:$GOPATH/bin

--- a/datadog-agent/local-docker.patch
+++ b/datadog-agent/local-docker.patch
@@ -1,0 +1,61 @@
+diff --git a/pkg/util/docker/event_pull.go b/pkg/util/docker/event_pull.go
+index b89c98078f..b7ba95e7ad 100644
+--- a/pkg/util/docker/event_pull.go
++++ b/pkg/util/docker/event_pull.go
+@@ -80,15 +80,15 @@ func (d *DockerUtil) processContainerEvent(ctx context.Context, msg events.Messa
+ 	action := msg.Action
+ 
+ 	// Fix the "exec_start: /bin/sh -c true" case
+-	if strings.Contains(action, ":") {
+-		action = strings.SplitN(action, ":", 2)[0]
++	if strings.Contains(string(action), ":") {
++		action = events.Action(strings.SplitN(string(action), ":", 2)[0])
+ 	}
+ 
+ 	event := &ContainerEvent{
+ 		ContainerID:   msg.Actor.ID,
+ 		ContainerName: containerName,
+ 		ImageName:     imageName,
+-		Action:        action,
++		Action:        string(action),
+ 		Timestamp:     timeFromMessage(msg),
+ 		Attributes:    msg.Actor.Attributes,
+ 	}
+@@ -105,7 +105,7 @@ func (d *DockerUtil) processImageEvent(msg events.Message) *ImageEvent {
+ 
+ 	return &ImageEvent{
+ 		ImageID:   msg.Actor.ID,
+-		Action:    msg.Action,
++		Action:    string(msg.Action),
+ 		Timestamp: timeFromMessage(msg),
+ 	}
+ }
+@@ -114,7 +114,7 @@ func (d *DockerUtil) processImageEvent(msg events.Message) *ImageEvent {
+ // It returns the latest event timestamp in the slice for the user to store and pass again in the next call.
+ func (d *DockerUtil) LatestContainerEvents(ctx context.Context, since time.Time, filter *containers.Filter) ([]*ContainerEvent, time.Time, error) {
+ 	var containerEvents []*ContainerEvent
+-	filters := map[string]string{"type": events.ContainerEventType}
++	filters := map[string]string{"type": string(events.ContainerEventType)}
+ 
+ 	ctx, cancel := context.WithTimeout(ctx, d.queryTimeout)
+ 	defer cancel()
+diff --git a/pkg/util/docker/event_stream.go b/pkg/util/docker/event_stream.go
+index 0fe7c8a10f..82e9207bbb 100644
+--- a/pkg/util/docker/event_stream.go
++++ b/pkg/util/docker/event_stream.go
+@@ -152,13 +152,13 @@ CONNECT: // Outer loop handles re-connecting in case the docker daemon closes th
+ func eventFilters() filters.Args {
+ 	res := filters.NewArgs()
+ 
+-	res.Add("type", events.ContainerEventType)
++	res.Add("type", string(events.ContainerEventType))
+ 	for _, containerEventAction := range containerEventActions {
+ 		res.Add("event", containerEventAction)
+ 	}
+ 
+ 	if config.Datadog.GetBool("container_image.enabled") {
+-		res.Add("type", events.ImageEventType)
++		res.Add("type", string(events.ImageEventType))
+ 		for _, imageEventAction := range imageEventActions {
+ 			res.Add("event", imageEventAction)
+ 		}


### PR DESCRIPTION
On the last [package update to 7.51.0](https://github.com/wolfi-dev/os/pull/13291) we removed go/bump for the module  github.com/moby/buildkit & github.com/opencontainers/runc

that results in the back of CVE GHSA-xr7r-f8xq-vfvv and GHSA-wr6v-9f75-vh2g
```
debasish-biswas:~/wolfi-os$ wolfictl scan packages/x86_64/datadog-agent-7.51.1-r2.apk 
🔎 Scanning "packages/x86_64/datadog-agent-7.51.1-r2.apk"
└── 📄 /opt/datadog-agent/bin/agent/agent
        📦 github.com/moby/buildkit v0.11.4 (go-module)
            Critical CVE-2024-23652 GHSA-4v98-7qmw-rqr8 fixed in 0.12.5
            Medium CVE-2024-23650 GHSA-9p26-698r-w4hx fixed in 0.12.5
            High CVE-2024-23651 GHSA-m3r6-h7wv-7xxv fixed in 0.12.5
            Critical CVE-2024-23653 GHSA-wr6v-9f75-vh2g fixed in 0.12.5
        📦 github.com/opencontainers/runc v1.1.10 (go-module)
            High CVE-2024-21626 GHSA-xr7r-f8xq-vfvv fixed in 1.1.12
```

As on the advisory, these cve's were marked as fixed on the previous version so ci were not catching these either I guess.

Now :
```
debasish-biswas:~/wolfi-os$ wolfictl scan packages/x86_64/datadog-agent-7.51.1-r3.apk 
🔎 Scanning "packages/x86_64/datadog-agent-7.51.1-r3.apk"
✅ No vulnerabilities found
```