### PR TITLE
dotnet-6: add back patch for CVE-2024-0057

### DIFF
--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-6
   version: 6.0.128 # We'll likely be able to remove the fix for CVE-2024-0057 at the next version.
-  epoch: 0
+  epoch: 1
   description: ".NET SDK, version 6"
   copyright:
     - license: MIT

--- a/dotnet-6/installer/src/SourceBuild/tarball/patches/installer/0001-Bump-NuGet-client.patch
+++ b/dotnet-6/installer/src/SourceBuild/tarball/patches/installer/0001-Bump-NuGet-client.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Philippe Deslauriers <philde@chainguard.dev>
+Date: Tue, 20 Feb 2024 15:44:33 -0800
+Subject: [PATCH] Bump NuGet client
+
+Signed-off-by: Philippe Deslauriers <philde@chainguard.dev>
+---
+ eng/Version.Details.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/Version.Details.xml b/eng/Version.Details.xml
+index 816b9b949..9e6dbd509 100644
+--- a/eng/Version.Details.xml
++++ b/eng/Version.Details.xml
+@@ -153,7 +153,7 @@
+     </Dependency>
+     <Dependency Name="NuGet.Build.Tasks" Version="6.0.6-rc.4" CoherentParentDependency="Microsoft.NET.Sdk">
+       <Uri>https://dev.azure.com/devdiv/DevDiv/_git/NuGet-NuGet.Client-Trusted</Uri>
+-      <Sha>7fe6b814c901490292f02d8ea12749505fbb959a</Sha>
++      <Sha>71a0d504510294ddc78d989aa1eb8ffea94308ec</Sha>
+       <SourceBuildTarball RepoName="nuget-client" ManagedOnly="true" />
+     </Dependency>
+     <Dependency Name="Microsoft.ApplicationInsights" Version="2.19.0">


### PR DESCRIPTION
Add back the patch. Our CI scanning was hiding a regression.