### PR TITLE
go-1.22.3-batch-8(a): go epoch bump

### DIFF
--- a/kubernetes-csi-external-attacher-4.3.yaml
+++ b/kubernetes-csi-external-attacher-4.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-attacher-4.3
   version: 4.3.0
-  epoch: 15
+  epoch: 16
   description: Sidecar container that watches Kubernetes VolumeAttachment objects and triggers ControllerPublish/Unpublish against a CSI endpoint
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-external-attacher-4.4.yaml
+++ b/kubernetes-csi-external-attacher-4.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-attacher-4.4
   version: 4.4.4
-  epoch: 2
+  epoch: 3
   description: Sidecar container that watches Kubernetes VolumeAttachment objects and triggers ControllerPublish/Unpublish against a CSI endpoint
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-external-provisioner.yaml
+++ b/kubernetes-csi-external-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-provisioner
   version: 4.0.1
-  epoch: 1
+  epoch: 2
   description: A dynamic provisioner for Kubernetes CSI plugins.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-external-resizer-1.10.yaml
+++ b/kubernetes-csi-external-resizer-1.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-resizer-1.10
   version: 1.10.1
-  epoch: 3
+  epoch: 4
   description: Sidecar container that watches Kubernetes PersistentVolumeClaims objects and triggers controller side expansion operation against a CSI endpoint
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-external-snapshotter.yaml
+++ b/kubernetes-csi-external-snapshotter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-snapshotter
   version: 7.0.2
-  epoch: 1
+  epoch: 2
   description: Sidecar container that watches Kubernetes Snapshot CRD objects and triggers CreateSnapshot/DeleteSnapshot against a CSI endpoint
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-livenessprobe.yaml
+++ b/kubernetes-csi-livenessprobe.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-livenessprobe
   version: 2.12.0
-  epoch: 4
+  epoch: 5
   description: A sidecar container that can be included in a CSI plugin pod to enable integration with Kubernetes Liveness Probe.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-node-driver-registrar-2.10.yaml
+++ b/kubernetes-csi-node-driver-registrar-2.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-node-driver-registrar-2.10
   version: 2.10.1
-  epoch: 1
+  epoch: 2
   description: Sidecar container that registers a CSI driver with the kubelet using the kubelet plugin registration mechanism.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-dashboard-metrics-scraper.yaml
+++ b/kubernetes-dashboard-metrics-scraper.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-metrics-scraper
   version: 1.0.9
-  epoch: 15
+  epoch: 16
   description: Container to scrape, store, and retrieve a window of time from the Metrics Server.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-dashboard.yaml
+++ b/kubernetes-dashboard.yaml
@@ -2,7 +2,7 @@ package:
   name: kubernetes-dashboard
   # When bumping, check to see if the GHSA mitigations below can be removed.
   version: 2.7.0
-  epoch: 17
+  epoch: 18
   description: General-purpose web UI for Kubernetes clusters
   copyright:
     - license: Apache-2.0

--- a/kubernetes-dns-node-cache.yaml
+++ b/kubernetes-dns-node-cache.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dns-node-cache
   version: 1.23.0
-  epoch: 5
+  epoch: 6
   description: NodeLocal DNSCache improves Cluster DNS performance by running a DNS caching agent on cluster nodes as a DaemonSet.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-event-exporter.yaml
+++ b/kubernetes-event-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-event-exporter
   version: "1.7"
-  epoch: 5
+  epoch: 6
   description: Export Kubernetes events to multiple destinations with routing and filtering
   copyright:
     - license: Apache-2.0

--- a/kubescape.yaml
+++ b/kubescape.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubescape
   version: 3.0.10
-  epoch: 0
+  epoch: 1
   description: Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources.
   copyright:
     - license: Apache-2.0 AND MIT

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubevela
   version: 1.9.11
-  epoch: 1
+  epoch: 2
   description: KubeVela is a modern application delivery platform that makes deploying and operating applications across today's hybrid, multi-cloud environments easier, faster and more reliable
   copyright:
     - license: Apache-2.0

--- a/kubewatch.yaml
+++ b/kubewatch.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubewatch
   version: 2.6.0
-  epoch: 0
+  epoch: 1
   description: Watch k8s events and trigger Handlers
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
supersedes https://github.com/wolfi-dev/os/pull/18854 - splits that batch into two, to see if it helps prevent the diff step from hanging