### PR TITLE
batch 5: sbom bump

### DIFF
--- a/alpine-keys.yaml
+++ b/alpine-keys.yaml
@@ -1,7 +1,7 @@
 package:
   name: alpine-keys
   version: 2.4
-  epoch: 3
+  epoch: 4
   description: Public keys for Alpine Linux packages
   copyright:
     - license: MIT

--- a/alsa-lib.yaml
+++ b/alsa-lib.yaml
@@ -1,7 +1,7 @@
 package:
   name: alsa-lib
   version: 1.2.11
-  epoch: 0
+  epoch: 1
   description: Advanced Linux Sound Architecture (ALSA) library
   copyright:
     - license: LGPL-2.1-or-later

--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: apk-tools
   version: 2.14.1
-  epoch: 0
+  epoch: 1
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only

--- a/apko.yaml
+++ b/apko.yaml
@@ -1,7 +1,7 @@
 package:
   name: apko
   version: 0.14.0
-  epoch: 7
+  epoch: 8
   description: Build OCI images using APK directly without Dockerfile
   copyright:
     - license: Apache-2.0

--- a/binutils.yaml
+++ b/binutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: binutils
   version: "2.42"
-  epoch: 0
+  epoch: 1
   description: "GNU binutils"
   copyright:
     - license: GPL-3.0-or-later

--- a/bubblewrap.yaml
+++ b/bubblewrap.yaml
@@ -1,7 +1,7 @@
 package:
   name: bubblewrap
   version: 0.9.0
-  epoch: 0
+  epoch: 1
   description: "Unprivileged sandboxing tool"
   copyright:
     - license: LGPL-2.0-or-later

--- a/build-base.yaml
+++ b/build-base.yaml
@@ -1,7 +1,7 @@
 package:
   name: build-base
   version: 1
-  epoch: 6
+  epoch: 7
   description: "virtual package for builds"
   copyright:
     - license: MIT

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,7 +1,7 @@
 package:
   name: busybox
   version: 1.36.1
-  epoch: 7
+  epoch: 8
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only

--- a/c-ares.yaml
+++ b/c-ares.yaml
@@ -1,7 +1,7 @@
 package:
   name: c-ares
   version: 1.28.1
-  epoch: 0
+  epoch: 1
   description: "an asynchronous DNS resolution library"
   copyright:
     - license: MIT

--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -1,7 +1,7 @@
 package:
   name: ca-certificates
   version: "20240315"
-  epoch: 0
+  epoch: 1
   description: "CA certificates from the Mozilla trusted root program"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/composer.yaml
+++ b/composer.yaml
@@ -1,7 +1,7 @@
 package:
   name: composer
   version: 2.7.4
-  epoch: 0
+  epoch: 1
   description: "the PHP package manager"
   copyright:
     - license: MIT

--- a/conntrack-tools.yaml
+++ b/conntrack-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: conntrack-tools
   version: "1.4.8"
-  epoch: 1
+  epoch: 2
   description: Connection tracking userspace tools
   copyright:
     - license: GPL-2.0-or-later

--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: 1.11.1
-  epoch: 13
+  epoch: 14
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0

--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: coreutils
   version: "9.5"
-  epoch: 0
+  epoch: 1
   description: "GNU core utilities"
   copyright:
     - license: GPL-3.0-or-later

--- a/cosign.yaml
+++ b/cosign.yaml
@@ -1,7 +1,7 @@
 package:
   name: cosign
   version: 2.2.4
-  epoch: 1
+  epoch: 2
   description: Container Signing
   copyright:
     - license: Apache-2.0

--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: 8.7.1
-  epoch: 1
+  epoch: 2
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT

--- a/dex.yaml
+++ b/dex.yaml
@@ -2,7 +2,7 @@ package:
   name: dex
   # When bumping the version check if the GHSA mitigations below can be removed.
   version: 2.39.1
-  epoch: 0
+  epoch: 1
   description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors
   copyright:
     - license: Apache-2.0

