### PR TITLE
python: fix MD5 nonsecurity usage with OpenSSL base+fips providers

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: 3.10.14
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -62,6 +62,10 @@ pipeline:
     with:
       patches: CVE-2023-27043-enable-disable.patch
 
+  - uses: patch
+    with:
+      patches: gh-118224.patch
+
   - name: Configure
     runs: |
       ./configure \
@@ -80,6 +84,7 @@ pipeline:
          --with-system-ffi \
          --with-system-libmpdec \
          --without-ensurepip \
+         --with-builtin-hashlib-hashes=blake2 \
          --with-lto
 
   - uses: autoconf/make

--- a/python-3.10/gh-118224.patch
+++ b/python-3.10/gh-118224.patch
@@ -1,0 +1,80 @@
+From 1c1e963118bf28c86c72c6bb36fe500a372b4d0b Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Wed, 24 Apr 2024 14:47:10 +0100
+Subject: [PATCH 1/2] [3.10] gh-118224: Load default OpenSSL provider for
+ nonsecurity algorithms
+
+When OpenSSL is configured to only load "base+fips" providers into the
+Null library context, md5 might not be available at all. In such cases
+currently CPython fallsback to internal hashlib implementation is
+there is one - as there might not be if one compiles python with
+--with-builtin-hashlib-hashes=blake2. With this change "default"
+provider is attempted to be loaded to access nonsecurity hashes.
+---
+ Modules/_hashopenssl.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/Modules/_hashopenssl.c b/Modules/_hashopenssl.c
+index 35addf49e96c63..6418e4295babf2 100644
+--- a/Modules/_hashopenssl.c
++++ b/Modules/_hashopenssl.c
+@@ -51,6 +51,7 @@
+ #define PY_OPENSSL_HAS_BLAKE2 1
+ 
+ #if OPENSSL_VERSION_NUMBER >= 0x30000000L
++#include <openssl/provider.h>
+ #define PY_EVP_MD EVP_MD
+ #define PY_EVP_MD_fetch(algorithm, properties) EVP_MD_fetch(NULL, algorithm, properties)
+ #define PY_EVP_MD_up_ref(md) EVP_MD_up_ref(md)
+@@ -217,6 +218,17 @@ typedef struct {
+     _Py_hashtable_t *hashtable;
+ } _hashlibstate;
+ 
++static void try_load_default_provider(void) {
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++    /* Load the default config file, and expected providers */
++    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
++    if (!OSSL_PROVIDER_available(NULL, "default")) {
++	/* System is configured without the default provider */
++        OSSL_PROVIDER_load(NULL, "default");
++    }
++#endif
++}
++
+ static inline _hashlibstate*
+ get_hashlib_state(PyObject *module)
+ {
+@@ -338,6 +350,7 @@ py_digest_by_name(PyObject *module, const char *name, enum Py_hash_type py_ht)
+             break;
+         case Py_ht_evp_nosecurity:
+             if (entry->evp_nosecurity == NULL) {
++                try_load_default_provider();
+                 entry->evp_nosecurity = PY_EVP_MD_fetch(entry->ossl_name, "-fips");
+             }
+             digest = entry->evp_nosecurity;
+@@ -355,6 +368,7 @@ py_digest_by_name(PyObject *module, const char *name, enum Py_hash_type py_ht)
+             digest = PY_EVP_MD_fetch(name, NULL);
+             break;
+         case Py_ht_evp_nosecurity:
++            try_load_default_provider();
+             digest = PY_EVP_MD_fetch(name, "-fips");
+             break;
+         }
+
+From f524cb58e096865cc440843385f0b5a7df1ea490 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Wed, 24 Apr 2024 23:28:53 +0100
+Subject: [PATCH 2/2] Add blurb
+
+---
+ .../next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst    | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst b/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+new file mode 100644
+index 00000000000000..c63b71ecbafc58
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+@@ -0,0 +1 @@
++Hashlib now supports using default OpenSSL provider instead of builtin fallback for nonsecurity hashes on hosts otherwise only using base and fips providers. This makes build configuration ``--with-builtin-hashlib-hashes=blake2`` fully supported on OpenSSL FIPS hosts.

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: 3.11.9
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -62,6 +62,10 @@ pipeline:
     with:
       patches: CVE-2023-27043-enable-disable.patch
 
+  - uses: patch
+    with:
+      patches: gh-118224.patch
+
   - name: Configure
     runs: |
       ./configure \
@@ -80,6 +84,7 @@ pipeline:
          --with-system-ffi \
          --with-system-libmpdec \
          --without-ensurepip \
