### PR TITLE
Add test/daemon-check-output pipeline and use it.

### DIFF
--- a/couchdb.yaml
+++ b/couchdb.yaml
@@ -77,58 +77,39 @@ test:
         - jq
   pipeline:
     - name: CouchDB Start Server
-      runs: |
-        #!/bin/bash
-
-        mkdir /var/log/couchdb
-
-        # Configure CouchDB
-        # https://docs.couchdb.org/en/stable/setup/single-node.html#configure-couchdb
-        sed -i '/\[couchdb\]/a single_node = true' /usr/share/couchdb/etc/local.ini
-
-        # https://docs.couchdb.org/en/stable/setup/single-node.html#configure-admins
-        sed -i '/\[admins\]/,/^;/s/^;//' /usr/share/couchdb/etc/local.ini
-
-        # Start CouchDB in the background
-        couchdb > /var/log/couchdb/couchdb.log 2>&1 &
-
-        # Check for "cluster stable" in the logs
-        TIMEOUT=30 # Timeout in seconds
-        START_TIME=$(date +%s)
-
-        while true; do
-            # Check if the current time is past the timeout
-            CURRENT_TIME=$(date +%s)
-            if [ $((CURRENT_TIME - START_TIME)) -ge $TIMEOUT ]; then
-                echo "Timeout reached without finding 'cluster stable' in the logs."
-                exit 1
-            fi
-
-            # Check the logs for "cluster stable"
-            if grep -q "cluster stable" /var/log/couchdb/couchdb.log; then
-                echo "'Cluster stable' found in the logs."
-                break
-            fi
-
-            sleep 1  # Wait for 1 second before checking again
-        done
-    - name: CouchDB Test UIs
-      runs: |
-        #!/bin/bash
-
-        # Now test the UI
-        # Make a request to CouchDB and store the response
-        response=$(curl -s http://127.0.0.1:5984/)
-
-        # Use jq to parse the response and extract the value associated with the key "couchdb"
-        couchdb_value=$(echo $response | jq -r '.couchdb')
-
-        # Check if the extracted value is "Welcome"
-        if [ "$couchdb_value" == "Welcome" ]; then
-            echo "Test passed: 'couchdb':'Welcome' is present in the response."
-        else
-            echo "Test failed: 'couchdb':'Welcome' is not present in the response."
-        fi
+      uses: test/daemon-check-output
+      with:
+        start: "env HOME=/root couchdb"
+        timeout: 30
+        expected_output: "cluster stable"
+        setup: |
+          #!/bin/sh -ex
+          cat >/usr/share/couchdb/etc/local.ini <<"EOF"
+          [couchdb]
+          single_node = true
+          [admins]
+          admin = s3cret
+          EOF
+        post: |
+          #!/bin/sh -e
+          url=http://127.0.0.1:5984/
+          echo "testing $url"
+          response=$(curl -s "$url") || {
+            echo "curl http://127.0.0.1:5984/ failed $?"
+            exit 1
+          }
+          found=$(echo "$response" | jq -r .couchdb) || {
+            echo "response from $url failed [$?] to parse with jq"
+            echo "response: $response"
+            exit 1
+          }
+          expected="Welcome"
+          if [ "$found" = "$expected" ]; then
+              echo "Got \"$expected\" in response from $url"
+          else
+              echo "Got \"$found\" in response from $url. Expected \"$expected\""
+              exit 1
+          fi
 
 update:
   enabled: true

--- a/couchdb.yaml
+++ b/couchdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: couchdb
   version: 3.3.3
-  epoch: 1
+  epoch: 2
   description: Seamless multi-master syncing database with an intuitive HTTP/JSON API, designed for reliability
   copyright:
     - license: Apache-2.0

--- a/couchdb.yaml
+++ b/couchdb.yaml
@@ -22,6 +22,7 @@ environment:
       - mozjs91
       - mozjs91-dev
       - nodejs
+      - npm
       - openssl-dev
       - python3
 

--- a/guacamole-server.yaml
+++ b/guacamole-server.yaml
@@ -115,44 +115,13 @@ test:
           exit 1
         }
     - name: "start daemon on localhost"
