### PR TITLE
github: add dependabot to update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Not sure if any other settings need to be adjusted on the repo. It
seems like some of our actions are not being upgraded. At least one
action is out of date which dependabot would upgrade.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
