### PR TITLE
valkey: init at 7.2.5

### DIFF
--- a/valkey.yaml
+++ b/valkey.yaml
@@ -1,0 +1,85 @@
+package:
+  name: valkey
+  version: 7.2.5
+  epoch: 0
+  description: Advanced key-value store
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    provides:
+      - redis=${{package.full-version}}
+    runtime:
+      - posix-libc-utils # `getent` is required on startup in ha mode for ip introspection cluster formation
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - linux-headers
+      - openssl-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/valkey-io/valkey
+      tag: ${{package.version}}
+      expected-commit: 26388270f197bce84817eea0a73d687d58442654
+
+  - uses: patch
+    with:
+      patches: 0000-Disable-protected-mode.patch
+
+  - runs: |
+      export CFLAGS="$CFLAGS -DUSE_MALLOC_USABLE_SIZE"
+        make USE_JEMALLOC=no \
+        MALLOC=libc \
+        BUILD_TLS=yes \
+        all -j$(nproc)
+      make install PREFIX=/usr INSTALL_BIN="${{targets.destdir}}/usr/bin"
+
+  - uses: strip
+
+subpackages:
+  - name: valkey-cli
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/valkey-cli "${{targets.subpkgdir}}"/usr/bin/valkey-cli
+    description: valkey-cli is the command line interface utility to talk with Valkey.
+
+  - name: valkey-benchmark
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/valkey-benchmark "${{targets.subpkgdir}}"/usr/bin/valkey-benchmark
+    description: valkey-benchmark utility that simulates running commands done by N clients while at the same time sending M total queries.
+
+update:
+  enabled: true
+  github:
+    identifier: valkey-io/valkey
+
+test:
+  environment:
+    contents:
+      packages:
+        - valkey-cli
+  pipeline:
+    - runs: |
+        cat <<EOF >> /tmp/valkey.conf
+        dbfilename dump.rdb
+        pidfile /tmp/valkey_6379.pid
+        dir /tmp/
+        EOF
+
+        valkey-server /tmp/valkey.conf &
+        sleep 2 # wait for valkey to start
+        valkey-cli SET bike:1 "Process 134" || exit 1
+        valkey-cli GET bike:1 | grep 'Process 134' || exit 1
+        valkey-cli exists bike:1 | grep 1 || exit 1
+        valkey-cli exists bike:2 | grep 0 || exit 1

--- a/valkey/0000-Disable-protected-mode.patch
+++ b/valkey/0000-Disable-protected-mode.patch
@@ -1,0 +1,29 @@
+From b91e39701c7a71f229be34dcf078579d37367436 Mon Sep 17 00:00:00 2001
+From: Dan Lorenc <dlorenc@chainguard.dev>
+Date: Sat, 24 Dec 2022 12:15:14 -0500
+Subject: [PATCH] Disable protected mode.
+
+See https://github.com/docker-library/redis/blob/19f345b2056588c009396bcfc22ba9241a669491/Dockerfile-alpine.template#L43
+for more context - we disable protected mode because it's not needed
+in a docker image and we can't do this via a config option.
+
+---
+ src/config.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/config.c b/src/config.c
+index 78553b758..8547d76c2 100644
+--- a/src/config.c
++++ b/src/config.c
+@@ -3013,7 +3013,7 @@ standardConfig static_configs[] = {
+     createBoolConfig("daemonize", NULL, IMMUTABLE_CONFIG, server.daemonize, 0, NULL, NULL),
+     createBoolConfig("io-threads-do-reads", NULL, DEBUG_CONFIG | IMMUTABLE_CONFIG, server.io_threads_do_reads, 0,NULL, NULL), /* Read + parse from threads? */
+     createBoolConfig("always-show-logo", NULL, IMMUTABLE_CONFIG, server.always_show_logo, 0, NULL, NULL),
+-    createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, server.protected_mode, 1, NULL, NULL),
++    createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, server.protected_mode, 0, NULL, NULL),
+     createBoolConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, server.rdb_compression, 1, NULL, NULL),
+     createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, server.rdb_del_sync_files, 0, NULL, NULL),
+     createBoolConfig("activerehashing", NULL, MODIFIABLE_CONFIG, server.activerehashing, 1, NULL, NULL),
+-- 
+2.37.1 (Apple Git-137.1)
+


### PR DESCRIPTION
Valkey first release is there https://www.linuxfoundation.org/press/valkey-community-announces-release-candidate-amid-growing-support-for-open-source-data-store
![image](https://github.com/wolfi-dev/os/assets/6224096/4c4c95ca-19aa-4435-9ac7-175daa44c37b)



### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
