### PR TITLE
varnish-modules: init at 0.24.0

### DIFF
--- a/varnish-modules.yaml
+++ b/varnish-modules.yaml
@@ -1,8 +1,8 @@
 package:
-  name: varnish
-  version: 7.5.0
-  epoch: 1
-  description: "Varnish Cache is a web application accelerator also known as a caching HTTP reverse proxy"
+  name: varnish-modules
+  version: 0.24.0
+  epoch: 0
+  description: "Collection of Varnish Cache modules (vmods) by Varnish Software"
   copyright:
     - license: BSD-2-Clause
 
@@ -22,16 +22,17 @@ environment:
       - pkgconf-dev
       - py3-docutils
       - py3-sphinx
+      - varnish-dev
       - wolfi-baselayout
 
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/varnishcache/varnish-cache
-      tag: varnish-${{package.version}}
-      expected-commit: eef25264e5ca5f96a77129308edb83ccf84cb1b1
+      repository: https://github.com/varnish/varnish-modules
+      tag: ${{package.version}}
+      expected-commit: 23b0df5cf667b5560d308d84baa2fbb2f9c67226
 
-  - runs: autoreconf -vif
+  - runs: ./bootstrap
 
   - uses: autoconf/configure
 
@@ -41,16 +42,8 @@ pipeline:
 
   - uses: strip
 
-subpackages:
-  - name: "varnish-dev"
-    description: "varnish dev"
-    pipeline:
-      - uses: split/dev
-
 update:
   enabled: true
   github:
-    identifier: varnishcache/varnish-cache
-    strip-prefix: varnish-
+    identifier: varnish/varnish-modules
     use-tag: true
-    tag-filter: varnish-

--- a/varnish-modules.yaml
+++ b/varnish-modules.yaml
@@ -46,4 +46,3 @@ update:
   enabled: true
   github:
     identifier: varnish/varnish-modules
-    use-tag: true


### PR DESCRIPTION
I need varnish xkeys for advanced tag based varnish invalidation. 

- Added a varnish-dev package
- Added varnish-modules

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
