### PR TITLE
add iptables-wrapper

### DIFF
--- a/iptables-wrapper.yaml
+++ b/iptables-wrapper.yaml
@@ -1,0 +1,54 @@
+package:
+  name: iptables-wrapper
+  version: 2
+  epoch: 0
+  description: Wrapper scripts for using iptables in containers
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - iptables
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - iptables
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/iptables-wrappers
+      tag: v${{package.version}}
+      expected-commit: e139a115350974aac8a82ec4b815d2845f86997e
+
+  - runs: |
+      # This script generates a wrapper based on the version
+      # of iptables provided by the build environment.
+      ./iptables-wrapper-installer.sh
+      mkdir -p ${{targets.contextdir}}/sbin
+      mkdir -p ${{targets.contextdir}}/usr/sbin
+      mv /sbin/iptables-wrapper ${{targets.contextdir}}/sbin/iptables-wrapper
+      ln -sf /sbin/iptables-wrapper ${{targets.contextdir}}/usr/sbin/iptables-wrapper
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by amazon-vpc-cni-k8s"
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          rm -rf ${{targets.contextdir}}/usr/sbin/iptables # Not needed for the compat package
+          mkdir -p "${{targets.contextdir}}"/usr/sbin
+          ln -sf /sbin/iptables-wrapper ${{targets.contextdir}}/usr/sbin/iptables
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/iptables-wrappers
+    use-tag: true
+    strip-prefix: v

--- a/iptables-wrappers.yaml
+++ b/iptables-wrappers.yaml
@@ -18,7 +18,6 @@ environment:
   contents:
     packages:
       - busybox
-      - ca-certificates-bundle
 
 pipeline:
   - uses: git-checkout

--- a/iptables-wrappers.yaml
+++ b/iptables-wrappers.yaml
@@ -1,5 +1,5 @@
 package:
-  name: iptables-wrapper
+  name: iptables-wrappers
   version: 2
   epoch: 0
   description: Wrapper scripts for using iptables in containers

--- a/iptables-wrappers.yaml
+++ b/iptables-wrappers.yaml
@@ -34,18 +34,6 @@ pipeline:
 
   - uses: strip
 
-subpackages:
-  - name: "${{package.name}}-compat"
-    description: "Compatibility package to place binaries in the location expected by amazon-vpc-cni-k8s"
-    dependencies:
-      runtime:
-        - ${{package.name}}
-    pipeline:
-      - runs: |
-          rm -rf ${{targets.contextdir}}/usr/sbin/iptables # Not needed for the compat package
-          mkdir -p "${{targets.contextdir}}"/usr/sbin
-          ln -sf /sbin/iptables-wrapper ${{targets.contextdir}}/usr/sbin/iptables
-
 update:
   enabled: true
   github:

--- a/iptables-wrappers.yaml
+++ b/iptables-wrappers.yaml
@@ -7,14 +7,18 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - iptables
+      - xtables
+
+vars:
+  wrapped-commands: |
+    iptables  iptables-restore  iptables-save \
+    ip6tables ip6tables-restore ip6tables-save
 
 environment:
   contents:
     packages:
       - busybox
       - ca-certificates-bundle
-      - iptables
 
 pipeline:
   - uses: git-checkout
@@ -22,17 +26,85 @@ pipeline:
       repository: https://github.com/kubernetes-sigs/iptables-wrappers
       tag: v${{package.version}}
       expected-commit: e139a115350974aac8a82ec4b815d2845f86997e
+      cherry-picks: |
+        master/680003b3c6e93b471a59ecc9ae87a8f9054b82f3: Convert iptables-wrapper to a static go program
 
-  - runs: |
-      # This script generates a wrapper based on the version
-      # of iptables provided by the build environment.
-      ./iptables-wrapper-installer.sh
-      mkdir -p ${{targets.contextdir}}/sbin
-      mkdir -p ${{targets.contextdir}}/usr/sbin
-      mv /sbin/iptables-wrapper ${{targets.contextdir}}/sbin/iptables-wrapper
-      ln -sf /sbin/iptables-wrapper ${{targets.contextdir}}/usr/sbin/iptables-wrapper
+  - uses: go/build
+    with:
+      packages: .
+      output: ${{context.name}}
 
-  - uses: strip
+  - name: Rename go binary to use upstream name
+    working-directory: ${{targets.contextdir}}
+    runs: |
+      mv usr/bin/iptables-wrappers usr/bin/iptables-wrapper
+
+  - working-directory: ${{targets.contextdir}}
+    runs: |
+      wrapped_cmds="${{vars.wrapped-commands}}"
+      for cmd in $wrapped_cmds; do
+        ln -s iptables-wrapper "usr/bin/$cmd"
+      done
+
+test:
+  pipeline:
+    - runs: |
+        check_target() {
+          local cmd="$1"
+          local symlinks_point_to="$2"
+          local target="$(readlink /usr/bin/$cmd)"
+
+          case "$symlinks_point_to" in
+            "wrapper")
+              [ "$target" = "iptables-wrapper" ]
+              ;;
+            "detected")
+              # wrapper will point to binaries in /usr/sbin, which
+              # relies on our usrmerge sbin->bin compat symlinks. We should
+              # submit a fix upstream.
+              target="$(echo $target | sed 's,^/usr/sbin/,,')"
+              [ "$target" = "xtables-nft-multi" ] || \
+                [ "$target" = "xtables-legacy-multi" ]
+              ;;
+            *)
+              echo "ERROR: Invalid parameter: [$2]" 1>&2
+              exit 1
+              ;;
+          esac
+          test -x "/usr/bin/$target"
+        }
+
+        wrapped_cmds="${{vars.wrapped-commands}}"
+        # on a fresh install, the symlink should point to the wrapper
+        symlinks_point_to="wrapper"
+        for cmd in $wrapped_cmds; do
+          check_target "$cmd" "$symlinks_point_to"
+          test -x "/usr/bin/$target"
+          # when invoked, the wrapper will detect the in-use variant
+          # (legacy | nft) and call its command instead. then, as an
+          # optimization, it will update the symlink to point directly
+          # to that command, bypassing the wrapper in subsequent calls
+          case "$cmd" in
+            ip*tables|ip*tables-restore)
+              for arg in "--help" "--version"; do
+                "$cmd" "$arg" || "$cmd" "$arg" 2>&1 | \
+                  grep "Protocol not supported"
+              done
+              ;;
+            ip*tables-save)
+              # has no help/version, but run it to trigger the wrapper's
+              # symlink replacement as a side-effect
+              "$cmd" || /bin/true
+              ;;
+            *)
+              echo "ERROR: Unknown command $cmd" 1>&2
+              exit 1
+          esac
+          # Once the wrapper has been called once, all symlinks should
+          # point to the detected variant
+          symlinks_point_to="detected"
+          check_target "$cmd" "$symlinks_point_to"
+        done
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
