### PR TITLE
add compat for symlink, add config file prometheus blackbox-exporter

### DIFF
--- a/prometheus-blackbox-exporter.yaml
+++ b/prometheus-blackbox-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-blackbox-exporter
   version: 0.24.0
-  epoch: 6
+  epoch: 7
   description: Blackbox prober exporter
   copyright:
     - license: Apache-2.0
@@ -31,9 +31,23 @@ pipeline:
       make common-build
 
   - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/bin
+      mkdir -p "${{targets.destdir}}"/etc/blackbox_exporter
       install -Dm755 blackbox_exporter "${{targets.destdir}}"/usr/bin/blackbox_exporter
+      install -Dm644 blackbox.yml "${{targets.destdir}}"/etc/blackbox_exporter/config.yml
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by Dockerfile"
+    pipeline:
+      - runs: |
+          # The Dockerfile expects the cass-operator binaries to be in /bin instead of /usr/bin
+          # https://github.com/prometheus/blackbox_exporter/blob/220d785fb022088163456980110df58334e41db8/Dockerfile#L12
+          mkdir -p "${{targets.subpkgdir}}"/bin
+          ln -sf /usr/bin/blackbox_exporter ${{targets.subpkgdir}}/bin/blackbox_exporter
+      - uses: strip
 
 update:
   enabled: true
@@ -42,3 +56,21 @@ update:
     strip-prefix: v
     use-tag: true
     tag-filter: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - prometheus-blackbox-exporter-compat
+  pipeline:
+    - runs: |
+        # run the blackbox_exporter in the background and test if there is any connection for :9115
+        /bin/blackbox_exporter --config.file /etc/blackbox_exporter/config.yml &
+        # find the PID
+        PID=$!
+        # wait for the blackbox_exporter to start
+        sleep 5
+        # check if the blackbox_exporter is running by checking :9115 connection
+        netstat -tuln | grep 9115
+        # kill the blackbox_exporter
+        kill $PID


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
