### PR TITLE
disable NTLM in curl & wget

### DIFF
--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: 8.9.1
-  epoch: 0
+  epoch: 1
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -37,10 +37,13 @@ pipeline:
         --with-nghttp2 \
         --with-pic \
         --disable-ldap \
+        --disable-ntlm \
         --without-libssh2 \
         --with-libpsl
 
   - uses: autoconf/make
+    with:
+      opts: CPPFLAGS="$CPPFLAGS -DOPENSSL_NO_ENGINE"
 
   - uses: autoconf/make-install
 

--- a/wget.yaml
+++ b/wget.yaml
@@ -1,7 +1,7 @@
 package:
   name: wget
   version: 1.24.5
-  epoch: 3
+  epoch: 4
   description: "GNU wget"
   copyright:
     - license: MPL-2.0 AND MIT
@@ -28,6 +28,7 @@ pipeline:
         --sysconfdir=/etc \
         --without-libidn \
         --with-ssl=openssl \
+        --disable-ntlm \
         --disable-nls
 
   - uses: autoconf/make


### PR DESCRIPTION
NTLM authentication relies on broken DES cryptography. Disable ntlm authentication in curl and wget, such that DES support can be removed from our builds of openssl.

Also build curl without deprecated engine support, such that engines can be turned off in openssl as well.

Note NTLM authentication already is not possible under FIPS.

Also see:

https://techcommunity.microsoft.com/t5/windows-it-pro-blog/the-evolution-of-windows-authentication/ba-p/3926848

Related: #16698