### PR TITLE
lua-resty-cookie.yaml: convert from fetch to git-checkout

### DIFF
--- a/lua-resty-cookie.yaml
+++ b/lua-resty-cookie.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-cookie
   version: 0.1.0
-  epoch: 2
+  epoch: 3
   description: "lua-resty-lrucache - Lua-land LRU cache based on the LuaJIT FFI."
   copyright:
     - license: BSD-3-Clause
@@ -17,10 +17,11 @@ environment:
     PREFIX: /usr
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/cloudflare/lua-resty-cookie/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: d81b33129c6fb5203b571fa4d8394823bf473d8872c0357a1d0f14420b1483bd
+      repository: https://github.com/cloudflare/lua-resty-cookie
+      tag: v${{package.version}}
+      expected-commit: bbd0df6bca3cac22138225d6a36243ce767d5881
       strip-components: 1
 
   - uses: autoconf/make


### PR DESCRIPTION
Convert lua-resty-cookie.yaml from fetch to git-checkout