### PR TITLE
Move libpng dev tools from libpng-utils to libpng-dev

### DIFF
--- a/libpng.yaml
+++ b/libpng.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpng
   version: 1.6.43
-  epoch: 1
+  epoch: 2
   description: Portable Network Graphics library
   copyright:
     - license: Libpng
@@ -46,13 +46,6 @@ subpackages:
     pipeline:
       - uses: split/static
 
-  - name: libpng-utils
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/share
-          mv ${{targets.destdir}}/usr/bin ${{targets.subpkgdir}}/usr/
-    description: libpng utils
-
   - name: libpng-dev
     pipeline:
       - uses: split/dev
@@ -60,6 +53,13 @@ subpackages:
       runtime:
         - libpng
     description: libpng dev
+
+  - name: libpng-utils
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share
+          mv ${{targets.destdir}}/usr/bin ${{targets.subpkgdir}}/usr/
+    description: libpng utils
 
 update:
   enabled: true


### PR DESCRIPTION
The programs libpng-config and libpng16-config are really development tools to help use libpng-dev.
