### PR TITLE
bump epochs to get valid SBOMs

### DIFF
--- a/alpine-keys.yaml
+++ b/alpine-keys.yaml
@@ -1,7 +1,7 @@
 package:
   name: alpine-keys
   version: 2.4
-  epoch: 3
+  epoch: 4
   description: Public keys for Alpine Linux packages
   copyright:
     - license: MIT

--- a/alsa-lib.yaml
+++ b/alsa-lib.yaml
@@ -1,7 +1,7 @@
 package:
   name: alsa-lib
   version: 1.2.11
-  epoch: 0
+  epoch: 1
   description: Advanced Linux Sound Architecture (ALSA) library
   copyright:
     - license: LGPL-2.1-or-later

--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: apk-tools
   version: 2.14.1
-  epoch: 0
+  epoch: 1
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only

--- a/apko.yaml
+++ b/apko.yaml
@@ -1,7 +1,7 @@
 package:
   name: apko
   version: 0.14.0
-  epoch: 7
+  epoch: 8
   description: Build OCI images using APK directly without Dockerfile
   copyright:
     - license: Apache-2.0

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: binutils
   version: "2.42"
-  epoch: 0
+  epoch: 1
   description: "GNU binutils"
   copyright:
     - license: GPL-3.0-or-later

--- a/bubblewrap.yaml
+++ b/bubblewrap.yaml
@@ -1,7 +1,7 @@
 package:
   name: bubblewrap
   version: 0.9.0
-  epoch: 0
+  epoch: 1
   description: "Unprivileged sandboxing tool"
   copyright:
     - license: LGPL-2.0-or-later

--- a/build-base.yaml
+++ b/build-base.yaml
@@ -1,7 +1,7 @@
 package:
   name: build-base
   version: 1
-  epoch: 6
+  epoch: 7
   description: "virtual package for builds"
   copyright:
     - license: MIT

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,7 +1,7 @@
 package:
   name: busybox
   version: 1.36.1
-  epoch: 7
+  epoch: 8
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only

--- a/c-ares.yaml
+++ b/c-ares.yaml
@@ -1,7 +1,7 @@
 package:
   name: c-ares
   version: 1.28.1
-  epoch: 0
+  epoch: 1
   description: "an asynchronous DNS resolution library"
   copyright:
     - license: MIT

--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -1,7 +1,7 @@
 package:
   name: ca-certificates
   version: "20240315"
-  epoch: 0
+  epoch: 1
   description: "CA certificates from the Mozilla trusted root program"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/composer.yaml
+++ b/composer.yaml
@@ -1,7 +1,7 @@
 package:
   name: composer
   version: 2.7.4
-  epoch: 0
+  epoch: 1
   description: "the PHP package manager"
   copyright:
     - license: MIT

--- a/conntrack-tools.yaml
+++ b/conntrack-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: conntrack-tools
   version: "1.4.8"
-  epoch: 1
+  epoch: 2
   description: Connection tracking userspace tools
   copyright:
     - license: GPL-2.0-or-later

--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: 1.11.1
-  epoch: 13
+  epoch: 14
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0

--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: coreutils
   version: "9.5"
-  epoch: 0
+  epoch: 1
   description: "GNU core utilities"
   copyright:
     - license: GPL-3.0-or-later

--- a/cosign.yaml
+++ b/cosign.yaml
@@ -1,7 +1,7 @@
 package:
   name: cosign
   version: 2.2.4
-  epoch: 1
+  epoch: 2
   description: Container Signing
   copyright:
     - license: Apache-2.0

--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: 8.7.1
-  epoch: 1
+  epoch: 2
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT

--- a/dex.yaml
+++ b/dex.yaml
@@ -2,7 +2,7 @@ package:
   name: dex
   # When bumping the version check if the GHSA mitigations below can be removed.
   version: 2.39.1
-  epoch: 0
+  epoch: 1
   description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors
   copyright:
     - license: Apache-2.0

--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-6
   version: 6.0.129 # We'll likely be able to remove the fix for CVE-2024-0057 at the next version.
-  epoch: 0
+  epoch: 1
   description: ".NET SDK, version 6"
   copyright:
     - license: MIT

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -2,7 +2,7 @@ package:
   name: dotnet-7
   # Remove `-sb` from the git-checkout tag at the next release
   version: 7.0.117
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT

