### PR TITLE
Unbreak aws-cli-v2 to become installable

### DIFF
--- a/aws-cli-v2.yaml
+++ b/aws-cli-v2.yaml
@@ -3,10 +3,14 @@
 package:
   name: aws-cli-v2
   version: 2.15.32
-  epoch: 0
+  epoch: 1
   description: "Universal Command Line Interface for Amazon Web Services (v2)"
   copyright:
     - license: Apache-2.0
+  options:
+    # melange generates incorrect SCA provides for vendored copies of
+    # libraries
+    no-provides: true
   dependencies:
     runtime:
       - groff

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,2 +1,3 @@
 coredns-1.11.2-r0.apk
 coredns-1.11.2-r1.apk
+aws-cli-v2-2.15.32-r0.apk


### PR DESCRIPTION
Fixes: https://github.com/wolfi-dev/os/pull/15808 https://github.com/wolfi-dev/os/pull/11127

Prevent vendored private libraries generating public SCA dependencies.
Withdraw broken aws-cli-v2 that adveritises that it provides public libcrypto library and similar.
This change makes aws-cli-v2 to be installable in `make local-wolfi` container.