### PR TITLE
fix: GHSA-rhh4-rh7c-7r5v

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent
   version: 7.52.1
-  epoch: 1
+  epoch: 2
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -57,6 +57,7 @@ pipeline:
   - uses: go/bump
     with:
       deps: google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4 github.com/moby/buildkit@v0.13.1 github.com/docker/docker@v25.0.5 golang.org/x/net@v0.23.0
+      replaces: github.com/mholt/archiver/v3=github.com/anchore/archiver/v3@v3.5.2
 
   - runs: |
       export PATH=$PATH:$GOPATH/bin

--- a/vault-1.14.yaml
+++ b/vault-1.14.yaml
@@ -2,7 +2,7 @@
 package:
   name: vault-1.14
   version: 1.14.11
-  epoch: 2
+  epoch: 3
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0
@@ -34,6 +34,7 @@ pipeline:
   - uses: go/bump
     with:
       deps: github.com/cockroachdb/cockroach-go@v2.0.1+incompatible google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0
+      replaces: github.com/mholt/archiver/v3=github.com/anchore/archiver/v3@v3.5.2
 
   - runs: |
       # Build plugins


### PR DESCRIPTION
Replace the vulnerable module with one with the CVE fixes.