### PR TITLE
chore: remove redundant ldflags

### DIFF
--- a/amass.yaml
+++ b/amass.yaml
@@ -1,7 +1,7 @@
 package:
   name: amass
   version: 4.2.0
-  epoch: 9
+  epoch: 10
   description: "attack surfaces and external asset discovery tools set"
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
       packages: ./cmd/amass
       modroot: .
       output: amass
-      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,7 +1,7 @@
 package:
   name: atlantis
   version: 0.27.3
-  epoch: 1
+  epoch: 2
   description: Terraform Pull Request Automation
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,7 @@ pipeline:
       modroot: .
       packages: .
       output: atlantis
-      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,7 +1,7 @@
 package:
   name: buf
   version: 1.31.0
-  epoch: 3
+  epoch: 4
   description: A new way of working with Protocol Buffers.
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,7 @@ pipeline:
       packages: ./cmd/buf
       modroot: .
       output: buf
-      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/cloud-sql-proxy.yaml
+++ b/cloud-sql-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloud-sql-proxy
   version: 2.11.0
-  epoch: 2
+  epoch: 3
   description: The Cloud SQL Auth Proxy is a utility for ensuring secure connections to your Cloud SQL instances
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,7 @@ pipeline:
     with:
       packages: .
       output: cloud-sql-proxy
-      ldflags: -w -X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container
+      ldflags: -X github.com/GoogleCloudPlatform/cloud-sql-proxy/v2/cmd.metadataString=container
 
   - uses: strip
 

--- a/conftest.yaml
+++ b/conftest.yaml
@@ -1,7 +1,7 @@
 package:
   name: conftest
   version: 0.52.0
-  epoch: 1
+  epoch: 2
   description: Write tests against structured configuration data using the Open Policy Agent Rego query language
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -w -s -X github.com/open-policy-agent/conftest/internal/commands.version=${{package.version}}
+      ldflags: -X github.com/open-policy-agent/conftest/internal/commands.version=${{package.version}}
       modroot: .
       output: conftest
       packages: .

--- a/controller-gen.yaml
+++ b/controller-gen.yaml
@@ -1,7 +1,7 @@
 package:
   name: controller-gen
   version: 0.15.0
-  epoch: 3
+  epoch: 4
   description: Tools to use with the controller-runtime libraries
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,7 @@ pipeline:
       packages: ./cmd/controller-gen
       modroot: .
       output: controller-gen
-      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane
   version: 1.15.2
-  epoch: 1
+  epoch: 2
   description: Cloud Native Control Planes
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,6 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -w
       output: crossplane
       packages: ./cmd/crossplane
 
@@ -44,7 +43,6 @@ subpackages:
           deps: github.com/go-git/go-git/v5@v5.11.0
       - uses: go/build
         with:
-          ldflags: -w
           output: crank
           packages: ./cmd/crank
           subpackage: "true"

--- a/cue.yaml
+++ b/cue.yaml
@@ -1,7 +1,7 @@
 package:
   name: cue
   version: 0.8.2
-  epoch: 1
+  epoch: 2
   description: The home of the CUE language! Validate and define text-based and dynamic configuration
   copyright:
     - license: Apache-2.0
@@ -34,7 +34,7 @@ pipeline:
       modroot: .
       packages: ./cmd/cue
       output: cue
-      ldflags: -w -buildid= -X cuelang.org/go/cmd/cue/cmd.version=${{package.version}}
+      ldflags: -buildid= -X cuelang.org/go/cmd/cue/cmd.version=${{package.version}}
 
   - uses: strip
 

--- a/dive.yaml
+++ b/dive.yaml
@@ -1,7 +1,7 @@
 package:
   name: dive
   version: 0.12.0
-  epoch: 5
+  epoch: 6
   description: A tool for exploring each layer in a docker image
   copyright:
     - license: MIT
@@ -30,7 +30,7 @@ pipeline:
     with:
       packages: .
       output: dive
