### PR TITLE
overmind: init at 2.5.1

### DIFF
--- a/overmind.yaml
+++ b/overmind.yaml
@@ -1,0 +1,34 @@
+package:
+  name: overmind
+  version: 2.5.1
+  epoch: 0
+  description: "Process manager for Procfile-based applications"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/DarthSim/overmind
+      tag: "v${{package.version}}"
+      expected-commit: a9907243c989baac013c705bcec415f8b82cb8c8
+
+  - uses: go/build
+    with:
+      ldflags: -s -w
+      output: overmind
+      packages: .
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: DarthSim/overmind
+    strip-prefix: v
+    tag-filter: v

--- a/overmind.yaml
+++ b/overmind.yaml
@@ -5,6 +5,9 @@ package:
   description: "Process manager for Procfile-based applications"
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      - tmux
 
 environment:
   contents:


### PR DESCRIPTION
supervisor is SOO huge, and overmind is with 4,5MB a pretty good replacement when you want to run two processes in a container.

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
