### PR TITLE
fluent-bit 3.0.2 update

### DIFF
--- a/fluent-bit.yaml
+++ b/fluent-bit.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-bit
-  version: 2.2.2
-  epoch: 1
+  version: 3.0.2
+  epoch: 0
   description: Fast and Lightweight Log processor and forwarder
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/fluent/fluent-bit
-      expected-commit: eeea396e88da26f586a7cc39df8017ab97f06939
+      expected-commit: 33ce918351cdae2056b9e1e470ee163293f3fb5d
       tag: v${{package.version}}
 
   - runs: |
@@ -95,7 +95,7 @@ update:
     identifier: fluent/fluent-bit
     strip-prefix: v
     # There are some malformed tags
-    tag-filter: v2
+    tag-filter: v3
     use-tag: true
 
 test:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
