### PR TITLE
include system-probe in the build

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -1,16 +1,17 @@
 package:
   name: datadog-agent
   version: 7.53.0
-  epoch: 4
+  epoch: 7
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
+      # - datadog-integrations-corentegrations-core
       - findutils
       - grep
       - libseccomp
-      - openjdk-11
+      # - openjdk-11
       - python3
       - shadow
 
@@ -20,11 +21,19 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - clang-16
+      - clang-16-dev
       - cmake
       - coreutils
       - curl
+      # https://github.com/DataDog/datadog-agent/blob/95f4d66f5fb0c10940e0f9b8fc2ab33f0c6099f0/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
+      - freetds-dev
+      # - gstatus # TODO: Required by gluster
       - gcc-12
-      - go
+      - go~1.21
+      - llvm16
+      - ninja
+      - procps-dev
       - py3-boto3
       - py3-codeowners
       - py3-docker
@@ -38,18 +47,25 @@ environment:
       - py3-toml
       - py3-urllib3
       - py3-wheel
+      # - py3-yaml
       - python-3-dev
+      - systemd-dev
+      - wget
   environment:
     # CGo allows Go programs to call C code
     CGO_ENABLED: "1"
     # -Os optimizes the code for size
     # -I/build/datadog-agent/dev/include adds the directory to search
-    CGO_CFLAGS: "-Os -I${{targets.destdir}}/home/build/dev/include/"
+    # CGO_CFLAGS: "-Os -I${{targets.destdir}}/home/build/dev/include/"
+    CGO_CFLAGS: "-Os -I${{targets.destdir}}/usr/include/"
     # Pass options to the linker. -L/build/datadog-agent/dev/lib adds directory to search for libraries
-    CGO_LDFLAGS: "-L${{targets.destdir}}/home/build/dev/lib/"
+    # CGO_LDFLAGS: "-L${{targets.destdir}}/home/build/dev/lib/"
+    CGO_LDFLAGS: "-L${{targets.destdir}}/usr/lib/"
     # disables generation of debugging information
     # omits the symbol table and debug information, further reducing the size of the binary.
     GOFLAGS: "-ldflags=-w -ldflags=-s"
+    # sysprobe build wnats to depend exclusively on clang-12
+    DD_SYSPROBE_SKIP_CLANG_CHECK: "true"
 
 pipeline:
   - uses: git-checkout
@@ -70,53 +86,76 @@ pipeline:
       ln -sf /home/build/ "$GOPATH"/src/github.com/DataDog/datadog-agent
       go mod tidy
 
-      # https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/datadog-agent.rb#L81
       invoke deps
-      invoke install-tools
 
       invoke -e rtloader.make \
         --python-runtimes=3 \
+        --install-prefix="${{targets.destdir}}/usr" \
         --cmake-options="\
+          -DCMAKE_INSTALL_PREFIX=/usr \
           -DCMAKE_INSTALL_LIBDIR=lib \
           -DCMAKE_CXX_FLAGS=-Os \
           -DCMAKE_C_FLAGS=-Os"
       invoke -e rtloader.install
 
+      mkdir -p /usr/src
+      inv -e system-probe.build --strip-object-files --no-bundle
+
+      # include system-agent in the bundle
       invoke -e agent.build \
-        --python-runtimes 3 \
+        --bundle process-agent \
+        --bundle trace-agent \
+        --bundle system-agent \
+        --bundle security-agent \
         --exclude-rtloader \
-        --build-exclude=systemd \
-        --no-development \
-        --rebuild
+        --python-runtimes 3 \
+        --build-exclude=jmx
 
   - runs: |
