### PR TITLE
bump controller-gen to 0.15.0

### DIFF
--- a/controller-gen.yaml
+++ b/controller-gen.yaml
@@ -1,7 +1,7 @@
 package:
   name: controller-gen
-  version: 0.14.0
-  epoch: 2
+  version: 0.15.0
+  epoch: 0
   description: Tools to use with the controller-runtime libraries
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,8 @@ update:
   github:
     identifier: kubernetes-sigs/controller-tools
     strip-prefix: v
+    tag-filter: v
+    use-tag: true
 
 test:
   pipeline:


### PR DESCRIPTION
bumps controller-gen to 0.15.0 

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

Fixes https://github.com/wolfi-dev/os/issues/17059