-      ldflags: -w -X main.version=v${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.buildTime=$(date +%F-%T)
+      ldflags: -X main.version=v${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.buildTime=$(date +%F-%T)
 
   - uses: strip
 

--- a/fq.yaml
+++ b/fq.yaml
@@ -1,7 +1,7 @@
 package:
   name: fq
   version: 0.11.0
-  epoch: 3
+  epoch: 4
   description: "jq for binary formats - tool, language and decoders for working with binary and text formats"
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ pipeline:
       packages: ./
       modroot: .
       output: fq
-      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/gcsfuse.yaml
+++ b/gcsfuse.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcsfuse
   version: 1.4.2
-  epoch: 6
+  epoch: 7
   description: A user-space file system for interacting with Google Cloud Storage
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ pipeline:
       packages: .
       modroot: .
       output: gcsfuse
-      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/gitlab-logger.yaml
+++ b/gitlab-logger.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitlab-logger
   version: 3.0.0
-  epoch: 7
+  epoch: 8
   description: GitLab Logger provides a means of wrapping non-structured log files within structure JSON.
   copyright:
     - license: MIT
@@ -21,7 +21,6 @@ pipeline:
     with:
       packages: ./cmd/gitlab-logger
       output: gitlab-logger
-      ldflags: -w
 
   - uses: strip
 

--- a/go-bindata.yaml
+++ b/go-bindata.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-bindata
   version: 3.1.3
-  epoch: 19
+  epoch: 20
   description: A small utility which generates Go code from any file
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,6 @@ pipeline:
     with:
       packages: ./go-bindata
       output: go-bindata
-      ldflags: -w
 
   - uses: strip
 

--- a/gobuster.yaml
+++ b/gobuster.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobuster
   version: 3.6.0
-  epoch: 10
+  epoch: 11
   description: "a tool used to brute force attack for URIs, DNS, etc."
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
       packages: .
       modroot: .
       output: gobuster
-      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/goreleaser-1.18.yaml
+++ b/goreleaser-1.18.yaml
@@ -1,7 +1,7 @@
 package:
   name: goreleaser-1.18
   version: 1.18.2
-  epoch: 10
+  epoch: 11
   description: Deliver Go binaries as fast and easily as possible
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ pipeline:
       packages: .
       modroot: .
       output: goreleaser
-      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,7 +1,7 @@
 package:
   name: goreleaser
   version: 1.26.0
-  epoch: 2
+  epoch: 3
   description: Deliver Go binaries as fast and easily as possible
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
       packages: .
       modroot: .
       output: goreleaser
-      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/gostatsd.yaml
+++ b/gostatsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: gostatsd
   version: 28.3.0
-  epoch: 2
+  epoch: 3
   description: An implementation of Etsy's statsd in Go with tags support
   copyright:
     - license: MIT
@@ -25,7 +25,7 @@ pipeline:
     with:
       output: gostatsd
       packages: ./cmd/gostatsd
-      ldflags: -w -X main.Version=${{package.version}} -X main.GitCommit=$(git rev-parse HEAD) -X main.BuildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X main.Version=${{package.version}} -X main.GitCommit=$(git rev-parse HEAD) -X main.BuildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/grype.yaml
+++ b/grype.yaml
@@ -1,7 +1,7 @@
 package:
   name: grype
   version: 0.77.4
-  epoch: 0
+  epoch: 1
   description: Vulnerability scanner for container images, filesystems, and SBOMs
   copyright:
     - license: Apache-2.0
@@ -19,7 +19,7 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -w -X main.version=${{package.version}}
+      ldflags: -X main.version=${{package.version}}
       output: grype
       packages: ./cmd/grype
 

--- a/guac.yaml
+++ b/guac.yaml
@@ -1,7 +1,7 @@
 package:
   name: guac
   version: 0.6.0
-  epoch: 1
+  epoch: 2
   description: GUAC aggregates software security metadata into a high fidelity graph database.
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ pipeline:
     with:
       packages: ./cmd/guaccollect
       output: guaccollect
-      ldflags: -w -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
+      ldflags: -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
 
   - uses: strip
 
@@ -34,7 +34,7 @@ subpackages:
     pipeline:
       - uses: go/build
         with:
-          ldflags: -w -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
+          ldflags: -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
           packages: ./cmd/guacingest
           output: guacingest
       - uses: strip
@@ -43,7 +43,7 @@ subpackages:
     pipeline:
       - uses: go/build
         with:
-          ldflags: -w -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
+          ldflags: -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
           packages: ./cmd/guacone
           output: guacone
       - uses: strip
@@ -52,7 +52,7 @@ subpackages:
     pipeline:
       - uses: go/build
         with:
-          ldflags: -w -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
+          ldflags: -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
           packages: ./cmd/guacgql
           output: guacgql
       - uses: strip
@@ -61,7 +61,7 @@ subpackages:
     pipeline:
       - uses: go/build
         with:
-          ldflags: -w -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
+          ldflags: -X github.com/guacsec/guac/pkg/version.Version=${{package.version}}
           packages: ./cmd/guaccsub
           output: guaccsub
       - uses: strip

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.15.2
-  epoch: 9
+  epoch: 10
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,7 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -w -X github.com/google/ko/pkg/commands.Version=${{package.version}}
+      ldflags: -X github.com/google/ko/pkg/commands.Version=${{package.version}}
       modroot: ko
       output: ko
       packages: .

--- a/kor.yaml
+++ b/kor.yaml
@@ -1,7 +1,7 @@
 package:
   name: kor
   version: 0.4.0
-  epoch: 0
+  epoch: 1
   description: A Golang Tool to discover unused Kubernetes Resources
   copyright:
     - license: MIT
@@ -17,7 +17,6 @@ pipeline:
     with:
       modroot: .
       packages: .
-      ldflags: -w
       output: kor
 
   - uses: strip

--- a/nats.yaml
+++ b/nats.yaml
@@ -1,7 +1,7 @@
 package:
   name: nats
   version: 0.1.4
-  epoch: 3
+  epoch: 4
   description: The NATS Command Line Interface.
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,6 @@ pipeline:
       packages: .
       output: nats
       modroot: nats
-      ldflags: -w
 
   - uses: strip
 

--- a/nsc.yaml
+++ b/nsc.yaml
@@ -1,7 +1,7 @@
 package:
   name: nsc
   version: 2.8.6
-  epoch: 5
+  epoch: 6
   description: Tool for creating nkey/jwt based configurations
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
       packages: .
       modroot: .
       output: nsc
-      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/sbom-scorecard.yaml
+++ b/sbom-scorecard.yaml
@@ -1,7 +1,7 @@
 package:
   name: sbom-scorecard
   version: 0.0.7
-  epoch: 11
+  epoch: 12
   description: Generate a score for your sbom to understand if it will actually be useful.
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
       packages: ./cmd/sbom-scorecard
       modroot: .
       output: sbom-scorecard
-      ldflags: -w -X github.com/eBay/sbom-scorecard.version=${{package.version}} -X github.com/eBay/sbom-scorecard.commit=$(git rev-parse HEAD) -X github.com/eBay/sbom-scorecard.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X github.com/eBay/sbom-scorecard.version=${{package.version}} -X github.com/eBay/sbom-scorecard.commit=$(git rev-parse HEAD) -X github.com/eBay/sbom-scorecard.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/sbomqs.yaml
+++ b/sbomqs.yaml
@@ -1,7 +1,7 @@
 package:
   name: sbomqs
   version: 0.1.3
-  epoch: 3
+  epoch: 4
   description: SBOM quality score - Quality metrics for your sboms
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ pipeline:
       packages: .
       modroot: .
       output: sbomqs
-      ldflags: -w -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}} -X sigs.k8s.io/release-utils/version.gitCommit=$(git rev-parse HEAD) -X sigs.k8s.io/release-utils/version.buildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}} -X sigs.k8s.io/release-utils/version.gitCommit=$(git rev-parse HEAD) -X sigs.k8s.io/release-utils/version.buildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/slsa-verifier.yaml
+++ b/slsa-verifier.yaml
@@ -1,7 +1,7 @@
 package:
   name: slsa-verifier
   version: 2.5.1
