### PR TITLE
fix: cve in protobuf and docker deps

### DIFF
--- a/k3d.yaml
+++ b/k3d.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3d
   version: 5.6.0
-  epoch: 8
+  epoch: 9
   description: Little helper to run CNCF's k3s in Docker
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.17.0 github.com/docker/docker@v24.0.7 golang.org/x/crypto@v0.17.0 github.com/opencontainers/runc@v1.1.12 github.com/containerd/containerd@v1.7.11 google.golang.org/protobuf@v1.33.0
+      deps: golang.org/x/net@v0.17.0 github.com/docker/docker@v24.0.9 golang.org/x/crypto@v0.17.0 github.com/opencontainers/runc@v1.1.12 github.com/containerd/containerd@v1.7.11 google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4
 
   - runs: |
       make build


### PR DESCRIPTION
k3d had some CVEs on the main package

```
🔎 Scanning "./packages/aarch64/k3d-5.6.0-r8.apk"
└── 📄 /usr/bin/k3d
        📦 github.com/docker/docker v24.0.7+incompatible (go-module)
            Medium CVE-2024-24557 GHSA-xw73-rw38-6vjc fixed in 24.0.9
        📦 google.golang.org/protobuf v1.31.0 (go-module)
            Medium CVE-2024-24786 GHSA-8r3f-844c-mc37 fixed in 1.33.0
```