### PR TITLE
kubernetes-csi-node-driver-registrar-2.10

### DIFF
--- a/kubernetes-csi-node-driver-registrar-2.10.yaml
+++ b/kubernetes-csi-node-driver-registrar-2.10.yaml
@@ -1,7 +1,7 @@
 package:
-  name: kubernetes-csi-node-driver-registrar-2.9
-  version: 2.9.3
-  epoch: 3
+  name: kubernetes-csi-node-driver-registrar-2.10
+  version: 2.10.0
+  epoch: 0
   description: Sidecar container that registers a CSI driver with the kubelet using the kubelet plugin registration mechanism.
   copyright:
     - license: Apache-2.0
@@ -19,7 +19,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 6736b89901d5cdce9b6d70c952025ab4e930cabc
+      expected-commit: ed043c200fb29960df0586e55d3a166acb4f4977
       repository: https://github.com/kubernetes-csi/node-driver-registrar
       tag: v${{package.version}}
 
@@ -53,4 +53,4 @@ update:
   github:
     identifier: kubernetes-csi/node-driver-registrar
     strip-prefix: v
-    tag-filter: v2.9.
+    tag-filter: v2.10.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
