### PR TITLE
command-not-found.yaml: convert from fetch to git-checkout

### DIFF
--- a/command-not-found.yaml
+++ b/command-not-found.yaml
@@ -1,7 +1,7 @@
 package:
   name: command-not-found
   version: 0.3
-  epoch: 0
+  epoch: 1
   description: friendly command not found handling
   copyright:
     - license: MIT
@@ -16,10 +16,11 @@ environment:
       - ca-certificates-bundle
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 93b144df20c08cc2a6d50531f2d06ad23d704576f793440ff5de454f29670e3b
-      uri: https://github.com/kaniini/command-not-found/archive/v${{package.version}}/command-not-found-${{package.version}}.tar.gz
+      expected-commit:
+      repository: https://github.com/kaniini/command-not-found
+      tag: v${{package.version}}/command-not-found-${{package.version}}
 
   - runs: |
       install -D -m755 command-not-found.sh "${{targets.destdir}}"/usr/libexec/command-not-found


### PR DESCRIPTION
Convert command-not-found.yaml from fetch to git-checkout