### PR TITLE
ruby3.2-sinatra.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-sinatra.yaml
+++ b/ruby3.2-sinatra.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-sinatra
   version: 3.1.0
-  epoch: 1
+  epoch: 2
   description: Sinatra is a DSL for quickly creating web applications in Ruby with minimal effort.
   copyright:
     - license: MIT
@@ -24,10 +24,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 2da7032b96077b8c6790a8f850e665df6560334de58f7f125db4e1d5f068625a
-      uri: https://github.com/sinatra/sinatra/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 85abd79915ce12fc2614dabb31f09e4bc967890c
+      repository: https://github.com/sinatra/sinatra
+      tag: v${{package.version}}
 
   - uses: ruby/unlock-spec
 
@@ -50,3 +51,4 @@ update:
   github:
     identifier: sinatra/sinatra
     strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
Convert ruby3.2-sinatra.yaml from fetch to git-checkout