### PR TITLE
font-liberation: use release download rather than file link

### DIFF
--- a/font-liberation.yaml
+++ b/font-liberation.yaml
@@ -2,7 +2,7 @@
 package:
   name: font-liberation
   version: 2.1.5
-  epoch: 0
+  epoch: 1
   description: Fonts to replace commonly used Microsoft Windows fonts
   copyright:
     - license: OFL-1.1

--- a/font-liberation.yaml
+++ b/font-liberation.yaml
@@ -20,8 +20,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 7191c669bf38899f73a2094ed00f7b800553364f90e2637010a69c0e268f25d0
-      uri: https://github.com/liberationfonts/liberation-fonts/files/7261482/liberation-fonts-ttf-${{package.version}}.tar.gz
+      expected-sha256: 9a823ccb33c8a8a865e84b982bcdc44d03ba4914adb91e6000df035dc0e55936
+      uri: https://github.com/liberationfonts/liberation-fonts/archive/refs/tags/{{package.version}}.tar.gz
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/share/fonts/${{package.name}} \


### PR DESCRIPTION
I'm adding a wolfictl rule to forbid /file/ links, as they include comment attachments. With /file/ links, it's impossible to tell between an officially generated tarball and one that a random person on the Internet attached to an issue.

For more info, see https://www.mcafee.com/blogs/other-blogs/mcafee-labs/redline-stealer-a-novel-approach/
