### PR TITLE
lua-resty-dns.yaml: convert from fetch to git-checkout

### DIFF
--- a/lua-resty-dns.yaml
+++ b/lua-resty-dns.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-dns
   version: "0.23"
-  epoch: 1
+  epoch: 2
   description: "lua-resty-lrucache - Lua-land LRU cache based on the LuaJIT FFI."
   copyright:
     - license: BSD-3-Clause
@@ -17,10 +17,11 @@ environment:
     PREFIX: /usr
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openresty/lua-resty-dns/archive/v${{package.version}}.tar.gz
-      expected-sha256: ecc80b91bfb4f795b8a80acfa69e1778288ef60649ddd87f30a9c4a57ac5da79
+      repository: https://github.com/openresty/lua-resty-dns
+      tag: v${{package.version}}
+      expected-commit: 273db4f348d4676f554c5319a902e7b836153192
       strip-components: 1
 
   - uses: autoconf/make-install


### PR DESCRIPTION
Convert lua-resty-dns.yaml from fetch to git-checkout