### PR TITLE
alpine-keys: convert from lots of fetch to git checkout

### DIFF
--- a/alpine-keys.yaml
+++ b/alpine-keys.yaml
@@ -1,7 +1,7 @@
 package:
   name: alpine-keys
   version: 2.4
-  epoch: 3
+  epoch: 4
   description: Public keys for Alpine Linux packages
   copyright:
     - license: MIT
@@ -10,114 +10,17 @@ environment:
   contents:
     packages:
       - busybox
-      - ca-certificates-bundle
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
-      expected-sha512: 2d4064cbe09ff958493ec86bcb925af9b7517825d1d9d8d00f2986201ad5952f986fea83d1e2c177e92130700bafa8c0bff61411b3cdb59a41e460ed719580a6
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub
-      expected-sha512: e18e65ee911eb1f8ea869f758e8f2c94cf2ac254ee7ab90a3de1d47b94a547c2066214abf710da21910ebedc0153d05fd4fe579cc5ce24f46e0cfd29a02b1a68
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub
-      expected-sha512: 698fda502f70365a852de3c10636eadfc4f70a7a00f096581119aef665e248b787004ceef63f4c8cb18c6f88d18b8b1bd6b3c5d260e79e6d73a3cc09537b196e
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub
-      expected-sha512: 721134f289ab1e7dde9158359906017daee40983199fe55f28206c8cdc46b8fcf177a36f270ce374b0eba5dbe01f68cbb3e385ae78a54bb0a2ed1e83a4d820a5
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub
-      expected-sha512: e4f9e314f8e506fba2cb3e599c6412a036ec37ce3a54990fc7d80a821d8728f40ee3b4aa8a15218d50341fa785d9ddf7c7471f45018c6a2065ab13664a1aa9e9
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-58cbb476.rsa.pub
-      expected-sha512: bb5a3df8fac14a62d5936fb3722873fa6a121219b703cba955eb77de38c4384aeaf378fb9321a655e255f0be761e894e309b3789867279c1524dab6300cd8ef1
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-58e4f17d.rsa.pub
-      expected-sha512: 0666389ca53121453578cd4bef5fd06e159e291164b3e3233e7d6521604f8bebd30caeef1663adcd5309e07278833402c8a92c33294ec0c5cada24dc47c8cc98
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-5e69ca50.rsa.pub
-      expected-sha512: 66ce9677e9c2a7961d5d7bc5b162ed3114a7aef6d01181073c1f42a9934966eecded2ec09deb210f5a389d434d1641ba35fe3abdd5246b2e97d5a5b26a945c5c
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-60ac2099.rsa.pub
-      expected-sha512: 34514100e502f449dcabe0aa550232c3330ed2f0b789b977eb228d4ac86afc93479474ac005914992a3b47c18ee3eb32ca27ccd0d392700a8f11f47d64a78969
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub
-      expected-sha512: 8b9c2208c904c9f34d9d01d3d68b224208530e684265df214deb8c9e6b4b19633aa48a405e673249c9e93a8ee194a336e951cd82a4e27e5e66e85fdc5e0d495e
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-61666e3f.rsa.pub
-      expected-sha512: b89d825e6af73687339848817791b294e2404162e2e069d9212d76d4ee53d6216eb75421a07b02f9778ef57dbb27962b2436247264eea1a1d882967ca0c18724
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-616a9724.rsa.pub
-      expected-sha512: 7aa5526a88519ae91f997bf914a9bd3d230b21c011587f155ce22c4bb94b70181b28590027eb555d96d1122dffb8242c1fb044228e99b4e9b7650fcf6f5121c7
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-616abc23.rsa.pub
-      expected-sha512: bad4da65221150a5d4cc6f63981e4dd203d40844d32e82c17f346eee5350e460e32d28f0e231a2b78d326ec32b898eec597d3787dae47dcacc9a9776d19fb4a1
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-616ac3bc.rsa.pub
-      expected-sha512: 83fc29066f6073418ecf01176ce24c1c0e788508f3083a97691706e2c78323e53448060fb0d2abb8118a759570f1f0db9d39953c63fe26fe06da2be05dff393c
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-616adfeb.rsa.pub
-      expected-sha512: a98095a626f2dcbda73ffd8873ba2d609ee1d881f5da13b0eb3469ddd58b06440b4b0b2f791b037c88073e9a17c6dfc62dc1a4c8491bed871524d772ef04ad24
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-616ae350.rsa.pub
-      expected-sha512: 51a5ec21283fe218809b2325202e1f8c9b2551705db48254b9d48a04f4ed0075de51e9886c4704647ffb309fd32d9850d14013848a53038039e85011251fe1cc
-      extract: false
-
-  - uses: fetch
-    with:
-      uri: https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-616db30d.rsa.pub
-      expected-sha512: 7cea57204a50d72bddff201c509ccbf06773d87062a3ead0a206cc6e4a00e0960f52d21f7cee7aaec6a4abba7a697e2e2e7f630fa1ccef7ee2c33908fca18998
-      extract: false
+      repository: https://git.alpinelinux.org/aports
+      tag: v20240329
+      expected-commit: 22b641f7ec3a1f16321a32383aec65854f71f315
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/share/apk/keys/
-      install -Dm644 *.pub "${{targets.destdir}}"/usr/share/apk/keys/
+      install -Dm644 main/alpine-keys/*.pub "${{targets.destdir}}"/usr/share/apk/keys/
 
       mkdir -p "${{targets.destdir}}"/usr/share/apk/keys/aarch64
       ln -s ../alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub "${{targets.destdir}}"/usr/share/apk/keys/aarch64/


### PR DESCRIPTION
sparse checkout would have helped, but aports checkout is only 25MB download, so it's ok. Plus this will not be rebuilt often.