### PR TITLE
Fix/wavefront proxy

### DIFF
--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: wavefront-proxy
   version: "13.4" # When version is bumped, check if patches are still needed to address CVE-2023-1428
-  epoch: 4
+  epoch: 5
   description: Wavefront Proxy Project
   copyright:
     - license: Apache-2.0

--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -72,6 +72,29 @@ subpackages:
         - wavefront-proxy-config
         - wavefront-proxy-licenses
 
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        set -- java -jar /usr/share/java/wavefront/wavefront-proxy/wavefront-proxy.jar
+        "$@" --help >out 2>&1 || {
+          rc=$?;
+          echo "failed [$rc]: $*"
+          cat out
+          exit $rc;
+        }
+        expected="Wavefront Proxy version ${{package.version}}"
+        grep "$expected" out || {
+          echo "command '$* --help' did not contain expected output"
+          echo "expected: $expected"
+          echo "actual:"
+          cat out
+          exit 1
+        }
+
 update:
   enabled: true
   github:

--- a/wavefront-proxy/proxy/pombump-deps.yaml
+++ b/wavefront-proxy/proxy/pombump-deps.yaml
@@ -14,12 +14,7 @@ patches:
   # Fixes GHSA-5jpm-x58v-624v
   - groupId: io.netty
     artifactId: netty-bom
-    version: 4.1.108.Final
-    scope: import
-    type: jar
-  - groupId: io.netty
-    artifactId: netty-codec-http
-    version: 4.1.108.Final
+    version: 4.1.109.Final
     scope: import
     type: jar
   - groupId: com.squareup.okio


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
