### PR TITLE
ruby3.2-timeout.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-timeout.yaml
+++ b/ruby3.2-timeout.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-timeout
   version: 0.4.1
-  epoch: 1
+  epoch: 2
   description: Auto-terminate potentially long-running operations in Ruby.
   copyright:
     - license: Ruby
@@ -18,10 +18,11 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: e645b34232af18857cbf121d35adf87039a157983dbcea500a3363639b8334e1
-      uri: https://github.com/ruby/timeout/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: badb8de012d98eefafbe601b3bc3b2919872e68c
+      repository: https://github.com/ruby/timeout
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-timeout.yaml from fetch to git-checkout