### PR TITLE
WIP: add apache-nifi

### DIFF
--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -53,7 +53,7 @@ pipeline:
         -Dfrontend.skipTests=true \
         -Drat.skip=true
       mkdir -p ${{targets.destdir}}/usr/share/
-      cp -ar nifi-assembly/target/nifi-1.26.0-bin/nifi-1.26.0 ${{targets.destdir}}/usr/share/nifi
+      cp -ar nifi-assembly/target/nifi-${{package.version}}-bin/nifi-${{package.version}} ${{targets.destdir}}/usr/share/nifi
 
   - runs: |
       for dir in conf database_repository flowfile_repository content_repository provenance_repository state; do

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -9,22 +9,23 @@ package:
     runtime:
       - bash
       - openjdk-11-jre
+      - xmlstarlet
 
 environment:
   contents:
     packages:
-      - busybox
       - bash
-      - coreutils
       - build-base
+      - busybox
+      - coreutils
       - maven
+      - nodejs-20
+      - npm
       - openjdk-11
       - openjdk-11-default-jvm
       - openssl-dev
-      - wolfi-base
-      - npm
-      - nodejs-20
       - rsync
+      - wolfi-base
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
     MAVEN_OPTS: |
@@ -34,6 +35,7 @@ environment:
       -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
       -Daether.connector.http.retryHandler.count=5
       -Daether.connector.http.connectionMaxTtl=30
+    NIFI_HOME: "opt/nifi/nifi-current"
 
 pipeline:
   - uses: git-checkout
@@ -43,7 +45,7 @@ pipeline:
       expected-commit: 338083f6850b61cd2651e41bbd73b3cb5330d98c
 
   - runs: |
-      mvn -T$(nproc)C -q package \
+      ./mvnw -T$(nproc)C -q package \
         --no-snapshot-updates \
         --no-transfer-progress \
         --fail-fast \
@@ -52,9 +54,33 @@ pipeline:
         -Drat.skip=true
       mkdir -p ${{targets.destdir}}/usr/share/
       cp -ar nifi-assembly/target/nifi-1.26.0-bin/nifi-1.26.0 ${{targets.destdir}}/usr/share/nifi
-      mkdir -p ${{targets.destdir}}/usr/share/nifi/run
+
+  - runs: |
+      for dir in conf database_repository flowfile_repository content_repository provenance_repository state; do
+        mkdir -p "${targets.destdir}/usr/share/nifi/${dir}"
+      done
+
+      for dir in conf database_repository flowfile_repository content_repository provenance_repository state; do
+        mkdir -p ${{targets.destdir}}/usr/share/nifi/logs/${dir}
+      done
+
+  - runs: |
+      echo "#!/bin/sh\n" > ${{targets.destdir}}/usr/share/nifi/bin/nifi-env.sh
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/nifi/scripts
+      install -m755 nifi-docker/dockerhub/*.sh "${{targets.destdir}}"/usr/share/nifi/scripts/
+      chmod -R +x ${{targets.destdir}}/usr/share/nifi/scripts
 
   - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream image"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/${NIFI_HOME}
+          ln -sf /usr/share/nifi "${{targets.contextdir}}"/${NIFI_HOME}/nifi
 
 update:
   enabled: true
@@ -66,3 +92,9 @@ update:
     use-tag: true
     strip-prefix: rel/nifi-
     tag-filter: rel/nifi-
+
+test:
+  pipeline:
+    - runs: |
+        export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+        /usr/share/nifi/bin/nifi.sh start

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,0 +1,68 @@
+package:
+  name: apache-nifi
+  version: 1.26.0
+  epoch: 0
+  description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - bash
+      - openjdk-11-jre
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - bash
+      - coreutils
+      - build-base
+      - maven
+      - openjdk-11
+      - openjdk-11-default-jvm
+      - openssl-dev
+      - wolfi-base
+      - npm
+      - nodejs-20
+      - rsync
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-11-openjdk
+    MAVEN_OPTS: |
+      -Xmx4g
+      -XX:ReservedCodeCacheSize=1g
+      -XX:+UseG1GC
+      -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
+      -Daether.connector.http.retryHandler.count=5
+      -Daether.connector.http.connectionMaxTtl=30
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/nifi
+      tag: rel/nifi-${{package.version}}
+      expected-commit: 338083f6850b61cd2651e41bbd73b3cb5330d98c
+
+  - runs: |
+      mvn -T$(nproc)C -q package \
+        --no-snapshot-updates \
+        --no-transfer-progress \
+        --fail-fast \
+        -DskipTests \
+        -Dfrontend.skipTests=true \
+        -Drat.skip=true
+      mkdir -p ${{targets.destdir}}/usr/share/
+      cp -ar nifi-assembly/target/nifi-1.26.0-bin/nifi-1.26.0 ${{targets.destdir}}/usr/share/nifi
+      mkdir -p ${{targets.destdir}}/usr/share/nifi/run
+
+  - uses: strip
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - -RC
+    - -M
+  github:
+    identifier: apache/nifi
+    use-tag: true
+    strip-prefix: rel/nifi-
+    tag-filter: rel/nifi-

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -57,7 +57,7 @@ pipeline:
 
   - runs: |
       for dir in conf database_repository flowfile_repository content_repository provenance_repository state; do
-        mkdir -p "${targets.destdir}/usr/share/nifi/${dir}"
+        mkdir -p "${{targets.destdir}}/usr/share/nifi/${dir}"
       done
 
       for dir in conf database_repository flowfile_repository content_repository provenance_repository state; do


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
