### PR TITLE
ruby3.2-protocol-http.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-protocol-http.yaml
+++ b/ruby3.2-protocol-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-protocol-http
   version: 0.26.4
-  epoch: 0
+  epoch: 1
   description: Provides abstractions to handle HTTP protocols.
   copyright:
     - license: MIT
@@ -23,10 +23,11 @@ vars:
   gem: protocol-http
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 055b581721a6e8aab92bdf995591cb9c6e5b4b10291a5598b7e88d8351832236
-      uri: https://github.com/socketry/protocol-http/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: fa196025f9fd978dcc28fa9e6c190782e188e90f
+      repository: https://github.com/socketry/protocol-http
+      tag: v${{package.version}}
 
   - uses: patch
     with:


### PR DESCRIPTION
Convert ruby3.2-protocol-http.yaml from fetch to git-checkout