-      runs: |
-        set -- guacd -b 127.0.0.1 -L info -p my.pid -f
-        "$@" >out 2>&1 &
-        kpid=$!
-        n=0
-        while [ $n -lt 60 ] && sleep 1; do
-            n=$((n+1))
-            [ -e my.pid ] && break
-        done
-        [ -e my.pid ] || { echo "my.pid did not exist after $n seconds"; exit 1; }
-        read pid < my.pid
-        [ "$kpid" = "$pid" ] || {
-          echo "pid from shell ($kpid) != pid from pidfile ($pid)";
-          exit 1;
-        }
-
-        n=0
-        expected="istening on host"
-        while [ $n -lt 10 ] && sleep 1; do
-            n=$((n+1))
-            grep -q "$expected" out && break
-        done
-        grep -q "$expected" out || {
-          echo "output did not contain expected output after $n seconds: $expected "
-          cat "$out"
-          exit 1
-        }
-
-        expected="Guacamole proxy daemon.*version ${{package.version}}"
-        grep "$expected" out || {
-          echo "command '$*' did not contain expected output"
-          echo "expected: $expected"
-          echo "actual:"
-          cat out
-          exit 1
-        }
-
-        kill $pid
+      uses: test/daemon-check-output
+      with:
+        start: "guacd -b 127.0.0.1 -L info -p my.pid -f"
+        timeout: 60
+        expected_output: |
+          istening on host
+          Guacamole proxy daemon.*version ${{package.version}}
 
 update:
   enabled: true

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -113,28 +113,10 @@ test:
         - jenkins-compat
         - jenkins-entrypoint
   pipeline:
-    - runs: |
-        cleanup() {
-          kill $JENKINS_PID
-        }
-        trap cleanup EXIT
-
-        echo "Launching Jenkins and performing log validation..."
-        jenkins.sh > jenkins.log 2>&1 &
-        JENKINS_PID=$!
-        TIMEOUT=60
-
-        while ! grep -q "Jenkins is fully up and running" jenkins.log && [ $TIMEOUT -gt 0 ]; do
-          sleep 5
-          TIMEOUT=$((TIMEOUT-1))
-        done
-
-        if [ $TIMEOUT -eq 0 ]; then
-          echo "Attempted to launch Jenkins in melange test, but log validation failed."
-          exit 1
-        fi
-
-        if grep -Eq "FAIL|FAILURE|ERROR" jenkins.log; then
-          echo "Successfully launched Jenkins, but errors where found in the logs."
-          exit 1
-        fi
+    - name: "start daemon on localhost"
+      uses: test/daemon-check-output
+      with:
+        start: jenkins.sh
+        timeout: 120
+        expected_output: |
+          Jenkins is fully up and running

--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -55,65 +55,28 @@ pipeline:
       done
 
 test:
-  environment:
-    contents:
-      packages:
-        - busybox
   pipeline:
