### PR TITLE
batch 6: sbom bump

### DIFF
--- a/kmod.yaml
+++ b/kmod.yaml
@@ -1,7 +1,7 @@
 package:
   name: kmod
   version: "32"
-  epoch: 0
+  epoch: 1
   description: Linux kernel module management utilities
   copyright:
     - license: GPL-2.0-or-later

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.15.2
-  epoch: 7
+  epoch: 8
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0

--- a/kots.yaml
+++ b/kots.yaml
@@ -1,7 +1,7 @@
 package:
   name: kots
   version: 1.108.10
-  epoch: 0
+  epoch: 1
   description: Kubernetes Off-The-Shelf (KOTS) Software
   copyright:
     - license: Apache-2.0

--- a/krb5-conf.yaml
+++ b/krb5-conf.yaml
@@ -1,7 +1,7 @@
 package:
   name: krb5-conf
   version: "1.0"
-  epoch: 1
+  epoch: 2
   description: Shared krb5.conf for both MIT krb5 and heimdal
   copyright:
     - license: MIT

--- a/kustomize.yaml
+++ b/kustomize.yaml
@@ -1,7 +1,7 @@
 package:
   name: kustomize
   version: 5.4.1
-  epoch: 0
+  epoch: 1
   description: Customization of kubernetes YAML configurations
   copyright:
     - license: Apache-2.0

--- a/lcms2.yaml
+++ b/lcms2.yaml
@@ -1,7 +1,7 @@
 package:
   name: lcms2
   version: "2.16"
-  epoch: 0
+  epoch: 1
   description: "Color Management Engine"
   copyright:
     - license: MIT AND GPL-3.0-only

--- a/libcap.yaml
+++ b/libcap.yaml
@@ -1,7 +1,7 @@
 package:
   name: libcap
   version: "2.69"
-  epoch: 3
+  epoch: 4
   description: "POSIX 1003.1e capabilities"
   copyright:
     - license: BSD-3-Clause OR GPL-2.0-only

--- a/libedit.yaml
+++ b/libedit.yaml
@@ -1,7 +1,7 @@
 package:
   name: libedit
   version: 3.1
-  epoch: 3
+  epoch: 4
   description: "the NetBSD editline library"
   copyright:
     - license: BSD-3-Clause

--- a/libev.yaml
+++ b/libev.yaml
@@ -1,7 +1,7 @@
 package:
   name: libev
   version: 4.33
-  epoch: 4
+  epoch: 5
   description: "event dispatch library"
   copyright:
     - license: BSD-2-Clause OR GPL-2.0-or-later

--- a/libffi.yaml
+++ b/libffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libffi
   version: 3.4.6
-  epoch: 0
+  epoch: 1
   description: "portable foreign function interface library"
   copyright:
     - license: MIT

--- a/libidn2.yaml
+++ b/libidn2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libidn2
   version: 2.3.7
-  epoch: 0
+  epoch: 1
   description: Encode/Decode library for internationalized domain names
   copyright:
     - license: GPL-2.0-or-later AND LGPL-3.0-or-later

--- a/libjpeg-turbo.yaml
+++ b/libjpeg-turbo.yaml
@@ -1,7 +1,7 @@
 package:
   name: libjpeg-turbo
   version: 3.0.2
-  epoch: 0
+  epoch: 1
   description: "Accelerated baseline JPEG compression and decompression library"
   copyright:
     - license: BSD-3-Clause AND IJG AND Zlib

--- a/libmnl.yaml
+++ b/libmnl.yaml
@@ -1,7 +1,7 @@
 package:
   name: libmnl
   version: 1.0.5
-  epoch: 1
+  epoch: 2
   description: Library for minimalistic netlink
   copyright:
     - license: LGPL-2.1-or-later

--- a/libnetfilter_conntrack.yaml
+++ b/libnetfilter_conntrack.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnetfilter_conntrack
   version: "1.0.9"
-  epoch: 1
+  epoch: 2
   description: programming interface (API) to the in-kernel connection tracking state table
   copyright:
     - license: GPL-2.0-or-later

--- a/libnetfilter_cthelper.yaml
+++ b/libnetfilter_cthelper.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnetfilter_cthelper
   version: "1.0.1"
-  epoch: 1
+  epoch: 2
   description: A Netfilter netlink library for connection tracking helpers
   copyright:
     - license: GPL-2.0-or-later

