### PR TITLE
ruby3.2-charlock_holmes.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-charlock_holmes.yaml
+++ b/ruby3.2-charlock_holmes.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-charlock_holmes
   version: 0.7.7
-  epoch: 1
+  epoch: 2
   description: charlock_holmes provides binary and text detection as well as text transcoding using libicu
   copyright:
     - license: MIT
@@ -20,10 +20,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 0ccfc3cf9c53c3ad1bfdc1e3b02a3fe226f811e72d8c6cf732e02c530ff9b329
-      uri: https://github.com/brianmario/charlock_holmes/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: de714475f5ea9d67966873c2e16705adfe051eb3
+      repository: https://github.com/brianmario/charlock_holmes
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-charlock_holmes.yaml from fetch to git-checkout