### PR TITLE
SPDX regeneration batch #1

### DIFF
--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -1,7 +1,7 @@
 package:
   name: ca-certificates
   version: "20240315"
-  epoch: 2
+  epoch: 3
   description: "CA certificates from the Mozilla trusted root program"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 13.2.0
-  epoch: 6
+  epoch: 7
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.39
-  epoch: 5
+  epoch: 6
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later

--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 10
+  epoch: 11
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT


### PR DESCRIPTION
Bump to regenerated SPDX with the following fixes:
 - **gcc** Components missing an supplier: libgcc,libstdc++
 - **all** add source code external references (pkg:generic or
     pkg:github)

The SDK image has up to date wolfictl that will fix the above.

This should make glibc-dynamic:latest image have valid SPDX with all source code references.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
