### PR TITLE
jitsucom-jitsu-{console,rotor}

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,0 +1,89 @@
+package:
+  name: jitsucom-jitsu
+  version: 2.6.0
+  epoch: 0
+  description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
+  copyright:
+    - license: MIT
+  target-architecture:
+    - x86_64
+  dependencies:
+    runtime:
+      - bash
+      - curl
+      - netcat-openbsd
+      - nodejs-18
+      - openssl
+      - procps
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - esbuild
+      - gcc-12
+      - gcc-12-default
+      - jq
+      - make
+      - node-gyp
+      - nodejs-18
+      - npm
+      - openssl
+      - pnpm
+      - python3
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 70fdf6a5000640ba46732331f65bea46e165e153
+      repository: https://github.com/jitsucom/jitsu
+      tag: jitsu2-v${{package.version}}
+
+  - uses: patch
+    with:
+      patches: upgrade-deps.patch
+
+  - runs: |
+      pnpm install -r --unsafe-perm
+      export NEXTJS_STANDALONE_BUILD=1
+      pnpm build
+
+subpackages:
+  - name: ${{package.name}}-console
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/app
+          mkdir -p ${{targets.contextdir}}/app/webapps
+          mkdir -p ${{targets.contextdir}}/app/webapps/console/public
+          mkdir -p ${{targets.contextdir}}/app/webapps/console/.next/static
+
+          npm -g install prisma@$(cat webapps/console/package.json | jq -r '.dependencies.prisma')
+          cp ./docker-start-console.sh ${{targets.contextdir}}/app/docker-start-console.sh
+          cp ./webapps/console/prisma/schema.prisma ${{targets.contextdir}}/app/
+          cp -r ./webapps/console/.next/standalone/* ${{targets.contextdir}}/app/
+          # remove esbuild which is build time dependency we don't need to ship it in the final package
+          rm -rf ${{targets.contextdir}}/app/node_modules/.pnpm/@esbuild+linux-x64@0.20.2
+          cp -r ./webapps/console/.next/static/* ${{targets.contextdir}}/app/webapps/console/.next/static
+          cp -r ./webapps/console/public/* ${{targets.contextdir}}/app/webapps/console/public
+    dependencies:
+      runtime:
+        - ${{package.name}}
+
+  - name: ${{package.name}}-rotor
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/app
+          mkdir -p ${{targets.contextdir}}/usr/local/bin
+          cp -r ./services/rotor/dist/* ${{targets.contextdir}}/app/
+          cp docker-entrypoint.sh ${{targets.contextdir}}/usr/local/bin/docker-entrypoint.sh
+    dependencies:
+      runtime:
+        - ${{package.name}}
+
+update:
+  enabled: true
+  github:
+    identifier: jitsucom/jitsu
+    strip-prefix: jitsu2-v

--- a/jitsucom-jitsu/docker-entrypoint.sh
+++ b/jitsucom-jitsu/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+# Run command with node if the first argument contains a "-" or is not a system command. The last
+# part inside the "{}" is a workaround for the following bug in ash/dash:
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=874264
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ] || { [ -f "${1}" ] && ! [ -x "${1}" ]; }; then
+  set -- node "$@"
+fi
+
+exec "$@"
+
+# rotor project uses the following as an entrypoint:
+# https://github.com/nodejs/docker-node/blob/main/docker-entrypoint.sh

--- a/jitsucom-jitsu/upgrade-deps.patch
+++ b/jitsucom-jitsu/upgrade-deps.patch
@@ -1,0 +1,36 @@
+From 2e6e23d825b76c43e53bb10d961997db05c420ea Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Mon, 6 May 2024 16:26:02 +0300
+Subject: [PATCH] upgrade deps
+
+Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+---
+ package.json | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/package.json b/package.json
+index 514fc5cc6..4e1bf4b6c 100644
+--- a/package.json
++++ b/package.json
+@@ -54,5 +54,16 @@
+     "services/*",
+     "cli/*",
+     "libs/*"
+-  ]
++  ],
++  "pnpm": {
++    "overrides": {
++      "nodemailer": "^6.9.9",
++      "next-auth": "^4.24.5",
++      "protobufjs": "^7.2.5",
++      "zod": "^3.22.3",
++      "jose": "^4.15.5",
++      "@sentry/nextjs": "^7.77.0",
++      "esbuild": "^0.20.2"
++    }
++  }
+ }
+\ No newline at end of file
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
   - https://github.com/wolfi-dev/advisories/pull/4618

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
