### PR TITLE
override the stage3 entrypoint

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent
   version: 7.53.0
-  epoch: 3
+  epoch: 4
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -253,6 +253,10 @@ subpackages:
 
           mkdir -p ${{targets.subpkgdir}}/
           tar -xvzf s6-overlay.tgz -C ${{targets.subpkgdir}}/
+
+          # Since this is essentially a hard fork only for datadog, we can do this without issue
+          # https://github.com/DataDog/datadog-agent/blob/f20521b4b0b05ad83314e3fc353ecbbe7e3e69a0/Dockerfiles/agent/Dockerfile#L200
+          mv ${{targets.subpkgdir}}/etc/s6/init/init-stage3 ${{targets.subpkgdir}}/etc/s6/init/init-stage3-original
 
 update:
   enabled: true


### PR DESCRIPTION
datadog's fork of s6-overlay relies on a custom `init-stage3` that is just a ternary for various stage3's depending on the arg passed to it:

```
#!/bin/bash
set -euo pipefail

if [[ $$ == 1 ]]; then
    exec /etc/s6/init/init-stage3-original
else
    exec /etc/s6/init/init-stage3-host-pid
fi
```

turns out this is important for the images entrypoints