### PR TITLE
ruby3.2-hashie.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-hashie.yaml
+++ b/ruby3.2-hashie.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-hashie
   version: 5.0.0
-  epoch: 0
+  epoch: 1
   description: Hashie is a collection of classes and mixins that make hashes more powerful.
   copyright:
     - license: MIT
@@ -18,10 +18,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: f16d5394d732678d6287a334aeb41e88bb12fe78c22c4b749ffcb0570014f59a
-      uri: https://github.com/hashie/hashie/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 789fa9ad3288f8f63e57e54be11a0637ec1dfc67
+      repository: https://github.com/hashie/hashie
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-hashie.yaml from fetch to git-checkout