### PR TITLE
fix cassandra-reaper 3.6.0

### DIFF
--- a/cassandra-reaper.yaml
+++ b/cassandra-reaper.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-reaper
   version: 3.6.0
-  epoch: 0
+  epoch: 1
   description: Automated Repair Awesomeness for Apache Cassandra
   copyright:
     - license: Apache-2.0
@@ -67,6 +67,7 @@ pipeline:
       cp -r $builddir/src/packaging/bin/spreaper "${{targets.destdir}}"/usr/local/bin/spreaper
 
       touch "${{targets.destdir}}"/etc/cassandra-reaper/cassandra-reaper.yml
+
       touch "${{targets.destdir}}"/etc/cassandra-reaper/shiro.ini
 
       chmod +x \
@@ -76,6 +77,10 @@ pipeline:
         "${{targets.destdir}}"/usr/local/bin/configure-metrics.sh \
         "${{targets.destdir}}"/usr/local/bin/configure-jmx-credentials.sh \
         "${{targets.destdir}}"/usr/local/bin/spreaper
+
+      # https://github.com/thelastpickle/cassandra-reaper/pull/1499/files#diff-a51813561d5bd959f98eb6965691410fb1aa3b3b659f6b437b418cfa30d366a9R87
+      mkdir -p "${{targets.destdir}}"/usr/lib/cassandra-reaper/storage
+      mkdir -p "${{targets.destdir}}"/var/tmp/cassandra-reaper
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
