### PR TITLE
nodejs-22: init at 22.0.0

### DIFF
--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -1,0 +1,106 @@
+package:
+  name: nodejs-22
+  version: 22.0.0
+  epoch: 0
+  description: "JavaScript runtime built on V8 engine"
+  dependencies:
+    provides:
+      - nodejs=${{package.full-version}}
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - brotli-dev
+      - build-base
+      - busybox
+      - c-ares-dev
+      - ca-certificates-bundle
+      - icu-dev
+      - libuv-dev
+      - linux-headers
+      - nghttp2-dev
+      - openssl-dev
+      - py3-jinja2
+      - py3-setuptools
+      - python3
+      - samurai
+      - wolfi-base
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://nodejs.org/dist/v${{package.version}}/node-v${{package.version}}.tar.gz
+      expected-sha256: 47cd57486564a8cb4728ec01f1d98b510c6547e19e96a7f7583cf882d803d0c6
+
+  - name: Configure and build
+    runs: |
+      # Add defines recommended in libuv readme.
+      common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+
+      # Compiling with O2 instead of Os increases binary size by ~10%
+      # (53.1 MiB -> 58.6 MiB), but also increases performance by ~20%
+      # according to v8/web-tooling-benchmark. Node.js is quite huge anyway;
+      # there are better options for size constrained environments.
+      export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
+      export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
+      export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
+      python3 configure.py --prefix=/usr \
+        --shared-brotli \
+        --shared-zlib \
+        --shared-openssl \
+        --shared-cares \
+        --shared-nghttp2 \
+        --shared-libuv \
+        --ninja \
+        --openssl-use-def-ca-store \
+        --with-icu-default-data-dir=$(icu-config --icudatadir) \
+        --with-intl=system-icu \
+        --openssl-conf-name=openssl_conf \
+        --without-corepack
+
+        make BUILDTYPE=Release -j$(nproc)
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      make DESTDIR="$${{targets.destdir}}" install
+
+  - uses: strip
+
+  # Get rid of the bundled npm, we don't need it.
+  - runs: |
+      rm -rf "${{targets.destdir}}"/usr/lib/node_modules
+      rm "${{targets.destdir}}"/usr/bin/npm
+      rm "${{targets.destdir}}"/usr/bin/npx
+
+update:
+  enabled: true
+  github:
+    identifier: nodejs/node
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v22.
+
+test:
+  pipeline:
+    - name: Verify Node.js Installation
+      runs: |
+        node --version || exit 1
+    - name: Execute Basic JavaScript
+      runs: |
+        cat <<'EOF' > test.js
+        console.log('Hello, World!');
+        EOF
+        node test.js | grep 'Hello, World!' || exit 1
+    - name: Test International Number Formatting
+      runs: |
+        cat <<'EOF' > testIntl.js
+        console.log(new Intl.NumberFormat('en-EN').format(1234.56));
+        console.log(new Intl.NumberFormat('de-DE').format(1234.56));
+        EOF
+        node testIntl.js | grep '1,234.56' && node testIntl.js | grep '1.234,56' || exit 1


### PR DESCRIPTION
![image](https://github.com/wolfi-dev/os/assets/6224096/46e537b9-b887-4a75-8fb2-b0412cb2a0e7)

new nodejs release 😱 
https://openjsf.org/blog/nodejs-22-available

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
