### PR TITLE
openssl: Add smoke test cases to prevent openssl missbuilt breaking Wolfi

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.3.0
-  epoch: 4
+  epoch: 5
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -123,6 +123,26 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/etc
           mv "${{targets.destdir}}"/etc/ssl "${{targets.subpkgdir}}"/etc/
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+        - git
+        - wget
+  pipeline:
+    - name: Verify curl still works
+      runs: |
+        curl -I https://github.com/openssl/openssl
+        ! curl https://expired.badssl.com/
+    - name: Verify git still works
+      runs: |
+        git ls-remote --exit-code https://github.com/openssl/openssl refs/tags/openssl-${{package.version}}
+    - name: Verify wget still works
+      runs: |
+        wget -O /dev/null https://github.com/openssl/openssl
+        ! wget https://expired.badssl.com/
 
 update:
   enabled: true


### PR DESCRIPTION
Test that wget, curl, and git still work after borked openssl updates.

This is in response to failures triggered by #16623