--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: 8.0.4
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT

--- a/dumb-init.yaml
+++ b/dumb-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: dumb-init
   version: 1.2.5
-  epoch: 1
+  epoch: 2
   description: "minimal init system for Linux containers"
   copyright:
     - license: MIT

--- a/execline.yaml
+++ b/execline.yaml
@@ -1,7 +1,7 @@
 package:
   name: execline
   version: 2.9.5.1
-  epoch: 0
+  epoch: 1
   description: "a small scripting language intended to be an alternative to shell scripting"
   copyright:
     - license: ISC

--- a/freetype.yaml
+++ b/freetype.yaml
@@ -1,7 +1,7 @@
 package:
   name: freetype
   version: 2.13.2
-  epoch: 2
+  epoch: 3
   description: TrueType font rendering library
   copyright:
     - license: FTL OR GPL-2.0-or-later

--- a/fuse-overlayfs-snapshotter.yaml
+++ b/fuse-overlayfs-snapshotter.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs-snapshotter
   version: 1.0.8
-  epoch: 7
+  epoch: 8
   description: fuse-overlayfs plugin for rootless containerd
   copyright:
     - license: Apache-2.0

--- a/fuse-overlayfs.yaml
+++ b/fuse-overlayfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs
   version: "1.13"
-  epoch: 2
+  epoch: 3
   description: FUSE implementation for overlayfs
   copyright:
     - license: GPL-2.0-or-later

--- a/fuse3.yaml
+++ b/fuse3.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse3
   version: 3.16.2
-  epoch: 1
+  epoch: 2
   description: The reference implementation of the Linux FUSE (Filesystem in Userspace) interface
   copyright:
     - license: GPL-2.0-only AND LGPL-2.1-only

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 13.2.0
-  epoch: 5
+  epoch: 6
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later

--- a/gdbm.yaml
+++ b/gdbm.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdbm
   version: 1.23
-  epoch: 4
+  epoch: 5
   description: "GNU dbm is a set of database routines which use extensible hashing"
   copyright:
     - license: GPL-3.0-or-later

--- a/giflib.yaml
+++ b/giflib.yaml
@@ -1,7 +1,7 @@
 package:
   name: giflib
   version: 5.2.2
-  epoch: 0
+  epoch: 1
   description: "A library for reading and writing GIF images"
   copyright:
     - license: MIT

--- a/git-lfs.yaml
+++ b/git-lfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-lfs
   version: 3.5.1
-  epoch: 1
+  epoch: 2
   description: "large file support for git"
   copyright:
     - license: MIT

--- a/git.yaml
+++ b/git.yaml
@@ -1,7 +1,7 @@
 package:
   name: git
   version: 2.45.0
-  epoch: 0
+  epoch: 1
   description: "distributed version control system"
   copyright:
     - license: GPL-2.0-or-later

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.39
-  epoch: 2
+  epoch: 3
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later

--- a/gmp.yaml
+++ b/gmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: gmp
   version: 6.3.0
-  epoch: 1
+  epoch: 2
   description: "a library for arbitrary precision arithmetic"
   copyright:
     - license: LGPL-3.0-or-later OR GPL-2.0-or-later

--- a/go-1.19.yaml
+++ b/go-1.19.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.19
   version: 1.19.13
-  epoch: 1
+  epoch: 2
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause

--- a/go-1.20.yaml
+++ b/go-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.20
   version: 1.20.14
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause

--- a/go-1.21.yaml
+++ b/go-1.21.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.21
   version: 1.21.9
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause

--- a/go-1.22.yaml
+++ b/go-1.22.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.22
   version: 1.22.2
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause

--- a/go-fips-1.20.yaml
+++ b/go-fips-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-fips-1.20
   version: 1.20.14
-  epoch: 0
+  epoch: 1
   description: "the Go programming language with OpenSSL cryptography"
   copyright:
     - license: BSD-3-Clause

--- a/go-fips-1.21.yaml
+++ b/go-fips-1.21.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-fips-1.21
   version: 1.21.9
-  epoch: 0
+  epoch: 1
   description: "the Go programming language with OpenSSL cryptography"
   copyright:
     - license: BSD-3-Clause

--- a/gomplate.yaml
+++ b/gomplate.yaml
@@ -1,7 +1,7 @@
 package:
   name: gomplate
   version: 3.11.7
