### PR TITLE
bump linux-headers epoch to rebuild with new SBOM

### DIFF
--- a/linux-headers.yaml
+++ b/linux-headers.yaml
@@ -1,7 +1,7 @@
 package:
   name: linux-headers
   version: 6.6.11
-  epoch: 0
+  epoch: 1
   description: "the Linux kernel headers (cross compilation)"
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
The existing package was last built with melange v0.5.5, which includes `files`, and those files seem to be invalid according to the official SPDX checker tool:

```
│ Analysis exception processing SPDX file: ID SPDXRef-File--usr-include-linux-netfilter-xtC95connmark.h already exists.
```

https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/linux-headers-6.6.11-r0.apk@sha1:76b42974a68e19c07e27778c08f6a322e3eebf95/var/lib/db/sbom/linux-headers-6.6.11-r0.spdx.json

We stopped including `files` altogether in https://github.com/chainguard-dev/melange/pull/1076, first released in melange 0.6.10.

Draft until this passes presubmit.