### PR TITLE
wavefront-proxy :::: fix: CVE GHSA-5jpm-x58v-624v

### DIFF
--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: wavefront-proxy
   version: "13.4" # When version is bumped, check if patches are still needed to address CVE-2023-1428
-  epoch: 3
+  epoch: 4
   description: Wavefront Proxy Project
   copyright:
     - license: Apache-2.0

--- a/wavefront-proxy/proxy/pombump-deps.yaml
+++ b/wavefront-proxy/proxy/pombump-deps.yaml
@@ -11,3 +11,19 @@ patches:
     version: 1.53.0
     scope: import
     type: jar
+  # Fixes GHSA-5jpm-x58v-624v
+  - groupId: io.netty
+    artifactId: netty-bom
+    version: 4.1.108.Final
+    scope: import
+    type: jar
+  - groupId: io.netty
+    artifactId: netty-codec-http
+    version: 4.1.108.Final
+    scope: import
+    type: jar
+  - groupId: com.squareup.okio
+    artifactId: okio
+    version: 3.4.0
+    scope: import
+    type: jar


### PR DESCRIPTION
These are the new results. Take into account that GHSA-264p-99wq-f4j6 doesn't have any fixed version yet.
```
🔎 Scanning "packages/x86_64/wavefront-proxy-13.4-r4.apk"
└── 📄 /usr/share/java/wavefront/wavefront-proxy/wavefront-proxy.jar
        📦 ion-java 1.0.2 (java-archive)
            High CVE-2024-21634 GHSA-264p-99wq-f4j6
```