### PR TITLE
Add /usr/local/lib to baselayout

### DIFF
--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 9
+  epoch: 10
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
@@ -37,7 +37,7 @@ pipeline:
 
   - name: Install
     runs: |
-      for i in bin etc etc/profile.d etc/secfixes.d home lib root var/log usr/bin usr/sbin usr/local tmp var/spool/cron opt run usr/lib; do
+      for i in bin etc etc/profile.d etc/secfixes.d home lib root var/log usr/bin usr/sbin usr/local/lib tmp var/spool/cron opt run usr/lib; do
         mkdir -p "${{targets.destdir}}"/${i}
       done
 


### PR DESCRIPTION
- **wolfi-baselayout: make usr/local/lib real**
  Right now we ship usr/local/lib64 as a dangling symlink to
  usr/local/lib. This confuses some software that gets excited to scan
  usr/local/lib64 and then fails. Add usr/local/lib as a real empty
  directory to the baselayout.
  
  This fixes, among many other things, warnings and errors from node in
  all node images.  