### PR TITLE
ruby3.2-connection_pool.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-connection_pool.yaml
+++ b/ruby3.2-connection_pool.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-connection_pool
   version: 2.4.1
-  epoch: 2
+  epoch: 3
   description: Generic connection pool for Ruby
   copyright:
     - license: MIT
@@ -17,10 +17,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 434649e14ffec71b46789f28198df008b51b314a378158a4aa577a0e3c5f2740
-      uri: https://github.com/mperham/connection_pool/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 8e3743b2021f51bcb3a6ec27de7cec836fcf9e72
+      repository: https://github.com/mperham/connection_pool
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-connection_pool.yaml from fetch to git-checkout