### PR TITLE
require at least one primary or subpackage test to merge

### DIFF
--- a/R-wk.yaml
+++ b/R-wk.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-wk
   version: 0.9.1
-  epoch: 0
+  epoch: 2
   description: Lightweight Well-Known Geometry Parsing
   copyright:
     - license: MIT
@@ -38,7 +38,7 @@ test:
 update:
   enabled: true
   ignore-regex-patterns:
-    - 'R-.*'
+    - "R-.*"
   github:
     identifier: cran/wk
     use-tag: true

--- a/Rcpp.yaml
+++ b/Rcpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: Rcpp
   version: 1.0.12
-  epoch: 0
+  epoch: 1
   description: Seamless R and C++ Integration
   copyright:
     - license: GPL-2.0-or-later
@@ -30,15 +30,10 @@ pipeline:
 
   - uses: strip
 
-test:
-  pipeline:
-    - runs: |
-        Rscript -e 'library(Rcpp)'
-
 update:
   enabled: true
   ignore-regex-patterns:
-    - 'R-.*'
+    - "R-.*"
   github:
     identifier: cran/Rcpp
     use-tag: true

--- a/lint.sh
+++ b/lint.sh
@@ -36,6 +36,13 @@ for p in $(make list); do
     yq -i 'del(.test.environment)' ${fn}
     yam ${fn}
   fi
+
+  if ! yq -e 'has("test") or (.subpackages | map(has("test")) | any)' ${fn}; then
+    echo "ERROR: No tests defined for package ${p}"
+    exit 1
+  fi
+  # Package must have at least one primary pipeline test
+  echo "Checking for at least one primary pipeline test or subpackage..."
 done
 
 # New section to check for .sts.yaml files under ./.github/chainguard/


### PR DESCRIPTION
This lint check is satisfied with either:

- a primary package test (`.test`)
- at least one subpackage test (`.subpackage[].test`)

Absent is the check that the test is of a sufficient quality, but we won't gate on that (yet!).

Notably, this hooks into our `make list`, which requires an epoch bump, so this doesn't prevent a package without an epoch bump from sneaking in without a test, but we have other checks for that