-    - runs: |
-        kspath=/usr/share/java/keycloak/conf/server.keystore
-        mypassword="seecret"
-        ver=${{package.version}}
-        # hostname needs to be resolvable
-        host=$(hostname)
-        echo "127.0.0.1 $host" >> /etc/hosts
-
-        keytool -v \
-            -keystore "$kspath" \
-            -alias localhost \
-            -genkeypair -sigalg SHA512withRSA -keyalg RSA -dname CN=localhost \
-            -storepass "$mypassword" || {
-              echo "failed [$?] to create keystore with keytool at $kspath"
-              exit 1
-        }
-
-        kc.sh start --hostname=localhost --https-key-store-password="$mypassword" >out 2>&1 &
-        pid=$!
-
-        # wait up to 30 seconds for 'Listening on' message
-        msg="Listening on"
-        n=0 ; max=30
-        set +x
-        echo "Started server in pid $pid. waiting up to $max seconds for '$msg' to appear in output"
-        while ! grep -q "$msg" out; do
-            if [ ! -d "/proc/$pid" ]; then
-                echo "kc.sh pid $pid died after $n seconds"
-                cat out
+    - name: "start daemon on localhost"
+      uses: test/daemon-check-output
+      with:
+        start: "kc.sh start --hostname=localhost --https-key-store-password=MYPASSWORD"
+        timeout: 60
+        expected_output: |
+          Listening on
+          Keycloak ${{package.version}}
+          Profile prod activated
+        setup: |
+          #!/bin/sh -ex
+          echo "127.0.0.1 $(hostname)" >> /etc/hosts
+          kspath=/usr/share/java/keycloak/conf/server.keystore
+          keytool -v \
+              -keystore $kspath \
+              -alias localhost \
+              -genkeypair -sigalg SHA512withRSA -keyalg RSA -dname CN=localhost \
+              -storepass MYPASSWORD || {
+                echo "failed [$?] to create keystore with keytool at $kspath"
                 exit 1
-            fi
-            n=$((n+1))
-            if [ $n -ge $max ]; then
-                echo "kc.sh output did not contain '$msg' after $max seconds'"
-                cat out
-                exit 1
-            fi
-            sleep 1
-        done
-
-        echo "Found '$msg' message in kc.sh output after $n seconds"
-        grep "$msg" out
-
-        grep "Keycloak ${ver}" out || {
-          echo "Did not find version message 'Keycloak ${ver}' in output"
-          cat out
-          exit 1
-        }
-
-        grep "Profile prod activated" out || {
-          echo "kc.sh output did not contain 'Profile prod activated'"
-          cat out
-          exit 1
-        }
+          }
 
 update:
   # The upstream repos releases contains a 'nightly' release. Which we want to

