### PR TITLE
Correct SPDX license tags spelling

### DIFF
--- a/asciidoc.yaml
+++ b/asciidoc.yaml
@@ -1,10 +1,10 @@
 package:
   name: asciidoc
   version: 10.2.0
-  epoch: 0
+  epoch: 1
   description: "Text based documentation"
   copyright:
-    - license: "GPL-2.0-or-later and GPL-1.0-or-later"
+    - license: GPL-2.0-or-later
 
 environment:
   contents:

--- a/jo.yaml
+++ b/jo.yaml
@@ -1,10 +1,10 @@
 package:
   name: jo
   version: 1.9
-  epoch: 0
+  epoch: 1
   description: "JSON output from a shell"
   copyright:
-    - license: "GPL-2.0-or-later and GPL-1.0-or-later"
+    - license: GPL-2.0-or-later
 
 environment:
   contents:

--- a/liburing.yaml
+++ b/liburing.yaml
@@ -1,10 +1,10 @@
 package:
   name: liburing
   version: 2.5
-  epoch: 0
+  epoch: 1
   description: Linux kernel io_uring access library.
   copyright:
-    - license: MIT or LGPL-2.0-or-later
+    - license: MIT OR LGPL-2.1-or-later
 
 environment:
   contents:

--- a/mailcap.yaml
+++ b/mailcap.yaml
@@ -1,10 +1,10 @@
 package:
   name: mailcap
   version: 2.1.54
-  epoch: 0
+  epoch: 1
   description: "Helper application and MIME type associations for file types"
   copyright:
-    - license: CC-PDDC and MIT
+    - license: CC-PDDC AND MIT
 
 environment:
   contents:

--- a/ocaml.yaml
+++ b/ocaml.yaml
@@ -1,10 +1,10 @@
 package:
   name: ocaml
   version: 5.1.1
-  epoch: 0
+  epoch: 1
   description: "The core OCaml system: compilers, runtime system, base libraries"
   copyright:
-    - license: LGPL-2.1-or-later-WITH-linking-exception
+    - license: LGPL-2.1-only WITH OCaml-LGPL-linking-exception
 
 environment:
   contents:

--- a/opam.yaml
+++ b/opam.yaml
@@ -1,10 +1,10 @@
 package:
   name: opam
   version: 2.1.5
-  epoch: 0
+  epoch: 1
   description: "opam is a source-based package manager. It supports multiple simultaneous compiler installations, flexible package constraints, and a Git-friendly development workflow."
   copyright:
-    - license: LGPL-2.1-or-later-WITH-linking-exception
+    - license: LGPL-2.1-only WITH OCaml-LGPL-linking-exception
 
 environment:
   contents:

--- a/perl-http-negotiate.yaml
+++ b/perl-http-negotiate.yaml
@@ -1,10 +1,10 @@
 package:
   name: perl-http-negotiate
   version: "6.01"
-  epoch: 1
+  epoch: 2
   description: HTTP::Negotiate perl module
   copyright:
-    - license: GPL-2.0 or Artistic
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
   dependencies:
     runtime:
       - perl-http-message

--- a/perl-ipc-run3.yaml
+++ b/perl-ipc-run3.yaml
@@ -2,10 +2,10 @@
 package:
   name: perl-ipc-run3
   version: "0.049"
-  epoch: 0
+  epoch: 1
   description: IPC::Run3 perl module
   copyright:
-    - license: GPL-2.0 or Artistic-1.0-Perl
+    - license: GPL-1.0-or-later OR Artistic-1.0 OR Artistic-2.0 OR BSD-2-Clause
   dependencies:
     runtime:
       - perl

--- a/perl-scope-guard.yaml
+++ b/perl-scope-guard.yaml
@@ -2,10 +2,10 @@
 package:
   name: perl-scope-guard
   version: "0.21"
-  epoch: 1
+  epoch: 2
   description: Scope::Guard perl module
   copyright:
-    - license: GPL-2.0 or Artistic
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
   dependencies:
     runtime:
       - perl

--- a/perl-www-robotrules.yaml
+++ b/perl-www-robotrules.yaml
@@ -1,10 +1,10 @@
 package:
   name: perl-www-robotrules
   version: "6.02"
-  epoch: 1
+  epoch: 2
   description: WWW::RobotRules perl module
   copyright:
-    - license: GPL-2.0 or Artistic
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
   dependencies:
     runtime:
       - perl-uri

--- a/py3-antlr4-python3-runtime.yaml
+++ b/py3-antlr4-python3-runtime.yaml
@@ -1,10 +1,10 @@
 package:
   name: py3-antlr4-python3-runtime
   version: 4.13.1
-  epoch: 0
+  epoch: 1
   description: ANTLR runtime for Python 3
   copyright:
-    - license: BSD-3
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-chardet.yaml
+++ b/py3-chardet.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-chardet
   version: 5.2.0
-  epoch: 0
+  epoch: 1
   description: Universal encoding detector for Python 3
   copyright:
-    - license: LGPL
+    - license: LGPL-2.1-or-later
   dependencies:
     runtime:
       - python-3

--- a/py3-cli-helpers.yaml
+++ b/py3-cli-helpers.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-cli-helpers
   version: 2.3.0
-  epoch: 1
+  epoch: 2
   description: Helpers for building command-line apps
   copyright:
-    - license: BSD License
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-configobj

--- a/py3-decorator.yaml
+++ b/py3-decorator.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-decorator
   version: 5.1.1
