### PR TITLE
NeuVector vulnerability scanner for the SUSE NeuVector Container

### DIFF
--- a/neuvector-5.3.yaml
+++ b/neuvector-5.3.yaml
@@ -140,3 +140,4 @@ update:
   github:
     identifier: neuvector/neuvector
     tag-filter: v5.3.
+    strip-prefix: v

--- a/neuvector-5.3.yaml
+++ b/neuvector-5.3.yaml
@@ -1,0 +1,135 @@
+package:
+  name: neuvector-5.3
+  version: 5.3.2
+  epoch: 0
+  description: NeuVector Full Lifecycle Container Security Platform.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - jansson-dev
+      - jemalloc-dev
+      - libnetfilter_queue-dev
+      - libnfnetlink-dev
+      - libpcap-dev
+      - pcre-dev
+      - pcre2-dev
+      - userspace-rcu-dev
+      - userspace-rcu-static
+  environment:
+    CGO_ENABLED: "1"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/neuvector/neuvector
+      tag: v${{package.version}}
+      expected-commit: edbdcba632835d56dcc92ba86323c8a196471289
+
+subpackages:
+  - name: ${{package.name}}-controller
+    description: NeuVector Controller
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: controller
+          packages: .
+          output: ${{package.name}}-controller
+          ldflags: "-s -w"
+          subpackage: "true"
+          vendor: true
+
+  - name: ${{package.name}}-agent
+    description: NeuVector Agent
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: agent
+          packages: .
+          output: ${{package.name}}-agent
+          ldflags: "-s -w"
+          subpackage: "true"
+          vendor: true
+
+  - name: ${{package.name}}-monitor
+    description: NeuVector Monitor
+    pipeline:
+      - runs: |
+          make -C monitor
+          mkdir -p ${{targets.contextdir}}/usr/local/bin
+          install -Dm755 monitor/monitor ${{targets.contextdir}}/usr/local/bin/${{package.name}}-monitor
+
+  - name: ${{package.name}}-dp
+    description: NeuVector DP
+    pipeline:
+      - runs: |
+          rm -rf /usr/include/urcu/map/urcu.h
+          ln -sf /usr/include/urcu/map/urcu-mb.h /usr/include/urcu/map/urcu.h
+          if [[ "${{build.arch}}" == "aarch64" ]]; then
+            make -C dp
+          else
+            make -C dp
+          fi
+          mkdir -p ${{targets.contextdir}}/usr/local/bin
+          install -Dm755 dp/dp ${{targets.contextdir}}/usr/local/bin/${{package.name}}-dp
+          
+  - name: ${{package.name}}-nstools
+    description: NeuVector NSTools
+    pipeline:
+      - runs: |
+          make -C tools/nstools
+          mkdir -p ${{targets.contextdir}}/usr/local/bin
+          install -Dm755 tools/nstools/nstools ${{targets.contextdir}}/usr/local/bin/${{package.name}}-nstools
+
+  - name: ${{package.name}}-enforcer
+    description: NeuVector Enforcer
+    dependencies:
+      runtime:
+        - neuvector-agent
+        - neuvector-dp
+        - neuvector-monitor
+        - neuvector-nstools
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/local/bin
+          install -Dm755 agent/nvbench/*.rem ${{targets.contextdir}}/usr/local/bin/
+          install -Dm755 agent/nvbench/*.tmpl ${{targets.contextdir}}/usr/local/bin/
+
+  - name: ${{package.name}}-scanner
+    description: NeuVector Scanner
+    pipeline:
+      - uses: git-checkout
+        with:
+          repository: https://github.com/neuvector/scanner
+          destination: /tmp/scanner
+      - uses: go/build
+        with:
+          modroot: /tmp/scanner
+          packages: .
+          output: neuvector-scanner
+          ldflags: "-s -w"
+          subpackage: "true"
+          vendor: true
+
+  - name: ${{package.name}}-task
+    description: NeuVector Task
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: /tmp/scanner/task
+          packages: .
+          output: neuvector-task
+          ldflags: "-s -w"
+          subpackage: "true"
+          vendor: true
+
+update:
+  enabled: true
+  github:
+    identifier: neuvector/neuvector
+    tag-filter: v5.3.

--- a/neuvector-5.3.yaml
+++ b/neuvector-5.3.yaml
@@ -35,6 +35,9 @@ subpackages:
   - name: ${{package.name}}-controller
     description: NeuVector Controller
     pipeline:
+      - uses: go/bump
+        with:
+          deps: github.com/opencontainers/image-spec@v1.1.0 golang.org/x/net@v0.17.0 github.com/docker/distribution@v2.8.2-beta.1+incompatible golang.org/x/crypto@v0.22.0 gopkg.in/yaml.v3@v3.0.0-20220521103104-8f96da9f5d5e 
       - uses: go/build
         with:
           modroot: controller
@@ -64,20 +67,20 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/local/bin
           install -Dm755 monitor/monitor ${{targets.contextdir}}/usr/local/bin/${{package.name}}-monitor
 
-  - name: ${{package.name}}-dp
-    description: NeuVector DP
-    pipeline:
-      - runs: |
-          rm -rf /usr/include/urcu/map/urcu.h
-          ln -sf /usr/include/urcu/map/urcu-mb.h /usr/include/urcu/map/urcu.h
-          if [[ "${{build.arch}}" == "aarch64" ]]; then
-            make -C dp
-          else
-            make -C dp
-          fi
-          mkdir -p ${{targets.contextdir}}/usr/local/bin
-          install -Dm755 dp/dp ${{targets.contextdir}}/usr/local/bin/${{package.name}}-dp
-          
+  # - name: ${{package.name}}-dp
+  #   description: NeuVector DP
+  #   pipeline:
+  #     - runs: |
+  #         rm -rf /usr/include/urcu/map/urcu.h
+  #         ln -sf /usr/include/urcu/map/urcu-mb.h /usr/include/urcu/map/urcu.h
+  #         if [[ "${{build.arch}}" == "aarch64" ]]; then
+  #           make -C dp
+  #         else
+  #           make -C dp
+  #         fi
+  #         mkdir -p ${{targets.contextdir}}/usr/local/bin
+  #         install -Dm755 dp/dp ${{targets.contextdir}}/usr/local/bin/${{package.name}}-dp
+
   - name: ${{package.name}}-nstools
     description: NeuVector NSTools
     pipeline:
@@ -107,6 +110,10 @@ subpackages:
         with:
           repository: https://github.com/neuvector/scanner
           destination: /tmp/scanner
+      - uses: go/bump
+        with:
+          modroot: /tmp/scanner
+          deps: github.com/containerd/containerd@v1.6.26 github.com/opencontainers/image-spec@v1.1.0 github.com/opencontainers/runc@v1.1.12 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 google.golang.org/protobuf@v1.33.0 github.com/docker/distribution@v2.8.2-beta.1+incompatible golang.org/x/sys@v0.1.0 github.com/docker/docker@v24.0.9
       - uses: go/build
         with:
           modroot: /tmp/scanner

--- a/neuvector-scanner.yaml
+++ b/neuvector-scanner.yaml
@@ -1,0 +1,59 @@
+package:
+  name: neuvector-scanner
+  version: 0_git20240408
+  epoch: 0
+  description: NeuVector vulnerability scanner for the SUSE NeuVector Container Security Platform
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "1"
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 02c7ebc446e1aaf3b1eed2c9403516ee79af84982b6c0f19082b84ed9c70fce2
+      uri: https://github.com/neuvector/scanner/archive/4ae32294c563020a13ff9c6fb90007fab66dab99.tar.gz
+
+  - uses: go/bump
+    with:
+      deps: github.com/containerd/containerd@v1.6.26 github.com/docker/docker@v26.0.0 github.com/opencontainers/image-spec@v1.1.0 github.com/opencontainers/runc@v1.1.12 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 google.golang.org/protobuf@v1.33.0 github.com/docker/distribution@v2.8.2-beta.1+incompatible
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: .
+      output: ${{package.name}}
+      vendor: true
+      ldflags: "-s -w"
+
+  - uses: strip
+
+data:
+  - name: binaries
+    items:
+      task: NeuVector Scanner Task
+      monitor: NeuVector Scanner Monitor
+
+subpackages:
+  - range: binaries
+    name: ${{package.name}}-${{range.key}}
+    description: "${{range.value}}"
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: .
+          output: ${{package.name}}-${{range.key}}
+          ldflags: "-s -w"
+          subpackage: "true"
+          vendor: true
+
+update:
+  enabled: false # No releases or tags


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
