### PR TITLE
openssl: add DES back in, as it seems to break wget and curl

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.3.0
-  epoch: 1
+  epoch: 2
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -52,7 +52,6 @@ pipeline:
          no-ssl3 \
          no-seed \
          no-weak-ssl-ciphers \
-         no-des \
          no-dsa \
          -Wa,--noexecstack
       perl configdata.pm --dump


### PR DESCRIPTION
openssl: add DES back in, as it seems to break wget and curl

Fixes: #16623 