### PR TITLE
tesseract: fix up build

### DIFF
--- a/leptonica.yaml
+++ b/leptonica.yaml
@@ -1,7 +1,7 @@
 package:
   name: leptonica
   version: 1.84.1
-  epoch: 0
+  epoch: 1
   description: Leptonica is an open source library containing software that is broadly useful for image processing and image analysis applications.
   copyright:
     - license: BSD-2-Clause
@@ -15,6 +15,14 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - giflib-dev
+      - libjpeg-turbo-dev
+      - libpng-dev
+      - libwebp-dev
+      - openjpeg-dev
+      - openjpeg-tools
+      - tiff-dev
+      - zlib-dev
 
 pipeline:
   - uses: git-checkout
@@ -35,6 +43,16 @@ subpackages:
   - name: leptonica-dev
     pipeline:
       - uses: split/dev
+    dependencies:
+      runtime:
+        - zlib-dev
+        - libpng-dev
+        - giflib-dev
+        - libjpeg-turbo-dev
+        - tiff-dev
+        - libwebp-dev
+        - openjpeg-dev
+        - openjpeg-tools
 
 update:
   enabled: true

--- a/openjpeg.yaml
+++ b/openjpeg.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjpeg
   version: 2.5.2
-  epoch: 0
+  epoch: 1
   description: "Open-source implementation of JPEG2000 image codec"
   copyright:
     - license: BSD-2-Clause
@@ -53,8 +53,8 @@ subpackages:
   - name: openjpeg-tools
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv ${{targets.destdir}}/usr/bin/ ${{targets.subpkgdir}}/usr/bin/
+          mkdir -p ${{targets.subpkgdir}}/usr
+          mv ${{targets.destdir}}/usr/bin/ ${{targets.subpkgdir}}/usr
     description: openjpeg (development tools)
 
 update:

--- a/tesseract.yaml
+++ b/tesseract.yaml
@@ -1,7 +1,7 @@
 package:
   name: tesseract
   version: 5.3.4
-  epoch: 1
+  epoch: 2
   description: Tesseract Open Source OCR Engine
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,7 @@ environment:
       - ca-certificates-bundle
       - cairo-dev
       - cmake
+      - curl-dev
       - expat-dev
       - fontconfig-config
       - fontconfig-dev
@@ -24,6 +25,7 @@ environment:
       - harfbuzz-dev
       - icu-dev
       - leptonica-dev
+      - libarchive-dev
       - libfontconfig1
       - libjpeg-turbo-dev
       - libxft-dev
@@ -32,7 +34,6 @@ environment:
       - pango-dev
       - pkgconf
       - pkgconf-dev
-      - zlib-dev
 
 data:
   - name: langs
@@ -128,7 +129,7 @@ pipeline:
 
   - uses: cmake/configure
     with:
-      opts: \ --enable-opencl
+      opts: -DTESSDATA_PREFIX=/usr/share -DUSE_SYSTEM_ICU=on
 
   - uses: cmake/build
 


### PR DESCRIPTION
openjpeg:

 - move binaries from /usr/bin/bin to /usr/bin, no idea how that was still generating automatic cmd: provides.

leptonica:

 - it seemed to have been a bare library without any graphic backends enabled. Enable support for all graphics formats.

tesseract:

 - enable support for loading graphical images with updated leptonica

 - enable all other optional features libarchive & curl support

 - fix up builtin location to tessdata, to actually make it possible to use as per documentation.

Now one can actually use tesseract and OCR an image.