### PR TITLE
fix build: use github repo for libkcapi

### DIFF
--- a/libkcapi.yaml
+++ b/libkcapi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libkcapi
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: Linux Kernel Crypto API User Space Interface Library
   copyright:
     - license: BSD-3-Clause OR GPL-2.0-or-later
@@ -20,8 +20,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 15b550c14165a266fa233b485d029d54508da593dfa6d1731ec5d5a285c716e9
-      uri: https://www.chronox.de/libkcapi/libkcapi-${{package.version}}.tar.xz
+      expected-sha256: f1d827738bda03065afd03315479b058f43493ab6e896821b947f391aa566ba0
+      uri: https://github.com/smuellerDD/libkcapi/archive/refs/tags/v${{package.version}}.tar.gz
 
   - uses: patch
     with:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
```
INFO 2024-05-25T16:04:17.034793041Z running step "Fetch and extract external object into workspace"
WARNING 2024-05-25T16:04:17.062227321Z --2024-05-25 16:04:17-- https://www.chronox.de/libkcapi/libkcapi-1.5.0.tar.xz
WARNING 2024-05-25T16:04:17.204989760Z Resolving www.chronox.de... 81.169.145.82, 2a01:238:20a:202:1082::
WARNING 2024-05-25T16:04:17.318636919Z Connecting to www.chronox.de|81.169.145.82|:443... connected.
WARNING 2024-05-25T16:04:17.671241116Z HTTP request sent, awaiting response... 404 Not Found
WARNING 2024-05-25T16:04:17.671296316Z 2024-05-25 16:04:17 ERROR 404: Not Found.

```

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
