### PR TITLE
ruby3.2-traces.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-traces.yaml
+++ b/ruby3.2-traces.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-traces
   version: 0.11.1
-  epoch: 1
+  epoch: 2
   description: Application instrumentation and tracing.
   copyright:
     - license: MIT
@@ -23,10 +23,11 @@ vars:
   gem: traces
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: faf69303e369f3d179622149b56422e55a4724ccacf2645f1c23a83a36aafac6
-      uri: https://github.com/socketry/traces/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: 6a84ad6b82da2ec3ab5dec2215385419716b5aaf
+      repository: https://github.com/socketry/traces
+      tag: v${{package.version}}
 
   - uses: patch
     with:


### PR DESCRIPTION
Convert ruby3.2-traces.yaml from fetch to git-checkout