### PR TITLE
feat: get hints for failed builds from Open AI on presubmits that are created from a branch, not a fork

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -81,7 +81,7 @@ jobs:
             runner: ubuntu-arm-16-cores
             oci: arm64
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: changes
     outputs:
       packages_were_built: ${{ steps.file_check.outputs.exists }}
@@ -149,40 +149,57 @@ jobs:
 
             mkdir -p .melangecache
             for package in ${{needs.changes.outputs.packages}}; do
-              make MELANGE_EXTRA_OPTS="--out-dir=/tmp/ --create-build-log --cache-dir=.melangecache" REPO="./packages" package/\$package -j1 2>&1 | tee /tmp/${package}.log
+              # use a script so we can log to standard out and a file, plus keep the exit code for the package build
+              ./build_and_log.sh "\${package}"
               make MELANGE_EXTRA_OPTS="--runner docker" REPO="./packages" "test/\$package" -j1
             done
 
-      - name: Print package log with the errors
-        run: |
-          for package in ${{needs.changes.outputs.packages}}; do
-            cat /tmp/${package}.log
-          done
+      - name: Check OPENAISECRET presence
+        id: check_secret
         if: failure()
+        run: |
+          if [ -z "${{ secrets.OPENAISECRET }}" ]; then
+            echo "OPENAISECRET_PRESENT=false" >> $GITHUB_ENV
+          else
+            echo "OPENAISECRET_PRESENT=true" >> $GITHUB_ENV
+          fi
 
       - name: Install gptscript
-        uses: hectorj2f/gptscript-installer@fix_installer
-        if: failure()
+        continue-on-error: true
+        uses: cpanato/gptscript-installer@f72d33f0b8f9d6e5c71704a553d7183705a57f74 # v0.2.2
+        if: failure() && env.OPENAISECRET_PRESENT == 'true'
 
       - name: Run gptscript against the build log
         id: gptscript
+        continue-on-error: true
         run:  |
           for package in ${{needs.changes.outputs.packages}}; do
-            pkgVersion=$(melange package-version ${package}.yaml)
-            # Use only the last 500 lines of the build log.
-            tail -n 500 /tmp/${package}.log >> ${package}.log
-            echo "Calling GTPScript..."
-            echo "GPTScript suggestions to solve the error while building the package ${package}:" >> wolfi-packages.log
-            gptscript $GITHUB_WORKSPACE/gptscripts/wolfi-logs.gpt $(pwd)/${package}.log $package >> wolfi-packages.log
+            # if error log file exists 
+            if [ -f /temp/${package}.error.log ]; then
+              # Use only the last 150 lines of the build log.
+              tail -n 200 /temp/${package}.error.log >> ${package}.log
+              echo "Calling GTPScript..."
+              echo "GPTScript suggestions to solve the error while building the package ${package}:" >> wolfi-packages.log
+              gptscript gptscripts/wolfi-logs.gpt $(pwd)/${package}.log $package >> wolfi-packages.log
+            fi
           done
-        if: failure() && matrix.arch == 'x86_64'
+        if: failure() && matrix.arch == 'x86_64' && env.OPENAISECRET_PRESENT == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAISECRET }}
 
+      - name: Check for chatgpt response
+        id: file_check_gpt_log
+        if: failure() && matrix.arch == 'x86_64' && env.OPENAISECRET_PRESENT == 'true'
+        run: |
+          if test -f "wolfi-packages.log"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: GPTScript PR comment diff
-        if: failure() && matrix.arch == 'x86_64'
+        if: failure() && matrix.arch == 'x86_64'&& env.OPENAISECRET_PRESENT == 'true' && steps.file_check_gpt_log.outputs.exists == 'true'
         uses: thollander/actions-comment-pull-request@632cf9ce90574d125be56b5f3405cda41a84e2fd # v2.3.1
-        # We're seeing jobs using merge queues fail
         continue-on-error: true
         with:
           filePath: wolfi-packages.log

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -81,7 +81,7 @@ jobs:
             runner: ubuntu-arm-16-cores
             oci: arm64
       fail-fast: false
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
     needs: changes
     outputs:
       packages_were_built: ${{ steps.file_check.outputs.exists }}
@@ -149,9 +149,44 @@ jobs:
 
             mkdir -p .melangecache
             for package in ${{needs.changes.outputs.packages}}; do
-              make MELANGE_EXTRA_OPTS="--create-build-log --cache-dir=.melangecache" REPO="./packages" package/\$package -j1
+              make MELANGE_EXTRA_OPTS="--out-dir=/tmp/ --create-build-log --cache-dir=.melangecache" REPO="./packages" package/\$package -j1 2>&1 | tee /tmp/${package}.log
               make MELANGE_EXTRA_OPTS="--runner docker" REPO="./packages" "test/\$package" -j1
             done
