### PR TITLE
fix build: add missing v prefix for tag for rstudio

### DIFF
--- a/rstudio.yaml
+++ b/rstudio.yaml
@@ -1,7 +1,7 @@
 package:
   name: rstudio
   version: 2023.12.1_p402
-  epoch: 0
+  epoch: 1
   description: RStudio is an integrated development environment (IDE) for R
   copyright:
     - license: GPL-3.0-or-later
@@ -57,9 +57,7 @@ pipeline:
     with:
       repository: https://github.com/rstudio/rstudio
       expected-commit: 4da58325ffcff29d157d9264087d4b1ab27f7204
-      # TODO: Upstream decided to drop the 'v' from the latest tag, they may
-      # revert this in future, if so, prepend with 'v'.
-      tag: ${{vars.mangled-package-version}}
+      tag: v${{vars.mangled-package-version}}
 
   - uses: patch
     with:
@@ -99,7 +97,6 @@ update:
   github:
     identifier: rstudio/rstudio
     use-tag: true
-    strip-prefix: v
 
 test:
   pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
```
WARNING 2024-05-26T01:08:26.581792297Z warning: Could not find remote branch 2023.12.1+402 to clone.
WARNING 2024-05-26T01:08:26.581843377Z fatal: Remote branch 2023.12.1+402 not found in upstream origin

```

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