+         --with-builtin-hashlib-hashes=blake2 \
          --with-lto
 
   - uses: autoconf/make

--- a/python-3.11/gh-118224.patch
+++ b/python-3.11/gh-118224.patch
@@ -1,0 +1,80 @@
+From d39e2a450eb3a3b1bedcd475e970bb038bbd2bc9 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Wed, 24 Apr 2024 14:47:10 +0100
+Subject: [PATCH 1/2] [3.11] gh-118224: Load default OpenSSL provider for
+ nonsecurity algorithms
+
+When OpenSSL is configured to only load "base+fips" providers into the
+Null library context, md5 might not be available at all. In such cases
+currently CPython fallsback to internal hashlib implementation is
+there is one - as there might not be if one compiles python with
+--with-builtin-hashlib-hashes=blake2. With this change "default"
+provider is attempted to be loaded to access nonsecurity hashes.
+---
+ Modules/_hashopenssl.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/Modules/_hashopenssl.c b/Modules/_hashopenssl.c
+index 57d64bd80c9727..adededbc199c8c 100644
+--- a/Modules/_hashopenssl.c
++++ b/Modules/_hashopenssl.c
+@@ -51,6 +51,7 @@
+ #define PY_OPENSSL_HAS_BLAKE2 1
+ 
+ #if OPENSSL_VERSION_NUMBER >= 0x30000000L
++#include <openssl/provider.h>
+ #define PY_EVP_MD EVP_MD
+ #define PY_EVP_MD_fetch(algorithm, properties) EVP_MD_fetch(NULL, algorithm, properties)
+ #define PY_EVP_MD_up_ref(md) EVP_MD_up_ref(md)
+@@ -217,6 +218,17 @@ typedef struct {
+     _Py_hashtable_t *hashtable;
+ } _hashlibstate;
+ 
++static void try_load_default_provider(void) {
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++    /* Load the default config file, and expected providers */
++    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
++    if (!OSSL_PROVIDER_available(NULL, "default")) {
++	/* System is configured without the default provider */
++        OSSL_PROVIDER_load(NULL, "default");
++    }
++#endif
++}
++
+ static inline _hashlibstate*
+ get_hashlib_state(PyObject *module)
+ {
+@@ -338,6 +350,7 @@ py_digest_by_name(PyObject *module, const char *name, enum Py_hash_type py_ht)
+             break;
+         case Py_ht_evp_nosecurity:
+             if (entry->evp_nosecurity == NULL) {
++                try_load_default_provider();
+                 entry->evp_nosecurity = PY_EVP_MD_fetch(entry->ossl_name, "-fips");
+             }
+             digest = entry->evp_nosecurity;
+@@ -355,6 +368,7 @@ py_digest_by_name(PyObject *module, const char *name, enum Py_hash_type py_ht)
+             digest = PY_EVP_MD_fetch(name, NULL);
+             break;
+         case Py_ht_evp_nosecurity:
++            try_load_default_provider();
+             digest = PY_EVP_MD_fetch(name, "-fips");
+             break;
+         }
+
+From 15b95f26bb495c0928029b2daeab020708dbab23 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Wed, 24 Apr 2024 23:28:53 +0100
+Subject: [PATCH 2/2] Add blurb
+
+---
+ .../next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst    | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst b/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+new file mode 100644
+index 00000000000000..c63b71ecbafc58
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+@@ -0,0 +1 @@
++Hashlib now supports using default OpenSSL provider instead of builtin fallback for nonsecurity hashes on hosts otherwise only using base and fips providers. This makes build configuration ``--with-builtin-hashlib-hashes=blake2`` fully supported on OpenSSL FIPS hosts.

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: 3.12.3
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -62,6 +62,10 @@ pipeline:
     with:
       patches: CVE-2023-27043-enable-disable.patch
 
+  - uses: patch
+    with:
+      patches: gh-118224.patch
+
   - name: Configure
     runs: |
       ./configure \
@@ -80,6 +84,7 @@ pipeline:
          --with-system-ffi \
          --with-system-libmpdec \
          --without-ensurepip \
+         --with-builtin-hashlib-hashes=blake2 \
          --with-lto
 
   - uses: autoconf/make

