### PR TITLE
Improve license info on glibc & gcc

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,10 +1,10 @@
 package:
   name: gcc
   version: 13.2.0
-  epoch: 5
+  epoch: 6
   description: "the GNU compiler collection"
   copyright:
-    - license: GPL-3.0-or-later
+    - license: GPL-3.0-or-later WITH GCC-exception-3.1
   dependencies:
     runtime:
       - binutils

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,10 +1,10 @@
 package:
   name: glibc
   version: 2.39
-  epoch: 2
+  epoch: 3
   description: "the GNU C library"
   copyright:
-    - license: GPL-3.0-or-later
+    - license: LGPL-2.1-or-later
   dependencies:
     runtime:
       # This prevents Alpine users from being able to `apk add` any Wolfi packages


### PR DESCRIPTION
Ideally need ability to inject license files into spdx. Ideally need ability to set a different license on per-subpackage basis.

Related: https://github.com/chainguard-dev/melange/issues/1007
