### PR TITLE
openssl: disable des dsa engine support for newly built packages only

### DIFF
--- a/cmake.yaml
+++ b/cmake.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake
   version: 3.29.0
-  epoch: 3
+  epoch: 4
   description: "CMake is an open-source, cross-platform family of tools designed to build, test and package software"
   dependencies:
     provider-priority: 10
@@ -40,6 +40,9 @@ pipeline:
   # them use cmake they are built with cmake-bootstrap instead. Apart
   # from cppdap, as we don't package it standalone.
   - runs: |
+      # Disable NTLM, somehow `bootstrap -- -DCURL_DISABLE_NTLM=ON` is not working
+      sed -i '/CURL_DISABLE_NTLM/s/OFF/ON/' Utilities/cmcurl/CMakeLists.txt
+      # Run bootstrap
       ./bootstrap \
         --prefix=/usr \
         --mandir=/share/man \

--- a/cyrus-sasl.yaml
+++ b/cyrus-sasl.yaml
@@ -1,7 +1,7 @@
 package:
   name: cyrus-sasl
   version: 2.1.28
-  epoch: 5
+  epoch: 6
   description: "Cyrus Simple Authentication Service Layer (SASL)"
   copyright:
     - license: BSD-3-Clause
@@ -65,7 +65,8 @@ pipeline:
         --enable-cram \
         --enable-digest \
         --enable-httpform \
-        --enable-ntlm \
+        --disable-ntlm \
+        --without-des \
         --enable-plain \
         --enable-login \
         --enable-auth-sasldb \

--- a/libgit2.yaml
+++ b/libgit2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgit2
   version: 1.8.4
-  epoch: 0
+  epoch: 1
   description: "A cross-platform, linkable library implementation of Git that you can use in your application."
   copyright:
     - license: GPL-2.0-only WITH GCC-exception-2.0
@@ -40,6 +40,7 @@ pipeline:
         -DREGEX_BACKEND=pcre2 \
         -DUSE_BUNDLED_ZLIB=OFF \
         -DUSE_SSH=ON \
+        -DUSE_NTLMCLIENT=OFF \
         -DBUILD_TESTS=OFF
       cmake --build build-shared
       DESTDIR=${{targets.destdir}} cmake --install build-shared
@@ -52,6 +53,7 @@ pipeline:
         -DREGEX_BACKEND=pcre2 \
         -DUSE_BUNDLED_ZLIB=OFF \
         -DUSE_SSH=ON \
+        -DUSE_NTLMCLIENT=OFF \
         -DBUILD_TESTS=OFF \
         -DBUILD_SHARED_LIBS=OFF
       cmake --build build-static

--- a/net-snmp.yaml
+++ b/net-snmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: net-snmp
   version: 5.9.4
-  epoch: 3
+  epoch: 4
   description: Simple Network Management Protocol
   copyright:
     - license: Net-SNMP
@@ -52,6 +52,8 @@ pipeline:
       	--enable-as-needed \
       	--enable-blumenthal-aes \
       	--with-perl-modules="INSTALLDIRS=vendor" \
+      	--disable-des \
+      	--disable-md5 \
       	--disable-embedded-perl
       # embedded-perl seems to create TEXTREL's
       make

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -2,7 +2,7 @@
 package:
   name: openssl
   version: 3.4.0
-  epoch: 2
+  epoch: 3
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -160,6 +160,40 @@ subpackages:
         - jitterentropy-library
     pipeline:
       - uses: split/dev
+      # Magic begins here
+      # To drop DES DSA ENGINE support without breaking userspace ABI:
+      # Reconfigure openssl, and install updated openssl/configuration.h only
+      # Meaning runtime library supports deprecated features for all existing binaries
+      # Yet, newly built software will believe that DES DSA ENGINE are not available
+      - runs: |
+          export CC=${{host.triplet.gnu}}-gcc
+          export CXX=${{host.triplet.gnu}}-g++
+          export CPP=${{host.triplet.gnu}}-cpp
+          perl ./Configure \
+            linux-$(uname -m) \
+            --prefix=/usr \
+            --libdir=lib \
+            --openssldir=/etc/ssl \
+            enable-ktls \
+            shared \
+            no-zlib \
+            no-async \
+            no-comp \
+            no-idea \
+            no-mdc2 \
+            no-rc5 \
+            no-ec2m \
+            no-sm2 \
+            no-sm4 \
+            no-ssl3 \
+            no-seed \
+            no-weak-ssl-ciphers \
+            no-des \
+            no-dsa \
+            no-engine \
+            -Wa,--noexecstack
+          perl configdata.pm --dump
+          cp include/openssl/configuration.h "${{targets.subpkgdir}}"/usr/include/openssl
     test:
       pipeline:
         - uses: test/pkgconf

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -188,6 +188,7 @@ subpackages:
             no-ssl3 \
             no-seed \
             no-weak-ssl-ciphers \
+            no-md4 \
             no-des \
             no-dsa \
             no-engine \

--- a/perl-net-snmp.yaml
+++ b/perl-net-snmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-net-snmp
   version: 6.0.1
-  epoch: 2
+  epoch: 3
   description: Object oriented interface to SNMP
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl

--- a/stunnel.yaml
+++ b/stunnel.yaml
@@ -1,7 +1,7 @@
 package:
   name: stunnel
   version: "5.73"
-  epoch: 1
+  epoch: 2
   description: SSL encryption wrapper between network client and server
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
Keep DES DSA ENGINE support in the library runtime ABI for existing packages.

Disable DES DSA ENGINE support, in openssl-dev headers only. Such that newly built software stops using deprecated features at runtime.

This should be a safer way to land #16623

The package tests for curl / wget should verify the above runtime guarantee. Follow up wolfictl bump of curl / wget should automatically drop DES DSA ENGINE support (will submit as a separate PR).