### PR TITLE
adds postgres-operator package

### DIFF
--- a/postgres-operator.yaml
+++ b/postgres-operator.yaml
@@ -1,0 +1,51 @@
+package:
+  name: postgres-operator
+  version: 1.11.0
+  epoch: 0
+  description: Postgres operator creates and manages PostgreSQL clusters running in Kubernetes
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 0f96eb20bfcc7381dacf0ec673e7d0824f442570
+      repository: https://github.com/zalando/postgres-operator.git
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd
+      output: postgres-operator
+      ldflags: -X=main.version=${{package.version}}
+
+  - uses: strip
+
+subpackages:
+  - name: postgres-operator-compat
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          # The helm chart/dockerfile expects the postgres-operator binaries to be in / instead of /usr/bin
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/postgres-operator ${{targets.subpkgdir}}/postgres-operator
+
+update:
+  enabled: true
+  github:
+    identifier: zalando/postgres-operator
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        /usr/bin/postgres-operator --help


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
