### PR TITLE
add `jitsucom-bulker-{bulker, ingest, sidecar, syncctl, ingmgr}` and `*-compat`

### DIFF
--- a/jitsucom-bulker.yaml
+++ b/jitsucom-bulker.yaml
@@ -1,0 +1,103 @@
+package:
+  name: jitsucom-bulker
+  version: 2.6.0
+  epoch: 0
+  description: Service for bulk-loading data to databases with automatic schema management (Redshift, Snowflake, BigQuery, ClickHouse, Postgres, MySQL)
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - jitsucom-bulker-bulker
+      - jitsucom-bulker-ingest
+      - jitsucom-bulker-ingmgr
+      - jitsucom-bulker-sidecar
+      - jitsucom-bulker-syncctl
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 315237cd54707f2d9395db087ec2d4b2ed1297f4
+      repository: https://github.com/jitsucom/bulker
+      tag: jitsu2-v${{package.version}}
+
+  - uses: go/bump
+    with:
+      # Mitigate CVE-2023-50658, GHSA-mhpq-9638-x6pw and CVE-2023-45288
+      deps: github.com/dvsekhvalnov/jose2go@v1.6.0
+      replaces: golang.org/x/net=golang.org/x/net@v0.23.0
+      modroot: bulkerapp
+
+  - uses: go/bump
+    with:
+      # Mitigate CVE-2023-45288
+      deps: golang.org/x/net@v0.23.0
+      modroot: ingest
+
+  - uses: go/bump
+    with:
+      # Mitigate CVE-2023-45288
+      deps: golang.org/x/net@v0.23.0
+      modroot: ingress-manager
+
+  - uses: go/bump
+    with:
+      # Mitigate CVE-2023-45288
+      deps: golang.org/x/net@v0.23.0
+      modroot: sync-controller
+
+data:
+  - name: commands
+    items:
+      bulker: bulkerapp
+      ingest: ingest
+      sidecar: sync-sidecar
+      syncctl: sync-controller
+      ingmgr: ingress-manager
+
+subpackages:
+  - range: commands
+    name: "${{package.name}}-${{range.key}}"
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: ./${{range.value}}
+          packages: .
+          ldflags: -s -w -X main.Commit=$(git rev-parse HEAD) -X main.Timestamp=$(date '+%F_%H:%M:%S')
+          output: ${{range.key}}
+
+  - range: commands
+    name: "${{package.name}}-${{range.key}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/app
+          ln -sf /usr/bin/${{range.key}} "${{targets.contextdir}}"/app/${{range.key}}
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - -beta.*
+  github:
+    identifier: jitsucom/bulker
+    strip-prefix: jitsu2-v
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-bulker
+        - ${{package.name}}-ingest
+        - ${{package.name}}-sidecar
+        - ${{package.name}}-syncctl
+        - ${{package.name}}-ingmgr
+  pipeline:
+    - runs: |
+        # We expect some commands to fail, but want its output anyway.
+        # The commands are not intended to run directly.
+        set +o pipefail
+        /usr/bin/bulker 2>&1 | grep -q "Starting bulker app"
+        /usr/bin/ingest 2>&1 | grep -q "Generated instance id"
+        /usr/bin/sidecar 2>&1 | grep -q "dial error" # It's OK to fail, as it tries to connect to a non-existent postgres socket
+        /usr/bin/syncctl 2>&1 | grep -q "unable to load in-cluster configuration"
+        /usr/bin/ingmgr 2>&1 | grep -q "Generated instance id"


### PR DESCRIPTION
with subpackages and compat variants:
* bulker
* ingest
* sidecar
* syncctl
* ingmgr

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
