### PR TITLE
rust: use llvm18 like oficial rust

### DIFF
--- a/rust-1.78.yaml
+++ b/rust-1.78.yaml
@@ -1,13 +1,13 @@
 package:
   name: rust-1.78
   version: 1.78.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
   dependencies:
     runtime:
-      - libLLVM-17
+      - libLLVM-18.1
     provides:
       - rust=${{package.full-version}}
 
@@ -21,11 +21,11 @@ environment:
       - coreutils
       - curl-dev
       - file
-      - libLLVM-17
+      - libLLVM-18.1
       - libgit2-dev
       - libssh2-dev
-      - llvm17
-      - llvm17-dev
+      - llvm18.1
+      - llvm18.1-dev
       - openssl-dev
       - patch
       - python3
@@ -46,8 +46,8 @@ pipeline:
       rm rustc-${{package.version}}-src.tar.xz
 
   - runs: |
-      export CFLAGS="$CFLAGS -O2 -I/usr/lib/llvm-17/include"
-      export CXXFLAGS="$CXXFLAGS -O2 -I/usr/lib/llvm-17/include"
+      export CFLAGS="$CFLAGS -O2 -I/usr/lib/llvm-18.1/include"
+      export CXXFLAGS="$CXXFLAGS -O2 -I/usr/lib/llvm-18.1/include"
       export OPENSSL_NO_VENDOR=1
       export RUST_BACKTRACE=1
       export ARCH=${{host.triplet.rust}}
@@ -60,8 +60,8 @@ pipeline:
         --release-channel="stable" \
         --enable-local-rust \
         --local-rust-root="/usr" \
-        --llvm-root="/usr/lib/llvm17" \
-        --llvm-config="/usr/lib/llvm17/bin/llvm-config" \
+        --llvm-root="/usr/lib/llvm18.1" \
+        --llvm-config="/usr/lib/llvm18.1/bin/llvm-config" \
         --disable-docs \
         --enable-extended \
         --tools="cargo,src,clippy,rustfmt" \
@@ -90,8 +90,8 @@ pipeline:
       unset CARGO_PROFILE_RELEASE_OPT_LEVEL
       unset CARGO_PROFILE_RELEASE_PANIC
       unset CARGO_PROFILE_RELEASE_CODEGEN_UNITS
-      export CFLAGS="$CFLAGS -O2 -Iusr/include/llvm17"
-      export CXXFLAGS="$CXXFLAGS -O2 -I/usr/include/llvm17"
+      export CFLAGS="$CFLAGS -O2 -Iusr/include/llvm18.1"
+      export CXXFLAGS="$CXXFLAGS -O2 -I/usr/include/llvm18.1"
       export OPENSSL_NO_VENDOR=1
       export RUST_BACKTRACE=1
       DESTDIR=${{targets.destdir}} python3 ./x.py install --jobs $(nproc)


### PR DESCRIPTION
* Rust 1.78 has upgraded its bundled LLVM to version 18