### PR TITLE
ruby3.2-prometheus-client.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-prometheus-client.yaml
+++ b/ruby3.2-prometheus-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-prometheus-client
   version: 4.2.2
-  epoch: 1
+  epoch: 2
   description: A suite of instrumentation metric primitivesthat can be exposed through a web services interface.
   copyright:
     - license: Apache-2.0
@@ -17,10 +17,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 6ff91792875e5132cd14c64c29dfe451c69d3d59dc4c67aeff461fafbe8d35d9
-      uri: https://github.com/prometheus/client_ruby/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 6fbdfa9ec1f4d6a342ad33562649ab93f8fd776b
+      repository: https://github.com/prometheus/client_ruby
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-prometheus-client.yaml from fetch to git-checkout