### PR TITLE
fix: remove py3-tensorflow-core provides tensorflow shared libraries

### DIFF
--- a/tensorflow-core.yaml
+++ b/tensorflow-core.yaml
@@ -2,7 +2,7 @@ package:
   name: tensorflow-core
   description: Framework for data-graph oriented computing (core libraries, oneDNN build)
   version: 2.13.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
 
@@ -144,7 +144,10 @@ subpackages:
           _pyver=$(python -c 'import sys; print(str(sys.version_info[0]) + "." + str(sys.version_info[1]))')
           _pypath="/usr/lib/python${_pyver}"
           mkdir -p "${{targets.contextdir}}"/usr/lib
+          mkdir -p "${{targets.contextdir}}"/usr/bin
           mv "${{targets.destdir}}"${_pypath} "${{targets.contextdir}}"${_pypath}
+          mv "${{targets.destdir}}"/usr/bin "${{targets.contextdir}}"/usr/bin
+          find "${{targets.contextdir}}"${_pypath} -name "libtensorflow*.so*" -exec rm -rf '{}' +
 
   - name: tensorflow-dev
     description: Tensorflow development headers


### PR DESCRIPTION
* Remove python cache files (.pyc )
* `/usr/bin/` files are Python scripts that should be provided by py3-tensorflow-core
* Remove tensor shared  libraries from py3-tensorflow-core because it's already been provided by tensorflow-core package.