### PR TITLE
Be safer with here docs in docker-run and lint-world actions.

### DIFF
--- a/.github/actions/docker-run/action.yaml
+++ b/.github/actions/docker-run/action.yaml
@@ -39,7 +39,7 @@ runs:
           -e GOOGLE_GHA_CREDS_PATH=${GOOGLE_GHA_CREDS_PATH} \
           -i \
           ${{ inputs.opts }} \
-          ${{ inputs.image }} <<EOF
+          ${{ inputs.image }} <<"_END_DOCKER_RUN"
         set -e
         ${{ inputs.run }}
-        EOF
+        _END_DOCKER_RUN

--- a/.github/workflows/build-beta.yaml
+++ b/.github/workflows/build-beta.yaml
@@ -75,7 +75,7 @@ jobs:
 
             # This is to avoid fatal errors about "dubious ownership" because we are
             # running inside of a container action with the workspace mounted in.
-            git config --global --add safe.directory "\$(pwd)"
+            git config --global --add safe.directory "$PWD"
 
             make local-melange.rsa
 

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -145,8 +145,8 @@ jobs:
 
             mkdir -p .melangecache
             for package in ${{needs.changes.outputs.packages}}; do
-              make MELANGE_EXTRA_OPTS="--create-build-log --cache-dir=.melangecache" REPO="./packages" package/\$package -j1
-              make MELANGE_EXTRA_OPTS="--runner docker" REPO="./packages" "test/\$package" -j1
+              make MELANGE_EXTRA_OPTS="--create-build-log --cache-dir=.melangecache" REPO="./packages" package/$package -j1
+              make MELANGE_EXTRA_OPTS="--runner docker" REPO="./packages" "test/$package" -j1
             done
 
       - name: "Check that packages can be installed with apk add"
@@ -165,9 +165,9 @@ jobs:
             apk update --root /tmp/emptyroot
 
             # Find .apk files and add them to the string
-            for f in \$(find packages -name '*.apk'); do
-                tar -Oxf \$f .PKGINFO
-                apk add --root /tmp/emptyroot --repository "./packages" --allow-untrusted --simulate \$f
+            for f in $(find packages -name '*.apk'); do
+                tar -Oxf "$f" .PKGINFO
+                apk add --root /tmp/emptyroot --repository "./packages" --allow-untrusted --simulate "$f"
             done
 
       - name: Reset file permissions
@@ -179,9 +179,9 @@ jobs:
         with:
           run: |
             apk add py3-ntia-conformance-checker spdx-tools-java
-            for f in \$(find packages -name '*.apk'); do
-                echo ==== Checking SBOM for \$f ====
-                tar -Oxf \$f var/lib/db/sbom/ > sbom.json
+            for f in $(find packages -name '*.apk'); do
+                echo "==== Checking SBOM for $f ===="
+                tar -Oxf "$f" var/lib/db/sbom/ > sbom.json
                 echo ::group::sbom.json
                 cat sbom.json
                 echo ::endgroup::

--- a/.github/workflows/lint-world.yaml
+++ b/.github/workflows/lint-world.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Setup k8s runner configs
         run: |
-          cat > .melange.k8s.yaml <<EOF
+          cat > .melange.k8s.yaml <<"_END_MELANGE_YAML"
           provider: gke
           repo: gcr.io/${{ env.EPHEMERAL_BUILD_PROJECT_ID }}/world-builds
           # Fully utilize {t2a,n2d}-standard-44
@@ -116,7 +116,7 @@ jobs:
                           # it's really annoying to make it all the way through only to
                           # fill up the disk at the end
                           storage: 15Gi
-          EOF
+          _END_MELANGE_YAML
 
       - name: Create ephemeral build cluster
         run: |


### PR DESCRIPTION
This allows the user of docker-run action to not have to worry that their document will be parsed by 2 shells.

from https://manpages.ubuntu.com/manpages/noble/en/man1/bash.1.html

> If any part of word is quoted, the delimiter  is the  result of quote
> removal on word, and the lines in the here-document are not expanded.
> If word is unquoted, all lines of the here-document are subjected to
> parameter  expansion, command  substitution,  and  arithmetic
> expansion,  the  character sequence \<newline> is ignored, and \ must be
> used to quote the characters \, $, and `.

What that sums up to is that there is less interpretation on the here document when using `<<"EOF"` than when using `<<EOF`.

