### PR TITLE
ruby3.2-mini_mime.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-mini_mime.yaml
+++ b/ruby3.2-mini_mime.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-mini_mime
   version: 1.1.5
-  epoch: 2
+  epoch: 3
   description: A lightweight mime type lookup toy
   copyright:
     - license: MIT
@@ -17,10 +17,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 920dcec03f599d654bed03a465801d85a3c4d9691c97fd5dc67ace013c1ad60e
-      uri: https://github.com/discourse/mini_mime/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 03f3cc946a383c1a5b04715bb6841bcb563c56a1
+      repository: https://github.com/discourse/mini_mime
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-mini_mime.yaml from fetch to git-checkout