### PR TITLE
Separating monitor package

### DIFF
--- a/neuvector-monitor-5.3.yaml
+++ b/neuvector-monitor-5.3.yaml
@@ -31,7 +31,7 @@ pipeline:
       install -Dm755 monitor/monitor ${{targets.contextdir}}/usr/bin/neuvector-monitor
 
 subpackages:
-  - name: ${{package.name}}-symlink
+  - name: ${{package.name}}-compat
     description: NeuVector Monitor binary symlink
     pipeline:
       - runs: |

--- a/neuvector-monitor-5.3.yaml
+++ b/neuvector-monitor-5.3.yaml
@@ -1,0 +1,38 @@
+package:
+  name: neuvector-monitor-5.3
+  version: 5.3.2
+  epoch: 0
+  description: NeuVector Full Lifecycle Container Security Platform.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - neuvector-monitor=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - gcc
+      - glibc-dev
+      - make
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/neuvector/neuvector
+      tag: v${{package.version}}
+      expected-commit: edbdcba632835d56dcc92ba86323c8a196471289
+
+  - runs: |
+      make -C monitor
+      mkdir -p ${{targets.contextdir}}/usr/local/bin
+      install -Dm755 monitor/monitor ${{targets.contextdir}}/usr/local/bin/${{package.name}}
+
+update:
+  enabled: true
+  github:
+    identifier: neuvector/neuvector
+    strip-prefix: v
+    tag-filter: v5.3.

--- a/neuvector-monitor-5.3.yaml
+++ b/neuvector-monitor-5.3.yaml
@@ -28,7 +28,15 @@ pipeline:
   - runs: |
       make -C monitor
       mkdir -p ${{targets.contextdir}}/usr/local/bin
-      install -Dm755 monitor/monitor ${{targets.contextdir}}/usr/local/bin/${{package.name}}
+      install -Dm755 monitor/monitor ${{targets.contextdir}}/usr/bin/neuvector-monitor
+
+subpackages:
+  - name: ${{package.name}}-symlink
+    description: NeuVector Monitor binary symlink
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/local/bin
+          ln -s /usr/bin/neuvector-monitor ${{targets.contextdir}}/usr/local/bin/monitor
 
 update:
   enabled: true

--- a/neuvector-scanner.yaml
+++ b/neuvector-scanner.yaml
@@ -51,14 +51,6 @@ subpackages:
           subpackage: "true"
           vendor: true
 
-  - name: ${{package.name}}-monitor
-    description: NeuVector Scanner Monitor
-    pipeline:
-      - runs: |
-          make -C monitor
-          mkdir -p ${{targets.contextdir}}/usr/local/bin
-          install -Dm755 monitor/monitor ${{targets.contextdir}}/usr/local/bin/${{package.name}}-monitor
-
 test:
   pipeline:
     - runs: |

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -46,3 +46,4 @@ sig-storage-local-static-provisioner-2.7.0-r0.apk
 sig-storage-local-static-provisioner-2.7.0-r1.apk
 sig-storage-local-static-provisioner-compat-2.7.0-r0.apk
 sig-storage-local-static-provisioner-compat-2.7.0-r1.apk
+neuvector-scanner-monitor-0_git20240417-r1.apk


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
