### PR TITLE
no change rebuild to get cmd: providers

### DIFF
--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: google-cloud-sdk
   version: 469.0.0
-  epoch: 0
+  epoch: 1
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
After changes to melange and wolfictl to consider symlinks as providers of cmd:, this should now make the following work:

    apk add cmd:gcloud

