### PR TITLE
fix: qt6-qtbase

### DIFF
--- a/qt6-qtbase.yaml
+++ b/qt6-qtbase.yaml
@@ -3,7 +3,7 @@
 package:
   name: qt6-qtbase
   version: 6.7.0
-  epoch: 0
+  epoch: 1
   description: qt
   copyright:
     - license: LGPL-3.0-or-later
@@ -97,18 +97,24 @@ subpackages:
   - name: qt6-qtbase-x11
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/qt6/plugins
           mv ${{targets.destdir}}/usr/lib/libQt6EglFSDeviceIntegration.so.* ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libQt6EglFsKms*Support.so.* ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libQt6Gui.so.* ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libQt6OpenGL*.so.* ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libQt6PrintSupport.so.* ${{targets.subpkgdir}}/usr/lib
           mv ${{targets.destdir}}/usr/lib/libQt6Widgets.so.* ${{targets.subpkgdir}}/usr/lib
-          mv ${{targets.destdir}}/usr/lib/qt6/plugins/egldeviceintegrations ${{targets.subpkgdir}}/usr/lib
-          mv ${{targets.destdir}}/usr/lib/qt6/plugins/generic ${{targets.subpkgdir}}/usr/lib
-          mv ${{targets.destdir}}/usr/lib/qt6/plugins/image* ${{targets.subpkgdir}}/usr/lib
-          mv ${{targets.destdir}}/usr/lib/qt6/plugins/platform* ${{targets.subpkgdir}}/usr/lib
-          mv ${{targets.destdir}}/usr/lib/qt6/plugins/printsupport* ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/qt6/plugins/egldeviceintegrations ${{targets.subpkgdir}}/usr/lib/qt6/plugins
+          mv ${{targets.destdir}}/usr/lib/qt6/plugins/generic ${{targets.subpkgdir}}/usr/lib/qt6/plugins
+          mv ${{targets.destdir}}/usr/lib/qt6/plugins/image* ${{targets.subpkgdir}}/usr/lib/qt6/plugins
+          mv ${{targets.destdir}}/usr/lib/qt6/plugins/platform* ${{targets.subpkgdir}}/usr/lib/qt6/plugins
+          mv ${{targets.destdir}}/usr/lib/qt6/plugins/printsupport* ${{targets.subpkgdir}}/usr/lib/qt6/plugins
+
+          cd "${{targets.subpkgdir}}/usr/lib/qt6/plugins"
+          find . -name "*.so" -type f | while read -r file; do
+              directory=$(dirname "$file")
+              ln -sf /usr/lib/qt6/plugins/${directory#./}/$(basename "$file") "${{targets.subpkgdir}}/usr/lib/$(basename "$file")"
+          done
 
   - name: qt6-qtbase-doc
     pipeline:


### PR DESCRIPTION
I'm working on opencv compilation, I discover when use `qt6-qtbase-x11` as buildtime dependency the plugins have to be under `/usr/lib/qt6/plugins` directory.

So I update the location and generate the symbolic links over `/usr/lib`.

Here is an error message example:
```terminal
CMake Error at /usr/lib64/cmake/Qt6Gui/Qt6QComposePlatformInputContextPluginTargets.cmake:98 (message):
  The imported target "Qt6::QComposePlatformInputContextPlugin" references
  the file

     "/usr/lib/qt6/plugins/platforminputcontexts/libcomposeplatforminputcontextplugin.so"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "/usr/lib64/cmake/Qt6Gui/Qt6QComposePlatformInputContextPluginTargets.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  /usr/lib64/cmake/Qt6Gui/Qt6QComposePlatformInputContextPluginConfig.cmake:64 (include)
  /usr/lib/cmake/Qt6/QtPublicPluginHelpers.cmake:518 (include)
  /usr/lib64/cmake/Qt6Gui/Qt6GuiPlugins.cmake:13 (__qt_internal_include_plugin_packages)
  /usr/lib64/cmake/Qt6Gui/Qt6GuiConfig.cmake:148 (include)
  /usr/lib64/cmake/Qt6/Qt6Config.cmake:177 (find_package)
  cmake/OpenCVFindLibsGUI.cmake:17 (find_package)
  cmake/OpenCVFindLibsGUI.cmake:32 (ocv_find_package_Qt)
  CMakeLists.txt:810 (include)
```

@dlorenc 