### PR TITLE
chore(memcached): add meaningful test

### DIFF
--- a/memcached.yaml
+++ b/memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached
   version: 1.6.25
-  epoch: 1
+  epoch: 2
   description: "Distributed memory object caching system"
   copyright:
     - license: BSD-3-Clause
@@ -78,16 +78,36 @@ test:
     contents:
       packages:
         - memcached-bitnami-compat
+    accounts:
+      groups:
+        - groupname: nonroot
+          gid: 65532
+      users:
+        - username: nonroot
+          gid: 65532
+          uid: 65532
+      run-as: 65532
   pipeline:
     # Check command can at least show version
     - runs: |
         /usr/bin/memcached --version
     # Check that command starts up and listens
     - runs: |
-        # TODO(mauren): implement a real test when the option to switch to a nonroot user is available
-        if /usr/bin/memcached -vvv 2>&1 | grep -qi "run as root without the -u switch"; then
-          exit 0
-        fi
+        /usr/bin/memcached -vvv > /tmp/output 2>&1 &
+        PID=$!
+        count=0
+        # Retries for a minute
+        while [ "$count" -lt 12 ]; do
+          if cat /tmp/output | grep -qi "server listening"; then
+            echo "started up successfully!"
+            kill $PID
+            exit 0
+          else
+            echo "waiting for service to start up..."
+            sleep 5
+          fi
+          count=$((count+1))
+        done
         exit 1
     # Check folder exists
     - runs: |


### PR DESCRIPTION
Include a meaningful test to the `memcached` package to ensure the service starts when run.