### PR TITLE
Adding poetry as runtime dep

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: 0.20.1
-  epoch: 0
+  epoch: 1
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -11,6 +11,7 @@ package:
     no-depends: true
   dependencies:
     runtime:
+      - poetry
       - python-3.11-base
 
 environment:


### PR DESCRIPTION
Upstream added a runtime dependency on 'poetry' in their entrypoint script: https://github.com/thelastpickle/cassandra-medusa/pull/679. 

Without this added as a runtiume dep, the latest medusa will fail on launch, similar to:

```bash
k logs cassandra-medusa-cassandra-medusa-medusa-standalone-56bfd7qbqmh -n k8s-medusa-loyal-minnow
MEDUSA_MODE = GRPC
sleeping for 0 sec
Starting Medusa gRPC service
/home/cassandra/docker-entrypoint.sh: line 51: exec: poetry: not found
```