### PR TITLE
nodejs-21: Add nodejs provide for nodejs

### DIFF
--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -4,6 +4,8 @@ package:
   epoch: 0
   description: "JavaScript runtime built on V8 engine"
   dependencies:
+    provides:
+      - nodejs=${{package.full-version}}
   copyright:
     - license: MIT
 


### PR DESCRIPTION
`nodejs-21` should provide `nodejs` (but not `nodejs-lts`!)