### PR TITLE
give rust builds more resources

### DIFF
--- a/rust-1.29.yaml
+++ b/rust-1.29.yaml
@@ -6,6 +6,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.29.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.30.yaml
+++ b/rust-1.30.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.30.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.31.yaml
+++ b/rust-1.31.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.31.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.32.yaml
+++ b/rust-1.32.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.32.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.33.yaml
+++ b/rust-1.33.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.33.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.34.yaml
+++ b/rust-1.34.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.34.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.35.yaml
+++ b/rust-1.35.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.35.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.36.yaml
+++ b/rust-1.36.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.36.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.37.yaml
+++ b/rust-1.37.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.37.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.38.yaml
+++ b/rust-1.38.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.38.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.39.yaml
+++ b/rust-1.39.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.39.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.40.yaml
+++ b/rust-1.40.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.40.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.41.yaml
+++ b/rust-1.41.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.41.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.42.yaml
+++ b/rust-1.42.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.42.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.43.yaml
+++ b/rust-1.43.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.43.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.44.yaml
+++ b/rust-1.44.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.44.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.45.yaml
+++ b/rust-1.45.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.45.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.46.yaml
+++ b/rust-1.46.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.46.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.47.yaml
+++ b/rust-1.47.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.47.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.48.yaml
+++ b/rust-1.48.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.48.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.49.yaml
+++ b/rust-1.49.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.49.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.50.yaml
+++ b/rust-1.50.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.50.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.51.yaml
+++ b/rust-1.51.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.51.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.52.yaml
+++ b/rust-1.52.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.52.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.53.yaml
+++ b/rust-1.53.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.53.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.54.yaml
+++ b/rust-1.54.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.54.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.55.yaml
+++ b/rust-1.55.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.55.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.56.yaml
+++ b/rust-1.56.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.56.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.57.yaml
+++ b/rust-1.57.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.57.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.58.yaml
+++ b/rust-1.58.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.58.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.59.yaml
+++ b/rust-1.59.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.59.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.60.yaml
+++ b/rust-1.60.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.60.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.61.yaml
+++ b/rust-1.61.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.61.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.62.yaml
+++ b/rust-1.62.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.62.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.63.yaml
+++ b/rust-1.63.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.63.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.64.yaml
+++ b/rust-1.64.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.64.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.65.yaml
+++ b/rust-1.65.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.65.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.66.yaml
+++ b/rust-1.66.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.66.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.67.yaml
+++ b/rust-1.67.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.67.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.68.yaml
+++ b/rust-1.68.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.68.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.69.yaml
+++ b/rust-1.69.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.69.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.70.yaml
+++ b/rust-1.70.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.70.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.71.yaml
+++ b/rust-1.71.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.71.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.72.yaml
+++ b/rust-1.72.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.72.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.73.yaml
+++ b/rust-1.73.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.73.0)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.74.yaml
+++ b/rust-1.74.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software. (version 1.74.1)"
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     provides:
       - rust=${{package.full-version}}

--- a/rust-1.75.yaml
+++ b/rust-1.75.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     runtime:
       - libLLVM-17

--- a/rust-1.76.yaml
+++ b/rust-1.76.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     runtime:
       - libLLVM-17

--- a/rust-1.77.yaml
+++ b/rust-1.77.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     runtime:
       - libLLVM-17

--- a/rust-1.78.yaml
+++ b/rust-1.78.yaml
@@ -5,6 +5,9 @@ package:
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
+  resources:
+    cpu: 16
+    memory: 16Gi
   dependencies:
     runtime:
       - libLLVM-18.1


### PR DESCRIPTION
These are requesting 2 CPUs currently, using 4 CPUs and taking an hour. Bumping the request to 16 CPUs to hopefully see them finish faster and use all the resources given. We can bump the request higher after that to see if that's useful.