### PR TITLE
neuvector-controller-5.3: use ldflags to set controller version so gr…

### DIFF
--- a/neuvector-controller-5.3.yaml
+++ b/neuvector-controller-5.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: neuvector-controller-5.3
   version: 5.3.2
-  epoch: 0
+  epoch: 1
   description: NeuVector Full Lifecycle Container Security Platform.
   copyright:
     - license: Apache-2.0
@@ -34,7 +34,7 @@ pipeline:
   - uses: go/build
     with:
       modroot: controller
-      ldflags: "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn"
+      ldflags: "-X main.Version=${{package.version}} -X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn"
       packages: .
       output: controller
 


### PR DESCRIPTION
…ype matches the correct version

With this change grype correctly recognises the neuvector-controller version:
```
~/controller # go build -ldflags "-X main.Version=5.3.2 -X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn"
~/controller # grype controller
 ⠙ Vulnerability DB                ━━━━━━━━━━━━━━━━━━━━  [checking for update]
 ⠹ Vulnerability DB                ━━━━━━━━━━━━━━━━━━━━  [checking for update]
 ⠹ Vulnerability DB                ━━━━━━━━━━━━━━━━━━━━  [checking for update]
 ⠹ Vulnerability DB                ━━━━━━━━━━━━━━━━━━━━  [checking for update]
 ⠸ Vulnerability DB                ━━━━━━━━━━━━━━━━━━━━  [checking for update]
 ✔ Vulnerability DB                [no update available]
 ✔ Vulnerability DB                [no update available]
                                                                              /home/build/controller
 ✔ Cataloged contents                                                                                                                                                                                                                                                          b00b1ec8048d8edec14644e9be934893e1afb9f2d8827263efa3492fbe4e44e3
   ├── ✔ Packages                        [90 packages]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]

   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
No vulnerabilities found
```

without, or setting a bogus version of 1.2.3:

```
~/controller # go build -ldflags "-X main.Version=1.2.3 -X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn"
~/controller # grype controller
 ⠙ Vulnerability DB                ━━━━━━━━━━━━━━━━━━━━  [checking for update]
 ⠙ Vulnerability DB                ━━━━━━━━━━━━━━━━━━━━  [checking for update]
 ⠹ Vulnerability DB                ━━━━━━━━━━━━━━━━━━━━  [checking for update]
 ⠹ Vulnerability DB                ━━━━━━━━━━━━━━━━━━━━  [checking for update]
 ⠹ Vulnerability DB                ━━━━━━━━━━━━━━━━━━━━  [checking for update]
 ⠸ Vulnerability DB                ━━━━━━━━━━━━━━━━━━━━  [checking for update]
 ✔ Vulnerability DB                [no update available]
 ✔ Vulnerability DB                [no update available]
                                                                              /home/build/controller
 ✔ Cataloged contents                                                                                                                                                                                                                                                          4ecd0f22e765e01234fa106d45c07ef050b26fca394d9217f5f02ba036817ff2
   ├── ✔ Packages                        [90 packages]
 ✔ Scanned for vulnerabilities     [1 vulnerability matches]
   ├── by severity: 1 critical, 0 high, 0 medium, 0 low, 0 negligiblelity matches]
   └── by status:   1 fixed, 0 not-fixed, 0 ignored
NAME                            INSTALLED  FIXED-IN  TYPE       VULNERABILITY        SEVERITY
github.com/neuvector/neuvector  v1.2.3     5.2.2     go-module  GHSA-622h-h2p8-743x  Critical
```

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
