### PR TITLE
Update traefik to use go/build pipeline and fix test to detect failure

### DIFF
--- a/traefik.yaml
+++ b/traefik.yaml
@@ -1,7 +1,7 @@
 package:
   name: traefik
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: The Cloud Native Application Proxy
   copyright:
     - license: MIT
@@ -22,22 +22,15 @@ pipeline:
       repository: https://github.com/traefik/traefik
       tag: v${{package.version}}
 
-  - runs: |
-      mkdir -p "${{targets.destdir}}/usr/bin"
-      TAG_NAME=$(git tag -l --contains HEAD)
-      SHA=$(git rev-parse HEAD)
-      VERSION_GIT=$(if [ -n "$TAG_NAME" ]; then echo "$TAG_NAME"; else echo "$SHA"; fi)
-      VERSION=$(if [ -n "$VERSION" ]; then echo "$VERSION"; else echo "$VERSION_GIT"; fi)
-
-      GOOS=$(go env GOOS) GOARCH=$(go env GOARCH)
-      DATE=$(date -u '+%Y-%m-%d_%I:%M:%S%p')
-
-      CGO_ENABLED=0 GOGC=off GOOS=${GOOS} GOARCH=${GOARCH} go build  -ldflags "-s -w \
-      -X github.com/traefik/traefik/v2/pkg/version.Version=$VERSION \
-      -X github.com/traefik/traefik/v2/pkg/version.Codename=$CODENAME \
-      -X github.com/traefik/traefik/v2/pkg/version.BuildDate=$DATE" \
-      -installsuffix nocgo -o "${{targets.destdir}}"/usr/bin/ ./cmd/traefik
-      go version -m "${{targets.destdir}}"/usr/bin/traefik
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/traefik
+      output: traefik
+      ldflags: |
+        -X github.com/traefik/traefik/v3/pkg/version.Version=${{package.version}}
+        -X github.com/traefik/traefik/v3/pkg/version.BuildDate=$(date -u '+%Y-%m-%d_%I:%M:%S%p')
+        -X github.com/traefik/traefik/v3/pkg/version.Codename=$CODENAME
 
 update:
   enabled: true
@@ -48,4 +41,5 @@ update:
 test:
   pipeline:
     - runs: |
-        traefik version
+        set -o pipefail
+        traefik version | grep ${{package.version}}


### PR DESCRIPTION
In the previous package update the ldflags are not setup properly
Previously
```
2024/04/29 16:22:36 WARN + traefik version
2024/04/29 16:22:36 INFO Version:      dev
2024/04/29 16:22:36 INFO Codename:     cheddar
2024/04/29 16:22:36 INFO Go version:   go1.22.2
2024/04/29 16:22:36 INFO Built:        I don't remember exactly
2024/04/29 16:22:36 INFO OS/Arch:      linux/amd64
```

