### PR TITLE
ruby3.2-faraday-net_http.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-faraday-net_http.yaml
+++ b/ruby3.2-faraday-net_http.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-faraday-net_http
   version: 3.1.0
-  epoch: 0
+  epoch: 1
   description: Faraday adapter for Net::HTTP
   copyright:
     - license: MIT
@@ -17,10 +17,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 2a91fc099048f32f94037277fccfa0ea75bc9f9fa8ec20efa603fd34a86a08bf
-      uri: https://github.com/lostisland/faraday-net_http/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 11953160f75dd488133a74857c2b07d41be8995d
+      repository: https://github.com/lostisland/faraday-net_http
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-faraday-net_http.yaml from fetch to git-checkout