### PR TITLE
batch 4: sbom bump

### DIFF
--- a/wait-for-it.yaml
+++ b/wait-for-it.yaml
@@ -1,7 +1,7 @@
 package:
   name: wait-for-it
   version: 0.20200823
-  epoch: 2
+  epoch: 3
   description: Pure bash script to test and wait on the availability of a TCP host and port
   copyright:
     - license: MIT

--- a/wget.yaml
+++ b/wget.yaml
@@ -1,7 +1,7 @@
 package:
   name: wget
   version: 1.24.5
-  epoch: 0
+  epoch: 1
   description: "GNU wget"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/wolfi-base.yaml
+++ b/wolfi-base.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-base
   version: 1
-  epoch: 4
+  epoch: 5
   description: "Wolfi base metapackage"
   copyright:
     - license: MIT

--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 7
+  epoch: 8
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT

--- a/wolfi-keys.yaml
+++ b/wolfi-keys.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-keys
   version: 1
-  epoch: 6
+  epoch: 7
   description: "Wolfi signing keyring"
   copyright:
     - license: MIT

--- a/xz.yaml
+++ b/xz.yaml
@@ -1,7 +1,7 @@
 package:
   name: xz
   version: 5.4.6
-  epoch: 0
+  epoch: 1
   description: "Library and CLI tools for XZ and LZMA compressed files"
   copyright:
     - license: GPL-3.0-or-later

--- a/yaml.yaml
+++ b/yaml.yaml
@@ -2,7 +2,7 @@
 package:
   name: yaml
   version: 0.2.5
-  epoch: 2
+  epoch: 3
   description: YAML 1.1 parser and emitter written in C
   copyright:
     - license: MIT

--- a/yarn.yaml
+++ b/yarn.yaml
@@ -1,7 +1,7 @@
 package:
   name: yarn
   version: 1.22.22
-  epoch: 0
+  epoch: 1
   description: Fast, reliable, and secure dependency management for Node.js
   copyright:
     - license: BSD-2-Clause

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: zlib
   version: 1.3.1
-  epoch: 0
+  epoch: 1
   description: "a library implementing the zlib compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT


### PR DESCRIPTION
Rebuilds packages with https://github.com/chainguard-dev/melange/pull/1184 so they have `supplier` set in their SBOMs.

Splitting https://github.com/wolfi-dev/os/pull/18026 into batches of 50

