### PR TITLE
Correct istio-install-cni package name

### DIFF
--- a/istio-cni-1.22.yaml
+++ b/istio-cni-1.22.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-cni-1.22
   version: 1.22.0
-  epoch: 1
+  epoch: 2
   description: Istio Container Network Interface
   copyright:
     - license: Apache-2.0
@@ -43,7 +43,7 @@ subpackages:
       provides:
         - istio-cni-compat=${{package.full-version}}
 
-  - name: istio-install-cni-1.21
+  - name: istio-install-cni-1.22
     pipeline:
       - uses: go/build
         with:
@@ -54,7 +54,7 @@ subpackages:
       provides:
         - istio-install-cni=${{package.full-version}}
 
-  - name: istio-install-cni-1.21-compat
+  - name: istio-install-cni-1.22-compat
     pipeline:
       - runs: |
           # See https://github.com/istio/istio/blob/1.20.0/cni/deployments/kubernetes/Dockerfile.install-cni


### PR DESCRIPTION
Looks like the automation missed this subpackage version. I tried to do

```yaml
var-transforms:
  - from: ${{package.name}}
    match: ^(istio)-(cni-\d+.\d+)$
    replace: "${1}-install-${2}"
    to: mangled-istio-install-name
```

and use the var as the package name but the build was throwing

```sh
2024/05/16 15:27:04 INFO error during command execution: validating configuration "istio-cni-1.22": build configuration is invalid: subpackage name "${{vars.mangled-istio-install-name}}" (subpackages index: 1) must match regex "^[a-zA-Z\\d][a-zA-Z\\d+_.-]*$"
```