### PR TITLE
ruby3.2-openid_connect.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-openid_connect.yaml
+++ b/ruby3.2-openid_connect.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-openid_connect
   version: 2.3.0
-  epoch: 0
+  epoch: 1
   description: OpenID Connect Server & Client Library
   copyright:
     - license: MIT
@@ -30,10 +30,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 72705f89aa2622cd052403f4ee537f2ba84c64d92a92175a00ade65233a5776f
-      uri: https://github.com/nov/openid_connect/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 7dd37fae8eef6b7b4564e0d5e4cb538d29d7cbe4
+      repository: https://github.com/nov/openid_connect
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-openid_connect.yaml from fetch to git-checkout