### PR TITLE
bump package for crossplane-provider-gcp from 1.1.0 to 1.2.0

### DIFF
--- a/crossplane-provider-gcp.yaml
+++ b/crossplane-provider-gcp.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-gcp
-  version: 1.1.0
-  epoch: 1
+  version: 1.2.0
+  epoch: 0
   description: Official GCP Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -26,9 +26,9 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/upbound/provider-gcp
+      repository: https://github.com/crossplane-contrib/provider-upjet-gcp
       tag: v${{package.version}}
-      expected-commit: d1d5a0ec3b200cdfbd67f67de7040e7f29427c62
+      expected-commit: 6738b686330f7ec2f4037a200e2718fa3628243e
 
   - runs: |
       # `make` downloads `up`, unless we move our prebuilt `up` to where it expects it.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
