### PR TITLE
php: add shmop, sysvsem, sysvshm and sysvmsg as core extensions

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: "8.1.32"
-  epoch: 40
+  epoch: 41
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -34,6 +34,7 @@ environment:
       - gmp-dev
       - icu-dev
       - libavif-dev
+      - libffi-dev
       - libjpeg-turbo-dev
       - libpng-dev
       - libsodium-dev
@@ -136,7 +137,12 @@ pipeline:
         --enable-xmlwriter=shared \
         --enable-posix=shared \
         --with-pgsql=shared \
-        --with-zip=shared
+        --with-zip=shared \
+        --enable-shmop=shared \
+        --enable-sysvsem=shared \
+        --enable-sysvshm=shared \
+        --enable-sysvmsg=shared \
+        --with-ffi=shared
 
   - uses: autoconf/make
 
@@ -180,6 +186,10 @@ data:
       dom: DOM
       pgsql: PostgreSQL
       posix: Posix
+      shmop: shmop
+      sysvmsg: sysvmsg
+      sysvsem: sysvsem
+      sysvshm: sysvshm
       simplexml: SimpleXML
       mysqli: MySQLi
       xml: XML
@@ -189,6 +199,7 @@ data:
       zip: Zip
       odbc: UnixODBC
       ftp: FTP
+      ffi: FFI
 
 subpackages:
   - name: ${{package.name}}-config

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: "8.2.28"
-  epoch: 40
+  epoch: 41
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -34,6 +34,7 @@ environment:
       - gmp-dev
       - icu-dev
       - libavif-dev
+      - libffi-dev
       - libjpeg-turbo-dev
       - libpng-dev
       - libpsl-dev
@@ -131,7 +132,12 @@ pipeline:
         --enable-xmlwriter=shared \
         --enable-posix=shared \
         --with-pgsql=shared \
-        --with-zip=shared
+        --with-zip=shared \
+        --enable-shmop=shared \
+        --enable-sysvsem=shared \
+        --enable-sysvshm=shared \
+        --enable-sysvmsg=shared \
+        --with-ffi=shared
 
   - uses: autoconf/make
 
@@ -175,6 +181,10 @@ data:
       dom: DOM
       pgsql: PostgreSQL
       posix: Posix
+      shmop: shmop
+      sysvmsg: sysvmsg
+      sysvsem: sysvsem
+      sysvshm: sysvshm
       simplexml: SimpleXML
       mysqli: MySQLi
       xml: XML
@@ -184,6 +194,7 @@ data:
       zip: Zip
       odbc: UnixODBC
       ftp: FTP
+      ffi: FFI
 
 subpackages:
   - name: ${{package.name}}-config

--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: "8.3.20"
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -40,6 +40,7 @@ environment:
       - gmp-dev
       - icu-dev
       - libavif-dev
+      - libffi-dev
       - libjpeg-turbo-dev
       - libpng-dev
       - libpsl-dev
@@ -136,7 +137,12 @@ pipeline:
         --enable-xmlwriter=shared \
         --enable-posix=shared \
         --with-pgsql=shared \
-        --with-zip=shared
+        --with-zip=shared \
+        --enable-shmop=shared \
+        --enable-sysvsem=shared \
+        --enable-sysvshm=shared \
+        --enable-sysvmsg=shared \
+        --with-ffi=shared
 
   - uses: autoconf/make
 
@@ -180,6 +186,10 @@ data:
       dom: DOM
       pgsql: PostgreSQL
       posix: Posix
+      shmop: shmop
+      sysvmsg: sysvmsg
+      sysvsem: sysvsem
+      sysvshm: sysvshm
       simplexml: SimpleXML
       mysqli: MySQLi
       xml: XML
@@ -189,6 +199,7 @@ data:
       zip: Zip
       odbc: UnixODBC
       ftp: FTP
+      ffi: FFI
 
 subpackages:
   - name: ${{package.name}}-config

--- a/php-8.4.yaml
+++ b/php-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4
   version: "8.4.6"
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -40,6 +40,7 @@ environment:
       - gmp-dev
       - icu-dev
       - libavif-dev
+      - libffi-dev
       - libjpeg-turbo-dev
       - libpng-dev
       - libpsl-dev
@@ -136,7 +137,12 @@ pipeline:
         --enable-xmlwriter=shared \
         --enable-posix=shared \
         --with-pgsql=shared \
-        --with-zip=shared
+        --with-zip=shared \
+        --enable-shmop=shared \
+        --enable-sysvsem=shared \
+        --enable-sysvshm=shared \
+        --enable-sysvmsg=shared \
+        --with-ffi=shared
 
   - uses: autoconf/make
 
@@ -180,6 +186,10 @@ data:
       dom: DOM
       pgsql: PostgreSQL
       posix: Posix
+      shmop: shmop
+      sysvmsg: sysvmsg
+      sysvsem: sysvsem
+      sysvshm: sysvshm
       simplexml: SimpleXML
       mysqli: MySQLi
       xml: XML
@@ -189,6 +199,7 @@ data:
       zip: Zip
       odbc: UnixODBC
       ftp: FTP
+      ffi: FFI
 
 subpackages:
   - name: ${{package.name}}-config


### PR DESCRIPTION
Added some missing bundled PHP packages: shmop, sysvsem, sysvshm, sysvmsg

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
