### PR TITLE
Withdraw bad go packages

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -49,3 +49,5 @@ sig-storage-local-static-provisioner-compat-2.7.0-r1.apk
 neuvector-scanner-monitor-0_git20240417-r1.apk
 harbor-2.10-db-2.10.2-r2.apk
 tomcat-10-10.1.23-r0.apk
+go-doc-1.20rc1-r0.apk
+go-doc-1.20rc1-r1.apk


### PR DESCRIPTION
These fail to parse as valid versions for us.

```
apk add go-doc=1.20rc1-r0
ERROR: 'go-doc=1.20rc1-r0' is not a valid world dependency, format is name(@tag)([<>~=]version)
```