### PR TITLE
fix "unable to install files for pkg llvm18.1" error

### DIFF
--- a/llvm17.yaml
+++ b/llvm17.yaml
@@ -5,6 +5,9 @@ package:
   description: "low-level virtual machine - core frameworks"
   copyright:
     - license: Apache-2.0
+  resources:
+    cpu: 32
+    memory: 32Gi
 
 environment:
   contents:

--- a/llvm18.1.yaml
+++ b/llvm18.1.yaml
@@ -108,7 +108,7 @@ subpackages:
     description: "LLVM 18.1 runtime library"
     pipeline:
       - runs: |
-          soname="libLLVM.so"
+          soname="libLLVM-18.so"
           sonamefull="libLLVM-${{package.version}}.so"
 
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/${{package.name}}/lib/
@@ -135,7 +135,7 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/${{package.name}}/bin
           mv "${{targets.destdir}}"/usr/lib/${{package.name}}/bin/llvm-config "${{targets.subpkgdir}}"/usr/lib/${{package.name}}/bin/
 
-          soname="libLLVM.so"
+          soname="libLLVM-18.so"
           sonamefull="libLLVM-${{package.version}}.so"
 
           rm -f "${{targets.subpkgdir}}"/usr/lib/${{package.name}}/lib/$soname

--- a/llvm18.1.yaml
+++ b/llvm18.1.yaml
@@ -1,10 +1,13 @@
 package:
   name: llvm18.1
   version: 18.1.6
-  epoch: 0
+  epoch: 1
   description: "low-level virtual machine - core frameworks"
   copyright:
     - license: Apache-2.0
+  resources:
+    cpu: 32
+    memory: 32Gi
 
 environment:
   contents:
@@ -67,36 +70,36 @@ pipeline:
       cmake --build build
 
   - runs: |
-      DESTDIR="${{targets.contextdir}}" cmake --install build
+      DESTDIR="${{targets.destdir}}" cmake --install build
 
   - runs: |
-      mkdir -p "${{targets.contextdir}}"/usr/bin
+      mkdir -p "${{targets.destdir}}"/usr/bin
 
-      for path in "${{targets.contextdir}}"/usr/lib/${{package.name}}/bin/*; do
+      for path in "${{targets.destdir}}"/usr/lib/${{package.name}}/bin/*; do
         name=${path##*/}
-        ln -s ../lib/${{package.name}}/bin/$name "${{targets.contextdir}}"/usr/bin/$name
+        ln -s ../lib/${{package.name}}/bin/$name "${{targets.destdir}}"/usr/bin/$name
       done
 
   - runs: |
-      cd "${{targets.contextdir}}"/usr/lib/${{package.name}}
+      cd "${{targets.destdir}}"/usr/lib/${{package.name}}
 
-      mkdir -p "${{targets.contextdir}}"/usr/lib/
-      for path in "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/*.a; do
+      mkdir -p "${{targets.destdir}}"/usr/lib/
+      for path in "${{targets.destdir}}"/usr/lib/${{package.name}}/lib/*.a; do
         name=${path##*/}
-        ln -s ../lib/${{package.name}}/lib/$name "${{targets.contextdir}}"/usr/lib/$name
+        ln -s ../lib/${{package.name}}/lib/$name "${{targets.destdir}}"/usr/lib/$name
       done
 
-      mkdir -p "${{targets.contextdir}}"/usr/lib/
-      for path in "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/*.so*; do
+      mkdir -p "${{targets.destdir}}"/usr/lib/
+      for path in "${{targets.destdir}}"/usr/lib/${{package.name}}/lib/*.so*; do
         name=${path##*/}
-        ln -s ../lib/${{package.name}}/lib/$name "${{targets.contextdir}}"/usr/lib/$name
+        ln -s ../lib/${{package.name}}/lib/$name "${{targets.destdir}}"/usr/lib/$name
       done
 
-  - working-directory: ${{targets.contextdir}}/usr/lib/${{package.name}}
+  - working-directory: ${{targets.destdir}}/usr/lib/${{package.name}}
     runs: |
