### PR TITLE
golangci-lint: do not depend on any go

### DIFF
--- a/golangci-lint.yaml
+++ b/golangci-lint.yaml
@@ -1,14 +1,13 @@
 package:
   name: golangci-lint
   version: 1.57.1
-  epoch: 0
+  epoch: 1
   description: Fast linters Runner for Go
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - diffutils
-      - go
 
 environment:
   contents:


### PR DESCRIPTION
WolfiOS and Chainguard provide over 8 differnt go toolchains. Also one can self-install self-built go, or download the official go lang toolchain. And all of them are usable with golangci-lint. Without any go toolchain one can run golangci-lint version successfully.

Dropping dependency on virtual go provides, ensures that installing golangci-lint doesn't pull in an unexpected, redudant, or random go toolchain.