### PR TITLE
nfs-subdir-external-provisioner/4.0.18-r5: cve remediation

### DIFF
--- a/nfs-subdir-external-provisioner.yaml
+++ b/nfs-subdir-external-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: nfs-subdir-external-provisioner
   version: 4.0.18
-  epoch: 5
+  epoch: 6
   description: Dynamic sub-dir volume provisioner on a remote NFS server.
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: golang.org/x/text@v0.9.0 golang.org/x/net@v0.17.0 gopkg.in/yaml.v3@v3.0.0-20220521103104-8f96da9f5d5e golang.org/x/crypto@v0.17.0 google.golang.org/protobuf@v1.33.0 github.com/prometheus/client_golang@v1.11.1
+      deps: golang.org/x/text@v0.9.0 gopkg.in/yaml.v3@v3.0.0-20220521103104-8f96da9f5d5e golang.org/x/crypto@v0.17.0 google.golang.org/protobuf@v1.33.0 github.com/prometheus/client_golang@v1.11.1 golang.org/x/net@v0.23.0
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
