### PR TITLE
Fix stdlib cve CVE-2024-24787 CVE-2024-24788

### DIFF
--- a/libnvidia-container.yaml
+++ b/libnvidia-container.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnvidia-container
   version: 1.15.0
-  epoch: 0
+  epoch: 1
   description: NVIDIA container runtime library
   copyright:
     - license: Apache-2.0

--- a/loki.yaml
+++ b/loki.yaml
@@ -1,7 +1,7 @@
 package:
   name: loki
   version: 3.0.0
-  epoch: 2
+  epoch: 3
   description: Like Prometheus, but for logs.
   copyright:
     - license: AGPL-3.0-or-later


### PR DESCRIPTION
loki
```
$ wolfictl scan loki --remote
📡 Finding remote packages
🔎 Scanning "/home/user/tmp/x86_64-loki-3.0.0-r2-3237338094.apk"
└── 📄 /usr/bin/loki
        📦 stdlib go1.22.2 (go-module)
            Unknown CVE-2024-24787
            Unknown CVE-2024-24788
```
libnvidia-container
```
$ wolfictl scan libnvidia-container --remote
📡 Finding remote packages
🔎 Scanning "/home/user/tmp/x86_64-libnvidia-container-1.15.0-r0-3065206254.apk"
└── 📄 /usr/lib/libnvidia-container-go.so.1.15.0
        📦 stdlib go1.22.2 (go-module)
            Unknown CVE-2024-24787
            Unknown CVE-2024-24788
```