### PR TITLE
fix download path for chrony

### DIFF
--- a/chrony.yaml
+++ b/chrony.yaml
@@ -1,7 +1,7 @@
 package:
   name: chrony
   version: "4.5"
-  epoch: 0
+  epoch: 1
   description: NTP client and server programs
   copyright:
     - license: GPL-2.0-or-later
@@ -32,7 +32,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha512: 58a449e23186da799064b16ab16f799c1673296984b152b43e87c620d86e272c55365e83439d410fc89e4e0ba0befd7d5c625eac78a6665813b7ea75444f71b5
-      uri: "https://download.tuxfamily.org/chrony/chrony-${{package.version}}.tar.gz"
+      uri: "https://chrony-project.org/releases/chrony-${{package.version}}.tar.gz"
 
   - runs: |
       mkdir -p pps-tools/sys


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
```
WARNING 2024-05-25T15:20:00.614003961Z --2024-05-25 15:20:00-- https://download.tuxfamily.org/chrony/chrony-4.5.tar.gz
WARNING 2024-05-25T15:20:04.431055566Z Resolving download.tuxfamily.org... 212.85.158.13, 2a02:2178:2:c::13
WARNING 2024-05-25T15:20:09.431224821Z Connecting to download.tuxfamily.org|212.85.158.13|:443... failed: Connection timed out.
WARNING 2024-05-25T15:20:09.431275111Z Connecting to download.tuxfamily.org|2a02:2178:2:c::13|:443... failed: Cannot assign requested address.
WARNING 2024-05-25T15:20:09.431283101Z Retrying.
WARNING 2024-05-25T15:20:09.431288711Z
WARNING 2024-05-25T15:20:10.431496497Z --2024-05-25 15:20:10-- (try: 2) https://download.tuxfamily.org/chrony/chrony-4.5.tar.gz
WARNING 2024-05-25T15:20:15.431627772Z Connecting to download.tuxfamily.org|212.85.158.13|:443... failed: Connection timed out.
WARNING 2024-05-25T15:20:15.431681512Z Connecting to download.tuxfamily.org|2a02:2178:2:c::13|:443... failed: Cannot assign requested address.
WARNING 2024-05-25T15:20:15.431688023Z Retrying.
WARNING 2024-05-25T15:20:15.431695572Z
WARNING 2024-05-25T15:20:17.431905786Z --2024-05-25 15:20:17-- (try: 3) https://download.tuxfamily.org/chrony/chrony-4.5.tar.gz
WARNING 2024-05-25T15:20:22.431985821Z Connecting to download.tuxfamily.org|212.85.158.13|:443... failed: Connection timed out.
WARNING 2024-05-25T15:20:22.432038992Z Connecting to download.tuxfamily.org|2a02:2178:2:c::13|:443... failed: Cannot assign requested address.
WARNING 2024-05-25T15:20:22.432046881Z Retrying.
WARNING 2024-05-25T15:20:22.432052232Z
WARNING 2024-05-25T15:20:25.432274852Z --2024-05-25 15:20:25-- (try: 4) https://download.tuxfamily.org/chrony/chrony-4.5.tar.gz
WARNING 2024-05-25T15:20:30.432408407Z Connecting to download.tuxfamily.org|212.85.158.13|:443... failed: Connection timed out.
WARNING 2024-05-25T15:20:30.432457417Z Connecting to download.tuxfamily.org|2a02:2178:2:c::13|:443... failed: Cannot assign requested address.
WARNING 2024-05-25T15:20:30.432464327Z Retrying.
WARNING 2024-05-25T15:20:30.432471047Z
WARNING 2024-05-25T15:20:34.432634965Z --2024-05-25 15:20:34-- (try: 5) https://download.tuxfamily.org/chrony/chrony-4.5.tar.gz
WARNING 2024-05-25T15:20:39.432754690Z Connecting to download.tuxfamily.org|212.85.158.13|:443... failed: Connection timed out.
WARNING 2024-05-25T15:20:39.432801170Z Connecting to download.tuxfamily.org|2a02:2178:2:c::13|:443... failed: Cannot assign requested address.
WARNING 2024-05-25T15:20:39.432808980Z Giving up.

```

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
