### PR TITLE
zfp package created

### DIFF
--- a/zfp.yaml
+++ b/zfp.yaml
@@ -1,0 +1,38 @@
+package:
+  name: zfp
+  version: 1.0.1
+  epoch: 0
+  description: zfp is a compressed format for representing multidimensional floating-point and integer arrays.
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/LLNL/zfp
+      tag: ${{package.version}}
+      expected-commit: f40868a6a1c190c802e7d8b5987064f044bf7812
+
+  - uses: cmake/configure
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: LLNL/zfp
+

--- a/zfp.yaml
+++ b/zfp.yaml
@@ -35,4 +35,3 @@ update:
   enabled: true
   github:
     identifier: LLNL/zfp
-

--- a/zfp.yaml
+++ b/zfp.yaml
@@ -35,7 +35,6 @@ pipeline:
       mv output/bin/testzfp ${{targets.destdir}}/usr/bin/testzfp
       mv output/bin/testviews ${{targets.destdir}}/usr/bin/testviews
 
-
 update:
   enabled: true
   github:

--- a/zfp.yaml
+++ b/zfp.yaml
@@ -29,9 +29,21 @@ pipeline:
 
   - uses: cmake/install
 
-  - uses: strip
+  - name: Adding tests to package
+    runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv output/bin/testzfp ${{targets.destdir}}/usr/bin/testzfp
+      mv output/bin/testviews ${{targets.destdir}}/usr/bin/testviews
+
 
 update:
   enabled: true
   github:
     identifier: LLNL/zfp
+
+test:
+  pipeline:
+    - name: Running tests provided by zfp
+      runs: |
+        testzfp || exit 1
+        testviews || exit 1


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
