### PR TITLE
New v3.15.1 of Gatekeeper.

### DIFF
--- a/gatekeeper-3.15.yaml
+++ b/gatekeeper-3.15.yaml
@@ -1,0 +1,68 @@
+package:
+  name: gatekeeper-3.15
+  version: 3.15.1
+  epoch: 0
+  description: Gatekeeper - Policy Controller for Kubernetes
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - gatekeeper=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - wolfi-baselayout
+
+pipeline:
+  # We can't use go/install because this requires specific ldflags to set the version
+  - uses: git-checkout
+    with:
+      repository: https://github.com/open-policy-agent/gatekeeper
+      tag: v${{package.version}}
+      expected-commit: 3350319f76d3e2d78df0b972c63258cba7c7915f
+
+  - uses: go/bump
+    with:
+      deps: google.golang.org/protobuf@v1.33.0 github.com/docker/docker@v24.0.9
+
+  - runs: |
+      FRAMEWORKS_VERSION=$(go list -f '{{ .Version }}' -m github.com/open-policy-agent/frameworks/constraint)
+      OPA_VERSION=$(go list -f '{{ .Version }}' -m github.com/open-policy-agent/opa)
+      CGO_ENABLED=0 GO111MODULE=on go build -mod vendor -a -ldflags "-w -X github.com/open-policy-agent/gatekeeper/pkg/version.Version=v${{package.version}} -X main.frameworksVersion=${FRAMEWORKS_VERSION} -X main.opaVersion=${OPA_VERSION}" -o manager
+      make gator
+      mkdir -p ${{targets.destdir}}/usr/bin
+      install -Dm755 ./manager ${{targets.destdir}}/usr/bin/manager
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}
+          ln -sf /usr/bin/manager ${{targets.subpkgdir}}/manager
+    dependencies:
+      provides:
+        - gatekeeper-compat=${{package.full-version}}
+
+  - name: ${{package.name}}-gator
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv bin/gator ${{targets.subpkgdir}}/usr/bin/gator
+    dependencies:
+      provides:
+        - gatekeeper-gator=${{package.full-version}}
+
+update:
+  enabled: true
+  github:
+    identifier: open-policy-agent/gatekeeper
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v3.15.

--- a/gatekeeper.yaml
+++ b/gatekeeper.yaml
@@ -1,5 +1,5 @@
 package:
-  name: gatekeeper-3.15
+  name: gatekeeper
   version: 3.15.1
   epoch: 0
   description: Gatekeeper - Policy Controller for Kubernetes
@@ -65,4 +65,3 @@ update:
     identifier: open-policy-agent/gatekeeper
     strip-prefix: v
     use-tag: true
-    tag-filter: v3.15.


### PR DESCRIPTION
Gatekeeper-3.15: new version of Gatekeeper package

Fixes:
https://github.com/chainguard-dev/customer-issues/issues/1332

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

"This PR links to the upstream project's support policy (e.g. `endoflife.date`)"

The project has no support policy I can find.


NB, the "gator" sub pkg doesnt appear in "apk search" results for v3.14. The 3.15 gator does. Don't know if that's my problem or the 3.14 pkg's problem or not a problem.
```
6066cd522060:/work/packages# apk search gatekeeper | sort
gatekeeper-3.12-3.12.0-r14
gatekeeper-3.12-compat-3.12.0-r14
gatekeeper-3.13-3.13.4-r5
gatekeeper-3.13-compat-3.13.4-r5
gatekeeper-3.13.0-r1
gatekeeper-3.14-3.14.1-r2
gatekeeper-3.14-compat-3.14.1-r2
gatekeeper-3.15-3.15.1-r0
gatekeeper-3.15-compat-3.15.1-r0
gatekeeper-3.15-gator-3.15.1-r0
gatekeeper-compat-3.13.0-r1
```

