### PR TITLE
Fix metrics collector for cassandra integration

### DIFF
--- a/metric-collector-for-apache-cassandra.yaml
+++ b/metric-collector-for-apache-cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: metric-collector-for-apache-cassandra
   version: 0.3.5
-  epoch: 4
+  epoch: 10
   description: Drop-in metrics collection and dashboards for Apache Cassandra
   copyright:
     - license: Apache-2.0
@@ -28,21 +28,21 @@ pipeline:
       expected-commit: f97a258ea95d055c71f762c3725061f43678ae1f
       tag: v${{package.version}}
 
-  # TODO: This is a temporary work-around to resolve an issue, where an upstream
-  # GH repo (dependency), was either removed or set to private. These files
-  # where grabbed from the following container image:
-  # - 'k8ssandra/cass-management-api:5.1-nightly-310d790'
+  - uses: maven/pombump
+
+  # Upstream made a change in the following commit which seems to have broken
+  # functionality with the wget plugin they where using in maven:
+  # - https://github.com/datastax/metric-collector-for-apache-cassandra/commit/13922679209b9836554a292a68476aba41d1999c
+  #
+  # This is a work-around until this is resolved, and until we're successfully
+  # able to build and package from source (which we are not today, but its WIP).
   - uses: fetch
     with:
-      uri: https://github.com/mamccorm/collectd/releases/download/v1/collectd.zip
-      expected-sha256: 361367aabbb08c4192147c3d92634b3dd0f3003725b7a4db2fd9f35aa55a717f
+      uri: https://github.com/datastax/collectd/releases/download/v0.1.7/insights-collectd-0.1.7.tar.gz
+      expected-sha256: 162012b03d9ee1b0c84e68d02f8cb7e443f12011197c738edab3abf4f06504bc
       extract: false
 
-  - runs: unzip -o collectd.zip
-
-  - uses: patch
-    with:
-      patches: upgrade-deps.patch
+  - runs: tar -xvzf insights-collectd-0.1.7.tar.gz
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector
@@ -55,7 +55,6 @@ pipeline:
       cp ./config/collectd.conf.tmpl "${{targets.destdir}}"/opt/metrics-collector/config
       cp ./config/metric-collector.yaml "${{targets.destdir}}"/opt/metrics-collector/config
       cp -r ./scripts "${{targets.destdir}}"/opt/metrics-collector
