### PR TITLE
Add provides for openjdk-jmods, fix flags to configure so they don't get ignored.

### DIFF
--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-21
   version: 21.0.3
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-or-later
@@ -57,9 +57,15 @@ pipeline:
 
   - runs: chmod +x configure
 
+  # Note that despite using --with-extra-cflags, --with-extra-cxxflags, and
+  # --with-extra-ldflags, the configure still produces warnings like:
+  # https://github.com/wolfi-dev/os/issues/18747
   - uses: autoconf/configure
     with:
       opts: |
+        --with-extra-cflags="$CFLAGS" \
+        --with-extra-cxxflags="$CXXFLAGS" \
+        --with-extra-ldflags="$LDFLAGS" \
         --with-boot-jdk=/usr/lib/jvm/java-20-openjdk \
         --prefix=/usr/lib/jvm/java-21-openjdk \
         --with-vendor-name=wolfi \
@@ -175,6 +181,9 @@ subpackages:
 
   - name: "openjdk-21-jmods"
     description: "OpenJDK 21 jmods"
+    dependencies:
+      provides:
+        - openjdk-jmods=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-21-openjdk

--- a/openjdk-22.yaml
+++ b/openjdk-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-22
   version: 22.0.1
-  epoch: 1
+  epoch: 2
   description: OpenJDK 22
   copyright:
     - license: GPL-2.0-or-later
@@ -57,9 +57,15 @@ pipeline:
 
   - runs: chmod +x configure
 
+  # Note that despite using --with-extra-cflags, --with-extra-cxxflags, and
+  # --with-extra-ldflags, the configure still produces warnings like:
+  # https://github.com/wolfi-dev/os/issues/18747
   - uses: autoconf/configure
     with:
       opts: |
+        --with-extra-cflags="$CFLAGS" \
+        --with-extra-cxxflags="$CXXFLAGS" \
+        --with-extra-ldflags="$LDFLAGS" \
         --with-boot-jdk=/usr/lib/jvm/java-21-openjdk \
         --prefix=/usr/lib/jvm/java-22-openjdk \
         --with-vendor-name=wolfi \
@@ -175,6 +181,9 @@ subpackages:
 
   - name: "${{package.name}}-jmods"
     description: "OpenJDK 22 jmods"
+    dependencies:
+      provides:
+        - openjdk-jmods=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-22-openjdk


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
