### PR TITLE
ruby3.2-multi_xml.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-multi_xml.yaml
+++ b/ruby3.2-multi_xml.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-multi_xml
   version: 0.6.0
-  epoch: 0
+  epoch: 1
   description: Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML.
   copyright:
     - license: MIT
@@ -18,10 +18,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: cc80d979f0540e1b585cb42c416b05c4b597269da409c5e9cd7cc00f8ca8f3e5
-      uri: https://github.com/sferik/multi_xml/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 5fffbc1f92e194c7ff1a285a350958e37fcbc1c0
+      repository: https://github.com/sferik/multi_xml
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:

--- a/ruby3.2-multi_xml.yaml
+++ b/ruby3.2-multi_xml.yaml
@@ -43,3 +43,4 @@ update:
   github:
     identifier: sferik/multi_xml
     strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
Convert ruby3.2-multi_xml.yaml from fetch to git-checkout