### PR TITLE
fix(httpie): add missing python deps

### DIFF
--- a/httpie.yaml
+++ b/httpie.yaml
@@ -7,6 +7,9 @@ package:
     - license: BSD-3-Clause
   dependencies:
     runtime:
+      - py3-multidict
+      - py3-pygments
+      - py3-requests
       - python3
 
 environment:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

I noticed that the `httpie` package was broken and required some Python deps for it to work.

---


1. `docker run --rm -it cgr.dev/chainguard/wolfi-base`
1. `apk update`
1. `apk add httpie`
1. `https vg.no`
1. Experience missing deps:

```
Traceback (most recent call last):
  File "/usr/bin/https", line 33, in <module>
    sys.exit(load_entry_point('httpie==3.2.2', 'console_scripts', 'https')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/httpie/__main__.py", line 8, in main
    from httpie.core import main
  File "/usr/lib/python3.12/site-packages/httpie/core.py", line 8, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'

Traceback (most recent call last):
  File "/usr/bin/https", line 33, in <module>
    sys.exit(load_entry_point('httpie==3.2.2', 'console_scripts', 'https')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/httpie/__main__.py", line 8, in main
    from httpie.core import main
  File "/usr/lib/python3.12/site-packages/httpie/core.py", line 9, in <module>
    from pygments import __version__ as pygments_version
ModuleNotFoundError: No module named 'pygments'

Traceback (most recent call last):
  File "/usr/bin/https", line 33, in <module>
    sys.exit(load_entry_point('httpie==3.2.2', 'console_scripts', 'https')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/httpie/__main__.py", line 8, in main
    from httpie.core import main
  File "/usr/lib/python3.12/site-packages/httpie/core.py", line 15, in <module>
    from .client import collect_messages
  File "/usr/lib/python3.12/site-packages/httpie/client.py", line 15, in <module>
    from .adapters import HTTPieHTTPAdapter
  File "/usr/lib/python3.12/site-packages/httpie/adapters.py", line 1, in <module>
    from httpie.cli.dicts import HTTPHeadersDict
  File "/usr/lib/python3.12/site-packages/httpie/cli/dicts.py", line 3, in <module>
    from multidict import MultiDict, CIMultiDict
```

Solution:

```
# apk add py3-multidict py3-pygments py3-requests
```

```
# https vg.no
HTTP/1.1 301 Moved
Connection: keep-alive
Content-Length: 0
Date: Fri, 19 Apr 2024 11:58:22 GMT
Server: Varnish
X-VG-TLSProxy: oa68-tlsproxy-01.int.vgnett.no
X-Varnish: 1035726526
location: https://www.vg.no/
```

---

Fixes:


Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
