### PR TITLE
php-xdebug: init at 3.3.1

### DIFF
--- a/php-8.1-xdebug.yaml
+++ b/php-8.1-xdebug.yaml
@@ -1,0 +1,51 @@
+package:
+  name: php-8.1-xdebug
+  version: 3.3.1
+  epoch: 0
+  description: "Step Debugger for PHP"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.1
+      - php-8.1-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/xdebug/xdebug
+      tag: "${{package.version}}"
+      expected-commit: 1943c479139008da3f9d26a4e2a6005e75c5ab34
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "zend_extension=xdebug.so" > "${{targets.subpkgdir}}/etc/php/conf.d/xdebug.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: xdebug/xdebug
+    use-tag: true

--- a/php-8.2-xdebug.yaml
+++ b/php-8.2-xdebug.yaml
@@ -1,0 +1,51 @@
+package:
+  name: php-8.2-xdebug
+  version: 3.3.1
+  epoch: 0
+  description: "Step Debugger for PHP"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.2
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.2
+      - php-8.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/xdebug/xdebug
+      tag: "${{package.version}}"
+      expected-commit: 1943c479139008da3f9d26a4e2a6005e75c5ab34
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "zend_extension=xdebug.so" > "${{targets.subpkgdir}}/etc/php/conf.d/xdebug.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: xdebug/xdebug
+    use-tag: true

--- a/php-8.3-xdebug.yaml
+++ b/php-8.3-xdebug.yaml
@@ -1,0 +1,51 @@
+package:
+  name: php-8.3-xdebug
+  version: 3.3.1
+  epoch: 0
+  description: "Step Debugger for PHP"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.3
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.3
+      - php-8.3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/xdebug/xdebug
+      tag: "${{package.version}}"
+      expected-commit: 1943c479139008da3f9d26a4e2a6005e75c5ab34
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "zend_extension=xdebug.so" > "${{targets.subpkgdir}}/etc/php/conf.d/xdebug.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: xdebug/xdebug
+    use-tag: true


### PR DESCRIPTION
XDebug is a PHP step debugger. https://github.com/xdebug/xdebug

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
