### PR TITLE
sqlpad: upgrade mysql2 instead of removing it

### DIFF
--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -1,7 +1,7 @@
 package:
   name: sqlpad
   version: 7.4.1 # when updating check the patch below as it contains dependency version updates which may downgrade if upstream upgrades them
-  epoch: 4
+  epoch: 5
   description: Web-based SQL editor. Legacy project in maintenance mode.
   copyright:
     - license: MIT
@@ -29,12 +29,12 @@ pipeline:
 
   - working-directory: /home/build/server
     runs: |
-      # Remove mysql2 from the lock to mitigate CVE-2024-21508
-      yarn remove mysql2
+      # Upgrade mysql2 to mitigate CVE-2024-21508
+      yarn upgrade mysql2@3.9.7
 
       # Create "resolutions" section of package.json
       jq '.resolutions |= (if . then . else {} end)' package.json > temp.json && mv temp.json package.json
-      for override in '"semver"="6.3.1"' '"@node-saml/node-saml"="4.0.5"' '"ip"="2.0.1"' '"jose"="4.15.5"' '"xlsx"="https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"' '"tar"="6.2.1"' '"mysql2"="3.9.4"'; do
+      for override in '"semver"="6.3.1"' '"@node-saml/node-saml"="4.0.5"' '"ip"="2.0.1"' '"jose"="4.15.5"' '"xlsx"="https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"' '"tar"="6.2.1"' '"mysql2"="3.9.7"'; do
         jq ".resolutions.${override}" package.json > temp.json && mv temp.json package.json
       done
 


### PR DESCRIPTION
As that seems to make mysql2 remain in the image as it is needed at
runtime.

confirmed that sqlpad with this change in place now starts.

```console
2772daf3cbba:/usr/app/sqlpad-server# node server.js --config ./config.dev.env
node:internal/errors:496
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'mysql2' imported from /usr/bin/sqlpad-server/drivers/mysql2/index.js
```

Currently the app fails to start, with this change in place it starts and prints "Welcome to sqlpad"
