### PR TITLE
Add LDFLAGS to a list of Go packages

### DIFF
--- a/amass.yaml
+++ b/amass.yaml
@@ -1,7 +1,7 @@
 package:
   name: amass
   version: 4.2.0
-  epoch: 8
+  epoch: 9
   description: "attack surfaces and external asset discovery tools set"
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,7 @@ pipeline:
       packages: ./cmd/amass
       modroot: .
       output: amass
+      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,7 +1,7 @@
 package:
   name: buf
   version: 1.31.0
-  epoch: 2
+  epoch: 3
   description: A new way of working with Protocol Buffers.
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,7 @@ pipeline:
       packages: ./cmd/buf
       modroot: .
       output: buf
+      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/controller-gen.yaml
+++ b/controller-gen.yaml
@@ -1,7 +1,7 @@
 package:
   name: controller-gen
   version: 0.15.0
-  epoch: 2
+  epoch: 3
   description: Tools to use with the controller-runtime libraries
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,7 @@ pipeline:
       packages: ./cmd/controller-gen
       modroot: .
       output: controller-gen
+      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/fq.yaml
+++ b/fq.yaml
@@ -1,7 +1,7 @@
 package:
   name: fq
   version: 0.11.0
-  epoch: 2
+  epoch: 3
   description: "jq for binary formats - tool, language and decoders for working with binary and text formats"
   copyright:
     - license: MIT
@@ -18,6 +18,7 @@ pipeline:
       packages: ./
       modroot: .
       output: fq
+      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/gcsfuse.yaml
+++ b/gcsfuse.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcsfuse
   version: 1.4.2
-  epoch: 5
+  epoch: 6
   description: A user-space file system for interacting with Google Cloud Storage
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,7 @@ pipeline:
       packages: .
       modroot: .
       output: gcsfuse
+      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/gobuster.yaml
+++ b/gobuster.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobuster
   version: 3.6.0
-  epoch: 9
+  epoch: 10
   description: "a tool used to brute force attack for URIs, DNS, etc."
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,7 @@ pipeline:
       packages: .
       modroot: .
       output: gobuster
+      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/goreleaser-1.18.yaml
+++ b/goreleaser-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: goreleaser-1.18
   version: 1.18.2
-  epoch: 9
+  epoch: 10
   description: Deliver Go binaries as fast and easily as possible
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,7 @@ pipeline:
       packages: .
       modroot: .
       output: goreleaser
+      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,7 +1,7 @@
 package:
   name: goreleaser
   version: 1.26.0
-  epoch: 1
+  epoch: 2
   description: Deliver Go binaries as fast and easily as possible
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,7 @@ pipeline:
       packages: .
       modroot: .
       output: goreleaser
+      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/nsc.yaml
+++ b/nsc.yaml
@@ -1,7 +1,7 @@
 package:
   name: nsc
   version: 2.8.6
-  epoch: 4
+  epoch: 5
   description: Tool for creating nkey/jwt based configurations
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,7 @@ pipeline:
       packages: .
       modroot: .
       output: nsc
+      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/sbom-scorecard.yaml
+++ b/sbom-scorecard.yaml
@@ -1,7 +1,7 @@
 package:
   name: sbom-scorecard
   version: 0.0.7
-  epoch: 10
+  epoch: 11
   description: Generate a score for your sbom to understand if it will actually be useful.
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,7 @@ pipeline:
       packages: ./cmd/sbom-scorecard
       modroot: .
       output: sbom-scorecard
+      ldflags: -w -X github.com/eBay/sbom-scorecard.version=${{package.version}} -X github.com/eBay/sbom-scorecard.commit=$(git rev-parse HEAD) -X github.com/eBay/sbom-scorecard.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/sbomqs.yaml
+++ b/sbomqs.yaml
@@ -1,7 +1,7 @@
 package:
   name: sbomqs
   version: 0.1.3
-  epoch: 2
+  epoch: 3
   description: SBOM quality score - Quality metrics for your sboms
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ pipeline:
       packages: .
       modroot: .
       output: sbomqs
+      ldflags: -w -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}} -X sigs.k8s.io/release-utils/version.gitCommit=$(git rev-parse HEAD) -X sigs.k8s.io/release-utils/version.buildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/slsa-verifier.yaml
+++ b/slsa-verifier.yaml
@@ -1,7 +1,7 @@
 package:
   name: slsa-verifier
   version: 2.5.1
-  epoch: 4
+  epoch: 5
   description: Verify provenance from SLSA compliant builders
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,7 @@ pipeline:
       packages: ./cli/slsa-verifier
       modroot: .
       output: slsa-verifier
+      ldflags: -w -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}} -X sigs.k8s.io/release-utils/version.gitCommit=$(git rev-parse HEAD) -X sigs.k8s.io/release-utils/version.buildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/supercronic.yaml
+++ b/supercronic.yaml
@@ -1,7 +1,7 @@
 package:
   name: supercronic
   version: 0.2.29
-  epoch: 5
+  epoch: 6
   description: Cron for containers
   copyright:
     - license: MIT
@@ -26,6 +26,7 @@ pipeline:
       packages: .
       modroot: .
       output: supercronic
+      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/vexctl.yaml
+++ b/vexctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: vexctl
   version: 0.2.6
-  epoch: 4
+  epoch: 5
   description: A tool to create, transform and attest VEX metadata
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ pipeline:
       packages: .
       modroot: .
       output: vexctl
+      ldflags: -w -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}} -X sigs.k8s.io/release-utils/version.gitCommit=$(git rev-parse HEAD) -X sigs.k8s.io/release-utils/version.buildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 


### PR DESCRIPTION
We converted some go/install pipelines to git-checkout + go/bump and forgot to set these flags to get the version info.