### PR TITLE
flux-kustomize-controller tests

### DIFF
--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-kustomize-controller
   version: 1.3.0
-  epoch: 1
+  epoch: 2
   description: The GitOps Toolkit Kustomize reconciler
   copyright:
     - license: Apache-2.0
@@ -38,7 +38,7 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w
+      ldflags: -s -w -X main.Version=${{package.version}}
       output: kustomize-controller
       packages: .
 

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-kustomize-controller
   version: 1.3.0
-  epoch: 2
+  epoch: 1
   description: The GitOps Toolkit Kustomize reconciler
   copyright:
     - license: Apache-2.0
@@ -38,7 +38,7 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w -X main.Version=${{package.version}}
+      ldflags: -s -w
       output: kustomize-controller
       packages: .
 
@@ -54,8 +54,16 @@ update:
     tag-filter: v
     use-tag: true
 
-test:
+test:  
+  environment:
+    contents:
+      packages:
+        - curl
   pipeline:
+    - uses: test/kwok/cluster
     - name: Verify kustomize-controller installation
       runs: |
-        ls -l /usr/bin/kustomize-controller
+        kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
+        kubectl wait --for=condition=Ready nodes --all
+        kustomize-controller --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1 & \
+        sleep 5; curl -s localhost:8081/metrics  | grep rest_client_requests_total

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -54,7 +54,7 @@ update:
     tag-filter: v
     use-tag: true
 
-test:  
+test:
   environment:
     contents:
       packages:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
