### PR TITLE
cleanup php packages

### DIFF
--- a/php-8.1-http.yaml
+++ b/php-8.1-http.yaml
@@ -1,13 +1,14 @@
 package:
-  name: php-8.1-pecl-http
-  version: 4.2.3
-  epoch: 3
+  name: php-8.1-http
+  version: 4.2.4
+  epoch: 0
   description: "Provides PHP 8.1 HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
   dependencies:
     provides:
       - php-pecl-http=${{package.full-version}}
+      - php-8.1-pecl-http=${{package.full-version}}
     runtime:
       - php-8.1
 
@@ -34,7 +35,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://pecl.php.net/get/pecl_http-${{package.version}}.tgz
-      expected-sha512: be8bac0947e9fb63da5afa3eaf7b75a70775ca59a8a8c24b5f4b1875909dd8b6b2f4b25bf462acef78f18d5dd739c02352786853d9963cb71f3c1b114f113558
+      expected-sha512: b1eb43a458f89b3fd384244bddc8f9d470f82d3162411df3070bf0adf0c3e0457bc1ce928c05e8fffe836fb52cbe4c88f733466a867c3f6320288c5051007b20
 
   - uses: pecl/phpize
 
@@ -52,4 +53,6 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 371919

--- a/php-8.1-mcrypt.yaml
+++ b/php-8.1-mcrypt.yaml
@@ -1,15 +1,16 @@
 package:
-  name: php-8.2-pecl-mcrypt
+  name: php-8.1-mcrypt
   version: 1.0.7
-  epoch: 1
-  description: "Provides PHP 8.2 bindings for the unmaintained libmcrypt - PECL"
+  epoch: 2
+  description: "Provides PHP 8.1 bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     provides:
       - php-pecl-mcrypt=${{package.full-version}}
+      - php-8.1-pecl-mcrypt=${{package.full-version}}
     runtime:
-      - php-8.2
+      - php-8.1
 
 environment:
   contents:
@@ -24,7 +25,7 @@ environment:
       - gcc
       - libmcrypt-dev
       - libtool
-      - php-8.2-dev
+      - php-8.1-dev
 
 pipeline:
   - uses: fetch

--- a/php-8.1-mongodb.yaml
+++ b/php-8.1-mongodb.yaml
@@ -1,15 +1,16 @@
 package:
-  name: php-8.2-pecl-mongodb
+  name: php-8.1-mongodb
   version: 1.18.0
-  epoch: 0
-  description: "PHP 8.2 MongoDB driver - PECL"
+  epoch: 1
+  description: "PHP MongoDB driver"
   copyright:
     - license: PHP-3.01
   dependencies:
     provides:
       - php-pecl-mongodb=${{package.full-version}}
+      - php-8.1-pecl-mongodb=${{package.full-version}}
     runtime:
-      - php-8.2
+      - php-8.1
 
 environment:
   contents:
@@ -26,7 +27,7 @@ environment:
       - icu-dev
       - libtool
       - openssl-dev>3
-      - php-8.2-dev
+      - php-8.1-dev
       - snappy-dev
       - zstd-dev
 

--- a/php-8.1-pdosqlsrv.yaml
+++ b/php-8.1-pdosqlsrv.yaml
@@ -1,13 +1,14 @@
 package:
-  name: php-8.1-pecl-pdosqlsrv
-  version: 5.11.1
-  epoch: 1
+  name: php-8.1-pdosqlsrv
+  version: 5.12.0
+  epoch: 0
   description: "Provides PHP 8.1 Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:
     provides:
       - php-pecl-pdosqlsrv=${{package.full-version}}
+      - php-8.1-pecl-pdosqlsrv=${{package.full-version}}
     runtime:
       - php-8.1
 
@@ -47,9 +48,7 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can find the releases in github but building it does not work
-# with fetching from there like it does when you use fetch.
-# Also seems like I can't watch the github repo for new releases, yet use
-# the fetch above together?
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 371923

