### PR TITLE
velero-plugin-for-aws

### DIFF
--- a/velero-plugin-for-aws.yaml
+++ b/velero-plugin-for-aws.yaml
@@ -1,0 +1,78 @@
+package:
+  name: velero-plugin-for-aws
+  version: 1.9.1
+  epoch: 0
+  description: Plugins to support Velero on AWS
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      tag: v${{package.version}}
+      expected-commit: cc4024b675b34661a5122dbb0c467486c6673872
+      repository: https://github.com/vmware-tanzu/velero-plugin-for-aws
+
+  - uses: go/bump
+    with:
+      deps: google.golang.org/protobuf@v1.33.0
+
+  - uses: go/build
+    with:
+      packages: ./velero-plugin-for-aws
+      output: velero-plugin-for-aws
+      ldflags: "-s -w"
+
+  - uses: go/build
+    with:
+      packages: ./hack/cp-plugin
+      output: cp-plugin
+      ldflags: "-s -w"
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    pipeline:
+      - runs: |
+          # The Dockerfile expects the binaries to be in /bin instead of /usr/bin
+          # also the plugin binary is expected to be in /plugins directory
+          # https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/60a7e327a32f7fd21bdc2b712f6e2cbd8fd09b26/Dockerfile#L30-L31
+          mkdir -p "${{targets.subpkgdir}}"/bin
+          mkdir -p "${{targets.subpkgdir}}"/plugins
+          # /target directory is created to match the Dockerfile
+          # https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/60a7e327a32f7fd21bdc2b712f6e2cbd8fd09b26/Dockerfile#L37
+          mkdir -p "${{targets.subpkgdir}}"/target
+          cp "${{targets.destdir}}"/usr/bin/velero-plugin-for-aws "${{targets.subpkgdir}}"/plugins/velero-plugin-for-aws
+          ln -sf /usr/bin/cp-plugin "${{targets.subpkgdir}}"/bin/cp-plugin
+
+update:
+  enabled: true
+  github:
+    identifier: vmware-tanzu/velero-plugin-for-aws
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - velero-plugin-for-aws-compat
+  pipeline:
+    - runs: |
+        /bin/cp-plugin /plugins/velero-plugin-for-aws /target/velero-plugin-for-aws
+        # check the /target directory if there ivelero-plugin-for-aws exist
+        ls /target/velero-plugin-for-aws
+        set +e
+        /target/velero-plugin-for-aws -h


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
