### PR TITLE
font-ubuntu and re2c: fix spdx license identifiers

### DIFF
--- a/font-ubuntu.yaml
+++ b/font-ubuntu.yaml
@@ -2,10 +2,10 @@
 package:
   name: font-ubuntu
   version: 0.869
-  epoch: 0
+  epoch: 1
   description: Ubuntu font family
   copyright:
-    - license: custom:Ubuntu Font License 1.0
+    - license: LicenseRef-ubuntu-font
 
 environment:
   contents:

--- a/re2c.yaml
+++ b/re2c.yaml
@@ -2,10 +2,10 @@
 package:
   name: re2c
   version: "3.1"
-  epoch: 0
+  epoch: 1
   description: Lexer generator for C, C++ and Go
   copyright:
-    - license: Public-Domain
+    - license: Unlicense
 
 environment:
   contents:


### PR DESCRIPTION
Related PR https://github.com/wolfi-dev/os/pull/19616

The differences with this PR and the one linked above is that this also fixes re2c and avoids the `license-path: LICENCE.txt` in the proposed font-ubuntu.yaml.

error:
```
Error: unable to decode configuration file "font-ubuntu.yaml": yaml: unmarshal errors:
  line 9: field license-path not found in type config.Copyright
```

This PR will unblock merging PRs into wolfi as all are now failing `wolfictl lint`

```
2024/05/17 08:31:07 INFO Package: font-ubuntu: [valid-spdx-license]: license "custom:Ubuntu Font License 1.0" is not valid SPDX license (ERROR)
2024/05/17 08:31:07 INFO Package: re2c: [valid-spdx-license]: license "Public-Domain" is not valid SPDX license (ERROR)
2024/05/17 08:31:07 INFO error during command execution: linting failed
```