### PR TITLE
ruby3.2-net-imap.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-net-imap.yaml
+++ b/ruby3.2-net-imap.yaml
@@ -47,3 +47,4 @@ update:
   github:
     identifier: ruby/net-imap
     strip-prefix: v
+    use-tag: true

--- a/ruby3.2-net-imap.yaml
+++ b/ruby3.2-net-imap.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-net-imap
   version: 0.4.10
-  epoch: 0
+  epoch: 1
   description: Ruby client api for Internet Message Access Protocol
   copyright:
     - license: Ruby
@@ -22,10 +22,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: ed7880b0ed4adde04cb1d48f714fbed1e10da2a449513de766df0918442590c1
-      uri: https://github.com/ruby/net-imap/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: bc7a74eb452559525cff0a490173e823d3197fe1
+      repository: https://github.com/ruby/net-imap
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-net-imap.yaml from fetch to git-checkout