+
+      - name: Print package log with the errors
+        run: |
+          for package in ${{needs.changes.outputs.packages}}; do
+            cat /tmp/${package}.log
+          done
+        if: failure()
+
+      - name: Install gptscript
+        uses: hectorj2f/gptscript-installer@fix_installer
+        if: failure()
+
+      - name: Run gptscript against the build log
+        id: gptscript
+        run:  |
+          for package in ${{needs.changes.outputs.packages}}; do
+            pkgVersion=$(melange package-version ${package}.yaml)
+            # Use only the last 500 lines of the build log.
+            tail -n 500 /tmp/${package}.log >> ${package}.log
+            echo "Calling GTPScript..."
+            echo "GPTScript suggestions to solve the error while building the package ${package}:" >> wolfi-packages.log
+            gptscript $GITHUB_WORKSPACE/gptscripts/wolfi-logs.gpt $(pwd)/${package}.log $package >> wolfi-packages.log
+          done
+        if: failure() && matrix.arch == 'x86_64'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAISECRET }}
+
+      - name: GPTScript PR comment diff
+        if: failure() && matrix.arch == 'x86_64'
+        uses: thollander/actions-comment-pull-request@632cf9ce90574d125be56b5f3405cda41a84e2fd # v2.3.1
+        # We're seeing jobs using merge queues fail
+        continue-on-error: true
+        with:
+          filePath: wolfi-packages.log
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Check that packages can be installed with apk add"
         uses: ./.github/actions/docker-run

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -89,6 +89,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # so we have permission to comment on pull requests
+      id-token: write # so we can securly fetch the openai secret from the secrets store
 
     steps:
       - name: Harden Runner
@@ -154,20 +155,25 @@ jobs:
               make MELANGE_EXTRA_OPTS="--runner docker" REPO="./packages" "test/\$package" -j1
             done
 
-      - name: Check OPENAISECRET presence
-        id: check_secret
-        if: failure()
-        run: |
-          if [ -z "${{ secrets.OPENAISECRET }}" ]; then
-            echo "OPENAISECRET_PRESENT=false" >> $GITHUB_ENV
-          else
-            echo "OPENAISECRET_PRESENT=true" >> $GITHUB_ENV
-          fi
+      # This is managed here: https://github.com/chainguard-dev/secrets/blob/main/wolfi-dev.tf
+      - uses: google-github-actions/auth@a6e2e39c0a0331da29f7fd2c2a20a427e8d3ad1f # v2.1.1
+        id: auth
+        with:
+          workload_identity_provider: "projects/12758742386/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "wolfi-dev@chainguard-github-secrets.iam.gserviceaccount.com"
+      - uses: google-github-actions/setup-gcloud@5a5f7b85fca43e76e53463acaa9d408a03c98d3a # v2.0.1
+        with:
+          project_id: "chainguard-github-secrets"
+      - uses: 'google-github-actions/get-secretmanager-secrets@ae0d4054c32840e2ced71207a9df55161ae3debc' # v2.0.0
+        id: secrets
+        with:
+          secrets: |-
+            token:chainguard-github-secrets/openai-secret
 
       - name: Install gptscript
         continue-on-error: true
         uses: cpanato/gptscript-installer@f72d33f0b8f9d6e5c71704a553d7183705a57f74 # v0.2.2
-        if: failure() && env.OPENAISECRET_PRESENT == 'true'
+        if: failure() && steps.secrets.outputs.token != ''
 
       - name: Run gptscript against the build log
         id: gptscript
@@ -183,13 +189,13 @@ jobs:
               gptscript gptscripts/wolfi-logs.gpt $(pwd)/${package}.log $package >> wolfi-packages.log
             fi
           done
-        if: failure() && matrix.arch == 'x86_64' && env.OPENAISECRET_PRESENT == 'true'
+        if: failure() && matrix.arch == 'x86_64' steps.secrets.outputs.token != ''
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAISECRET }}
+          OPENAI_API_KEY: steps.secrets.outputs.token
 
       - name: Check for chatgpt response
         id: file_check_gpt_log
-        if: failure() && matrix.arch == 'x86_64' && env.OPENAISECRET_PRESENT == 'true'
+        if: failure() && matrix.arch == 'x86_64' steps.secrets.outputs.token != ''
         run: |
           if test -f "wolfi-packages.log"; then
             echo "exists=true" >> $GITHUB_OUTPUT
@@ -198,7 +204,7 @@ jobs:
           fi
 
       - name: GPTScript PR comment diff