-  epoch: 1
+  epoch: 2
   description: Decorators for Humans
   copyright:
-    - license: new BSD License
+    - license: BSD-2-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-entrypoints.yaml
+++ b/py3-entrypoints.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-entrypoints
   version: "0.4"
-  epoch: 1
+  epoch: 2
   description: Discover and load entry points from installed packages.
   copyright:
-    - license: "MIT License"
+    - license: MIT
   dependencies:
     runtime:
       - python-3

--- a/py3-paramiko.yaml
+++ b/py3-paramiko.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-paramiko
   version: 3.4.0
-  epoch: 1
+  epoch: 2
   description: SSH2 protocol library
   copyright:
-    - license: LGPL
+    - license: LGPL-2.1-or-later
   dependencies:
     runtime:
       - py3-bcrypt

--- a/py3-pgspecial.yaml
+++ b/py3-pgspecial.yaml
@@ -1,10 +1,10 @@
 package:
   name: py3-pgspecial
   version: 2.1.1
-  epoch: 0
+  epoch: 1
   description: Meta-commands handler for Postgres Database.
   copyright:
-    - license: LICENSE.txt
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-click

--- a/py3-prompt-toolkit.yaml
+++ b/py3-prompt-toolkit.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-prompt-toolkit
   version: 3.0.43
-  epoch: 0
+  epoch: 1
   description: Library for building powerful interactive command lines in Python
   copyright:
-    - license: BSD License
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - py3-wcwidth

--- a/py3-py4j.yaml
+++ b/py3-py4j.yaml
@@ -1,10 +1,10 @@
 package:
   name: py3-py4j
   version: 0.10.9.7
-  epoch: 1
+  epoch: 2
   description: Enables Python programs to dynamically access arbitrary Java objects
   copyright:
-    - license: BSD License
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python3

--- a/py3-pyaes.yaml
+++ b/py3-pyaes.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-pyaes
   version: 1.6.1
-  epoch: 1
+  epoch: 2
   description: Pure-Python Implementation of the AES block-cipher and common modes of operation
   copyright:
-    - license: 'License :: OSI Approved :: MIT License'
+    - license: MIT
   dependencies:
     runtime:
       - python3

--- a/py3-regex.yaml
+++ b/py3-regex.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-regex
   version: 2023.12.25
-  epoch: 0
+  epoch: 1
   description: Alternative regular expression module, to replace re.
   copyright:
-    - license: Apache Software License
+    - license: Apache-2.0
   dependencies:
     runtime:
       - python-3

--- a/py3-scandir.yaml
+++ b/py3-scandir.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-scandir
   version: 1.10.0
-  epoch: 2
+  epoch: 3
   description: scandir, a better directory iterator and faster os.walk()
   copyright:
-    - license: New BSD License
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-send2trash.yaml
+++ b/py3-send2trash.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-send2trash
   version: 1.8.2
-  epoch: 1
+  epoch: 2
   description: Send file to trash natively under Mac OS X, Windows and Linux
   copyright:
-    - license: BSD License
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python-3

--- a/py3-sphinxcontrib-packages.yaml
+++ b/py3-sphinxcontrib-packages.yaml
@@ -1,10 +1,10 @@
 package:
   name: py3-sphinxcontrib-packages
   version: 1.1.2
-  epoch: 3
+  epoch: 4
   description: This packages contains the Packages sphinx extension, which provides directives to display packages installed on the host machine
   copyright:
-    - license: AGPLv3 or any later version
+    - license: AGPL-3.0-or-later
   dependencies:
     runtime:
       - py3-distro

--- a/py3-sqlparse.yaml
+++ b/py3-sqlparse.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-sqlparse
   version: 0.4.4
-  epoch: 1
+  epoch: 2
   description: A non-validating SQL parser.
   copyright:
-    - license: BSD License
+    - license: BSD-3-Clause
   dependencies:
     runtime:
       - python3

--- a/py3-ssh-python.yaml
+++ b/py3-ssh-python.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-ssh-python
   version: 1.0.0
-  epoch: 0
+  epoch: 1
   description: libssh C library bindings for Python.
   copyright:
-    - license: LGPLv2.1
+    - license: LGPL-2.1-only
   dependencies:
     runtime:
       - python3

--- a/py3-ssh2-python.yaml
+++ b/py3-ssh2-python.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-ssh2-python
   version: 1.0.0
-  epoch: 0
+  epoch: 1
   description: Bindings for libssh2 C library
   copyright:
-    - license: LGPLv2
+    - license: LGPL-2.1-only
   dependencies:
     runtime:
       - python-3

--- a/ruby3.2-openssl_pkcs8_pure.yaml
+++ b/ruby3.2-openssl_pkcs8_pure.yaml
@@ -2,10 +2,10 @@
 package:
   name: ruby3.2-openssl_pkcs8_pure
   version: 0.0.0.2
-  epoch: 0
+  epoch: 1
   description: OpenSSL::PKey::[DSA/RSA/EC]#to_pem_pkcs8 written in Ruby
   copyright:
-    - license: Ruby License (2-clause BSDL or Artistic)
+    - license: BSD-2-Clause
 
 environment:
   contents:


### PR DESCRIPTION
Use uppercase AND OR in the license tags. Use
https://github.com/go-enry/go-license-detector/tree/master/cmd/license-detector to double check licenses and fix up spelling to valid SPDX tag.