### PR TITLE
opentelemetry-collector: add compat subpkg for helm chart

### DIFF
--- a/opentelemetry-collector.yaml
+++ b/opentelemetry-collector.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-collector
   version: 0.99.0
-  epoch: 0
+  epoch: 1
   description: OpenTelemetry Collector
   copyright:
     - license: Apache-2.0
@@ -52,6 +52,15 @@ pipeline:
       rm -f ${{targets.destdir}}/usr/bin/ocb
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: Compatability package to place binary in the location expected by upstream helm chart
+    pipeline:
+      - runs: |
+          # The helm chart expects the binary to be /otelcol instead of /usr/bin/otelcorecol
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/otelcorecol ${{targets.subpkgdir}}/otelcol
 
 update:
   enabled: true


### PR DESCRIPTION
### Pre-review Checklist

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
