### PR TITLE
fluent-bit renamed as fluent-bit-3.0

### DIFF
--- a/fluent-bit-3.0.yaml
+++ b/fluent-bit-3.0.yaml
@@ -1,10 +1,13 @@
 package:
-  name: fluent-bit
+  name: fluent-bit-3.0
   version: 3.0.2
   epoch: 0
   description: Fast and Lightweight Log processor and forwarder
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - fluent-bit=${{package.full-version}}
 
 environment:
   contents:
@@ -74,20 +77,25 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: fluent-bit-dev
+  - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
     dependencies:
       runtime:
         - fluent-bit
+      provides:
+        - fluent-bit-dev=${{package.full-version}}
     description: fluent-bit dev
 
-  - name: fluent-bit-compat
+  - name: ${{package.name}}-compat
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/fluent-bit/bin/
           # The upstream chart expects the fluent-bit binary to be in /fluent-bit/bin/fluent-bit
           ln -sf /usr/bin/fluent-bit ${{targets.subpkgdir}}/fluent-bit/bin/fluent-bit
+    dependencies:
+      provides:
+        - fluent-bit-compat=${{package.full-version}}
 
 update:
   enabled: true
@@ -95,7 +103,7 @@ update:
     identifier: fluent/fluent-bit
     strip-prefix: v
     # There are some malformed tags
-    tag-filter: v3
+    tag-filter: v3.0
     use-tag: true
 
 test:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Thanks to @dentrax he reminded me that there is multiple supported versions in fluent-bit according to the doc [here](https://fluentbit.io/announcements/older-versions/) so we renamed the fluent-bit package with the latest version of it.

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