-  epoch: 5
+  epoch: 6
   description: Verify provenance from SLSA compliant builders
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
       packages: ./cli/slsa-verifier
       modroot: .
       output: slsa-verifier
-      ldflags: -w -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}} -X sigs.k8s.io/release-utils/version.gitCommit=$(git rev-parse HEAD) -X sigs.k8s.io/release-utils/version.buildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}} -X sigs.k8s.io/release-utils/version.gitCommit=$(git rev-parse HEAD) -X sigs.k8s.io/release-utils/version.buildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
 update:
   enabled: true

--- a/step-kms-plugin.yaml
+++ b/step-kms-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: step-kms-plugin
   version: 0.11.1
-  epoch: 1
+  epoch: 2
   description: step plugin to manage keys and certificates on a cloud KMSs and HSMs
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ pipeline:
     with:
       packages: ./cmd
       output: step-kms-plugin
-      ldflags: -w -X "main.Version=${{package.version}}"
+      ldflags: -X "main.Version=${{package.version}}"
 
   - uses: strip
 

--- a/supercronic.yaml
+++ b/supercronic.yaml
@@ -1,7 +1,7 @@
 package:
   name: supercronic
   version: 0.2.29
-  epoch: 6
+  epoch: 7
   description: Cron for containers
   copyright:
     - license: MIT
