### PR TITLE
rustls-ffi: build using cargo capi to generate pkg-config file

### DIFF
--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl-rustls
   version: 8.6.0
-  epoch: 1
+  epoch: 2
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -23,7 +23,7 @@ environment:
       - nghttp2-dev
       - openssl-dev
       - perl
-      - rustls-ffi
+      - rustls-ffi-dev
       - wolfi-base
       - zlib-dev
 

--- a/rustls-ffi.yaml
+++ b/rustls-ffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: rustls-ffi
   version: 0.13.0
-  epoch: 0
+  epoch: 1
   description: "C-to-rustls bindings"
   copyright:
     - license: MIT
@@ -13,6 +13,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-c
       - rust
       - wolfi-base
 
@@ -24,14 +25,19 @@ pipeline:
       expected-commit: 5700454570cb1641c18d6f9663086671dc695487
 
   - runs: |
-      # gcc 13 throws extra error, suppress them
-      sed -i "s/CFLAGS := -Werror/CFLAGS := -Werror -Wno-maybe-uninitialized/" Makefile
-
-  - uses: autoconf/make
-
-  - uses: autoconf/make-install
+      cargo capi build --release
+      cargo capi install --prefix=/usr --destdir "${{targets.contextdir}}"
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-dev
+    description: "${{package.name}} development headers"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - ${{package.name}}
 
 update:
   enabled: true


### PR DESCRIPTION
This is needed by next curl rust build

Fixes: https://github.com/wolfi-dev/os/pull/15887