### PR TITLE
lua-resty-core.yaml: convert from fetch to git-checkout

### DIFF
--- a/lua-resty-core.yaml
+++ b/lua-resty-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-core
   version: 0.1.28
-  epoch: 1
+  epoch: 2
   description: "lua-resty-core - New FFI-based Lua API for ngx_http_lua_module and/or ngx_stream_lua_module"
   copyright:
     - license: BSD-3-Clause
@@ -17,10 +17,11 @@ environment:
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openresty/lua-resty-core/archive/v${{package.version}}.tar.gz
-      expected-sha256: 62230dee287edcabb2dcb9c3b44ad162a6cc7ad2b8f508bc52e592f0137aa6a1
+      repository: https://github.com/openresty/lua-resty-core
+      tag: v${{package.version}}
+      expected-commit: 812b2d3871eb0d8da8f0198759ad9164f0eccac6
 
   - runs: |
       export LUAJIT_LIB=/usr/lib


### PR DESCRIPTION
Convert lua-resty-core.yaml from fetch to git-checkout