--- a/libnetfilter_cttimeout.yaml
+++ b/libnetfilter_cttimeout.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnetfilter_cttimeout
   version: "1.0.1"
-  epoch: 1
+  epoch: 2
   description: Library for the connection tracking timeout infrastructure
   copyright:
     - license: GPL-2.0-or-later

--- a/libnetfilter_queue.yaml
+++ b/libnetfilter_queue.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnetfilter_queue
   version: "1.0.5"
-  epoch: 1
+  epoch: 2
   description: API to packets that have been queued by the kernel packet filter
   copyright:
     - license: GPL-2.0-or-later

--- a/libnfnetlink.yaml
+++ b/libnfnetlink.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnfnetlink
   version: "1.0.2"
-  epoch: 1
+  epoch: 2
   description: low-level library for netfilter related kernel/userspace communication
   copyright:
     - license: GPL-2.0-or-later

--- a/libnftnl.yaml
+++ b/libnftnl.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnftnl
   version: 1.2.6
-  epoch: 1
+  epoch: 2
   description: Netfilter library providing interface to the nf_tables subsystem
   copyright:
     - license: GPL-2.0-or-later

--- a/libpng.yaml
+++ b/libpng.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpng
   version: 1.6.43
-  epoch: 0
+  epoch: 1
   description: Portable Network Graphics library
   copyright:
     - license: Libpng

--- a/libpsl.yaml
+++ b/libpsl.yaml
@@ -2,7 +2,7 @@
 package:
   name: libpsl
   version: 0.21.5
-  epoch: 0
+  epoch: 1
   description: C library for the Publix Suffix List
   copyright:
     - license: MIT

--- a/libseccomp.yaml
+++ b/libseccomp.yaml
@@ -1,7 +1,7 @@
 package:
   name: libseccomp
   version: 2.5.5
-  epoch: 2
+  epoch: 3
   description: interface to the Linux Kernel's syscall filtering mechanism
   copyright:
     - license: LGPL-2.1-or-later

--- a/libsodium.yaml
+++ b/libsodium.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsodium
   version: 1.0.18
-  epoch: 3
+  epoch: 4
   description: P(ortable|ackageable) NaCl-based crypto library
   copyright:
     - license: ISC

--- a/libtasn1.yaml
+++ b/libtasn1.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtasn1
   version: 4.19.0
-  epoch: 1
+  epoch: 2
   description: The ASN.1 library used in GNUTLS
   copyright:
     - license: LGPL-2.1-or-later

--- a/libunistring.yaml
+++ b/libunistring.yaml
@@ -1,7 +1,7 @@
 package:
   name: libunistring
   version: "1.2"
-  epoch: 0
+  epoch: 1
   description: Library for manipulating Unicode strings and C strings
   copyright:
     - license: GPL-2.0-or-later OR LGPL-3.0-or-later

--- a/libunwind.yaml
+++ b/libunwind.yaml
@@ -1,7 +1,7 @@
 package:
   name: libunwind
   version: 1.8.1
-  epoch: 0
+  epoch: 1
   description: "Portable and efficient C programming interface (API) to determine the call-chain of a program"
   copyright:
     - license: MIT

--- a/libuv.yaml
+++ b/libuv.yaml
@@ -1,7 +1,7 @@
 package:
   name: libuv
   version: 1.48.0
-  epoch: 0
+  epoch: 1
   description: "cross-platform asynchronous I/O library"
   copyright:
     - license: MIT AND ISC

--- a/libx11.yaml
+++ b/libx11.yaml
@@ -1,7 +1,7 @@
 package:
   name: libx11
   version: 1.8.9
-  epoch: 0
+  epoch: 1
   description: X11 client-side library
   copyright:
     - license: XFree86-1.1

--- a/libxau.yaml
+++ b/libxau.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxau
   version: 1.0.11
-  epoch: 4
+  epoch: 5
   description: X11 authorisation library
   copyright:
     - license: MIT

--- a/libxcb.yaml
+++ b/libxcb.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcb
   version: 1.17.0
-  epoch: 0
+  epoch: 1
   description: X11 client-side library
   copyright:
     - license: MIT

--- a/libxcomposite.yaml
+++ b/libxcomposite.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcomposite
   version: 0.4.6
-  epoch: 1
+  epoch: 2
   description: X11 Composite extension library
   copyright:
     - license: MIT

