### PR TITLE
binutils: convert from fetch to git-checkout

### DIFF
--- a/binutils.yaml
+++ b/binutils.yaml
@@ -1,7 +1,8 @@
+#nolint:git-checkout-must-use-github-updates
 package:
   name: binutils
   version: "2.42"
-  epoch: 1
+  epoch: 2
   description: "GNU binutils"
   copyright:
     - license: GPL-3.0-or-later
@@ -9,18 +10,28 @@ package:
 environment:
   contents:
     packages:
+      - bison
       - build-base
       - busybox
       - ca-certificates-bundle
+      - flex
       - isl
+      - posix-libc-utils
       - texinfo
       - wolfi-baselayout
 
+var-transforms:
+  - from: ${{package.version}}
+    match: \.
+    replace: _
+    to: underscore-package-version
+
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ftp.gnu.org/gnu/binutils/binutils-${{package.version}}.tar.gz
-      expected-sha256: 5d2a6c1d49686a557869caae08b6c2e83699775efd27505e01b2f4db1a024ffc
+      repository: https://sourceware.org/git/binutils-gdb.git
+      tag: binutils-${{vars.underscore-package-version}}
+      expected-commit: c7f28aad0c99d1d2fec4e52ebfa3735d90ceb8e9
 
   - name: 'Configure binutils'
     runs: |
@@ -33,6 +44,7 @@ pipeline:
         --disable-werror \
         --disable-multilib \
         --disable-gprofng \
+        --disable-gdb \
         --enable-deterministic-archives \
         --enable-ld=default \
         --enable-gold \


### PR DESCRIPTION
Note bintuils-gdb git repository contains both binutils and gdb. gdb
is packaged separately. Disable gdb build in binutils.

Add additional build-dependencies for generated files that are
otherwise part of the tarball. These are now generated during build
time.
