### PR TITLE
Add jmods provides for jdks 18-20, fix configure flags

### DIFF
--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -73,9 +73,6 @@ pipeline:
   - uses: autoconf/configure
     with:
       opts: |
-        --with-extra-cflags="$CFLAGS" \
-        --with-extra-cxxflags="$CXXFLAGS" \
-        --with-extra-ldflags="$LDFLAGS" \
         --with-boot-jdk=/usr/lib/jvm/java-17-openjdk \
         --prefix=/usr/lib/jvm/java-18-openjdk \
         --with-vendor-name=wolfi \

--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -70,6 +70,12 @@ pipeline:
   # Note that despite using --with-extra-cflags, --with-extra-cxxflags, and
   # --with-extra-ldflags, the configure still produces warnings like:
   # https://github.com/wolfi-dev/os/issues/18747
+  # This version of JDK fails if we try to use those flags, so the following
+  # are commented out until we can figure out how to fix it.
+  # https://github.com/wolfi-dev/os/issues/19814
+  # --with-extra-cflags="$CFLAGS" \
+  # --with-extra-cxxflags="$CXXFLAGS" \
+  # --with-extra-ldflags="$LDFLAGS" \
   - uses: autoconf/configure
     with:
       opts: |

--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-18
   version: 18.0.2.1.0
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-or-later
@@ -64,9 +64,15 @@ pipeline:
 
   - runs: chmod +x configure
 
+  # Note that despite using --with-extra-cflags, --with-extra-cxxflags, and
+  # --with-extra-ldflags, the configure still produces warnings like:
+  # https://github.com/wolfi-dev/os/issues/18747
   - uses: autoconf/configure
     with:
       opts: |
+        --with-extra-cflags="$CFLAGS" \
+        --with-extra-cxxflags="$CXXFLAGS" \
+        --with-extra-ldflags="$LDFLAGS" \
         --with-boot-jdk=/usr/lib/jvm/java-17-openjdk \
         --prefix=/usr/lib/jvm/java-18-openjdk \
         --with-vendor-name=wolfi \
@@ -175,6 +181,9 @@ subpackages:
 
   - name: "openjdk-18-jmods"
     description: "OpenJDK 18 jmods"
+    dependencies:
+      provides:
+        - openjdk-jmods=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-18-openjdk

--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -37,6 +37,9 @@ environment:
       - openjdk-17
       - openjdk-17-default-jvm
       - zip
+  environment:
+    # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
+    SOURCE_DATE_EPOCH: 315532900
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
 var-transforms:

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-19
   version: 19.0.2.7
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-or-later
@@ -64,9 +64,15 @@ pipeline:
 
   - runs: chmod +x configure
 
+  # Note that despite using --with-extra-cflags, --with-extra-cxxflags, and
+  # --with-extra-ldflags, the configure still produces warnings like:
+  # https://github.com/wolfi-dev/os/issues/18747
   - uses: autoconf/configure
     with:
       opts: |
+        --with-extra-cflags="$CFLAGS" \
+        --with-extra-cxxflags="$CXXFLAGS" \
+        --with-extra-ldflags="$LDFLAGS" \
         --with-boot-jdk=/usr/lib/jvm/java-18-openjdk \
         --prefix=/usr/lib/jvm/java-19-openjdk \
         --with-vendor-name=wolfi \
@@ -175,6 +181,9 @@ subpackages:
 
   - name: "openjdk-19-jmods"
     description: "OpenJDK 19 jmods"
+    dependencies:
+      provides:
+        - openjdk-jmods=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-19-openjdk

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -37,6 +37,9 @@ environment:
       - openjdk-18
       - openjdk-18-default-jvm
       - zip
+  environment:
+    # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
+    SOURCE_DATE_EPOCH: 315532900
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
 var-transforms:

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-20
   version: 20.0.2.9
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: GPL-2.0-or-later
@@ -37,6 +37,9 @@ environment:
       - openjdk-19
       - openjdk-19-default-jvm
       - zip
+  environment:
+    # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
+    SOURCE_DATE_EPOCH: 315532900
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
 var-transforms:
@@ -64,9 +67,15 @@ pipeline:
 
   - runs: chmod +x configure
 
+  # Note that despite using --with-extra-cflags, --with-extra-cxxflags, and
+  # --with-extra-ldflags, the configure still produces warnings like:
+  # https://github.com/wolfi-dev/os/issues/18747
   - uses: autoconf/configure
     with:
       opts: |
+        --with-extra-cflags="$CFLAGS" \
+        --with-extra-cxxflags="$CXXFLAGS" \
+        --with-extra-ldflags="$LDFLAGS" \
         --with-boot-jdk=/usr/lib/jvm/java-19-openjdk \
         --prefix=/usr/lib/jvm/java-20-openjdk \
         --with-vendor-name=wolfi \
@@ -181,6 +190,9 @@ subpackages:
 
   - name: "openjdk-20-jmods"
     description: "OpenJDK 20 jmods"
+    dependencies:
+      provides:
+        - openjdk-jmods=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-20-openjdk


### PR DESCRIPTION
Related to: https://github.com/wolfi-dev/os/issues/18747 for 18-20.

Note that jdk 18 fails to build with the configure flags, I've created: #19814 to track that. I think we should get it in with the others because:
 * It does now handle the jmods properly
 * configure flags are the same as before for 18, so there's no regression for it, and there's now context in comments.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
