### PR TITLE
Convert go/install pipelines to git-checkout and go/build

### DIFF
--- a/amass.yaml
+++ b/amass.yaml
@@ -1,7 +1,7 @@
 package:
   name: amass
   version: 4.2.0
-  epoch: 6
+  epoch: 7
   description: "attack surfaces and external asset discovery tools set"
   copyright:
     - license: Apache-2.0
@@ -12,10 +12,17 @@ environment:
       - go
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/owasp-amass/amass/v4/...
-      version: v${{package.version}}
+      repository: https://github.com/owasp-amass/amass
+      tag: v${{package.version}}
+      expected-commit: 5f1f7176bae60975c1e5be64273cb201f1bb37c3
+
+  - uses: go/build
+    with:
+      packages: ./cmd/amass
+      modroot: .
+      output: amass
 
   - uses: strip
 

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,7 +1,7 @@
 package:
   name: buf
   version: 1.31.0
-  epoch: 1
+  epoch: 2
   description: A new way of working with Protocol Buffers.
   copyright:
     - license: Apache-2.0
@@ -13,9 +13,17 @@ environment:
       - wolfi-baselayout
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/bufbuild/buf/cmd/buf@v${{package.version}}
+      repository: https://github.com/bufbuild/buf
+      tag: v${{package.version}}
+      expected-commit: c9863a60f33385e3eba90f368ae57f50ecc65d1f
+
+  - uses: go/build
+    with:
+      packages: ./cmd/buf
+      modroot: .
+      output: buf
 
   - uses: strip
 

--- a/controller-gen.yaml
+++ b/controller-gen.yaml
@@ -1,7 +1,7 @@
 package:
   name: controller-gen
   version: 0.15.0
-  epoch: 1
+  epoch: 2
   description: Tools to use with the controller-runtime libraries
   copyright:
     - license: Apache-2.0
@@ -16,10 +16,17 @@ environment:
     CGO_ENABLED: "0"
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: sigs.k8s.io/controller-tools/cmd/controller-gen
-      version: v${{package.version}}
+      repository: https://github.com/kubernetes-sigs/controller-tools
+      tag: v${{package.version}}
+      expected-commit: 473c02870bcfdc40955b2813ea2c73f0d3a34712
+
+  - uses: go/build
+    with:
+      packages: ./cmd/controller-gen
+      modroot: .
+      output: controller-gen
 
   - uses: strip
 

--- a/fq.yaml
+++ b/fq.yaml
@@ -1,16 +1,23 @@
 package:
   name: fq
   version: 0.11.0
-  epoch: 1
+  epoch: 2
   description: "jq for binary formats - tool, language and decoders for working with binary and text formats"
   copyright:
     - license: MIT
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/wader/fq
-      version: v${{package.version}}
+      repository: https://github.com/wader/fq
+      tag: v${{package.version}}
+      expected-commit: d30755b06e2653bf5f09723e5b5e03cac5b20b77
+
+  - uses: go/build
+    with:
+      packages: ./
+      modroot: .
+      output: fq
 
   - uses: strip
 

--- a/gcsfuse.yaml
+++ b/gcsfuse.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcsfuse
   version: 1.4.2
-  epoch: 3
+  epoch: 4
   description: A user-space file system for interacting with Google Cloud Storage
   copyright:
     - license: Apache-2.0
@@ -10,9 +10,17 @@ package:
       - fuse3
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/googlecloudplatform/gcsfuse@v${{package.version}}
+      repository: https://github.com/googlecloudplatform/gcsfuse
+      tag: v${{package.version}}
+      expected-commit: 342c39b1863fedeb3bd947aaad2d0188dd0737fa
+
+  - uses: go/build
+    with:
+      packages: .
+      modroot: .
+      output: gcsfuse
 
 update:
   enabled: true

--- a/gobuster.yaml
+++ b/gobuster.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobuster
   version: 3.6.0
-  epoch: 7
+  epoch: 8
   description: "a tool used to brute force attack for URIs, DNS, etc."
   copyright:
     - license: Apache-2.0
