### PR TITLE
add datadog-agent-s6-overlay subpackage

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -124,6 +124,7 @@ subpackages:
       runtime:
         - bash
         - coreutils
+        - datadog-agent-s6-overlay
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin
@@ -218,21 +219,40 @@ subpackages:
               output: fakeintake
               subpackage: "true"
 
-  # The datadog-agent image uses a deprecated 2 year old version of s6-overlay
-  # we don't want to maintain a package for. So instead, include
-  # the raw release of that version of s6-overlay as a
-  # datadog-agent subpackage, only to be used by image builders.
+  # The datadog-agent image uses a deprecated 3 year old version of s6-overlay
+  # we don't want to maintain a package for. Instead, include the
+  # raw release of that version of s6-overlay as a datadog-agent
+  # subpackage, only to be used by image builders.
   - name: datadog-agent-s6-overlay
     description: "Deprecated s6-overlay for datadog-agent"
     options:
+      # Hide this from our SCA and dag, this package should _only_ ever be used by datadog-agent
       no-provides: true
     pipeline:
       - runs: |
-          S6_VERSION=v2.2.0.3
-          JUST_CONTAINERS_DOWNLOAD_LOCATION=https://github.com/just-containers/s6-overlay/releases/download
-          S6ARCH=$([ "$TARGETARCH" = "amd64" ] && echo "amd64" || echo "aarch64") && curl -L ${JUST_CONTAINERS_DOWNLOAD_LOCATION}/${S6_VERSION}/s6-overlay-${S6ARCH}.tar.gz -o s6.tgz
+          S6_OVERLAY_VERSION=v2.2.0.3
+
+          case $(uname -m) in
+          aarch64)
+            _arch="aarch64"
+            expected_sha256="84f585a100b610124bb80e441ef2dc2d68ac2c345fd393d75a6293e0951ccfc5"
+            ;;
+          x86_64)
+            _arch="amd64"
+            expected_sha256="a7076cf205b331e9f8479bbb09d9df77dbb5cd8f7d12e9b74920902e0c16dd98"
+            ;;
+          *)
+            echo "Unsupported architecture $(uname -m)"
+            exit 1
+            ;;
+          esac
+
+          curl -o s6-overlay.tgz -L https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-${_arch}.tar.gz
+
+          echo "${expected_sha256}  s6-overlay.tgz" | sha256sum -c
+
           mkdir -p ${{targets.subpkgdir}}/
-          tar -xvzf s6.tgz -C ${{targets.subpkgdir}}/
+          tar -xvzf s6-overlay.tgz -C ${{targets.subpkgdir}}/
 
 update:
   enabled: true

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent
   version: 7.53.0
-  epoch: 0
+  epoch: 1
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - coreutils
+      - curl
       - gcc-12
       - go
       - py3-boto3
@@ -37,7 +38,6 @@ environment:
       - py3-toml
       - py3-urllib3
       - py3-wheel
-      - python-3
       - python-3-dev
   environment:
     # CGo allows Go programs to call C code
@@ -145,7 +145,7 @@ subpackages:
           install -Dm755 entrypoint.sh ${{targets.subpkgdir}}/bin/entrypoint.sh
 
           mkdir -p ${{targets.subpkgdir}}/opt/entrypoints
-          cp -r entrypoint.d ${{targets.subpkgdir}}/opt/entrypoints/
+          cp entrypoint.d/* ${{targets.subpkgdir}}/opt/entrypoints/
 
           mkdir -p ${{targets.subpkgdir}}/etc/
           cp -r s6-services ${{targets.subpkgdir}}/etc/services.d/
@@ -217,6 +217,22 @@ subpackages:
               packages: ./cmd/server
               output: fakeintake
               subpackage: "true"
+
+  # The datadog-agent image uses a deprecated 2 year old version of s6-overlay
+  # we don't want to maintain a package for. So instead, include
+  # the raw release of that version of s6-overlay as a
+  # datadog-agent subpackage, only to be used by image builders.
+  - name: datadog-agent-s6-overlay
+    description: "Deprecated s6-overlay for datadog-agent"
+    options:
+      no-provides: true
+    pipeline:
+      - runs: |
+          S6_VERSION=v2.2.0.3
+          JUST_CONTAINERS_DOWNLOAD_LOCATION=https://github.com/just-containers/s6-overlay/releases/download
+          S6ARCH=$([ "$TARGETARCH" = "amd64" ] && echo "amd64" || echo "aarch64") && curl -L ${JUST_CONTAINERS_DOWNLOAD_LOCATION}/${S6_VERSION}/s6-overlay-${S6ARCH}.tar.gz -o s6.tgz
+          mkdir -p ${{targets.subpkgdir}}/
+          tar -xvzf s6.tgz -C ${{targets.subpkgdir}}/
 
 update:
   enabled: true


### PR DESCRIPTION
I don't love this approach, and am open to suggestions. Before relying on this, I first tried with no success:

- using the embedded `s6` in apko via `service-bundle`
- using the recent 3.x `s6-overlay`

The level of indirections baked into the `datadog-agent` startup scripts is just too error prone to be comfortable with anything other than using the same s6 setup. This is the only thing I've got successfully working in the image.

I chose to just fetch the release directly from `s6-overlay` rather than build a `s6-overlay-2` package because the [build process](https://github.com/just-containers/s6-overlay/blob/v2.2.0.3/builder/build-latest) looks like it simply just curls from other sources, which is a lot of onion peeling for questionable gains.