### PR TITLE
ruby3.2-faraday.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-faraday.yaml
+++ b/ruby3.2-faraday.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-faraday
   version: 2.9.0
-  epoch: 0
+  epoch: 1
   description: HTTP/REST API client library.
   copyright:
     - license: MIT
@@ -21,10 +21,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 34efb26482f24eb84bdfbaf4c150085a43196a05a5c792b7207589668dca29b4
-      uri: https://github.com/lostisland/faraday/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: cc5d60776645d3d341ff0f425c45b3b3d48d98e0
+      repository: https://github.com/lostisland/faraday
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-faraday.yaml from fetch to git-checkout