### PR TITLE
WIP: add kibana

### DIFF
--- a/elastic-dockerfiles.yaml
+++ b/elastic-dockerfiles.yaml
@@ -1,0 +1,51 @@
+package:
+  name: elastic-dockerfiles
+  version: 8.13.3
+  epoch: 0
+  description: Dockerfiles for the official Elastic Stack images
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 4e109d7042669ade22f16643084c86c217b12ee0
+      repository: https://github.com/elastic/dockerfiles
+      tag: v${{package.version}}
+
+data:
+  - name: configs
+    items:
+      elasticsearch: elasticsearch
+      kibana: kibana
+      logstash: logstash
+
+subpackages:
+  - range: configs
+    name: "${{package.name}}-${{range.key}}"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.destdir}}/usr/share/${{range.key}}/config
+          cp -r ${{range.value}}/* ${{targets.destdir}}/usr/share/${{range.key}}/config
+      - runs: |
+          mkdir -p ${{targets.destdir}}/usr/share/${{range.key}}/bin
+          cp -r bin/* ${{targets.destdir}}/usr/share/${{range.key}}/bin
+          # Dockerfile(s) expects binaries in /usr/local/bin
+          for file in ${{targets.destdir}}/usr/share/${{range.key}}/bin/*; do
+            ln -s $file ${{targets.destdir}}/usr/local/bin/$(basename $file)
+          done
+
+update:
+  enabled: true
+  github:
+    identifier: elastic/dockerfiles
+    use-tag: true
+    tag-filter: v
+    strip-prefix: v

--- a/kibana.yaml
+++ b/kibana.yaml
@@ -1,0 +1,68 @@
+package:
+  name: kibana
+  version: 8.13.3
+  epoch: 0
+  description: Your window into the Elastic Stack
+  copyright:
+    - license: Apache-2.0
+    - license: Elastic-2.0
+  dependencies:
+    runtime:
+      - bash
+      - curl
+      - elastic-dockerfiles-kibana
+      - font-liberation
+      - font-noto-cjk
+      - fontconfig
+      - libfontconfig1
+      - libnss
+      - tini
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - make
+      - yarn
+      - nvm
+      - maven
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/elastic/kibana
+      tag: v${{package.version}}
+      expected-commit: 003e4a42946390c2eb93dfb3586498ce7520a530
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/share/kibana
+      chmod g+ws "${{targets.destdir}}"/usr/share/kibana
+
+  - runs: |
+      builddir=$(pwd)
+      source /usr/share/nvm/nvm.sh
+      nvm use
+      yarn kbn bootstrap
+      yarn start --run-examples
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    # https://github.com/elastic/dockerfiles/blob/4269a02cf8a56844db30e5e74b23087840ee6fcb/kibana/Dockerfile#L82C29-L82C40
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    dependencies:
+      runtime:
+        - "${{package.name}}"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/opt
+          ln -sf /usr/share/kibana ${{targets.contextdir}}/opt/kibana
+
+update:
+  enabled: true
+  github:
+    strip-prefix: v
+    identifier: elastic/kibana


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
