### PR TITLE
rabbitmq-default-user-credential-updater: new package

### DIFF
--- a/rabbitmq-default-user-credential-updater.yaml
+++ b/rabbitmq-default-user-credential-updater.yaml
@@ -25,3 +25,8 @@ update:
   github:
     identifier: rabbitmq/default-user-credential-updater
     strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        default-user-credential-updater -h  2>&1 | grep "Usage of default-user-credential-updater:"

--- a/rabbitmq-default-user-credential-updater.yaml
+++ b/rabbitmq-default-user-credential-updater.yaml
@@ -1,0 +1,27 @@
+package:
+  name: rabbitmq-default-user-credential-updater
+  version: 1.0.4
+  epoch: 0
+  description: Updates RabbitMQ default user password
+  copyright:
+    - license: MPL-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rabbitmq/default-user-credential-updater
+      tag: v${{package.version}}
+      expected-commit: ba4bb24402338245e8cc4fba062900993a0c94a4
+
+  - uses: go/build
+    with:
+      packages: .
+      output: default-user-credential-updater
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: rabbitmq/default-user-credential-updater
+    strip-prefix: v


### PR DESCRIPTION
```
 $ wolfictl scan packages/aarch64/rabbitmq-default-user-credential-updater-1.0.4-r0.apk
🔎 Scanning "packages/aarch64/rabbitmq-default-user-credential-updater-1.0.4-r0.apk"
✅ No vulnerabilities found
```

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
