### PR TITLE
tls-cipher fix

### DIFF
--- a/argo-cd-2.10.yaml
+++ b/argo-cd-2.10.yaml
@@ -24,7 +24,7 @@ pipeline:
     with:
       repository: https://github.com/argoproj/argo-cd
       tag: v${{package.version}}
-      expected-commit: b060053b099b4c81c1e635839a309c9c8c1863e9
+      expected-commit: 37b1cf5306f9c245f188c4c0566c23a0f80cdc65
 
   - uses: patch
     with:

--- a/argo-cd-2.10.yaml
+++ b/argo-cd-2.10.yaml
@@ -1,118 +1,112 @@
 package:
-  name: argo-cd-2.10
-  version: 2.10.7
-  epoch: 1
-  description: Declarative continuous deployment for Kubernetes.
-  copyright:
-    - license: Apache-2.0
-  dependencies:
-    provides:
-      - argo-cd=${{package.full-version}}
-
+    name: argo-cd-2.10
+    version: 2.10.8
+    epoch: 0
+    description: Declarative continuous deployment for Kubernetes.
+    copyright:
+        - license: Apache-2.0
+    dependencies:
+        provides:
+            - argo-cd=${{package.full-version}}
 environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
-      - nodejs-20
-      - python3
-      - yarn
-
+    contents:
+        packages:
+            - busybox
+            - ca-certificates-bundle
+            - go
+            - nodejs-20
+            - python3
+            - yarn
 pipeline:
-  - uses: git-checkout
-    with:
-      repository: https://github.com/argoproj/argo-cd
-      tag: v${{package.version}}
-      expected-commit: b060053b099b4c81c1e635839a309c9c8c1863e9
+    - uses: git-checkout
+      with:
+        repository: https://github.com/argoproj/argo-cd
+        tag: v${{package.version}}
+        expected-commit: b060053b099b4c81c1e635839a309c9c8c1863e9
+    - uses: patch
+      with:
+        patches: tls-cipher-removed.patch
+    - uses: go/bump
+      with:
+        deps: golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.1 github.com/go-jose/go-jose/v3@v3.0.3 google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4 golang.org/x/net@v0.23.0
+    - runs: |
+        cd ui
+        yarn install
+        yarn cache clean
+        NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTIONS=--max_old_space_size=8192 yarn build
 
-  - uses: go/bump
-    with:
-      deps: golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.1 github.com/go-jose/go-jose/v3@v3.0.3 google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4 golang.org/x/net@v0.23.0
+        cd ..
 
-  - runs: |
-      cd ui
-      yarn install
-      yarn cache clean
-      NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTIONS=--max_old_space_size=8192 yarn build
+        # Our global LDFLAGS conflict with a Makefile parameter
+        unset LDFLAGS
+        # Our global `-pie` flag results in a binary that cannot be copied to a non chainguard image
+        # Disable the `-pie` flag here since ArgoCD's helm charts like to copy around the multicall binary to different images (ie: dex)
 
-      cd ..
+        unset GOFLAGS
 
-      # Our global LDFLAGS conflict with a Makefile parameter
-      unset LDFLAGS
-      # Our global `-pie` flag results in a binary that cannot be copied to a non chainguard image
-      # Disable the `-pie` flag here since ArgoCD's helm charts like to copy around the multicall binary to different images (ie: dex)
+        make argocd-all
 
-      unset GOFLAGS
+        mkdir -p ${{targets.destdir}}/usr/bin
+        mv dist/argocd* ${{targets.destdir}}/usr/bin/
 
-      make argocd-all
-
-      mkdir -p ${{targets.destdir}}/usr/bin
-      mv dist/argocd* ${{targets.destdir}}/usr/bin/
-
-      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-server
-      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-repo-server
-      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-cmp-server
-      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-application-controller
-      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-notifications
-      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-applicationset-controller
-      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-k8s-auth
-
-  - uses: strip
-
+        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-server
+        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-repo-server
+        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-cmp-server
+        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-application-controller
+        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-notifications
+        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-applicationset-controller
+        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-k8s-auth
+    - uses: strip
 subpackages:
