### PR TITLE
ruby3.2-async.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-async.yaml
+++ b/ruby3.2-async.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-async
   version: 2.10.2
-  epoch: 0
+  epoch: 1
   description: A concurrency framework for Ruby.
   copyright:
     - license: MIT
@@ -26,10 +26,11 @@ vars:
   gem: async
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 61e8ab00ae1828ca3212f8a90f4c613fadb3bb72ccf5a64645b7aa40e7ccae10
-      uri: https://github.com/socketry/async/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: fd7b636dc1c31ce6f507471dbaca1384791dc71c
+      repository: https://github.com/socketry/async
+      tag: v${{package.version}}
 
   - uses: patch
     with:


### PR DESCRIPTION
Convert ruby3.2-async.yaml from fetch to git-checkout