### PR TITLE
Add Wolfi package jenkins-remoting (jenkins agent)

### DIFF
--- a/jenkins-remoting
+++ b/jenkins-remoting
@@ -49,4 +49,3 @@ update:
   enabled: true
   github:
     identifier: jenkinsci/remoting
-    strip-prefix: remoting-

--- a/jenkins-remoting
+++ b/jenkins-remoting
@@ -1,0 +1,52 @@
+package:
+  name: jenkings-remoting
+  version: 4.14
+  epoch: 0
+  description: Jenkins Remoting is a library, and executable Java archive, which implements the communication layer in Jenkins
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - bash
+      - openjdk-17-default-jvm
+
+environment:
+  contents:
+    packages:
+      - bash
+      - busybox
+      - ca-certificates-bundle
+      - maven
+      - openjdk-17
+      - openjdk-17-default-jvm
+  environment:
+    LANG: en_US.UTF-8
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/jenkinsci/remoting
+      tag: remoting-${{package.version}}
+      expected-commit: 0deac8e130d82d0027812e2341c5ff781a18cbba
+
+  - runs: |
+      export MAVEN_OPTS=-Djansi.force=true
+      mkdir -p "${{targets.destdir}}/usr/share/jenkins"
+
+      mvn -B -V -e --ntp clean package || { echo "Maven build failed"; exit 1; }
+      export remoting_jar_fullpath=$(ls -l target/remoting-*.jar | grep 'remoting-[^-]*\.jar$' | awk '{print $9}')
+      remoting_jar_filename=$(basename $remoting_jar_fullpath)
+      echo "remoting jar: $remoting_jar_filename"
+      mv "$remoting_jar_fullpath" "${{targets.destdir}}/usr/share/jenkins/$remoting_jar_filename"
+
+      chmod +x "${{targets.destdir}}/usr/share/jenkins/$remoting_jar_filename"
+      ln -sf "/usr/share/jenkins/$remoting_jar_filename" "${{targets.destdir}}/usr/share/jenkins/agent.jar"
+      ln -sf "/usr/share/jenkins/$remoting_jar_filename" "${{targets.destdir}}/usr/share/jenkins/slave.jar"
+      echo "success"
+
+update:
+  enabled: true
+  github:
+    identifier: jenkinsci/remoting
+    strip-prefix: remoting-

--- a/jenkins-remoting
+++ b/jenkins-remoting
@@ -1,6 +1,6 @@
 package:
   name: jenkings-remoting
-  version: 4.14
+  version: 3206.vb_15dcf73f6a_9
   epoch: 0
   description: Jenkins Remoting is a library, and executable Java archive, which implements the communication layer in Jenkins
   copyright:

--- a/jenkins-remoting
+++ b/jenkins-remoting
@@ -28,7 +28,7 @@ pipeline:
     with:
       repository: https://github.com/jenkinsci/remoting
       tag: remoting-${{package.version}}
-      expected-commit: 0deac8e130d82d0027812e2341c5ff781a18cbba
+      expected-commit: b15dcf73f6a9b71da045bc471697702d99e871af
 
   - runs: |
       export MAVEN_OPTS=-Djansi.force=true


### PR DESCRIPTION
This package adds a source build to pair with the Jenkins Agent. We decided not to use the embedded Jenkins Agent that  gets built with the existing Jenkins build since Maven is not fully building it from source.

Scanning the image shows 0 CVEs (grype scan attacahed)

[jenkins-remoting-grype-output.json](https://github.com/wolfi-dev/os/files/15167064/jenkins-remoting-grype-output.json)

Agent executables remoting.jar is named agent.jar or slave.jar in Jenkins (symbolic links added for that reason)
https://www.jenkins.io/projects/remoting
https://github.com/jenkinsci/docker-agent/blob/master/alpine/Dockerfile#L77