-      mkdir -p "${{targets.contextdir}}"/usr/lib/cmake
-      mv lib/cmake/llvm "${{targets.contextdir}}"/usr/lib/cmake/${{package.name}}
-      ln -s ${{package.name}} "${{targets.contextdir}}"/usr/lib/cmake/llvm
+      mkdir -p "${{targets.destdir}}"/usr/lib/cmake
+      mv lib/cmake/llvm "${{targets.destdir}}"/usr/lib/cmake/${{package.name}}
+      ln -s ${{package.name}} "${{targets.destdir}}"/usr/lib/cmake/llvm
 
   - uses: strip
 
@@ -108,13 +111,12 @@ subpackages:
           soname="libLLVM.so"
           sonamefull="libLLVM-${{package.version}}.so"
 
-          mkdir -p "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/
-          mv "${{targets.destdir}}"/usr/lib/${{package.name}}/lib/$soname "${{targets.contextdir}}"/usr/lib/
-          ln -s $soname "${{targets.contextdir}}"/usr/lib/$sonamefull
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/${{package.name}}/lib/
+          mv "${{targets.destdir}}"/usr/lib/${{package.name}}/lib/$soname "${{targets.subpkgdir}}"/usr/lib/
+          ln -s $soname "${{targets.subpkgdir}}"/usr/lib/$sonamefull
 
-          ln -s ../../$soname "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/$soname
-          ln -s ../../$soname "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/$sonamefull
-
+          ln -s ../../$soname "${{targets.subpkgdir}}"/usr/lib/${{package.name}}/lib/$soname
+          ln -s ../../$soname "${{targets.subpkgdir}}"/usr/lib/${{package.name}}/lib/$sonamefull
 
 
           ls -al "${{targets.destdir}}"/usr/lib/${{package.name}}/lib
@@ -130,18 +132,18 @@ subpackages:
     pipeline:
       - uses: split/dev
       - runs: |
-          mkdir -p "${{targets.contextdir}}"/usr/lib/${{package.name}}/bin
-          mv "${{targets.destdir}}"/usr/lib/${{package.name}}/bin/llvm-config "${{targets.contextdir}}"/usr/lib/${{package.name}}/bin/
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/${{package.name}}/bin
+          mv "${{targets.destdir}}"/usr/lib/${{package.name}}/bin/llvm-config "${{targets.subpkgdir}}"/usr/lib/${{package.name}}/bin/
 
           soname="libLLVM.so"
           sonamefull="libLLVM-${{package.version}}.so"
 
-          rm -f "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/$soname
-          rm -f "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/$sonamefull
+          rm -f "${{targets.subpkgdir}}"/usr/lib/${{package.name}}/lib/$soname
+          rm -f "${{targets.subpkgdir}}"/usr/lib/${{package.name}}/lib/$sonamefull
 
-          rm -f "${{targets.contextdir}}"/usr/lib/libLLVM.so
-          rm -f "${{targets.contextdir}}"/usr/lib/$soname
-          rm -f "${{targets.contextdir}}"/usr/lib/$sonamefull
+          rm -f "${{targets.subpkgdir}}"/usr/lib/libLLVM.so
+          rm -f "${{targets.subpkgdir}}"/usr/lib/$soname
+          rm -f "${{targets.subpkgdir}}"/usr/lib/$sonamefull
     dependencies:
       runtime:
         - libLLVM-18.1


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
```
error during command execution: failed to build package: unable to build guest: unable to generate image: installing apk packages: installing packages: installing llvm18.1 (ver:18.1.6-r0 arch:aarch64): unable to install files for pkg llvm18.1: unable to install symlink from usr/bin/FileCheck -> ../lib/llvm18.1/bin/FileCheck: symlink ../lib/llvm18.1/bin/FileCheck /tmp/melange-guest-2930954217/usr/bin/FileCheck: file exists
```
in 
- wasker
- wasi-sdk
- mozjs91
- firefox
- bun

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
