### PR TITLE
bump to latest version

### DIFF
--- a/confluent-kafka.yaml
+++ b/confluent-kafka.yaml
@@ -9,7 +9,7 @@ package:
   # with the `version:` field.
   # 2. Created a new variable `mangled-package-version` to append `-ccs` to the
   # version.
-  version: 7.8.0.3
+  version: 7.8.0.9
   epoch: 0
   description: Community edition of Confluent Kafka.
   copyright:
@@ -42,7 +42,7 @@ var-transforms:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: de0bb04e22016a2f4eaba2a1083a3e821167fb8f162165a5631a6315d42cfe08
+      expected-sha256: 61f4349c2014c608222f7c5cf7c1cb0051ebe54d421aab0d749ae20c35a45f1c
       uri: https://github.com/confluentinc/kafka/archive/refs/tags/v${{vars.mangled-package-version}}.tar.gz
 
   - runs: |


### PR DESCRIPTION
bump to latest version - the repo does multiple releases every few hours, so automation / releasemonitor a bit behind, but need the bump now to remediate vulns for an image PR.

Also tested locally with a local image build, which included the kafka automated tests. 