### PR TITLE
ruby3.2-i18n.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-i18n.yaml
+++ b/ruby3.2-i18n.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-i18n
   version: 1.14.4
-  epoch: 0
+  epoch: 1
   description: New wave Internationalization support for Ruby.
   copyright:
     - license: MIT
@@ -20,10 +20,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 39a45365718213fde2a0ad284bf09b5e6a03f858a4b6c3552b519147d66c38bd
-      uri: https://github.com/ruby-i18n/i18n/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 5b042bd620dfd4edb6a3ad7b1b6893effae4f53e
+      repository: https://github.com/ruby-i18n/i18n
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-i18n.yaml from fetch to git-checkout