### PR TITLE
ruby3.2-net-http-persistent.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-net-http-persistent.yaml
+++ b/ruby3.2-net-http-persistent.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-net-http-persistent
   version: 4.0.2
-  epoch: 2
+  epoch: 3
   description: Manages persistent connections using Net::HTTP including a thread pool for connecting to multiple hosts.
   copyright:
     - license: MIT
@@ -20,10 +20,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 10aab67179e80159f4e080dea3b47d86742331d693a8712803fe3906b5b1f6db
-      uri: https://github.com/drbrain/net-http-persistent/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 1fb915ff6e700a06d711ebf0217b2f12f559f33c
+      repository: https://github.com/drbrain/net-http-persistent
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-net-http-persistent.yaml from fetch to git-checkout