### PR TITLE
ruby3.2-nio4r.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-nio4r.yaml
+++ b/ruby3.2-nio4r.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-nio4r
   version: 2.7.1
-  epoch: 0
+  epoch: 1
   description: Cross-platform asynchronous I/O primitives for scalable network clients and servers. Inspired by the Java NIO API, but simplified for ease-of-use.
   copyright:
     - license: MIT
@@ -18,10 +18,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: a818b18c93e5c253d0f223d73dc96e1c5e18406f4f66a5bc9530257ce696d348
-      uri: https://github.com/socketry/nio4r/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: e8796986cbc31a458082dc07422c4908412ec0f4
+      repository: https://github.com/socketry/nio4r
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-nio4r.yaml from fetch to git-checkout