### PR TITLE
spirv-headers.yaml: convert from fetch to git-checkout

### DIFF
--- a/spirv-headers.yaml
+++ b/spirv-headers.yaml
@@ -2,7 +2,7 @@
 package:
   name: spirv-headers
   version: 1.3.261.1
-  epoch: 0
+  epoch: 1
   description: Machine-readable files for the SPIR-V Registry
   copyright:
     - license: GPL-3.0-or-later
@@ -19,10 +19,11 @@ environment:
       - samurai
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 32b4c6ae6a2fa9b56c2c17233c8056da47e331f76e117729925825ea3e77a739
-      uri: https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/sdk-${{package.version}}.tar.gz
+      expected-commit: 124a9665e464ef98b8b718d572d5f329311061eb
+      repository: https://github.com/KhronosGroup/SPIRV-Headers
+      tag: sdk-${{package.version}}
 
   - runs: |
       cmake -B build -G Ninja \


### PR DESCRIPTION
Convert spirv-headers.yaml from fetch to git-checkout