### PR TITLE
ruby3.2-io-event.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-io-event.yaml
+++ b/ruby3.2-io-event.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-io-event
   version: 1.4.3
-  epoch: 0
+  epoch: 1
   description: An event loop.
   copyright:
     - license: MIT
@@ -23,10 +23,11 @@ vars:
   gem: io-event
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 4040338f8a976f5a11f6dd395c95f4505422198d7034d3296f95d28994fbee66
-      uri: https://github.com/socketry/io-event/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 5fbad065ddf6815fd8a6af146df5e714f47a4cb7
+      repository: https://github.com/socketry/io-event
+      tag: v${{package.version}}
 
   - uses: patch
     with:


### PR DESCRIPTION
Convert ruby3.2-io-event.yaml from fetch to git-checkout