### PR TITLE
add kubecolor package

### DIFF
--- a/kubecolor.yaml
+++ b/kubecolor.yaml
@@ -1,0 +1,48 @@
+package:
+  name: kubecolor
+  version: 0.2.2
+  epoch: 0
+  description: Colorize your kubectl output
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - kubectl
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubecolor/kubecolor
+      tag: v${{package.version}}
+      expected-commit: 44922b41665dea35b12c994d932d2ea6c67962d1
+
+  - uses: go/build
+    with:
+      packages: .
+      repository: https://github.com/kubecolor/kubecolor
+      ldflags: |
+        -s -w
+        -X main.version=${{package.version}}
+      output: kubecolor
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubecolor/kubecolor
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        kubecolor version

--- a/kubecolor.yaml
+++ b/kubecolor.yaml
@@ -45,4 +45,4 @@ update:
 test:
   pipeline:
     - runs: |
-        kubecolor version
+        kubecolor version --client=true


### PR DESCRIPTION
colorize your kubectl output

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
