### PR TITLE
fix(openjdk): remove the prerelease suffix from Java 21 and 22

### DIFF
--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-21
   version: 21.0.2
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: GPL-2.0-or-later
@@ -77,6 +77,7 @@ pipeline:
         --with-giflib=system \
         --with-lcms=system \
         --with-gtest="/home/build/googletest" \
+        --with-version-pre="no" \
         --with-version-string=""
 
   - runs: make jdk-image

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -37,6 +37,9 @@ environment:
       - openjdk-20
       - openjdk-20-default-jvm
       - zip
+    environment:
+      # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
+      SOURCE_DATE_EPOCH: 315532900
 
 pipeline:
   - uses: git-checkout

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -37,9 +37,9 @@ environment:
       - openjdk-20
       - openjdk-20-default-jvm
       - zip
-    environment:
-      # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
-      SOURCE_DATE_EPOCH: 315532900
+  environment:
+    # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
+    SOURCE_DATE_EPOCH: 315532900
 
 pipeline:
   - uses: git-checkout

--- a/openjdk-22.yaml
+++ b/openjdk-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-22
   version: 22.0.0
-  epoch: 0
+  epoch: 1
   description: OpenJDK 22
   copyright:
     - license: GPL-2.0-or-later
@@ -88,6 +88,7 @@ pipeline:
         --with-giflib=system \
         --with-lcms=system \
         --with-gtest="/home/build/googletest" \
+        --with-version-pre="no" \
         --with-version-string=""
 
   - runs: make jdk-image


### PR DESCRIPTION
Our packages for Java 21 and 22 currently have a prerelease suffix of `-internal` being shown. Remove that with automake `--with-version-pre=no` option.