### PR TITLE
feat(apache-nifi): Add NiFi toolkit

### DIFF
--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -10,7 +10,6 @@ package:
       - bash
       - busybox
       - coreutils
-      - openjdk-11
       - openjdk-11-default-jvm
       - openjdk-11-jre
       - xmlstarlet
@@ -39,7 +38,8 @@ environment:
       -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
       -Daether.connector.http.retryHandler.count=5
       -Daether.connector.http.connectionMaxTtl=30
-    NIFI_HOME: "opt/nifi/nifi-current"
+    NIFI_BASE: "/usr/share/nifi"
+    NIFI_HOME: "/usr/share/nifi/nifi-current"
 
 pipeline:
   - uses: git-checkout
@@ -56,36 +56,38 @@ pipeline:
         -DskipTests \
         -Dfrontend.skipTests=true \
         -Drat.skip=true
-      mkdir -p ${{targets.destdir}}/usr/share/
-      cp -ar nifi-assembly/target/nifi-${{package.version}}-bin/nifi-${{package.version}} ${{targets.destdir}}/usr/share/nifi
-
-  - runs: |
-      for dir in conf database_repository flowfile_repository content_repository provenance_repository state; do
-        mkdir -p "${{targets.destdir}}/usr/share/nifi/${dir}"
-      done
+      mkdir -p "${{targets.contextdir}}/${NIFI_BASE}"
+      cp -ar "nifi-assembly/target/nifi-${{package.version}}-bin/nifi-${{package.version}}" "${{targets.contextdir}}/${NIFI_HOME}"
 
       for dir in conf database_repository flowfile_repository content_repository provenance_repository state; do
-        mkdir -p ${{targets.destdir}}/usr/share/nifi/logs/${dir}
+        mkdir -p "${{targets.contextdir}}/${NIFI_HOME}/${dir}"
       done
 
-  - runs: |
-      echo "#!/bin/sh\n" > ${{targets.destdir}}/usr/share/nifi/bin/nifi-env.sh
+      echo "#!/bin/sh\n" > "${{targets.contextdir}}/${NIFI_HOME}/bin/nifi-env.sh"
 
