### PR TITLE
keycloak: add test to validate package.

### DIFF
--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -54,6 +54,67 @@ pipeline:
         ln -sf /usr/share/java/keycloak/bin/$i ${{targets.destdir}}/usr/bin/$i
       done
 
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        kspath=/usr/share/java/keycloak/conf/server.keystore
+        mypassword="seecret"
+        ver=${{package.version}}
+        # hostname needs to be resolvable
+        host=$(hostname)
+        echo "127.0.0.1 $host" >> /etc/hosts
+
+        keytool -v \
+            -keystore "$kspath" \
+            -alias localhost \
+            -genkeypair -sigalg SHA512withRSA -keyalg RSA -dname CN=localhost \
+            -storepass "$mypassword" || {
+              echo "failed [$?] to create keystore with keytool at $kspath"
+              exit 1
+        }
+
+        kc.sh start --hostname=localhost --https-key-store-password="$mypassword" >out 2>&1 &
+        pid=$!
+
+        # wait up to 30 seconds for 'Listening on' message
+        msg="Listening on"
+        n=0 ; max=30
+        set +x
+        echo "Started server in pid $pid. waiting up to $max seconds for '$msg' to appear in output"
+        while ! grep -q "$msg" out; do
+            if [ ! -d "/proc/$pid" ]; then
+                echo "kc.sh pid $pid died after $n seconds"
+                cat out
+                exit 1
+            fi
+            n=$((n+1))
+            if [ $n -ge $max ]; then
+                echo "kc.sh output did not contain '$msg' after $max seconds'"
+                cat out
+                exit 1
+            fi
+            sleep 1
+        done
+
+        echo "Found '$msg' message in kc.sh output after $n seconds"
+        grep "$msg" out
+
+        grep "Keycloak ${ver}" out || {
+          echo "Did not find version message 'Keycloak ${ver}' in output"
+          cat out
+          exit 1
+        }
+
+        grep "Profile prod activated" out || {
+          echo "kc.sh output did not contain 'Profile prod activated'"
+          cat out
+          exit 1
+        }
+
 update:
   # The upstream repos releases contains a 'nightly' release. Which we want to
   # exclude from discovery.


### PR DESCRIPTION
This is very similar to the image test that is currently in place.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
