### PR TITLE
copy the install.sh to right folder for correct usage argocd-extension-installer

### DIFF
--- a/argocd-extension-installer.yaml
+++ b/argocd-extension-installer.yaml
@@ -4,7 +4,7 @@ package:
   # This project doesn't do releases and everything is commit based.
   # This corresponds to commit 880f978f59bd6434202504355c62c12e251e327a
   version: 0.0_git20231025
-  epoch: 0
+  epoch: 1
   description: Install Argo CD extensions using init-containers
   copyright:
     - license: Apache-2.0
@@ -28,8 +28,10 @@ pipeline:
       branch: main
 
   - runs: |
-      mkdir -p "${{targets.destdir}}"/
-      install -Dm755 install.sh "${{targets.destdir}}"/install.sh
+      # https://github.com/argoproj-labs/argocd-extension-installer/blob/880f978f59bd6434202504355c62c12e251e327a/Dockerfile#L14
+      # we are going to call the script from /home/ext-installer to be able to use it as `./install.sh` in the entrypoint of the container image
+      mkdir -p "${{targets.destdir}}"/home/ext-installer
+      install -Dm755 install.sh "${{targets.destdir}}"/home/ext-installer/install.sh
 
 # Upstream repo doesn't provide any tags or releases
 update:
@@ -43,7 +45,7 @@ test:
       EXTENSION_CHECKSUM_URL: https://github.com/argoproj-labs/argocd-extension-metrics/releases/download/v1.0.0/extension_checksums.txt
   pipeline:
     - runs: |
-        /install.sh
+        /home/ext-installer/install.sh
         # check if there is any extension installed in /tmp/extensions/resources/ folder
         # file `extension-Metrics.js` should be present in /tmp/extensions/resources/ folder
         if [ ! -f /tmp/extensions/resources/extension-Metrics.js/extensions-Metrics.js ]; then


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
