### PR TITLE
ci: update tj-actions/changed-files to fix determining correct changeset

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Look for changed files
         id: changes
-        uses: tj-actions/changed-files@20576b4b9ed46d41e2d45a2256e5e2316dde6834 # v43.0.1
+        uses: tj-actions/changed-files@2d756ea4c53f7f6b397767d8723b3a10a9f35bf2 # v44.0.0
         with:
           files_yaml: |
             melange:

--- a/.github/workflows/wolfictl-check-update.yaml
+++ b/.github/workflows/wolfictl-check-update.yaml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Get changed files
       id: files
-      uses: tj-actions/changed-files@20576b4b9ed46d41e2d45a2256e5e2316dde6834 # v43.0.1
+      uses: tj-actions/changed-files@2d756ea4c53f7f6b397767d8723b3a10a9f35bf2 # v44.0.0
       with:
         separator: ' '
         files: "*.yaml"


### PR DESCRIPTION
Right now the PR experience is annoying, as checking for updates or building always takes too many packages and then it fails.

Example pipeline: https://github.com/wolfi-dev/os/actions/runs/8581882036/job/23519481012?pr=16436
I added overmind and it fails because of a random other package:
```
2024/04/06 14:51:20 INFO error during command execution: package py3-gcloud-aio-auth: update found newer version 5.3.1 compared with package.version 5.3.0 in melange config
```

and this problem seems fixed by changed-files v44 action 🎉 https://github.com/tj-actions/changed-files/releases/tag/v44

This PR updates the action to use the newest version