### PR TITLE
chore(conda-init): Create base environment if it doesn't exist

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -3,7 +3,7 @@
 package:
   name: conda
   version: 24.3.0
-  epoch: 2
+  epoch: 3
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause

--- a/conda/init.sh
+++ b/conda/init.sh
@@ -2,5 +2,10 @@
 if [[ ! -f ~/.conda-initialized ]]; then
   conda init
   source ~/.bashrc
+  # Create base env if it doesn't exist
+  if [[ ! -d ~/conda ]]; then
+    conda config --set root_prefix ~/conda
+    conda create -n base
+  fi
   touch ~/.conda-initialized
 fi

--- a/conda/init.sh
+++ b/conda/init.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 if [[ ! -f ~/.conda-initialized ]]; then
-  conda init
-  source ~/.bashrc
+  conda init 1>/dev/null
+  source ~/.bashrc 1>/dev/null
   # Create base env if it doesn't exist
   if [[ ! -d ~/conda ]]; then
-    conda config --set root_prefix ~/conda
-    conda create -n base
+    conda config --set root_prefix ~/conda 1>/dev/null
+    conda create -n base 1>/dev/null
   fi
-  touch ~/.conda-initialized
+  touch ~/.conda-initialized 1>/dev/null
 fi


### PR DESCRIPTION
Creates a base environment after initializing conda if one can't be found. This is user agnostic however, the conda-base package should still be maintained to cut down on time to entry - this is a bandaid for nonroot users

Also redirect stdout to /dev/null during initialization to avoid throwing it in the user's face :)