### PR TITLE
php-protobuf: init at 4.26.1

### DIFF
--- a/php-8.1-protobuf.yaml
+++ b/php-8.1-protobuf.yaml
@@ -1,0 +1,49 @@
+package:
+  name: php-8.1-protobuf
+  version: 4.26.1
+  epoch: 0
+  description: "Protocol Buffers - Google's data interchange format"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.1
+      - php-8.1-dev
+      - protobuf-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/protobuf-${{package.version}}.tgz
+      expected-sha512: d29bd9fe03a5a1a39d77524d48ddcedcf0699aaa2e42e8f1e0756885e2585615fc5076d326af7099876a383219490851c094f8f16a3fdeee76c3176b81d61740
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=protobuf.so" > "${{targets.subpkgdir}}/etc/php/conf.d/protobuf.ini"
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 141406

--- a/php-8.2-protobuf.yaml
+++ b/php-8.2-protobuf.yaml
@@ -1,0 +1,49 @@
+package:
+  name: php-8.2-protobuf
+  version: 4.26.1
+  epoch: 0
+  description: "Protocol Buffers - Google's data interchange format"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.2
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.2
+      - php-8.2-dev
+      - protobuf-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/protobuf-${{package.version}}.tgz
+      expected-sha512: d29bd9fe03a5a1a39d77524d48ddcedcf0699aaa2e42e8f1e0756885e2585615fc5076d326af7099876a383219490851c094f8f16a3fdeee76c3176b81d61740
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=protobuf.so" > "${{targets.subpkgdir}}/etc/php/conf.d/protobuf.ini"
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 141406

--- a/php-8.3-protobuf.yaml
+++ b/php-8.3-protobuf.yaml
@@ -1,0 +1,49 @@
+package:
+  name: php-8.3-protobuf
+  version: 4.26.1
+  epoch: 0
+  description: "Protocol Buffers - Google's data interchange format"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.3
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.3
+      - php-8.3-dev
+      - protobuf-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://pecl.php.net/get/protobuf-${{package.version}}.tgz
+      expected-sha512: d29bd9fe03a5a1a39d77524d48ddcedcf0699aaa2e42e8f1e0756885e2585615fc5076d326af7099876a383219490851c094f8f16a3fdeee76c3176b81d61740
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=protobuf.so" > "${{targets.subpkgdir}}/etc/php/conf.d/protobuf.ini"
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 141406


### PR DESCRIPTION
The native protobuf extension is faster than the user land implementation.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
