### PR TITLE
velero-plugin-for-csi

### DIFF
--- a/velero-plugin-for-csi.yaml
+++ b/velero-plugin-for-csi.yaml
@@ -1,0 +1,78 @@
+package:
+  name: velero-plugin-for-csi
+  version: 0.7.0
+  epoch: 0
+  description: Velero plugins for integrating with CSI snapshot API
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      tag: v${{package.version}}
+      expected-commit: f6f3583c49009df7588183b71ee4847e67d96fb5
+      repository: https://github.com/vmware-tanzu/velero-plugin-for-csi
+
+  - uses: go/bump
+    with:
+      deps: google.golang.org/protobuf@v1.33.0
+
+  - uses: go/build
+    with:
+      packages: .
+      output: velero-plugin-for-csi
+      ldflags: "-s -w"
+
+  - uses: go/build
+    with:
+      packages: ./hack/cp-plugin
+      output: cp-plugin
+      ldflags: "-s -w"
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    pipeline:
+      - runs: |
+          # The Dockerfile expects the binaries to be in /bin instead of /usr/bin
+          # also the plugin binary is expected to be in /plugins directory
+          # https://github.com/vmware-tanzu/velero-plugin-for-csi/blob/36e5755ebeb6fa34ce72f6e4afa309d72b619469/Dockerfile#L33-L34
+          mkdir -p "${{targets.subpkgdir}}"/bin
+          mkdir -p "${{targets.subpkgdir}}"/plugins
+          # /target directory is created to match the Dockerfile
+          # https://github.com/vmware-tanzu/velero-plugin-for-csi/blob/36e5755ebeb6fa34ce72f6e4afa309d72b619469/Dockerfile#L36C66-L36C95
+          mkdir -p "${{targets.subpkgdir}}"/target
+          cp "${{targets.destdir}}"/usr/bin/velero-plugin-for-csi "${{targets.subpkgdir}}"/plugins/velero-plugin-for-csi
+          ln -sf /usr/bin/cp-plugin "${{targets.subpkgdir}}"/bin/cp-plugin
+
+update:
+  enabled: true
+  github:
+    identifier: vmware-tanzu/velero-plugin-for-csi
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - velero-plugin-for-csi-compat
+  pipeline:
+    - runs: |
+        /bin/cp-plugin /plugins/velero-plugin-for-csi /target/velero-plugin-for-csi
+        # check the /target directory if there is velero-plugin-for-csi exist
+        ls /target/velero-plugin-for-csi
+        set +e
+        /target/velero-plugin-for-csi -h


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
