### PR TITLE
fix(shadowsocks-rust): recude package size

### DIFF
--- a/shadowsocks-rust.yaml
+++ b/shadowsocks-rust.yaml
@@ -1,7 +1,7 @@
 package:
   name: shadowsocks-rust
   version: 1.18.2
-  epoch: 2
+  epoch: 3
   description: A Rust port of shadowsocks
   copyright:
     - license: MIT
@@ -30,10 +30,6 @@ pipeline:
 
   - runs: |
       cargo build --target "${{host.triplet.rust}}" --release --features "local-tun local-redir stream-cipher aead-cipher-2022"
-
-      mkdir -p "${{targets.destdir}}"/target/release/
-      mv target/${{host.triplet.rust}}/release/ss* "${{targets.destdir}}"/target/release/
-
       install -Dm644 examples/config.json "${{targets.destdir}}"/etc/shadowsocks-rust/config.json
       install -Dm755 docker/docker-entrypoint.sh "${{targets.destdir}}"/usr/bin/docker-entrypoint.sh
 
@@ -53,27 +49,23 @@ subpackages:
     name: "${{package.name}}-${{range.key}}"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin/
-          install -Dm755 "${{targets.destdir}}"/target/release/${{range.key}} "${{targets.subpkgdir}}"/usr/bin/
+          mkdir -p "${{targets.contextdir}}"/usr/bin/
+          install -Dm755 target/${{host.triplet.rust}}/release/${{range.key}} "${{targets.contextdir}}"/usr/bin/
     dependencies:
       runtime:
         - shadowsocks-rust
         - busybox # The entrypoint script uses `#!/bin/sh`
+    test:
+      pipeline:
+        - runs: ${{range.key}} --version
 
 test:
   environment:
     contents:
       packages:
         - shadowsocks-rust-sslocal
-        - shadowsocks-rust-ssmanager
         - shadowsocks-rust-ssserver
-        - shadowsocks-rust-ssservice
-        - shadowsocks-rust-ssurl
   pipeline:
-    - runs: |
-        ssservice --version
-        ssmanager --version
-        ssurl --version
     - runs: |
         for bin in sslocal ssserver; do
           echo "Starting $bin"


### PR DESCRIPTION
Fixes an issue where all sub-packages were containing the all other binaries.