### PR TITLE
ruby3.2-async-io.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-async-io.yaml
+++ b/ruby3.2-async-io.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-async-io
   version: 1.43.2
-  epoch: 0
+  epoch: 1
   description: Provides support for asynchonous TCP, UDP, UNIX and SSL sockets.
   copyright:
     - license: MIT
@@ -24,10 +24,11 @@ vars:
   gem: async-io
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 7fd67a6df2000be71f0eb22466f4d770a2ccd1d6e63c6b7befe8b7fb0e899aa5
-      uri: https://github.com/socketry/async-io/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 268c0b564e9904ad49a4d8d1435279003721c297
+      repository: https://github.com/socketry/async-io
+      tag: v${{package.version}}
 
   - uses: patch
     with:


### PR DESCRIPTION
Convert ruby3.2-async-io.yaml from fetch to git-checkout