### PR TITLE
kubeflow-katib/0.16.0-r8: cve remediation

### DIFF
--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -47,14 +47,15 @@ subpackages:
     name: "katib-${{range.key}}"
     description: Kubeflow Katib ${{range.key}}
     pipeline:
+      - uses: go/bump
+        with:
+          deps: github.com/docker/distribution@v2.8.2 github.com/docker/docker@v26.0.2+incompatible google.golang.org/grpc@v1.56.3 google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0
       - uses: go/build
         with:
           packages: "./cmd/${{range.value}}"
           output: katib-${{range.key}}
           ldflags: -w -X main.version=${{package.version}}
           subpackage: true
-          deps: golang.org/x/net@v0.23.0 github.com/docker/distribution@v2.8.2 github.com/docker/docker@v26.0.2+incompatible google.golang.org/grpc@v1.56.3 golang.org/x/crypto@v0.17.0 google.golang.org/protobuf@v1.33.0
-          replaces: golang.org/x/net=golang.org/x/net@v0.23.0
       - uses: strip
 
   - range: go-builds

--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -1,6 +1,6 @@
 package:
   name: kubeflow-katib
-  epoch: 8
+  epoch: 9
   version: 0.16.0
   description: Kubeflow Katib services
   copyright:
@@ -33,6 +33,10 @@ pipeline:
       repository: https://github.com/kubeflow/katib
       expected-commit: fc6beec8358f1c4a50d86de63c5906fce2eba373
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: google.golang.org/protobuf@v1.33.0 github.com/docker/docker@v24.0.9 golang.org/x/net@v0.23.0
 
   - uses: patch
     with:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
