### PR TITLE
Add build dependency on npm for packages that did not have it.

### DIFF
--- a/eslint.yaml
+++ b/eslint.yaml
@@ -1,7 +1,7 @@
 package:
   name: eslint
   version: 8.57.0
-  epoch: 0
+  epoch: 1
   description: An AST-based pattern checker for JavaScript
   copyright:
     - license: MIT
@@ -16,6 +16,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - nodejs
+      - npm
       - rsync
       - wolfi-base
 

--- a/hubble-ui.yaml
+++ b/hubble-ui.yaml
@@ -1,7 +1,7 @@
 package:
   name: hubble-ui
   version: 0.13.0
-  epoch: 3
+  epoch: 4
   description: "Observability & troubleshooting for Kubernetes services"
   copyright:
     - license: "Apache-2.0"
@@ -21,6 +21,7 @@ environment:
       - git
       - go
       - nodejs
+      - npm
       # node-gyp currently needs 3.11: https://github.com/nodejs/node-gyp/issues/2869
       - python-3.11
       - wolfi-baselayout

--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-centraldashboard
   version: 1.8.0
-  epoch: 1
+  epoch: 2
   description: Landing page and central dashboard for Kubeflow deployments
   copyright:
     - license: MIT
@@ -15,6 +15,7 @@ environment:
       - git
       - jq
       - nodejs-18
+      - npm
       - openssl
       - wolfi-base
 

--- a/kubeflow-jupyter-web-app.yaml
+++ b/kubeflow-jupyter-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-jupyter-web-app
   version: 1.8.0
-  epoch: 4
+  epoch: 5
   description: Kubeflow jupyter web app component
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,7 @@ environment:
       - ca-certificates-bundle
       - cython
       - nodejs-16
+      - npm
       - openssl
       - py3-pip
       - py3-setuptools

--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: 2.0.5
-  epoch: 5
+  epoch: 6
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -23,6 +23,7 @@ environment:
       - jq
       - kubectl
       - nodejs
+      - npm
       - py3-gpep517
       - py3-pip
       - py3-setuptools

--- a/kubeflow-volumes-web-app.yaml
+++ b/kubeflow-volumes-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-volumes-web-app
   version: 1.8.0
-  epoch: 4
+  epoch: 5
   description: Kubeflow volumes web app component
   copyright:
     - license: Apache-2.0
@@ -19,6 +19,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - nodejs-16
+      - npm
       - openssl
       - py3-pip
       - py3-setuptools

--- a/kubernetes-dashboard.yaml
+++ b/kubernetes-dashboard.yaml
@@ -2,7 +2,7 @@ package:
   name: kubernetes-dashboard
   # When bumping, check to see if the GHSA mitigations below can be removed.
   version: 2.7.0
-  epoch: 13
+  epoch: 14
   description: General-purpose web UI for Kubernetes clusters
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,7 @@ environment:
       - curl
       - go
       - nodejs
+      - npm
       - perl
       - posix-libc-utils
       - yarn

--- a/kyverno-policy-reporter-ui.yaml
+++ b/kyverno-policy-reporter-ui.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-policy-reporter-ui
   version: 1.9.2
-  epoch: 2
+  epoch: 3
   description: Policy Reporter UI
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ environment:
       - go
       - node-gyp
       - nodejs-18
+      - npm
       - openssl
       - python-3.11
       - wolfi-baselayout

--- a/lerna.yaml
+++ b/lerna.yaml
@@ -1,7 +1,7 @@
 package:
   name: lerna
   version: 8.1.2
-  epoch: 0
+  epoch: 1
   description: "Lerna is a fast, modern build system for managing and publishing multiple JavaScript/TypeScript packages from the same repository."
   copyright:
     - license: MIT
@@ -20,6 +20,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - nodejs
+      - npm
       - py3-setuptools
       - python3
 

--- a/node-gyp.yaml
+++ b/node-gyp.yaml
@@ -1,7 +1,7 @@
 package:
   name: node-gyp
   version: 10.1.0
-  epoch: 0
+  epoch: 1
   description: "the npm package manager for javascript, mainline"
   copyright:
     - license: Artistic-2.0
@@ -14,6 +14,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - nodejs
+      - npm
 
 pipeline:
   - name: npm install

--- a/npm-async.yaml
+++ b/npm-async.yaml
@@ -1,7 +1,7 @@
 package:
   name: npm-async
   version: 3.2.5
-  epoch: 0
+  epoch: 1
   description: "Async is a utility module which provides straight-forward, powerful functions for working with asynchronous JavaScript"
   copyright:
     - license: MIT
@@ -17,6 +17,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - nodejs
+      - npm
 
 pipeline:
   - name: npm install

--- a/npm-lodash.yaml
+++ b/npm-lodash.yaml
@@ -1,7 +1,7 @@
 package:
   name: npm-lodash
   version: 4.17.21
-  epoch: 0
+  epoch: 1
   description: "A modern JavaScript utility library delivering modularity, performance & extras"
   copyright:
     - license: MIT
@@ -17,6 +17,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - nodejs
+      - npm
 
 pipeline:
   - name: npm install

--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-dashboards-2
   version: 2.12.0
-  epoch: 0
+  epoch: 1
   description: Open source visualization dashboards for OpenSearch
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,7 @@ environment:
       - git
       - node-gyp
       - nodejs-18
+      - npm
       - posix-libc-utils
       - py3-setuptools
       - python3

--- a/playwright.yaml
+++ b/playwright.yaml
@@ -1,7 +1,7 @@
 package:
   name: playwright
   version: 1.42.1
-  epoch: 0
+  epoch: 1
   description: "Framework for Web Testing and Automation. It allows testing Chromium, Firefox and WebKit with a single API"
   copyright:
     - license: Apache-2.0
@@ -15,6 +15,7 @@ environment:
       - build-base
       - busybox
       - nodejs
+      - npm
 
 pipeline:
   - name: npm install

--- a/renovate.yaml
+++ b/renovate.yaml
@@ -1,7 +1,7 @@
 package:
   name: renovate
   version: 37.273.0
-  epoch: 0
+  epoch: 1
   description: "Automated dependency updates. Multi-platform and multi-language."
   copyright:
     - license: AGPL-3.0-only
@@ -21,6 +21,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - nodejs
+      - npm
 
 pipeline:
   - name: npm install

--- a/vite.yaml
+++ b/vite.yaml
@@ -1,7 +1,7 @@
 package:
   name: vite
   version: 5.2.6
-  epoch: 0
+  epoch: 1
   description: Vite (French word for "quick", pronounced /vit/, like "veet") is a build tool that aims to provide a faster and leaner development experience for modern web projects.
   copyright:
     - license: MIT
@@ -17,6 +17,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - nodejs
+      - npm
 
 pipeline:
   - name: npm install


### PR DESCRIPTION
We removed npm as a dependency of node in #13926 .  These packages were getting and using npm as a result of a nodejs dependency in their build environment.