### PR TITLE
openldap: add hin files to include dir

### DIFF
--- a/openldap.yaml
+++ b/openldap.yaml
@@ -1,7 +1,7 @@
 package:
   name: openldap
   version: 2.6.8
-  epoch: 0
+  epoch: 1
   description: LDAP Server
   copyright:
     - license: OLDAP-2.8
@@ -230,6 +230,7 @@ subpackages:
         - libevent-dev
         - libsodium-dev
         - util-linux-dev
+        - openldap-hin
     description: openldap dev
 
   - name: openldap-doc
@@ -365,6 +366,12 @@ subpackages:
     pipeline:
       - runs: mkdir -p ${{targets.subpkgdir}}
     description: Virtual package that installs all OpenLDAP backends
+
+  - name: openldap-hin
+    pipeline:
+      - runs: mkdir -p ${{targets.subpkgdir}}/usr/include
+      - runs: install -m755 include/*.hin "${{targets.subpkgdir}}"/usr/include/
+    description: openldap hin files
 
 update:
   enabled: true


### PR DESCRIPTION
`openldap-dev` doesn't provide `*.hin` files in `/usr/include/` dir so we couldn't compile `pqchecker` package: https://bitbucket.org/ameddeb/pqchecker/src/2813c1922c4233d72066201d11b6b4ad4f61239d/configure#lines-12777

