### PR TITLE
adds some needed scripts for keycloak-operator

### DIFF
--- a/keycloak-operator.yaml
+++ b/keycloak-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-operator
   version: 24.0.4
-  epoch: 1
+  epoch: 2
   description: A Kubernetes Operator based on the Operator SDK for installing and managing Keycloak.
   copyright:
     - license: Apache-2.0
@@ -40,10 +40,24 @@ pipeline:
 
 subpackages:
   - name: keycloak-operator-compat
+    dependencies:
+      runtime:
+        - keycloak
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/opt/
-          ln -s /usr/share/java/quarkus-app/ "${{targets.subpkgdir}}"/opt/keycloak
+          mkdir -p "${{targets.subpkgdir}}"/opt/keycloak
+
+          # Create symbolic links for the contents of quarkus-app in /opt/keycloak
+          for item in /usr/share/java/quarkus-app/*; do
+            ln -sf "$item" "${{targets.subpkgdir}}"/opt/keycloak/$(basename "$item")
+          done
+
+          # Operator expects kc.sh in /opt/keycloak/bin as its hardcoded here
+          # https://github.com/keycloak/keycloak/blob/1d613d90378e486f661117e66840cacd37448107/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportJobDependentResource.java#L134
+          mkdir -p "${{targets.subpkgdir}}"/opt/keycloak/bin
+          for i in kc.sh kcadm.sh kcreg.sh; do
+            ln -sf /usr/share/java/keycloak/bin/$i "${{targets.subpkgdir}}"/opt/keycloak/bin/$i
+          done
 
 test:
   pipeline:

--- a/keycloak-operator.yaml
+++ b/keycloak-operator.yaml
@@ -42,21 +42,18 @@ subpackages:
   - name: keycloak-operator-compat
     dependencies:
       runtime:
-        - keycloak
+        - keycloak-scripts
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/opt/keycloak
 
-          # Create symbolic links for the contents of quarkus-app in /opt/keycloak
-          for item in /usr/share/java/quarkus-app/*; do
-            ln -sf "$item" "${{targets.subpkgdir}}"/opt/keycloak/$(basename "$item")
-          done
-
+          # Copy the contents of quarkus-app into /opt/keycloak
+          cp -r "${{targets.destdir}}"/usr/share/java/quarkus-app/* "${{targets.subpkgdir}}"/opt/keycloak/
           # Operator expects kc.sh in /opt/keycloak/bin as its hardcoded here
           # https://github.com/keycloak/keycloak/blob/1d613d90378e486f661117e66840cacd37448107/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportJobDependentResource.java#L134
           mkdir -p "${{targets.subpkgdir}}"/opt/keycloak/bin
           for i in kc.sh kcadm.sh kcreg.sh; do
-            ln -sf /usr/share/java/keycloak/bin/$i "${{targets.subpkgdir}}"/opt/keycloak/bin/$i
+            ln -sf /usr/bin/$i "${{targets.subpkgdir}}"/opt/keycloak/bin/$i
           done
 
 test:

--- a/keycloak-operator.yaml
+++ b/keycloak-operator.yaml
@@ -47,8 +47,11 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/opt/keycloak
 
-          # Copy the contents of quarkus-app into /opt/keycloak
+          # Copy the contents of quarkus-app into /opt/keycloak since symlink failed as that led to directory of quarkus-app itself being copied
+          # rather than its contents. If I still try to symlink with "${{targets.subpkgdir}}"/opt/keycloak, it fails to find keycloak directory for
+          # for the contents of `bin` to be symlinked below, so we resolved to this way
           cp -r "${{targets.destdir}}"/usr/share/java/quarkus-app/* "${{targets.subpkgdir}}"/opt/keycloak/
+
           # Operator expects kc.sh in /opt/keycloak/bin as its hardcoded here
           # https://github.com/keycloak/keycloak/blob/1d613d90378e486f661117e66840cacd37448107/operator/src/main/java/org/keycloak/operator/controllers/KeycloakRealmImportJobDependentResource.java#L134
           mkdir -p "${{targets.subpkgdir}}"/opt/keycloak/bin

--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -1,13 +1,14 @@
 package:
   name: keycloak
   version: 24.0.4
-  epoch: 1
+  epoch: 2
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - bash # Keycloak helper scripts require bash, aren't compatible with busybox.
+      - keycloak-scripts # Separate package for these scripts as they might be reused by other packages like keycloak-operator
       - openjdk-17-default-jvm
 
 environment:
@@ -49,11 +50,6 @@ pipeline:
       unzip -d ${{targets.destdir}}/usr/share/java quarkus/dist/target/keycloak-*.zip
       mv ${{targets.destdir}}/usr/share/java/keycloak-* ${{targets.destdir}}/usr/share/java/keycloak
 
-      mkdir -p ${{targets.destdir}}/usr/bin
-      for i in kc.sh kcadm.sh kcreg.sh; do
-        ln -sf /usr/share/java/keycloak/bin/$i ${{targets.destdir}}/usr/bin/$i
-      done
-
 # images like keycloak-operator may need it as they expect it to find keycloak in /opt/keycloak
 # For ref: https://github.com/keycloak/keycloak/blob/4b194d00bed51458acb3d125eba9a0ba654c930a/operator/Dockerfile#L11
 subpackages:
@@ -62,6 +58,13 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/opt
           ln -s /usr/share/java/keycloak "${{targets.subpkgdir}}"/opt/
+  - name: keycloak-scripts
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          for i in kc.sh kcadm.sh kcreg.sh; do
+            cp ${{targets.destdir}}/usr/share/java/keycloak/bin/$i ${{targets.subpkgdir}}/usr/bin/$i
+          done
 
 test:
   pipeline:

--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -63,7 +63,7 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           for i in kc.sh kcadm.sh kcreg.sh; do
-            cp ${{targets.destdir}}/usr/share/java/keycloak/bin/$i ${{targets.subpkgdir}}/usr/bin/$i
+            ln -sf /usr/share/java/keycloak/bin/$i ${{targets.subpkgdir}}/usr/bin/$i
           done
 
 test:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
