### PR TITLE
go-1.22.3-batch-8(b): go epoch bump

### DIFF
--- a/kustomize.yaml
+++ b/kustomize.yaml
@@ -1,7 +1,7 @@
 package:
   name: kustomize
   version: 5.4.1
-  epoch: 3
+  epoch: 4
   description: Customization of kubernetes YAML configurations
   copyright:
     - license: Apache-2.0

--- a/kwok.yaml
+++ b/kwok.yaml
@@ -1,7 +1,7 @@
 package:
   name: kwok
   version: 0.5.2
-  epoch: 1
+  epoch: 2
   description: Kubernetes WithOut Kubelet - Simulates thousands of Nodes and Clusters.
   copyright:
     - license: BSD-3-Clause

--- a/kyverno-policy-reporter-kyverno-plugin.yaml
+++ b/kyverno-policy-reporter-kyverno-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-policy-reporter-kyverno-plugin
   version: 1.6.3
-  epoch: 4
+  epoch: 5
   description: Policy Reporter Kyverno Plugin
   copyright:
     - license: Apache-2.0

--- a/kyverno-policy-reporter-ui.yaml
+++ b/kyverno-policy-reporter-ui.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-policy-reporter-ui
   version: 1.9.2
-  epoch: 5
+  epoch: 6
   description: Policy Reporter UI
   copyright:
     - license: Apache-2.0

--- a/kyverno-policy-reporter.yaml
+++ b/kyverno-policy-reporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-policy-reporter
   version: 2.18.2
-  epoch: 2
+  epoch: 3
   description: Monitoring and Observability Tool for the PolicyReport CRD with an optional UI.
   copyright:
     - license: Apache-2.0

--- a/kyverno.yaml
+++ b/kyverno.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno
   version: 1.12.1
-  epoch: 1
+  epoch: 2
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0

--- a/lazygit.yaml
+++ b/lazygit.yaml
@@ -1,7 +1,7 @@
 package:
   name: lazygit
   version: 0.41.0
-  epoch: 2
+  epoch: 3
   description: simple terminal UI for git commands
   copyright:
     - license: MIT

--- a/libnvidia-container.yaml
+++ b/libnvidia-container.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnvidia-container
   version: 1.15.0
-  epoch: 0
+  epoch: 1
   description: NVIDIA container runtime library
   copyright:
     - license: Apache-2.0

--- a/litefs.yaml
+++ b/litefs.yaml
@@ -1,7 +1,7 @@
 package:
   name: litefs
   version: 0.5.11
-  epoch: 4
+  epoch: 5
   description: "FUSE-based file system for replicating SQLite databases across a cluster of machines"
   copyright:
     - license: Apache-2.0

--- a/litestream.yaml
+++ b/litestream.yaml
@@ -1,7 +1,7 @@
 package:
   name: litestream
   version: 0.3.13
-  epoch: 1
+  epoch: 2
   description: Streaming replication for SQLite.
   copyright:
     - license: Apache-2.0

--- a/local-path-provisioner.yaml
+++ b/local-path-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: local-path-provisioner
   version: 0.0.26
-  epoch: 6
+  epoch: 7
   description: Dynamically provisioning persistent local storage with Kubernetes
   copyright:
     - license: Apache-2.0

--- a/local-static-provisioner.yaml
+++ b/local-static-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: local-static-provisioner
   version: 2.7.0
-  epoch: 1
+  epoch: 2
   description: Static provisioner of local volumes
   copyright:
     - license: Apache-2.0

--- a/logstash-exporter.yaml
+++ b/logstash-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: logstash-exporter
   version: 1.6.4
-  epoch: 0
+  epoch: 1
   description: Prometheus exporter for Logstash written in Go
   copyright:
     - license: Apache-2.0

--- a/logstash.yaml
+++ b/logstash.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash
   version: 8.13.3
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0

--- a/loki.yaml
+++ b/loki.yaml
@@ -1,7 +1,7 @@
 package:
   name: loki
   version: 3.0.0
-  epoch: 2
+  epoch: 3
   description: Like Prometheus, but for logs.
   copyright:
     - license: AGPL-3.0-or-later


### PR DESCRIPTION
supersedes https://github.com/wolfi-dev/os/pull/18854 - splits that batch into two, to see if it helps prevent the diff step from hanging