--- a/php-8.1-raphf.yaml
+++ b/php-8.1-raphf.yaml
@@ -1,13 +1,14 @@
 package:
-  name: php-8.1-pecl-raphf
+  name: php-8.1-raphf
   version: 2.0.1
-  epoch: 2
+  epoch: 3
   description: "Provides PHP 8.1 resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     provides:
       - php-pecl-raphf=${{package.full-version}}
+      - php-8.1-pecl-raphf=${{package.full-version}}
     runtime:
       - php-8.1
 
@@ -53,6 +54,7 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can't find in release-monitoring, or github.
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 371925

--- a/php-8.1-sqlsrv.yaml
+++ b/php-8.1-sqlsrv.yaml
@@ -1,13 +1,14 @@
 package:
-  name: php-8.1-pecl-sqlsrv
-  version: 5.11.1
-  epoch: 1
+  name: php-8.1-sqlsrv
+  version: 5.12.0
+  epoch: 0
   description: "Provides PHP 8.1 Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:
     provides:
       - php-pecl-sqlsrv=${{package.full-version}}
+      - php-8.1-pecl-sqlsrv=${{package.full-version}}
     runtime:
       - php-8.1
 
@@ -30,7 +31,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://pecl.php.net/get/sqlsrv-${{package.version}}.tgz
-      expected-sha512: ee63d7225b7ea8d26e8f53ed25e94fb356cefd3c463405bad1a3543edb820c6b5e3c554842b0190352c521c7aa314f42b6590b8b3cb859fead1f05348fb43f46
+      expected-sha512: 485ad60332aa9788beb25accae20bb11885a6dfc285525a6b739f57f8968f67f00a4d46ef0f1485a6f0bfecd8a5a458beb91ac60df014baf84a87c7c7e993f32
 
   - uses: pecl/phpize
 
@@ -47,9 +48,7 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can find the releases in github but building it does not work
-# with fetching from there like it does when you use fetch.
-# Also seems like I can't watch the github repo for new releases, yet use
-# the fetch above together?
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 371921

--- a/php-8.2-http.yaml
+++ b/php-8.2-http.yaml
@@ -1,13 +1,14 @@
 package:
-  name: php-8.2-pecl-http
-  version: 4.2.3
-  epoch: 3
+  name: php-8.2-http
+  version: 4.2.4
+  epoch: 0
   description: "Provides PHP 8.2 HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
   dependencies:
     provides:
       - php-pecl-http=${{package.full-version}}
+      - php-8.2-pecl-http=${{package.full-version}}
     runtime:
       - php-8.2
 
@@ -34,7 +35,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://pecl.php.net/get/pecl_http-${{package.version}}.tgz
-      expected-sha512: be8bac0947e9fb63da5afa3eaf7b75a70775ca59a8a8c24b5f4b1875909dd8b6b2f4b25bf462acef78f18d5dd739c02352786853d9963cb71f3c1b114f113558
+      expected-sha512: b1eb43a458f89b3fd384244bddc8f9d470f82d3162411df3070bf0adf0c3e0457bc1ce928c05e8fffe836fb52cbe4c88f733466a867c3f6320288c5051007b20
 
   - uses: pecl/phpize
 
@@ -52,4 +53,6 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 371919

--- a/php-8.2-mcrypt.yaml
+++ b/php-8.2-mcrypt.yaml
@@ -1,15 +1,16 @@
 package:
-  name: php-8.1-pecl-mcrypt
+  name: php-8.2-mcrypt
   version: 1.0.7
-  epoch: 1
-  description: "Provides PHP 8.1 bindings for the unmaintained libmcrypt - PECL"
+  epoch: 2
+  description: "Provides PHP 8.2 bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     provides:
       - php-pecl-mcrypt=${{package.full-version}}
+      - php-8.2-pecl-mcrypt=${{package.full-version}}
     runtime:
-      - php-8.1
+      - php-8.2
 
 environment:
   contents:
@@ -24,7 +25,7 @@ environment:
       - gcc
       - libmcrypt-dev
       - libtool
