### PR TITLE
caddy: add src package for xcaddy usage

### DIFF
--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: caddy
   version: 2.7.6
-  epoch: 6
+  epoch: 7
   description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
   copyright:
     - license: Apache-2.0
@@ -33,6 +33,8 @@ pipeline:
     with:
       deps: golang.org/x/crypto@v0.17.0 github.com/quic-go/quic-go@v0.42.0 google.golang.org/protobuf@v1.33.0 github.com/jackc/pgx/v4@v4.18.2
 
+  - runs: tar cfv caddy-src.tar .
+
   - uses: go/build
     with:
       ldflags: -s -w
@@ -43,11 +45,19 @@ pipeline:
 
 subpackages:
   - name: caddy-man
+    description: caddy manpages
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share
           "${{targets.destdir}}"/usr/bin/caddy manpage --directory "${{targets.subpkgdir}}"/usr/share/
-    description: caddy manpages
+
+  - name: caddy-src
+    description: Caddy sources
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/usr/src/caddy"
+          tar xfv caddy-src.tar -C "${{targets.subpkgdir}}/usr/src/caddy"
+          rm caddy-src.tar
 
 update:
   enabled: true

--- a/caddy.yaml
+++ b/caddy.yaml
@@ -57,7 +57,6 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/src/caddy"
           tar xfv caddy-src.tar -C "${{targets.subpkgdir}}/usr/src/caddy"
-          rm caddy-src.tar
 
 update:
   enabled: true


### PR DESCRIPTION
When you use xcaddy to build your own caddy with extensions, it fetches by default the latest version of caddy. Now the problem starts that you have again all CVE that has been fixed here.

So my solution is that the caddy package creates a subpackage `caddy-src` with the patched source code. So we can install in the build environment xcaddy and caddy-dev and can do this:

```
xcaddy build \
          --with github.com/caddyserver/caddy/v2=/usr/src/caddy
```

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
