### PR TITLE
Add npm as runtime dependency of kubeflow-centraldashboard

### DIFF
--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,10 +1,13 @@
 package:
   name: kubeflow-centraldashboard
   version: 1.8.0
-  epoch: 3
+  epoch: 4
   description: Landing page and central dashboard for Kubeflow deployments
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      - npm
 
 environment:
   contents:


### PR DESCRIPTION
npm was removed as a runtime dep from nodejs in https://github.com/wolfi-dev/os/pull/13926/files

kubeflow-centraldashboard tests have been failing because the centraldashboard Pod expects npm to be there, this should fix them.