### PR TITLE
Revert "Attempt to fix gcsfuse read-only issues (#18950)"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,13 +63,9 @@ jobs:
           mkdir -p /gcsfuse/wolfi-registry
           gcsfuse -o ro --implicit-dirs --only-dir os wolfi-production-registry-destination /gcsfuse/wolfi-registry
 
-          # Give gcsfuse some time to settle down.
-          sleep 30
-
           mkdir -p ./packages/${{ matrix.arch }}
-
           # Symlink the gcsfuse mount to ./packages/ to workaround the Makefile CWD assumptions
-          for f in $(find /gcsfuse/wolfi-registry/${{ matrix.arch }} -name '*.apk'); do
+          for f in /gcsfuse/wolfi-registry/${{ matrix.arch }}/*.apk; do
             ln -s "$f" ./packages/${{ matrix.arch }}/
           done
 


### PR DESCRIPTION
This reverts commit 84a61543c8e1104e3808887ba5c2d16efdff5d31.

https://github.com/wolfi-dev/os/pull/18951 should contain a real fix.