### PR TITLE
wgcf: new package

### DIFF
--- a/wgcf.yaml
+++ b/wgcf.yaml
@@ -34,3 +34,19 @@ update:
   github:
     identifier: ViRb3/wgcf
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - ca-certificates-bundle
+  pipeline:
+    - name: "Run wgcf"
+      runs: |
+        wgcf || exit 1
+    - name: "Test wgcf register"
+      runs: |
+        wgcf register --accept-tos || exit 1
+    - name: "Test wgcf generate"
+      runs: |
+        wgcf generate || exit 1

--- a/wgcf.yaml
+++ b/wgcf.yaml
@@ -1,0 +1,36 @@
+package:
+  name: wgcf
+  version: 2.2.22
+  epoch: 0
+  description: Cross-platform, unofficial CLI for Cloudflare Warp
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 7db4fc9fa5d9bdcc87a7d44dd1af9a3a25294e4c
+      repository: https://github.com/ViRb3/wgcf
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      ldflags: -s -w
+      output: wgcf
+      packages: .
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: ViRb3/wgcf
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
* wgcf: new package
<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
