### PR TITLE
feat: add ksops package

### DIFF
--- a/ksops.yaml
+++ b/ksops.yaml
@@ -20,6 +20,11 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 5ced30d87a6b3a659e5d2c1bf542e8660a3054b2
 
+  - uses: go/bump
+    with:
+      deps: golang.org/x/net@v0.23.0 google.golang.org/protobuf@v1.33.0
+      replaces: github.com/go-jose/go-jose/v3=github.com/go-jose/go-jose/v3@v3.0.3
+
   - uses: go/build
     with:
       packages: ksops.go

--- a/ksops.yaml
+++ b/ksops.yaml
@@ -1,0 +1,34 @@
+package:
+  name: ksops
+  version: 4.3.1
+  epoch: 0
+  description: Flexible Kustomize Plugin for SOPS Encrypted Resources
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/viaduct-ai/kustomize-sops.git
+      tag: v${{package.version}}
+      expected-commit: 5ced30d87a6b3a659e5d2c1bf542e8660a3054b2
+
+  - uses: go/build
+    with:
+      packages: ksops.go
+      output: ksops
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: viaduct-ai/kustomize-sops
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

I based this on `sops.yaml`, but I did not understand the `go/bump` pipeline.

I've verified it to compile and run:
```
17fdcbe467aa:/# apk add /work/packages/aarch64/ksops-4.3.1-r0.apk --allow-untrusted
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/1) Installing ksops (4.3.1-r0)
OK: 34 MiB in 15 packages
17fdcbe467aa:/# ksops

KSOPS is a flexible kustomize plugin for SOPS encrypted resources.
KSOPS supports both legacy and KRM style exec kustomize functions.

kustomize Usage:
- kustomize build --enable-alpha-plugins --enable-exec

Standalone Usage :
- Legacy: ksops secret-generator.yaml
- KRM: cat secret-generator.yaml | ksops
17fdcbe467aa:/# 
```

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #17986

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
