### PR TITLE
fix broken compilation of influxd

### DIFF
--- a/influxd.yaml
+++ b/influxd.yaml
@@ -1,7 +1,7 @@
 package:
   name: influxd
   version: 2.7.6
-  epoch: 0
+  epoch: 1
   description: Scalable datastore for metrics, events, and real-time analytics
   copyright:
     - license: MIT

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -16,7 +16,7 @@ environment:
       - curl
       - git
       - go
-      - rust
+      - rust-1.77
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
influxd is currently broken in main, it is failing with the following error:
We need to set rust-1.77 to fix it.
```
WARN    Compiling flux-core v0.154.0 (/home/build/.cache/go-build/pkgconfig/github.com/influxdata/flux@v0.194.5/libflux/flux-core)
2024/05/14 08:46:52 WARN error: methods `into_type` and `location` are never used
2024/05/14 08:46:52 WARN     --> flux-core/src/semantic/types.rs:2192:8
2024/05/14 08:46:52 WARN      |
2024/05/14 08:46:52 WARN 2189 | pub(crate) trait TypeLike {
2024/05/14 08:46:52 WARN      |                  -------- methods in this trait
2024/05/14 08:46:52 WARN ...
2024/05/14 08:46:52 WARN 2192 |     fn into_type(self) -> MonoType;
2024/05/14 08:46:52 WARN      |        ^^^^^^^^^
2024/05/14 08:46:52 WARN 2193 |     fn error(&self, error: Error) -> Self::Error;
2024/05/14 08:46:52 WARN 2194 |     fn location(&self) -> crate::ast::SourceLocation;
2024/05/14 08:46:52 WARN      |        ^^^^^^^^
2024/05/14 08:46:52 WARN      |
2024/05/14 08:46:52 WARN note: the lint level is defined here
2024/05/14 08:46:52 WARN     --> flux-core/src/lib.rs:1:38
2024/05/14 08:46:52 WARN      |
2024/05/14 08:46:52 WARN 1    | #![cfg_attr(feature = "strict", deny(warnings, missing_docs))]
2024/05/14 08:46:52 WARN      |                                      ^^^^^^^^
2024/05/14 08:46:52 WARN      = note: `#[deny(dead_code)]` implied by `#[deny(warnings)]`
2024/05/14 08:46:52 WARN
2024/05/14 08:46:52 WARN error: could not compile `flux-core` (lib) due to 1 previous error
2024/05/14 08:46:52 WARN warning: build failed, waiting for other jobs to finish...
2024/05/14 08:46:52 WARN warning: methods `into_type` and `location` are never used
2024/05/14 08:46:52 WARN     --> flux-core/src/semantic/types.rs:2192:8
2024/05/14 08:46:52 WARN      |
2024/05/14 08:46:52 WARN 2189 | pub(crate) trait TypeLike {
2024/05/14 08:46:52 WARN      |                  -------- methods in this trait
2024/05/14 08:46:52 WARN ...
2024/05/14 08:46:52 WARN 2192 |     fn into_type(self) -> MonoType;
2024/05/14 08:46:52 WARN      |        ^^^^^^^^^
2024/05/14 08:46:52 WARN 2193 |     fn error(&self, error: Error) -> Self::Error;
2024/05/14 08:46:52 WARN 2194 |     fn location(&self) -> crate::ast::SourceLocation;
2024/05/14 08:46:52 WARN      |        ^^^^^^^^
2024/05/14 08:46:52 WARN      |
2024/05/14 08:46:52 WARN note: the lint level is defined here
2024/05/14 08:46:52 WARN     --> flux-core/src/lib.rs:1:38
2024/05/14 08:46:52 WARN      |
2024/05/14 08:46:52 WARN 1    | #![cfg_attr(feature = "strict", deny(warnings, missing_docs))]
2024/05/14 08:46:52 WARN      |                                      ^^^^^^^^
2024/05/14 08:46:52 WARN      = note: `#[warn(dead_code)]` implied by `#[warn(warnings)]`
2024/05/14 08:46:52 WARN
2024/05/14 08:46:52 WARN warning: `flux-core` (lib) generated 1 warning
2024/05/14 08:46:52 WARN Error installing library    {"name": "flux", "error": "exit status 101"}
2024/05/14 08:47:02 WARN make: *** [GNUmakefile:84: bin/linux/influxd] Error 1
2024/05/14 08:47:02 ERRO ERROR: failed to build package. the build environment has been preserved:
```