### PR TITLE
ruby3.2-jwt.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-jwt.yaml
+++ b/ruby3.2-jwt.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-jwt
   version: 2.8.1
-  epoch: 0
+  epoch: 1
   description: A pure ruby implementation of the RFC 7519 OAuth JSON Web Token (JWT) standard.
   copyright:
     - license: MIT
@@ -18,10 +18,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 35ce94394e4db19661c7771dc66a452de098b6fbae0d853b5d7a7f3a2756cff1
-      uri: https://github.com/jwt/ruby-jwt/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: a9d1dc6b8c3d90e2f1ff63f407ed3500d2d5062f
+      repository: https://github.com/jwt/ruby-jwt
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-jwt.yaml from fetch to git-checkout