### PR TITLE
Attempt to fix gcsfuse read-only issues

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,9 +63,13 @@ jobs:
           mkdir -p /gcsfuse/wolfi-registry
           gcsfuse -o ro --implicit-dirs --only-dir os wolfi-production-registry-destination /gcsfuse/wolfi-registry
 
+          # Give gcsfuse some time to settle down.
+          sleep 30
+
           mkdir -p ./packages/${{ matrix.arch }}
+
           # Symlink the gcsfuse mount to ./packages/ to workaround the Makefile CWD assumptions
-          for f in /gcsfuse/wolfi-registry/${{ matrix.arch }}/*.apk; do
+          for f in $(find /gcsfuse/wolfi-registry/${{ matrix.arch }} -name '*.apk'); do
             ln -s "$f" ./packages/${{ matrix.arch }}/
           done
 


### PR DESCRIPTION
Current theory is:

A post-submit partially fails and we upload the packages that were built but don't update the APKINDEX.

On the next post-submit, we stat those files via gcsfuse, but we get a file not found, even though those files do exist. For some reason, we think gcsfuse is too slow or something.

Since they don't appear exist, we attempt to build them, but then get a read-only filesystem failure because that file does exist and is a gcsfuse symlink, which means we can't open for write.

This change does two things:

1. Replace the file glob with `find` if there are just too many files.
2. Do a 30 second sleep after we start up gcsfuse.

We're going to try to drop gcsfuse entirely and make wolfictl build do a HEAD request against the bucket, at which point both these hacks can be deleted.