### PR TITLE
bump version crossplane-provider-aws from 1.4.0 to 1.5.0

### DIFF
--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-aws
-  version: 1.4.0
-  epoch: 1
+  version: 1.5.0
+  epoch: 0
   description: Official AWS Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
@@ -26,8 +26,8 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 58c776555632217d5ac28758b704d2bc206b108f
-      repository: https://github.com/upbound/provider-aws
+      expected-commit: 0bc985c2b3d6c10ecf701371ee3f3031f8e990c0
+      repository: https://github.com/crossplane-contrib/provider-upjet-aws
       tag: v${{package.version}}
 
   - runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
