### PR TITLE
Updates to medusa package

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: 0.20.1
-  epoch: 1
+  epoch: 2
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
@@ -59,18 +59,23 @@ pipeline:
       .venv/bin/pip install -I python-snappy --no-compile
 
   - runs: |
-      mkdir -p ${{targets.destdir}}/usr/share/medusa
-      mv .venv ${{targets.destdir}}/usr/share/medusa/
+      mkdir -p ${{targets.destdir}}/home/cassandra
+      mv .venv ${{targets.destdir}}/home/cassandra/
 
       # edit the venv paths
-      sed -i "s|/home/build|/usr/share/medusa|g" ${{targets.destdir}}/usr/share/medusa/.venv/bin/*
+      sed -i "s|/home/build|${{targets.destdir}}/home/cassandra|g" ${{targets.destdir}}/home/cassandra/.venv/bin/*
 
       # allow site-packages
-      sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/medusa/.venv/pyvenv.cfg
+      sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/home/cassandra/.venv/pyvenv.cfg
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
-      ln -s /usr/share/medusa/.venv/bin/medusa ${{targets.destdir}}/usr/bin/medusa
+      ln -s /home/cassandra/.venv/bin/medusa ${{targets.destdir}}/usr/bin/medusa
+
+  - runs: |
+      cp pyproject.toml ${{targets.destdir}}/home/cassandra
+      cp k8s/docker-entrypoint.sh ${{targets.destdir}}/home/cassandra
+      chmod +x ${{targets.destdir}}/home/cassandra/docker-entrypoint.sh
 
 subpackages:
   - name: "${{package.name}}-compat"
@@ -85,10 +90,6 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/home/cassandra/"
           ln -sf /usr/bin/medusa ${{targets.subpkgdir}}/home/cassandra/medusa
-
-          cp k8s/docker-entrypoint.sh ${{targets.subpkgdir}}/home/cassandra/
-          chmod +x ${{targets.subpkgdir}}/home/cassandra/docker-entrypoint.sh
-
           # Symlink the binary from usr/bin to /bin
           mkdir -p "${{targets.subpkgdir}}"/bin
           ln -sf /usr/bin/grpc-health-probe ${{targets.subpkgdir}}/bin/grpc_health_probe
@@ -111,7 +112,7 @@ test:
     - runs: |
         set +e
         fail() { echo "$@" 1>&2; exit 1; }
-        out=$(/usr/share/medusa/.venv/bin/python3 -m medusa.service.grpc.server 2>&1)
+        out=$(/home/cassandra/.venv/bin/python3 -m medusa.service.grpc.server 2>&1)
         status=$?
         echo "$out" | grep -q '/etc/medusa/medusa.ini' || fail "medusa.service.grpc.server output did not contain expected 'medusa.ini' message. Exit status $status: $out"
         echo "medusa.service.grpc.server exited with expected error message"

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -70,7 +70,8 @@ pipeline:
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin
-      ln -s /home/cassandra/.venv/bin/medusa ${{targets.destdir}}/usr/bin/medusa
+      cp k8s/medusa.sh ${{targets.destdir}}/usr/bin/medusa
+      chmod +x ${{targets.destdir}}/usr/bin/medusa
 
   - runs: |
       cp pyproject.toml ${{targets.destdir}}/home/cassandra


### PR DESCRIPTION
Upstream made some significant changes in this recent commit: https://github.com/thelastpickle/cassandra-medusa/pull/679, as well as to [their Dockerfile](https://github.com/thelastpickle/cassandra-medusa/blob/edb76efd6078715a6311e24e1a1fd08641e92810/k8s/Dockerfile#L60-L63).

This PR brings the package in line with those changes. The package was tested locally with the image, which we also added some more test coverage for [in this PR](https://github.com/chainguard-images/images/pull/2558).

