### PR TITLE
gdb: py3.12 bump

### DIFF
--- a/gdb.yaml
+++ b/gdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdb
   version: "14.2"
-  epoch: 0
+  epoch: 1
   description: The GNU Debugger
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later


### PR DESCRIPTION
Update gdb linked in interpreter to 3.12.
