### PR TITLE
fix(postgresql-16): Create base package for entrypoint

### DIFF
--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.2"
-  epoch: 5
+  epoch: 6
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -103,9 +103,9 @@ subpackages:
       provides:
         - postgresql-dev=${{package.full-version}}
       runtime:
-        - postgresql-16
+        - ${{package.name}}
         - openssl-dev
-        - postgresql-16-client
+        - ${{package.name}}-client
         - libpq-16
     description: postgresql dev
 
@@ -164,21 +164,34 @@ subpackages:
       provides:
         - libecpg=${{package.full-version}}
 
-  - name: ${{package.name}}-oci-entrypoint
-    description: Entrypoint for using PostgreSQL in OCI containers
+  - name: ${{package.name}}-oci-entrypoint-base
+    description: Base for PostgreSQL entrypoint in OCI containers
     dependencies:
       runtime:
         - bash
         - su-exec
     pipeline:
       - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}
+          install -Dm755 postgresql-entrypoint.sh ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/postgresql-entrypoint.sh
+
+  - name: ${{package.name}}-oci-entrypoint
+    description: Entrypoint for using PostgreSQL in OCI containers
+    dependencies:
+      provides:
+        - postgresql-oci-entrypoint=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
           mkdir -p ${{targets.subpkgdir}}/var/lib/postgres/initdb
-          install -Dm755 postgresql-entrypoint.sh ${{targets.contextdir}}/usr/libexec/${{vars.mangled-package-name}}/postgresql-entrypoint.sh
+          ln -s /usr/libexec/${{vars.mangled-package-name}}/postgresql-entrypoint.sh ${{targets.subpkgdir}}/usr/bin/postgresql-entrypoint.sh
           ln -s /usr/libexec/${{vars.mangled-package-name}}/postgresql-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/postgresql-entrypoint.sh
 
   - name: ${{package.name}}-bitnami-compat
     description: "compat package with postgresql image"
     dependencies:
+      provides:
+        - postgresql-bitnami-compat=${{package.full-version}}
       runtime:
         - ${{package.name}}
         # Required by startup scripts


### PR DESCRIPTION
Previously, the entrypoint wasn't installed because the installation directory for the entrypoint script was changed. Resolve this by introducing a base package