### PR TITLE
ruby3.2-async-pool.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-async-pool.yaml
+++ b/ruby3.2-async-pool.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-async-pool
   version: 0.6.1
-  epoch: 0
+  epoch: 1
   description: A singleplex and multiplex resource pool for implementing robust clients.
   copyright:
     - license: MIT
@@ -24,10 +24,11 @@ vars:
   gem: async-pool
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 7c936f51a10b1ce34962a1e69495683207cfeed4b631ab6d0fcdec7c995e7e29
-      uri: https://github.com/socketry/async-pool/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 8f2b63fb7ed87c745ce5190e5d105da8342c290d
+      repository: https://github.com/socketry/async-pool
+      tag: v${{package.version}}
 
   - uses: patch
     with:


### PR DESCRIPTION
Convert ruby3.2-async-pool.yaml from fetch to git-checkout