-      mkdir -p ${{targets.destdir}}/usr/lib/include
-      cp dev/lib/* ${{targets.destdir}}/usr/lib/
-      cp dev/include/* ${{targets.destdir}}/usr/lib/include/
-
-      conf_dir="${{targets.destdir}}/etc/datadog-agent"
-      mkdir -p $conf_dir
-      mkdir -p ${{targets.destdir}}/bin/
-      mkdir -p ${{targets.destdir}}/run/
-      mkdir -p ${{targets.destdir}}/scripts/
-
       install -Dm755 bin/agent/agent ${{targets.destdir}}/usr/bin/agent
-      cp bin/agent/dist/datadog.yaml $conf_dir/datadog.yaml.example
-      cp -r bin/agent/dist/conf.d $conf_dir/
-      cp -r bin/agent ${{targets.destdir}}/bin/
+      # *-agent is just a symlink to the "agent" multicall
+      ln -s agent ${{targets.destdir}}/usr/bin/process-agent
+      ln -s agent ${{targets.destdir}}/usr/bin/security-agent
+      ln -s agent ${{targets.destdir}}/usr/bin/trace-agent
 
-      # *-agent is just a symlink to the agent multicall
-      ln -s /usr/bin/agent ${{targets.destdir}}/usr/bin/trace-agent
-      ln -s /usr/bin/agent ${{targets.destdir}}/usr/bin/process-agent
-      ln -s /usr/bin/agent ${{targets.destdir}}/usr/bin/security-agent
+      mkdir -p ${{targets.destdir}}/opt/datadog-agent/bin/agent/dist
 
-      cp bin/agent/dist/security-agent.yaml $conf_dir/security-agent.yaml.example
+      cp -r bin/agent/dist/checks ${{targets.destdir}}/opt/datadog-agent/bin/agent/dist/
+      install -Dm644 bin/agent/dist/config.py ${{targets.destdir}}/opt/datadog-agent/bin/agent/dist/config.py
+      cp -r bin/agent/dist/utils ${{targets.destdir}}/opt/datadog-agent/bin/agent/dist/
+      cp -r bin/agent/dist/views ${{targets.destdir}}/opt/datadog-agent/bin/agent/dist/
 
-      cp \
-        Dockerfiles/agent/datadog-docker.yaml \
-        Dockerfiles/agent/datadog-ecs.yaml \
-        bin/agent/dist/system-probe.yaml \
-        ${{targets.destdir}}/etc/datadog-agent/
+      mkdir -p ${{targets.destdir}}/etc/datadog-agent/
+
+      cp -r Dockerfiles/agent/s6-services ${{targets.destdir}}/etc/services.d
+      cp -r Dockerfiles/agent/cont-init.d ${{targets.destdir}}/etc/cont-init.d
+      install -Dm755 Dockerfiles/agent/entrypoint.sh ${{targets.destdir}}/bin/entrypoint.sh
+      cp -r Dockerfiles/agent/entrypoint.d ${{targets.destdir}}/opt/entrypoints
+      install -Dm644 Dockerfiles/agent/datadog-docker.yaml ${{targets.destdir}}/etc/datadog-agent/datadog-docker.yaml
+      install -Dm644 Dockerfiles/agent/datadog-ecs.yaml ${{targets.destdir}}/etc/datadog-agent/datadog-ecs.yaml
+      install -Dm644 bin/agent/dist/system-probe.yaml ${{targets.destdir}}/etc/datadog-agent/system-probe.yaml
+      install -Dm644 bin/agent/dist/datadog.yaml ${{targets.destdir}}/etc/datadog-agent/datadog.yaml.example
+
+      install -Dm755 Dockerfiles/agent/probe.sh ${{targets.destdir}}/probe.sh
+      install -Dm755 Dockerfiles/agent/initlog.sh ${{targets.destdir}}/initlog.sh
+      install -Dm755 Dockerfiles/agent/secrets-helper/readsecret.py ${{targets.destdir}}/readsecret.py
+      install -Dm755 Dockerfiles/agent/secrets-helper/readsecret.sh ${{targets.destdir}}/readsecret.sh
+      install -Dm755 Dockerfiles/agent/secrets-helper/readsecret_multiple_providers.sh ${{targets.destdir}}/readsecret_multiple_providers.sh
+
+      cp -r bin/agent/dist/conf.d ${{targets.destdir}}/etc/datadog-agent/conf.d
+
+      # Remove services for agents that are not built
+      # TODO: We currently don't build the sysprobe agent
+      rm -rf ${{targets.destdir}}/etc/services.d/sysprobe
+
+      # Setup s3-overlay overrides
+      mkdir -p ${{targets.destdir}}/etc/s6/init
+      cp -r Dockerfiles/agent/init-stage3 ${{targets.destdir}}/etc/s6/init/init-stage3
+      cp Dockerfiles/agent/init-stage3-host-pid ${{targets.destdir}}/etc/s6/init/init-stage3-host-pid
+
+      mkdir -p ${{targets.destdir}}/usr/lib ${{targets.destdir}}/usr/include
+      cp dev/lib/* ${{targets.destdir}}/usr/lib/
+      cp dev/include/* ${{targets.destdir}}/usr/include/
 
 subpackages:
   - name: datadog-agent-oci-compat
@@ -125,48 +164,7 @@ subpackages:
         - bash
         - coreutils
         - datadog-agent-s6-overlay
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin
-          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin/trace-agent
-          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin/process-agent
-          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin/security-agent
-
-          mkdir -p \
-            ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent \
-            ${{targets.subpkgdir}}/opt/datadog-agent/run
-
-          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/agent
-
-          cp -r bin/agent/dist \
-            ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/
-      # https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/Dockerfile#L222
-      - working-directory: Dockerfiles/agent
-        runs: |
-          install -Dm755 entrypoint.sh ${{targets.subpkgdir}}/bin/entrypoint.sh
-
-          mkdir -p ${{targets.subpkgdir}}/opt/entrypoints
-          cp entrypoint.d/* ${{targets.subpkgdir}}/opt/entrypoints/
-
-          mkdir -p ${{targets.subpkgdir}}/etc/
-          cp -r s6-services ${{targets.subpkgdir}}/etc/services.d/
-          cp -r cont-init.d ${{targets.subpkgdir}}/etc/cont-init.d/
-
-          # https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/Dockerfile#L154
-          for f in probe.sh initlog.sh; do
-            install -Dm755 $f ${{targets.subpkgdir}}/$f
-          done
-
-          for f in readsecret.py readsecret.sh readsecret_multiple_providers.sh; do
-            install -Dm755 secrets-helper/$f ${{targets.subpkgdir}}/$f
-          done
-
-          mkdir -p ${{targets.subpkgdir}}/etc/s6/init
-          cp -r init-stage3 ${{targets.subpkgdir}}/etc/s6/init/init-stage3
-          cp -r init-stage3-host-pid ${{targets.subpkgdir}}/etc/s6/init/init-stage3-host-pid
-
-          mkdir -p ${{targets.subpkgdir}}/conf.d
-          mkdir -p ${{targets.subpkgdir}}/checks.d
+        # - datadog-security-agent-policies
 
   - name: datadog-cluster-agent
     dependencies:

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -1,71 +1,68 @@
 package:
   name: datadog-agent
   version: 7.53.0
-  epoch: 7
+  epoch: 5
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      # - datadog-integrations-corentegrations-core
+      - datadog-agent-core-integrations
       - findutils
       - grep
       - libseccomp
-      # - openjdk-11
-      - python3
       - shadow
 
 environment:
   contents:
     packages:
+      - bison
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang-16
-      - clang-16-dev
+      # NOTE: Package requires clang-12, which it downloads from a known source
+      # during the build process. Currently its not simple to replace this with
+      # a modern clang, but leaving this commented out in case this changes in
+      # the future.
+      # - clang-16
+      # - clang-16-dev
       - cmake
       - coreutils
-      - curl
+      - dpkg
+      - elfutils-dev
+      - findutils
+      - flex
       # https://github.com/DataDog/datadog-agent/blob/95f4d66f5fb0c10940e0f9b8fc2ab33f0c6099f0/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
       - freetds-dev
       # - gstatus # TODO: Required by gluster
       - gcc-12
-      - go~1.21
-      - llvm16
+      - gnutar
+      - go~1.21 # strictly requires go 1.21
+      - krb5-dev
+      - libbpf-dev
+      - libedit-dev
+      - libzip
+      - linux-headers
       - ninja
       - procps-dev
-      - py3-boto3
-      - py3-codeowners
-      - py3-docker
-      - py3-docker-squash
-      - py3-dulwich
-      - py3-invoke
-      - py3-packaging
-      - py3-pip
-      - py3-reno
-      - py3-requests
-      - py3-toml
-      - py3-urllib3
-      - py3-wheel
-      # - py3-yaml
-      - python-3-dev
+      - py3.11-pip
+      - python3-dev~3.11 # strictly requires python3.11
       - systemd-dev
-      - wget
+      - wget # Required for downloading clang-12 and kernel headers from debian
   environment:
     # CGo allows Go programs to call C code
     CGO_ENABLED: "1"
-    # -Os optimizes the code for size
-    # -I/build/datadog-agent/dev/include adds the directory to search
-    # CGO_CFLAGS: "-Os -I${{targets.destdir}}/home/build/dev/include/"
+    # -Os optimizes the code for size and add the directory to rtlinkers includes
     CGO_CFLAGS: "-Os -I${{targets.destdir}}/usr/include/"
-    # Pass options to the linker. -L/build/datadog-agent/dev/lib adds directory to search for libraries
-    # CGO_LDFLAGS: "-L${{targets.destdir}}/home/build/dev/lib/"
+    # Pass options to the linker.
     CGO_LDFLAGS: "-L${{targets.destdir}}/usr/lib/"
     # disables generation of debugging information
     # omits the symbol table and debug information, further reducing the size of the binary.
     GOFLAGS: "-ldflags=-w -ldflags=-s"
-    # sysprobe build wnats to depend exclusively on clang-12
-    DD_SYSPROBE_SKIP_CLANG_CHECK: "true"
+    # The version of linux-headers to fetch kernel headers for
+    LINUX_HEADERS_VERSION: "5.10.0-0.deb10.29"
+    # The version of linux to fetch kernel headers for
+    LINUX_KERNEL_VERSION: "5.10.216-1~deb10u1"
 
 pipeline:
   - uses: git-checkout
@@ -74,34 +71,88 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 0eec38de4bfcd752cc10dfa700c06dd7bcdb3f36
 
+  # Pull in a patch simplifying invoke tasks for checks
+  # Ref: https://github.com/DataDog/datadog-agent/pull/25348
+  # TODO: Remove when 7.55.0 is released
+  - uses: patch
+    with:
+      patches: 25348.patch
+
+  # Install `invoke` (build) dependencies. We ultimately package with venv so
+  # these won't leak into the package.
+  - runs: |
+      # install `invoke` and its dependencies
+      python3.11 -m pip install invoke requests toml pyyaml packaging
+
   - uses: go/bump
     with:
       deps: github.com/moby/buildkit@v0.13.1 golang.org/x/net@v0.23.0
       replaces: github.com/mholt/archiver/v3=github.com/anchore/archiver/v3@v3.5.2
 
-  # This step essentially replicates https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/datadog-agent.rb
+  - if: ${{build.arch}} == 'aarch64'
+    runs: |
+      mkdir -p /usr/src
+      wget -O arch.deb http://deb.debian.org/debian-security/pool/updates/main/l/linux-5.10/linux-headers-${LINUX_HEADERS_VERSION}-arm64_${LINUX_KERNEL_VERSION}_arm64.deb
+      echo "a9f5b8614dc1dc123b13de540bb98283cd927a29438e0fe010c9e477b5448124 arch.deb" | sha256sum -c
+
+      dpkg -x arch.deb /tmp/arch
+      ln -s /tmp/arch/usr/src/linux-headers-${LINUX_HEADERS_VERSION}-arm64 /usr/src/linux-headers-${LINUX_HEADERS_VERSION}-arm64
+
+      wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/clang+llvm-12.0.1-aarch64-linux-gnu.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
+      echo "3d4ad804b7c85007686548cbc917ab067bf17eaedeab43d9eb83d3a683d8e9d4  /tmp/clang.tar.xz" | sha256sum --check
+
+  - if: ${{build.arch}} == 'x86_64'
+    runs: |
+      mkdir -p /usr/src
+      wget -O arch.deb http://deb.debian.org/debian-security/pool/updates/main/l/linux-5.10/linux-headers-${LINUX_HEADERS_VERSION}-amd64_${LINUX_KERNEL_VERSION}_amd64.deb
+      echo "6090e3d5c874ae8ac99d777bbbcb692051af93d8d8d0cbefa6b7376b9e112317 arch.deb" | sha256sum -c
+
+      dpkg -x arch.deb /tmp/arch
+      ln -s /tmp/arch/usr/src/linux-headers-${LINUX_HEADERS_VERSION}-amd64 /usr/src/linux-headers-${LINUX_HEADERS_VERSION}-amd64
+
+      # https://github.com/DataDog/datadog-agent-buildimages/blob/main/system-probe_x64/Dockerfile#L80
+      wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
+      echo "6b3cc55d3ef413be79785c4dc02828ab3bd6b887872b143e3091692fc6acefe7  /tmp/clang.tar.xz" | sha256sum --check
+
+  - runs: |
+      wget -O common.deb http://deb.debian.org/debian-security/pool/updates/main/l/linux-5.10/linux-headers-${LINUX_HEADERS_VERSION}-common_${LINUX_KERNEL_VERSION}_all.deb
+      dpkg -x common.deb /tmp/common
+      ln -s /tmp/common/usr/src/linux-headers-${LINUX_HEADERS_VERSION}-common /usr/src/linux-headers-${LINUX_HEADERS_VERSION}-common
+
+      mkdir -p /opt/clang
+      tar xf /tmp/clang.tar.xz --no-same-owner -C /opt/clang --strip-components=1
+      PATH="/opt/clang/bin:${PATH}"
+
+      # HOW DOES THIS WORK: https://stackoverflow.com/a/60357720
+      ln -s /usr/lib/libncursesw.so.6 /usr/lib/libtinfo.so.5
+
+      # Build once to correctly setup links/generates. The system-probe we end
+      # up using will be part of the multicall below.
+      invoke -e system-probe.build \
+        --strip-object-files \
+        --no-bundle \
+        --bundle-ebpf
+
   - runs: |
       export PATH=$PATH:$GOPATH/bin
       mkdir -p "$GOPATH/src/github.com/DataDog/"
       ln -sf /home/build/ "$GOPATH"/src/github.com/DataDog/datadog-agent
       go mod tidy
 
-      invoke deps
+      invoke -e deps
 
+  - runs: |
       invoke -e rtloader.make \
         --python-runtimes=3 \
         --install-prefix="${{targets.destdir}}/usr" \
         --cmake-options="\
-          -DCMAKE_INSTALL_PREFIX=/usr \
           -DCMAKE_INSTALL_LIBDIR=lib \
           -DCMAKE_CXX_FLAGS=-Os \
           -DCMAKE_C_FLAGS=-Os"
       invoke -e rtloader.install
 
-      mkdir -p /usr/src
-      inv -e system-probe.build --strip-object-files --no-bundle
-
-      # include system-agent in the bundle
+      # Default includes [process-agent, security-agent, trace-agent]. Add in
+      # the `system-probe` as well, which saves us ~140Mb.
       invoke -e agent.build \
         --bundle process-agent \
         --bundle trace-agent \
@@ -109,7 +160,9 @@ pipeline:
         --bundle security-agent \
         --exclude-rtloader \
         --python-runtimes 3 \
-        --build-exclude=jmx
+        --no-development \
+        --bundle-ebpf \
+        --embedded-path /usr/lib
 
   - runs: |
       install -Dm755 bin/agent/agent ${{targets.destdir}}/usr/bin/agent
@@ -117,25 +170,20 @@ pipeline:
       ln -s agent ${{targets.destdir}}/usr/bin/process-agent
       ln -s agent ${{targets.destdir}}/usr/bin/security-agent
       ln -s agent ${{targets.destdir}}/usr/bin/trace-agent
-
-      mkdir -p ${{targets.destdir}}/opt/datadog-agent/bin/agent/dist
-
-      cp -r bin/agent/dist/checks ${{targets.destdir}}/opt/datadog-agent/bin/agent/dist/
-      install -Dm644 bin/agent/dist/config.py ${{targets.destdir}}/opt/datadog-agent/bin/agent/dist/config.py
-      cp -r bin/agent/dist/utils ${{targets.destdir}}/opt/datadog-agent/bin/agent/dist/
-      cp -r bin/agent/dist/views ${{targets.destdir}}/opt/datadog-agent/bin/agent/dist/
+      ln -s agent ${{targets.destdir}}/usr/bin/system-probe
 
       mkdir -p ${{targets.destdir}}/etc/datadog-agent/
 
       cp -r Dockerfiles/agent/s6-services ${{targets.destdir}}/etc/services.d
       cp -r Dockerfiles/agent/cont-init.d ${{targets.destdir}}/etc/cont-init.d
-      install -Dm755 Dockerfiles/agent/entrypoint.sh ${{targets.destdir}}/bin/entrypoint.sh
-      cp -r Dockerfiles/agent/entrypoint.d ${{targets.destdir}}/opt/entrypoints
+
       install -Dm644 Dockerfiles/agent/datadog-docker.yaml ${{targets.destdir}}/etc/datadog-agent/datadog-docker.yaml
       install -Dm644 Dockerfiles/agent/datadog-ecs.yaml ${{targets.destdir}}/etc/datadog-agent/datadog-ecs.yaml
-      install -Dm644 bin/agent/dist/system-probe.yaml ${{targets.destdir}}/etc/datadog-agent/system-probe.yaml
       install -Dm644 bin/agent/dist/datadog.yaml ${{targets.destdir}}/etc/datadog-agent/datadog.yaml.example
+      install -Dm644 bin/agent/dist/system-probe.yaml ${{targets.destdir}}/etc/datadog-agent/system-probe.yaml.example
+      install -Dm644 bin/agent/dist/security-agent.yaml ${{targets.destdir}}/etc/datadog-agent/security-agent.yaml.example
 
+      install -Dm755 Dockerfiles/agent/entrypoint.sh ${{targets.destdir}}/bin/entrypoint.sh
       install -Dm755 Dockerfiles/agent/probe.sh ${{targets.destdir}}/probe.sh
       install -Dm755 Dockerfiles/agent/initlog.sh ${{targets.destdir}}/initlog.sh
       install -Dm755 Dockerfiles/agent/secrets-helper/readsecret.py ${{targets.destdir}}/readsecret.py
@@ -144,27 +192,125 @@ pipeline:
 
       cp -r bin/agent/dist/conf.d ${{targets.destdir}}/etc/datadog-agent/conf.d
 
-      # Remove services for agents that are not built
-      # TODO: We currently don't build the sysprobe agent
-      rm -rf ${{targets.destdir}}/etc/services.d/sysprobe
-
       # Setup s3-overlay overrides
       mkdir -p ${{targets.destdir}}/etc/s6/init
       cp -r Dockerfiles/agent/init-stage3 ${{targets.destdir}}/etc/s6/init/init-stage3
       cp Dockerfiles/agent/init-stage3-host-pid ${{targets.destdir}}/etc/s6/init/init-stage3-host-pid
 
-      mkdir -p ${{targets.destdir}}/usr/lib ${{targets.destdir}}/usr/include
-      cp dev/lib/* ${{targets.destdir}}/usr/lib/
-      cp dev/include/* ${{targets.destdir}}/usr/include/
+  - uses: strip
 
 subpackages:
+  - name: datadog-agent-jmx
+    description: "Datadog agent with JMX integration"
+    dependencies:
+      runtime:
+        - openjdk-11-default-jvm
+        - datadog-agent
+
   - name: datadog-agent-oci-compat
     dependencies:
       runtime:
         - bash
         - coreutils
         - datadog-agent-s6-overlay
-        # - datadog-security-agent-policies
+        - datadog-security-agent-policies
+    pipeline:
+      - runs: |
+          mkdir -p \
+            ${{targets.subpkgdir}}/conf.d \
+            ${{targets.subpkgdir}}/checks.d \
+            ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/dist \
+            ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin
+
+          # several startup scripts assume binaries are located in /opt/datadog-agent/...
+          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/agent
+          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin/system-probe
+          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin/security-agent
+          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin/process-agent
+          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin/trace-agent
+
+          cp -r /opt/datadog-agent/embedded/share ${{targets.subpkgdir}}/opt/datadog-agent/embedded/share
+
+          cp -r bin/agent/dist/checks ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/dist/
+          install -Dm644 bin/agent/dist/config.py ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/dist/config.py
+          cp -r bin/agent/dist/utils ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/dist/
+          cp -r bin/agent/dist/views ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/dist/
+
+          cp -r Dockerfiles/agent/entrypoint.d ${{targets.subpkgdir}}/opt/entrypoints
+
+  - name: datadog-agent-core-integrations
+    dependencies:
+      runtime:
+        - bash
+        - coreutils
+        - python-3.11
+    pipeline:
+      - working-directory: /home/integrations
+        pipeline:
+          - uses: git-checkout
+            with:
+              repository: https://github.com/DataDog/integrations-core
+              tag: ${{package.version}}
+              expected-commit: 052a2ee6820d3dc120b66f2a91d9eb22b00af01b
+          - runs: |
+              # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
+              SOURCE_DATE_EPOCH=315532800
+
+              # Create virtual environment
+              python3.11 -m venv .venv
+
+              # Install locked dependencies
+              .venv/bin/pip install --require-hashes --only-binary=:all: --no-deps -r .deps/resolved/linux-${{build.arch}}_py3.txt
+
+              excludes="datadog_checks_base datadog_checks_dev datadog_checks_tests_helper docker_daemon esxi teleport"
+              checks=$(invoke -r /home/build agent.collect-integrations /home/integrations/ 3 linux --excluded "$excludes")
+
+              # Install core and dependencies
+              .venv/bin/pip install \
+                "./datadog_checks_base[deps, http]" \
+                $(echo ${checks} | xargs -n1 echo | sed 's|^|./|')
+
+              find .venv -name "*.pyc" -delete
+              find .venv -name "__pycache__" -exec rm -rf {} +
+
+              mkdir -p ${{targets.contextdir}}/opt/datadog-agent
+              .venv/bin/pip freeze > ${{targets.contextdir}}/opt/datadog-agent/final_constraints-py3.txt
+
+              # Use Python in virtual environment
+              sed -i "s|$(pwd)/.venv|/usr/share/datadog-agent|g" .venv/pyvenv.cfg
+              sed -i "s|$(pwd)/.venv|/usr/share/datadog-agent|g" .venv/bin/*
+
+              # Install virtual environment
+              mkdir -p ${{targets.contextdir}}/usr/share/datadog-agent
+              cp -r .venv/* ${{targets.contextdir}}/usr/share/datadog-agent/
+
+              # this is intentionally referencing the main package, since we only "install" if a config doesn't already exist
+              conf_dir="${{targets.destdir}}/etc/datadog-agent/conf.d"
+              mkdir -p $conf_dir
+
+              for c in $checks; do
+                check_conf_dir="${conf_dir}/${c}.d"
+
+                # copy the configuration file if they don't already exist
+                for f in conf.yaml.example conf.yaml.default metrics.yaml auto_conf.yaml; do
+
+                  src="$c/datadog_checks/$c/data/$f"
+                  dst="$check_conf_dir"
+
+                  if [ -f "$src" ] && [ ! -f "$dst/$f" ]; then
+                    mkdir -p $dst
+                    cp $src $dst
+                  fi
+                done
+
+                # copy SNMP profiles
+                for p in profiles default_profiles; do
+                  folder_path="$c/datadog_checks/$c/data/$p"
+                  if [ -d "$folder_path" ]; then
+                    cp -r "${folder_path}" "${check_conf_dir}"
+                  fi
+                done
+              done
 
   - name: datadog-cluster-agent
     dependencies:
@@ -173,7 +319,7 @@ subpackages:
         - libseccomp
     pipeline:
       - runs: |
-          inv -e cluster-agent.build
+          invoke -e cluster-agent.build
           go generate cmd/cluster-agent/main.go
 
           install -Dm755 bin/datadog-cluster-agent/datadog-cluster-agent ${{targets.subpkgdir}}/usr/bin/datadog-cluster-agent
@@ -217,7 +363,7 @@ subpackages:
               output: fakeintake
               subpackage: "true"
 
-  # The datadog-agent image uses a deprecated 3 year old version of s6-overlay
+  # The datadog-agent image uses a deprecated version of s6-overlay from 2020
   # we don't want to maintain a package for. Instead, include the
   # raw release of that version of s6-overlay as a datadog-agent
   # subpackage, only to be used by image builders.
@@ -245,7 +391,7 @@ subpackages:
             ;;
           esac
 
-          curl -o s6-overlay.tgz -L https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-${_arch}.tar.gz
+          wget -O s6-overlay.tgz https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-${_arch}.tar.gz
 
           echo "${expected_sha256}  s6-overlay.tgz" | sha256sum -c
 
@@ -268,10 +414,15 @@ test:
     contents:
       packages:
         - datadog-agent-fakeintake
+        - datadog-agent-core-integrations
+    environment:
+      PYTHONPATH: "/usr/share/datadog-agent/lib/python3.11/site-packages"
   pipeline:
-    - runs: |
-        export PATH=$PATH:/opt/datadog-agent/bin/agent
-
+    - name: Ensure checks can be loaded
+      runs: |
+        python -c "import datadog_checks.base"
+    - name: Ensure agent can be started
+      runs: |
         cat > /etc/datadog-agent/datadog.yaml <<EOF
         api_key: "test"
         dd_url: "http://localhost:80"

--- a/datadog-agent/25348.patch
+++ b/datadog-agent/25348.patch
@@ -1,0 +1,426 @@
+From 26f294c49378020b143385f32253d10027501a70 Mon Sep 17 00:00:00 2001
+From: Alex Lopez <alex.lopez@datadoghq.com>
+Date: Fri, 3 May 2024 19:55:08 +0200
+Subject: [PATCH 1/5] Move whole collection to invoke task to avoid calling
+ invoke in a loop
+
+---
+ .../datadog-agent-integrations-py2.rb         | 46 ++-----------
+ .../datadog-agent-integrations-py3.rb         | 46 ++-----------
+ tasks/agent.py                                | 65 +++++++++++++++----
+ 3 files changed, 68 insertions(+), 89 deletions(-)
+
+diff --git a/omnibus/config/software/datadog-agent-integrations-py2.rb b/omnibus/config/software/datadog-agent-integrations-py2.rb
+index 5b0c15f776f54..e4d8c9cc2a349 100644
+--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
++++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
+@@ -120,47 +120,15 @@
+     cached_wheels_dir = "#{wheel_build_dir}/.cached"
+   end
+ 
++  # Create the array outside the block so that it can be referenced both inside and outside the block
+   checks_to_install = Array.new
+-
+   block "Collect integrations to install" do
+-    # Go through every integration package in `integrations-core`, build and install
+-    Dir.glob("#{project_dir}/*").each do |check_dir|
+-      check = check_dir.split('/').last
+-
+-      # do not install excluded integrations
+-      next if !File.directory?("#{check_dir}") || excluded_folders.include?(check)
+-
+-      # If there is no manifest file, then we should assume the folder does not
+-      # contain a working check and move onto the next
+-      manifest_file_path = "#{check_dir}/manifest.json"
+-
+-      # If there is no manifest file, then we should assume the folder does not
+-      # contain a working check and move onto the next
+-      File.exist?(manifest_file_path) || next
+-
+-      manifest = JSON.parse(File.read(manifest_file_path))
+-      if manifest.key?("supported_os")
+-        manifest["supported_os"].include?(os) || next
+-      else
+-        if os == "mac_os"
+-          tag = "Supported OS::macOS"
+-        else
+-          tag = "Supported OS::#{os.capitalize}"
+-        end
+-
+-        manifest["tile"]["classifier_tags"].include?(tag) || next
+-      end
+-
+-      File.file?("#{check_dir}/setup.py") || File.file?("#{check_dir}/pyproject.toml") || next
+-      # Check if it supports Python 2.
+-      support = `inv agent.check-supports-python-version #{check_dir} 2`
+-      if support == "False"
+-        log.info(log_key) { "Skipping '#{check}' since it does not support Python 2." }
+-        next
+-      end
+-
+-      checks_to_install.push(check)
+-    end
++    tasks_dir_in = windows_safe_path(Dir.pwd)
++    to_install = (
++      shellout! "inv agent.collect-integrations #{project_dir} 2 #{os} #{excluded_folders.join(',')}",
++                :cwd => tasks_dir_in
++    ).stdout.split()
++    checks_to_install.concat(to_install)
+   end
+ 
+   installed_list = Array.new
+diff --git a/omnibus/config/software/datadog-agent-integrations-py3.rb b/omnibus/config/software/datadog-agent-integrations-py3.rb
+index e3e6a7607aa42..17a887c4df862 100644
+--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
++++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
+@@ -121,47 +121,15 @@
+     cached_wheels_dir = "#{wheel_build_dir}/.cached"
+   end
+ 
++  # Create the array outside the block so that it can be referenced both inside and outside the block
+   checks_to_install = Array.new
+-
+   block "Collect integrations to install" do
+-    # Go through every integration package in `integrations-core`, build and install
+-    Dir.glob("#{project_dir}/*").each do |check_dir|
+-      check = check_dir.split('/').last
+-
+-      # do not install excluded integrations
+-      next if !File.directory?("#{check_dir}") || excluded_folders.include?(check)
+-
+-      # If there is no manifest file, then we should assume the folder does not
+-      # contain a working check and move onto the next
+-      manifest_file_path = "#{check_dir}/manifest.json"
+-
+-      # If there is no manifest file, then we should assume the folder does not
+-      # contain a working check and move onto the next
+-      File.exist?(manifest_file_path) || next
+-
+-      manifest = JSON.parse(File.read(manifest_file_path))
+-      if manifest.key?("supported_os")
+-        manifest["supported_os"].include?(os) || next
+-      else
+-        if os == "mac_os"
+-          tag = "Supported OS::macOS"
+-        else
+-          tag = "Supported OS::#{os.capitalize}"
+-        end
+-
+-        manifest["tile"]["classifier_tags"].include?(tag) || next
+-      end
+-
+-      File.file?("#{check_dir}/setup.py") || File.file?("#{check_dir}/pyproject.toml") || next
+-      # Check if it supports Python 3.
+-      support = `inv agent.check-supports-python-version #{check_dir} 3`
+-      if support == "False"
+-        log.info(log_key) { "Skipping '#{check}' since it does not support Python 3." }
+-        next
+-      end
+-
+-      checks_to_install.push(check)
+-    end
++    tasks_dir_in = windows_safe_path(Dir.pwd)
++    to_install = (
++      shellout! "inv agent.collect-integrations #{project_dir} 3 #{os} #{excluded_folders.join(',')}",
++                :cwd => tasks_dir_in
++    ).stdout.split()
++    checks_to_install.concat(to_install)
+   end
+ 
+   installed_list = Array.new
+diff --git a/tasks/agent.py b/tasks/agent.py
+index 91ef837fd8de1..1d93112457924 100644
+--- a/tasks/agent.py
++++ b/tasks/agent.py
+@@ -623,8 +623,7 @@ def _linux_integration_tests(ctx, race=False, remote_docker=False, go_mod="mod",
+         ctx.run(f"{go_cmd} {prefix}")
+ 
+ 
+-@task
+-def check_supports_python_version(_, check_dir, python):
++def check_supports_python_version(check_dir, python):
+     """
+     Check if a Python project states support for a given major Python version.
+     """
+@@ -642,17 +641,15 @@ def check_supports_python_version(_, check_dir, python):
+ 
+         project_metadata = data['project']
+         if 'requires-python' not in project_metadata:
+-            print('True', end='')
+-            return
++            return True
+ 
+         specifier = SpecifierSet(project_metadata['requires-python'])
+         # It might be e.g. `>=3.8` which would not immediatelly contain `3`
+         for minor_version in range(100):
+             if specifier.contains(f'{python}.{minor_version}'):
+-                print('True', end='')
+-                return
++                return True
+         else:
+-            print('False', end='')
++            return False
+     elif os.path.isfile(setup_file):
+         with open(setup_file) as f:
+             tree = ast.parse(f.read(), filename=setup_file)
+@@ -661,13 +658,59 @@ def check_supports_python_version(_, check_dir, python):
+         for node in ast.walk(tree):
+             if isinstance(node, ast.keyword) and node.arg == 'classifiers':
+                 classifiers = ast.literal_eval(node.value)
+-                print(any(cls.startswith(prefix) for cls in classifiers), end='')
+-                return
++                return any(cls.startswith(prefix) for cls in classifiers)
+         else:
+-            print('False', end='')
++            return False
+     else:
+-        raise Exit('not a Python project', code=1)
++        return False
++
++
++@task
++def collect_integrations(_, integrations_dir, python_version, target_os, excluded):
++    """
++    Collect and print the list of integrations to install.
++
++    `excluded` is a comma-separated list of directories that don't contain an actual integration
++    """
++    import json
++
++    excluded = excluded.split(',')
++    integrations = []
++
++    for entry in os.listdir(integrations_dir):
++        int_path = os.path.join(integrations_dir, entry)
++        if not os.path.isdir(int_path) or entry in excluded:
++            continue
++
++        manifest_file_path = os.path.join(int_path, "manifest.json")
++
++        # If there is no manifest file, then we should assume the folder does not
++        # contain a working check and move onto the next
++        if not os.path.exists(manifest_file_path):
++            continue
++
++        with open(manifest_file_path) as f:
++            manifest = json.load(f)
++
++        # Figure out whether the integration is supported on the target oS
++        if 'supported_os' in manifest:
++            if target_os not in manifest['supported_os']:
++                continue
++        else:
++            if target_os == 'mac_os':
++                tag = 'Supported OS::macOS'
++            else:
++                tag = f'Supported OS::{target_os.capitalize()}'
++
++        if tag not in manifest['tile']['classifier_tags']:
++            continue
++
++        if not check_supports_python_version(int_path, python_version):
++            continue
++
++        integrations.append(entry)
+ 
++    print(' '.join(sorted(integrations)))
+ 
+ @task
+ def clean(ctx):
+
+From 7b2902f4bd98772baef2a4e9203c4f7a91428b90 Mon Sep 17 00:00:00 2001
+From: Alex Lopez <alex.lopez@datadoghq.com>
+Date: Sun, 5 May 2024 20:29:24 +0200
+Subject: [PATCH 2/5] Simplify by merging blocks
+
+---
+ .../datadog-agent-integrations-py2.rb         | 20 ++++++++-----------
+ .../datadog-agent-integrations-py3.rb         | 16 ++++++---------
+ 2 files changed, 14 insertions(+), 22 deletions(-)
+
+diff --git a/omnibus/config/software/datadog-agent-integrations-py2.rb b/omnibus/config/software/datadog-agent-integrations-py2.rb
+index e4d8c9cc2a349..414b675a11609 100644
+--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
++++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
+@@ -120,21 +120,16 @@
+     cached_wheels_dir = "#{wheel_build_dir}/.cached"
+   end
+ 
+-  # Create the array outside the block so that it can be referenced both inside and outside the block
+-  checks_to_install = Array.new
+-  block "Collect integrations to install" do
++  block "Install integrations" do
+     tasks_dir_in = windows_safe_path(Dir.pwd)
+-    to_install = (
++    # Collect integrations to install
++    checks_to_install = (
+       shellout! "inv agent.collect-integrations #{project_dir} 2 #{os} #{excluded_folders.join(',')}",
+                 :cwd => tasks_dir_in
+     ).stdout.split()
+-    checks_to_install.concat(to_install)
+-  end
+ 
+-  installed_list = Array.new
+-  cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
+-  block "Install integrations" do
+-    tasks_dir_in = windows_safe_path(Dir.pwd)
++    # Retrieving integrations from cache
++    cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
+     cache_branch = (shellout! "inv release.get-release-json-value base_branch", cwd: File.expand_path('..', tasks_dir_in)).stdout.strip
+     # On windows, `aws` actually executes Ruby's AWS SDK, but we want the Python one
+     awscli = if windows_target? then '"c:\Program files\python311\scripts\aws"' else 'aws' end
+@@ -154,12 +149,13 @@
+         shellout! "#{python} -m pip install --no-deps --no-index " \
+                   "--find-links #{windows_safe_path(cached_wheels_dir)} -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
+       else
+-        shellout! "#{pip} install --no-deps --no-index " \
+-                  " --find-links #{cached_wheels_dir} -r #{cached_wheels_dir}/found.txt"
++        shellout! "#{python} -m pip install --no-deps --no-index " \
++                  "--find-links #{cached_wheels_dir} -r #{cached_wheels_dir}/found.txt"
+       end
+     end
+ 
+     # get list of integration wheels already installed from cache
++    installed_list = Array.new
+     if cache_bucket != ''
+       if windows_target?
+         installed_out = (shellout! "#{python} -m pip list --format json").stdout
+diff --git a/omnibus/config/software/datadog-agent-integrations-py3.rb b/omnibus/config/software/datadog-agent-integrations-py3.rb
+index 17a887c4df862..79b8300019006 100644
+--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
++++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
+@@ -121,21 +121,16 @@
+     cached_wheels_dir = "#{wheel_build_dir}/.cached"
+   end
+ 
+-  # Create the array outside the block so that it can be referenced both inside and outside the block
+-  checks_to_install = Array.new
+-  block "Collect integrations to install" do
++  block "Install integrations" do
+     tasks_dir_in = windows_safe_path(Dir.pwd)
+-    to_install = (
++    # Collect integrations to install
++    checks_to_install = (
+       shellout! "inv agent.collect-integrations #{project_dir} 3 #{os} #{excluded_folders.join(',')}",
+                 :cwd => tasks_dir_in
+     ).stdout.split()
+-    checks_to_install.concat(to_install)
+-  end
+ 
+-  installed_list = Array.new
+-  cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
+-  block "Install integrations" do
+-    tasks_dir_in = windows_safe_path(Dir.pwd)
++    # Retrieving integrations from cache
++    cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
+     cache_branch = (shellout! "inv release.get-release-json-value base_branch", cwd: File.expand_path('..', tasks_dir_in)).stdout.strip
+     # On windows, `aws` actually executes Ruby's AWS SDK, but we want the Python one
+     awscli = if windows_target? then '"c:\Program files\python311\scripts\aws"' else 'aws' end
+@@ -161,6 +156,7 @@
+     end
+ 
+     # get list of integration wheels already installed from cache
++    installed_list = Array.new
+     if cache_bucket != ''
+       installed_out = (shellout! "#{python} -m pip list --format json").stdout
+       if $?.exitstatus == 0
+
+From 09a42a692c09b62e628eeff48a86323c2be4ecc7 Mon Sep 17 00:00:00 2001
+From: Alex Lopez <alex.lopez@datadoghq.com>
+Date: Sun, 5 May 2024 22:21:40 +0200
+Subject: [PATCH 3/5] Fixup an error that surface after reordering
+
+Usage of the special $? variable requires a previous shell invocation
+via ``; this was working because there was a `` call above (not the
+actual one we intended to check). This commit corrects that.
+---
+ omnibus/config/software/datadog-agent-integrations-py2.rb | 6 +-----
+ omnibus/config/software/datadog-agent-integrations-py3.rb | 2 +-
+ 2 files changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/omnibus/config/software/datadog-agent-integrations-py2.rb b/omnibus/config/software/datadog-agent-integrations-py2.rb
+index 414b675a11609..d654bf752b6e0 100644
+--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
++++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
+@@ -157,11 +157,7 @@
+     # get list of integration wheels already installed from cache
+     installed_list = Array.new
+     if cache_bucket != ''
+-      if windows_target?
+-        installed_out = (shellout! "#{python} -m pip list --format json").stdout
+-      else
+-        installed_out = (shellout! "#{pip} list --format json").stdout
+-      end
++      installed_out = `#{python} -m pip list --format json`
+       if $?.exitstatus == 0
+         installed = JSON.parse(installed_out)
+         installed.each do |package|
+diff --git a/omnibus/config/software/datadog-agent-integrations-py3.rb b/omnibus/config/software/datadog-agent-integrations-py3.rb
+index 79b8300019006..1ceb159dfc1fa 100644
+--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
++++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
+@@ -158,7 +158,7 @@
+     # get list of integration wheels already installed from cache
+     installed_list = Array.new
+     if cache_bucket != ''
+-      installed_out = (shellout! "#{python} -m pip list --format json").stdout
++      installed_out = `#{python} -m pip list --format json`
+       if $?.exitstatus == 0
+         installed = JSON.parse(installed_out)
+         installed.each do |package|
+
+From 50931a25d19867a339f7488c92c0bcc1b0dadde0 Mon Sep 17 00:00:00 2001
+From: Alex Lopez <alex.lopez.zorzano@gmail.com>
+Date: Mon, 6 May 2024 17:38:07 +0200
+Subject: [PATCH 4/5] Fix capitalization
+
+Co-authored-by: Dustin Long <me@dustmop.io>
+---
+ tasks/agent.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tasks/agent.py b/tasks/agent.py
+index 1d93112457924..9d869a5d9b76c 100644
+--- a/tasks/agent.py
++++ b/tasks/agent.py
+@@ -692,7 +692,7 @@ def collect_integrations(_, integrations_dir, python_version, target_os, exclude
+         with open(manifest_file_path) as f:
+             manifest = json.load(f)
+ 
+-        # Figure out whether the integration is supported on the target oS
++        # Figure out whether the integration is supported on the target OS
+         if 'supported_os' in manifest:
+             if target_os not in manifest['supported_os']:
+                 continue
+
+From 2be302e1ebcca6d1a8d80b7afa6476c63c54e9f6 Mon Sep 17 00:00:00 2001
+From: Alex Lopez <alex.lopez@datadoghq.com>
+Date: Mon, 6 May 2024 04:28:27 +0200
+Subject: [PATCH 5/5] Remove logic for old manifest
+
+---
+ tasks/agent.py | 10 +++-------
+ 1 file changed, 3 insertions(+), 7 deletions(-)
+
+diff --git a/tasks/agent.py b/tasks/agent.py
+index 9d869a5d9b76c..cd904210dd6eb 100644
+--- a/tasks/agent.py
++++ b/tasks/agent.py
+@@ -693,14 +693,10 @@ def collect_integrations(_, integrations_dir, python_version, target_os, exclude
+             manifest = json.load(f)
+ 
+         # Figure out whether the integration is supported on the target OS
+-        if 'supported_os' in manifest:
+-            if target_os not in manifest['supported_os']:
+-                continue
++        if target_os == 'mac_os':
++            tag = 'Supported OS::macOS'
+         else:
+-            if target_os == 'mac_os':
+-                tag = 'Supported OS::macOS'
+-            else:
+-                tag = f'Supported OS::{target_os.capitalize()}'
++            tag = f'Supported OS::{target_os.capitalize()}'
+ 
+         if tag not in manifest['tile']['classifier_tags']:
+             continue


### PR DESCRIPTION
this turned into a large PR, in general I assumed the existing package is wrong/broken, so I took quite a bit of liberty in restructuring things. the highlights of this change are:

- bundles the `system-probe` component in the multicall `agent`
  - this uses kernel headers from debian stable `5.10.216-1~deb10u1` (to match what upstream is doing)
- fixes the CGO impl by using the correct include paths 
- fixes the `rtloader` integration by using the correct `--embedded-path`
  - fixes the `RPATH` used by the `agent` to call the appropriate `rtloader` headers
- creates a new `datadog-agent-core-integrations` subpackage that includes all the python plugin check integrations
  - installed using the py3.11 venv approach
  - pulls in a [patch](https://github.com/DataDog/datadog-agent/pull/25348) from upstream to simplify the discovery of checks
- better matches the directory structure to upstream, including a few key hardcoded paths
  - place multicall symlinks to `/opt/datadog-agent/embedded` where the entrypoints are expecting
- embed the `jmx` integration in the multicall, but separate the runtime dependency on `openjdk` as a separate package, included at image build time
- downgrade go (1.21) and python (3.11) to match upstreams dependency locks

there's a lot of changes at once here, for some additional confidence, this has been tested (in its image form) against the standard [docker](https://docs.datadoghq.com/containers/docker/?tab=standard) and [fargate](https://docs.datadoghq.com/integrations/ecs_fargate/?tab=webui) setup