### PR TITLE
use the correct component name for `system-probe`

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent
   version: 7.53.0
-  epoch: 5
+  epoch: 6
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -156,7 +156,7 @@ pipeline:
       invoke -e agent.build \
         --bundle process-agent \
         --bundle trace-agent \
-        --bundle system-agent \
+        --bundle system-probe \
         --bundle security-agent \
         --exclude-rtloader \
         --python-runtimes 3 \
@@ -430,3 +430,9 @@ test:
 
         export DD_HOSTNAME_FILE=/etc/hostname
         agent check uptime
+    - name: Validate multicall components are correctly linked
+      runs: |
+        trace-agent version | grep trace-agent
+        security-agent version | grep "Security agent"
+        process-agent version | grep Agent
+        system-probe version | grep "System Probe"


### PR DESCRIPTION
this got renamed incorrectly during the refactor 😮‍💨 