### PR TITLE
Correct linux-headers license

### DIFF
--- a/linux-headers.yaml
+++ b/linux-headers.yaml
@@ -1,10 +1,10 @@
 package:
   name: linux-headers
   version: 6.6.11
-  epoch: 2
+  epoch: 3
   description: "the Linux kernel headers (cross compilation)"
   copyright:
-    - license: GPL-3.0-or-later
+    - license: GPL-2.0-only WITH Linux-syscall-note
 
 environment:
   contents:

--- a/linux-headers.yaml
+++ b/linux-headers.yaml
@@ -1,7 +1,7 @@
 package:
   name: linux-headers
-  version: 6.6.11
-  epoch: 3
+  version: 6.6.29
+  epoch: 0
   description: "the Linux kernel headers (cross compilation)"
   copyright:
     - license: GPL-2.0-only WITH Linux-syscall-note
@@ -16,10 +16,11 @@ environment:
       - wolfi-baselayout
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://www.kernel.org/pub/linux/kernel/v6.x/linux-${{package.version}}.tar.gz
-      expected-sha256: 188e61502d3030005790392ae2ca421619ae55c02316aa07f6e8b3a49555fd50
+      repository: https://github.com/gregkh/linux
+      tag: v${{package.version}}
+      expected-commit: a3463f08104612fc979c41fa54733e925205d3d7
 
   - runs: |
       make mrproper
@@ -36,6 +37,8 @@ pipeline:
 update:
   enabled: true
   manual: true # be careful upgrading this package
-  # the release monitor tracks only 6.6 LTS
-  release-monitor:
-    identifier: 370853
+  github:
+    identifier: gregkh/linux
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v6.6.


### PR DESCRIPTION
it's gpl-v2 only, with syscall exception making it available to all

note this package only ships files under the syscall exception.