### PR TITLE
add libnvidia-container and lsb-release-minimal

### DIFF
--- a/libnvidia-container.yaml
+++ b/libnvidia-container.yaml
@@ -1,0 +1,83 @@
+package:
+  name: libnvidia-container
+  version: 1.15.0
+  epoch: 0
+  description: NVIDIA container runtime library
+  copyright:
+    - license: Apache-2.0
+    - license: GPL-3.0-only
+    - license: LGPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - automake
+      - bmake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - coreutils # for GNU date
+      - curl
+      - glibc-dev
+      - go
+      - libcap-dev # for sys/capability.h
+      - libseccomp
+      - libseccomp-dev
+      - libtirpc-dev # for rpc/rpc.h
+      - libtool
+      - linux-headers
+      - lsb-release-minimal
+      - m4
+      - nfs-utils # for rpcgen
+      - patch
+      - pkgconf-dev
+  environment:
+    CPATH: /usr/include/tirpc
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/NVIDIA/libnvidia-container
+      tag: v${{package.version}}
+      expected-commit: 6c8f1df7fd32cea3280cf2a2c6e931c9b3132465
+
+  # Fix prefix to /usr instead of /usr/local
+  - runs: sed -i 's|export prefix *= */usr/local|export prefix = /usr|' Makefile
+
+  - uses: autoconf/make
+    with:
+      opts: |
+        WITH_TIRPC=yes \
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - rc*
+  github:
+    identifier: NVIDIA/libnvidia-container
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - posix-libc-utils
+        - sudo-rs
+        - shadow # for useradd
+  pipeline:
+    - name: Ensure the libraries are linked correctly
+      runs: |
+        ldd /usr/lib/libnvidia-container.so
+        ldd /usr/lib/libnvidia-container-go.so
+    - name: Test nvidia-container-cli
+      runs: nvidia-container-cli --version
+    - name: Test nvidia-container-cli with privileged mode
+      runs: |
+        set +e
+        useradd nvidia
+        # This is the expected error since `libnvidia-ml.so` must be available on the host system. Library can be found in the CUDA.
+        sudo -u nvidia nvidia-container-cli --user=nvidia info | grep -qi "load library failed: libnvidia-ml.so.1"

--- a/lsb-release-minimal.yaml
+++ b/lsb-release-minimal.yaml
@@ -1,0 +1,35 @@
+package:
+  name: lsb-release-minimal
+  version: 12.0
+  epoch: 0
+  description: Minimal fake lsb-release that uses os-release
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gsl-dev
+      - libtool
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: cd10a4430fec5ffb9b361c371c230fec3344fbd2b0bd0c72f48bf71e6d8a6256
+      uri: https://salsa.debian.org/gioele/lsb-release-minimal/-/archive/v${{package.version}}/lsb-release-minimal-v${{package.version}}.tar.gz
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 372229


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
