### PR TITLE
Add test to guacamole-server.

### DIFF
--- a/guacamole-server.yaml
+++ b/guacamole-server.yaml
@@ -92,6 +92,68 @@ subpackages:
     pipeline:
       - uses: split/dev
 
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - name: "check -v output"
+      runs: |
+        guacd -v >out 2>&1 || {
+          rc=$?
+          echo "failed [$rc]: guacd -v"
+          cat out
+          exit $rc
+        }
+        expected="version ${{package.version}}"
+        grep "$expected" out || {
+          echo "command 'guacd -v' did not contain expected output"
+          echo "expected: $expected"
+          echo "actual:"
+          cat out
+          exit 1
+        }
+    - name: "start daemon on localhost"
+      runs: |
+        set -- guacd -b 127.0.0.1 -L info -p my.pid -f
+        "$@" >out 2>&1 &
+        kpid=$!
+        n=0
+        while [ $n -lt 60 ] && sleep 1; do
+            n=$((n+1))
+            [ -e my.pid ] && break
+        done
+        [ -e my.pid ] || { echo "my.pid did not exist after $n seconds"; exit 1; }
+        read pid < my.pid
+        [ "$kpid" = "$pid" ] || {
+          echo "pid from shell ($kpid) != pid from pidfile ($pid)";
+          exit 1;
+        }
+
+        n=0
+        expected="istening on host"
+        while [ $n -lt 10 ] && sleep 1; do
+            n=$((n+1))
+            grep -q "$expected" out && break
+        done
+        grep -q "$expected" out || {
+          echo "output did not contain expected output after $n seconds: $expected "
+          cat "$out"
+          exit 1
+        }
+
+        expected="Guacamole proxy daemon.*version ${{package.version}}"
+        grep "$expected" out || {
+          echo "command '$*' did not contain expected output"
+          echo "expected: $expected"
+          echo "actual:"
+          cat out
+          exit 1
+        }
+
+        kill $pid
+
 update:
   enabled: true
   release-monitor:


### PR DESCRIPTION
Check '-v' output (version) and then run a daemon on localhost and check that it says 'Listening'.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