@@ -12,10 +12,17 @@ environment:
       - go
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/OJ/gobuster/v3
-      version: v${{package.version}}
+      repository: https://github.com/OJ/gobuster
+      tag: v${{package.version}}
+      expected-commit: ba619dd1be7bf3055c5b229308648079cf255894
+
+  - uses: go/build
+    with:
+      packages: .
+      modroot: .
+      output: gobuster
 
   - uses: strip
 

--- a/goreleaser-1.18.yaml
+++ b/goreleaser-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: goreleaser-1.18
   version: 1.18.2
-  epoch: 8
+  epoch: 9
   description: Deliver Go binaries as fast and easily as possible
   copyright:
     - license: Apache-2.0
@@ -15,9 +15,17 @@ environment:
       - git
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/goreleaser/goreleaser@v${{package.version}}
+      repository: https://github.com/goreleaser/goreleaser
+      tag: v${{package.version}}
+      expected-commit: ad000694196f30e2cdfe561fd20b20bb85c5258b
+
+  - uses: go/build
+    with:
+      packages: .
+      modroot: .
+      output: goreleaser
 
 update:
   enabled: true

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,7 +1,7 @@
 package:
   name: goreleaser
   version: 1.26.0
-  epoch: 0
+  epoch: 1
   description: Deliver Go binaries as fast and easily as possible
   copyright:
     - license: Apache-2.0
@@ -12,9 +12,17 @@ environment:
       - git
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/goreleaser/goreleaser@v${{package.version}}
+      repository: https://github.com/goreleaser/goreleaser
+      tag: v${{package.version}}
+      expected-commit: 0481e63fb3d9d6d1e1d8cbee16789d644b652ab1
+
+  - uses: go/build
+    with:
+      packages: .
+      modroot: .
+      output: goreleaser
 
 update:
   enabled: true

--- a/nsc.yaml
+++ b/nsc.yaml
@@ -1,15 +1,23 @@
 package:
   name: nsc
   version: 2.8.6
-  epoch: 2
+  epoch: 3
   description: Tool for creating nkey/jwt based configurations
   copyright:
     - license: Apache-2.0
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/nats-io/nsc/v2@v${{package.version}}
+      repository: https://github.com/nats-io/nsc
+      tag: v${{package.version}}
+      expected-commit: bcb05a434540c0e6b936746a2dfa878e6d28b1cb
+
+  - uses: go/build
+    with:
+      packages: .
+      modroot: .
+      output: nsc
 
 update:
   enabled: true

--- a/protoc-gen-go-grpc.yaml
+++ b/protoc-gen-go-grpc.yaml
@@ -1,15 +1,23 @@
 package:
   name: protoc-gen-go-grpc
   version: 1.3.0
-  epoch: 10
+  epoch: 11
   description: Go support for Google's protocol buffers services
   copyright:
     - license: Apache-2.0
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${{package.version}}
+      repository: https://github.com/grpc/grpc-go
+      tag: cmd/protoc-gen-go-grpc/v${{package.version}}
+      expected-commit: 8ba23be9613c672d40ae261d2a1335d639bdd59b
+
+  - uses: go/build
+    with:
+      packages: .
+      modroot: .
+      output: protoc-gen-go-grpc
 
   - uses: strip
 

--- a/protoc-gen-go.yaml
+++ b/protoc-gen-go.yaml
@@ -1,15 +1,23 @@
 package:
   name: protoc-gen-go
   version: 1.34.1
-  epoch: 1
+  epoch: 2
   description: Go support for Google's protocol buffers
   copyright:
     - license: BSD-3-Clause
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: google.golang.org/protobuf/cmd/protoc-gen-go@v${{package.version}}
+      repository: https://github.com/protocolbuffers/protobuf-go
+      tag: v${{package.version}}
+      expected-commit: 4a76e11653e368b9331815e1eb98e0cedc28997f
+
+  - uses: go/build
+    with:
+      packages: ./cmd/protoc-gen-go
+      modroot: .
+      output: protoc-gen-go
 
   - uses: strip
 

--- a/sbom-scorecard.yaml
+++ b/sbom-scorecard.yaml
@@ -1,7 +1,7 @@
 package:
   name: sbom-scorecard
   version: 0.0.7
