### PR TITLE
NeuVector vulnerability scanner for the SUSE NeuVector Container Secu…

### DIFF
--- a/neuvector-scanner.yaml
+++ b/neuvector-scanner.yaml
@@ -1,0 +1,70 @@
+package:
+  name: neuvector-scanner
+  version: 0_git20240417
+  epoch: 0
+  description: NeuVector vulnerability scanner for the SUSE NeuVector Container Security Platform
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: f616895dd7737b60f74eb520dda71996dc050720fb4c67fea906a845c23aa867
+      uri: https://github.com/neuvector/scanner/archive/ad2e622edd04a04981813076f4f5b23b407593f4.tar.gz
+
+  - uses: go/bump
+    with:
+      deps: github.com/containerd/containerd@v1.6.26 github.com/docker/docker@v26.0.0 github.com/opencontainers/image-spec@v1.1.0 github.com/opencontainers/runc@v1.1.12 golang.org/x/net@v0.17.0 google.golang.org/grpc@v1.56.3 google.golang.org/protobuf@v1.33.0 github.com/docker/distribution@v2.8.2-beta.1+incompatible golang.org/x/sys@v0.19.0
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: .
+      output: ${{package.name}}
+      vendor: true
+
+  - runs: |
+      # Retrieve certs
+      mkdir -p ${{targets.contextdir}}/etc/neuvector/certs/internal/
+      wget https://raw.githubusercontent.com/neuvector/manifests/main/build/share/etc/neuvector/certs/internal/ca.cert -P ${{targets.contextdir}}/etc/neuvector/certs/internal/
+      wget https://raw.githubusercontent.com/neuvector/manifests/main/build/share/etc/neuvector/certs/internal/cert.pem -P ${{targets.contextdir}}/etc/neuvector/certs/internal/
+      wget https://raw.githubusercontent.com/neuvector/manifests/main/build/share/etc/neuvector/certs/internal/cert.key -P ${{targets.contextdir}}/etc/neuvector/certs/internal/
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-task
+    description: NeuVector Scanner Task
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: .
+          output: ${{package.name}}-task
+          subpackage: "true"
+          vendor: true
+
+  - name: ${{package.name}}-monitor
+    description: NeuVector Scanner Monitor
+    pipeline:
+      - runs: |
+          make -C monitor
+          mkdir -p ${{targets.contextdir}}/usr/local/bin
+          install -Dm755 monitor/monitor ${{targets.contextdir}}/usr/local/bin/${{package.name}}-monitor
+
+test:
+  pipeline:
+    - runs: |
+        if neuvector-scanner --help | grep -q "usage: scan [OPTIONS]"; then
+            exit 0
+        fi
+
+update:
+  enabled: false # No releases or tags


### PR DESCRIPTION
…rity Platform

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
