### PR TITLE
run package tests with docker runner by default round 2

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -86,8 +86,14 @@ jobs:
       - name: Free up runner disk space
         run: |
           set -x
+          printf "==> Available space before cleanup\n"
+          df -h
           rm -rf /usr/share/dotnet
           rm -rf "$AGENT_TOOLSDIRECTORY"
+
+          printf "==> Available space after cleanup\n"
+          df -h
+
       - uses: actions/checkout@v4
       - name: Setup Docker
         run: |
@@ -119,6 +125,11 @@ jobs:
         with:
           opts: "-v /temp:/temp -v /var/run/docker.sock:/var/run/docker.sock"
           run: |
+            # Use a different shared $TMPDIR accessible and non-conflicting to
+            # both the host and container since we're running docker out of
+            # docker
+            export TMPDIR="/temp"
+
             # This is to avoid fatal errors about "dubious ownership" because we are
             # running inside of a container action with the workspace mounted in.
             git config --global --add safe.directory .
@@ -126,7 +137,7 @@ jobs:
             mkdir -p .melangecache
             for package in ${{needs.changes.outputs.packages}}; do
               make MELANGE_EXTRA_OPTS="--create-build-log --cache-dir=.melangecache" REPO="./packages" package/\$package -j1
-              TMPDIR="/temp" make REPO="./packages" test/\$package -j1
+              make MELANGE_EXTRA_OPTS="--runner docker" REPO="./packages" "test/\$package" -j1
             done
 
       - name: "Check that packages can be installed with apk add"


### PR DESCRIPTION
follow up to #14707 and #15538 , this time with the actual fix: https://github.com/chainguard-dev/melange/pull/1101

the image update with the melange fix got pulled in with https://github.com/wolfi-dev/os/pull/15633

