### PR TITLE
chore(kafka): Move to OpenJDK 17 and implement package test

### DIFF
--- a/kafka.yaml
+++ b/kafka.yaml
@@ -67,6 +67,51 @@ subpackages:
           ln -s /usr/lib/kafka/config ${{targets.subpkgdir}}/opt/bitnami/kafka/config
           ln -s /usr/lib/kafka/logs ${{targets.subpkgdir}}/opt/bitnami/kafka/logs
 
+test:
+  environment:
+    contents:
+      packages:
+        - uuidgen
+  pipeline:
+    - runs: |
+        cd /usr/lib/kafka
+
+        # Start ZooKeeper
+        bin/zookeeper-server-start.sh config/zookeeper.properties &
+        ZK_PID=$!
+
+        # Start Kafka
+        bin/kafka-server-start.sh config/server.properties &
+        KAFKA_PID=$!
+        sleep 5
+
+        TOPIC_NAME="test-topic-$(uuidgen)"
+        PARTITIONS=1
+        REPLICATION_FACTOR=1
+
+        # Create a Kafka topic
+        bin/kafka-topics.sh --create --topic "${TOPIC_NAME}" --partitions "${PARTITIONS}" --replication-factor "${REPLICATION_FACTOR}" --if-not-exists --bootstrap-server localhost:9092
+
+        # Produce a test message
+        echo "Hello Kafka" | bin/kafka-console-producer.sh --broker-list localhost:9092 --topic "${TOPIC_NAME}"
+
+        # Consume the message
+        consumed_message=$(timeout 10 bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic "${TOPIC_NAME}" --from-beginning --max-messages 1)
+
+        # Verify the message
+        if [[ "${consumed_message}" == "Hello Kafka" ]]; then
+          echo "Successfully produced and consumed a test message."
+        else
+          echo "Failed to verify the consumed message."
+        fi
+
+        # Clean up the test topic
+        bin/kafka-topics.sh --delete --topic "${TOPIC_NAME}" --bootstrap-server localhost:9092
+
+        # Kill Kafka and ZooKeeper
+        kill "${KAFKA_PID}"
+        kill "${ZK_PID}"
+
 update:
   enabled: true
   github:

--- a/kafka.yaml
+++ b/kafka.yaml
@@ -22,7 +22,10 @@ environment:
       - curl
       - gradle
       - openjdk-17
-      - sbt
+      - openjdk-17-default-jvm
+  environment:
+    LANG: en_US.UTF-8
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 pipeline:
   - uses: git-checkout
@@ -36,8 +39,6 @@ pipeline:
       patches: CVE-2024-23944.patch
 
   - runs: |
-      export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
-
       gradle clean releaseTarGz
 
       tar -xf core/build/distributions/kafka_2.13-${{package.version}}.tgz
@@ -72,6 +73,9 @@ test:
     contents:
       packages:
         - uuidgen
+    environment:
+      LANG: en_US.UTF-8
+      JAVA_HOME: "/usr/lib/jvm/default-jvm"
   pipeline:
     - runs: |
         cd /usr/lib/kafka

--- a/kafka.yaml
+++ b/kafka.yaml
@@ -2,7 +2,7 @@ package:
   name: kafka
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.7.0
-  epoch: 3
+  epoch: 4
   description: Apache Kafka is a distributed event streaming platformm
   copyright:
     - paths:
@@ -12,7 +12,7 @@ package:
   dependencies:
     runtime:
       - bash # some helper scripts use bash
-      - openjdk-11-jre
+      - openjdk-17-default-jvm
 
 environment:
   contents:
@@ -21,7 +21,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - gradle
-      - openjdk-11
+      - openjdk-17
       - sbt
 
 pipeline:


### PR DESCRIPTION
Moves Kafka from OpenJDK 11 to OpenJDK 17 and implements package test