### PR TITLE
`bincapz`: add package

### DIFF
--- a/bincapz.yaml
+++ b/bincapz.yaml
@@ -1,0 +1,65 @@
+package:
+  name: bincapz
+  version: 0.7.0
+  epoch: 0
+  description: enumerate binary capabilities, including malicious behaviors
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+      - yara
+
+environment:
+  contents:
+    packages:
+      - openssl-dev
+      - yara-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/chainguard-dev/bincapz/archive/v${{package.version}}/v${{package.version}}.tar.gz
+      expected-sha256: 860f569631174659bd251b323e489bb919f7f25f4fe4f1514776f2dd639a55dc
+
+  - uses: go/build
+    with:
+      packages: .
+      ldflags: -s -w
+      output: bincapz
+
+  - uses: strip
+
+test:
+  environment:
+    contents:
+      packages:
+        - openssl
+        - crane
+  pipeline:
+    - name: Verify bincapz on itself
+      runs: |
+        set -o pipefail
+        bincapz /usr/bin/bincapz | grep Risk: | grep 4/CRITICAL
+    - name: Verify bincapz on yara
+      runs: |
+        set -o pipefail
+        bincapz /usr/bin/yara | grep Risk: | grep 1/LOW
+    - name: Verify bincapz on openssl
+      runs: |
+        set -o pipefail
+        bincapz /usr/bin/openssl | grep Risk: | grep 2/MEDIUM
+    - name: Verify bincapz on crane
+      runs: |
+        set -o pipefail
+        bincapz /usr/bin/crane | grep Risk: | grep 2/MEDIUM
+    - name: Verify bincapz diff
+      runs: |
+        set -o pipefail
+        bincapz -diff /usr/bin/openssl /usr/bin/crane | grep "[+]2/MED.*archives/zip"
+
+update:
+  enabled: true
+  github:
+    identifier: chainguard-dev/bincapz
+    strip-prefix: v


### PR DESCRIPTION
This adds a Wolfi package for `bincapz`

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
