### PR TITLE
fix(rust): Build jemalloc under aarch64 with 64k page support

### DIFF
--- a/build-aarch64.env
+++ b/build-aarch64.env
@@ -5,3 +5,5 @@ export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack"
 export GOFLAGS=""
 export GOTOOLCHAIN=local
+# Build jemalloc with 64k page support
+export JEMALLOC_SYS_WITH_LG_PAGE=16


### PR DESCRIPTION
While running an image I built under Asahi Remix on an MBP with an M2 Max, I ecountered this error:

`<jemalloc>: Unsupported system page size`

Support 8k, 16k, and 64k aligned processors under aarch64 by setting the page size to 64k. By default, jemalloc pulls the page size from the builder, but this results in binaries that can't be ran universally