### PR TITLE
kafka: Fix CVE-2024-23944

### DIFF
--- a/kafka.yaml
+++ b/kafka.yaml
@@ -2,7 +2,7 @@ package:
   name: kafka
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.7.0
-  epoch: 1
+  epoch: 2
   description: Apache Kafka is a distributed event streaming platformm
   copyright:
     - paths:
@@ -30,6 +30,10 @@ pipeline:
       repository: https://github.com/apache/kafka
       tag: ${{package.version}}
       expected-commit: 2ae524ed625438c5fee89e78648bd73e64a3ada0
+
+  - uses: patch
+    with:
+      patches: CVE-2024-23944.patch
 
   - runs: |
       export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8

--- a/kafka/CVE-2024-23944.patch
+++ b/kafka/CVE-2024-23944.patch
@@ -1,0 +1,26 @@
+From 4e1ba5ece549d326ed868501de24cc6286eaeece Mon Sep 17 00:00:00 2001
+From: Philippe Deslauriers <philde@chainguard.dev>
+Date: Fri, 5 Apr 2024 14:35:42 -0700
+Subject: [PATCH] Fix CVE-2024-23944
+
+Signed-off-by: Philippe Deslauriers <philde@chainguard.dev>
+---
+ gradle/dependencies.gradle | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gradle/dependencies.gradle b/gradle/dependencies.gradle
+index 39b1a142d1..36a71e4dcf 100644
+--- a/gradle/dependencies.gradle
++++ b/gradle/dependencies.gradle
+@@ -163,7 +163,7 @@ versions += [
+   snappy: "1.1.10.5",
+   spotbugs: "4.8.0",
+   zinc: "1.9.2",
+-  zookeeper: "3.8.3",
++  zookeeper: "3.8.4",
+   zstd: "1.5.5-6"
+ ]
+
+--
+2.44.0
+


### PR DESCRIPTION
Bumps zookeeper from 3.8.3 -> 3.8.4