### PR TITLE
amazon-vpc-cni-k8s

### DIFF
--- a/amazon-vpc-cni-k8s.yaml
+++ b/amazon-vpc-cni-k8s.yaml
@@ -5,6 +5,10 @@ package:
   description: Networking plugin repository for pod networking in Kubernetes using Elastic Network Interfaces on AWS
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - cilium-iptables # This package contains the iptables-wrapper script: https://github.com/aws/amazon-vpc-cni-k8s/blob/b46e7038bff87059a3f182562447478f21177613/scripts/dockerfiles/Dockerfile.release#L27
+      - iptables
 
 environment:
   contents:
@@ -12,6 +16,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cilium-iptables
+      - dpkg
       - go
       - iptables
 
@@ -31,21 +36,14 @@ pipeline:
           install -m 755 -D ./$binary "${{targets.contextdir}}"/app/$binary
       done
 
-  - uses: strip
+  - runs: |
+      mkdir -p "${{targets.contextdir}}"/usr/sbin
+      mkdir -p "${{targets.contextdir}}"/sbin
+      ln -sf /sbin/iptables "${{targets.contextdir}}"/usr/sbin/iptables
+      update-alternatives --install "${{targets.contextdir}}"/usr/sbin/iptables iptables /sbin/iptables-wrapper 100
+      update-alternatives --set iptables /sbin/iptables-wrapper
 
-subpackages:
-  - name: "${{package.name}}-compat"
-    # https://github.com/aws/amazon-vpc-cni-k8s/blob/389f5ebd62fda05776e837ad9a2dad5a8aec02cd/scripts/dockerfiles/Dockerfile.release#L27
-    description: "This manually sets the symlink so that calls to iptables use the iptables-wrapper"
-    dependencies:
-      runtime:
-        # https://github.com/wolfi-dev/os/blob/388b536baaf146b259bd57909e854ab403a07732/cilium-1.15.yaml#L169-L183
-        # https://github.com/aws/amazon-vpc-cni-k8s/blob/389f5ebd62fda05776e837ad9a2dad5a8aec02cd/scripts/dockerfiles/Dockerfile.release#L27
-        - cilium-iptables # it contains the iptables-wrapper script
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.contextdir}}"/sbin
-          ln -s /usr/sbin/iptables-wrapper "${{targets.contextdir}}"/sbin/iptables
+  - uses: strip
 
 update:
   enabled: true
@@ -54,13 +52,6 @@ update:
     strip-prefix: v
 
 test:
-  environment:
-    contents:
-      packages:
-        # - busybox
-        # - ca-certificates-bundle
-        - iptables
-        - cilium-iptables
   pipeline:
     - runs: |
         set +e

--- a/amazon-vpc-cni-k8s.yaml
+++ b/amazon-vpc-cni-k8s.yaml
@@ -1,0 +1,69 @@
+package:
+  name: amazon-vpc-cni-k8s
+  version: 1.18.0
+  epoch: 0
+  description: Networking plugin repository for pod networking in Kubernetes using Elastic Network Interfaces on AWS
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - cilium-iptables
+      - go
+      - iptables
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/aws/amazon-vpc-cni-k8s
+      tag: v${{package.version}}
+      expected-commit: b46e7038bff87059a3f182562447478f21177613
+
+  - runs: |
+      go version | awk '{print $3}' | sed 's/go//' > .go-version
+      make build-aws-vpc-cni && make build-linux
+      mkdir -p "${{targets.contextdir}}"/app
+      install -m 755 -D ./misc/10-aws.conflist "${{targets.contextdir}}"/app/10-aws.conflist
+      for binary in aws-cni aws-k8s-agent grpc-health-probe egress-cni aws-vpc-cni; do
+          install -m 755 -D ./$binary "${{targets.contextdir}}"/app/$binary
+      done
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    # https://github.com/aws/amazon-vpc-cni-k8s/blob/389f5ebd62fda05776e837ad9a2dad5a8aec02cd/scripts/dockerfiles/Dockerfile.release#L27
+    description: "This manually sets the symlink so that calls to iptables use the iptables-wrapper"
+    dependencies:
+      runtime:
+        # https://github.com/wolfi-dev/os/blob/388b536baaf146b259bd57909e854ab403a07732/cilium-1.15.yaml#L169-L183
+        # https://github.com/aws/amazon-vpc-cni-k8s/blob/389f5ebd62fda05776e837ad9a2dad5a8aec02cd/scripts/dockerfiles/Dockerfile.release#L27
+        - cilium-iptables # it contains the iptables-wrapper script
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/sbin
+          ln -s /usr/sbin/iptables-wrapper "${{targets.contextdir}}"/sbin/iptables
+
+update:
+  enabled: true
+  github:
+    identifier: aws/amazon-vpc-cni-k8s
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        # - busybox
+        # - ca-certificates-bundle
+        - iptables
+        - cilium-iptables
+  pipeline:
+    - runs: |
+        set +e
+        # same issue persists in the upstream container, see:
+        # $ docker container run --rm public.ecr.aws/eks/amazon-k8s-cni:v1.18.0-eksbuild.1
+        /app/aws-vpc-cni | grep "Failed to install CNI binaries"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
