### PR TITLE
ruby3.2-net-protocol.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-net-protocol.yaml
+++ b/ruby3.2-net-protocol.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-net-protocol
   version: 0.2.2
-  epoch: 1
+  epoch: 2
   description: The abstract interface for net-* client.
   copyright:
     - license: Ruby
@@ -21,10 +21,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 2067b051be476a00a2bb4c2ad2e5d8a8b6a351b61833472d74eabfc54918a6a7
-      uri: https://github.com/ruby/net-protocol/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 258fdc626fd5027608e6992e61eb53a9b482b622
+      repository: https://github.com/ruby/net-protocol
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-net-protocol.yaml from fetch to git-checkout