### PR TITLE
ruby3.2-date.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-date.yaml
+++ b/ruby3.2-date.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-date
   version: 3.3.4
-  epoch: 1
+  epoch: 2
   description: A subclass of Object includes Comparable module for handling dates.
   copyright:
     - license: Ruby
@@ -18,10 +18,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 888b24131f08049130b1e29c2f90cf2b12e43193d5d64068da6c2b75facaccaf
-      uri: https://github.com/ruby/date/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 77c38e1fd110afc0c51a1b5e2edfdb3701804c76
+      repository: https://github.com/ruby/date
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-date.yaml from fetch to git-checkout