### PR TITLE
fix(apache-nifi): Copy correct scripts

### DIFF
--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,13 +1,14 @@
 package:
   name: apache-nifi
   version: 1.26.0
-  epoch: 0
+  epoch: 1
   description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - bash
+      - busybox
       - openjdk-11-jre
       - xmlstarlet
 
@@ -69,8 +70,9 @@ pipeline:
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/share/nifi/scripts
-      install -m755 nifi-docker/dockerhub/*.sh "${{targets.destdir}}"/usr/share/nifi/scripts/
+      install -m755 nifi-docker/dockerhub/sh/*.sh "${{targets.destdir}}"/usr/share/nifi/scripts/
       chmod -R +x ${{targets.destdir}}/usr/share/nifi/scripts
+      rm ${{targets.destdir}}/usr/share/nifi/bin/*.bat
 
   - uses: strip
 


### PR DESCRIPTION
The scripts used at runtime are located in the `sh` subfolder. The other scripts are used to build and run the Docker container which are not applicable to us

Additionally, add busybox as it is needed by these scripts and remove unused batch scripts
