### PR TITLE
add shadowsocks-rust

### DIFF
--- a/shadowsocks-rust.yaml
+++ b/shadowsocks-rust.yaml
@@ -1,0 +1,63 @@
+package:
+  name: shadowsocks-rust
+  version: 1.18.2
+  epoch: 0
+  description: A Rust port of shadowsocks
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - glibc-dev
+      - rust
+      - rustup
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/shadowsocks/shadowsocks-rust
+      tag: v${{package.version}}
+      expected-commit: dcdeca032cad409d1ad133abeafa0270bb32a945
+
+  - name: Configure
+    runs: |
+      rustup override set stable
+      rustup target add "${{host.triplet.rust}}"
+
+  - runs: |
+      cargo build --target "${{host.triplet.rust}}" --release --features "local-tun local-redir stream-cipher aead-cipher-2022"
+
+      mkdir -p "${{targets.destdir}}"/target/release/
+      mv target/${{host.triplet.rust}}/release/ss* "${{targets.destdir}}"/target/release/
+
+      install -Dm644 examples/config.json "${{targets.destdir}}"/etc/shadowsocks-rust/config.json
+      install -Dm755 docker/docker-entrypoint.sh "${{targets.destdir}}"/usr/bin/docker-entrypoint.sh
+
+  - uses: strip
+
+data:
+  - name: components
+    items:
+      sslocal: sslocal
+      ssmanager: ssmanager
+      ssserver: ssserver
+      ssservice: ssservice
+      ssurl: ssurl
+
+subpackages:
+  - range: components
+    name: "${{package.name}}-${{range.key}}"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin/
+          install -Dm755 "${{targets.destdir}}"/target/release/${{range.key}} "${{targets.subpkgdir}}"/usr/bin/
+
+update:
+  enabled: true
+  github:
+    identifier: shadowsocks/shadowsocks-rust
+    strip-prefix: v

--- a/shadowsocks-rust.yaml
+++ b/shadowsocks-rust.yaml
@@ -56,6 +56,39 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/bin/
           install -Dm755 "${{targets.destdir}}"/target/release/${{range.key}} "${{targets.subpkgdir}}"/usr/bin/
 
+test:
+  environment:
+    contents:
+      packages:
+        - shadowsocks-rust-sslocal
+        - shadowsocks-rust-ssmanager
+        - shadowsocks-rust-ssserver
+        - shadowsocks-rust-ssservice
+        - shadowsocks-rust-ssurl
+  pipeline:
+    - runs: |
+        ssservice --version
+        ssmanager --version
+        ssurl --version
+    - runs: |
+        for bin in sslocal ssserver; do
+          echo "Starting $bin"
+          nohup $bin > $bin.out 2> $bin.err < /dev/null &
+          pid=$!
+          sleep 3
+
+          if ! (cat $bin.out $bin.err | grep "listening on"); then
+            echo "Could not find expected 'listening on' log message in '$bin' output!"
+            cat $bin.out
+            cat $bin.err
+            exit 1
+          fi
+
+          echo "Stopping $bin"
+          kill $pid
+          sleep 3
+        done
+
 update:
   enabled: true
   github:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
