### PR TITLE
Add a bash-binsh package to have bash provide /bin/sh

### DIFF
--- a/bash.yaml
+++ b/bash.yaml
@@ -1,7 +1,7 @@
 package:
   name: bash
   version: 5.2.21
-  epoch: 1
+  epoch: 2
   description: "GNU bourne again shell"
   copyright:
     - license: GPL-3.0-or-later
@@ -41,6 +41,20 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: bash-binsh
+    dependencies:
+      provider-priority: 60
+      runtime:
+        - bash
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/bin
+          ln -s bash "${{targets.subpkgdir}}"/bin/sh
+    test:
+      pipeline:
+        - runs: |
+            [ /bin/sh -ef /bin/bash ] || { echo "/bin/sh is not same as /bin/bash"; exit 1; }
+
   - name: "bash-doc"
     description: "bash documentation"
     pipeline:


### PR DESCRIPTION
If you have bash installed, then you can have it be /bin/sh also.  Previously if you had bash in an image and wanted a /bin/sh you would need to install another shell.

This adds bash-binsh package to provide the /bin/sh symlink.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
