### PR TITLE
gops: assert no crypto usage

### DIFF
--- a/gops.yaml
+++ b/gops.yaml
@@ -1,7 +1,7 @@
 package:
   name: gops
   version: 0.3.28
-  epoch: 6
+  epoch: 7
   description: gops is a command to list and diagnose Go processes currently running on your system.
   copyright:
     - license: BSD-3-Clause
@@ -13,12 +13,22 @@ environment:
       - git
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/google/gops
-      version: v${{package.version}}
+      expected-commit: 272083c1fabc7d81ee985d9a4371dd444a3dd9fe
+      repository: https://github.com/google/gops
+      tag: v${{package.version}}
 
-  - uses: strip
+  - runs: |
+      # This package is used in FIPS context
+      # Assert that no cryptography is used
+      echo Checking crypto is not used
+      [ -z "$(go build -a -n 2>&1 | grep 'packagefile crypto=')" ]
+
+  - uses: go/build
+    with:
+      packages: .
+      output: gops
 
 update:
   enabled: true


### PR DESCRIPTION
During build, verify that golang crypto module is not used. This ensures that no cryptography is performed by this software, and thus it does not need a FIPS variant.

Also use git-checkout and asserts expected tag hash.