### PR TITLE
openssl: make openssl-config pure virtual package

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.3.0
-  epoch: 5
+  epoch: 6
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -117,8 +117,12 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/ossl-modules
           mv "${{targets.destdir}}"/usr/lib/ossl-modules/legacy.so "${{targets.subpkgdir}}"/usr/lib/ossl-modules/
 
-  - name: "openssl-config"
-    description: "OpenSSL configuration"
+  - name: "openssl-config-default"
+    description: "OpenSSL configuration using default provider"
+    dependencies:
+      provider-priority: 10
+      provides:
+        - openssl-config=${{package.version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/etc


### PR DESCRIPTION
Make openssl-config a pure virtual package. Set provider-priority on the openssl-config-default. This allows to build
openssl-config-fipshardened separately, with a matching provides that will always work.

Fixes: inability to seamlessly install openssl-config-fipshardened when provides versions drift.