### PR TITLE
vertical-pod-autoscaler: add tests

### DIFF
--- a/vertical-pod-autoscaler.yaml
+++ b/vertical-pod-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: vertical-pod-autoscaler
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -51,8 +51,6 @@ pipeline:
       packages: ./pkg/recommender
       ldflags: -w
       output: recommender
-      # Mitigate CVE-2023-39325 and CVE-2023-3978
-      deps: golang.org/x/net@v0.17.0
       vendor: "true"
 
   - uses: strip
@@ -77,3 +75,16 @@ update:
     strip-prefix: vertical-pod-autoscaler-
     use-tag: true
     tag-filter: vertical-pod-autoscaler-
+
+test:
+  environment:
+    contents:
+      packages:
+        - vertical-pod-autoscaler-updater
+        - vertical-pod-autoscaler-recommender
+  pipeline:
+    - runs: |
+        for component in admission-controller updater recommender; do
+          $component -h 2>&1 | grep -q "Usage of $component"
+          $component 2>&1 | grep -q "unable to load in-cluster configuration"
+        done


### PR DESCRIPTION
Also `golang.org/x/net@v0.17.0` is no longer needed.