--- a/python-3.12/gh-118224.patch
+++ b/python-3.12/gh-118224.patch
@@ -1,0 +1,80 @@
+From 49f920e41aef131f7f11657a65a4a986839ea193 Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Wed, 24 Apr 2024 14:47:10 +0100
+Subject: [PATCH 1/2] [3.12] gh-118224: Load default OpenSSL provider for
+ nonsecurity algorithms
+
+When OpenSSL is configured to only load "base+fips" providers into the
+Null library context, md5 might not be available at all. In such cases
+currently CPython fallsback to internal hashlib implementation is
+there is one - as there might not be if one compiles python with
+--with-builtin-hashlib-hashes=blake2. With this change "default"
+provider is attempted to be loaded to access nonsecurity hashes.
+---
+ Modules/_hashopenssl.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/Modules/_hashopenssl.c b/Modules/_hashopenssl.c
+index 2998820953bda9..9b28c5174bfe3e 100644
+--- a/Modules/_hashopenssl.c
++++ b/Modules/_hashopenssl.c
+@@ -56,6 +56,7 @@
+ #endif
+ 
+ #if OPENSSL_VERSION_NUMBER >= 0x30000000L
++#include <openssl/provider.h>
+ #define PY_EVP_MD EVP_MD
+ #define PY_EVP_MD_fetch(algorithm, properties) EVP_MD_fetch(NULL, algorithm, properties)
+ #define PY_EVP_MD_up_ref(md) EVP_MD_up_ref(md)
+@@ -265,6 +266,17 @@ typedef struct {
+     _Py_hashtable_t *hashtable;
+ } _hashlibstate;
+ 
++static void try_load_default_provider(void) {
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++    /* Load the default config file, and expected providers */
++    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
++    if (!OSSL_PROVIDER_available(NULL, "default")) {
++	/* System is configured without the default provider */
++        OSSL_PROVIDER_load(NULL, "default");
++    }
++#endif
++}
++
+ static inline _hashlibstate*
+ get_hashlib_state(PyObject *module)
+ {
+@@ -386,6 +398,7 @@ py_digest_by_name(PyObject *module, const char *name, enum Py_hash_type py_ht)
+             break;
+         case Py_ht_evp_nosecurity:
+             if (entry->evp_nosecurity == NULL) {
++                try_load_default_provider();
+                 entry->evp_nosecurity = PY_EVP_MD_fetch(entry->ossl_name, "-fips");
+             }
+             digest = entry->evp_nosecurity;
+@@ -403,6 +416,7 @@ py_digest_by_name(PyObject *module, const char *name, enum Py_hash_type py_ht)
+             digest = PY_EVP_MD_fetch(name, NULL);
+             break;
+         case Py_ht_evp_nosecurity:
++            try_load_default_provider();
+             digest = PY_EVP_MD_fetch(name, "-fips");
+             break;
+         }
+
+From d5e209887d7fa05e46afc1d17dc362cccb0bd53b Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
+Date: Wed, 24 Apr 2024 23:28:53 +0100
+Subject: [PATCH 2/2] Add blurb
+
+---
+ .../next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst    | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+
+diff --git a/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst b/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+new file mode 100644
+index 00000000000000..c63b71ecbafc58
+--- /dev/null
++++ b/Misc/NEWS.d/next/Build/2024-04-24-16-58-45.gh-issue-118224.wnjFHn.rst
+@@ -0,0 +1 @@
++Hashlib now supports using default OpenSSL provider instead of builtin fallback for nonsecurity hashes on hosts otherwise only using base and fips providers. This makes build configuration ``--with-builtin-hashlib-hashes=blake2`` fully supported on OpenSSL FIPS hosts.


### PR DESCRIPTION
Compile python without hashlib fallbacks for NIST algorithms, as they are slower and allow to bypass OpenSSL implementations in certain conditions.

Fix OpenSSL base and fips provider usage for unapproved algorithms, such that one can use MD5 for non-security. And vice versa.

Fixes: https://github.com/python/cpython/issues/118224

Patches are backports linked in the above upstream issue.

With this change python-fips releases 3.10..3.12 now work.

CVE checks is failing on 3.10 as there is a medium CVE without an upstream patch that we self-fixed in 3.11+

This removes unused builtin non-hw accelerated cryptographic implementations, to instead always use OpenSSL as was always the case for vanilla builds. FIPS builds, depending on OpenSSL configuration, had opportunity to missuse the fallback in unapproved ways:

- 28.0K	_md5.cpython-312-x86_64-linux-gnu.so
- 28.0K	_sha1.cpython-312-x86_64-linux-gnu.so
- 64.0K	_sha2.cpython-312-x86_64-linux-gnu.so
- 40.0K	_sha3.cpython-312-x86_64-linux-gnu.so