-        if: failure() && matrix.arch == 'x86_64'&& env.OPENAISECRET_PRESENT == 'true' && steps.file_check_gpt_log.outputs.exists == 'true'
+        if: failure() && matrix.arch == 'x86_64'&& steps.secrets.outputs.token != '' && steps.file_check_gpt_log.outputs.exists == 'true'
         uses: thollander/actions-comment-pull-request@632cf9ce90574d125be56b5f3405cda41a84e2fd # v2.3.1
         continue-on-error: true
         with:

--- a/build_and_log.sh
+++ b/build_and_log.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# The first argument is the package name
+package=$1
+
+echo "Building package $package"
+
+# Run the command and pipe its output. Use a subshell if necessary.
+make MELANGE_EXTRA_OPTS="--create-build-log --cache-dir=.melangecache" REPO="./packages" package/$package -j1 2>&1 | tee /tmp/build.log
+
+# Immediately capture the PIPESTATUS of the make command, we don't want the exit code of the tee command
+exit_code=${PIPESTATUS[0]}
+
+# Act on the exit code from the make command
+if [ "$exit_code" -ne 0 ]; then
+    # Move the build log to the $TMPDIR directory so it can be used in a subsequent step
+    mv /tmp/build.log $TMPDIR/$package.error.log
+    exit $exit_code
+fi

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-helm-controller
   version: 0.37.4
-  epoch: 5
+  epoch: 6
   description: The GitOps Toolkit Helm reconciler, for declarative Helming
   copyright:
     - license: Apache-2.0
@@ -21,10 +21,6 @@ pipeline:
       expected-commit: 0114b20936a970d149d83b59b6ab965a956ad811
       repository: https://github.com/fluxcd/helm-controller
       tag: v${{package.version}}
-
-  - uses: patch
-    with:
-      patches: rest-mapper.patch
 
   - uses: go/bump
     with:

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-helm-controller
   version: 0.37.4
-  epoch: 6
+  epoch: 5
   description: The GitOps Toolkit Helm reconciler, for declarative Helming
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,10 @@ pipeline:
       expected-commit: 0114b20936a970d149d83b59b6ab965a956ad811
       repository: https://github.com/fluxcd/helm-controller
       tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      patches: rest-mapper.patch
 
   - uses: go/bump
     with:

--- a/gptscripts/wolfi-logs.gpt
+++ b/gptscripts/wolfi-logs.gpt
@@ -1,0 +1,28 @@
+tools: wolfi-gpt-engineer
+args: project: The name of the project.
+args: file_path: The file path of the raw log.
+
+Tell me more about the log in the error logs in ${file_path} for the project ${project}.
+
+---
+name: wolfi-gpt-engineer
+description: Analyze the log output when building a Wolfi package
+args: file_path: The file path of the raw log.
+args: project: The name of the project.
+tools: sys.read, sys.find, sys.write, investigate, sys.abort
+
+When analyzing the log, follow these steps in strict order:
+1. Read the last 280 lines of file in ${file_path} and extract the error message from its content.
+2. Call investigate to explain how to fix the errors.
+
+---
+name: investigate
+args: error: the error log of the project.
+args: project: The name of the project.
+description: Explain how to fix the error by analyzing the message.
+
+As an AI expert and extremely intelligent engineering assistant focusing on the ${project} GitHub repository,
+your key role is to engage with engineers, offering precise and reliable
+information about the following error message delimited by triple dashes written in  --- ${error} ---.
+Your responses should be concise yet thorough, backed by diligent verification.
+Provide detailed suggestions on how to fix this error in a step by step style in no more than 500 characters.


### PR DESCRIPTION
The bulk of this work comes from @hectorj2f 🙏

We get a fairly large number of Pull Requests that fail presubmit checks. It can be a little hard to parse logs with human eyes from every build system and language ecosystem, let's try using machines 🤖!

This feature is an initial pass at getting automated hints from Open AI based on failed build logs, these suggested hints are posted back to the PR as a comment. The aim is to reduce the initial time it takes to understand what the error may be and consider possible fixes.

E.g.
<img width="934" alt="Screenshot 2024-03-29 at 10 33 45" src="https://github.com/wolfi-dev/os/assets/1457180/767e1b89-9df9-4fd4-9df0-676aee5d492e">

As a secret is required to interact withe the Open AI API, this feature is only available for PRs created from a branch on the main repo, not forks. This means it will work with the automation that we have in Wolfi for package updates and CVE remediation but not outside contributions. For now at least, options to move out of GitHub Actions in the future if this feature proves useful.

One slightly annoying this is I had to move the make foo command that performs the build into a script so we can both log to standard out AND log to a file that we can trim and send to the Open AI endpoint.

Note, these presubmit jobs are likely to change to using a parallel build system in the near future so we will need to change how we collect failed build logs. I'm hoping that until then, we can merge this and get real world feedback on how affective this approach of automated hints can be.