### PR TITLE
aws-network-policy-agent

### DIFF
--- a/aws-network-policy-agent.yaml
+++ b/aws-network-policy-agent.yaml
@@ -1,0 +1,64 @@
+package:
+  name: aws-network-policy-agent
+  version: 1.1.0
+  epoch: 0
+  description: Amazon EKS Network Policy Agent is a daemonset that is responsible for enforcing configured network policies on the cluster.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - bpftool
+      - busybox
+      - ca-certificates-bundle
+      - clang-16-dev
+      - elfutils-dev
+      - file
+      - gcc
+      - go
+      - iproute2
+      - libbpf-dev
+      - linux-headers
+      - llvm16-dev
+      - procps
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/aws/aws-network-policy-agent
+      tag: v${{package.version}}
+      expected-commit: 8449a8a8d3790b81f06889d2b11513f947672a91
+
+  - runs: |
+      make EBPF_SDK_OVERRIDE=y setup-ebpf-sdk-override
+      # gives error: flag provided but not defined: -Wl,--as-needed,-O1,--sort-common
+      unset LDFLAGS
+      mkdir -p "${{targets.contextdir}}"/usr/bin
+      make build-linux
+      install -m755 -D ./controller "${{targets.contextdir}}"/usr/bin/controller
+      install -m755 -D ./aws-eks-na-cli "${{targets.contextdir}}"/usr/bin/aws-eks-na-cli
+      install -m755 -D ./aws-eks-na-cli-v6 "${{targets.contextdir}}"/usr/bin/aws-eks-na-cli-v6
+
+      mkdir -p "${{targets.contextdir}}"/pkg/ebpf/c
+      file /sys/kernel/btf/vmlinux
+      make vmlinuxh
+      install -m755 -D ./pkg/ebpf/c/vmlinux.h "${{targets.contextdir}}"/pkg/ebpf/c
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"
+          # https://github.com/aws/aws-network-policy-agent/blob/b3d2257ca51e859f6f559760dc6ddc2772e29499/Dockerfile#L61
+          ln -sf /usr/bin/controller ${{targets.contextdir}}/controller
+
+update:
+  enabled: true
+  github:
+    identifier: aws/aws-network-policy-agent
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
