### PR TITLE
ruby3.2-rexml.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-rexml.yaml
+++ b/ruby3.2-rexml.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-rexml
   version: 3.2.6
-  epoch: 1
+  epoch: 2
   description: An XML toolkit for Ruby
   copyright:
     - license: BSD-2-Clause
@@ -23,10 +23,11 @@ vars:
   gem: rexml
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 38239d0b3068549d4efd0d8f32ca650be76af83223caeacaa536b69f81011113
-      uri: https://github.com/ruby/rexml/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: d87afbc9002929e938359e5cb5dee66b2208b13d
+      repository: https://github.com/ruby/rexml
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-rexml.yaml from fetch to git-checkout