### PR TITLE
ruby3.2-tilt.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-tilt.yaml
+++ b/ruby3.2-tilt.yaml
@@ -43,3 +43,4 @@ update:
   github:
     identifier: jeremyevans/tilt
     strip-prefix: v
+    use-tag: true

--- a/ruby3.2-tilt.yaml
+++ b/ruby3.2-tilt.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-tilt
   version: 2.3.0
-  epoch: 1
+  epoch: 2
   description: Generic interface to multiple Ruby template engines
   copyright:
     - license: MIT
@@ -18,10 +18,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 344882278fc0a50a760a562e3c25f0997fc9b8816b4c5c259b4188604bf8d5c9
-      uri: https://github.com/jeremyevans/tilt/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 2aa512efccf41d11e117dade65ab08cda07358c1
+      repository: https://github.com/jeremyevans/tilt
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-tilt.yaml from fetch to git-checkout