--- a/pipelines/test/daemon-check-output.yaml
+++ b/pipelines/test/daemon-check-output.yaml
@@ -1,0 +1,218 @@
+name: Check Daemon Output
+
+needs:
+  packages:
+    - busybox
+
+inputs:
+  start:
+    description: |
+      The command to run to start the daemon.
+      WARNING: executed with a shell.
+    required: true
+  setup:
+    description: |
+      Command to run before starting daemon.
+      Content is placed into a file and executed. If no '#!' is present,
+      then '#!/bin/sh -ex' will be prepended.
+      WARNING: The content of this field goes through shell. Avoid single quotes.
+    required: false
+  timeout:
+    description: "Time in seconds to wait before giving up."
+    default: 30
+  expected_output:
+    description: "newline separated list of strings expected to be found in output."
+    required: true
+  error_strings:
+    description: |
+      newline separated list of strings that are considered error if found.
+      set to empty for none.
+    required: true
+    default: |
+      ERROR
+      FAIL
+      Traceback.*most.recent.call
+      Exception in thread
+
+pipeline:
+  - name: "start daemon on localhost"
+    runs: |
+      info() { echo "$@"; }
+      # term_wait_kill(pid, ttime, ktime)
+      # wait ttime seconds, send SIGTERM to pid
+      # then wait up to stime seconds for pid to die.
+      # if it is still alive after ktime more seconds, SIGKILL it.
+      term_wait_kill() {
+        local pid="$1" ttime="$2" ktime="$3" n=""
+        n=0
+        [ -d "/proc/$pid" ] || {
+          info "twk: pid $pid did not exist"
+          return 0
+        }
+        while [ $n -lt $ttime ] && n=$((n+1)); do
+            if [ ! -d "/proc/$pid" ]; then
+                info "twk: pid $pid did not exist after $n seconds"
+                return 0
+            fi
+            sleep 1
+        done
+        if [ ! -d "/proc/$pid" ]; then
+            info "twk: pid $pid died on its own within $n seconds"
+            return 0
+        fi
+        kill -TERM "$pid"
+        info "twk: SIGTERM sent to pid $pid. kill returned $?."
+        n=0
+        while [ $n -lt $ktime ] && n=$((n+1)); do
+            if [ ! -d "/proc/$pid" ]; then
+                info "twk: pid $pid exited within $n seconds after SIGTERM"
+                return 0
+            fi
+            sleep 1
+        done
+        if [ ! -d "/proc/$pid" ]; then
+            info "twk: pid $pid exited within $n seconds after SIGTERM"
+            return 0
+        fi
+        kill -KILL "$pid"
+        info "twk: SIGKILL sent to pid $pid [kill returned $?]"
+        return 0
+      }
+
+      cleanup() {
+        # stop subshells from cleaning up.
+        if [ "$$" != "$MAINPID" ]; then
+            return 0
+        fi
+        rm -Rf "$TMPD"
+      }
+
+      set +x
+      MAINPID=$$
+      TMPD=$(mktemp -d)
+      trap cleanup EXIT
+      KID=""
+      OUT_F="${TMPD}/out"
+      EXPECTED_F="${TMPD}/expected"
+      MISSING_F="${TMPD}/missing"
+      ERRORS_F="${TMPD}/errorstrings"
+      ERRORS_FOUND_F="${TMPD}/errorstrings-found"
+      SETUP_F="${TMPD}/setup"
+
+      timeout=${{inputs.timeout}}
+      setup='${{inputs.setup}}'
+      expected_strings='${{inputs.expected_output}}'
+      printf "%s\n" "${expected_strings}" > "${EXPECTED_F}"
+      error_strings='${{inputs.error_strings}}'
+      printf "%s\n" "${error_strings}" > "${ERRORS_F}"
+
+      set --
+      while read line ; do
+          [ "$line" = "" ] && continue
+          set -- "$@" "$line"
+      done < "$EXPECTED_F"
+      num_lines=$#
+
+      if [ -n "$setup" ]; then
+          shbang="#!"
+          if [ "${setup#${shbang}}" = "$shbang" ]; then
+              printf "%s\n" '#!/bin/sh -ex' > "${SETUP_F}"
+          fi
+          printf "%s\n" "$setup" >> "${SETUP_F}"
+          chmod 755 "${SETUP_F}"
+          info "running setup from ${SETUP_F}"
+          "${SETUP_F}" || {
+            rc=$?
+            info "ERROR: setup failed with $rc"
+            exit $rc
+          }
+      fi
+
+      set -- ${{inputs.start}}
+      n=$#
+      "$@" >"$OUT_F" 2>&1 </dev/null &
+      KID=$!
+      info "daemon started as pid $KID with: $*"
+      info "looking for ${num_lines} lines in output within $timeout seconds"
+
+      set --
+      while read line ; do
+          [ "$line" = "" ] && continue
+          set -- "$@" "$line"
+      done < "$EXPECTED_F"
+      found=0
+
+      n=0
+      while n=$((n+1)); do
+          while [ $# -gt 0 ] && grep -q "$1" "$OUT_F"; do
+              info "found within $n seconds: $1"
+              found=$((found+1))
+              shift
+          done
+          [ $# -eq 0 ] && break
+          [ -d "/proc/$KID" ] || { info "process $KID no longer exists"; break; }
+          if [ $n -gt $timeout ]; then
+              info "timeout $timeout seconds reached."
+              break
+          fi
+          sleep 1
+      done
+
+      term_wait_kill "$KID" 0 30 &
+
+      while [ $# -ne 0 ]; do
+          if grep -q "$1" "$OUT_F"; then
+              info "found within $n seconds: $line"
+              found=$((found+1))
+          else
+              info "missing expected output: $1"
+              echo "$1" >> "$MISSING_F"
+          fi
+          shift
+      done
+
+      # now look for errors.
+      errors_found=0
+      num_error_strings=0
+      if [ -z "${error_strings}" ]; then
+          info "error string checking is disabled."
+      else
+          set --
+          while read line ; do
+              [ "$line" = "" ] && continue
+              set -- "$@" "$line"
+          done < "$ERRORS_F"
+          num_error_strings=$#
+          for errmsg in "$@"; do
+              if out=$(grep "$errmsg" "$OUT_F"); then
+                  info "ERROR: found error message '$errmsg' in output: $out"
+                  errors_found=$((errors_found+1))
+                  echo "$errmsg" >> "$ERRORS_FOUND_F"
+              fi
+          done
+      fi
+
+      info "-- begin output --"
+      sed 's,^,> ,' "$OUT_F"
+      info "-- end   output --"
+
+      rc=0
+      if [ $found -ne $num_lines ]; then
+          rc=1
+          info "ERROR: found $found of expected ${num_lines} lines in output."
+          info "missing:"
+          sed 's,^,> ,' "$MISSING_F"
+      else
+          info "found $found of expected ${num_lines} lines in output."
+      fi
+
+      if [ $errors_found -ne 0 ]; then
+          rc=1
+          info "ERROR: matched ${errors_found} error strings below in output above:"
+          sed 's,^,> ,' "$ERRORS_FOUND_F"
+      elif [ $num_error_strings -ne 0 ]; then
+          info "found 0 / ${num_error_strings} error strings in output."
+      fi
+
+      wait || info "wait returned $?"
+      exit $rc

--- a/pipelines/test/daemon-check-output.yaml
+++ b/pipelines/test/daemon-check-output.yaml
@@ -17,6 +17,10 @@ inputs:
       then '#!/bin/sh -ex' will be prepended.
       WARNING: The content of this field goes through shell. Avoid single quotes.
     required: false
+  post:
+    description: |
+      Command to run after. Handled just like setup.
+    required: false
   timeout:
     description: "Time in seconds to wait before giving up."
     default: 30
@@ -98,6 +102,8 @@ pipeline:
       ERRORS_F="${TMPD}/errorstrings"
       ERRORS_FOUND_F="${TMPD}/errorstrings-found"
       SETUP_F="${TMPD}/setup"
+      POST_F="${TMPD}/post"
+      rc=0
 
       timeout=${{inputs.timeout}}
       setup='${{inputs.setup}}'
@@ -105,6 +111,7 @@ pipeline:
       printf "%s\n" "${expected_strings}" > "${EXPECTED_F}"
       error_strings='${{inputs.error_strings}}'
       printf "%s\n" "${error_strings}" > "${ERRORS_F}"
+      post='${{inputs.post}}'
 
       set --
       while read line ; do
@@ -126,6 +133,15 @@ pipeline:
             info "ERROR: setup failed with $rc"
             exit $rc
           }
+      fi
+
+      if [ -n "$post" ]; then
+          shbang="#!"
+          if [ "${post#${shbang}}" = "$shbang" ]; then
+              printf "%s\n" '#!/bin/sh -ex' > "${POST_F}"
+          fi
+          printf "%s\n" "$post" >> "${POST_F}"
+          chmod 755 "${POST_F}"
       fi
 
       set -- ${{inputs.start}}
@@ -150,15 +166,17 @@ pipeline:
               shift
           done
           [ $# -eq 0 ] && break
-          [ -d "/proc/$KID" ] || { info "process $KID no longer exists"; break; }
+          [ -d "/proc/$KID" ] || {
+             wait $KID || rc=$?
+             info "process $KID died inside $n seconds. exited $rc"
+             break;
+          }
           if [ $n -gt $timeout ]; then
               info "timeout $timeout seconds reached."
               break
           fi
           sleep 1
       done
-
-      term_wait_kill "$KID" 0 30 &
 
       while [ $# -ne 0 ]; do
           if grep -q "$1" "$OUT_F"; then
@@ -192,11 +210,18 @@ pipeline:
           done
       fi
 
+      if [ -f "$POST_F" ]; then
+          info "running post from ${POST_F}"
+          "${POST_F}" || {
+            rc=$?
+            info "ERROR: post failed with $rc"
+          }
+      fi
+
       info "-- begin output --"
       sed 's,^,> ,' "$OUT_F"
       info "-- end   output --"
 
-      rc=0
       if [ $found -ne $num_lines ]; then
           rc=1
           info "ERROR: found $found of expected ${num_lines} lines in output."
@@ -214,5 +239,6 @@ pipeline:
           info "found 0 / ${num_error_strings} error strings in output."
       fi
 
+      term_wait_kill "$KID" 0 30
       wait || info "wait returned $?"
       exit $rc


### PR DESCRIPTION
I recently had added a test to keycloak and guacamole-server which would run a the daemon and then look in output for some given strings.

This adds a reusable piepline to do that which is implemented in shell. Ultimately it'd be nicer to have this in melange proper without any shell dependencies.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
