### PR TITLE
mold.yaml: convert from fetch to git-checkout

### DIFF
--- a/mold.yaml
+++ b/mold.yaml
@@ -1,7 +1,7 @@
 package:
   name: mold
   version: 2.30.0
-  epoch: 0
+  epoch: 1
   description: "mold linker"
   copyright:
     - license: MIT
@@ -20,10 +20,11 @@ environment:
       - wolfi-baselayout
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/rui314/mold/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: 6e5178ccafe828fdb4ba0dd841d083ff6004d3cb41e56485143eb64c716345fd
+      repository: https://github.com/rui314/mold
+      tag: v${{package.version}}
+      expected-commit: c7f6a91da512ef8a2634a1bef5d4ba82104659fe
 
   - name: 'Configure mold'
     runs: |


### PR DESCRIPTION
Convert mold.yaml from fetch to git-checkout