### PR TITLE
php-ds: init at 1.5.0

### DIFF
--- a/php-8.1-ds.yaml
+++ b/php-8.1-ds.yaml
@@ -1,0 +1,54 @@
+package:
+  name: php-8.1-ds
+  version: 1.5.0
+  epoch: 0
+  description: "An extension providing efficient data structures for PHP"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.1
+      - php-8.1-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-ds/ext-ds
+      tag: "v${{package.version}}"
+      expected-commit: d42dec515291e1d3d928c7dd404f6dfe818a45a8
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: |
+      set -x
+      ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=ds.so" > "${{targets.subpkgdir}}/etc/php/conf.d/ds.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: php-ds/ext-ds
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/php-8.2-ds.yaml
+++ b/php-8.2-ds.yaml
@@ -1,0 +1,54 @@
+package:
+  name: php-8.2-ds
+  version: 1.5.0
+  epoch: 0
+  description: "An extension providing efficient data structures for PHP"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.2
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.2
+      - php-8.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-ds/ext-ds
+      tag: "v${{package.version}}"
+      expected-commit: d42dec515291e1d3d928c7dd404f6dfe818a45a8
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: |
+      set -x
+      ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=ds.so" > "${{targets.subpkgdir}}/etc/php/conf.d/ds.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: php-ds/ext-ds
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/php-8.3-ds.yaml
+++ b/php-8.3-ds.yaml
@@ -1,0 +1,54 @@
+package:
+  name: php-8.3-ds
+  version: 1.5.0
+  epoch: 0
+  description: "An extension providing efficient data structures for PHP"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.3
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.3
+      - php-8.3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-ds/ext-ds
+      tag: "v${{package.version}}"
+      expected-commit: d42dec515291e1d3d928c7dd404f6dfe818a45a8
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: |
+      set -x
+      ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=ds.so" > "${{targets.subpkgdir}}/etc/php/conf.d/ds.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: php-ds/ext-ds
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true


### PR DESCRIPTION
The DS extension provides Collections and other data structures for PHP, more efficient than user-defined classes

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
