### PR TITLE
sig-storage-local-static-provisioner

### DIFF
--- a/sig-storage-local-static-provisioner.yaml
+++ b/sig-storage-local-static-provisioner.yaml
@@ -1,0 +1,100 @@
+package:
+  name: sig-storage-local-static-provisioner
+  version: 2.7.0
+  epoch: 0
+  description: Static provisioner of local volumes
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - bash
+      - busybox
+      - e2fsprogs-dev
+      - util-linux-dev
+      - util-linux-misc
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
+      tag: v${{package.version}}
+      expected-commit: 4f81db77908ff67d8cac223c31413a293cd65d73
+
+  - uses: go/bump
+    with:
+      deps: google.golang.org/protobuf@v1.33.0
+
+  - uses: go/build
+    with:
+      packages: ./cmd/local-volume-provisioner
+      output: local-provisioner
+      ldflags: -s -w -a -extldflags '-static'
+      vendor: truei
+
+  - runs: |
+      mkdir -p ${{targets.contextdir}}/scripts
+      cp -r deployment/docker/scripts/* "${{targets.contextdir}}"/scripts/
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    # https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/4f81db77908ff67d8cac223c31413a293cd65d73/deployment/docker/Dockerfile#L32
+    description: The Dockerfile expects the binary to be executed as '/local-provisioner'
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/
+          ln -sf /usr/bin/local-provisioner "${{targets.contextdir}}"/local-provisioner
+
+  - name: node-cleanup-controller
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/node-cleanup
+          output: main
+          ldflags: -s -w -a -extldflags '-static'
+          subpackage: true
+          vendor: true
+
+  - name: node-cleanup-controller-compat
+    # https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/4f81db77908ff67d8cac223c31413a293cd65d73/cmd/node-cleanup/Dockerfile#L21
+    description: The Dockerfile expects the binary to be executed as '/main'
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/
+          ln -sf /usr/bin/main "${{targets.contextdir}}"/main
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/sig-storage-local-static-provisioner
+    strip-prefix: v
+  ignore-regex-patterns:
+    - 'local-static-provisioner-'
+
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-compat
+        - node-cleanup-controller-compat
+        - node-cleanup-controller
+  pipeline:
+    - name: "Test local-provisioner"
+      runs: |
+        local-provisioner -h
+        # test symlink
+        /local-provisioner -h
+    - name: "Test node-cleanup-controller"
+      runs: |
+        set +e
+        main -h
+        # test symlink
+        /main -h


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
