### PR TITLE
protoc-gen-go-grpc: fix build to compile the CLI

### DIFF
--- a/protoc-gen-go-grpc.yaml
+++ b/protoc-gen-go-grpc.yaml
@@ -28,3 +28,8 @@ update:
     strip-prefix: cmd/protoc-gen-go-grpc/v
     tag-filter: cmd/protoc-gen-go-grpc/
     use-tag: true
+
+test:
+  pipeline:
+    - runs: |
+        protoc-gen-go-grpc --version

--- a/protoc-gen-go-grpc.yaml
+++ b/protoc-gen-go-grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: protoc-gen-go-grpc
   version: 1.3.0
-  epoch: 11
+  epoch: 12
   description: Go support for Google's protocol buffers services
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,7 @@ pipeline:
   - uses: go/build
     with:
       packages: .
-      modroot: .
+      modroot: ./cmd/protoc-gen-go-grpc
       output: protoc-gen-go-grpc
 
   - uses: strip


### PR DESCRIPTION
Related: https://github.com/wolfi-dev/os/pull/19132 (introduced regression)

Currently the `protoc-gen-go-grpc` package installs the _library_ as `/usr/bin/protoc-gen-go-grpc` instead of the CLI as it did before. Seems like a simple oversight from the broader refactor.