### PR TITLE
opentelemetry-collector: update build config

### DIFF
--- a/opentelemetry-collector.yaml
+++ b/opentelemetry-collector.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-collector
   version: 0.99.0
-  epoch: 1
+  epoch: 2
   description: OpenTelemetry Collector
   copyright:
     - license: Apache-2.0
@@ -10,31 +10,24 @@ environment:
   contents:
     packages:
       - busybox
+      - curl
       - go
 
 pipeline:
+  - runs: |
+      set -x
+
+      # Use the build config from the official otel-core release
+      # https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/distributions/otelcol/manifest.yaml
+      # The manifest is updated as part of the release process and so should match the
+      # lastest version released from open-telemetry/opentelemetry-collector
+      curl -o builder-config.yaml https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-releases/main/distributions/otelcol/manifest.yaml
+
   - uses: git-checkout
     with:
       repository: https://github.com/open-telemetry/opentelemetry-collector
       tag: v${{package.version}}
       expected-commit: fb9d80d3c44c9007f2064baecc59687588d48499
-
-  - runs: |
-      set -x
-      # Open-telementry builder documentation recommends using cmd/otelcorecol/builder-config.yaml
-      # to build a default collector configuration:
-      # https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder#running
-      cp cmd/otelcorecol/builder-config.yaml .
-
-      # Specify the output path
-      sed -i '2i\ \ output_path: ./otel-col' ./builder-config.yaml
-
-      # Replace some of the default values that refer to it as a testing or dev build.
-      sed -i -E 's/description: .+/description: OpenTelemetry Collector/' ./builder-config.yaml
-      sed -i -E 's/version: .+/version: ${{package.version}}/' ./builder-config.yaml
-
-      # Change relative paths in replaces block from two levels to one level above root
-      sed -i -E 's/\.\.\/\.\.\//\.\.\//' ./builder-config.yaml
 
   - uses: go/build
     with:
@@ -44,11 +37,10 @@ pipeline:
 
   - runs: |
       set -x
-      mkdir otel-col
+      # Use the builder to compile opentelemetry-collector
       ${{targets.destdir}}/usr/bin/ocb --config=builder-config.yaml
 
-  - runs: |
-      install -Dm755 ./otel-col/otelcorecol "${{targets.destdir}}"/usr/bin/otelcorecol
+      install -Dm755 ./_build/otelcol "${{targets.destdir}}"/usr/bin/otelcol
       rm -f ${{targets.destdir}}/usr/bin/ocb
 
   - uses: strip
@@ -58,7 +50,7 @@ subpackages:
     description: Compatability package to place binary in the location expected by upstream helm chart
     pipeline:
       - runs: |
-          # The helm chart expects the binary to be /otelcol instead of /usr/bin/otelcorecol
+          # The helm chart expects the binary to be /otelcol instead of /usr/bin/otelcol
           mkdir -p "${{targets.subpkgdir}}"
           ln -sf /usr/bin/otelcorecol ${{targets.subpkgdir}}/otelcol
 


### PR DESCRIPTION
Use `manifest.yaml` from `open-telemetry/opentelemetry-collector-releases` repo for the `build-config.yaml` provider to the builder so the resulting `otelcol` binary matches what is found in `open-telemetry/opentelemetry-collector-releases`

