### PR TITLE
zot: use up to date go

### DIFF
--- a/zot.yaml
+++ b/zot.yaml
@@ -1,7 +1,7 @@
 package:
   name: zot
   version: 2.0.3
-  epoch: 1
+  epoch: 2
   description: A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification)
   copyright:
     - license: Apache-2.0
@@ -15,7 +15,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - curl
-      - go-1.21
+      - go
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Do not hard code which go toolchain to use.

For example, this prevented mass-rebuilds for go-1.22 to actually do anything.