### PR TITLE
addon-resizer

### DIFF
--- a/addon-resizer.yaml
+++ b/addon-resizer.yaml
@@ -1,0 +1,67 @@
+package:
+  name: addon-resizer
+  version: 1.8.20
+  epoch: 0
+  description: Autoscaling components for Kubernetes
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes/autoscaler
+      tag: addon-resizer-${{package.version}}
+      expected-commit: a3e243f14f24091f1712333b086d807ef38bbd4f
+
+  - uses: go/bump
+    with:
+      deps: google.golang.org/protobuf@v1.33.0
+      modroot: addon-resizer
+
+  - uses: go/build
+    with:
+      modroot: addon-resizer
+      packages: nanny/main/pod_nanny.go
+      ldflags: -s -w -X k8s.io/autoscaler/addon-resizer/nanny.AddonResizerVersion=${{package.name}}
+      output: pod_nanny
+      vendor: true
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          # https://github.com/kubernetes/autoscaler/blob/a3e243f14f24091f1712333b086d807ef38bbd4f/addon-resizer/Dockerfile#L21
+          ln -sf /usr/bin/pod_nanny ${{targets.subpkgdir}}/pod_nanny
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes/autoscaler
+    strip-prefix: addon-resizer-
+    use-tag: true
+    tag-filter: addon-resizer-1.8
+
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-compat
+  pipeline:
+    - runs: |
+        set +e
+        pod_nanny -h
+        /pod_nanny -h


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

Note to the reviewer:
---

We also created an issue to the upstream project because there are different types of versioning scheme available so couldn't decide wihch one is the latest version flow but the most recent one was **1.8.20**, this is why we pick it up to move forward:

- https://github.com/kubernetes/autoscaler/issues/6702

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
