### PR TITLE
Adding monitor as Subpackage

### DIFF
--- a/neuvector-monitor-5.3.yaml
+++ b/neuvector-monitor-5.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: neuvector-monitor-5.3
   version: 5.3.2
-  epoch: 0
+  epoch: 1
   description: NeuVector Full Lifecycle Container Security Platform.
   copyright:
     - license: Apache-2.0
@@ -29,10 +29,10 @@ pipeline:
 
   - runs: |
       make -C monitor
-      mkdir -p ${{targets.destdir}}/usr/local/bin
-      cp scripts/teardown.sh ${{targets.destdir}}/usr/local/bin/
-      cp scripts/configure.sh ${{targets.destdir}}/usr/local/bin/
-      install -Dm755 monitor/monitor ${{targets.destdir}}/usr/local/bin/neuvector-monitor
+      mkdir -p ${{targets.contextdir}}/usr/local/bin
+      cp scripts/teardown.sh ${{targets.contextdir}}/usr/local/bin/
+      cp scripts/configure.sh ${{targets.contextdir}}/usr/local/bin/
+      install -Dm755 monitor/monitor ${{targets.contextdir}}/usr/local/bin/neuvector-monitor
 
 update:
   enabled: true

--- a/neuvector-monitor-5.3.yaml
+++ b/neuvector-monitor-5.3.yaml
@@ -6,6 +6,8 @@ package:
   copyright:
     - license: Apache-2.0
   dependencies:
+    runtime:
+      - consul-1.16-oci-entrypoint
     provides:
       - neuvector-monitor=${{package.full-version}}
 
@@ -27,16 +29,10 @@ pipeline:
 
   - runs: |
       make -C monitor
-      mkdir -p ${{targets.contextdir}}/usr/local/bin
-      install -Dm755 monitor/monitor ${{targets.contextdir}}/usr/bin/neuvector-monitor
-
-subpackages:
-  - name: ${{package.name}}-compat
-    description: NeuVector Monitor binary symlink
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.contextdir}}/usr/local/bin
-          ln -s /usr/bin/neuvector-monitor ${{targets.contextdir}}/usr/local/bin/monitor
+      mkdir -p ${{targets.destdir}}/usr/local/bin
+      cp scripts/teardown.sh ${{targets.destdir}}/usr/local/bin/
+      cp scripts/configure.sh ${{targets.destdir}}/usr/local/bin/
+      install -Dm755 monitor/monitor ${{targets.destdir}}/usr/local/bin/neuvector-monitor
 
 update:
   enabled: true

--- a/neuvector-scanner.yaml
+++ b/neuvector-scanner.yaml
@@ -1,7 +1,7 @@
 package:
   name: neuvector-scanner
   version: 0_git20240417
-  epoch: 2
+  epoch: 3
   description: NeuVector vulnerability scanner for the SUSE NeuVector Container Security Platform
   copyright:
     - license: Apache-2.0
@@ -50,6 +50,15 @@ subpackages:
           output: ${{package.name}}-task
           subpackage: "true"
           vendor: true
+
+  # Need a separate monitor subpackage for neuvector/scanner/monitor different from neuvector/neuvector/monitor
+  - name: ${{package.name}}-monitor
+    description: NeuVector Scanner Monitor
+    pipeline:
+      - runs: |
+          make -C monitor
+          mkdir -p ${{targets.contextdir}}/usr/local/bin
+          install -Dm755 monitor/monitor ${{targets.contextdir}}/usr/local/bin/${{package.name}}-monitor
 
 test:
   pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