-  - runs: |
-      mkdir -p ${{targets.destdir}}/usr/share/nifi/scripts
-      install -m755 nifi-docker/dockerhub/sh/*.sh "${{targets.destdir}}"/usr/share/nifi/scripts/
-      chmod -R +x ${{targets.destdir}}/usr/share/nifi/scripts
-      rm ${{targets.destdir}}/usr/share/nifi/bin/*.bat
+      mkdir -p "${{targets.contextdir}}/${NIFI_BASE}/scripts"
+      install -m755 nifi-docker/dockerhub/sh/*.sh "${{targets.contextdir}}/${NIFI_BASE}/scripts/"
+      chmod -R +x "${{targets.contextdir}}/${NIFI_BASE}/scripts"
+      rm "${{targets.contextdir}}/${NIFI_HOME}"/bin/*.bat
+
+      ln -sf "${NIFI_HOME}" "${{targets.contextdir}}/${NIFI_HOME}/nifi-${{package.version}}"
 
   - uses: strip
 
 subpackages:
   - name: "${{package.name}}-compat"
     description: "Compatibility package to place binaries in the location expected by upstream image"
+    dependencies:
+      runtime:
+        - apache-nifi
     pipeline:
       - runs: |
-          mkdir -p "${{targets.contextdir}}"/${NIFI_HOME}
-          ln -sf /usr/share/nifi "${{targets.contextdir}}"/${NIFI_HOME}/nifi
+          mkdir -p "${{targets.contextdir}}"/opt/nifi
+          ln -sf "${NIFI_BASE}" "${{targets.contextdir}}"/opt/nifi
+    test:
+      pipeline:
+        - runs: |
+            test -d /opt/nifi/nifi-current
 
 update:
   enabled: true
@@ -102,4 +104,4 @@ test:
   pipeline:
     - runs: |
         export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
-        /usr/share/nifi/bin/nifi.sh start
+        "${NIFI_HOME}"/bin/nifi.sh start

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -40,6 +40,7 @@ environment:
       -Daether.connector.http.connectionMaxTtl=30
     NIFI_BASE: "/usr/share/nifi"
     NIFI_HOME: "/usr/share/nifi/nifi-current"
+    TOOLKIT_HOME: "/usr/share/nifi/nifi-toolkit-current"
 
 pipeline:
   - uses: git-checkout
@@ -49,6 +50,7 @@ pipeline:
       expected-commit: 338083f6850b61cd2651e41bbd73b3cb5330d98c
 
   - runs: |
+      # Build NiFi
       ./mvnw -T$(nproc)C -q package \
         --no-snapshot-updates \
         --no-transfer-progress \
@@ -56,25 +58,65 @@ pipeline:
         -DskipTests \
         -Dfrontend.skipTests=true \
         -Drat.skip=true
+
+      # Install NiFi
       mkdir -p "${{targets.contextdir}}/${NIFI_BASE}"
       cp -ar "nifi-assembly/target/nifi-${{package.version}}-bin/nifi-${{package.version}}" "${{targets.contextdir}}/${NIFI_HOME}"
 
+      # Create expected directories
       for dir in conf database_repository flowfile_repository content_repository provenance_repository state; do
         mkdir -p "${{targets.contextdir}}/${NIFI_HOME}/${dir}"
       done
 
+      # Set shell in environment script
       echo "#!/bin/sh\n" > "${{targets.contextdir}}/${NIFI_HOME}/bin/nifi-env.sh"
 
+      # Install scripts
       mkdir -p "${{targets.contextdir}}/${NIFI_BASE}/scripts"
       install -m755 nifi-docker/dockerhub/sh/*.sh "${{targets.contextdir}}/${NIFI_BASE}/scripts/"
+
+      # Ensure scripts are executable
       chmod -R +x "${{targets.contextdir}}/${NIFI_BASE}/scripts"
+
+      # Fix paths in scripts
+      sed -i "s|/opt|/usr/share|g" "${{targets.contextdir}}/${NIFI_BASE}"/scripts/*.sh
+
+      # Remove batch scripts
       rm "${{targets.contextdir}}/${NIFI_HOME}"/bin/*.bat
 
-      ln -sf "${NIFI_HOME}" "${{targets.contextdir}}/${NIFI_HOME}/nifi-${{package.version}}"
+      # Symlink current release to versioned path
+      ln -sf "${NIFI_HOME}" "${{targets.contextdir}}/${NIFI_BASE}/nifi-${{package.version}}"
 
   - uses: strip
 
 subpackages:
+  - name: "${{package.name}}-toolkit"
+    description: "Toolkit for Apache NiFi"
+    dependencies:
+      runtime:
+        - apache-nifi
+    pipeline:
+      - runs: |
+          TARGET_DIR="nifi-toolkit/nifi-toolkit-assembly/target"
+
+          # Unzip toolkit
+          unzip "${TARGET_DIR}/nifi-toolkit-1.26.0-bin.zip" -d "${TARGET_DIR}"
+
+          # Install toolkit
+          mkdir -p "${{targets.contextdir}}/${NIFI_BASE}"
+          cp -ar "${TARGET_DIR}/nifi-toolkit-${{package.version}}" "${{targets.contextdir}}/${TOOLKIT_HOME}"
+
+          # Remove batch scripts
+          rm "${{targets.contextdir}}/${TOOLKIT_HOME}"/bin/*.bat
+
+          # Symlink current release to versioned path
+          ln -sf "${TOOLKIT_HOME}" "${{targets.contextdir}}/${NIFI_BASE}/nifi-toolkit-${{package.version}}"
+      - uses: strip
+    test:
+      pipeline:
+        - runs: |
+            echo "help" | "${TOOLKIT_HOME}/bin/cli.sh"
+
   - name: "${{package.name}}-compat"
     description: "Compatibility package to place binaries in the location expected by upstream image"
     dependencies:
@@ -82,8 +124,8 @@ subpackages:
         - apache-nifi
     pipeline:
       - runs: |
-          mkdir -p "${{targets.contextdir}}"/opt/nifi
-          ln -sf "${NIFI_BASE}" "${{targets.contextdir}}"/opt/nifi
+          mkdir -p "${{targets.contextdir}}/opt"
+          ln -sf "${NIFI_BASE}" "${{targets.contextdir}}/opt/nifi"
     test:
       pipeline:
         - runs: |

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi
   version: 1.26.0
-  epoch: 1
+  epoch: 2
   description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
   copyright:
     - license: Apache-2.0
@@ -9,6 +9,9 @@ package:
     runtime:
       - bash
       - busybox
+      - coreutils
+      - openjdk-11
+      - openjdk-11-default-jvm
       - openjdk-11-jre
       - xmlstarlet
 

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -65,7 +65,7 @@ pipeline:
       cp -ar "nifi-assembly/target/nifi-${{package.version}}-bin/nifi-${{package.version}}" "${{targets.contextdir}}/${NIFI_HOME}"
 
       # Create expected directories
-      for dir in conf database_repository flowfile_repository content_repository provenance_repository state; do
+      for dir in conf logs database_repository flowfile_repository content_repository provenance_repository state; do
         mkdir -p "${{targets.contextdir}}/${NIFI_HOME}/${dir}"
       done
 

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -51,8 +51,15 @@ pipeline:
       expected-commit: 338083f6850b61cd2651e41bbd73b3cb5330d98c
 
   - runs: |
+      # Use single thread on x86_64
+      if [[ "${{build.arch}}" == "x86_64" ]]; then
+        MAVEN_THREADS=1
+      else
+        MAVEN_THREADS=$(nproc)
+      fi
+
       # Build NiFi
-      ./mvnw -T$(nproc)C -q package \
+      ./mvnw -T${MAVEN_THREADS}C -q package \
         --no-snapshot-updates \
         --no-transfer-progress \
         --fail-fast \

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -10,6 +10,7 @@ package:
       - bash
       - busybox
       - coreutils
+      - glibc-locale-en
       - openjdk-11-default-jvm
       - openjdk-11-jre
       - xmlstarlet

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -116,7 +116,7 @@ subpackages:
     test:
       pipeline:
         - runs: |
-            echo "help" | "${TOOLKIT_HOME}/bin/cli.sh"
+            echo "help" | /usr/share/nifi/nifi-toolkit-current/bin/cli.sh
 
   - name: "${{package.name}}-compat"
     description: "Compatibility package to place binaries in the location expected by upstream image"
@@ -147,4 +147,4 @@ test:
   pipeline:
     - runs: |
         export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
-        "${NIFI_HOME}"/bin/nifi.sh start
+        /usr/share/nifi/nifi-current/bin/nifi.sh start


### PR DESCRIPTION
- Adds NiFi toolkit
- Corrects NiFi installation paths
- Adds openjdk-default-jvm and coreutils as runtime deps
- Adds package test for the compat package
- Cleans up unused duplicate directories in the logs subfolder