### PR TITLE
add nifi-toolkit and symlinks for compat

### DIFF
--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,12 +1,13 @@
 package:
   name: apache-nifi
   version: 1.26.0
-  epoch: 1
+  epoch: 2
   description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
+      - apache-nifi-toolkit
       - bash
       - busybox
       - openjdk-11-jre
@@ -37,6 +38,7 @@ environment:
       -Daether.connector.http.retryHandler.count=5
       -Daether.connector.http.connectionMaxTtl=30
     NIFI_HOME: "opt/nifi/nifi-current"
+    NIFI_TOOLKIT_HOME: "opt/nifi/nifi-toolkit-current"
 
 pipeline:
   - uses: git-checkout
@@ -54,6 +56,8 @@ pipeline:
         -Dfrontend.skipTests=true \
         -Drat.skip=true
       mkdir -p ${{targets.destdir}}/usr/share/
+      ls -latrd nifi-assembly || true
+      ls -latrd nifi-assembly/target || true
       cp -ar nifi-assembly/target/nifi-${{package.version}}-bin/nifi-${{package.version}} ${{targets.destdir}}/usr/share/nifi
 
   - runs: |
@@ -77,12 +81,28 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: "${{package.name}}-toolkit"
+    description: "Compatibility package to place binaries in the location expected by upstream image"
+    pipeline:
+      - working-directory: nifi-toolkit
+        pipeline:
+          - runs: |
+              mkdir -p "${{targets.contextdir}}"/usr/share
+              mvn clean install --no-snapshot-updates --no-transfer-progress --fail-fast -DskipTests
+              ls -latrd target || true
+              ls -latrd target/nifi* || true
+              cp -ar nifi-assembly/target/nifi-toolkit-${{package.version}}-bin/nifi-toolkit-${{package.version}} ${{targets.destdir}}/usr/share/nifi-toolkit
+
   - name: "${{package.name}}-compat"
     description: "Compatibility package to place binaries in the location expected by upstream image"
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/${NIFI_HOME}
-          ln -sf /usr/share/nifi "${{targets.contextdir}}"/${NIFI_HOME}/nifi
+          mkdir -p "${{targets.contextdir}}"/${NIFI_TOOLKIT_HOME}
+          ln -sf /usr/share/nifi "${{targets.contextdir}}"/${NIFI_HOME}
+          ln -sf /usr/share/nifi-toolkit "${{targets.contextdir}}"/${NIFI_TOOLKIT_HOME}
+          ln -sf /${NIFI_HOME} /opt/nifi/nifi-${{package.version}}
+          ln -sf /${NIFI_TOOLKIT_HOME} /opt/nifi/nifi-toolkit-${{package.version}}
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
