### PR TITLE
php-decimal: init at 1.5.0

### DIFF
--- a/php-8.1-decimal.yaml
+++ b/php-8.1-decimal.yaml
@@ -1,0 +1,54 @@
+package:
+  name: php-8.1-decimal
+  version: 1.5.0
+  epoch: 0
+  description: Correctly-rounded, arbitrary-precision decimal arithmetic for PHP
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - mpdecimal-dev
+      - php-8.1
+      - php-8.1-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-decimal/ext-decimal
+      tag: "v${{package.version}}"
+      expected-commit: 9b4d6f4cf282230a0949ef4204e0b6bfe29b2c51
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=decimal.so" > "${{targets.subpkgdir}}/etc/php/conf.d/decimal.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: php-decimal/ext-decimal
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/php-8.2-decimal.yaml
+++ b/php-8.2-decimal.yaml
@@ -1,0 +1,54 @@
+package:
+  name: php-8.2-decimal
+  version: 1.5.0
+  epoch: 0
+  description: Correctly-rounded, arbitrary-precision decimal arithmetic for PHP
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.2
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - mpdecimal-dev
+      - php-8.2
+      - php-8.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-decimal/ext-decimal
+      tag: "v${{package.version}}"
+      expected-commit: 9b4d6f4cf282230a0949ef4204e0b6bfe29b2c51
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=decimal.so" > "${{targets.subpkgdir}}/etc/php/conf.d/decimal.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: php-decimal/ext-decimal
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true

--- a/php-8.3-decimal.yaml
+++ b/php-8.3-decimal.yaml
@@ -1,0 +1,54 @@
+package:
+  name: php-8.3-decimal
+  version: 1.5.0
+  epoch: 0
+  description: Correctly-rounded, arbitrary-precision decimal arithmetic for PHP
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.3
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - mpdecimal-dev
+      - php-8.3
+      - php-8.3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/php-decimal/ext-decimal
+      tag: "v${{package.version}}"
+      expected-commit: 9b4d6f4cf282230a0949ef4204e0b6bfe29b2c51
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=decimal.so" > "${{targets.subpkgdir}}/etc/php/conf.d/decimal.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: php-decimal/ext-decimal
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true


### PR DESCRIPTION
This adds Correctly-rounded, arbitrary-precision decimal arithmetic for PHP

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
