### PR TITLE
postgis - Use protoc instead of protoc-c.

### DIFF
--- a/postgis.yaml
+++ b/postgis.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgis
   version: 3.4.2
-  epoch: 2
+  epoch: 3
   description: Geographic Information Systems Extensions to PostgreSQL
   copyright:
     - license: GPL-2.0-or-later
@@ -22,8 +22,8 @@ environment:
       - perl-dev
       - postgresql-dev
       - proj-dev
-      - protobuf
       - protobuf-c-dev
+      - protoc
 
 pipeline:
   - uses: fetch
@@ -36,6 +36,8 @@ pipeline:
          --libdir=/usr/lib
 
   - uses: autoconf/make
+    with:
+      opts: PROTOCC=protoc
 
   - runs: |
       make install DESTDIR="${{targets.destdir}}"


### PR DESCRIPTION
protoc-c has problems with newer versions of protobuf which cause build errors if using protoc-c
See https://github.com/protobuf-c/protobuf-c/pull/711

The failures look like:

    protoc-c -I. --c_out=. vector_tile.proto
        command_line_interface.cc:1534] Built-in generator
          --c_out specifies a maximum edition PROTO3
          which is not the protoc maximum 2023.

Fixes https://github.com/wolfi-dev/os/issues/19840

