### PR TITLE
fix(glibc): Split additional locales into subpackages, add locale test

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.39
-  epoch: 0
+  epoch: 1
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later
@@ -171,6 +171,7 @@ data:
       fur: Friulian
       fy: Western Frisian
       ga: Irish
+      gbm: Garhwali
       gd: Scottish Gaelic
       gez: Geez
       gl: Galician
@@ -205,6 +206,7 @@ data:
       ko: Korean
       ks: Kashmiri
       ku: Kurdish
+      kv: Komi
       kw: Cornish
       ky: Kyrgyz
       lb: Luxembourgish
@@ -276,7 +278,9 @@ data:
       sq: Albanian
       sr: Serbian
       ss: Swati
+      ssy: Swaho
       st: Southern Sotho
+      su: Sundanese
       sv: Swedish
       sw: Swahili
       syr: Syriac
@@ -293,6 +297,7 @@ data:
       tl: Tagalog
       tn: Tswana
       to: Tongan
+      tok: Toki Pona
       tpi: Tok Pisin
       tr: Turkish
       ts: Tsonga
@@ -313,6 +318,7 @@ data:
       yo: Yoruba
       yue: Cantonese
       yuw: Yau
+      zgh: Moroccan Berber
       zh: Mandarin Chinese
       zu: Zulu
 
@@ -510,6 +516,20 @@ subpackages:
     checks:
       disabled:
         - empty
+
+test:
+  pipeline:
+    - runs: |
+        # Ensure locales are excluded from glibc
+        cd /usr/lib/locale
+        locales=$(ls | grep -v C.utf8 || true)
+
+        if [[ -n "${locales}" ]]; then
+          for locale in "${locales}"; do
+            echo "Error: locale $locale found in main package, please add to locale list"
+          done
+          exit 1
+        fi
 
 update:
   enabled: true


### PR DESCRIPTION
Fixes: Splits recently introduced locales into their own respective subpackages and tests for locales in the main glibc package