### PR TITLE
jitterentropy-rngd: Statically link prebuilt jitterentropy

### DIFF
--- a/jitterentropy-rngd.yaml
+++ b/jitterentropy-rngd.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitterentropy-rngd
   version: 1.2.8
-  epoch: 0
+  epoch: 1
   description: Jitterentropy RNGd
   copyright:
     - license: GPL-2.0-only
@@ -11,6 +11,7 @@ environment:
     packages:
       - build-base
       - busybox
+      - jitterentropy-library-dev
 
 pipeline:
   - uses: git-checkout
@@ -20,11 +21,13 @@ pipeline:
       tag: v${{package.version}}
 
   - runs: |
-      # jitterentropy must *not* be compiled with optimizations
-      export CFLAGS="$CFLAGS -O0"
-      export CPPFLAGS="$CPPFLAGS -O0"
-      export CXXFLAGS="$CXXFLAGS -O0"
-      make
+      # Remove embedded copy of jitterentropy-library
+      rm -rf lib/*
+      rm -rf jitterentropy.h jitterentropy-base-user.h
+      # Link against public static libjitter-entoropy
+      sed '/^LIBRARIES/s/$/ :libjitterentropy.a/' -i Makefile
+      # Install into /usr
+      sed '/^PREFIX/s|/usr/local|/usr|' -i Makefile
 
   - uses: autoconf/make-install
 


### PR DESCRIPTION
Instead of rebuilding jitterentropy library, link against prebuilt
static copy of it.

Fix install location to use /usr prefix.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
