### PR TITLE
ruby3.2-redis-client.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-redis-client.yaml
+++ b/ruby3.2-redis-client.yaml
@@ -46,3 +46,4 @@ update:
   github:
     identifier: redis-rb/redis-client
     strip-prefix: v
+    use-tag: true

--- a/ruby3.2-redis-client.yaml
+++ b/ruby3.2-redis-client.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-redis-client
   version: 0.18.0
-  epoch: 1
+  epoch: 2
   description: Simple low-level client for Redis 6+
   copyright:
     - license: MIT
@@ -21,10 +21,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 71188d8ce02955dca67d200ca85158551d2a9a3431f5f10efae214c0bf979c2e
-      uri: https://github.com/redis-rb/redis-client/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 05c46e4b6434be662b89e1a639c1d57c96543f2e
+      repository: https://github.com/redis-rb/redis-client
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-redis-client.yaml from fetch to git-checkout