### PR TITLE
php-ssh2: init at 1.4.1

### DIFF
--- a/php-8.1-ssh2.yaml
+++ b/php-8.1-ssh2.yaml
@@ -1,0 +1,52 @@
+package:
+  name: php-8.1-ssh2
+  version: 1.4.1
+  epoch: 0
+  description: "Bindings for the libssh2 library"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - libssh2-dev
+      - php-8.1
+      - php-8.1-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php/pecl-networking-ssh2
+      tag: "${{package.version}}"
+      expected-commit: 65c0da1b18373e2286d1569a176101583225a2c0
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=ssh2.so" > "${{targets.subpkgdir}}/etc/php/conf.d/ssh2.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: php/pecl-networking-ssh2
+    use-tag: true
+    tag-filter-prefix: 1.

--- a/php-8.2-ssh2.yaml
+++ b/php-8.2-ssh2.yaml
@@ -1,0 +1,52 @@
+package:
+  name: php-8.2-ssh2
+  version: 1.4.1
+  epoch: 0
+  description: "Bindings for the libssh2 library"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.2
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - libssh2-dev
+      - php-8.2
+      - php-8.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php/pecl-networking-ssh2
+      tag: "${{package.version}}"
+      expected-commit: 65c0da1b18373e2286d1569a176101583225a2c0
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=ssh2.so" > "${{targets.subpkgdir}}/etc/php/conf.d/ssh2.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: php/pecl-networking-ssh2
+    use-tag: true
+    tag-filter-prefix: 1.

--- a/php-8.3-ssh2.yaml
+++ b/php-8.3-ssh2.yaml
@@ -1,0 +1,52 @@
+package:
+  name: php-8.3-ssh2
+  version: 1.4.1
+  epoch: 0
+  description: "Bindings for the libssh2 library"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.3
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - libssh2-dev
+      - php-8.3
+      - php-8.3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php/pecl-networking-ssh2
+      tag: "${{package.version}}"
+      expected-commit: 65c0da1b18373e2286d1569a176101583225a2c0
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Build
+    runs: ./configure
+
+  - name: Make install
+    runs: |
+      INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=ssh2.so" > "${{targets.subpkgdir}}/etc/php/conf.d/ssh2.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: php/pecl-networking-ssh2
+    use-tag: true
+    tag-filter-prefix: 1.


### PR DESCRIPTION
The ssh2 extension allows PHP to open ssh/sftp connections to remote hosts.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
