### PR TITLE
go/build cleanups

### DIFF
--- a/velero-plugin-for-aws.yaml
+++ b/velero-plugin-for-aws.yaml
@@ -1,21 +1,10 @@
 package:
   name: velero-plugin-for-aws
   version: 1.9.2
-  epoch: 3
+  epoch: 4
   description: Plugins to support Velero on AWS
   copyright:
     - license: Apache-2.0
-
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - git
-      - go
-  environment:
-    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout
@@ -32,13 +21,11 @@ pipeline:
     with:
       packages: ./velero-plugin-for-aws
       output: velero-plugin-for-aws
-      ldflags: "-s -w"
 
   - uses: go/build
     with:
       packages: ./hack/cp-plugin
       output: cp-plugin
-      ldflags: "-s -w"
 
   - uses: strip
 

--- a/velero-plugin-for-csi.yaml
+++ b/velero-plugin-for-csi.yaml
@@ -1,21 +1,10 @@
 package:
   name: velero-plugin-for-csi
   version: 0.7.1
-  epoch: 3
+  epoch: 4
   description: Velero plugins for integrating with CSI snapshot API
   copyright:
     - license: Apache-2.0
-
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - git
-      - go
-  environment:
-    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout
@@ -32,13 +21,11 @@ pipeline:
     with:
       packages: .
       output: velero-plugin-for-csi
-      ldflags: "-s -w"
 
   - uses: go/build
     with:
       packages: ./hack/cp-plugin
       output: cp-plugin
-      ldflags: "-s -w"
 
   - uses: strip
 

--- a/xcaddy.yaml
+++ b/xcaddy.yaml
@@ -1,14 +1,10 @@
 package:
   name: xcaddy
   version: 0.4.1
-  epoch: 1
+  epoch: 2
   description: Build Caddy with plugins
   copyright:
     - license: Apache-2.0
-
-environment:
-  environment:
-    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout
@@ -19,7 +15,6 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w
       output: xcaddy
       packages: ./cmd/xcaddy
 

--- a/yam.yaml
+++ b/yam.yaml
@@ -1,19 +1,10 @@
 package:
   name: yam
   version: 0.0.7
-  epoch: 0
+  epoch: 1
   description: A sweet little formatter for YAML
   copyright:
     - license: Apache-2.0
-
-environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
-  environment:
-    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout

--- a/yq.yaml
+++ b/yq.yaml
@@ -1,14 +1,10 @@
 package:
   name: yq
   version: 4.44.1
-  epoch: 0
+  epoch: 1
   description: "yq is a portable command-line YAML, JSON, XML, CSV and properties processor"
   copyright:
     - license: Apache-2.0
-
-environment:
-  environment:
-    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout

--- a/ytt.yaml
+++ b/ytt.yaml
@@ -1,14 +1,10 @@
 package:
   name: ytt
   version: 0.49.0
-  epoch: 3
+  epoch: 4
   description: YAML templating tool that works on YAML structure instead of text
   copyright:
     - license: Apache-2.0
-
-environment:
-  environment:
-    CGO_ENABLED: 0
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Cleanup redudant stanzas, or those contrary to the pipeline built-in
defaults.

Default go/build pipeline sets usertags for static binaries
automatically; required dependencies are pre-declared; built-in
ldflags already set to strip.

This also ensures that any future changes to defaults are adopted
automatically, and makes packaging easier to adapt for go-fips.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
