### PR TITLE
fix: Rebuild pgaudit and pgvector

### DIFF
--- a/pgaudit-16.yaml
+++ b/pgaudit-16.yaml
@@ -3,7 +3,7 @@
 package:
   name: pgaudit-16
   version: 16.0
-  epoch: 1
+  epoch: 2
   description: PostgreSQL Audit Extension
   copyright:
     - license: BSD-3-Clause

--- a/pgvector-16.yaml
+++ b/pgvector-16.yaml
@@ -3,7 +3,7 @@
 package:
   name: pgvector-16
   version: 0.7.0
-  epoch: 0
+  epoch: 1
   description: Open-source vector similarity search for PostgreSQL
   copyright:
     - license: PostgreSQL


### PR DESCRIPTION
When co-installation was implemented in Postgres, these were never rebuilt so they never picked up the new paths
