### PR TITLE
scorecard: CVE fixes

### DIFF
--- a/scorecard.yaml
+++ b/scorecard.yaml
@@ -1,7 +1,7 @@
 package:
   name: scorecard
   version: 4.13.1
-  epoch: 3
+  epoch: 4
   description: OpenSSF Scorecard - Security health metrics for Open Source
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,10 @@ pipeline:
     with:
       uri: https://github.com/ossf/scorecard/archive/v${{package.version}}/v${{package.version}}.tar.gz
       expected-sha256: 03e86871efd505247b05a577539ef6f6ce572a99bc89d6921272e6e293dbe94f
+
+  - uses: go/bump
+    with:
+      deps: google.golang.org/protobuf@v1.33.0 github.com/cloudflare/circl@v1.3.7 github.com/docker/docker@v24.0.9 google.golang.org/grpc@v1.57.1 github.com/go-git/go-git/v5@v5.11.0 golang.org/x/crypto@v0.17.0 github.com/moby/buildkit@v0.12.5
 
   - runs: |
       make build-scorecard


### PR DESCRIPTION
```
➜  os git:(cve-temporal-2e6ea32e09a6769e716ddc6bf07e8b0a) ✗ ../wolfictl/wolfictl scan packages/aarch64/scorecard-4.13.1-r3.apk
🔎 Scanning "packages/aarch64/scorecard-4.13.1-r3.apk"
└── 📄 /usr/bin/scorecard
        📦 github.com/cloudflare/circl v1.3.3 (go-module)
            High GHSA-9763-4f94-gfch fixed in 1.3.7
        📦 github.com/docker/docker v24.0.4+incompatible (go-module)
            Medium GHSA-jq35-85cj-fj4p fixed in 24.0.7
            Medium CVE-2024-24557 GHSA-xw73-rw38-6vjc fixed in 24.0.9
        📦 github.com/go-git/go-git/v5 v5.9.0 (go-module)
            Critical CVE-2023-49569 GHSA-449p-3h89-pw88 fixed in 5.11.0
            High CVE-2023-49568 GHSA-mw99-9chc-xw7r fixed in 5.11.0
        📦 github.com/moby/buildkit v0.12.2 (go-module)
            Critical CVE-2024-23652 GHSA-4v98-7qmw-rqr8 fixed in 0.12.5
            Medium CVE-2024-23650 GHSA-9p26-698r-w4hx fixed in 0.12.5
            High CVE-2024-23651 GHSA-m3r6-h7wv-7xxv fixed in 0.12.5
            Critical CVE-2024-23653 GHSA-wr6v-9f75-vh2g fixed in 0.12.5
        📦 golang.org/x/crypto v0.14.0 (go-module)
            Medium CVE-2023-48795 GHSA-45x7-px36-x8w8 fixed in 0.17.0
        📦 google.golang.org/grpc v1.57.0 (go-module)
            High GHSA-m425-mq94-257g fixed in 1.57.1
            Medium CVE-2023-44487 GHSA-qppj-fm5r-hxr3 fixed in 1.57.1
        📦 google.golang.org/protobuf v1.31.0 (go-module)
            Medium CVE-2024-24786 GHSA-8r3f-844c-mc37 fixed in 1.33.0

➜  os git:(cve-temporal-2e6ea32e09a6769e716ddc6bf07e8b0a) ✗ ../wolfictl/wolfictl scan packages/aarch64/scorecard-4.13.1-r4.apk
🔎 Scanning "packages/aarch64/scorecard-4.13.1-r4.apk"
✅ No vulnerabilities found
```