### PR TITLE
cronie: fix description

### DIFF
--- a/cronie.yaml
+++ b/cronie.yaml
@@ -2,7 +2,7 @@ package:
   name: cronie
   version: 1.7.2
   epoch: 0
-  description: Library for extensible, efficient structure packing
+  description: Cron daemon for executing programs at set times
   copyright:
     - license: ISC
 


### PR DESCRIPTION
Fixes the description of the `cronie` package, which appears to have a copy+and+paste error from protobuf. Uses same descriptions as in packages for other linux distros.