### PR TITLE
ruby3.2-fiber-local.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-fiber-local.yaml
+++ b/ruby3.2-fiber-local.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-fiber-local
   version: 1.0.0
-  epoch: 3
+  epoch: 4
   description: Provides a class-level mixin to make fiber local state easy.
   copyright:
     - license: MIT
@@ -23,10 +23,11 @@ vars:
   gem: fiber-local
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 6391f85334ab6bf103e0ded475cc4b59909a068dd63cc45e80bb0753cb6cc5dd
-      uri: https://github.com/socketry/fiber-local/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: cced2ed7b0ba9d7b32e64581ef29504d73fb4375
+      repository: https://github.com/socketry/fiber-local
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-fiber-local.yaml from fetch to git-checkout