### PR TITLE
ruby3.2-protocol-http2.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-protocol-http2.yaml
+++ b/ruby3.2-protocol-http2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-protocol-http2
   version: 0.17.0
-  epoch: 0
+  epoch: 1
   description: A low level implementation of the HTTP/2 protocol.
   copyright:
     - license: MIT
@@ -25,10 +25,11 @@ vars:
   gem: protocol-http2
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: e893a1c3b08aee31dbd11b2cf42447cba8f418599112f9db1d478d4d20079cb1
-      uri: https://github.com/socketry/protocol-http2/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 57ef23f0b6323f9ba158cd34d762d677babf3394
+      repository: https://github.com/socketry/protocol-http2
+      tag: v${{package.version}}
 
   - uses: patch
     with:


### PR DESCRIPTION
Convert ruby3.2-protocol-http2.yaml from fetch to git-checkout