### PR TITLE
ruby3.2-protocol-http1.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-protocol-http1.yaml
+++ b/ruby3.2-protocol-http1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-protocol-http1
   version: 0.19.1
-  epoch: 0
+  epoch: 1
   description: A low level implementation of the HTTP/1 protocol.
   copyright:
     - license: MIT
@@ -24,10 +24,11 @@ vars:
   gem: protocol-http1
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 7a9659eaa7c012cbc31a84e61dad33082fdae2c0144eb3651c15c8c0c7feda0c
-      uri: https://github.com/socketry/protocol-http1/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 4a20b5401fcb493c51ffdaeb5bc73fcecf04c606
+      repository: https://github.com/socketry/protocol-http1
+      tag: v${{package.version}}
 
   - uses: patch
     with:


### PR DESCRIPTION
Convert ruby3.2-protocol-http1.yaml from fetch to git-checkout