-  - name: ${{package.name}}-repo-server
-    description: "ArgoCD repo server"
-    dependencies:
-      runtime:
-        - ${{package.name}}-compat
-        - git
-        - git-lfs
-        - gnupg
-        - gpg
-        - gpg-agent
-        - tzdata
-        - helm
-        - kustomize
-        - openssh
-      provides:
-        - argo-cd-repo-server=${{package.full-version}}
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          cp hack/gpg-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/gpg-wrapper.sh
-          cp hack/git-verify-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/git-verify-wrapper.sh
+    - name: ${{package.name}}-repo-server
+      description: "ArgoCD repo server"
+      dependencies:
+        runtime:
+            - ${{package.name}}-compat
+            - git
+            - git-lfs
+            - gnupg
+            - gpg
+            - gpg-agent
+            - tzdata
+            - helm
+            - kustomize
+            - openssh
+        provides:
+            - argo-cd-repo-server=${{package.full-version}}
+      pipeline:
+        - runs: |
+            mkdir -p "${{targets.subpkgdir}}"/usr/bin
+            cp hack/gpg-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/gpg-wrapper.sh
+            cp hack/git-verify-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/git-verify-wrapper.sh
+    - name: ${{package.name}}-compat
+      description: "Compatibility package for locating binaries according to upstream helm charts"
+      pipeline:
+        - runs: |
+            # ArgoCD manifests and helm charts all hardcode the executables path to /usr/local/bin/*
+            mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
+            # This must be copied and not symlinked due to how `argocd` copies executables between (init)containers
+            # example: https://github.com/argoproj/argo-helm/blob/argo-cd-5.33.1/charts/argo-cd/templates/dex/deployment.yaml#L136-L143
+            cp ${{targets.destdir}}/usr/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd
 
-  - name: ${{package.name}}-compat
-    description: "Compatibility package for locating binaries according to upstream helm charts"
-    pipeline:
-      - runs: |
-          # ArgoCD manifests and helm charts all hardcode the executables path to /usr/local/bin/*
-          mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
-          # This must be copied and not symlinked due to how `argocd` copies executables between (init)containers
-          # example: https://github.com/argoproj/argo-helm/blob/argo-cd-5.33.1/charts/argo-cd/templates/dex/deployment.yaml#L136-L143
-          cp ${{targets.destdir}}/usr/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd
-
-          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-server
-          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-repo-server
-          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-cmp-server
-          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-application-controller
-          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-notifications
-          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-applicationset-controller
-          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-k8s-auth
-    dependencies:
-      provides:
-        - argo-cd-compat=${{package.full-version}}
-
+            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-server
+            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-repo-server
+            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-cmp-server
+            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-application-controller
+            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-notifications
+            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-applicationset-controller
+            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-k8s-auth
+      dependencies:
+        provides:
+            - argo-cd-compat=${{package.full-version}}
 update:
-  enabled: true
-  github:
-    identifier: argoproj/argo-cd
-    strip-prefix: v
-    tag-filter: v2.10.
-
+    enabled: true
+    github:
+        identifier: argoproj/argo-cd
+        strip-prefix: v
+        tag-filter: v2.10.
 test:
-  pipeline:
-    - name: ArgoCD Version Check
-      runs: |
-        argocd version --short --client || exit 1
+    pipeline:
+        - name: ArgoCD Version Check
+          runs: |
+            argocd version --short --client || exit 1

--- a/argo-cd-2.10.yaml
+++ b/argo-cd-2.10.yaml
@@ -1,112 +1,122 @@
 package:
-    name: argo-cd-2.10
-    version: 2.10.8
-    epoch: 0
-    description: Declarative continuous deployment for Kubernetes.
-    copyright:
-        - license: Apache-2.0
-    dependencies:
-        provides:
-            - argo-cd=${{package.full-version}}
+  name: argo-cd-2.10
+  version: 2.10.8
+  epoch: 0
+  description: Declarative continuous deployment for Kubernetes.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - argo-cd=${{package.full-version}}
+
 environment:
-    contents:
-        packages:
-            - busybox
-            - ca-certificates-bundle
-            - go
-            - nodejs-20
-            - python3
-            - yarn
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - nodejs-20
+      - python3
+      - yarn
+
 pipeline:
-    - uses: git-checkout
-      with:
-        repository: https://github.com/argoproj/argo-cd
-        tag: v${{package.version}}
-        expected-commit: b060053b099b4c81c1e635839a309c9c8c1863e9
-    - uses: patch
-      with:
-        patches: tls-cipher-removed.patch
-    - uses: go/bump
-      with:
-        deps: golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.1 github.com/go-jose/go-jose/v3@v3.0.3 google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4 golang.org/x/net@v0.23.0
-    - runs: |
-        cd ui
-        yarn install
-        yarn cache clean
-        NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTIONS=--max_old_space_size=8192 yarn build
+  - uses: git-checkout
+    with:
+      repository: https://github.com/argoproj/argo-cd
+      tag: v${{package.version}}
+      expected-commit: b060053b099b4c81c1e635839a309c9c8c1863e9
 
-        cd ..
+  - uses: patch
+    with:
+      patches: tls-cipher-removed.patch
 
-        # Our global LDFLAGS conflict with a Makefile parameter
-        unset LDFLAGS
-        # Our global `-pie` flag results in a binary that cannot be copied to a non chainguard image
-        # Disable the `-pie` flag here since ArgoCD's helm charts like to copy around the multicall binary to different images (ie: dex)
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0 github.com/cloudflare/circl@v1.3.7 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.1 github.com/go-jose/go-jose/v3@v3.0.3 google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4 golang.org/x/net@v0.23.0
 
-        unset GOFLAGS
+  - runs: |
+      cd ui
+      yarn install
+      yarn cache clean
+      NODE_ENV='production' NODE_ONLINE_ENV='online' NODE_OPTIONS=--max_old_space_size=8192 yarn build
 
-        make argocd-all
+      cd ..
 
-        mkdir -p ${{targets.destdir}}/usr/bin
-        mv dist/argocd* ${{targets.destdir}}/usr/bin/
+      # Our global LDFLAGS conflict with a Makefile parameter
+      unset LDFLAGS
+      # Our global `-pie` flag results in a binary that cannot be copied to a non chainguard image
+      # Disable the `-pie` flag here since ArgoCD's helm charts like to copy around the multicall binary to different images (ie: dex)
 
-        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-server
-        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-repo-server
-        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-cmp-server
-        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-application-controller
-        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-notifications
-        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-applicationset-controller
-        ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-k8s-auth
-    - uses: strip
+      unset GOFLAGS
+
+      make argocd-all
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv dist/argocd* ${{targets.destdir}}/usr/bin/
+
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-server
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-repo-server
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-cmp-server
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-application-controller
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-notifications
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-applicationset-controller
+      ln -s /usr/bin/argocd ${{targets.destdir}}/usr/bin/argocd-k8s-auth
+
+  - uses: strip
+
 subpackages:
