### PR TITLE
batch 3: sbom bump

### DIFF
--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
   version: 6.4_p20231125
-  epoch: 3
+  epoch: 1
   description: "console display library"
   copyright:
     - license: MIT

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
   version: 6.4_p20231125
-  epoch: 2
+  epoch: 3
   description: "console display library"
   copyright:
     - license: MIT

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-mainline
   version: 1.25.5
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-18
   version: 18.20.2
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-20
   version: 20.12.2
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   dependencies:
     provides:

--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-21
   version: 21.7.3
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-22
   version: 22.0.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/oauth2-proxy.yaml
+++ b/oauth2-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: oauth2-proxy
   version: 7.6.0
-  epoch: 4
+  epoch: 5
   description: Reverse proxy and static file server that provides authentication using various providers to validate accounts by email, domain or group.
   copyright:
     - license: MIT

--- a/oniguruma.yaml
+++ b/oniguruma.yaml
@@ -1,7 +1,7 @@
 package:
   name: oniguruma
   version: 6.9.9
-  epoch: 1
+  epoch: 2
   description: "a regular expressions library"
   copyright:
     - license: BSD-2-Clause

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
   version: 11.0.23 # TODO(jason): on version bump, ensure to update downstream projects that are pinned to a specific prerelease version
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-14.yaml
+++ b/openjdk-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-14
   version: 14.0.2.12
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-15
   version: 15.0.10.5
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-16
   version: 16.0.2.7
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
   version: 17.0.11 # TODO(jason): on version bump ensure to update downstream projects that are pinned to a specific prerelease version, i.e. https://github.com/chainguard-images/images/tree/main/images
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-21
   version: 21.0.3
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-22.yaml
+++ b/openjdk-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-22
   version: 22.0.1
-  epoch: 0
+  epoch: 1
   description: OpenJDK 22
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.392.08 # this corresponds to same release as jdk8u392-ga / jdk8u392-b08
-  epoch: 1
+  epoch: 2
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later

--- a/p11-kit.yaml
+++ b/p11-kit.yaml
@@ -1,7 +1,7 @@
 package:
   name: p11-kit
   version: 0.25.3
-  epoch: 1
+  epoch: 2
   description: Library for loading and sharing PKCS#11 modules
   copyright:
     - license: BSD-3-Clause

--- a/pcre.yaml
+++ b/pcre.yaml
@@ -1,7 +1,7 @@
 package:
   name: pcre
   version: "8.45"
-  epoch: 1
+  epoch: 2
   description: Perl-compatible regular expression library
   copyright:
     - license: BSD-3-Clause

--- a/pkgconf.yaml
+++ b/pkgconf.yaml
@@ -1,7 +1,7 @@
 package:
   name: pkgconf
   version: 2.2.0
-  epoch: 0
+  epoch: 1
   description: "An implementation of pkg-config"
   copyright:
     - license: ISC

--- a/posix-cc-wrappers.yaml
+++ b/posix-cc-wrappers.yaml
@@ -1,7 +1,7 @@
 package:
   name: posix-cc-wrappers
   version: 1
-  epoch: 1
+  epoch: 2
   description: "Wrappers around GCC and Clang for POSIX conformance"
   copyright:
     - license: MIT

--- a/py3-magic.yaml
+++ b/py3-magic.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-magic
   version: 0.4.27
-  epoch: 4
+  epoch: 5
   description: "Python3 wrapper for libmagic"
   copyright:
     - license: MIT

--- a/py3-python-dateutil.yaml
+++ b/py3-python-dateutil.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-python-dateutil
   version: 2.9.0
-  epoch: 0
+  epoch: 1
   description: Extensions to the standard Python datetime module
   copyright:
     - license: Apache-2.0

--- a/py3-six.yaml
+++ b/py3-six.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-six
   version: 1.16.0
-  epoch: 7
+  epoch: 8
   description: "python 2 and 3 compatibility library"
   copyright:
     - license: MIT

--- a/py3.10-pip.yaml
+++ b/py3.10-pip.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3.10-pip
   version: "24.0"
-  epoch: 0
+  epoch: 1
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT

--- a/py3.10-setuptools.yaml
+++ b/py3.10-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.10-setuptools
   version: 69.5.1
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"

--- a/py3.11-pip.yaml
+++ b/py3.11-pip.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3.11-pip
   version: "24.0"
-  epoch: 0
+  epoch: 1
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT

--- a/py3.11-setuptools.yaml
+++ b/py3.11-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.11-setuptools
   version: 69.5.1 # When bumping this, also bump the provides below!
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"

--- a/py3.12-pip.yaml
+++ b/py3.12-pip.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.12-pip
   version: "24.0"
-  epoch: 1
+  epoch: 2
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT

--- a/py3.12-setuptools.yaml
+++ b/py3.12-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3.12-setuptools
   version: 69.5.1
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"