@@ -26,7 +26,7 @@ pipeline:
       packages: .
       modroot: .
       output: supercronic
-      ldflags: -w -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X main.version=${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/syft.yaml
+++ b/syft.yaml
@@ -1,7 +1,7 @@
 package:
   name: syft
   version: 1.4.1
-  epoch: 0
+  epoch: 1
   description: CLI tool and library for generating a Software Bill of Materials from container images and filesystems
   copyright:
     - license: Apache-2.0
@@ -19,7 +19,7 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -w -X main.version=${{package.version}}
+      ldflags: -X main.version=${{package.version}}
       output: syft
       packages: ./cmd/syft
 

--- a/trillian.yaml
+++ b/trillian.yaml
@@ -1,7 +1,7 @@
 package:
   name: trillian
   version: 1.6.0
-  epoch: 5
+  epoch: 6
   description: Merkle tree implementation used in Sigstore
   copyright:
     - license: Apache-2.0
@@ -35,7 +35,6 @@ subpackages:
           subpackage: "true"
           packages: ./cmd/trillian_log_server
           output: trillian_log_server
-          ldflags: -w
       - uses: strip
 
   - name: ${{package.name}}-logsigner
@@ -46,7 +45,6 @@ subpackages:
           subpackage: "true"
           packages: ./cmd/trillian_log_signer
           output: trillian_log_signer
-          ldflags: -w
       - uses: strip
 
 update:

--- a/vertical-pod-autoscaler.yaml
+++ b/vertical-pod-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: vertical-pod-autoscaler
   version: 1.1.1
-  epoch: 2
+  epoch: 3
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,6 @@ pipeline:
     with:
       modroot: vertical-pod-autoscaler
       packages: ./pkg/admission-controller
-      ldflags: -w
       output: admission-controller
 
   - uses: go/bump
@@ -42,14 +41,12 @@ pipeline:
     with:
       modroot: vertical-pod-autoscaler
       packages: ./pkg/updater
-      ldflags: -w
       output: updater
 
   - uses: go/build
     with:
       modroot: vertical-pod-autoscaler
       packages: ./pkg/recommender
-      ldflags: -w
       output: recommender
       vendor: "true"
 

--- a/vexctl.yaml
+++ b/vexctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: vexctl
   version: 0.2.6
-  epoch: 5
+  epoch: 6
   description: A tool to create, transform and attest VEX metadata
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ pipeline:
       packages: .
       modroot: .
       output: vexctl
-      ldflags: -w -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}} -X sigs.k8s.io/release-utils/version.gitCommit=$(git rev-parse HEAD) -X sigs.k8s.io/release-utils/version.buildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
+      ldflags: -X sigs.k8s.io/release-utils/version.gitVersion=${{package.version}} -X sigs.k8s.io/release-utils/version.gitCommit=$(git rev-parse HEAD) -X sigs.k8s.io/release-utils/version.buildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")
 
   - uses: strip
 

--- a/wave.yaml
+++ b/wave.yaml
@@ -1,7 +1,7 @@
 package:
   name: wave
   version: 0.8.0
-  epoch: 1
+  epoch: 2
   description: Kubernetes configuration tracking controller
   copyright:
     - license: Apache-2.0
@@ -21,7 +21,7 @@ pipeline:
     with:
       packages: ./cmd/manager
       output: wave
-      ldflags: -w -X main.VERSION=${{package.version}}
+      ldflags: -X main.VERSION=${{package.version}}
 
   - uses: strip
 

--- a/ytt.yaml
+++ b/ytt.yaml
@@ -1,7 +1,7 @@
 package:
   name: ytt
   version: 0.49.0
-  epoch: 2
+  epoch: 3
   description: YAML templating tool that works on YAML structure instead of text
   copyright:
     - license: Apache-2.0
@@ -21,7 +21,7 @@ pipeline:
     with:
       packages: ./cmd/ytt
       output: ytt
-      ldflags: -w -X github.com/vmware-tanzu/carvel-ytt/pkg/version.Version=v${{package.version}}
+      ldflags: -X github.com/vmware-tanzu/carvel-ytt/pkg/version.Version=v${{package.version}}
 
   - uses: strip
 


### PR DESCRIPTION
The go package comes with a default `ldflag: -w` so we can safely remove it from the list of set ldflags in the package definitions. 