### PR TITLE
snappy.yaml: convert from fetch to git-checkout

### DIFF
--- a/snappy.yaml
+++ b/snappy.yaml
@@ -1,7 +1,7 @@
 package:
   name: snappy
   version: 1.2.0
-  epoch: 0
+  epoch: 1
   description: Fast compression and decompression library
   copyright:
     - license: BSD-3-Clause
@@ -18,10 +18,11 @@ environment:
       - samurai
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/google/snappy/archive/${{package.version}}.tar.gz
-      expected-sha256: 9b8f10fbb5e3bc112f2e5e64f813cb73faea42ec9c533a5023b5ae08aedef42e
+      repository: https://github.com/google/snappy
+      tag: ${{package.version}}
+      expected-commit: 23b3286820105438c5dbb9bc22f1bb85c5812c8a
 
   - uses: patch
     with:


### PR DESCRIPTION
Convert snappy.yaml from fetch to git-checkout