### PR TITLE
ruby3.2-redis.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-redis.yaml
+++ b/ruby3.2-redis.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-redis
   version: 5.0.8
-  epoch: 1
+  epoch: 2
   description: A Ruby client that tries to match Redis API one-to-one, while still providing an idiomatic interface.
   copyright:
     - license: MIT
@@ -21,10 +21,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 1a5905a91ac57c34fcbff54e5d0b7d4df63689a1d3dd420800eb4fe64e99fd1d
-      uri: https://github.com/redis/redis-rb/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: ba744a6da2d9ce9ad960e2e0706ff76a8b5c1971
+      repository: https://github.com/redis/redis-rb
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:

--- a/ruby3.2-redis.yaml
+++ b/ruby3.2-redis.yaml
@@ -46,3 +46,4 @@ update:
   github:
     identifier: redis/redis-rb
     strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
Convert ruby3.2-redis.yaml from fetch to git-checkout