### PR TITLE
Make Jenkins agent its own subpackage

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -59,9 +59,38 @@ pipeline:
       mvn install -DskipTests=true
 
       mkdir -p ${{targets.destdir}}/usr/share/java/jenkins
-      mv war/target/jenkins.war ${{targets.destdir}}/usr/share/java/jenkins/
+      cp -p war/target/jenkins.war ${{targets.destdir}}/usr/share/java/jenkins/
 
 subpackages:
+  #
+  # Agent executables (remoting.jar is named agent.jar or slave.jar in Jenkins)
+  - name: "jenkins-agent"
+    description: "Jenkins Remoting is a library, and executable Java archive, which implements the communication layer in Jenkins"
+    pipeline:
+      - runs: |
+          mkdir -p /home/build/agent/
+          mv war/target/jenkins.war /home/build/agent/
+          cd /home/build/agent/
+
+          remoting_jar=$(unzip -l jenkins.war "WEB-INF/lib/remoting-*.jar" | grep 'remoting-' | awk '{ print $4 }')
+          if [ -z "$remoting_jar" ]; then
+            echo "Error: No remoting jar found in the WAR file."
+            exit 1
+          fi
+          echo "remoting jar version: " + "$remoting_jar"
+
+          mkdir -p "${{targets.subpkgdir}}/usr/share/jenkins"
+          unzip -q jenkins.war "$remoting_jar" -d "/home/build/agent/"
+          mv "/home/build/agent/$remoting_jar" "${{targets.subpkgdir}}/usr/share/jenkins/agent.jar"
+          if [ -f "${{targets.subpkgdir}}/usr/share/jenkins/agent.jar" ]; then
+            echo "Extraction successful"
+          else
+            echo "Extraction failed."
+          fi
+          chmod +x "${{targets.subpkgdir}}/usr/share/jenkins/agent.jar"
+          ln -sf /usr/share/jenkins/agent.jar "${{targets.subpkgdir}}/usr/share/jenkins/slave.jar"
+      - uses: strip
+
   # The Jenkins entrypoint script expects directories to exist, and the .war file
   # under a different location.
   - name: "jenkins-compat"


### PR DESCRIPTION
This PR allows users to leverage the Jenkins Agent embedded in the Jenkins.war file as opposed to pulling down the prebuilt binary (as in the official image):
https://github.com/jenkinsci/docker-agent/tree/master

Jenkins Agent and Slave are the same executables so this allows for the .jar to be used both ways (similar to upstream):
[Agent executables (remoting.jar is named agent.jar or slave.jar in Jenkins)](https://www.jenkins.io/projects/remoting/)
https://github.com/jenkinsci/docker-agent/blob/master/alpine/Dockerfile#L77