-  epoch: 3
+  epoch: 4
   description: A go templating utility.
   copyright:
     - license: MIT

--- a/gops.yaml
+++ b/gops.yaml
@@ -1,7 +1,7 @@
 package:
   name: gops
   version: 0.3.28
-  epoch: 8
+  epoch: 9
   description: gops is a command to list and diagnose Go processes currently running on your system.
   copyright:
     - license: BSD-3-Clause

--- a/gradle-8.yaml
+++ b/gradle-8.yaml
@@ -3,7 +3,7 @@ package:
   version: 8.7.0 # Remove "bump-deps.patch" when upgrading to 8.8.0
   # For version upgrades check whether patches are still needed.
   # Upstream changes are being tracked in https://github.com/gradle/gradle/issues/25945
-  epoch: 1
+  epoch: 2
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0

--- a/helm.yaml
+++ b/helm.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm
   version: 3.14.4
-  epoch: 1
+  epoch: 2
   description: The Kubernetes Package Manager
   copyright:
     - license: Apache-2.0

--- a/hubble-ui.yaml
+++ b/hubble-ui.yaml
@@ -1,7 +1,7 @@
 package:
   name: hubble-ui
   version: 0.13.0
-  epoch: 7
+  epoch: 8
   description: "Observability & troubleshooting for Kubernetes services"
   copyright:
     - license: "Apache-2.0"

--- a/icu.yaml
+++ b/icu.yaml
@@ -1,7 +1,7 @@
 package:
   name: icu
   version: 74.2 # remove LICENSE file from wolfi source folder when updating as upstream should have fixed the broken symlink
-  epoch: 0
+  epoch: 1
   description: "International Components for Unicode library"
   copyright:
     - license: MIT

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables
   version: 1.8.10
-  epoch: 1
+  epoch: 2
   description: Linux kernel firewall, NAT and packet mangling tools
   copyright:
     - license: GPL-2.0-or-later

--- a/isl.yaml
+++ b/isl.yaml
@@ -1,7 +1,7 @@
 package:
   name: isl
   version: 0.26
-  epoch: 1
+  epoch: 2
   description: "an integer set library for the polyhedral model"
   copyright:
     - license: MIT

--- a/java-cacerts.yaml
+++ b/java-cacerts.yaml
@@ -2,7 +2,7 @@ package:
   name: java-cacerts
   # Update this when ca-certificates is updated.
   version: 20230106
-  epoch: 3
+  epoch: 4
   description: "default certificate authorities for Java"
   copyright:
     - license: MIT

--- a/java-common.yaml
+++ b/java-common.yaml
@@ -1,7 +1,7 @@
 package:
   name: java-common
   version: 0.1
-  epoch: 1
+  epoch: 2
   description: "Compatibility infrastructure for JVM runtimes"
   copyright:
     - license: GPL-2.0-or-later

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.29.3
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: Apache-2.0

--- a/kmod.yaml
+++ b/kmod.yaml
@@ -1,7 +1,7 @@
 package:
   name: kmod
   version: "32"
-  epoch: 0
+  epoch: 1
   description: Linux kernel module management utilities
   copyright:
     - license: GPL-2.0-or-later

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.15.2
-  epoch: 7
+  epoch: 8
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0

--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
   version: 1.108.10
-  epoch: 0
+  epoch: 1
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0

--- a/krb5-conf.yaml
+++ b/krb5-conf.yaml
@@ -1,7 +1,7 @@
 package:
   name: krb5-conf
   version: "1.0"
-  epoch: 1
+  epoch: 2
   description: Shared krb5.conf for both MIT krb5 and heimdal
   copyright:
     - license: MIT

--- a/kustomize.yaml
+++ b/kustomize.yaml
@@ -1,7 +1,7 @@
 package:
   name: kustomize
   version: 5.4.1
-  epoch: 0
+  epoch: 1
   description: Customization of kubernetes YAML configurations
   copyright:
     - license: Apache-2.0

--- a/lcms2.yaml
+++ b/lcms2.yaml
@@ -1,7 +1,7 @@
 package:
   name: lcms2
   version: "2.16"
-  epoch: 0
+  epoch: 1
   description: "Color Management Engine"
   copyright:
     - license: MIT AND GPL-3.0-only

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcap
   version: "2.69"
