### PR TITLE
Move trace and logs artifacts to expected place

### DIFF
--- a/.github/workflows/build-beta.yaml
+++ b/.github/workflows/build-beta.yaml
@@ -99,6 +99,12 @@ jobs:
       - name: Create an archive for uploading
         if: ${{ always() }}
         run: |
+            # Move logs so we can upload them separately.
+            mv ./packages/${{ matrix.arch }}/buildlogs /tmp/buildlogs
+
+            # Move trace so we can upload it separately.
+            mv ./packages/${{ matrix.arch }}/trace.json /tmp/trace.json
+
             tar -cvzf /tmp/packages-${{ matrix.arch }}.tar.gz ./packages/${{ matrix.arch }}
 
       # Always run these steps for https://github.com/wolfi-dev/os/issues/8698


### PR DESCRIPTION
These aren't getting uploaded separately because they're still under ./packages (and not in /tmp as expected).