### PR TITLE
node-feature-discovery-0.15: new package

### DIFF
--- a/node-feature-discovery-0.15.yaml
+++ b/node-feature-discovery-0.15.yaml
@@ -1,0 +1,94 @@
+package:
+  name: node-feature-discovery-0.15
+  version: 0.15.4
+  epoch: 0
+  description: Node feature discovery for Kubernetes
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - protoc
+    provides:
+      - node-feature-discovery=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - protoc
+  environment:
+    GRPC_GO_LOG_SEVERITY_LEVEL: "INFO"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/node-feature-discovery
+      tag: v${{package.version}}
+      expected-commit: 08c731f67fddff47b13aad83fafc2d4e745a72cd
+
+  - name: copy conf
+    runs: |
+      mkdir -p ${{targets.contextdir}}/etc/kubernetes/node-feature-discovery/
+      cp ./deployment/components/worker-config/nfd-worker.conf.example ${{targets.contextdir}}/etc/kubernetes/node-feature-discovery/nfd-worker.conf
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/kubectl-nfd
+      output: kubectl-nfd
+      tags: osusergo,netgo
+      ldflags: "-X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}} -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-"
+      go-package: go
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/nfd-gc
+      output: nfd-gc
+      tags: osusergo,netgo
+      ldflags: "-X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}} -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-"
+      go-package: go
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/nfd-master
+      output: nfd-master
+      tags: osusergo,netgo
+      ldflags: "-X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}} -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-"
+      go-package: go
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/nfd-topology-updater
+      output: nfd-topology-updater
+      tags: osusergo,netgo
+      ldflags: "-X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}} -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-"
+      go-package: go
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/nfd-worker
+      output: nfd-worker
+      tags: osusergo,netgo
+      ldflags: "-X sigs.k8s.io/node-feature-discovery/pkg/version.version=${{package.version}} -X sigs.k8s.io/node-feature-discovery/pkg/utils/hostpath.pathPrefix=/host-"
+      go-package: go
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/node-feature-discovery
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v0.15.
+
+test:
+  pipeline:
+    - runs: kubectl-nfd -h
+    - runs: nfd-gc -version
+    - runs: nfd-master -version
+    - runs: nfd-topology-updater -version
+    - runs: nfd-worker -version

--- a/node-feature-discovery-0.15.yaml
+++ b/node-feature-discovery-0.15.yaml
@@ -6,8 +6,6 @@ package:
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - protoc
     provides:
       - node-feature-discovery=${{package.full-version}}
 
@@ -15,8 +13,6 @@ environment:
   contents:
     packages:
       - protoc
-  environment:
-    GRPC_GO_LOG_SEVERITY_LEVEL: "INFO"
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