-  epoch: 3
+  epoch: 4
   description: "POSIX 1003.1e capabilities"
   copyright:
     - license: BSD-3-Clause OR GPL-2.0-only

--- a/libedit.yaml
+++ b/libedit.yaml
@@ -1,7 +1,7 @@
 package:
   name: libedit
   version: 3.1
-  epoch: 3
+  epoch: 4
   description: "the NetBSD editline library"
   copyright:
     - license: BSD-3-Clause

--- a/libev.yaml
+++ b/libev.yaml
@@ -1,7 +1,7 @@
 package:
   name: libev
   version: 4.33
-  epoch: 4
+  epoch: 5
   description: "event dispatch library"
   copyright:
     - license: BSD-2-Clause OR GPL-2.0-or-later

--- a/libffi.yaml
+++ b/libffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libffi
   version: 3.4.6
-  epoch: 0
+  epoch: 1
   description: "portable foreign function interface library"
   copyright:
     - license: MIT

--- a/libidn2.yaml
+++ b/libidn2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libidn2
   version: 2.3.7
-  epoch: 0
+  epoch: 1
   description: Encode/Decode library for internationalized domain names
   copyright:
     - license: GPL-2.0-or-later AND LGPL-3.0-or-later

--- a/libjpeg-turbo.yaml
+++ b/libjpeg-turbo.yaml
@@ -1,7 +1,7 @@
 package:
   name: libjpeg-turbo
   version: 3.0.2
-  epoch: 0
+  epoch: 1
   description: "Accelerated baseline JPEG compression and decompression library"
   copyright:
     - license: BSD-3-Clause AND IJG AND Zlib

--- a/libmnl.yaml
+++ b/libmnl.yaml
@@ -1,7 +1,7 @@
 package:
   name: libmnl
   version: 1.0.5
-  epoch: 1
+  epoch: 2
   description: Library for minimalistic netlink
   copyright:
     - license: LGPL-2.1-or-later

--- a/libnetfilter_conntrack.yaml
+++ b/libnetfilter_conntrack.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnetfilter_conntrack
   version: "1.0.9"
-  epoch: 1
+  epoch: 2
   description: programming interface (API) to the in-kernel connection tracking state table
   copyright:
     - license: GPL-2.0-or-later

--- a/libnetfilter_cthelper.yaml
+++ b/libnetfilter_cthelper.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnetfilter_cthelper
   version: "1.0.1"
-  epoch: 1
+  epoch: 2
   description: A Netfilter netlink library for connection tracking helpers
   copyright:
     - license: GPL-2.0-or-later

--- a/libnetfilter_cttimeout.yaml
+++ b/libnetfilter_cttimeout.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnetfilter_cttimeout
   version: "1.0.1"
-  epoch: 1
+  epoch: 2
   description: Library for the connection tracking timeout infrastructure
   copyright:
     - license: GPL-2.0-or-later

--- a/libnetfilter_queue.yaml
+++ b/libnetfilter_queue.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnetfilter_queue
   version: "1.0.5"
-  epoch: 1
+  epoch: 2
   description: API to packets that have been queued by the kernel packet filter
   copyright:
     - license: GPL-2.0-or-later

--- a/libnfnetlink.yaml
+++ b/libnfnetlink.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnfnetlink
   version: "1.0.2"
-  epoch: 1
+  epoch: 2
   description: low-level library for netfilter related kernel/userspace communication
   copyright:
     - license: GPL-2.0-or-later

--- a/libnftnl.yaml
+++ b/libnftnl.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnftnl
   version: 1.2.6
-  epoch: 1
+  epoch: 2
   description: Netfilter library providing interface to the nf_tables subsystem
   copyright:
     - license: GPL-2.0-or-later

--- a/libpng.yaml
+++ b/libpng.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpng
   version: 1.6.43
-  epoch: 0
+  epoch: 1
   description: Portable Network Graphics library
   copyright:
     - license: Libpng

--- a/libpsl.yaml
+++ b/libpsl.yaml
@@ -2,7 +2,7 @@
 package:
   name: libpsl
   version: 0.21.5
-  epoch: 0
+  epoch: 1
   description: C library for the Publix Suffix List
   copyright:
     - license: MIT

--- a/libseccomp.yaml
+++ b/libseccomp.yaml
@@ -1,7 +1,7 @@
 package:
   name: libseccomp
   version: 2.5.5