--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-6
   version: 6.0.129 # We'll likely be able to remove the fix for CVE-2024-0057 at the next version.
-  epoch: 0
+  epoch: 1
   description: ".NET SDK, version 6"
   copyright:
     - license: MIT

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -2,7 +2,7 @@ package:
   name: dotnet-7
   # Remove `-sb` from the git-checkout tag at the next release
   version: 7.0.117
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT

--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: 8.0.4
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT

--- a/dumb-init.yaml
+++ b/dumb-init.yaml
@@ -1,7 +1,7 @@
 package:
   name: dumb-init
   version: 1.2.5
-  epoch: 1
+  epoch: 2
   description: "minimal init system for Linux containers"
   copyright:
     - license: MIT

--- a/execline.yaml
+++ b/execline.yaml
@@ -1,7 +1,7 @@
 package:
   name: execline
   version: 2.9.5.1
-  epoch: 0
+  epoch: 1
   description: "a small scripting language intended to be an alternative to shell scripting"
   copyright:
     - license: ISC

--- a/freetype.yaml
+++ b/freetype.yaml
@@ -1,7 +1,7 @@
 package:
   name: freetype
   version: 2.13.2
-  epoch: 2
+  epoch: 3
   description: TrueType font rendering library
   copyright:
     - license: FTL OR GPL-2.0-or-later

--- a/fuse-overlayfs-snapshotter.yaml
+++ b/fuse-overlayfs-snapshotter.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs-snapshotter
   version: 1.0.8
-  epoch: 7
+  epoch: 8
   description: fuse-overlayfs plugin for rootless containerd
   copyright:
     - license: Apache-2.0

--- a/fuse-overlayfs.yaml
+++ b/fuse-overlayfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs
   version: "1.13"
-  epoch: 2
+  epoch: 3
   description: FUSE implementation for overlayfs
   copyright:
     - license: GPL-2.0-or-later

--- a/fuse3.yaml
+++ b/fuse3.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse3
   version: 3.16.2
-  epoch: 1
+  epoch: 2
   description: The reference implementation of the Linux FUSE (Filesystem in Userspace) interface
   copyright:
     - license: GPL-2.0-only AND LGPL-2.1-only

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 13.2.0
-  epoch: 5
+  epoch: 6
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later

--- a/gdbm.yaml
+++ b/gdbm.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdbm
   version: 1.23
-  epoch: 4
+  epoch: 5
   description: "GNU dbm is a set of database routines which use extensible hashing"
   copyright:
     - license: GPL-3.0-or-later

--- a/giflib.yaml
+++ b/giflib.yaml
@@ -1,7 +1,7 @@
 package:
   name: giflib
   version: 5.2.2
-  epoch: 0
+  epoch: 1
   description: "A library for reading and writing GIF images"
   copyright:
     - license: MIT

--- a/git-lfs.yaml
+++ b/git-lfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-lfs
   version: 3.5.1
-  epoch: 1
+  epoch: 2
   description: "large file support for git"
   copyright:
     - license: MIT

--- a/git.yaml
+++ b/git.yaml
@@ -1,7 +1,7 @@
 package:
   name: git
   version: 2.45.0
-  epoch: 0
+  epoch: 1
   description: "distributed version control system"
   copyright:
     - license: GPL-2.0-or-later

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.39
-  epoch: 2
+  epoch: 3
   description: "the GNU C library"
   copyright:
     - license: GPL-3.0-or-later

--- a/gmp.yaml
+++ b/gmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: gmp
   version: 6.3.0
-  epoch: 1
+  epoch: 2
   description: "a library for arbitrary precision arithmetic"
   copyright:
     - license: LGPL-3.0-or-later OR GPL-2.0-or-later

--- a/go-1.19.yaml
+++ b/go-1.19.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.19
   version: 1.19.13
-  epoch: 1
+  epoch: 2
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause

--- a/go-1.20.yaml
+++ b/go-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.20
   version: 1.20.14
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause

