### PR TITLE
lua-resty-lock.yaml: convert from fetch to git-checkout

### DIFF
--- a/lua-resty-lock.yaml
+++ b/lua-resty-lock.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-lock
   version: 0.09
-  epoch: 2
+  epoch: 3
   description: "Simple nonblocking lock API for ngx_lua based on shared memory dictionaries"
   copyright:
     - license: BSD-3-Clause
@@ -17,11 +17,11 @@ environment:
     PREFIX: /usr
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openresty/lua-resty-lock/archive/v${{package.version}}.tar.gz
-      expected-sha256: b4ddcd47db347e9adf5c1e1491a6279a6ae2a3aff3155ef77ea0a65c998a69c1
-      strip-components: 1
+      repository: https://github.com/openresty/lua-resty-lock
+      tag: v${{package.version}}
+      expected-commit: 9dc550e56b6f3b1a2f1a31bb270a91813b5b6861
 
   - uses: autoconf/make-install
 


### PR DESCRIPTION
Convert lua-resty-lock.yaml from fetch to git-checkout