### PR TITLE
add lofo GH bot trust policy

### DIFF
--- a/.github/chainguard/lofo.sts.yaml
+++ b/.github/chainguard/lofo.sts.yaml
@@ -1,0 +1,9 @@
+# LOg FOrwarder GH Bot
+
+issuer: https://accounts.google.com
+
+subject: "107094302893801739313"
+
+permissions:
+  actions: read
+  workflows: read


### PR DESCRIPTION
currently wired into "staging", but will be changed to the prod implementation in the future