### PR TITLE
ruby3.2-redis-namespace.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-redis-namespace.yaml
+++ b/ruby3.2-redis-namespace.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-redis-namespace
   version: 1.11.0
-  epoch: 1
+  epoch: 2
   description: Adds a Redis::Namespace class which can be used to namespace calls to Redis. This is useful when using a single instance of Redis with multiple, different applications.
   copyright:
     - license: MIT
@@ -20,10 +20,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: b61d67f0186394c0dd75b46648a31e09b3fb3494a2a7971ac1ede6343cbec4f3
-      uri: https://github.com/resque/redis-namespace/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 313909f8d39869e4329c821988f412eeb9e53541
+      repository: https://github.com/resque/redis-namespace
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-redis-namespace.yaml from fetch to git-checkout