### PR TITLE
fix(postgresql-16): Correct prefix in entrypoint scripts

### DIFF
--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.2"
-  epoch: 8
+  epoch: 9
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -182,6 +182,7 @@ subpackages:
           curl https://raw.githubusercontent.com/docker-library/postgres/master/16/alpine"${ALPINE_VERSION}"/docker-ensure-initdb.sh -o \
             ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/docker-ensure-initdb.sh
           sed -i "s|/docker-entrypoint-initdb.d|/var/lib/postgres/initdb|g" ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/*.sh
+          sed -i "s|/usr/local|/usr|g" ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/*.sh
           chmod +x ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/*.sh
 
   - name: ${{package.name}}-oci-entrypoint


### PR DESCRIPTION
Use /usr instead of /usr/local