### PR TITLE
ruby3.2-oj.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-oj.yaml
+++ b/ruby3.2-oj.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-oj
   version: 3.16.3
-  epoch: 0
+  epoch: 1
   description: The fastest JSON parser and object serializer.
   copyright:
     - license: MIT
@@ -23,10 +23,11 @@ vars:
   gem: oj
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 8c3138a52ad2cf2c8232f75a3bcf328adc7a29edd3946002c1ad226bf3783b31
-      uri: https://github.com/ohler55/oj/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: ccccbf3a7316b4a6d2d41817ded469ab1c9c3c52
+      repository: https://github.com/ohler55/oj
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-oj.yaml from fetch to git-checkout