### PR TITLE
lua-resty-global-throttle.yaml: convert from fetch to git-checkout

### DIFF
--- a/lua-resty-global-throttle.yaml
+++ b/lua-resty-global-throttle.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-global-throttle
   version: 0.2.0
-  epoch: 2
+  epoch: 3
   description: "lua-resty-dns - Lua DNS resolver for the ngx_lua based on the cosocket API"
   copyright:
     - license: BSD-3-Clause
@@ -17,10 +17,11 @@ environment:
     PREFIX: /usr
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/ElvinEfendi/lua-resty-global-throttle/archive/v${{package.version}}.tar.gz
-      expected-sha256: 0fb790e394510e73fdba1492e576aaec0b8ee9ef08e3e821ce253a07719cf7ea
+      repository: https://github.com/ElvinEfendi/lua-resty-global-throttle
+      tag: v${{package.version}}
+      expected-commit: 18f1e58083211ef1eaa5fd77f796fd67d9437285
       strip-components: 1
 
   - uses: autoconf/make-install


### PR DESCRIPTION
Convert lua-resty-global-throttle.yaml from fetch to git-checkout