### PR TITLE
Add fio package

### DIFF
--- a/fio.yaml
+++ b/fio.yaml
@@ -1,0 +1,41 @@
+package:
+  name: fio
+  version: "3.37"
+  epoch: 0
+  description: Flexible I/O Tester
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - libaio-dev
+      - zlib-dev
+      - coreutils
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/axboe/fio
+      tag: fio-${{package.version}}
+      expected-commit: 028fcc7db00155fe329497d7501184e8fe49342f
+
+  - runs: |
+      ./configure --prefix=/usr
+      make
+      make DESTDIR="${{targets.destdir}}" install
+
+subpackages:
+  - name: fio-docs
+    pipeline:
+      - uses: split/manpages
+
+update:
+  enabled: true
+  github:
+    identifier: axboe/fio
+    strip-prefix: fio-

--- a/fio.yaml
+++ b/fio.yaml
@@ -27,7 +27,7 @@ pipeline:
   - runs: |
       ./configure --prefix=/usr
       make
-      make DESTDIR="${{targets.destdir}}" install
+      make DESTDIR="${{targets.contextdir}}" install
 
 subpackages:
   - name: fio-docs

--- a/fio.yaml
+++ b/fio.yaml
@@ -12,10 +12,10 @@ environment:
       - bash
       - build-base
       - busybox
+      - ca-certificates-bundle
+      - coreutils
       - libaio-dev
       - zlib-dev
-      - coreutils
-      - ca-certificates-bundle
 
 pipeline:
   - uses: git-checkout

--- a/fio.yaml
+++ b/fio.yaml
@@ -39,9 +39,9 @@ update:
   github:
     identifier: axboe/fio
     strip-prefix: fio-
- 
+
 test:
   pipeline:
     - name: Verify fio installation
       runs: |
-          fio --version || exit 1   
+        fio --version || exit 1   

--- a/fio.yaml
+++ b/fio.yaml
@@ -39,3 +39,9 @@ update:
   github:
     identifier: axboe/fio
     strip-prefix: fio-
+ 
+test:
+  pipeline:
+    - name: Verify fio installation
+      runs: |
+          fio --version || exit 1   

--- a/fio.yaml
+++ b/fio.yaml
@@ -44,4 +44,4 @@ test:
   pipeline:
     - name: Verify fio installation
       runs: |
-        fio --version || exit 1   
+        fio --version || exit 1


### PR DESCRIPTION
Fixes:
* #19701

#### For new package PRs only
- [x] This PR is marked as fixing a pre-existing package request bug
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

