### PR TITLE
ruby3.2-faraday-follow_redirects.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-faraday-follow_redirects.yaml
+++ b/ruby3.2-faraday-follow_redirects.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-faraday-follow_redirects
   version: 0.3.0
-  epoch: 2
+  epoch: 3
   description: |
     Faraday 2.x compatible extraction of FaradayMiddleware::FollowRedirects.
   copyright:
@@ -21,10 +21,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: e94429b66744a7b83443e45076cf7580d4cf3e1f3cc260556906c0f213fbe4c1
-      uri: https://github.com/tisba/faraday-follow-redirects/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: b2804e5930ecae7ec5b0cf23da5a3514e1f8d8ae
+      repository: https://github.com/tisba/faraday-follow-redirects
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-faraday-follow_redirects.yaml from fetch to git-checkout