### PR TITLE
Bump epoch for harbor-registry and helm-operator

### DIFF
--- a/harbor-registry.yaml
+++ b/harbor-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-registry
   version: 3.0.0_alpha1
-  epoch: 0
+  epoch: 1
   description: An open source trusted cloud native registry project that stores, signs, and scans content (registry)
   copyright:
     - license: Apache-2.0

--- a/helm-operator.yaml
+++ b/helm-operator.yaml
@@ -24,7 +24,7 @@ pipeline:
   - uses: go/bump
     with:
       deps: golang.org/x/crypto@v0.19.0 github.com/docker/distribution@v2.8.3+incompatible helm.sh/helm/v3@v3.14.2 google.golang.org/protobuf@v1.33.0 github.com/docker/docker@v24.0.9
-      replaces: github.com/google/gnostic=github.com/google/gnostic@v0.7.0 k8s.io/kube-openapi=k8s.io/kube-openapi@v0.0.0-20231010175941-2dd684a91f00
+      replaces: github.com/google/gnostic=github.com/google/gnostic@v0.7.0 k8s.io/kube-openapi=k8s.io/kube-openapi@v0.0.0-20231010175941-2dd684a91f00 github.com/distribution/reference=github.com/distribution/reference@v0.5.0
 
   - runs: |
       make build/operator-sdk build/helm-operator

--- a/helm-operator.yaml
+++ b/helm-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm-operator
   version: 1.34.1
-  epoch: 2
+  epoch: 3
   description: open source toolkit to manage Kubernetes native applications.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bump the epoch of those packages to get built using the latest go version.