### PR TITLE
stern: new package

### DIFF
--- a/stern.yaml
+++ b/stern.yaml
@@ -1,0 +1,38 @@
+package:
+  name: stern
+  version: 1.28.0
+  epoch: 0
+  description: Multi pod and container log tailing for Kubernetes
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/stern/stern
+      tag: v${{package.version}}
+      expected-commit: 9763d953d86d8f60cf9a5e5da3531e6a1aa47c5c
+
+  - uses: go/bump
+    with:
+      # Mitigates GHSA-8r3f-844c-mc37
+      deps: google.golang.org/protobuf@v1.33.0
+
+  - uses: go/build
+    with:
+      packages: .
+      output: stern
+      ldflags: -s -w -X github.com/stern/stern/cmd.version=v${{package.version}} -X github.com/stern/stern/cmd.commit=$(git rev-parse HEAD) -X github.com/stern/stern/cmd.date=$(date +%F-%T)
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: stern/stern
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        stern --version


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
