### PR TITLE
feat(packages): Add datastax collectd

### DIFF
--- a/datastax-collectd.yaml
+++ b/datastax-collectd.yaml
@@ -79,6 +79,10 @@ pipeline:
       patches: disable-scribe.patch
 
   - runs: |
+      # Copy source for MCAC
+      mkdir -p /tmp/collectd
+      cp -rf . /tmp/collectd/
+
       ./clean.sh
       ./build.sh
 
@@ -196,8 +200,20 @@ pipeline:
 
   - uses: strip
 
+subpackages:
+  - name: ${{package.name}}-mcac
+    description: Provides collectd source code for MCAC
+    dependencies:
+      runtime:
+        - datastax-collectd
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/opt/metrics-collector/lib/collectd
+          cp -rf /tmp/collectd/* "${{targets.contextdir}}"/opt/metrics-collector/lib/collectd/
+
 update:
   enabled: true
   github:
     identifier: datastax/collectd
+    strip-prefix: v
     use-tag: true

--- a/datastax-collectd.yaml
+++ b/datastax-collectd.yaml
@@ -1,0 +1,203 @@
+# This package is required for the metric-collector-for-apache-cassandra.
+# There are bunch of plugins are disabled to trim down the size of the final package and to avoid unnecessary dependencies.
+# But in case you need a collectd package with a plugin we already disabled we could do that by separating the collectd into subpackages
+# for each package that uses collectd. For example, if you need the collectd package with the write_riemann plugin enabled, you could
+# create a subpackage for it and enable the plugin in the subpackage. The subpackage will be built and installed alongside the main package.
+package:
+  name: datastax-collectd
+  version: 0.1.7
+  epoch: 0
+  description: "The system statistics collection daemon."
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bison
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cairo-dev
+      - curl-dev
+      - eudev-dev
+      - flex
+      - gdk-pixbuf-dev
+      - gpsd-dev
+      - harfbuzz-dev
+      - hiredis-dev
+      - i2c-tools-dev
+      - iptables-dev
+      - jansson-dev
+      - libatasmart-dev
+      - libdbi-dev
+      - libgcrypt-dev
+      - libmemcached-dev
+      - libmicrohttpd-dev
+      - libmnl-dev
+      - libmodbus-dev
+      - libnotify-dev
+      - liboping-dev
+      - libpcap-dev
+      - libpq-16
+      - librdkafka-dev
+      - libtool
+      - libxml2-dev
+      - lm-sensors-dev
+      - mosquitto-dev
+      - net-snmp-dev
+      - openipmi-dev
+      - openjdk-17-default-jdk
+      - openldap-dev
+      - openssl-dev>3
+      - owfs-dev
+      - pango-dev
+      - patchelf
+      - perl-dev
+      - pkgconf
+      - pkgconf-dev
+      - postgresql-16-dev
+      - rabbitmq-c
+      - rabbitmq-c-dev
+      - riemann-c-client-dev
+      - rrdtool-dev
+      - varnish
+      - yajl-dev
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 64f01e378864d90fb889567cdd638b594185fe28
+      repository: https://github.com/datastax/collectd.git
+      tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      patches: disable-scribe.patch
+
+  - runs: |
+      ./clean.sh
+      ./build.sh
+
+      CFLAGS="-Wno-error=stringop-overflow \
+        -Wno-error=unused-variable \
+        -Wno-error=unused-function \
+        -Wno-error=cpp \
+        -Wno-error=stringop-truncation \
+        -Wno-error=format-truncation \
+        -Wno-error=deprecated-declarations \
+        -Wno-error=incompatible-pointer-types \
+        -Wno-error=dangling-pointer= \
+        -fPIC"
+      CPPFLAGS="$CFLAGS" \
+      CXXFLAGS="$CFLAGS"
+      ./configure \
+        --build=$CBUILD \
+        --host=$CHOST \
+        --prefix=/usr \
+        --sysconfdir=/etc/collectd \
+        --mandir=/usr/share/man \
+        --infodir=/usr/share/info \
+        --localstate=/var \
+        --with-data-max-name-len=1024 \
+        --enable-all-plugins \
+        --disable-turbostat \
+        --disable-virt \
+        --disable-xencpu \
+        --disable-debug \
+        --disable-ascent \
+        --disable-rrdcached \
+        --disable-lvm \
+        --disable-write_kafka \
+        --disable-curl_xml \
+        --disable-dpdkstat \
+        --disable-dpdkevents \
+        --disable-gmond \
+        --disable-grpc \
+        --disable-gps \
+        --disable-ipmi \
+        --disable-lua \
+        --disable-mqtt \
+        --disable-modbus \
+        --disable-mysql \
+        --disable-intel_pmu \
+        --disable-intel_rdt \
+        --disable-static \
+        --disable-write_riemann \
+        --disable-zone \
+        --disable-apple_sensors \
+        --disable-lpar \
+        --disable-tape \
+        --disable-aquaero \
+        --disable-mic \
+        --disable-netapp \
+        --disable-notify_email \
+        --disable-nut \
+        --disable-onewire \
+        --disable-oracle \
+        --disable-pf \
+        --disable-python \
+        --disable-redis \
+        --disable-write_redis \
+        --disable-routeros \
+        --disable-rrdtool \
+        --disable-write_scribe \
+        --disable-sensors \
+        --disable-sigrok \
+        --disable-write_mongodb \
+        --disable-xmms \
+        --disable-write_sensu \
+        --disable-zfs-arc \
+        --disable-tokyotyrant \
+        --disable-write_kafka \
+        --disable-barometer \
+        --with-perl-bindings="INSTALLDIRS=vendor INSTALL_BASE=" \
+        --without-libaquaero5 \
+        --without-libstatgrab \
+        --without-libupsclient \
+        --without-included-ltdl \
+        --without-libgrpc++ \
+        --without-libgps \
+        --without-libmodbus \
+        --without-libpython \
+        --without-libsensors \
+        --without-mic
+
+      make
+      make DESTDIR="${{targets.destdir}}" install
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+      mkdir -p "${{targets.destdir}}"/etc/collectd.d
+      mkdir -p "${{targets.destdir}}"/etc/init.d
+      mkdir -p "${{targets.destdir}}"/usr/include/collectd/core
+      mkdir -p "${{targets.destdir}}"/usr/include/collectd/liboconfig
+
+      install -D -m755 ./collectd.initd "${{targets.destdir}}"/etc/init.d/collectd
+
+      # Install all header files to allow building out-of-tree plugins.
+      # This is based on Debian.
+      for path in $(find src -path src/libcollectdclient -prune \
+        -o -path src/liboconfig -prune \
+        -o -name '*.h' -print)
+      do
+        install -D -m644 "$path" "${{targets.destdir}}"/usr/include/collectd/core/${path#src/}
+      done
+
+      install -D -m644 ./src/liboconfig/oconfig.h -t "${{targets.destdir}}"/usr/include/collectd/liboconfig/
+      cd "${{targets.destdir}}"/usr/include/collectd/
+      # Update include path for collectd core header files.
+      headers=$(find ./core ./liboconfig -type f -name '*.h')
+      for path in $headers; do
+        sed -r -i "s|(include\s+)\".*\<${path##*/}\"|\1\"collectd/${path#./}\"|" $headers
+      done
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: datastax/collectd
+    use-tag: true