-  epoch: 9
+  epoch: 10
   description: Generate a score for your sbom to understand if it will actually be useful.
   copyright:
     - license: Apache-2.0
@@ -12,9 +12,17 @@ environment:
       - git
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/ebay/sbom-scorecard/cmd/sbom-scorecard@${{package.version}}
+      repository: https://github.com/ebay/sbom-scorecard
+      tag: ${{package.version}}
+      expected-commit: dc7a7080db71fba617f6287615feeee175626435
+
+  - uses: go/build
+    with:
+      packages: ./cmd/sbom-scorecard
+      modroot: .
+      output: sbom-scorecard
 
 update:
   enabled: true

--- a/sbomqs.yaml
+++ b/sbomqs.yaml
@@ -1,16 +1,23 @@
 package:
   name: sbomqs
   version: 0.1.3
-  epoch: 1
+  epoch: 2
   description: SBOM quality score - Quality metrics for your sboms
   copyright:
     - license: Apache-2.0
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/interlynk-io/sbomqs
-      version: v${{package.version}}
+      repository: https://github.com/interlynk-io/sbomqs
+      tag: v${{package.version}}
+      expected-commit: 7f26bc8266e3df340a35606394b1e10c5baa860d
+
+  - uses: go/build
+    with:
+      packages: .
+      modroot: .
+      output: sbomqs
 
   - uses: strip
 

--- a/slsa-verifier.yaml
+++ b/slsa-verifier.yaml
@@ -1,15 +1,23 @@
 package:
   name: slsa-verifier
   version: 2.5.1
-  epoch: 2
+  epoch: 3
   description: Verify provenance from SLSA compliant builders
   copyright:
     - license: Apache-2.0
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v${{package.version}}
+      repository: https://github.com/slsa-framework/slsa-verifier
+      tag: v${{package.version}}
+      expected-commit: eb7007070baa04976cb9e25a0d8034f8db030a86
+
+  - uses: go/build
+    with:
+      packages: ./cli/slsa-verifier
+      modroot: .
+      output: slsa-verifier
 
 update:
   enabled: true

--- a/supercronic.yaml
+++ b/supercronic.yaml
@@ -1,7 +1,7 @@
 package:
   name: supercronic
   version: 0.2.29
-  epoch: 3
+  epoch: 4
   description: Cron for containers
   copyright:
     - license: MIT
@@ -10,9 +10,17 @@ package:
       - go
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/aptible/supercronic@v${{package.version}}
+      repository: https://github.com/aptible/supercronic
+      tag: v${{package.version}}
+      expected-commit: 538ad7df148e8b265a8c2db42db6492b55abe463
+
+  - uses: go/build
+    with:
+      packages: .
+      modroot: .
+      output: supercronic
 
   - uses: strip
 

--- a/task.yaml
+++ b/task.yaml
@@ -1,7 +1,7 @@
 package:
   name: task
   version: 3.37.2
-  epoch: 0
+  epoch: 1
   description: A task runner / simpler Make alternative written in Go
   copyright:
     - license: MIT
@@ -9,9 +9,17 @@ package:
         - "*"
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/go-task/task/v3/cmd/task@v${{package.version}}
+      repository: https://github.com/go-task/task
+      tag: v${{package.version}}
+      expected-commit: 57c094f415cd784e0b40d49d3b523ad3d15a0678
+
+  - uses: go/build
+    with:
+      packages: ./cmd/task
+      modroot: .
+      output: task
 
 update:
   enabled: true

--- a/vexctl.yaml
+++ b/vexctl.yaml
@@ -1,16 +1,23 @@
 package:
   name: vexctl
   version: 0.2.6
-  epoch: 3
+  epoch: 4
   description: A tool to create, transform and attest VEX metadata
   copyright:
     - license: Apache-2.0
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/openvex/vexctl
-      version: v${{package.version}}
+      repository: https://github.com/openvex/vexctl
+      tag: v${{package.version}}
+      expected-commit: 13fa934d15cb49ad2981ce4d3f5e6ecbef599919
+
+  - uses: go/build
+    with:
+      packages: .
+      modroot: .
+      output: vexctl
 
   - uses: strip
 


### PR DESCRIPTION
go/install does not work when handling automated bumps for any CVE fixes.