### PR TITLE
cert-manager-webhook-pdns

### DIFF
--- a/cert-manager-webhook-pdns.yaml
+++ b/cert-manager-webhook-pdns.yaml
@@ -1,0 +1,45 @@
+package:
+  name: cert-manager-webhook-pdns
+  version: 2.5.1
+  epoch: 0
+  description: A PowerDNS webhook for cert-manager
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 4c96aef32157844c40afa685f9d389c94021b637
+      repository: https://github.com/zachomedia/cert-manager-webhook-pdns
+      tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 golang.org/x/crypto@v0.17.0 google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0 go.opentelemetry.io/otel/sdk@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
+
+  - uses: go/build
+    with:
+      output: webhook
+      packages: .
+      ldflags: '-w -extldflags "-static"'
+
+update:
+  enabled: true
+  github:
+    identifier: zachomedia/cert-manager-webhook-pdns
+    strip-prefix: v
+  ignore-regex-patterns:
+    - 'cert-manager-webhook-pdns-'
+
+# https://github.com/zachomedia/cert-manager-webhook-pdns/blob/bf4d525dca7345538aaad8840f6315a73c27f38b/README.md?plain=1#L45
+test:
+  environment:
+    environment:
+      GROUP_NAME: "acme.zacharyseguin.ca"
+  pipeline:
+    - runs: |
+        webhook -h


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
