### PR TITLE
Withdraw problematic packages

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -30,3 +30,6 @@ libsamplerate-doc-0.2.2-r0.apk
 libsamplerate-static-0.2.2-r0.apk
 apk-tools-2.14.3-r0.apk
 apk-tools-dev-2.14.3-r0.apk
+harbor-2.10-portal-2.10.1-r1.apk
+harbor-2.10-portal-nginx-config-2.10.1-r1.apk
+harbor-2.10-registryctl-2.10.1-r1.apk


### PR DESCRIPTION
Fixing a previous issue where an unintentional 'provides' was added to the harbor packages. As a result we need to withdraw the packages in this PR.

After these changes are applied, https://github.com/wolfi-dev/os/pull/16300 needs to be re-run to apply the fix to the harbor package and get a green check.