### PR TITLE
consul-1.16/1.16.7-r2: cve remediation

### DIFF
--- a/consul-1.16.yaml
+++ b/consul-1.16.yaml
@@ -1,7 +1,7 @@
 package:
   name: consul-1.16
   version: 1.16.7
-  epoch: 2
+  epoch: 3
   description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
   copyright:
     - license: MPL-2.0
@@ -23,6 +23,11 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: cb00a73e9db283bb1ee286e957bb01def6a17f1a
       destination: ${{package.name}}
+
+  - uses: go/bump
+    with:
+      deps: github.com/coredns/coredns@v1.11.2
+      modroot: ${{package.name}}
 
   - working-directory: ${{package.name}}
     pipeline:

--- a/consul-1.16.yaml
+++ b/consul-1.16.yaml
@@ -24,16 +24,11 @@ pipeline:
       expected-commit: cb00a73e9db283bb1ee286e957bb01def6a17f1a
       destination: ${{package.name}}
 
-  - uses: go/bump
-    with:
-      deps: github.com/coredns/coredns@v1.11.2
-      modroot: ${{package.name}}
-
   - working-directory: ${{package.name}}
     pipeline:
       - uses: go/bump
         with:
-          deps: golang.org/x/net@v0.23.0
+          deps: golang.org/x/net@v0.23.0 github.com/coredns/coredns@v1.11.2
       - runs: |
           make linux
       - runs: |

--- a/consul-1.16.yaml
+++ b/consul-1.16.yaml
@@ -28,7 +28,7 @@ pipeline:
     pipeline:
       - uses: go/bump
         with:
-          deps: golang.org/x/net@v0.23.0 github.com/coredns/coredns@v1.11.2
+          deps: golang.org/x/net@v0.23.0 github.com/coredns/coredns@v1.11.2 github.com/go-jose/go-jose/v3@v3.0.3
       - runs: |
           make linux
       - runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