-  epoch: 2
+  epoch: 3
   description: interface to the Linux Kernel's syscall filtering mechanism
   copyright:
     - license: LGPL-2.1-or-later

--- a/libsodium.yaml
+++ b/libsodium.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsodium
   version: 1.0.18
-  epoch: 3
+  epoch: 4
   description: P(ortable|ackageable) NaCl-based crypto library
   copyright:
     - license: ISC

--- a/libtasn1.yaml
+++ b/libtasn1.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtasn1
   version: 4.19.0
-  epoch: 1
+  epoch: 2
   description: The ASN.1 library used in GNUTLS
   copyright:
     - license: LGPL-2.1-or-later

--- a/libunistring.yaml
+++ b/libunistring.yaml
@@ -1,7 +1,7 @@
 package:
   name: libunistring
   version: "1.2"
-  epoch: 0
+  epoch: 1
   description: Library for manipulating Unicode strings and C strings
   copyright:
     - license: GPL-2.0-or-later OR LGPL-3.0-or-later

--- a/libunwind.yaml
+++ b/libunwind.yaml
@@ -1,7 +1,7 @@
 package:
   name: libunwind
   version: 1.8.1
-  epoch: 0
+  epoch: 1
   description: "Portable and efficient C programming interface (API) to determine the call-chain of a program"
   copyright:
     - license: MIT

--- a/libuv.yaml
+++ b/libuv.yaml
@@ -1,7 +1,7 @@
 package:
   name: libuv
   version: 1.48.0
-  epoch: 0
+  epoch: 1
   description: "cross-platform asynchronous I/O library"
   copyright:
     - license: MIT AND ISC

--- a/libx11.yaml
+++ b/libx11.yaml
@@ -1,7 +1,7 @@
 package:
   name: libx11
   version: 1.8.9
-  epoch: 0
+  epoch: 1
   description: X11 client-side library
   copyright:
     - license: XFree86-1.1

--- a/libxau.yaml
+++ b/libxau.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxau
   version: 1.0.11
-  epoch: 4
+  epoch: 5
   description: X11 authorisation library
   copyright:
     - license: MIT

--- a/libxcb.yaml
+++ b/libxcb.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcb
   version: 1.17.0
-  epoch: 0
+  epoch: 1
   description: X11 client-side library
   copyright:
     - license: MIT

--- a/libxcomposite.yaml
+++ b/libxcomposite.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcomposite
   version: 0.4.6
-  epoch: 1
+  epoch: 2
   description: X11 Composite extension library
   copyright:
     - license: MIT

--- a/libxcrypt.yaml
+++ b/libxcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcrypt
   version: 4.4.36
-  epoch: 4
+  epoch: 5
   description: "Modern library for one-way hashing of passwords"
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/libxdmcp.yaml
+++ b/libxdmcp.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxdmcp
   version: 1.1.5
-  epoch: 0
+  epoch: 1
   description: X11 Display Manager Control Protocol library
   copyright:
     - license: MIT

--- a/libxext.yaml
+++ b/libxext.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxext
   version: 1.3.6
-  epoch: 0
+  epoch: 1
   description: X11 miscellaneous extensions library
   copyright:
     - license: MIT

--- a/libxi.yaml
+++ b/libxi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxi
   version: 1.8.1
-  epoch: 1
+  epoch: 2
   description: X11 Input extension library
   copyright:
     - license: MIT AND X11

--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxml2
   version: 2.12.6
-  epoch: 0
+  epoch: 1
   description: XML parsing library, version 2
   copyright:
     - license: MIT

--- a/libxrender.yaml
+++ b/libxrender.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxrender
   version: 0.9.11
-  epoch: 4
+  epoch: 5
   description: X Rendering Extension client library
   copyright:
     - license: XFree86-1.1

--- a/libxtst.yaml
+++ b/libxtst.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxtst
   version: 1.2.4
-  epoch: 5
+  epoch: 6
   description: X11 Testing -- Resource extension library
   copyright:
     - license: XFree86-1.1

--- a/linux-headers.yaml
+++ b/linux-headers.yaml
@@ -1,7 +1,7 @@
 package:
   name: linux-headers
   version: 6.6.11
-  epoch: 1
+  epoch: 2
   description: "the Linux kernel headers (cross compilation)"
   copyright:
     - license: GPL-3.0-or-later

