### PR TITLE
Ignore temporal-server pre-release that contains `m` in it and add test

### DIFF
--- a/temporal-server.yaml
+++ b/temporal-server.yaml
@@ -123,10 +123,16 @@ subpackages:
 update:
   enabled: true
   ignore-regex-patterns:
-    - rc
-    - m1
+    - "rc"
+    - "-m"
   github:
     identifier: temporalio/temporal
     strip-prefix: v
     use-tag: true
     tag-filter-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        set -o pipefail
+        temporal-server --version | grep "${{package.version}}"


### PR DESCRIPTION
Closes: #16548
