### PR TITLE
Add new package jitterentropy-library

### DIFF
--- a/jitterentropy-library.yaml
+++ b/jitterentropy-library.yaml
@@ -1,0 +1,47 @@
+package:
+  name: jitterentropy-library
+  version: 3.4.1
+  epoch: 0
+  description: Jitterentropy Library
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/smuellerDD/jitterentropy-library
+      expected-commit: f6df495516c7e8619cefe4c287dbf9de607e34a9
+      tag: v${{package.version}}
+
+  - runs: |
+      # jitterentropy must *not* be compiled with optimizations
+      export CFLAGS="$CFLAGS -O0"
+      export CPPFLAGS=""
+      export CXXFLAGS="$CXXFLAGS -O0"
+      # install into /usr
+      sed 's|/usr/local|/usr|' -i Makefile
+      make
+      make install install-static DESTDIR="${{targets.contextdir}}"
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-dev
+    pipeline:
+      - uses: split/dev
+      - uses: split/manpages
+      - uses: split/static
+    description: ${{package.name}} development headers and static library
+
+update:
+  enabled: true
+  github:
+    identifier: smuellerDD/jitterentropy-library
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
This library offers userspace implementation of entropy gathering. Intentionally compiled unoptimised, to achieve entropy.

See manpage for usage. Static library is provided for convenience of producing statically linked builds with a built-in entropy source.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)