### PR TITLE
ruby3.2-pg.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-pg.yaml
+++ b/ruby3.2-pg.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-pg
   version: 1.5.6
-  epoch: 1
+  epoch: 2
   description: Pg is the Ruby interface to the PostgreSQL RDBMS. It works with PostgreSQL 9.3 and later.
   copyright:
     - license: BSD-2-Clause
@@ -20,10 +20,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 26e579e32888cb6b1b104a6da4299d43d81e6670d93ea45262f5dc31f34f204a
-      uri: https://github.com/ged/ruby-pg/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 55ffd7e534e3378b33cd7f91202513bcd16805ca
+      repository: https://github.com/ged/ruby-pg
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-pg.yaml from fetch to git-checkout