### PR TITLE
msttcorefonts-installer: remove unncesesary mv command

### DIFF
--- a/msttcorefonts-installer.yaml
+++ b/msttcorefonts-installer.yaml
@@ -7,8 +7,8 @@ package:
     - license: GPL-2.0-or-later
   dependencies:
     runtime:
-      - wget
       - cabextract
+      - wget
 
 environment:
   contents:

--- a/msttcorefonts-installer.yaml
+++ b/msttcorefonts-installer.yaml
@@ -1,13 +1,14 @@
 package:
   name: msttcorefonts-installer
   version: 3.8.1
-  epoch: 0
+  epoch: 1
   description: Installer for Microsoft TrueType core fonts
   copyright:
     - license: GPL-2.0-or-later
   dependencies:
     runtime:
       - wget
+      - cabextract
 
 environment:
   contents:
@@ -29,6 +30,10 @@ pipeline:
   - uses: patch
     with:
       patches: remove-debian-stuff.patch
+
+  - uses: patch
+    with:
+      patches: fix_mv.patch
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin

--- a/msttcorefonts-installer/fix_mv.patch
+++ b/msttcorefonts-installer/fix_mv.patch
@@ -1,0 +1,12 @@
+diff --git a/update-ms-fonts b/update-ms-fonts
+index 89d95c3..8c76af5 100755
+--- a/update-ms-fonts
++++ b/update-ms-fonts
+@@ -196,7 +196,6 @@ EOF
+     for ff in $FONTFILES; do
+         for ttf in `grep $ff msfonts.info | awk '{print $4}'`; do
+             longname=`awk "/$ttf/ { print \\$2 }" msfonts.info`
+-            mv -Z $ttf $FONTDIR/$longname
+             ln -sf $longname $FONTDIR/$ttf
+         done
+     done


### PR DESCRIPTION
* add needed `cabextract` dependency 
* remove unncesary mv, now `update-ms-fonts` fails