### PR TITLE
chore(clickhouse-24): Use our OpenSSL

### DIFF
--- a/clickhouse-24.yaml
+++ b/clickhouse-24.yaml
@@ -43,25 +43,17 @@ pipeline:
     with:
       patches: allow_cflags.patch
 
-  - runs: |
-      git submodule update --init
-      mkdir build
-      cd build
-      cmake \
-        -DCOMPILER_CACHE=disabled \
-        -DCMAKE_INSTALL_PREFIX=/usr \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DNO_ARMV81_OR_HIGHER=1 \
-        -DCMAKE_INSTALL_LIBDIR=lib \
-        ..
+  - runs: git submodule update --init
 
-  - runs: |
-      cd build
-      ninja -j $(nproc)
-      mkdir -p  ${{targets.destdir}}/var/lib/clickhouse
-      mkdir -p  ${{targets.destdir}}/var/log/clickhouse-server
-      DESTDIR=${{targets.destdir}} ninja install
-      rm -rf ${{targets.destdir}}/usr/lib/debug
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DCOMPILER_CACHE=disabled \
+        -DNO_ARMV81_OR_HIGHER=1
+
+  - uses: cmake/build
+
+  - uses: cmake/install
 
   - uses: strip
 

--- a/clickhouse-24.yaml
+++ b/clickhouse-24.yaml
@@ -26,6 +26,7 @@ environment:
       - llvm-lld-17-dev
       - nasm
       - ninja
+      - openssl-dev
       - perl
       - python3
       - rust
@@ -41,13 +42,17 @@ pipeline:
   # The default build script is defensive and tries to protect against defining cflags.
   - uses: patch
     with:
-      patches: allow_cflags.patch
+      patches: |
+        allow_cflags.patch \
+        dynamically_link_openssl.patch
 
   - runs: git submodule update --init
 
   - uses: cmake/configure
     with:
       opts: |
+        -DCMAKE_C_FLAGS="${CFLAGS} -fPIC -Wno-error=unused-result" \
+        -DCMAKE_CXX_FLAGS="${CXXFLAGS} -fPIC -Wno-error=unused-result" \
         -DCOMPILER_CACHE=disabled \
         -DNO_ARMV81_OR_HIGHER=1
 

--- a/clickhouse-24.yaml
+++ b/clickhouse-24.yaml
@@ -16,21 +16,19 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang-17
       - clang-17-dev
       - cmake
       - coreutils
       - findutils
       - git
       - grep
-      - llvm-libcxx-17
       - llvm-libcxx-17-dev
-      - llvm-lld-17
       - llvm-lld-17-dev
       - nasm
       - ninja
       - perl
       - python3
+      - rust
       - yasm
 
 pipeline:

--- a/clickhouse-24.yaml
+++ b/clickhouse-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-24
-  version: 24.1.8.22
-  epoch: 0
+  version: 24.4.1.2088
+  epoch: 1
   description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
   copyright:
     - license: Apache-2.0

--- a/clickhouse-24.yaml
+++ b/clickhouse-24.yaml
@@ -51,8 +51,8 @@ pipeline:
   - uses: cmake/configure
     with:
       opts: |
-        -DCMAKE_C_FLAGS="${CFLAGS} -fPIC -Wno-error=unused-result" \
-        -DCMAKE_CXX_FLAGS="${CXXFLAGS} -fPIC -Wno-error=unused-result" \
+        -DCMAKE_C_FLAGS="-fPIC" \
+        -DCMAKE_CXX_FLAGS="-fPIC" \
         -DCOMPILER_CACHE=disabled \
         -DNO_ARMV81_OR_HIGHER=1
 

--- a/clickhouse-24.yaml
+++ b/clickhouse-24.yaml
@@ -37,7 +37,7 @@ pipeline:
     with:
       repository: https://github.com/ClickHouse/ClickHouse
       tag: v${{package.version}}-stable
-      expected-commit: 7fb8f96d3da26cbcd42aa967a9f06b8a780de351
+      expected-commit: 6d4b31322d168356c8b10c43b4cef157c82337ff
 
   # The default build script is defensive and tries to protect against defining cflags.
   - uses: patch

--- a/clickhouse-24/dynamically_link_openssl.patch
+++ b/clickhouse-24/dynamically_link_openssl.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index be804a14765..759bdfeb23a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -455,12 +455,7 @@ endif ()
+ 
+ enable_testing() # Enable for tests without binary
+ 
+-if (ARCH_S390X)
+-    set(ENABLE_OPENSSL_DYNAMIC_DEFAULT ON)
+-else ()
+-    set(ENABLE_OPENSSL_DYNAMIC_DEFAULT OFF)
+-endif ()
+-option(ENABLE_OPENSSL_DYNAMIC "This option removes SSL from ClickHouse and will link to the OpenSSL version supplied by OS." ${ENABLE_OPENSSL_DYNAMIC_DEFAULT})
++option(ENABLE_OPENSSL_DYNAMIC "This option removes SSL from ClickHouse and will link to the OpenSSL version supplied by OS." ON)
+ 
+ # when installing to /usr - place configs to /etc but for /usr/local place to /usr/local/etc
+ if (CMAKE_INSTALL_PREFIX STREQUAL "/usr")


### PR DESCRIPTION
- Updates ClickHouse to the latest version
- Adds missing buildtime dependency (rust)
- Integrates melange's cmake pipelines
- Use our OpenSSL