### PR TITLE
Support convert JP2 (JPEG 2000) images

### DIFF
--- a/imagemagick.yaml
+++ b/imagemagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: imagemagick
   version: 7.1.1.31
-  epoch: 0
+  epoch: 1
   description: Tools and libraries for manipulating common image formats
   copyright:
     - license: ImageMagick
@@ -30,6 +30,7 @@ environment:
       - libx11-dev
       - libxext-dev
       - libxml2-dev
+      - openjpeg-dev
       - pango-dev
       - perl-dev
       - tiff-dev


### PR DESCRIPTION
### Why?

To support convert JPEG 2000 format. 
```
# Current apk
# convert -version
Version: ImageMagick 7.1.1-31 Q16-HDRI aarch64 46db807b1:20240421 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): bzlib freetype jng jpeg lcms lzma png tiff webp x xml zlib zstd
Compiler: gcc (13.2)

# Result apk after update
# convert --version
Version: ImageMagick 7.1.1-30 Q16-HDRI aarch64 babe7ad2f:20240407 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): bzlib freetype jng jp2 jpeg lcms lzma png tiff webp x xml zlib zstd
Compiler: gcc (13.2)
```