### PR TITLE
njs

### DIFF
--- a/njs.yaml
+++ b/njs.yaml
@@ -1,0 +1,77 @@
+# Generated from https://git.alpinelinux.org/aports/plain/community/njs/APKBUILD
+package:
+  name: njs
+  version: 0.8.3
+  epoch: 0
+  description: njs scripting language CLI utility
+  copyright:
+    - license: BSD-2-Clause
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libedit-dev
+      - libxml2-dev
+      - openssl-dev
+      - pcre-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/nginx/njs
+      tag: ${{package.version}}
+      expected-commit: fd37a9e4ddf6c61f8b01ac0970ab0ae9a4481e36
+
+  - runs: |
+      ./configure \
+      --build-dir='build-debug' \
+      --debug=YES
+
+      make njs
+
+      ./configure --cc-opt='-Os' --ld-opt='-Os'
+
+      make njs
+
+      mkdir -p "${{targets.contextdir}}"/usr/bin
+      mkdir -p "${{targets.contextdir}}"/usr/lib
+      install -m 755 -D build/njs "${{targets.contextdir}}"/usr/bin/njs
+      install -m 644 -D build/libnjs.a "${{targets.contextdir}}"/usr/lib/libnjs.a
+      install -m 644 -D build-debug/libnjs.a "${{targets.contextdir}}"/usr/lib/libnjs-debug.a
+
+  - uses: strip
+
+subpackages:
+  - name: njs-debug
+    pipeline:
+      - runs: |
+          builddir=$(pwd)
+          mkdir -p "${{targets.contextdir}}"/usr/bin
+          install -m 755 -D "$builddir"/build-debug/njs "${{targets.contextdir}}"/usr/bin/njs-debug
+    description: njs built with additional runtime checks and debug symbols
+
+  - name: njs-libs-static
+    pipeline:
+      - uses: split/static
+    description: njs static
+
+test:
+  environment:
+    contents:
+      packages:
+        - njs-debug
+  pipeline:
+    - runs: |
+        njs -v
+        njs-debug -v
+
+update:
+  enabled: true
+  github:
+    identifier: nginx/njs
+    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
