### PR TITLE
Bump pkgconf and switch to a git clone instead of fetch.

### DIFF
--- a/pkgconf.yaml
+++ b/pkgconf.yaml
@@ -1,6 +1,6 @@
 package:
   name: pkgconf
-  version: 2.1.1
+  version: 2.2.0
   epoch: 0
   description: "An implementation of pkg-config"
   copyright:
@@ -9,16 +9,23 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
+      - m4
       - wolfi-baselayout
 
 pipeline:
   - uses: fetch
     with:
-      uri: https://distfiles.ariadne.space/pkgconf/pkgconf-${{package.version}}.tar.gz
-      expected-sha256: 1a00b7fa08c7b506a24c40f7cc8d9e0e59be748d731af8f7aa0b4d722bd8ccbe
+      uri: https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-${{package.version}}.tar.gz
+      expected-sha256: 2c72cbf37b2d42a9fbf7ed8f0e5432a0b0925481f67995a21ecf77962a6000bc
+
+  - runs: |
+      autoreconf -fiv
 
   - name: 'Configure pkgconf'
     runs: |


### PR DESCRIPTION
~This requires using the bootstrap repo to avoid a circular dependency, because pkgconf depends on itself.~
