### PR TITLE
go-1.22.3-a5: go bump

### DIFF
--- a/metallb.yaml
+++ b/metallb.yaml
@@ -1,7 +1,7 @@
 package:
   name: metallb
   version: 0.14.5
-  epoch: 1
+  epoch: 2
   description: "A network load-balancer implementation for Kubernetes using standard routing protocols"
   copyright:
     - license: Apache-2.0

--- a/nerdctl.yaml
+++ b/nerdctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: nerdctl
   version: 1.7.6
-  epoch: 3
+  epoch: 4
   description: Docker-compatible CLI for containerd, with support for Compose, Rootless, eStargz, OCIcrypt, IPFS, ...
   copyright:
     - license: Apache-2.0

--- a/newrelic-fluent-bit-output.yaml
+++ b/newrelic-fluent-bit-output.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-fluent-bit-output
   version: 1.19.2
-  epoch: 4
+  epoch: 5
   description: A Fluent Bit output plugin that sends logs to New Relic
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