-      - php-8.1-dev
+      - php-8.2-dev
 
 pipeline:
   - uses: fetch

--- a/php-8.2-mongodb.yaml
+++ b/php-8.2-mongodb.yaml
@@ -1,15 +1,16 @@
 package:
-  name: php-8.1-pecl-mongodb
+  name: php-8.2-mongodb
   version: 1.18.0
-  epoch: 0
-  description: "PHP 8.1 MongoDB driver - PECL"
+  epoch: 1
+  description: "PHP 8.2 MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     provides:
       - php-pecl-mongodb=${{package.full-version}}
+      - php-8.2-pecl-mongodb=${{package.full-version}}
     runtime:
-      - php-8.1
+      - php-8.2
 
 environment:
   contents:
@@ -26,7 +27,7 @@ environment:
       - icu-dev
       - libtool
       - openssl-dev>3
-      - php-8.1-dev
+      - php-8.2-dev
       - snappy-dev
       - zstd-dev
 

--- a/php-8.2-pdosqlsrv.yaml
+++ b/php-8.2-pdosqlsrv.yaml
@@ -1,13 +1,14 @@
 package:
-  name: php-8.2-pecl-pdosqlsrv
-  version: 5.11.1
-  epoch: 1
+  name: php-8.2-pdosqlsrv
+  version: 5.12.0
+  epoch: 0
   description: "Provides PHP 8.2 Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:
     provides:
       - php-pecl-pdosqlsrv=${{package.full-version}}
+      - php-8.2-pecl-pdosqlsrv=${{package.full-version}}
     runtime:
       - php-8.2
 
@@ -47,9 +48,7 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can find the releases in github but building it does not work
-# with fetching from there like it does when you use fetch.
-# Also seems like I can't watch the github repo for new releases, yet use
-# the fetch above together?
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 371923

--- a/php-8.2-raphf.yaml
+++ b/php-8.2-raphf.yaml
@@ -1,13 +1,14 @@
 package:
-  name: php-8.2-pecl-raphf
+  name: php-8.2-raphf
   version: 2.0.1
-  epoch: 1
+  epoch: 2
   description: "Provides PHP 8.2 resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     provides:
       - php-pecl-raphf=${{package.full-version}}
+      - php-8.2-pecl-raphf=${{package.full-version}}
     runtime:
       - php-8.2
 
@@ -53,6 +54,7 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can't find in release-monitoring, or github.
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 371925

--- a/php-8.2-sqlsrv.yaml
+++ b/php-8.2-sqlsrv.yaml
@@ -1,6 +1,6 @@
 package:
-  name: php-8.2-pecl-sqlsrv
-  version: 5.11.1
+  name: php-8.2-sqlsrv
+  version: 5.12.0
   epoch: 0
   description: "Provides PHP 8.2 Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
@@ -8,6 +8,7 @@ package:
   dependencies:
     provides:
       - php-pecl-sqlsrv=${{package.full-version}}
+      - php-8.2-pecl-sqlsrv=${{package.full-version}}
     runtime:
       - php-8.2
 
@@ -30,7 +31,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://pecl.php.net/get/sqlsrv-${{package.version}}.tgz
-      expected-sha512: ee63d7225b7ea8d26e8f53ed25e94fb356cefd3c463405bad1a3543edb820c6b5e3c554842b0190352c521c7aa314f42b6590b8b3cb859fead1f05348fb43f46
+      expected-sha512: 485ad60332aa9788beb25accae20bb11885a6dfc285525a6b739f57f8968f67f00a4d46ef0f1485a6f0bfecd8a5a458beb91ac60df014baf84a87c7c7e993f32
 
   - uses: pecl/phpize
 
@@ -47,9 +48,7 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can find the releases in github but building it does not work
-# with fetching from there like it does when you use fetch.
-# Also seems like I can't watch the github repo for new releases, yet use
-# the fetch above together?
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 371921


### PR DESCRIPTION
- Setup release monitoring for all packages which don't have it
- Remove pecl suffix from packages to have similar naming
- Updated package if available

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
