### PR TITLE
created kube-webhook-certgen package

### DIFF
--- a/ingress-nginx-controller.yaml
+++ b/ingress-nginx-controller.yaml
@@ -520,13 +520,7 @@ update:
     tag-filter: "controller-v"
 
 test:
-  environment:
-    contents:
-      packages:
-        - kube-webhook-certgen
   pipeline:
     - runs: |
         /usr/bin/nginx -v
         /usr/bin/nginx-ingress-controller --version
-    - runs: |
-        kube-webhook-certgen --help

--- a/ingress-nginx-controller.yaml
+++ b/ingress-nginx-controller.yaml
@@ -520,7 +520,13 @@ update:
     tag-filter: "controller-v"
 
 test:
+  environment:
+    contents:
+      packages:
+        - kube-webhook-certgen
   pipeline:
     - runs: |
         /usr/bin/nginx -v
         /usr/bin/nginx-ingress-controller --version
+    - runs: |
+        kube-webhook-certgen --help

--- a/kube-webhook-certgen.yaml
+++ b/kube-webhook-certgen.yaml
@@ -1,0 +1,40 @@
+package:
+  name: kube-webhook-certgen
+  version: 1.10.1
+  epoch: 0
+  description: Kubernetes webhook certificate generator and patcher
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes/ingress-nginx
+      tag: controller-v${{package.version}}
+      expected-commit: 51847ac1b537c547cdb7bfb06d14e6d3d8476a73
+
+  - uses: go/build
+    with:
+      modroot: ./images/kube-webhook-certgen/rootfs
+      packages: .
+      output: kube-webhook-certgen
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes/ingress-nginx
+    strip-prefix: controller-v
+    tag-filter: "controller-v"
+
+test:
+  pipeline:
+    - runs: |
+        kube-webhook-certgen --help


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
