### PR TITLE
Rebuild vault with the go/build pipeline

### DIFF
--- a/vault-1.14.yaml
+++ b/vault-1.14.yaml
@@ -2,7 +2,7 @@
 package:
   name: vault-1.14
   version: 1.14.11
-  epoch: 0
+  epoch: 1
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0
@@ -17,10 +17,12 @@ environment:
       - ca-certificates-bundle
       - go
       - libcap-utils
-      - nodejs-18
+      - nodejs-20
       - npm
       - python3
       - yarn
+  environment:
+    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout
@@ -34,31 +36,30 @@ pipeline:
       deps: github.com/cockroachdb/cockroach-go@v2.0.1+incompatible google.golang.org/protobuf@v1.33.0
 
   - runs: |
-      go mod tidy
-      go generate $(go list ./... | grep -v /vendor/)
-
       # Build plugins
       grep "^[a-z].*plugin[:]" Makefile | cut -f1 -d: | while IFS= read -r plugin; do
         echo "--> Building $plugin"
         make "$plugin"
       done
 
-      NODE_OPTIONS="--openssl-legacy-provider" make static-dist
-      _gotags="vault ui"
+      make static-dist
 
-      _go_ldflags="
-      -s -w
-      -X github.com/hashicorp/vault/version.fullVersion=${{package.version}}
-      -X github.com/hashicorp/vault/version.GitCommit=$(git rev-parse HEAD)
-      -X github.com/hashicorp/vault/version.BuildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
-      "
-
-      CGO_ENABLED=0 go build -v -o bin/vault -ldflags "$_go_ldflags" -tags "$_gotags"
+  - uses: go/build
+    with:
+      packages: .
+      output: vault
+      vendor: true
+      tags: "vault,ui"
+      ldflags: |
+        -X github.com/hashicorp/vault/version.fullVersion=${{package.version}}
+        -X github.com/hashicorp/vault/version.GitCommit=$(git rev-parse HEAD)
+        -X github.com/hashicorp/vault/version.BuildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - runs: |
       install -m644 -D "./vault.confd" "${{targets.destdir}}/etc/conf.d/vault"
 
-      install -m755 -D ./bin/vault "${{targets.destdir}}/usr/bin/vault"
+      # Correct Permissions
+      chmod 755 "${{targets.destdir}}/usr/bin/vault"
 
       # Directory for config. Vault user needs write privileges
       install -m777 -d "${{targets.destdir}}/etc/vault"
@@ -101,10 +102,5 @@ update:
 test:
   pipeline:
     - runs: |
-        output=$(vault version | grep ${{package.version}})
-        if [ -z "$output" ]; then
-          echo "Test failed: Output is empty"
-          exit 1
-        else
-          echo "Test passed: Output is not empty"
-        fi
+        set -o pipefail
+        vault version | grep "${{package.version}}"


### PR DESCRIPTION
- Build with the go/build pipeline.
- update nodejs to its current LTS nodejs-20.
- Update the test pipeline.

Taken reference from https://github.com/chainguard-dev/enterprise-packages/pull/3230