### PR TITLE
newrelic-nri-statsd and gostatsd

### DIFF
--- a/gostatsd.yaml
+++ b/gostatsd.yaml
@@ -1,0 +1,38 @@
+package:
+  name: gostatsd
+  version: 28.3.0
+  epoch: 0
+  description: An implementation of Etsy's statsd in Go with tags support
+  copyright:
+    - license: MIT
+
+environment:
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 9ca2a2e1ebaa4ac9d595f2601e8d66ef2afd967c
+      repository: https://github.com/atlassian/gostatsd
+      tag: ${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: github.com/gogo/protobuf@v1.3.2 golang.org/x/crypto@v0.17.0 golang.org/x/net@v0.17.0 k8s.io/client-go@v0.17.16 github.com/aws/aws-sdk-go@v1.34.0
+
+  - uses: go/build
+    with:
+      output: gostatsd
+      packages: ./cmd/gostatsd
+      ldflags: -w -X main.Version=${{package.version}} -X main.GitCommit=$(git rev-parse HEAD) -X main.BuildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+
+update:
+  enabled: true
+  github:
+    identifier: atlassian/gostatsd
+
+test:
+  pipeline:
+    - runs: |
+        gostatsd -h

--- a/newrelic-nri-statsd.yaml
+++ b/newrelic-nri-statsd.yaml
@@ -1,0 +1,43 @@
+package:
+  name: newrelic-nri-statsd
+  version: 2.9.1
+  epoch: 0
+  description: An implementation of Etsy's statsd in Go with tags support
+  copyright:
+    - license: MIT
+
+environment:
+  environment:
+    CGO_ENABLED: "0"
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - gostatsd
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 63734ae0fdf478478771a016f8901333abe3e58a
+      repository: https://github.com/newrelic/nri-statsd
+      tag: ${{package.version}}
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/bin
+      mkdir -p "${{targets.destdir}}"/home/nonroot
+      mv /usr/bin/gostatsd "${{targets.destdir}}"/bin
+      # we created this directory because nri-statsd.sh expects it run-statsd.sh in working-dir
+      # https://github.com/newrelic/nri-statsd/blob/e160a9db92e998d0a4d0262950fdd35d0f231ae4/nri-statsd.sh#L66
+      # so as the user is going to be a nonroot at image, we need to create this directory and copy the files
+      install -Dm755 nri-statsd.sh "${{targets.destdir}}"/home/nonroot/nri-statsd.sh
+      install -Dm755 run-statsd.sh "${{targets.destdir}}"/home/nonroot/run-statsd.sh
+
+update:
+  enabled: true
+  github:
+    identifier: newrelic/nri-statsd
+
+test:
+  pipeline:
+    - runs: |
+        gostatsd -h


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
