### PR TITLE
bump mariadb epochs for separeate test packages

### DIFF
--- a/mariadb-10.11.yaml
+++ b/mariadb-10.11.yaml
@@ -2,7 +2,7 @@ package:
   name: mariadb-10.11
   # Latest LTS
   version: 10.11.7
-  epoch: 0
+  epoch: 1
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later

--- a/mariadb-10.6.yaml
+++ b/mariadb-10.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-10.6
   version: 10.6.17
-  epoch: 0
+  epoch: 1
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later

--- a/mariadb-11.2.yaml
+++ b/mariadb-11.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-11.2
   version: 11.2.3
-  epoch: 1
+  epoch: 2
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
PR #16417 only created the subpackages for mariadb-test, but didn't remove the files from the main mariadb packages. This PR bumps the main package epoch to force rebuilds.