### PR TITLE
ruby3.2-async-http.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-async-http.yaml
+++ b/ruby3.2-async-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-async-http
   version: 0.66.2
-  epoch: 0
+  epoch: 1
   description: A HTTP client and server library.
   copyright:
     - license: MIT
@@ -30,10 +30,11 @@ vars:
   gem: async-http
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 941dcf96430146dc3d16a052dad62e475d3010be2ba05e14e199fb612649fe56
-      uri: https://github.com/socketry/async-http/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 827a0a8b1ccc88a8cd37acaa3b9bdd10f288d38e
+      repository: https://github.com/socketry/async-http
+      tag: v${{package.version}}
 
   - uses: patch
     with:


### PR DESCRIPTION
Convert ruby3.2-async-http.yaml from fetch to git-checkout