### PR TITLE
apk-tools: revert to version  2.14.1

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -62,6 +62,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib "${{targets.subpkgdir}}"/usr/lib
 
 update:
-  enabled: true
+  # setting the update to false until the latest apk tools fails for previously built packages
+  enabled: false
   release-monitor:
     identifier: 20466

--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,6 +1,6 @@
 package:
   name: apk-tools
-  version: 2.14.3
+  version: 2.14.1
   epoch: 0
   description: "apk-tools (Wolfi package manager)"
   copyright:
@@ -26,7 +26,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://gitlab.alpinelinux.org/alpine/apk-tools/-/archive/v${{package.version}}/apk-tools-v${{package.version}}.tar.gz
-      expected-sha256: 5391ad16a7941c6550f098d282c6c9bbb8afdb5edd3e971d679a2e3a2fb5eb86
+      expected-sha256: c06487563cae9e92161dfe1a81e714f700229cc0ad075b6c26ac3f157892e732
 
   - runs: |
       sed -i -e 's:-Werror::' Make.rules

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -28,3 +28,5 @@ libsamplerate-0.2.2-r0.apk
 libsamplerate-dev-0.2.2-r0.apk
 libsamplerate-doc-0.2.2-r0.apk
 libsamplerate-static-0.2.2-r0.apk
+apk-tools-2.14.3-r0.apk
+apk-tools-dev-2.14.3-r0.apk


### PR DESCRIPTION
The latest version of apk-tools fails to add (few) packages which were previously built like grep , exa , sed , automake etc  

```
apk add sed
(1/1) Installing sed (4.9-r2)
ERROR: Failed to create var/lib/db/sbom/sed-4.9-r2.spdx.json: Bad message
ERROR: sed-4.9-r2: BAD archive
1 error; 13 MiB in 15 packages
```

eventhough there were no changes to  the packages in a while 

we suspect recent changes on the app-tools there might be a feature or bug which is causing this 
![image](https://github.com/wolfi-dev/os/assets/1015125/20b274e8-29d2-401f-851e-9ea857ae6830)


https://github.com/alpinelinux/apk-tools/compare/v2.14.1...v2.14.3