--- a/lttng-ust.yaml
+++ b/lttng-ust.yaml
@@ -1,7 +1,7 @@
 package:
   name: lttng-ust
   version: 2.13.8
-  epoch: 0
+  epoch: 1
   description: LTTng 2.0 Userspace Tracer
   copyright:
     - license: LGPL-2.1-or-later

--- a/make.yaml
+++ b/make.yaml
@@ -1,7 +1,7 @@
 package:
   name: make
   version: 4.4.1
-  epoch: 1
+  epoch: 2
   description: "GNU make"
   copyright:
     - license: GPL-3.0-or-later

--- a/maven.yaml
+++ b/maven.yaml
@@ -1,7 +1,7 @@
 package:
   name: maven
   version: 3.9.6
-  epoch: 1
+  epoch: 2
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0

--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: 0.6.11
-  epoch: 3
+  epoch: 4
   description: build APKs from source code
   copyright:
     - license: Apache-2.0

--- a/mpc.yaml
+++ b/mpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: mpc
   version: 1.3.1
-  epoch: 1
+  epoch: 2
   description: "multiple-precision C library"
   copyright:
     - license: LGPL-3.0-or-later

--- a/mpdecimal.yaml
+++ b/mpdecimal.yaml
@@ -1,7 +1,7 @@
 package:
   name: mpdecimal
   version: 4.0.0
-  epoch: 0
+  epoch: 1
   description: "complete implementation of the general decimal arithmetic specification"
   copyright:
     - license: MIT

--- a/mpfr.yaml
+++ b/mpfr.yaml
@@ -1,7 +1,7 @@
 package:
   name: mpfr
   version: 4.2.1
-  epoch: 1
+  epoch: 2
   description: "multiple-precision floating-point library"
   copyright:
     - license: LGPL-3.0-or-later

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
   version: 6.4_p20231125
-  epoch: 1
+  epoch: 2
   description: "console display library"
   copyright:
     - license: MIT

--- a/nghttp2.yaml
+++ b/nghttp2.yaml
@@ -1,7 +1,7 @@
 package:
   name: nghttp2
   version: 1.61.0
-  epoch: 0
+  epoch: 1
   description: "experimental HTTP/2 client, server and library"
   copyright:
     - license: MIT

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-mainline
   version: 1.25.5
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-18
   version: 18.20.2
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-20
   version: 20.12.2
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   dependencies:
     provides:

--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-21
   version: 21.7.3
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-22
   version: 22.0.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/npm.yaml
+++ b/npm.yaml
@@ -1,7 +1,7 @@
 package:
   name: npm
   version: 10.6.0
-  epoch: 0
+  epoch: 1
   description: "the npm package manager for javascript, mainline"
   copyright:
     - license: Artistic-2.0

--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: oauth2-proxy
   version: 7.6.0
-  epoch: 4
+  epoch: 5
   description: Reverse proxy and static file server that provides authentication using various providers to validate accounts by email, domain or group.
   copyright:
     - license: MIT

--- a/oniguruma.yaml
+++ b/oniguruma.yaml
@@ -1,7 +1,7 @@
 package:
   name: oniguruma
   version: 6.9.9
-  epoch: 1
+  epoch: 2
   description: "a regular expressions library"
   copyright:
     - license: BSD-2-Clause

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
   version: 11.0.23 # TODO(jason): on version bump, ensure to update downstream projects that are pinned to a specific prerelease version
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-14.yaml
+++ b/openjdk-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-14
   version: 14.0.2.12
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-15
   version: 15.0.10.5
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-16
   version: 16.0.2.7
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
   version: 17.0.11 # TODO(jason): on version bump ensure to update downstream projects that are pinned to a specific prerelease version, i.e. https://github.com/chainguard-images/images/tree/main/images
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-21
   version: 21.0.3
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-22.yaml
+++ b/openjdk-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-22
   version: 22.0.1
-  epoch: 0
+  epoch: 1
   description: OpenJDK 22
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.392.08 # this corresponds to same release as jdk8u392-ga / jdk8u392-b08
-  epoch: 1
+  epoch: 2
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later

--- a/p11-kit.yaml
+++ b/p11-kit.yaml
@@ -1,7 +1,7 @@
 package:
   name: p11-kit
   version: 0.25.3
-  epoch: 1
+  epoch: 2
   description: Library for loading and sharing PKCS#11 modules
   copyright:
     - license: BSD-3-Clause

