### PR TITLE
go sdtlib cve 

### DIFF
--- a/kyverno.yaml
+++ b/kyverno.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno
   version: 1.12.1
-  epoch: 1
+  epoch: 2
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0

--- a/newrelic-nri-statsd.yaml
+++ b/newrelic-nri-statsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-nri-statsd
   version: 2.9.1
-  epoch: 2
+  epoch: 3
   description: An implementation of Etsy's statsd in Go with tags support
   copyright:
     - license: MIT


### PR DESCRIPTION
fixing
```
📦 stdlib go1.22.2 (go-module)
            Unknown CVE-2024-24787
            Unknown CVE-2024-24788
```