--- a/libxcrypt.yaml
+++ b/libxcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcrypt
   version: 4.4.36
-  epoch: 4
+  epoch: 5
   description: "Modern library for one-way hashing of passwords"
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/libxdmcp.yaml
+++ b/libxdmcp.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxdmcp
   version: 1.1.5
-  epoch: 0
+  epoch: 1
   description: X11 Display Manager Control Protocol library
   copyright:
     - license: MIT

--- a/libxext.yaml
+++ b/libxext.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxext
   version: 1.3.6
-  epoch: 0
+  epoch: 1
   description: X11 miscellaneous extensions library
   copyright:
     - license: MIT

--- a/libxi.yaml
+++ b/libxi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxi
   version: 1.8.1
-  epoch: 1
+  epoch: 2
   description: X11 Input extension library
   copyright:
     - license: MIT AND X11

--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxml2
   version: 2.12.6
-  epoch: 0
+  epoch: 1
   description: XML parsing library, version 2
   copyright:
     - license: MIT

--- a/libxrender.yaml
+++ b/libxrender.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxrender
   version: 0.9.11
-  epoch: 4
+  epoch: 5
   description: X Rendering Extension client library
   copyright:
     - license: XFree86-1.1

--- a/libxtst.yaml
+++ b/libxtst.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxtst
   version: 1.2.4
-  epoch: 5
+  epoch: 6
   description: X11 Testing -- Resource extension library
   copyright:
     - license: XFree86-1.1

--- a/linux-headers.yaml
+++ b/linux-headers.yaml
@@ -1,7 +1,7 @@
 package:
   name: linux-headers
   version: 6.6.11
-  epoch: 1
+  epoch: 2
   description: "the Linux kernel headers (cross compilation)"
   copyright:
     - license: GPL-3.0-or-later

--- a/lttng-ust.yaml
+++ b/lttng-ust.yaml
@@ -1,7 +1,7 @@
 package:
   name: lttng-ust
   version: 2.13.8
-  epoch: 0
+  epoch: 1
   description: LTTng 2.0 Userspace Tracer
   copyright:
     - license: LGPL-2.1-or-later

--- a/make.yaml
+++ b/make.yaml
@@ -1,7 +1,7 @@
 package:
   name: make
   version: 4.4.1
-  epoch: 1
+  epoch: 2
   description: "GNU make"
   copyright:
     - license: GPL-3.0-or-later

--- a/maven.yaml
+++ b/maven.yaml
@@ -1,7 +1,7 @@
 package:
   name: maven
   version: 3.9.6
-  epoch: 1
+  epoch: 2
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0

--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: 0.6.11
-  epoch: 3
+  epoch: 4
   description: build APKs from source code
   copyright:
     - license: Apache-2.0

--- a/mpc.yaml
+++ b/mpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: mpc
   version: 1.3.1
-  epoch: 1
+  epoch: 2
   description: "multiple-precision C library"
   copyright:
     - license: LGPL-3.0-or-later

--- a/mpdecimal.yaml
+++ b/mpdecimal.yaml
@@ -1,7 +1,7 @@
 package:
   name: mpdecimal
   version: 4.0.0
-  epoch: 0
+  epoch: 1
   description: "complete implementation of the general decimal arithmetic specification"
   copyright:
     - license: MIT

--- a/mpfr.yaml
+++ b/mpfr.yaml
@@ -1,7 +1,7 @@
 package:
   name: mpfr
   version: 4.2.1
-  epoch: 1
+  epoch: 2
   description: "multiple-precision floating-point library"
   copyright:
     - license: LGPL-3.0-or-later

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
   version: 6.4_p20231125
-  epoch: 1
+  epoch: 2
   description: "console display library"
   copyright:
     - license: MIT

--- a/nghttp2.yaml
+++ b/nghttp2.yaml
@@ -1,7 +1,7 @@
 package:
   name: nghttp2
   version: 1.61.0
-  epoch: 0
+  epoch: 1
   description: "experimental HTTP/2 client, server and library"
   copyright:
     - license: MIT

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-mainline
   version: 1.25.5
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-18
   version: 18.20.2
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT


### PR DESCRIPTION
Rebuilds packages with https://github.com/chainguard-dev/melange/pull/1184 so they have `supplier` set in their SBOMs.

Splitting https://github.com/wolfi-dev/os/pull/18026 into batches of 50

