### PR TITLE
Remove /usr/mariadb-test from mariadb packages

### DIFF
--- a/mariadb-10.11.yaml
+++ b/mariadb-10.11.yaml
@@ -231,7 +231,6 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr
           mv mysql-test "${{targets.subpkgdir}}"/usr/mariadb-test
 
-
 update:
   enabled: true
   github:

--- a/mariadb-10.11.yaml
+++ b/mariadb-10.11.yaml
@@ -222,6 +222,16 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/mariadb-embedded  "${{targets.subpkgdir}}"/usr/bin
 
+  - name: mariadb-10.11-test
+    dependencies:
+      provides:
+        - mariadb-test=10.11.999
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr
+          mv mysql-test "${{targets.subpkgdir}}"/usr/mariadb-test
+
+
 update:
   enabled: true
   github:

--- a/mariadb-10.6.yaml
+++ b/mariadb-10.6.yaml
@@ -227,6 +227,15 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/mariadb-embedded  "${{targets.subpkgdir}}"/usr/bin
 
+  - name: mariadb-10.6-test
+    dependencies:
+      provides:
+        - mariadb-test=10.6.999
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr
+          mv mysql-test "${{targets.subpkgdir}}"/usr/mariadb-test
+
 update:
   enabled: true
   github:

--- a/mariadb-11.2.yaml
+++ b/mariadb-11.2.yaml
@@ -207,6 +207,15 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/mariadb-embedded  "${{targets.subpkgdir}}"/usr/bin
 
+  - name: "${{package.name}}-test"
+    dependencies:
+      provides:
+        - mariadb-test=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr
+          mv "${{targets.destdir}}"/usr/mariadb-test "${{targets.subpkgdir}}"/usr/
+
 update:
   enabled: true
   github:


### PR DESCRIPTION
These test files are taking up ~250mb or so when installed, and shouldn't be in the main package.