### PR TITLE
Add jmods provides for jdks 12-16, fix configure flags.

### DIFF
--- a/openjdk-12.yaml
+++ b/openjdk-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-12
   version: 12.0.2.10
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: GPL-2.0-only
@@ -60,9 +60,15 @@ pipeline:
 
   - runs: chmod +x configure
 
+  # Note that despite using --with-extra-cflags, --with-extra-cxxflags, and
+  # --with-extra-ldflags, the configure still produces warnings like:
+  # https://github.com/wolfi-dev/os/issues/18747
   - uses: autoconf/configure
     with:
       opts: |
+        --with-extra-cflags="$CFLAGS" \
+        --with-extra-cxxflags="$CXXFLAGS" \
+        --with-extra-ldflags="$LDFLAGS" \
         --with-boot-jdk=/usr/lib/jvm/java-11-openjdk \
         --prefix=/usr/lib/jvm/java-12-openjdk \
         --with-vendor-name=wolfi \
@@ -179,6 +185,9 @@ subpackages:
 
   - name: "openjdk-12-jmods"
     description: "OpenJDK 12 jmods"
+    dependencies:
+      provides:
+        - openjdk-jmods=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-12-openjdk

--- a/openjdk-13.yaml
+++ b/openjdk-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-13
   version: 13.0.14.5
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: GPL-2.0-only
@@ -57,9 +57,15 @@ pipeline:
 
   - runs: chmod +x configure
 
+  # Note that despite using --with-extra-cflags, --with-extra-cxxflags, and
+  # --with-extra-ldflags, the configure still produces warnings like:
+  # https://github.com/wolfi-dev/os/issues/18747
   - uses: autoconf/configure
     with:
       opts: |
+        --with-extra-cflags="$CFLAGS" \
+        --with-extra-cxxflags="$CXXFLAGS" \
+        --with-extra-ldflags="$LDFLAGS" \
         --with-boot-jdk=/usr/lib/jvm/java-12-openjdk \
         --prefix=/usr/lib/jvm/java-13-openjdk \
         --with-vendor-name=wolfi \
@@ -175,6 +181,9 @@ subpackages:
 
   - name: "openjdk-13-jmods"
     description: "OpenJDK 13 jmods"
+    dependencies:
+      provides:
+        - openjdk-jmods=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-13-openjdk

--- a/openjdk-14.yaml
+++ b/openjdk-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-14
   version: 14.0.2.12
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: GPL-2.0-only
@@ -57,9 +57,15 @@ pipeline:
 
   - runs: chmod +x configure
 
+  # Note that despite using --with-extra-cflags, --with-extra-cxxflags, and
+  # --with-extra-ldflags, the configure still produces warnings like:
+  # https://github.com/wolfi-dev/os/issues/18747
   - uses: autoconf/configure
     with:
       opts: |
+        --with-extra-cflags="$CFLAGS" \
+        --with-extra-cxxflags="$CXXFLAGS" \
+        --with-extra-ldflags="$LDFLAGS" \
         --with-boot-jdk=/usr/lib/jvm/java-13-openjdk \
         --prefix=/usr/lib/jvm/java-14-openjdk \
         --with-vendor-name=wolfi \
@@ -170,6 +176,9 @@ subpackages:
 
   - name: "openjdk-14-jmods"
     description: "OpenJDK 14 jmods"
+    dependencies:
+      provides:
+        - openjdk-jmods=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-14-openjdk

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-15
   version: 15.0.10.5
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: GPL-2.0-only
@@ -64,6 +64,9 @@ pipeline:
 
   - runs: chmod +x configure
 
+  # Note that despite using --with-extra-cflags, --with-extra-cxxflags, and
+  # --with-extra-ldflags, the configure still produces warnings like:
+  # https://github.com/wolfi-dev/os/issues/18747
   - uses: autoconf/configure
     with:
       opts: |
@@ -177,6 +180,9 @@ subpackages:
 
   - name: "openjdk-15-jmods"
     description: "OpenJDK 15 jmods"
+    dependencies:
+      provides:
+        - openjdk-jmods=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-15-openjdk

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-16
   version: 16.0.2.7
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: GPL-2.0-only
@@ -64,9 +64,15 @@ pipeline:
 
   - runs: chmod +x configure
 
+  # Note that despite using --with-extra-cflags, --with-extra-cxxflags, and
+  # --with-extra-ldflags, the configure still produces warnings like:
+  # https://github.com/wolfi-dev/os/issues/18747
   - uses: autoconf/configure
     with:
       opts: |
+        --with-extra-cflags="$CFLAGS" \
+        --with-extra-cxxflags="$CXXFLAGS" \
+        --with-extra-ldflags="$LDFLAGS" \
         --with-boot-jdk=/usr/lib/jvm/java-15-openjdk \
         --prefix=/usr/lib/jvm/java-16-openjdk \
         --with-vendor-name=wolfi \
@@ -177,6 +183,9 @@ subpackages:
 
   - name: "openjdk-16-jmods"
     description: "OpenJDK 16 jmods"
+    dependencies:
+      provides:
+        - openjdk-jmods=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-16-openjdk


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

Related to: https://github.com/wolfi-dev/os/issues/18747 for 12-16.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
