### PR TITLE
local-static-provisioner and node-cleanup, withdraw old packages

### DIFF
--- a/local-static-provisioner.yaml
+++ b/local-static-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
-  name: sig-storage-local-static-provisioner
+  name: local-static-provisioner
   version: 2.7.0
-  epoch: 1
+  epoch: 0
   description: Static provisioner of local volumes
   copyright:
     - license: Apache-2.0
@@ -53,7 +53,7 @@ subpackages:
           mkdir -p "${{targets.contextdir}}"/
           ln -sf /usr/bin/local-provisioner "${{targets.contextdir}}"/local-provisioner
 
-  - name: node-cleanup-controller
+  - name: local-volume-node-cleanup
     pipeline:
       - uses: go/build
         with:
@@ -63,7 +63,7 @@ subpackages:
           subpackage: true
           vendor: true
 
-  - name: node-cleanup-controller-compat
+  - name: local-volume-node-cleanup-compat
     # https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/4f81db77908ff67d8cac223c31413a293cd65d73/cmd/node-cleanup/Dockerfile#L21
     description: The Dockerfile expects the binary to be executed as '/main'
     pipeline:
@@ -84,15 +84,15 @@ test:
     contents:
       packages:
         - ${{package.name}}-compat
-        - node-cleanup-controller-compat
-        - node-cleanup-controller
+        - local-volume-node-cleanup-compat
+        - local-volume-node-cleanup
   pipeline:
     - name: "Test local-provisioner"
       runs: |
         local-provisioner -h
         # test symlink
         /local-provisioner -h
-    - name: "Test node-cleanup-controller"
+    - name: "Test node-cleanup"
       runs: |
         set +e
         main -h

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -38,3 +38,11 @@ conda-build-24.1.2-r0.apk
 conda-24.1.1-r0.apk
 conda-24.1.1-r1.apk
 conda-24.1.2-r0.apk
+node-cleanup-controller-2.7.0-r0.apk
+node-cleanup-controller-2.7.0-r1.apk
+node-cleanup-controller-compat-2.7.0-r0.apk
+node-cleanup-controller-compat-2.7.0-r1.apk
+sig-storage-local-static-provisioner-2.7.0-r0.apk
+sig-storage-local-static-provisioner-2.7.0-r1.apk
+sig-storage-local-static-provisioner-compat-2.7.0-r0.apk
+sig-storage-local-static-provisioner-compat-2.7.0-r1.apk


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
