### PR TITLE
ruby3.2-tzinfo-data.yaml: convert from fetch to git-checkout

### DIFF
--- a/ruby3.2-tzinfo-data.yaml
+++ b/ruby3.2-tzinfo-data.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-tzinfo-data
   version: 1.2024.1
-  epoch: 0
+  epoch: 1
   description: TZInfo::Data contains data from the IANA Time Zone database packaged as Ruby modules for use with TZInfo.
   copyright:
     - license: MIT
@@ -24,10 +24,11 @@ vars:
   gem: tzinfo-data
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: c8029225eb9a8e35a7f3d7320bd3017fbfd26b85c8a75673869afb64ffdae431
-      uri: https://github.com/tzinfo/tzinfo-data/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-commit: adcefa9525b501f0d80373a9544fd93ace100ab2
+      repository: https://github.com/tzinfo/tzinfo-data
+      tag: v${{package.version}}
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
Convert ruby3.2-tzinfo-data.yaml from fetch to git-checkout