### PR TITLE
Add superset v4.0.0

### DIFF
--- a/superset.yaml
+++ b/superset.yaml
@@ -43,8 +43,8 @@ pipeline:
   - runs: |
       # Back-end build
 
-      python -m venv .venv --system-site-packages
-      source .venv/bin/activate
+      python -m venv venv --system-site-packages
+      source venv/bin/activate
 
       # To install mysqlclient wheel
       export MYSQLCLIENT_CFLAGS=`mysql_config --cflags`
@@ -73,9 +73,9 @@ pipeline:
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/share/superset
-      mv .venv ${{targets.destdir}}/usr/share/superset
-      rm -rf ${{targets.destdir}}/usr/share/superset/.venv/bin/__pycache*
-      sed -i "s|/home/build|/usr/share/superset|g" ${{targets.destdir}}/usr/share/superset/.venv/bin/*
+      mv venv ${{targets.destdir}}/usr/share/superset
+      rm -rf ${{targets.destdir}}/usr/share/superset/venv/bin/__pycache*
+      sed -i "s|/home/build|/usr/share/superset|g" ${{targets.destdir}}/usr/share/superset/venv/bin/*
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin/
@@ -104,6 +104,6 @@ test:
         - superset
   pipeline:
     - runs: |
-        export PATH=/usr/share/superset/.venv/bin:$PATH
+        export PATH=/usr/share/superset/venv/bin:$PATH
         export SUPERSET_SECRET_KEY="$(openssl rand -base64 42)"
         superset --help

--- a/superset.yaml
+++ b/superset.yaml
@@ -89,6 +89,9 @@ pipeline:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+      - '^superset-helm-chart'
+      - 'rc\d+$'
   github:
     identifier: apache/superset
     use-tag: true

--- a/superset.yaml
+++ b/superset.yaml
@@ -1,0 +1,106 @@
+package:
+  name: superset
+  version: 4.0.0
+  epoch: 0
+  description: Data Visualization and Data Exploration Platform
+  copyright:
+    - license: Apache-2.0
+  options:
+    no-depends: true
+  dependencies:
+    runtime:
+      - openssl
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - mariadb-connector-c-dev
+      - mariadb-dev
+      - nodejs
+      - npm
+      - nvm
+      - openldap-dev
+      - py3-sqlparse
+      - py3.11-pip
+      - python-3.11-dev
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/superset.git
+      tag: ${{package.version}}
+      expected-commit: c35842e9f1c987d5e684969540fea3d8a5d03ad9
+
+  - uses: patch
+    with:
+      # to relax gunicorn and sqlparse version requirements
+      patches: version-requirements.patch
+
+  - runs: |
+      # Back-end build
+
+      python -m venv .venv --system-site-packages
+      source .venv/bin/activate
+
+      # To install mysqlclient wheel
+      export MYSQLCLIENT_CFLAGS=`mysql_config --cflags`
+      export MYSQLCLIENT_LDFLAGS=`mysql_config --libs`
+
+      pip install -r requirements/base.txt
+
+      # To fix vulnerabilities
+      pip install --upgrade dnspython==2.6.1 gunicorn==22.0.0 idna==3.7 setuptools==65.5.1 sqlparse==0.5.0
+      # Dependencies required during runtime
+      pip install pillow pyarrow
+      # For running translations
+      pip install flask flask-appbuilder
+
+      # Build Apache Superset
+      pip install .
+
+      # translations for the web application, Is a non-blocking call, so errors may be ignored
+      flask fab babel-compile --target superset/translations
+
+  - runs: |
+      # Front-end build
+      cd superset-frontend
+      npm install
+      npm run build
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/superset
+      mv .venv ${{targets.destdir}}/usr/share/superset
+      rm -rf ${{targets.destdir}}/usr/share/superset/.venv/bin/__pycache*
+      sed -i "s|/home/build|/usr/share/superset|g" ${{targets.destdir}}/usr/share/superset/.venv/bin/*
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin/
+      cp  ./docker/run-server.sh ${{targets.destdir}}/usr/bin/
+      chmod 755 ${{targets.destdir}}/usr/bin/run-server.sh
+
+      mkdir -p ${{targets.destdir}}/app/superset-frontend
+      cp -r ./superset ${{targets.destdir}}/app/
+      cp setup.py MANIFEST.in README.md ${{targets.destdir}}/app/
+      cp superset-frontend/package.json ${{targets.destdir}}/app/superset-frontend/
+
+update:
+  enabled: true
+  github:
+    identifier: apache/superset
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - wolfi-base
+        - superset
+  pipeline:
+    - runs: |
+        export PATH=/usr/share/superset/.venv/bin:$PATH
+        export SUPERSET_SECRET_KEY="$(openssl rand -base64 42)"
+        superset --help

--- a/superset.yaml
+++ b/superset.yaml
@@ -6,6 +6,9 @@ package:
   copyright:
     - license: Apache-2.0
   options:
+    #  There is a dependency on libarrow-substrait.so although it
+    #  is provided in the virtual environment. Enabling no-depends
+    #  works around this
     no-depends: true
   dependencies:
     runtime:

--- a/superset.yaml
+++ b/superset.yaml
@@ -90,8 +90,8 @@ pipeline:
 update:
   enabled: true
   ignore-regex-patterns:
-      - '^superset-helm-chart'
-      - 'rc\d+$'
+    - '^superset-helm-chart'
+    - 'rc\d+$'
   github:
     identifier: apache/superset
     use-tag: true

--- a/superset/version-requirements.patch
+++ b/superset/version-requirements.patch
@@ -1,0 +1,34 @@
+From 7bf18ce49c110a1e6135f2d0c24e95aabb0b056c Mon Sep 17 00:00:00 2001
+From: Srishti Hegde <srishti.hegde@chainguard.dev>
+Date: Tue, 30 Apr 2024 16:16:09 -0700
+Subject: [PATCH] version requirements
+
+---
+ setup.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 1ecf23f284..f91ec6365a 100644
+--- a/setup.py
++++ b/setup.py
+@@ -93,7 +93,7 @@ setup(
+         "flask-wtf>=1.1.0, <2.0",
+         "func_timeout",
+         "geopy",
+-        "gunicorn>=21.2.0, <22.0; sys_platform != 'win32'",
++        "gunicorn>=21.2.0",
+         "hashids>=1.3.1, <2",
+         "holidays>=0.25, <0.26",
+         "humanize",
+@@ -127,7 +127,7 @@ setup(
+         "sqlalchemy>=1.4, <2",
+         "sqlalchemy-utils>=0.38.3, <0.39",
+         "sqlglot>=23.0.2,<24",
+-        "sqlparse>=0.4.4, <0.5",
++        "sqlparse>=0.4.4",
+         "tabulate>=0.8.9, <0.9",
+         "typing-extensions>=4, <5",
+         "waitress; sys_platform == 'win32'",
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ x ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ x ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
