### PR TITLE
Added tests to flux-helm-controller and flux-notification-controller

### DIFF
--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-helm-controller
   version: 1.0.1
-  epoch: 0
+  epoch: 1
   description: The GitOps Toolkit Helm reconciler, for declarative Helming
   copyright:
     - license: Apache-2.0

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -39,3 +39,17 @@ update:
     strip-prefix: v
     tag-filter: v
     use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+  pipeline:
+    - uses: test/kwok/cluster
+    - name: Verify helm-controller installation
+      runs: |
+        kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
+        kubectl wait --for=condition=Ready nodes --all
+        helm-controller --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1 & \
+        sleep 5; curl -s localhost:8081/metrics  | grep rest_client_requests_total

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -24,7 +24,7 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w
+      ldflags: -s -w -X main.Version=${{package.version}}
       output: helm-controller
       packages: .
 

--- a/flux-notification-controller.yaml
+++ b/flux-notification-controller.yaml
@@ -23,6 +23,7 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin
       CGO_ENABLED=0 go build \
+        -ldflags="-X main.Version=${{package.version}}" \
         -trimpath -a -o "${{targets.destdir}}"/usr/bin/notification-controller .
 
   - uses: strip

--- a/flux-notification-controller.yaml
+++ b/flux-notification-controller.yaml
@@ -33,3 +33,17 @@ update:
     identifier: fluxcd/notification-controller
     strip-prefix: v
     tag-filter: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+  pipeline:
+    - uses: test/kwok/cluster
+    - name: Verify notification-controller installation
+      runs: |
+        kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
+        kubectl wait --for=condition=Ready nodes --all
+        notification-controller --health-addr :9441 --metrics-addr :8081 > /dev/null 2>&1 & \
+        sleep 5; curl -s localhost:8081/metrics  | grep rest_client_requests_total

--- a/flux-notification-controller.yaml
+++ b/flux-notification-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-notification-controller
   version: 1.3.0
-  epoch: 1
+  epoch: 2
   description: The GitOps Toolkit event forwarded and notification dispatcher
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