-    - name: ${{package.name}}-repo-server
-      description: "ArgoCD repo server"
-      dependencies:
-        runtime:
-            - ${{package.name}}-compat
-            - git
-            - git-lfs
-            - gnupg
-            - gpg
-            - gpg-agent
-            - tzdata
-            - helm
-            - kustomize
-            - openssh
-        provides:
-            - argo-cd-repo-server=${{package.full-version}}
-      pipeline:
-        - runs: |
-            mkdir -p "${{targets.subpkgdir}}"/usr/bin
-            cp hack/gpg-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/gpg-wrapper.sh
-            cp hack/git-verify-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/git-verify-wrapper.sh
-    - name: ${{package.name}}-compat
-      description: "Compatibility package for locating binaries according to upstream helm charts"
-      pipeline:
-        - runs: |
-            # ArgoCD manifests and helm charts all hardcode the executables path to /usr/local/bin/*
-            mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
-            # This must be copied and not symlinked due to how `argocd` copies executables between (init)containers
-            # example: https://github.com/argoproj/argo-helm/blob/argo-cd-5.33.1/charts/argo-cd/templates/dex/deployment.yaml#L136-L143
-            cp ${{targets.destdir}}/usr/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd
-
-            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-server
-            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-repo-server
-            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-cmp-server
-            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-application-controller
-            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-notifications
-            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-applicationset-controller
-            ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-k8s-auth
-      dependencies:
-        provides:
-            - argo-cd-compat=${{package.full-version}}
-update:
-    enabled: true
-    github:
-        identifier: argoproj/argo-cd
-        strip-prefix: v
-        tag-filter: v2.10.
-test:
+  - name: ${{package.name}}-repo-server
+    description: "ArgoCD repo server"
+    dependencies:
+      runtime:
+        - ${{package.name}}-compat
+        - git
+        - git-lfs
+        - gnupg
+        - gpg
+        - gpg-agent
+        - tzdata
+        - helm
+        - kustomize
+        - openssh
+      provides:
+        - argo-cd-repo-server=${{package.full-version}}
     pipeline:
-        - name: ArgoCD Version Check
-          runs: |
-            argocd version --short --client || exit 1
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          cp hack/gpg-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/gpg-wrapper.sh
+          cp hack/git-verify-wrapper.sh "${{targets.subpkgdir}}"/usr/bin/git-verify-wrapper.sh
+
+  - name: ${{package.name}}-compat
+    description: "Compatibility package for locating binaries according to upstream helm charts"
+    pipeline:
+      - runs: |
+          # ArgoCD manifests and helm charts all hardcode the executables path to /usr/local/bin/*
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
+          # This must be copied and not symlinked due to how `argocd` copies executables between (init)containers
+          # example: https://github.com/argoproj/argo-helm/blob/argo-cd-5.33.1/charts/argo-cd/templates/dex/deployment.yaml#L136-L143
+          cp ${{targets.destdir}}/usr/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd
+
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-server
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-repo-server
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-cmp-server
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-application-controller
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-notifications
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-applicationset-controller
+          ln -s /usr/local/bin/argocd "${{targets.subpkgdir}}"/usr/local/bin/argocd-k8s-auth
+    dependencies:
+      provides:
+        - argo-cd-compat=${{package.full-version}}
+
+update:
+  enabled: true
+  github:
+    identifier: argoproj/argo-cd
+    strip-prefix: v
+    tag-filter: v2.10.
+
+test:
+  pipeline:
+    - name: ArgoCD Version Check
+      runs: |
+        argocd version --short --client || exit 1

--- a/argo-cd-2.10/tls-cipher-removed.patch
+++ b/argo-cd-2.10/tls-cipher-removed.patch
@@ -1,0 +1,26 @@
+From 60e5cc4f940a65fbd5fbf294ad8e8d05877342c2 Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Fri, 26 Apr 2024 12:39:47 +0300
+Subject: [PATCH] tls-cipher fix
+
+Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+---
+ util/tls/tls.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/util/tls/tls.go b/util/tls/tls.go
+index 5e18c8eb7..c7925b832 100644
+--- a/util/tls/tls.go
++++ b/util/tls/tls.go
+@@ -28,7 +28,7 @@ const (
+ 	DefaultRSABits = 2048
+ 	// The default TLS cipher suites to provide to clients - see https://cipherlist.eu for updates
+ 	// Note that for TLS v1.3, cipher suites are not configurable and will be chosen automatically.
+-	DefaultTLSCipherSuite = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_RSA_WITH_AES_256_GCM_SHA384"
++	DefaultTLSCipherSuite = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+ 	// The default minimum TLS version to provide to clients
+ 	DefaultTLSMinVersion = "1.2"
+ 	// The default maximum TLS version to provide to clients
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/argoproj/argo-cd/pull/17569

> [!IMPORTANT]
> Once the change that was made by Josh released we should remove the patch file and update the argo-cd version but today instead of waiting the release we applied that change as a patch file**

/cc @joshrwolf @mamccorm 

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
