### PR TITLE
fix(py3-itsdangerous): Fixup packaging, make it not so dangerous

### DIFF
--- a/py3-itsdangerous.yaml
+++ b/py3-itsdangerous.yaml
@@ -2,10 +2,13 @@
 package:
   name: py3-itsdangerous
   version: 2.2.0
-  epoch: 1
+  epoch: 2
   description: Safely pass data to untrusted environments and back.
   copyright:
     - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - python3
 
 environment:
   contents:
@@ -13,7 +16,6 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-pip
       - python3
       - wolfi-base
 
@@ -24,20 +26,14 @@ pipeline:
       uri: https://files.pythonhosted.org/packages/source/i/itsdangerous/itsdangerous-${{package.version}}.tar.gz
 
   - name: Python Build
-    runs: |
-      pip install flit
-
-  - name: Flit Build
-    runs: |
-      flit build
-      FLIT_ROOT_INSTALL=1 flit install
-
-  - name: Install
-    runs: |
-      mkdir -p "${{targets.destdir}}/lib"
-      cp -r src/itsdangerous "${{targets.destdir}}/lib"
+    uses: python/build-wheel
 
   - uses: strip
+
+test:
+  pipeline:
+    - runs: |
+        python -c "from itsdangerous import URLSafeSerializer"
 
 update:
   enabled: true


### PR DESCRIPTION
This was previously installing to the root of the build env and not to the package itself