### PR TITLE
lua-resty-balancer.yaml: convert from fetch to git-checkout

### DIFF
--- a/lua-resty-balancer.yaml
+++ b/lua-resty-balancer.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-balancer
   version: 0.05
-  epoch: 2
+  epoch: 3
   description: "A generic consistent hash implementation for OpenResty/Lua"
   copyright:
     - license: BSD-3-Clause
@@ -17,10 +17,11 @@ environment:
     PREFIX: /usr
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openresty/lua-resty-balancer/archive/v${{package.version}}.tar.gz
-      expected-sha256: 8b2ff4edefc240dea0d3adb9dd065a42e8c09e06ba8bb0a188464cf76c9e4d06
+      repository: https://github.com/openresty/lua-resty-balancer
+      tag: v${{package.version}}
+      expected-commit: 1cd4363c0a239afe4765ec607dcfbbb4e5900eea
       strip-components: 1
 
   - uses: autoconf/make


### PR DESCRIPTION
Convert lua-resty-balancer.yaml from fetch to git-checkout