### PR TITLE
git bootstrap

### DIFF
--- a/git-bootstrap.yaml
+++ b/git-bootstrap.yaml
@@ -1,0 +1,162 @@
+# Ideally zlib-dev openssl-dev curl-dev and maybe even git-bootstrap
+# should be in bootstrap-stage2/bootstrap-stage3. Until such time, add
+# git-bootstrap in wolfi-dev/os which statically links against
+# self-built dependencies. This enables using git-checkout to build
+# any package in wolfi, including git itself. As git-bootstrap
+# provides git that is installable and buildable using
+# bootstrap-stage3 alone.
+package:
+  name: git-bootstrap
+  version: 2.45.2
+  epoch: 0
+  description: "distributed version control system"
+  copyright:
+    - license: GPL-2.0-or-later
+  dependencies:
+    provider-priority: 5
+    provides:
+      - git
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - perl
+
+vars:
+  zlib-version: 1.3.1
+  openssl-version: 3.3.0
+  curl-version: 8.7.1
+
+pipeline:
+  - working-directory: zlib
+    pipeline:
+      - uses: fetch
+        with:
+          uri: https://zlib.net/zlib-${{vars.zlib-version}}.tar.gz
+          expected-sha256: 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+      - runs: |
+          CHOST="${{host.triplet.gnu}}" ./configure \
+          --prefix=/usr \
+          --libdir=/lib
+      - uses: autoconf/make
+      - runs: |
+          make install pkgconfigdir="/usr/lib/pkgconfig"
+
+  - working-directory: openssl
+    pipeline:
+      - uses: fetch
+        with:
+          uri: https://www.openssl.org/source/openssl-${{vars.openssl-version}}.tar.gz
+          expected-sha256: 53e66b043322a606abf0087e7699a0e033a37fa13feb9742df35c3a33b18fb02
+      - name: Configure and build
+        runs: |
+          export CC=${{host.triplet.gnu}}-gcc
+          export CXX=${{host.triplet.gnu}}-g++
+          export CPP=${{host.triplet.gnu}}-cpp
+          perl ./Configure \
+             linux-$(uname -m) \
+             --prefix=/usr \
+             --libdir=lib \
+             --openssldir=/etc/ssl \
+             enable-ktls \
+             shared \
+             no-zlib \
+             no-async \
+             no-comp \
+             no-idea \
+             no-mdc2 \
+             no-rc5 \
+             no-ec2m \
+             no-sm2 \
+             no-sm4 \
+             no-ssl3 \
+             no-seed \
+             no-weak-ssl-ciphers \
+             no-docs \
+             -Wa,--noexecstack
+          perl configdata.pm --dump
+          make -j$(nproc)
+          make install
+
+  - working-directory: curl
+    pipeline:
+      - uses: fetch
+        with:
+          uri: https://curl.se/download/curl-${{vars.curl-version}}.tar.xz
+          expected-sha256: 6fea2aac6a4610fbd0400afb0bcddbe7258a64c63f1f68e5855ebc0c659710cd
+      - uses: autoconf/configure
+        with:
+          opts: --with-openssl --disable-docs --disable-manual --disable-shared
+      - runs: |
+          make -C lib/ -j$(nproc)
+          make -C src/ -j$(nproc)
+          make -C include/ -j$(nproc)
+          make -C lib/ install
+          make -C src/ install
+          make -C include/ install
+
+  - working-directory: git
+    pipeline:
+      - uses: fetch
+        with:
+          uri: https://www.kernel.org/pub/software/scm/git/git-${{package.version}}.tar.xz
+          expected-sha256: 51bfe87eb1c02fed1484051875365eeab229831d30d0cec5d89a14f9e40e9adb
+      - runs: |
+          cat >> config.mak <<-EOF
+          NO_GETTEXT=YesPlease
+          NO_SVN_TESTS=YesPlease
+          NO_REGEX=YesPlease
+          NO_SYS_POLL_H=1
+          ICONV_OMITS_BOM=Yes
+          INSTALL_SYMLINKS=1
+          NO_PERL=YesPlease
+          NO_TCLTK=YesPlease
+          NO_EXPAT=YesPlease
+          EOF
+      - runs: |
+          make prefix=/usr \
+            CFLAGS="-O2 -Wall" \
+            DESTDIR="${{targets.destdir}}" \
+            INSTALLDIRS=vendor \
+            CURL_LDFLAGS="-l:libcurl.a -lssl -lcrypto" \
+            install -j$(nproc)
+      - runs: |
+          mkdir -p "${{targets.destdir}}"/var/git
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5350
+
+test:
+  environment:
+    environment:
+      HOME: /tmp
+  pipeline:
+    - name: Verify git installation
+      runs: |
+        git --version || exit 1
+    - name: Basic git operations
+      runs: |
+        git config --global user.name "Wolfi"
+        git config --global user.email "wolf@wolfi.dev"
+        mkdir test_repo && cd test_repo
+        git init
+        touch README.md
+        git add README.md
+        git commit -m "Initial commit"
+        git status | grep 'nothing to commit, working tree clean' || exit 1
+    - name: Clone repository
+      runs: |
+        git clone --depth 1 https://github.com/wolfi-dev/os.git test_clone
+        [ -d "test_clone/.git" ] || exit 1
+    - name: Fetch repository updates
+      runs: |
+        cd test_clone
+        git fetch || exit 1
+    - name: Check git configuration
+      runs: |
+        git config --list | grep 'user.name=Wolfi' || exit 1
+        git config --list | grep 'user.email=wolf@wolfi.dev' || exit 1

--- a/git.yaml
+++ b/git.yaml
@@ -1,10 +1,12 @@
 package:
   name: git
   version: 2.45.2
-  epoch: 0
+  epoch: 1
   description: "distributed version control system"
   copyright:
     - license: GPL-2.0-or-later
+  dependencies:
+    provider-priority: 10
 
 environment:
   contents:

--- a/lz4.yaml
+++ b/lz4.yaml
@@ -1,7 +1,7 @@
 package:
   name: lz4
   version: 1.9.4
-  epoch: 4
+  epoch: 5
   description: "lossless high performance compression algorithm"
   copyright:
     - license: BSD-2-Clause AND GPL-2.0-only
@@ -15,10 +15,11 @@ environment:
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/lz4/lz4/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: 0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b
+      repository: https://github.com/lz4/lz4
+      tag: v${{package.version}}
+      expected-commit: 5ff839680134437dbf4678f3d0c7b371d84f4964
 
   - runs: |
       make -j$(nproc) CC=${{host.triplet.gnu}}-gcc

--- a/lz4.yaml
+++ b/lz4.yaml
@@ -55,5 +55,7 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 1865
+  github:
+    identifier: lz4/lz4
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
- **git-bootstrap: add git with vendored curl**
    Ideally zlib-dev openssl-dev curl-dev and maybe even git-bootstrap
    should be in bootstrap-stage2/bootstrap-stage3. Until such time, add
    git-bootstrap in wolfi-dev/os which statically links against
    self-built dependencies. This enables using git-checkout to build any
    package in wolfi, including git itself. As git-bootstrap provides git
    that is installable and buildable using bootstrap-stage3 alone.
  

- **lz4.yaml: convert from fetch to git-checkout**
  

- **lz4.yaml: convert relese-monitor to github**

Previously submissions of lz4.yaml would error out, enable to resolve build cycle. See https://github.com/wolfi-dev/os/pull/18260 