--- a/pcre.yaml
+++ b/pcre.yaml
@@ -1,7 +1,7 @@
 package:
   name: pcre
   version: "8.45"
-  epoch: 1
+  epoch: 2
   description: Perl-compatible regular expression library
   copyright:
     - license: BSD-3-Clause

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: 8.2.18
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/pkgconf.yaml
+++ b/pkgconf.yaml
@@ -1,7 +1,7 @@
 package:
   name: pkgconf
   version: 2.2.0
-  epoch: 0
+  epoch: 1
   description: "An implementation of pkg-config"
   copyright:
     - license: ISC

--- a/posix-cc-wrappers.yaml
+++ b/posix-cc-wrappers.yaml
@@ -1,7 +1,7 @@
 package:
   name: posix-cc-wrappers
   version: 1
-  epoch: 1
+  epoch: 2
   description: "Wrappers around GCC and Clang for POSIX conformance"
   copyright:
     - license: MIT

--- a/py3-magic.yaml
+++ b/py3-magic.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-magic
   version: 0.4.27
-  epoch: 4
+  epoch: 5
   description: "Python3 wrapper for libmagic"
   copyright:
     - license: MIT

--- a/py3-python-dateutil.yaml
+++ b/py3-python-dateutil.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-python-dateutil
   version: 2.9.0
-  epoch: 0
+  epoch: 1
   description: Extensions to the standard Python datetime module
   copyright:
     - license: Apache-2.0

--- a/py3-six.yaml
+++ b/py3-six.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-six
   version: 1.16.0
-  epoch: 7
+  epoch: 8
   description: "python 2 and 3 compatibility library"
   copyright:
     - license: MIT

--- a/py3.10-pip.yaml
+++ b/py3.10-pip.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3.10-pip
   version: "24.0"
-  epoch: 0
+  epoch: 1
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT

--- a/py3.10-setuptools.yaml
+++ b/py3.10-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.10-setuptools
   version: 69.5.1
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"

--- a/py3.11-pip.yaml
+++ b/py3.11-pip.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3.11-pip
   version: "24.0"
-  epoch: 0
+  epoch: 1
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT

--- a/py3.11-setuptools.yaml
+++ b/py3.11-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.11-setuptools
   version: 69.5.1 # When bumping this, also bump the provides below!
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"

--- a/py3.12-pip.yaml
+++ b/py3.12-pip.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.12-pip
   version: "24.0"
-  epoch: 1
+  epoch: 2
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT

--- a/py3.12-setuptools.yaml
+++ b/py3.12-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.12-setuptools
   version: 69.5.1
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"

--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: 3.10.14
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: 3.11.9
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: 3.12.3
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/readline.yaml
+++ b/readline.yaml
@@ -1,7 +1,7 @@
 package:
   name: readline
   version: "8.2"
-  epoch: 3
+  epoch: 4
   description: "GNU readline library"
   copyright:
     - license: GPL-3.0-or-later

--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.0
   version: 3.0.7
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.5 # You may have to remove CVE patches at the next version
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: 3.2.4
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.3
   version: 3.3.1
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby3.0-bundler.yaml
+++ b/ruby3.0-bundler.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.0-bundler
   version: 2.5.9
-  epoch: 0
+  epoch: 1
   description: "Manage an application's gem dependencies"
   copyright:
     - license: MIT

--- a/ruby3.1-bundler.yaml
+++ b/ruby3.1-bundler.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.1-bundler
   version: 2.5.9
-  epoch: 0
+  epoch: 1
   description: "Manage an application's gem dependencies"
   copyright:
     - license: MIT

--- a/ruby3.2-bundler.yaml
+++ b/ruby3.2-bundler.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-bundler
   version: 2.5.9
-  epoch: 0
+  epoch: 1
   description: "Manage an application's gem dependencies"
   copyright:
     - license: MIT

--- a/ruby3.3-bundler.yaml
+++ b/ruby3.3-bundler.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.3-bundler
   version: 2.5.9
-  epoch: 0
+  epoch: 1
   description: "Manage an application's gem dependencies"
   copyright:
     - license: MIT

--- a/runc.yaml
+++ b/runc.yaml
@@ -1,7 +1,7 @@
 package:
   name: runc
   version: 1.1.12
