### PR TITLE
bump mariadb to 10.6.18

### DIFF
--- a/mariadb-10.6.yaml
+++ b/mariadb-10.6.yaml
@@ -1,10 +1,13 @@
 package:
   name: mariadb-10.6
-  version: 10.6.17
-  epoch: 1
+  version: 10.6.18
+  epoch: 0
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
+  resources:
+    cpu: 32
+    memory: 32Gi
   dependencies:
     runtime:
       - pwgen
@@ -32,8 +35,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.osuosl.org/pub/mariadb/mariadb-${{package.version}}/source/mariadb-${{package.version}}.tar.gz
-      expected-sha256: fb41b0702059c046832d60138733acb73e4c0e5a1a0681061709d25591e4b086
+      uri: https://archive.mariadb.org/mariadb-${{package.version}}/source/mariadb-${{package.version}}.tar.gz
+      expected-sha256: 6898a1111f47130709e28ba2c7bd1a57e4bb57101f6e109e597d51e6d385cf18
 
   - name: "Cmake"
     runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