--- a/datastax-collectd/collectd.initd
+++ b/datastax-collectd/collectd.initd
@@ -1,0 +1,17 @@
+#!/sbin/openrc-run
+
+COLLECTD_USER=${COLLECTD_USER:-"collectd"}
+COLLECTD_GROUP=${COLLECTD_GROUP:-"collectd"}
+COLLECTD_ARGS=${COLLECTD_ARGS:-""}
+COLLECTD_PIDFILE=${COLLECTD_PIDFILE:-"/run/collectd/collectd.pid"}
+
+command=/usr/sbin/collectd
+pidfile="$COLLECTD_PIDFILE"
+command_args="${COLLECTD_ARGS} -P $pidfile"
+start_stop_daemon_args="--user ${COLLECTD_USER}:${COLLECTD_GROUP}"
+retry=${COLLECTD_TERMTIMEOUT:-"TERM/25/KILL/5"}
+
+start_pre() {
+	checkpath --directory --owner "$COLLECTD_USER":"$COLLECTD_GROUP" \
+		--mode 0770 "$(dirname $pidfile)" /var/lib/collectd
+}

--- a/datastax-collectd/disable-scribe.patch
+++ b/datastax-collectd/disable-scribe.patch
@@ -1,0 +1,24 @@
+diff --git a/Makefile.am b/Makefile.am
+index 5a5715d1..b1f9a8a6 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -427,7 +427,6 @@ libcmds_la_SOURCES = \
+ 	src/utils_cmd_getthreshold.c \
+ 	src/utils_cmd_getthreshold.h \
+ 	src/utils_cmd_getval.c \
+-	src/utils_cmd_putinsight.c \
+ 	src/utils_cmd_getval.h \
+ 	src/utils_cmd_listval.c \
+ 	src/utils_cmd_listval.h \
+diff --git a/configure.ac b/configure.ac
+index d5d6a8b5..c54a44c9 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,7 +1,6 @@
+ dnl Process this file with autoconf to produce a configure script.
+ AC_PREREQ([2.60])
+ AC_INIT([collectd],[m4_esyscmd(./version-gen.sh)])
+-AC_CONFIG_MACRO_DIR([./aclocal])
+ AC_CONFIG_SRCDIR(src/target_set.c)
+ AC_CONFIG_HEADERS(src/config.h)
+ AC_CONFIG_AUX_DIR([build-aux])

--- a/metric-collector-for-apache-cassandra.yaml
+++ b/metric-collector-for-apache-cassandra.yaml
@@ -1,13 +1,13 @@
 package:
   name: metric-collector-for-apache-cassandra
   version: 0.3.5
-  epoch: 2
+  epoch: 3
   description: Drop-in metrics collection and dashboards for Apache Cassandra
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - collectd
+      - datastax-collectd-mcac
 
 environment:
   contents:
@@ -35,7 +35,7 @@ pipeline:
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector/lib
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector/config
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
-      mvn -q -ff package -DskipTests
+      mvn -Ddownload.plugin.skip -q -ff package -DskipTests
       cp ./target/datastax-mcac-agent-*.jar "${{targets.destdir}}"/opt/metrics-collector/lib/datastax-mcac-agent.jar
       cp ./config/collectd.conf.tmpl "${{targets.destdir}}"/opt/metrics-collector/config
       cp ./config/metric-collector.yaml "${{targets.destdir}}"/opt/metrics-collector/config


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
