### PR TITLE
golangci-lint.yaml: convert from fetch to git-checkout

### DIFF
--- a/golangci-lint.yaml
+++ b/golangci-lint.yaml
@@ -1,7 +1,7 @@
 package:
   name: golangci-lint
   version: 1.57.2
-  epoch: 1
+  epoch: 2
   description: Fast linters Runner for Go
   copyright:
     - license: Apache-2.0
@@ -18,10 +18,11 @@ environment:
       - go
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/golangci/golangci-lint/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: 965e91f54c8fcdccea30630c175299322088804110319282fc87a629bcb02b08
+      repository: https://github.com/golangci/golangci-lint
+      tag: v${{package.version}}
+      expected-commit: 77a8601aa372eaab3ad2d7fa1dffa71f28005393
 
   - runs: |
       make build


### PR DESCRIPTION
Convert golangci-lint.yaml from fetch to git-checkout