### PR TITLE
ruby-3.2: use git-checkout

### DIFF
--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: 3.2.4
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -10,6 +10,8 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - bison
       - build-base
       - busybox
       - bzip2-dev
@@ -23,6 +25,7 @@ environment:
       - oniguruma-dev
       - openssl-dev
       - readline-dev
+      - ruby-3.1
       - rust
       - sqlite-dev
       - xz-dev
@@ -32,14 +35,22 @@ environment:
 vars:
   prefix: /usr
 
-pipeline:
-  - uses: fetch
-    with:
-      uri: https://cache.ruby-lang.org/pub/ruby/3.2/ruby-${{package.version}}.tar.gz
-      expected-sha256: c72b3c5c30482dca18b0f868c9075f3f47d8168eaf626d4e682ce5b59c858692
+var-transforms:
+  - from: ${{package.version}}
+    match: \.
+    replace: _
+    to: underscore-package-version
 
-  - name: Configure
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ruby/ruby
+      tag: v${{vars.underscore-package-version}}
+      expected-commit: af471c0e0127eea0cafa6f308c0425bbfab0acf5
+
+  - name: Generate and Configure
     runs: |
+      ./autogen.sh
       ./configure \
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \
@@ -97,14 +108,19 @@ subpackages:
 
 update:
   enabled: true
-  manual: true # be careful with auto updates as we don't want to include 3.3, we currently don't offer a filter on release monitor versions
-  release-monitor:
-    identifier: 4223
+  version-transform:
+    - match: "_"
+      replace: .
+  github:
+    identifier: ruby/ruby
+    strip-prefix: v
+    use-tag: true
+    tag-filter-prefix: v3_2_
 
 test:
   pipeline:
     - runs: |
-        ruby --version
+        ruby --version | grep ${{package.version}}
 
         cat <<EOF >> /tmp/hello.rb
         puts("Hello Wolfi!")


### PR DESCRIPTION
- Moves ruby-3.2 to git checkout and builds from the git releases
- checks version in the tests