### PR TITLE
ruby3.0-bundler.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.0-bundler.yaml
+++ b/ruby3.0-bundler.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.0-bundler
   version: 2.5.9
-  epoch: 1
+  epoch: 2
   description: "Manage an application's gem dependencies"
   copyright:
     - license: MIT
@@ -23,10 +23,11 @@ vars:
   gem: bundler
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 77d160f7d821acac31bd892134d1abe6f172f24fd04f3d25c0f84c4dd4d60c93
-      uri: https://github.com/rubygems/rubygems/archive/bundler-v${{package.version}}.tar.gz
+      expected-commit: 9b866d01b17dd35e9eed2fad3b471a0ba6cdd900
+      repository: https://github.com/rubygems/rubygems
+      tag: bundler-v${{package.version}}
 
   - working-directory: ${{vars.gem}}
     pipeline:


### PR DESCRIPTION
Convert ruby3.0-bundler.yaml from fetch to git-checkout