### PR TITLE
new pkg: valkey

### DIFF
--- a/valkey-7.2.yaml
+++ b/valkey-7.2.yaml
@@ -1,0 +1,91 @@
+package:
+  name: valkey-7.2
+  version: 7.2.5
+  epoch: 2
+  description: an open source, in-memory data store
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    provides:
+      - valkey=${{package.full-version}}
+    runtime:
+      - posix-libc-utils # `getent` is required on startup in ha mode for ip introspection cluster formation
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - linux-headers
+      - openssl-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: c7c7a758edabe7693b3692db58fe5328130036b06224df64ab1f0c12fe265a76
+      uri: https://github.com/valkey-io/valkey/archive/refs/tags/${{package.version}}.tar.gz
+
+  - uses: patch
+    with:
+      patches: 0000-Disable-protected-mode.patch
+
+  - runs: |
+      export CFLAGS="$CFLAGS -DUSE_MALLOC_USABLE_SIZE"
+        make USE_JEMALLOC=no \
+        MALLOC=libc \
+        BUILD_TLS=yes \
+        all -j$(nproc)
+      make install PREFIX=/usr INSTALL_BIN="${{targets.destdir}}/usr/bin"
+
+  - uses: strip
+
+subpackages:
+  - name: valkey-cli-7.2
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/valkey-cli "${{targets.subpkgdir}}"/usr/bin/valkey-cli
+    description: valkey-cli is the command line interface utility to talk with Valkey.
+    dependencies:
+      provides:
+        - valkey-cli=${{package.full-version}}
+
+  - name: valkey-benchmark-7.2
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/valkey-benchmark "${{targets.subpkgdir}}"/usr/bin/valkey-benchmark
+    description: valkey-benchmark utility that simulates running commands done by N clients while at the same time sending M total queries.
+    dependencies:
+      provides:
+        - valkey-benchmark=${{package.full-version}}
+
+update:
+  enabled: true
+  github:
+    identifier: valkey-io/valkey
+    tag-filter-prefix: "7.2."
+
+test:
+  environment:
+    contents:
+      packages:
+        - valkey-cli
+  pipeline:
+    - runs: |
+        cat <<EOF >> /tmp/valkey.conf
+        dbfilename dump.rdb
+        pidfile /tmp/valkey_6379.pid
+        dir /tmp/
+        EOF
+
+        valkey-server /tmp/valkey.conf &
+        sleep 2 # wait for valkey to start
+        valkey-cli SET bike:1 "Process 134" || exit 1
+        valkey-cli GET bike:1 | grep 'Process 134' || exit 1
+        valkey-cli exists bike:1 | grep 1 || exit 1
+        valkey-cli exists bike:2 | grep 0 || exit 1

--- a/valkey-7.2.yaml
+++ b/valkey-7.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: valkey-7.2
   version: 7.2.5
-  epoch: 2
+  epoch: 0
   description: an open source, in-memory data store
   copyright:
     - license: BSD-3-Clause

--- a/valkey-7.2/0000-Disable-protected-mode.patch
+++ b/valkey-7.2/0000-Disable-protected-mode.patch
@@ -1,0 +1,29 @@
+From b91e39701c7a71f229be34dcf078579d37367436 Mon Sep 17 00:00:00 2001
+From: Dan Lorenc <dlorenc@chainguard.dev>
+Date: Sat, 24 Dec 2022 12:15:14 -0500
+Subject: [PATCH] Disable protected mode.
+
+See https://github.com/docker-library/redis/blob/19f345b2056588c009396bcfc22ba9241a669491/Dockerfile-alpine.template#L43
+for more context - we disable protected mode because it's not needed
+in a docker image and we can't do this via a config option.
+
+---
+ src/config.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/config.c b/src/config.c
+index 78553b758..8547d76c2 100644
+--- a/src/config.c
++++ b/src/config.c
+@@ -3013,7 +3013,7 @@ standardConfig static_configs[] = {
+     createBoolConfig("daemonize", NULL, IMMUTABLE_CONFIG, server.daemonize, 0, NULL, NULL),
+     createBoolConfig("io-threads-do-reads", NULL, DEBUG_CONFIG | IMMUTABLE_CONFIG, server.io_threads_do_reads, 0,NULL, NULL), /* Read + parse from threads? */
+     createBoolConfig("always-show-logo", NULL, IMMUTABLE_CONFIG, server.always_show_logo, 0, NULL, NULL),
+-    createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, server.protected_mode, 1, NULL, NULL),
++    createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, server.protected_mode, 0, NULL, NULL),
+     createBoolConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, server.rdb_compression, 1, NULL, NULL),
+     createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, server.rdb_del_sync_files, 0, NULL, NULL),
+     createBoolConfig("activerehashing", NULL, MODIFIABLE_CONFIG, server.activerehashing, 1, NULL, NULL),
+-- 
+2.37.1 (Apple Git-137.1)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

This is pretty much a copy of redis-7.2 package.

- Add a new package `valkey-7.2` and its subpackages
- Remove bitnami-compat-* packages because I'm not sure we want to provide drop-in replacement image for Valkey with bitnami/redis chart. I can re-add it if you think it's good idea.


<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
