### PR TITLE
fix(mlflow): Various fixes

### DIFF
--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -60,6 +60,7 @@ pipeline:
       pip uninstall --yes pip
 
       # Use Python in virtual environment
+      sed -i "s|/home/build/venv|/usr/share/mlflow|g" venv/pyvenv.cfg
       sed -i "s|/home/build/venv|/usr/share/mlflow|g" venv/bin/*
 
       # Install virtual environment
@@ -77,7 +78,6 @@ subpackages:
         with:
           image: mlflow
           version-path: 2/debian-12
-
       - runs: |
           # Create auth symlink expected in Bitnami Helm chart
           mkdir -p ${{targets.contextdir}}/bitnami

--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -37,8 +37,8 @@ pipeline:
   - runs: |
       # Build UI
       cd mlflow/server/js
-      yarn install
-      yarn run build
+      #yarn install
+      #yarn run build
       cd -
 
       # Create virtual environment
@@ -72,6 +72,15 @@ subpackages:
         with:
           image: mlflow
           version-path: 2/debian-12
+
+      - runs: |
+          # Create auth symlink expected in Bitnami Helm chart
+          mkdir -p ${{targets.contextdir}}/bitnami
+          ln -sf /usr/share/mlflow/lib/python3.12/site-packages/mlflow/server/auth ${{targets.contextdir}}/bitnami/mlflow-basic-auth
+    test:
+      pipeline:
+        - runs: |
+            ls /bitnami/mlflow-basic-auth/ | grep "basic_auth.ini"
 
 test:
   environment:

--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -12,6 +12,8 @@ package:
     no-provides: true
   dependencies:
     runtime:
+      - bash
+      - git
       - py3-pip
       - python3
 
@@ -37,8 +39,8 @@ pipeline:
   - runs: |
       # Build UI
       cd mlflow/server/js
-      #yarn install
-      #yarn run build
+      yarn install
+      yarn run build
       cd -
 
       # Create virtual environment
@@ -67,6 +69,9 @@ pipeline:
 subpackages:
   - name: mlflow-bitnami-compat
     description: Compat package for the Bitnami mlflow Helm chart
+    dependencies:
+      runtime:
+        - mlflow
     pipeline:
       - uses: bitnami/compat
         with:

--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: mlflow
   version: 2.12.1
-  epoch: 0
+  epoch: 1
   description: Open source platform for the machine learning lifecycle
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ package:
     no-provides: true
   dependencies:
     runtime:
+      - py3-pip
       - python3
 
 environment:


### PR DESCRIPTION
Resolves:
- Bash not being available for MLflow projects
- Git not being available for GitPython
- Bitnami not being able to find MLflow's auth directory
- The virtual environment command using /home/build instead of /usr/share/mlflow
- Pip being unavailable to MLflow