### PR TITLE
push "aarch64" packages first

### DIFF
--- a/.github/workflows/build-beta.yaml
+++ b/.github/workflows/build-beta.yaml
@@ -193,7 +193,7 @@ jobs:
 
       - name: 'Update the APKINDEX'
         run: |
-          for arch in "x86_64" "aarch64"; do
+          for arch in "aarch64" "x86_64"; do
             mkdir -p ./packages/${arch}
 
             # Consolidate with the built artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -226,7 +226,7 @@ jobs:
 
       - name: 'Update the APKINDEX'
         run: |
-          for arch in "x86_64" "aarch64"; do
+          for arch in "aarch64" "x86_64"; do
             mkdir -p ./packages/${arch}
 
             # Consolidate with the built artifacts
@@ -257,7 +257,7 @@ jobs:
 
       - name: 'Upload packages to GCS'
         run: |
-          for arch in "x86_64" "aarch64"; do
+          for arch in "aarch64" "x86_64"; do
             # Only attempt to upload when *.apk's exist
             apks=$(ls ./packages/${arch}/*.apk 2>/dev/null || true)
             if [ -n "$apks" ]; then
@@ -330,7 +330,7 @@ jobs:
         run: |
           tar xvf /tmp/artifacts/indexes.tar.gz
 
-          for arch in "x86_64" "aarch64"; do
+          for arch in "aarch64" "x86_64"; do
             # Don't cache the APKINDEX.
             gcloud --quiet storage cp \
                 --cache-control=no-store \


### PR DESCRIPTION
this to align with the lifecycle automation where we wait for the x86 but expect for aarch64 to be available

no big changes just the order when we upload the packages