-
       cp -R ./collectd/* "${{targets.destdir}}"/opt/metrics-collector/lib/collectd
 
 update:

--- a/metric-collector-for-apache-cassandra.yaml
+++ b/metric-collector-for-apache-cassandra.yaml
@@ -1,13 +1,15 @@
 package:
   name: metric-collector-for-apache-cassandra
   version: 0.3.5
-  epoch: 3
+  epoch: 4
   description: Drop-in metrics collection and dashboards for Apache Cassandra
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - collectd
+  target-architecture:
+    - x86_64
 
 environment:
   contents:
@@ -26,11 +28,17 @@ pipeline:
       expected-commit: f97a258ea95d055c71f762c3725061f43678ae1f
       tag: v${{package.version}}
 
-  # TODO: Temp testing - do not merge without updating
+  # TODO: This is a temporary work-around to resolve an issue, where an upstream
+  # GH repo (dependency), was either removed or set to private. These files
+  # where grabbed from the following container image:
+  # - 'k8ssandra/cass-management-api:5.1-nightly-310d790'
   - uses: fetch
     with:
-      uri: https://github.com/mamccorm/collectd/archive/refs/tags/collectd.tar.gz
-      expected-sha256: 30b08a264725df67ebaa133a10a9e9faade285bc1c3dfcb6938aa8e1150eb965
+      uri: https://github.com/mamccorm/collectd/releases/download/v1/collectd.zip
+      expected-sha256: 361367aabbb08c4192147c3d92634b3dd0f3003725b7a4db2fd9f35aa55a717f
+      extract: false
+
+  - runs: unzip -o collectd.zip
 
   - uses: patch
     with:
@@ -48,8 +56,7 @@ pipeline:
       cp ./config/metric-collector.yaml "${{targets.destdir}}"/opt/metrics-collector/config
       cp -r ./scripts "${{targets.destdir}}"/opt/metrics-collector
 
-      # TODO: Temp testing - do not merge without updating
-      tar -xzvf collectd.tar.gz -C "${{targets.destdir}}"/opt/metrics-collector/lib/collectd
+      cp -R ./collectd/* "${{targets.destdir}}"/opt/metrics-collector/lib/collectd
 
 update:
   enabled: true

--- a/metric-collector-for-apache-cassandra.yaml
+++ b/metric-collector-for-apache-cassandra.yaml
@@ -28,6 +28,8 @@ pipeline:
       expected-commit: f97a258ea95d055c71f762c3725061f43678ae1f
       tag: v${{package.version}}
 
+  # DO NOT bump snakeyaml to v2.0, as this version has breaking changes. This
+  # needs to remain on v1.x stream.
   - uses: maven/pombump
 
   # Upstream made a change in the following commit which seems to have broken
@@ -50,7 +52,7 @@ pipeline:
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector/lib/collectd
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector/config
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
-      mvn -Ddownload.plugin.skip -q -ff package -DskipTests
+      mvn -q -ff package -DskipTests
       cp ./target/datastax-mcac-agent-*.jar "${{targets.destdir}}"/opt/metrics-collector/lib/datastax-mcac-agent.jar
       cp ./config/collectd.conf.tmpl "${{targets.destdir}}"/opt/metrics-collector/config
       cp ./config/metric-collector.yaml "${{targets.destdir}}"/opt/metrics-collector/config

--- a/metric-collector-for-apache-cassandra.yaml
+++ b/metric-collector-for-apache-cassandra.yaml
@@ -29,7 +29,7 @@ pipeline:
       tag: v${{package.version}}
 
   # DO NOT bump snakeyaml to v2.0, as this version has breaking changes. This
-  # needs to remain on v1.x stream.
+  # needs to remain on v1.x
   - uses: maven/pombump
 
   # Upstream made a change in the following commit which seems to have broken
@@ -52,7 +52,7 @@ pipeline:
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector/lib/collectd
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector/config
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
-      mvn -q -ff package -DskipTests
+      mvn -Ddownload.plugin.skip -q -ff package -DskipTests
       cp ./target/datastax-mcac-agent-*.jar "${{targets.destdir}}"/opt/metrics-collector/lib/datastax-mcac-agent.jar
       cp ./config/collectd.conf.tmpl "${{targets.destdir}}"/opt/metrics-collector/config
       cp ./config/metric-collector.yaml "${{targets.destdir}}"/opt/metrics-collector/config

--- a/metric-collector-for-apache-cassandra.yaml
+++ b/metric-collector-for-apache-cassandra.yaml
@@ -8,8 +8,8 @@ package:
   dependencies:
     runtime:
       - collectd
-  target-architecture:
-    - x86_64
+  options:
+    no-depends: true
 
 environment:
   contents:

--- a/metric-collector-for-apache-cassandra.yaml
+++ b/metric-collector-for-apache-cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: metric-collector-for-apache-cassandra
   version: 0.3.5
-  epoch: 2
+  epoch: 3
   description: Drop-in metrics collection and dashboards for Apache Cassandra
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,12 @@ pipeline:
       expected-commit: f97a258ea95d055c71f762c3725061f43678ae1f
       tag: v${{package.version}}
 
+  # TODO: Temp testing - do not merge without updating
+  - uses: fetch
+    with:
+      uri: https://github.com/mamccorm/collectd/archive/refs/tags/collectd.tar.gz
+      expected-sha256: 30b08a264725df67ebaa133a10a9e9faade285bc1c3dfcb6938aa8e1150eb965
+
   - uses: patch
     with:
       patches: upgrade-deps.patch
@@ -33,13 +39,17 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector/lib
+      mkdir -p "${{targets.destdir}}"/opt/metrics-collector/lib/collectd
       mkdir -p "${{targets.destdir}}"/opt/metrics-collector/config
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
-      mvn -q -ff package -DskipTests
+      mvn -Ddownload.plugin.skip -q -ff package -DskipTests
       cp ./target/datastax-mcac-agent-*.jar "${{targets.destdir}}"/opt/metrics-collector/lib/datastax-mcac-agent.jar
       cp ./config/collectd.conf.tmpl "${{targets.destdir}}"/opt/metrics-collector/config
       cp ./config/metric-collector.yaml "${{targets.destdir}}"/opt/metrics-collector/config
       cp -r ./scripts "${{targets.destdir}}"/opt/metrics-collector
+
+      # TODO: Temp testing - do not merge without updating
+      tar -xzvf collectd.tar.gz -C "${{targets.destdir}}"/opt/metrics-collector/lib/collectd
 
 update:
   enabled: true

--- a/metric-collector-for-apache-cassandra.yaml
+++ b/metric-collector-for-apache-cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: metric-collector-for-apache-cassandra
   version: 0.3.5
-  epoch: 10
+  epoch: 3
   description: Drop-in metrics collection and dashboards for Apache Cassandra
   copyright:
     - license: Apache-2.0
@@ -35,7 +35,7 @@ pipeline:
   # - https://github.com/datastax/metric-collector-for-apache-cassandra/commit/13922679209b9836554a292a68476aba41d1999c
   #
   # This is a work-around until this is resolved, and until we're successfully
-  # able to build and package from source (which we are not today, but its WIP).
+  # able to build and package from source (which we are not today).
   - uses: fetch
     with:
       uri: https://github.com/datastax/collectd/releases/download/v0.1.7/insights-collectd-0.1.7.tar.gz

--- a/metric-collector-for-apache-cassandra/pombump-deps.yaml
+++ b/metric-collector-for-apache-cassandra/pombump-deps.yaml
@@ -1,0 +1,6 @@
+patches:
+  - groupId:  org.yaml
+    artifactId: snakeyaml
+    version: 1.33
+    scope: import
+    type: pom


### PR DESCRIPTION
This one's been some journey! These changes should remediate the issue and unblock, but in parallel we're continuing to debug and explore other options