### PR TITLE
newrelic-fluent-bit-output: Bump to latest go

### DIFF
--- a/newrelic-fluent-bit-output.yaml
+++ b/newrelic-fluent-bit-output.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-fluent-bit-output
   version: 1.19.2
-  epoch: 0
+  epoch: 1
   description: A Fluent Bit output plugin that sends logs to New Relic
   copyright:
     - license: Apache-2.0
@@ -12,7 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - go-1.20
+      - go
       - wolfi-baselayout
 
 pipeline:


### PR DESCRIPTION
It appears the go issue was fixed in go 1.22.

AWS is planning to move to 1.22: https://github.com/aws/aws-for-fluent-bit/issues/746#issuecomment-2007767605