### PR TITLE
fix netcat version

### DIFF
--- a/netcat-openbsd.yaml
+++ b/netcat-openbsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: netcat-openbsd
   version: "1.226"
-  epoch: 1
+  epoch: 2
   description: The TCP/IP swiss army knife. OpenBSD variant from debian.
   copyright:
     - license: BSD-3-Clause
@@ -25,14 +25,14 @@ pipeline:
 
   - uses: fetch
     with:
-      uri: http://deb.debian.org/debian/pool/main/n/netcat-openbsd/netcat-openbsd_${{package.version}}-1.debian.tar.xz
-      expected-sha512: b7ab1a133cbfcca37864df4b2cc5b8d5fab25104670fb03a6ead538c6433064c736ec7c25b930a2c3ea28e19dc8279130f4465607174f1a4806b8d2f94596e74
+      uri: http://deb.debian.org/debian/pool/main/n/netcat-openbsd/netcat-openbsd_${{package.version}}-1.1.debian.tar.xz
+      expected-sha512: 2c146964b99df3b37ae1afdc524b6bd59bc1a95d75a2abb1bc77c11b9641542ce7094136c0f918cebf04f957258e73d1727fd794affa617e333024c3942196cc
       extract: false
       delete: false
 
   - runs: |
       mkdir -p debian
-      tar -x '--strip-components=1' -f "netcat-openbsd_${{package.version}}-1.debian.tar.xz" -C debian
+      tar -x '--strip-components=1' -f "netcat-openbsd_${{package.version}}-1.1.debian.tar.xz" -C debian
       while read -r patch; do
         patch -Np1 < ./debian/patches/"$patch"
       done < ./debian/patches/series


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
