### PR TITLE
ruby3.2-timers.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-timers.yaml
+++ b/ruby3.2-timers.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-timers
   version: 4.3.5
-  epoch: 3
+  epoch: 4
   description: Pure Ruby one-shot and periodic timers.
   copyright:
     - license: MIT
@@ -23,10 +23,11 @@ vars:
   gem: timers
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 413d3c424f8b83ffbd022bd0324eb453c2d8416b6992d74f2a64c65c5ae749fb
-      uri: https://github.com/socketry/timers/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: e16c2eca80b7dd574a17b3761a185d19676ed907
+      repository: https://github.com/socketry/timers
+      tag: v${{package.version}}
 
   - uses: patch
     with:


### PR DESCRIPTION
Convert ruby3.2-timers.yaml from fetch to git-checkout