### PR TITLE
use new release scheme for argocd-extension-installer

### DIFF
--- a/argocd-extension-installer.yaml
+++ b/argocd-extension-installer.yaml
@@ -1,10 +1,10 @@
-#nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: argocd-extension-installer
-  # This project doesn't do releases and everything is commit based.
-  # This corresponds to commit 880f978f59bd6434202504355c62c12e251e327a
-  version: 0.0_git20231025
-  epoch: 1
+  # they started to create new releases for this project by following the semver rules
+  # in the beginning there were no releases, so we were using the commit hash as the version
+  # now we are using the latest release version
+  version: 0.0.5
+  epoch: 0
   description: Install Argo CD extensions using init-containers
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/argoproj-labs/argocd-extension-installer
-      branch: main
+      tag: v${{package.version}}
+      expected-commit: 57ce7fcaed37b3ff6b1da5d593275fb9c2eee903
 
   - runs: |
       # https://github.com/argoproj-labs/argocd-extension-installer/blob/880f978f59bd6434202504355c62c12e251e327a/Dockerfile#L14
@@ -35,7 +36,11 @@ pipeline:
 
 # Upstream repo doesn't provide any tags or releases
 update:
-  enabled: false
+  enabled: true
+  github:
+    identifier: argoproj-labs/argocd-extension-installer
+    strip-prefix: v
+    use-tag: true
 
 # https://raw.githubusercontent.com/argoproj/argo-helm/main/charts/argo-cd/values.yaml
 test:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
