### PR TITLE
Kafka Proxy package

### DIFF
--- a/kafka-proxy.yaml
+++ b/kafka-proxy.yaml
@@ -1,0 +1,27 @@
+package:
+  name: kafka-proxy
+  version: 0.3.9
+  epoch: 0
+  description: Allows a service to connect to Kafka brokers without having to deal with SASL/PLAIN authentication and SSL certificates
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/grepplabs/kafka-proxy
+      tag: v${{package.version}}
+      expected-commit: 1839a885e16e05fe670033690999abf0d34f695a
+
+  - uses: go/build
+    with:
+      packages: .
+      output: kafka-proxy
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: grepplabs/kafka-proxy
+    strip-prefix: v

--- a/kafka-proxy.yaml
+++ b/kafka-proxy.yaml
@@ -33,4 +33,4 @@ update:
 test:
   pipeline:
     - runs: |
-        kafka-proxy --version
+        kafka-proxy --help

--- a/kafka-proxy.yaml
+++ b/kafka-proxy.yaml
@@ -12,7 +12,10 @@ pipeline:
       repository: https://github.com/grepplabs/kafka-proxy
       tag: v${{package.version}}
       expected-commit: 1839a885e16e05fe670033690999abf0d34f695a
-
+  
+  - uses: go/bump
+    with:
+      deps: google.golang.org/protobuf@1.33.0
   - uses: go/build
     with:
       packages: .

--- a/kafka-proxy.yaml
+++ b/kafka-proxy.yaml
@@ -15,7 +15,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: google.golang.org/protobuf@1.33.0
+      deps: google.golang.org/protobuf@v1.33.0
 
   - uses: go/build
     with:

--- a/kafka-proxy.yaml
+++ b/kafka-proxy.yaml
@@ -12,10 +12,11 @@ pipeline:
       repository: https://github.com/grepplabs/kafka-proxy
       tag: v${{package.version}}
       expected-commit: 1839a885e16e05fe670033690999abf0d34f695a
-  
+
   - uses: go/bump
     with:
       deps: google.golang.org/protobuf@1.33.0
+
   - uses: go/build
     with:
       packages: .
@@ -28,3 +29,8 @@ update:
   github:
     identifier: grepplabs/kafka-proxy
     strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        kafka-proxy --version


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
