### PR TITLE
adds keycloak-operator

### DIFF
--- a/keycloak-operator.yaml
+++ b/keycloak-operator.yaml
@@ -7,6 +7,8 @@ package:
     - license: Apache-2.0
   dependencies:
     runtime:
+      # As per dockerfile, we might need this
+      - keycloak
       - openjdk-17-default-jvm
 
 environment:
@@ -42,7 +44,7 @@ test:
   pipeline:
     - runs: |
         # This only runs in k8s but make sure it errors correctly
-        java -Djava.util.logging.manager=org.jboss.logmanager.LogManager -jar quarkus-run.jar 2>&1 | grep "Couldn't retrieve the currently connected namespace"
+        java -Djava.util.logging.manager=org.jboss.logmanager.LogManager -jar /usr/share/java/quarkus-app/quarkus-run.jar 2>&1 | grep "Couldn't retrieve the currently connected namespace"
 
 update:
   # The upstream repos releases contains a 'nightly' release. Which we want to

--- a/keycloak-operator.yaml
+++ b/keycloak-operator.yaml
@@ -1,0 +1,54 @@
+package:
+  name: keycloak-operator
+  version: 24.0.3
+  epoch: 0
+  description: A Kubernetes Operator based on the Operator SDK for installing and managing Keycloak.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - openjdk-17-default-jvm
+
+environment:
+  contents:
+    packages:
+      - bash
+      - busybox
+      - ca-certificates-bundle
+      - openjdk-17
+      - openjdk-17-default-jvm
+      - wolfi-base
+      - wolfi-baselayout
+  environment:
+    LANG: en_US.UTF-8
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/keycloak/keycloak
+      tag: ${{package.version}}
+      expected-commit: 27d38787d9eae0854f79a358cda77f834008b71a
+
+  - uses: maven/pombump
+
+  - runs: |
+      cd operator
+      ../mvnw clean package
+      mkdir -p "${{targets.destdir}}"/usr/share/java
+      cp -r target/quarkus-app "${{targets.destdir}}"/usr/share/java/
+
+test:
+  pipeline:
+    - runs: |
+        # This only runs in k8s but make sure it errors correctly
+        java -Djava.util.logging.manager=org.jboss.logmanager.LogManager -jar quarkus-run.jar 2>&1 | grep "Couldn't retrieve the currently connected namespace"
+
+update:
+  # The upstream repos releases contains a 'nightly' release. Which we want to
+  # exclude from discovery.
+  ignore-regex-patterns:
+    - '.*nightly.*'
+  enabled: true
+  github:
+    identifier: keycloak/keycloak

--- a/keycloak-operator/pombump-deps.yaml
+++ b/keycloak-operator/pombump-deps.yaml
@@ -1,0 +1,12 @@
+patches:
+  # Fixes CVE-2024-29025
+  - groupId: io.netty
+    artifactId: netty-codec-http
+    version: 4.1.108.Final
+    scope: import
+  # Fixes CVE-2024-34447
+  - groupId: org.bouncycastle
+    artifactId: bcprov-jdk18on
+    version: 1.78
+    scope: import
+    type: jar


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
