### PR TITLE
redis: stop updates beyond 7.2

### DIFF
--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -146,6 +146,7 @@ update:
   enabled: true
   github:
     identifier: redis/redis
+    tag-filter-prefix: "7.2."
 
 test:
   environment:


### PR DESCRIPTION
Future releases of Redis will not be under OSI approved licenses, so let's prevent accidentally sneaking one into Wolfi via updates: https://redis.com/blog/redis-adopts-dual-source-available-licensing/