-  epoch: 4
+  epoch: 5
   description: CLI tool for spawning and running containers according to the OCI specification
   copyright:
     - license: Apache-2.0

--- a/rust.yaml
+++ b/rust.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust
   version: 1.77.2
-  epoch: 0
+  epoch: 1
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rustls-ffi.yaml
+++ b/rustls-ffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: rustls-ffi
   version: 0.13.0
-  epoch: 1
+  epoch: 2
   description: "C-to-rustls bindings"
   copyright:
     - license: MIT

--- a/rustup.yaml
+++ b/rustup.yaml
@@ -1,7 +1,7 @@
 package:
   name: rustup
   version: 1.27.0
-  epoch: 0
+  epoch: 1
   description: "rustup is an installer for the systems programming language Rust"
   copyright:
     - license: MIT

--- a/s3cmd.yaml
+++ b/s3cmd.yaml
@@ -1,7 +1,7 @@
 package:
   name: s3cmd
   version: 2.4.0
-  epoch: 1
+  epoch: 2
   description: Command-line tool for managing Amazon S3 and CloudFront services
   copyright:
     - license: GPL-2.0-or-later

--- a/s6.yaml
+++ b/s6.yaml
@@ -1,7 +1,7 @@
 package:
   name: s6
   version: 2.12.0.4
-  epoch: 0
+  epoch: 1
   description: "skarnet.org's small & secure supervision software suite."
   copyright:
     - license: ISC

--- a/skalibs.yaml
+++ b/skalibs.yaml
@@ -1,7 +1,7 @@
 package:
   name: skalibs
   version: 2.14.1.1
-  epoch: 0
+  epoch: 1
   description: "set of general-purpose C programming libraries for skarnet.org software"
   copyright:
     - license: ISC

--- a/tzdata.yaml
+++ b/tzdata.yaml
@@ -1,7 +1,7 @@
 package:
   name: tzdata
   version: 2024a
-  epoch: 0
+  epoch: 1
   description: "Timezone data provided by IANA"
   copyright:
     - license: CC-PDDC

--- a/wait-for-it.yaml
+++ b/wait-for-it.yaml
@@ -1,7 +1,7 @@
 package:
   name: wait-for-it
   version: 0.20200823
-  epoch: 2
+  epoch: 3
   description: Pure bash script to test and wait on the availability of a TCP host and port
   copyright:
     - license: MIT

--- a/wget.yaml
+++ b/wget.yaml
@@ -1,7 +1,7 @@
 package:
   name: wget
   version: 1.24.5
-  epoch: 0
+  epoch: 1
   description: "GNU wget"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/wolfi-base.yaml
+++ b/wolfi-base.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-base
   version: 1
-  epoch: 4
+  epoch: 5
   description: "Wolfi base metapackage"
   copyright:
     - license: MIT

--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 7
+  epoch: 8
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT

--- a/wolfi-keys.yaml
+++ b/wolfi-keys.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-keys
   version: 1
-  epoch: 6
+  epoch: 7
   description: "Wolfi signing keyring"
   copyright:
     - license: MIT

--- a/xz.yaml
+++ b/xz.yaml
@@ -1,7 +1,7 @@
 package:
   name: xz
   version: 5.4.6
-  epoch: 0
+  epoch: 1
   description: "Library and CLI tools for XZ and LZMA compressed files"
   copyright:
     - license: GPL-3.0-or-later

--- a/yaml.yaml
+++ b/yaml.yaml
@@ -2,7 +2,7 @@
 package:
   name: yaml
   version: 0.2.5
-  epoch: 2
+  epoch: 3
   description: YAML 1.1 parser and emitter written in C
   copyright:
     - license: MIT

--- a/yarn.yaml
+++ b/yarn.yaml
@@ -1,7 +1,7 @@
 package:
   name: yarn
   version: 1.22.22
-  epoch: 0
+  epoch: 1
   description: Fast, reliable, and secure dependency management for Node.js
   copyright:
     - license: BSD-2-Clause

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: zlib
   version: 1.3.1
-  epoch: 0
+  epoch: 1
   description: "a library implementing the zlib compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT


### PR DESCRIPTION
This builds with https://github.com/chainguard-dev/melange/pull/1184 so SBOMs include `supplier` and are valid according to the latest NTIA conformance checker.

There are a lot more packages that need this, but this accounts for a fairly large swath of packages in images.