--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: 3.10.14
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: 3.11.9
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: 3.12.3
-  epoch: 1
+  epoch: 2
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/readline.yaml
+++ b/readline.yaml
@@ -1,7 +1,7 @@
 package:
   name: readline
   version: "8.2"
-  epoch: 3
+  epoch: 4
   description: "GNU readline library"
   copyright:
     - license: GPL-3.0-or-later

--- a/readline.yaml
+++ b/readline.yaml
@@ -17,8 +17,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/readline/readline-8.1.tar.gz
-      expected-sha256: f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02
+      uri: https://ftp.gnu.org/gnu/readline/readline-${{package.version}}.tar.gz
+      expected-sha256: 3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35
 
   - uses: patch
     with:

--- a/readline.yaml
+++ b/readline.yaml
@@ -1,7 +1,7 @@
 package:
   name: readline
   version: "8.2"
-  epoch: 4
+  epoch: 3
   description: "GNU readline library"
   copyright:
     - license: GPL-3.0-or-later
@@ -17,8 +17,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/readline/readline-${{package.version}}.tar.gz
-      expected-sha256: 3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35
+      uri: https://ftp.gnu.org/gnu/readline/readline-8.1.tar.gz
+      expected-sha256: f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02
 
   - uses: patch
     with:

--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.0
   version: 3.0.7
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.5 # You may have to remove CVE patches at the next version
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: 3.2.4
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.3
   version: 3.3.1
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby3.0-bundler.yaml
+++ b/ruby3.0-bundler.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.0-bundler
   version: 2.5.9
-  epoch: 0
+  epoch: 1
   description: "Manage an application's gem dependencies"
   copyright:
     - license: MIT

--- a/ruby3.1-bundler.yaml
+++ b/ruby3.1-bundler.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.1-bundler
   version: 2.5.9
-  epoch: 0
+  epoch: 1
   description: "Manage an application's gem dependencies"
   copyright:
     - license: MIT

--- a/ruby3.2-bundler.yaml
+++ b/ruby3.2-bundler.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-bundler
   version: 2.5.9
-  epoch: 0
+  epoch: 1
   description: "Manage an application's gem dependencies"
   copyright:
     - license: MIT

--- a/ruby3.3-bundler.yaml
+++ b/ruby3.3-bundler.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.3-bundler
   version: 2.5.9
-  epoch: 0
+  epoch: 1
   description: "Manage an application's gem dependencies"
   copyright:
     - license: MIT

--- a/runc.yaml
+++ b/runc.yaml
@@ -1,7 +1,7 @@
 package:
   name: runc
   version: 1.1.12
-  epoch: 4
+  epoch: 5
   description: CLI tool for spawning and running containers according to the OCI specification
   copyright:
     - license: Apache-2.0

--- a/rust.yaml
+++ b/rust.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust
   version: 1.77.2
-  epoch: 0
+  epoch: 1
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rustls-ffi.yaml
+++ b/rustls-ffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: rustls-ffi
   version: 0.13.0
-  epoch: 1
+  epoch: 2
   description: "C-to-rustls bindings"
   copyright:
     - license: MIT

--- a/rustup.yaml
+++ b/rustup.yaml
@@ -1,7 +1,7 @@
 package:
   name: rustup
   version: 1.27.0
-  epoch: 0
+  epoch: 1
   description: "rustup is an installer for the systems programming language Rust"
   copyright:
     - license: MIT

--- a/s3cmd.yaml
+++ b/s3cmd.yaml
@@ -1,7 +1,7 @@
 package:
   name: s3cmd
   version: 2.4.0
-  epoch: 1
+  epoch: 2
   description: Command-line tool for managing Amazon S3 and CloudFront services
   copyright:
     - license: GPL-2.0-or-later

--- a/s6.yaml
+++ b/s6.yaml
@@ -1,7 +1,7 @@
 package:
   name: s6
   version: 2.12.0.4
-  epoch: 0
+  epoch: 1
   description: "skarnet.org's small & secure supervision software suite."
   copyright:
     - license: ISC

--- a/skalibs.yaml
+++ b/skalibs.yaml
@@ -1,7 +1,7 @@
 package:
   name: skalibs
   version: 2.14.1.1
-  epoch: 0
+  epoch: 1
   description: "set of general-purpose C programming libraries for skarnet.org software"
   copyright:
     - license: ISC

--- a/tzdata.yaml
+++ b/tzdata.yaml
@@ -1,7 +1,7 @@
 package:
   name: tzdata
   version: 2024a
-  epoch: 0
+  epoch: 1
   description: "Timezone data provided by IANA"
   copyright:
     - license: CC-PDDC


### PR DESCRIPTION
Rebuilds packages with https://github.com/chainguard-dev/melange/pull/1184 so they have `supplier` set in their SBOMs.

Splitting https://github.com/wolfi-dev/os/pull/18026 into batches of 50

