### PR TITLE
bump njs for fetching the latest ngin-mainline-src

### DIFF
--- a/njs.yaml
+++ b/njs.yaml
@@ -1,7 +1,7 @@
 package:
   name: njs
   version: 0.8.4
-  epoch: 1
+  epoch: 2
   description: njs scripting language CLI utility
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: 

We talked about this and aware of it since wolfi-bot upgraded the nginx-mainline to newest version which is 1.25.5 [here](https://github.com/wolfi-dev/os/commit/61db8371bc3ca964d37e9d610c546857d638c707) so during the building njs package we were installing 1.25.4-r2 [here](https://github.com/wolfi-dev/os/actions/runs/8706054571/job/23877825026#step:8:3238) so we should bump the njs package version to rebuild it with newest nginx-mainline version.

```
nginx: [emerg] module "/usr/lib/nginx/modules/ngx_http_js_module.so" version 1025004 instead of 1025005 in /etc/nginx/nginx.conf:3
```

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
