### PR TITLE
bump common base packages to get valid SBOMs

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: apk-tools
   version: 2.14.1
-  epoch: 1
+  epoch: 2
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only

--- a/busybox.yaml
+++ b/busybox.yaml
@@ -1,7 +1,7 @@
 package:
   name: busybox
   version: 1.36.1
-  epoch: 8
+  epoch: 9
   description: "swiss-army knife for embedded systems"
   copyright:
     - license: GPL-2.0-only

--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -1,7 +1,7 @@
 package:
   name: ca-certificates
   version: "20240315"
-  epoch: 1
+  epoch: 2
   description: "CA certificates from the Mozilla trusted root program"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/tzdata.yaml
+++ b/tzdata.yaml
@@ -1,7 +1,7 @@
 package:
   name: tzdata
   version: 2024a
-  epoch: 1
+  epoch: 2
   description: "Timezone data provided by IANA"
   copyright:
     - license: CC-PDDC

--- a/wget.yaml
+++ b/wget.yaml
@@ -1,7 +1,7 @@
 package:
   name: wget
   version: 1.24.5
-  epoch: 1
+  epoch: 3
   description: "GNU wget"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 8
+  epoch: 9
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT


### PR DESCRIPTION
bumps our 4 most used packages to get valid SBOMs according to NTIA conformance checker

Prior to this:

```
│ Is this SBOM NTIA minimum element conformant? False
│ 
│ Individual elements                            | Status
│ -------------------------------------------------------
│ All component names provided?                  | True
│ All component versions provided?               | True
│ All component identifiers provided?            | True
│ All component suppliers provided?              | False
│ SBOM author name provided?                     | True
│ SBOM creation timestamp provided?              | True
│ Dependency relationships provided?             | True
│ 
│ Components missing an supplier:
│ ca-certificates-bundle,wolfi-baselayout,busybox,tzdata

```

also `apk-tools` and `wget` since those are used in a lot of places too.