### PR TITLE
kube-vip

### DIFF
--- a/kube-vip.yaml
+++ b/kube-vip.yaml
@@ -1,0 +1,51 @@
+package:
+  name: kube-vip
+  version: 0.8.0
+  epoch: 0
+  description: Kubernetes Control Plane Virtual IP and Load-Balancer
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 722c47fc08b33c1635cd30d31e745d932e6336d8
+      repository: https://github.com/kube-vip/kube-vip
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      ldflags: -s -w -X=main.Version=${{package.version}} -X=main.Build=$(git rev-parse HEAD) -extldflags -static
+      output: kube-vip
+      packages: .
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    # https://github.com/kube-vip/kube-vip/blob/2872256a89a1e39b62c9518728ec22e2f33af4eb/Dockerfile#L19
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/kube-vip ${{targets.subpkgdir}}/kube-vip
+
+update:
+  enabled: true
+  github:
+    identifier: kube-vip/kube-vip
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-compat
+  pipeline:
+    - runs: |
+        kube-vip -h
+        /kube-vip -h


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
