### PR TITLE
fix py tensorflow-core missing libhdf5.so

### DIFF
--- a/py3.10-tensorflow-core.yaml
+++ b/py3.10-tensorflow-core.yaml
@@ -2,12 +2,12 @@ package:
   name: py3.10-tensorflow-core
   description: Framework for data-graph oriented computing (core libraries, oneDNN build)
   version: 2.16.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   resources:
-    cpu: 32
-    memory: 32Gi
+    cpu: 44
+    memory: 64Gi
   options:
     no-provides: true
     no-depends: true
@@ -29,6 +29,8 @@ environment:
       - curl-dev
       - gcc-12-default
       - giflib-dev
+      - hdf5
+      - hdf5-dev
       - icu-dev
       - libjpeg-turbo-dev
       - libpng-dev


### PR DESCRIPTION
fixes:
```
2024/05/25 04:40:00 WARN       Loading library to get build settings and version: [libhdf5.so](http://libhdf5.so/)
2024/05/25 04:40:00 WARN       error: Unable to load dependency HDF5, make sure HDF5 is installed properly
2024/05/25 04:40:00 WARN       Library dirs checked: []
2024/05/25 04:40:00 WARN       error: libhdf5.so: cannot open shared object file: No such file or directory
2024/05/25 04:40:00 WARN       [end of output]
2024/05/25 04:40:00 WARN   
2024/05/25 04:40:00 WARN   note: This error originates from a subprocess, and is likely not a problem with pip.
2024/05/25 04:40:00 WARN   ERROR: Failed building wheel for h5py
2024/05/25 04:40:00 INFO Failed to build h5py
2024/05/25 04:40:00 WARN ERROR: Could not build wheels for h5py, which is required to install pyproject.toml-based projects
```