### PR TITLE
add strimzi-kafka

### DIFF
--- a/cruise-control.yaml
+++ b/cruise-control.yaml
@@ -30,12 +30,14 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 703c85849f65a177ffbbcf514a2020f4c4ae06e9
 
-  - runs: |
-      ./gradlew clean jar
+  - uses: patch
+    with:
+      patches: fix-CVEs.patch
 
   - runs: |
+      ./gradlew clean jar
       mkdir -p ${{targets.destdir}}/opt/cruise-control/libs
-      cp cruise-control/build/libs/${{package.name}}-${{package.version}}.jar ${{targets.destdir}}/opt/cruise-control/libs/
+      cp cruise-control/build/libs/* ${{targets.destdir}}/opt/cruise-control/libs/
       # copies dependant-library jars
       cp cruise-control/build/dependant-libs/* ${{targets.destdir}}/opt/cruise-control/libs/
 

--- a/cruise-control.yaml
+++ b/cruise-control.yaml
@@ -1,0 +1,40 @@
+package:
+  name: cruise-control
+  version: 2.5.137
+  epoch: 0
+  description: Cruise Control is a product that helps run Apache Kafka clusters at large scale.
+  copyright:
+    - license: BSD-2-Clause
+  dependencies:
+    runtime:
+      - bash
+      - openjdk-17-jre
+
+environment:
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+    JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
+    KAFKA_HOME: /opt/kafka
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - gradle
+      - openjdk-17
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/linkedin/cruise-control
+      tag: ${{package.version}}
+      expected-commit: 703c85849f65a177ffbbcf514a2020f4c4ae06e9
+
+  - runs: |
+      gradle clean jar
+
+update:
+  enabled: true
+  github:
+    identifier: linkedin/cruise-control
+    use-tag: true

--- a/cruise-control.yaml
+++ b/cruise-control.yaml
@@ -12,9 +12,9 @@ package:
 
 environment:
   environment:
+    CC_HOME: /usr/lib/cruise-control
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk
     JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
-    KAFKA_HOME: /opt/kafka
   contents:
     packages:
       - busybox
@@ -36,10 +36,10 @@ pipeline:
 
   - runs: |
       ./gradlew clean jar
-      mkdir -p ${{targets.destdir}}/opt/cruise-control/libs
-      cp cruise-control/build/libs/* ${{targets.destdir}}/opt/cruise-control/libs/
+      mkdir -p "${{targets.contextdir}}/${CC_HOME}/libs"
+      cp ./cruise-control/build/libs/* "${{targets.contextdir}}/${CC_HOME}/libs/"
       # copies dependant-library jars
-      cp cruise-control/build/dependant-libs/* ${{targets.destdir}}/opt/cruise-control/libs/
+      cp ./cruise-control/build/dependant-libs/* "${{targets.contextdir}}/${CC_HOME}/libs/"
 
 update:
   enabled: true

--- a/cruise-control.yaml
+++ b/cruise-control.yaml
@@ -36,6 +36,8 @@ pipeline:
   - runs: |
       mkdir -p ${{targets.destdir}}/opt/cruise-control/libs
       cp cruise-control/build/libs/${{package.name}}-${{package.version}}.jar ${{targets.destdir}}/opt/cruise-control/libs/
+      # copies dependant-library jars
+      cp cruise-control/build/dependant-libs/* ${{targets.destdir}}/opt/cruise-control/libs/
 
 update:
   enabled: true

--- a/cruise-control.yaml
+++ b/cruise-control.yaml
@@ -31,7 +31,11 @@ pipeline:
       expected-commit: 703c85849f65a177ffbbcf514a2020f4c4ae06e9
 
   - runs: |
-      gradle clean jar
+      ./gradlew clean jar
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/opt/cruise-control/libs
+      cp cruise-control/build/libs/${{package.name}}-${{package.version}}.jar ${{targets.destdir}}/opt/cruise-control/libs/
 
 update:
   enabled: true

--- a/cruise-control/fix-CVEs.patch
+++ b/cruise-control/fix-CVEs.patch
@@ -1,0 +1,40 @@
+diff --git a/build.gradle b/build.gradle
+index e00794fd..0bdc8581 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -287,7 +287,7 @@ project(':cruise-control') {
+     implementation 'com.google.code.gson:gson:2.9.0'
+     implementation "org.eclipse.jetty:jetty-server:${jettyVersion}"
+     implementation 'io.dropwizard.metrics:metrics-jmx:4.2.9'
+-    implementation 'com.nimbusds:nimbus-jose-jwt:9.24'
++    implementation 'com.nimbusds:nimbus-jose-jwt:9.37.3'
+     implementation 'io.swagger.parser.v3:swagger-parser-v3:2.1.16'
+     implementation 'io.github.classgraph:classgraph:4.8.141'
+     implementation 'com.google.code.findbugs:jsr305:3.0.2'
+@@ -301,7 +301,7 @@ project(':cruise-control') {
+     api 'io.swagger.core.v3:swagger-core:2.0.2'
+     api 'com.google.guava:guava:32.1.3-jre'
+     api 'org.json:json:20231013'
+-    api 'org.xerial.snappy:snappy-java:1.1.10.1'
++    api 'org.xerial.snappy:snappy-java:1.1.10.5'
+ 
+     testImplementation project(path: ':cruise-control-metrics-reporter', configuration: 'testOutput')
+     testImplementation project(path: ':cruise-control-core', configuration: 'testOutput')
+diff --git a/gradle.properties b/gradle.properties
+index 0a71cbff..b759d561 100644
+--- a/gradle.properties
++++ b/gradle.properties
+@@ -1,9 +1,9 @@
+ org.gradle.daemon=false
+ org.gradle.parallel=false
+ org.gradle.jvmargs=-Xms512m -Xmx512m
+ scalaVersion=2.13.10
+ kafkaVersion=3.5.1
+-zookeeperVersion=3.7.2
+-nettyVersion=4.1.100.Final
+-jettyVersion=9.4.53.v20231009
+-vertxVersion=4.5.0
++zookeeperVersion=3.8.4
++nettyVersion=4.1.108.Final
++jettyVersion=9.4.54.v20240208
++vertxVersion=4.5.7

--- a/kafka.yaml
+++ b/kafka.yaml
@@ -2,8 +2,8 @@ package:
   name: kafka
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.7.0
-  epoch: 3
-  description: Apache Kafka is a distributed event streaming platformm
+  epoch: 4
+  description: Apache Kafka is a distributed event streaming platform
   copyright:
     - paths:
         - "*"

--- a/kafka.yaml
+++ b/kafka.yaml
@@ -2,7 +2,7 @@ package:
   name: kafka
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.7.0
-  epoch: 4
+  epoch: 3
   description: Apache Kafka is a distributed event streaming platform
   copyright:
     - paths:

--- a/strimzi-kafka.yaml
+++ b/strimzi-kafka.yaml
@@ -64,6 +64,13 @@ pipeline:
       # Symlink KAFKA_HOME to /opt/kafka
       ln -sf "${KAFKA_HOME}" ${{targets.destdir}}/opt/kafka
 
+      # Remove JARs that Kafka already provides
+      rm ${{targets.destdir}}/usr/lib/kafka/libs/jackson-annotations-*.jar
+      rm ${{targets.destdir}}/usr/lib/kafka/libs/jackson-core-*.jar
+      rm ${{targets.destdir}}/usr/lib/kafka/libs/jackson-databind-*.jar
+      rm ${{targets.destdir}}/usr/lib/kafka/libs/jsr305-*.jar
+      rm ${{targets.destdir}}/usr/lib/kafka/libs/metrics-core-*.jar
+
 update:
   enabled: true
   github:

--- a/strimzi-kafka.yaml
+++ b/strimzi-kafka.yaml
@@ -37,8 +37,9 @@ pipeline:
 
   - runs: |
       set -e
-      mkdir -p ${{targets.destdir}}/opt
-      mkdir -p ${{targets.destdir}}/${KAFKA_HOME}/libs
+
+      mkdir -p "${{targets.contextdir}}/opt"
+      mkdir -p "${{targets.contextdir}}/${KAFKA_HOME}/libs"
 
       # Build the Kafka thirdparty libs
       cd ./docker-images/artifacts
@@ -46,30 +47,37 @@ pipeline:
       mkdir -p ./binaries/kafka-thirdparty-libs
       rm -f ./binaries/kafka-thirdparty-libs/3.7.x.zip
       zip -j ./binaries/kafka-thirdparty-libs/3.7.x.zip kafka-thirdparty-libs/3.7.x/target/dependency/*
-      cp kafka-thirdparty-libs/3.7.x/target/dependency/* ${{targets.destdir}}/${KAFKA_HOME}/libs/
+      cp kafka-thirdparty-libs/3.7.x/target/dependency/* "${{targets.contextdir}}/${KAFKA_HOME}/libs/"
       cd -
 
       # Build the strimzi agents
       for component in kafka-agent mirror-maker-agent tracing-agent; do
-        cd ./${component}
+        cd "./${component}"
         make java_install
-        cp target/${component}-${{package.version}}.jar ${{targets.destdir}}/${KAFKA_HOME}/libs/
+        cp "target/${component}-${{package.version}}.jar" "${{targets.contextdir}}/${KAFKA_HOME}/libs/"
         cd -
       done
 
+      # Copy the Kafka scripts
+      cp -r ./docker-images/kafka-based/kafka/scripts/* "${{targets.contextdir}}/${KAFKA_HOME}/"
+
       # Copy the Kafka exporter scripts
-      mkdir -p ${{targets.destdir}}/opt/kafka-exporter
-      cp ./docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh ${{targets.destdir}}/opt/kafka-exporter/kafka_exporter_run.sh
+      mkdir -p ${{targets.contextdir}}/opt/kafka-exporter
+      cp -r ./docker-images/kafka-based/kafka/exporter-scripts/* "${{targets.contextdir}}/opt/kafka-exporter/"
+
+      # Copy the Cruise Control scripts
+      mkdir -p "${{targets.contextdir}}/opt/cruise-control"
+      cp -r ./docker-images/kafka-based/kafka/cruise-control-scripts/* "${{targets.contextdir}}/opt/cruise-control/"
 
       # Symlink KAFKA_HOME to /opt/kafka
-      ln -sf "${KAFKA_HOME}" ${{targets.destdir}}/opt/kafka
+      ln -sf "${KAFKA_HOME}" "${{targets.contextdir}}/opt/kafka"
 
       # Remove JARs that Kafka already provides
-      rm ${{targets.destdir}}/usr/lib/kafka/libs/jackson-annotations-*.jar
-      rm ${{targets.destdir}}/usr/lib/kafka/libs/jackson-core-*.jar
-      rm ${{targets.destdir}}/usr/lib/kafka/libs/jackson-databind-*.jar
-      rm ${{targets.destdir}}/usr/lib/kafka/libs/jsr305-*.jar
-      rm ${{targets.destdir}}/usr/lib/kafka/libs/metrics-core-*.jar
+      rm "${{targets.contextdir}}/${KAFKA_HOME}"/libs/jackson-annotations-*.jar
+      rm "${{targets.contextdir}}/${KAFKA_HOME}"/libs/jackson-core-*.jar
+      rm "${{targets.contextdir}}/${KAFKA_HOME}"/libs/jackson-databind-*.jar
+      rm "${{targets.contextdir}}/${KAFKA_HOME}"/libs/jsr305-*.jar
+      rm "${{targets.contextdir}}/${KAFKA_HOME}"/libs/metrics-core-*.jar
 
 update:
   enabled: true

--- a/strimzi-kafka.yaml
+++ b/strimzi-kafka.yaml
@@ -72,6 +72,10 @@ pipeline:
       # Symlink KAFKA_HOME to /opt/kafka
       ln -sf "${KAFKA_HOME}" "${{targets.contextdir}}/opt/kafka"
 
+      # Symlink Kafka exporter to /opt/kafka-exporter
+      mkdir -p "${{targets.contextdir}}/opt/kafka-exporter"
+      ln -sf /usr/bin/kafka_exporter "${{targets.contextdir}}/opt/kafka-exporter/kafka_exporter"
+
       # Remove JARs that Kafka already provides
       rm "${{targets.contextdir}}/${KAFKA_HOME}"/libs/jackson-annotations-*.jar
       rm "${{targets.contextdir}}/${KAFKA_HOME}"/libs/jackson-core-*.jar

--- a/strimzi-kafka.yaml
+++ b/strimzi-kafka.yaml
@@ -56,7 +56,7 @@ pipeline:
       for component in kafka-agent mirror-maker-agent tracing-agent; do
         cd "./${component}"
         make java_install
-        cp "target/${component}-${{package.version}}.jar" "${{targets.contextdir}}/${KAFKA_HOME}/libs/"
+        cp target/*.jar "${{targets.contextdir}}/${KAFKA_HOME}/libs/"
         cd -
       done
 

--- a/strimzi-kafka.yaml
+++ b/strimzi-kafka.yaml
@@ -24,6 +24,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - curl
+      - kafka
       - make
       - maven
       - openjdk-17
@@ -78,11 +79,12 @@ pipeline:
       ln -sf /usr/bin/kafka_exporter "${{targets.contextdir}}/opt/kafka-exporter/kafka_exporter"
 
       # Remove JARs that Kafka already provides
-      rm "${{targets.contextdir}}/${KAFKA_HOME}"/libs/jackson-annotations-*.jar
-      rm "${{targets.contextdir}}/${KAFKA_HOME}"/libs/jackson-core-*.jar
-      rm "${{targets.contextdir}}/${KAFKA_HOME}"/libs/jackson-databind-*.jar
-      rm "${{targets.contextdir}}/${KAFKA_HOME}"/libs/jsr305-*.jar
-      rm "${{targets.contextdir}}/${KAFKA_HOME}"/libs/metrics-core-*.jar
+      cd "${{targets.contextdir}}/${KAFKA_HOME}/libs"
+      for jar in *.jar; do
+        if [[ -f "${KAFKA_HOME}/lib/${jar}" ]]; then
+          rm "${jar}"
+        fi
+      done
 
 update:
   enabled: true

--- a/strimzi-kafka.yaml
+++ b/strimzi-kafka.yaml
@@ -50,7 +50,7 @@ pipeline:
       for component in kafka-agent mirror-maker-agent tracing-agent; do
         cd ./${component}
         make java_install
-        cp /home/build/.m2/repository/io/strimzi/${component}/${{package.version}}/${component}-${{package.version}}.jar ${{targets.destdir}}/${KAFKA_HOME}/libs/
+        cp target/${component}-${{package.version}}.jar ${{targets.destdir}}/${KAFKA_HOME}/libs/
         cd -
       done
 

--- a/strimzi-kafka.yaml
+++ b/strimzi-kafka.yaml
@@ -10,6 +10,7 @@ package:
       - bash
       - cruise-control
       - kafka
+      - kafka_exporter
       - openjdk-17-jre
 
 environment:

--- a/strimzi-kafka.yaml
+++ b/strimzi-kafka.yaml
@@ -1,0 +1,60 @@
+package:
+  name: strimzi-kafka
+  version: 0.40.0
+  epoch: 0
+  description: Kafka addons for Strimzi
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - bash
+      - openjdk-17-jre
+
+environment:
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+    JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
+    KAFKA_HOME: /opt/kafka
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - gradle
+      - openjdk-17
+      - maven
+      - make
+      - zip
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/strimzi/strimzi-kafka-operator
+      tag: ${{package.version}}
+      expected-commit: 1b5ce127db873913923f267ed4e213c719179a59
+
+  - runs: |
+      cd ./docker-images/artifacts
+      mvn dependency:copy-dependencies ${MVN_ARGS} -f ./kafka-thirdparty-libs/3.7.x/pom.xml
+      mkdir -p ./binaries/kafka-thirdparty-libs
+      rm -f ./binaries/kafka-thirdparty-libs/${version_lib}.zip
+      zip -j ./binaries/kafka-thirdparty-libs/${version_lib}.zip kafka-thirdparty-libs/3.7.x/target/dependency/*
+      cd -
+
+      mkdir -p ${{targets.destdir}}/${KAFKA_HOME}/libs/
+
+      set -e
+      for component in kafka-agent mirror-maker-agent tracing-agent; do
+        cd ./${component}
+        make java_install
+        cp /home/build/.m2/repository/io/strimzi/${component}/${{package.version}}/${component}-${{package.version}}.jar ${{targets.destdir}}/${KAFKA_HOME}/libs/
+        cd -
+      done
+
+      cp ./docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh ${{targets.destdir}}/opt/kafka-exporter/kafka_exporter_run.sh
+
+update:
+  enabled: true
+  github:
+    identifier: strimzi/strimzi-kafka-operator
+    use-tag: true

--- a/strimzi-kafka.yaml
+++ b/strimzi-kafka.yaml
@@ -85,7 +85,7 @@ pipeline:
       # Remove JARs that Kafka already provides
       cd "${{targets.contextdir}}/${KAFKA_HOME}/libs"
       for jar in *.jar; do
-        if [[ -f "${KAFKA_HOME}/lib/${jar}" ]]; then
+        if [[ -f "${KAFKA_HOME}/libs/${jar}" ]]; then
           rm "${jar}"
         fi
       done

--- a/strimzi-kafka.yaml
+++ b/strimzi-kafka.yaml
@@ -15,15 +15,15 @@ environment:
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk
     JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
     KAFKA_HOME: /opt/kafka
+    HOME: /home/build
   contents:
     packages:
       - busybox
       - ca-certificates-bundle
       - curl
-      - gradle
-      - openjdk-17
-      - maven
       - make
+      - maven
+      - openjdk-17
       - zip
 
 pipeline:
@@ -34,16 +34,19 @@ pipeline:
       expected-commit: 1b5ce127db873913923f267ed4e213c719179a59
 
   - runs: |
+      set -e
+      mkdir -p ${{targets.destdir}}/${KAFKA_HOME}/libs/
+
+      # Build the Kafka thirdparty libs
       cd ./docker-images/artifacts
       mvn dependency:copy-dependencies ${MVN_ARGS} -f ./kafka-thirdparty-libs/3.7.x/pom.xml
       mkdir -p ./binaries/kafka-thirdparty-libs
-      rm -f ./binaries/kafka-thirdparty-libs/${version_lib}.zip
-      zip -j ./binaries/kafka-thirdparty-libs/${version_lib}.zip kafka-thirdparty-libs/3.7.x/target/dependency/*
+      rm -f ./binaries/kafka-thirdparty-libs/3.7.x.zip
+      zip -j ./binaries/kafka-thirdparty-libs/3.7.x.zip kafka-thirdparty-libs/3.7.x/target/dependency/*
+      cp kafka-thirdparty-libs/3.7.x/target/dependency/* ${{targets.destdir}}/${KAFKA_HOME}/libs/
       cd -
 
-      mkdir -p ${{targets.destdir}}/${KAFKA_HOME}/libs/
-
-      set -e
+      # Build the strimzi agents
       for component in kafka-agent mirror-maker-agent tracing-agent; do
         cd ./${component}
         make java_install
@@ -51,6 +54,8 @@ pipeline:
         cd -
       done
 
+      # Copy the Kafka exporter scripts
+      mkdir -p ${{targets.destdir}}/opt/kafka-exporter
       cp ./docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh ${{targets.destdir}}/opt/kafka-exporter/kafka_exporter_run.sh
 
 update:

--- a/strimzi-kafka.yaml
+++ b/strimzi-kafka.yaml
@@ -8,13 +8,15 @@ package:
   dependencies:
     runtime:
       - bash
+      - cruise-control
+      - kafka
       - openjdk-17-jre
 
 environment:
   environment:
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk
     JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
-    KAFKA_HOME: /opt/kafka
+    KAFKA_HOME: /usr/lib/kafka
     HOME: /home/build
   contents:
     packages:
@@ -35,7 +37,8 @@ pipeline:
 
   - runs: |
       set -e
-      mkdir -p ${{targets.destdir}}/${KAFKA_HOME}/libs/
+      mkdir -p ${{targets.destdir}}/opt
+      mkdir -p ${{targets.destdir}}/${KAFKA_HOME}/libs
 
       # Build the Kafka thirdparty libs
       cd ./docker-images/artifacts
@@ -57,6 +60,9 @@ pipeline:
       # Copy the Kafka exporter scripts
       mkdir -p ${{targets.destdir}}/opt/kafka-exporter
       cp ./docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh ${{targets.destdir}}/opt/kafka-exporter/kafka_exporter_run.sh
+
+      # Symlink KAFKA_HOME to /opt/kafka
+      ln -sf "${KAFKA_HOME}" ${{targets.destdir}}/opt/kafka
 
 update:
   enabled: true

--- a/strimzi-kafka.yaml
+++ b/strimzi-kafka.yaml
@@ -17,6 +17,7 @@ environment:
   environment:
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk
     JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
+    CC_HOME: /usr/lib/cruise-control
     KAFKA_HOME: /usr/lib/kafka
     HOME: /home/build
   contents:
@@ -68,8 +69,8 @@ pipeline:
       cp -r ./docker-images/kafka-based/kafka/exporter-scripts/* "${{targets.contextdir}}/opt/kafka-exporter/"
 
       # Copy the Cruise Control scripts
-      mkdir -p "${{targets.contextdir}}/opt/cruise-control"
-      cp -r ./docker-images/kafka-based/kafka/cruise-control-scripts/* "${{targets.contextdir}}/opt/cruise-control/"
+      mkdir -p "${{targets.contextdir}}/${CC_HOME}"
+      cp -r ./docker-images/kafka-based/kafka/cruise-control-scripts/* "${{targets.contextdir}}/${CC_HOME}/"
 
       # Symlink KAFKA_HOME to /opt/kafka
       ln -sf "${KAFKA_HOME}" "${{targets.contextdir}}/opt/kafka"
@@ -77,6 +78,9 @@ pipeline:
       # Symlink Kafka exporter to /opt/kafka-exporter
       mkdir -p "${{targets.contextdir}}/opt/kafka-exporter"
       ln -sf /usr/bin/kafka_exporter "${{targets.contextdir}}/opt/kafka-exporter/kafka_exporter"
+
+      # Symlink CC_HOME to /opt/cruise-control
+      ln -sf "${CC_HOME}" "${{targets.contextdir}}/opt/cruise-control"
 
       # Remove JARs that Kafka already provides
       cd "${{targets.contextdir}}/${KAFKA_HOME}/libs"


### PR DESCRIPTION
strimzi agents: https://github.com/strimzi/strimzi-kafka-operator/blob/a13058f2543aff1bc19c66a12c898b3aa976dd1d/docker-images/kafka-based/kafka/Dockerfile#L73-L78

The intention is for this package + kafka + kafka_exporter to become an image compatible with quay.io/strimzi/kafka

TODO:
- [x] cruise control agent
- [x] third party libs
