### PR TITLE
lua-resty-cache.yaml: convert from fetch to git-checkout

### DIFF
--- a/lua-resty-cache.yaml
+++ b/lua-resty-cache.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-cache
   version: 0.13
-  epoch: 2
+  epoch: 3
   description: "lua-resty-lrucache - Lua-land LRU cache based on the LuaJIT FFI."
   copyright:
     - license: BSD-3-Clause
@@ -17,10 +17,11 @@ environment:
     PREFIX: /usr
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openresty/lua-resty-lrucache/archive/v${{package.version}}.tar.gz
-      expected-sha256: 573184006b98ccee2594b0d134fa4d05e5d2afd5141cbad315051ccf7e9b6403
+      repository: https://github.com/openresty/lua-resty-lrucache
+      tag: v${{package.version}}
+      expected-commit: a79615ec9dc547fdb4aaee59ef8f5a50648ce9fd
       strip-components: 1
 
   - uses: autoconf/make-install


### PR DESCRIPTION
Convert lua-resty-cache.yaml from fetch to git-checkout