### PR TITLE
zookeeper bitnami compat path fixes

### DIFF
--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -69,10 +69,16 @@ subpackages:
           version-path: 3.9/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/zookeeper/
-          ln -s /usr/share/java/zookeeper/bin ${{targets.subpkgdir}}/opt/bitnami/zookeeper/bin
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/zookeeper/bin
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/zookeeper/conf
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/zookeeper/conf.default
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/zookeeper/logs
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/scripts/zookeeper/
+
+          cp -r ${{targets.destdir}}/usr/share/java/zookeeper/bin/* ${{targets.subpkgdir}}/opt/bitnami/zookeeper/bin
           ln -s /usr/share/java/zookeeper/lib ${{targets.subpkgdir}}/opt/bitnami/zookeeper/lib
-          ln -s /usr/share/java/zookeeper/conf ${{targets.subpkgdir}}/opt/bitnami/zookeeper/conf
-          ln -s /usr/share/java/zookeeper/logs ${{targets.subpkgdir}}/opt/bitnami/zookeeper/logs
+          cp -r conf/* ${{targets.subpkgdir}}/opt/bitnami/zookeeper/conf/
+          cp -r conf/* ${{targets.subpkgdir}}/opt/bitnami/zookeeper/conf.default
 
           # create symlinks for both /entrypoint.sh and /run.sh to make it compatible with bitnami/zookeeper helm chart
           ln -sf /opt/bitnami/scripts/zookeeper/entrypoint.sh "${{targets.subpkgdir}}"/entrypoint.sh


### PR DESCRIPTION
This fixes the zookeeper bitnami subpackage paths to work with the helm chart in testing. Previously a pod would fail because of a missing `/opt/bitnami/zookeeper/conf.default` directory, as well as the associated `zoo.cfg` file needed for start up.