### PR TITLE
feat: add age package

### DIFF
--- a/age.yaml
+++ b/age.yaml
@@ -1,0 +1,41 @@
+---
+package:
+  name: age
+  version: 1.1.1
+  epoch: 0
+  description: A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability.
+  copyright:
+    - license: BSD-3-Clause
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/FiloSottile/age.git
+      tag: v${{package.version}}
+      expected-commit: c6dcfa1efcaa27879762a934d5bea0d1b83a894c
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.17.0
+
+  - uses: go/build
+    with:
+      packages: ./cmd/age/
+      output: age
+      ldflags: |
+        -X main.Version=${{package.version}}
+
+  - uses: go/build
+    with:
+      packages: ./cmd/age-keygen/
+      output: age-keygen
+      ldflags: |
+        -X main.Version=${{package.version}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: FiloSottile/age
+    strip-prefix: v

--- a/age.yaml
+++ b/age.yaml
@@ -35,7 +35,8 @@ pipeline:
 
 test:
   pipeline:
-    - runs: |
+    - name: "Encrypt and decrypt a secret"
+      runs: |
         echo "Hello, World!" > data.txt
         age-keygen -o key.txt
         age -r $(grep 'public key' key.txt | awk '{ print $4 }') -o data.txt.age data.txt

--- a/age.yaml
+++ b/age.yaml
@@ -1,4 +1,3 @@
----
 package:
   name: age
   version: 1.1.1

--- a/age.yaml
+++ b/age.yaml
@@ -33,6 +33,15 @@ pipeline:
 
   - uses: strip
 
+test:
+  pipeline:
+    - run: |
+        echo "Hello, World!" > data.txt
+        age-keygen -o key.txt
+        age -r $(grep 'public key' key.txt | awk '{ print $4 }') -o data.txt.age data.txt
+        age -d -i key.txt data.txt.age > data_extracted.txt
+        diff data.txt data_extracted.txt
+
 update:
   enabled: true
   github:

--- a/age.yaml
+++ b/age.yaml
@@ -35,7 +35,7 @@ pipeline:
 
 test:
   pipeline:
-    - run: |
+    - runs: |
         echo "Hello, World!" > data.txt
         age-keygen -o key.txt
         age -r $(grep 'public key' key.txt | awk '{ print $4 }') -o data.txt.age data.txt


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

[`age`](https://age-encryption.org/) can be used as a secret manager for [`sops`](https://github.com/getsops/sops#encrypting-using-age).

I'm not sure I've done it correctly with multiple binaries.  Could not find a proper example for `mkdir bin && go build -o bin cmd/...`

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

[Author's security policy](https://github.com/FiloSottile/FiloSottile/blob/main/maintenance.md#security)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
