### PR TITLE
ruby3.2-console.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-console.yaml
+++ b/ruby3.2-console.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-console
   version: 1.24.0
-  epoch: 0
+  epoch: 1
   description: Beautiful logging for Ruby.
   copyright:
     - license: MIT
@@ -24,10 +24,11 @@ vars:
   gem: console
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: c856add94af3a04ba88ce7c12d5bcbb0639393aeb6c1a6a3b08613703a17c396
-      uri: https://github.com/socketry/console/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: fcbe0e5778f4c06275dfbd3cc7a5c9f3e152c4ad
+      repository: https://github.com/socketry/console
+      tag: v${{package.version}}
 
   - uses: patch
     with:


### PR DESCRIPTION
Convert ruby3.2-console.yaml from fetch to git-checkout