### PR TITLE
cluster-autoscaler-1.29/1.29.2-r1: cve remediation

### DIFF
--- a/cluster-autoscaler-1.29.yaml
+++ b/cluster-autoscaler-1.29.yaml
@@ -29,6 +29,7 @@ pipeline:
   - uses: go/bump
     with:
       deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0 go.opentelemetry.io/otel/sdk@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 golang.org/x/crypto@v0.17.0 golang.org/x/net@v0.23.0 k8s.io/kubernetes@v1.29.4
+      replaces: k8s.io/apimachinery=k8s.io/apimachinery@v0.29.4 k8s.io/apiserver=k8s.io/apiserver@v0.29.4 k8s.io/cloud-provider-aws=k8s.io/cloud-provider-aws@v1.29.2
       modroot: cluster-autoscaler
 
   - uses: go/build

--- a/cluster-autoscaler-1.29.yaml
+++ b/cluster-autoscaler-1.29.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.29
   version: 1.29.2
-  epoch: 1
+  epoch: 2
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0 go.opentelemetry.io/otel/sdk@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 golang.org/x/crypto@v0.17.0 golang.org/x/net@v0.23.0
+      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.0 go.opentelemetry.io/otel/sdk@v1.21.0 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0 golang.org/x/crypto@v0.17.0 golang.org/x/net@v0.23.0 k8s.io/kubernetes@v1.29.4
       modroot: cluster-autoscaler
 
   - uses: go/build


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