--- a/go-1.21.yaml
+++ b/go-1.21.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.21
   version: 1.21.9
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause

--- a/go-1.22.yaml
+++ b/go-1.22.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.22
   version: 1.22.2
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause

--- a/go-fips-1.20.yaml
+++ b/go-fips-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-fips-1.20
   version: 1.20.14
-  epoch: 0
+  epoch: 1
   description: "the Go programming language with OpenSSL cryptography"
   copyright:
     - license: BSD-3-Clause

--- a/go-fips-1.21.yaml
+++ b/go-fips-1.21.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-fips-1.21
   version: 1.21.9
-  epoch: 0
+  epoch: 1
   description: "the Go programming language with OpenSSL cryptography"
   copyright:
     - license: BSD-3-Clause

--- a/gomplate.yaml
+++ b/gomplate.yaml
@@ -1,7 +1,7 @@
 package:
   name: gomplate
   version: 3.11.7
-  epoch: 3
+  epoch: 4
   description: A go templating utility.
   copyright:
     - license: MIT

--- a/gops.yaml
+++ b/gops.yaml
@@ -1,7 +1,7 @@
 package:
   name: gops
   version: 0.3.28
-  epoch: 8
+  epoch: 9
   description: gops is a command to list and diagnose Go processes currently running on your system.
   copyright:
     - license: BSD-3-Clause

--- a/gradle-8.yaml
+++ b/gradle-8.yaml
@@ -3,7 +3,7 @@ package:
   version: 8.7.0 # Remove "bump-deps.patch" when upgrading to 8.8.0
   # For version upgrades check whether patches are still needed.
   # Upstream changes are being tracked in https://github.com/gradle/gradle/issues/25945
-  epoch: 1
+  epoch: 2
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0

--- a/helm.yaml
+++ b/helm.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm
   version: 3.14.4
-  epoch: 1
+  epoch: 2
   description: The Kubernetes Package Manager
   copyright:
     - license: Apache-2.0

--- a/hubble-ui.yaml
+++ b/hubble-ui.yaml
@@ -1,7 +1,7 @@
 package:
   name: hubble-ui
   version: 0.13.0
-  epoch: 7
+  epoch: 8
   description: "Observability & troubleshooting for Kubernetes services"
   copyright:
     - license: "Apache-2.0"

--- a/icu.yaml
+++ b/icu.yaml
@@ -1,7 +1,7 @@
 package:
   name: icu
   version: 74.2 # remove LICENSE file from wolfi source folder when updating as upstream should have fixed the broken symlink
-  epoch: 0
+  epoch: 1
   description: "International Components for Unicode library"
   copyright:
     - license: MIT

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables
   version: 1.8.10
-  epoch: 1
+  epoch: 2
   description: Linux kernel firewall, NAT and packet mangling tools
   copyright:
     - license: GPL-2.0-or-later

--- a/isl.yaml
+++ b/isl.yaml
@@ -1,7 +1,7 @@
 package:
   name: isl
   version: 0.26
-  epoch: 1
+  epoch: 2
   description: "an integer set library for the polyhedral model"
   copyright:
     - license: MIT

--- a/java-cacerts.yaml
+++ b/java-cacerts.yaml
@@ -2,7 +2,7 @@ package:
   name: java-cacerts
   # Update this when ca-certificates is updated.
   version: 20230106
-  epoch: 3
+  epoch: 4
   description: "default certificate authorities for Java"
   copyright:
     - license: MIT

--- a/java-common.yaml
+++ b/java-common.yaml
@@ -1,7 +1,7 @@
 package:
   name: java-common
   version: 0.1
-  epoch: 1
+  epoch: 2
   description: "Compatibility infrastructure for JVM runtimes"
   copyright:
     - license: GPL-2.0-or-later

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.29.3
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Rebuilds packages with https://github.com/chainguard-dev/melange/pull/1184 so they have `supplier` set in their SBOMs.

Splitting https://github.com/wolfi-dev/os/pull/18026 into batches of 50

