### PR TITLE
neuvector-controller-5.3: New package

### DIFF
--- a/neuvector-controller-5.3.yaml
+++ b/neuvector-controller-5.3.yaml
@@ -1,0 +1,46 @@
+package:
+  name: neuvector-controller-5.3
+  version: 5.3.2
+  epoch: 1
+  description: NeuVector Full Lifecycle Container Security Platform.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - neuvector-controller=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - pcre-dev
+      - pcre2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/neuvector/neuvector
+      tag: v${{package.version}}
+      expected-commit: edbdcba632835d56dcc92ba86323c8a196471289
+
+  - uses: go/bump
+    with:
+      how-diff: true
+      deps: golang.org/x/net@v0.23.0 golang.org/x/crypto@v0.22.0 github.com/opencontainers/image-spec@v1.1.0 github.com/docker/distribution@v2.8.2-beta.1+incompatible github.com/opencontainers/runc@v1.1.12 github.com/containerd/containerd@v1.6.26 google.golang.org/grpc@v1.56.3 google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4 github.com/docker/docker@v26.1.0+incompatible
+      replaces: github.com/samalba/dockerclient=github.com/Dentrax/dockerclient@v0.1.0 github.com/dgrijalva/jwt-go=github.com/golang-jwt/jwt/v4@v4.4.2
+
+  - uses: go/build
+    with:
+      modroot: controller
+      ldflags: "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn"
+      packages: .
+      output: controller
+
+update:
+  enabled: true
+  github:
+    identifier: neuvector/neuvector-controller
+    strip-prefix: v
+    tag-filter: v5.3.

--- a/neuvector-controller-5.3.yaml
+++ b/neuvector-controller-5.3.yaml
@@ -41,6 +41,6 @@ pipeline:
 update:
   enabled: true
   github:
-    identifier: neuvector/neuvector-controller
+    identifier: neuvector/controller
     strip-prefix: v
     tag-filter: v5.3.

--- a/neuvector-controller-5.3.yaml
+++ b/neuvector-controller-5.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: neuvector-controller-5.3
   version: 5.3.2
-  epoch: 1
+  epoch: 0
   description: NeuVector Full Lifecycle Container Security Platform.
   copyright:
     - license: Apache-2.0

--- a/neuvector-controller-5.3.yaml
+++ b/neuvector-controller-5.3.yaml
@@ -41,6 +41,6 @@ pipeline:
 update:
   enabled: true
   github:
-    identifier: neuvector/controller
+    identifier: neuvector/neuvector
     strip-prefix: v
     tag-filter: v5.3.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
