### PR TITLE
php-ddtrace: init at 0.99.1

### DIFF
--- a/php-8.1-ddtrace.yaml
+++ b/php-8.1-ddtrace.yaml
@@ -1,0 +1,55 @@
+package:
+  name: php-8.1-ddtrace
+  version: 0.99.1
+  epoch: 0
+  description: "Datadog PHP Clients"
+  copyright:
+    - license: Apache-2.0 OR BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - curl-dev
+      - php-8.1
+      - php-8.1-dev
+      - posix-libc-utils
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/DataDog/dd-trace-php
+      tag: "${{package.version}}"
+      expected-commit: 8de3b1fb481960857fff1d55d5e1862f7cf39fca
+
+  - name: Clone submodules
+    runs: git submodule update --init --recursive
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=ddtrace.so" > "${{targets.subpkgdir}}/etc/php/conf.d/ddtrace.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: DataDog/dd-trace-php
+    use-tag: true

--- a/php-8.2-ddtrace.yaml
+++ b/php-8.2-ddtrace.yaml
@@ -1,0 +1,55 @@
+package:
+  name: php-8.2-ddtrace
+  version: 0.99.1
+  epoch: 0
+  description: "Datadog PHP Clients"
+  copyright:
+    - license: Apache-2.0 OR BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.2
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - curl-dev
+      - php-8.2
+      - php-8.2-dev
+      - posix-libc-utils
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/DataDog/dd-trace-php
+      tag: "${{package.version}}"
+      expected-commit: 8de3b1fb481960857fff1d55d5e1862f7cf39fca
+
+  - name: Clone submodules
+    runs: git submodule update --init --recursive
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=ddtrace.so" > "${{targets.subpkgdir}}/etc/php/conf.d/ddtrace.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: DataDog/dd-trace-php
+    use-tag: true

--- a/php-8.3-ddtrace.yaml
+++ b/php-8.3-ddtrace.yaml
@@ -1,0 +1,55 @@
+package:
+  name: php-8.3-ddtrace
+  version: 0.99.1
+  epoch: 0
+  description: "Datadog PHP Clients"
+  copyright:
+    - license: Apache-2.0 OR BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.3
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - curl-dev
+      - php-8.3
+      - php-8.3-dev
+      - posix-libc-utils
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/DataDog/dd-trace-php
+      tag: "${{package.version}}"
+      expected-commit: 8de3b1fb481960857fff1d55d5e1862f7cf39fca
+
+  - name: Clone submodules
+    runs: git submodule update --init --recursive
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=ddtrace.so" > "${{targets.subpkgdir}}/etc/php/conf.d/ddtrace.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: DataDog/dd-trace-php
+    use-tag: true


### PR DESCRIPTION
DataDog PHP extension for profiling

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
