### PR TITLE
libpsl-native.yaml: convert from fetch to git-checkout

### DIFF
--- a/libpsl-native.yaml
+++ b/libpsl-native.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpsl-native
   version: 7.4.0
-  epoch: 1
+  epoch: 2
   description: this library provides functionality missing from .NET Core via system calls
   copyright:
     - license: MIT
@@ -15,10 +15,11 @@ environment:
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 5220f99755442720486e20682269fecdabbbabff9e082c1a51250b66465f40cf
-      uri: https://github.com/PowerShell/PowerShell-Native/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 6f702fd3cca8f85a168ddda1181ba9c8db1c0ca8
+      repository: https://github.com/PowerShell/PowerShell-Native
+      tag: v${{package.version}}
 
   - working-directory: /home/build/src/libpsl-native
     pipeline:


### PR DESCRIPTION
Convert libpsl-native.yaml from fetch to git-checkout