### PR TITLE
gmp: switch from gmplib to gnu mirrors

### DIFF
--- a/gmp.yaml
+++ b/gmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: gmp
   version: 6.3.0
-  epoch: 1
+  epoch: 2
   description: "a library for arbitrary precision arithmetic"
   copyright:
     - license: LGPL-3.0-or-later OR GPL-2.0-or-later
@@ -19,7 +19,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://gmplib.org/download/gmp/gmp-${{package.version}}.tar.xz
+      uri: https://ftp.gnu.org/gnu/gmp/gmp-${{package.version}}.tar.xz
       expected-sha256: a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898
 
   - runs: |


### PR DESCRIPTION
As gmplib primary location blocks access.
