### PR TITLE
xcaddy: init at 0.3.5

### DIFF
--- a/xcaddy.yaml
+++ b/xcaddy.yaml
@@ -1,0 +1,48 @@
+package:
+  name: xcaddy
+  version: 0.3.5
+  epoch: 0
+  description: Build Caddy with plugins
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 4227917de22c3ba072ba68aecaa7f48eb34e7b8f
+      repository: https://github.com/caddyserver/xcaddy
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      ldflags: -s -w
+      output: xcaddy
+      packages: ./cmd/xcaddy
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: caddyserver/xcaddy
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+        - go
+  pipeline:
+    - runs: |
+        export GOPATH=/tmp
+        export GOCACHE=/tmp
+        xcaddy build \
+          --with github.com/caddyserver/ntlm-transport
+        ./caddy -v


### PR DESCRIPTION
I can use then xcaddy in my own package to build a custom variant of caddy server with more modules

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
