### PR TITLE
chore(neuvector): Drop streaming, fix updates, and remove certs

### DIFF
--- a/neuvector-controller.yaml
+++ b/neuvector-controller.yaml
@@ -62,8 +62,7 @@ pipeline:
 update:
   enabled: true
   ignore-regex-patterns:
-    - '.*beta.*'
-    - '.*\-b.*'
+    - '.*\-.*'
   github:
     identifier: neuvector/neuvector
     strip-prefix: v

--- a/neuvector-controller.yaml
+++ b/neuvector-controller.yaml
@@ -61,6 +61,9 @@ pipeline:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - '.*beta.*'
+    - '.*\-b.*'
   github:
     identifier: neuvector/neuvector
     strip-prefix: v

--- a/neuvector-controller.yaml
+++ b/neuvector-controller.yaml
@@ -1,13 +1,10 @@
 package:
-  name: neuvector-controller-5.3
+  name: neuvector-controller
   version: 5.3.2
-  epoch: 2
+  epoch: 3
   description: NeuVector Full Lifecycle Container Security Platform.
   copyright:
     - license: Apache-2.0
-  dependencies:
-    provides:
-      - neuvector-controller=${{package.full-version}}
 
 environment:
   contents:
@@ -67,7 +64,6 @@ update:
   github:
     identifier: neuvector/neuvector
     strip-prefix: v
-    tag-filter: v5.3.
 
 test:
   pipeline:

--- a/neuvector-manager.yaml
+++ b/neuvector-manager.yaml
@@ -1,13 +1,11 @@
 package:
-  name: neuvector-manager-5.3
+  name: neuvector-manager
   version: 5.3.2
-  epoch: 0
+  epoch: 1
   description: NeuVector Security Center Admin Console.
   copyright:
     - license: Apache-2.0
   dependencies:
-    provides:
-      - neuvector-manager=${{package.full-version}}
     runtime:
       - openjdk-11-default-jvm
 
@@ -53,8 +51,6 @@ subpackages:
   - name: ${{package.name}}-cli
     description: NeuVector Manager CLI
     dependencies:
-      provides:
-        - neuvector-manager-cli=${{package.full-version}}
       runtime:
         - py3-click
         - py3-requests
@@ -98,5 +94,4 @@ update:
   github:
     identifier: neuvector/manager
     strip-prefix: v
-    tag-filter: v5.3.
     use-tag: true

--- a/neuvector-manager.yaml
+++ b/neuvector-manager.yaml
@@ -87,8 +87,7 @@ test:
 update:
   enabled: true
   ignore-regex-patterns:
-    - '.*beta.*'
-    - '.*\-b.*'
+    - '.*\-.*'
   github:
     identifier: neuvector/manager
     strip-prefix: v

--- a/neuvector-manager.yaml
+++ b/neuvector-manager.yaml
@@ -86,6 +86,9 @@ test:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - '.*beta.*'
+    - '.*\-b.*'
   github:
     identifier: neuvector/manager
     strip-prefix: v

--- a/neuvector-manager.yaml
+++ b/neuvector-manager.yaml
@@ -40,11 +40,6 @@ pipeline:
       install -Dm755 admin/target/scala-2.11/admin-assembly-1.0.jar ${{targets.contextdir}}/usr/local/bin/
       install -Dm755 scripts/* ${{targets.contextdir}}/usr/local/bin/
 
-      # Retrieve certs
-      mkdir -p ${{targets.contextdir}}/etc/neuvector/certs
-      wget https://raw.githubusercontent.com/neuvector/manifests/main/build/share/etc/neuvector/certs/ssl-cert.key -P ${{targets.contextdir}}/etc/neuvector/certs/
-      wget https://raw.githubusercontent.com/neuvector/manifests/main/build/share/etc/neuvector/certs/ssl-cert.pem -P ${{targets.contextdir}}/etc/neuvector/certs/
-
   - uses: strip
 
 subpackages:

--- a/neuvector-manager.yaml
+++ b/neuvector-manager.yaml
@@ -88,7 +88,10 @@ update:
   enabled: true
   ignore-regex-patterns:
     - '.*\-.*'
+    - '.*[aA-zZ].*'
+    - '^(\d)(\d)(\d)(\d).*'
   github:
     identifier: neuvector/manager
+    tag-filter: v
     strip-prefix: v
     use-tag: true

--- a/neuvector-monitor.yaml
+++ b/neuvector-monitor.yaml
@@ -35,8 +35,7 @@ pipeline:
 update:
   enabled: true
   ignore-regex-patterns:
-    - '.*beta.*'
-    - '.*\-b.*'
+    - '.*\-.*'
   github:
     identifier: neuvector/neuvector
     strip-prefix: v

--- a/neuvector-monitor.yaml
+++ b/neuvector-monitor.yaml
@@ -1,15 +1,13 @@
 package:
-  name: neuvector-monitor-5.3
+  name: neuvector-monitor
   version: 5.3.2
-  epoch: 1
+  epoch: 2
   description: NeuVector Full Lifecycle Container Security Platform.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - consul-1.16-oci-entrypoint
-    provides:
-      - neuvector-monitor=${{package.full-version}}
 
 environment:
   contents:
@@ -39,4 +37,3 @@ update:
   github:
     identifier: neuvector/neuvector
     strip-prefix: v
-    tag-filter: v5.3.

--- a/neuvector-monitor.yaml
+++ b/neuvector-monitor.yaml
@@ -34,6 +34,9 @@ pipeline:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - '.*beta.*'
+    - '.*\-b.*'
   github:
     identifier: neuvector/neuvector
     strip-prefix: v

--- a/neuvector-nstools.yaml
+++ b/neuvector-nstools.yaml
@@ -27,6 +27,9 @@ pipeline:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - '.*beta.*'
+    - '.*\-b.*'
   github:
     identifier: neuvector/neuvector
     strip-prefix: v

--- a/neuvector-nstools.yaml
+++ b/neuvector-nstools.yaml
@@ -1,7 +1,7 @@
 package:
-  name: neuvector-nstools-5.3
+  name: neuvector-nstools
   version: 5.3.2
-  epoch: 1
+  epoch: 2
   description: "NeuVector NSTools"
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,6 @@ update:
   github:
     identifier: neuvector/neuvector
     strip-prefix: v
-    tag-filter: v5.3.
 
 test:
   pipeline:

--- a/neuvector-nstools.yaml
+++ b/neuvector-nstools.yaml
@@ -28,8 +28,7 @@ pipeline:
 update:
   enabled: true
   ignore-regex-patterns:
-    - '.*beta.*'
-    - '.*\-b.*'
+    - '.*\-.*'
   github:
     identifier: neuvector/neuvector
     strip-prefix: v

--- a/neuvector-prometheus-exporter.yaml
+++ b/neuvector-prometheus-exporter.yaml
@@ -1,6 +1,6 @@
 package:
   name: neuvector-prometheus-exporter
-  version: 5.3.0
+  version: 1.1.0.0
   epoch: 0
   description: Python client for the Prometheus monitoring system.
   copyright:
@@ -20,12 +20,19 @@ environment:
       - python-3
       - wolfi-base
 
+# Replace first dot with a dash
+var-transforms:
+  - from: ${{package.version}}
+    match: '^(.*?)\.'
+    replace: $1-$2
+    to: mangled-package-version
+
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: c8616b8c85a141d25cdf254664fe48cb8c9cbedc
+      expected-commit: b6b3d59be490921592d3be25919f3c705793e891
       repository: https://github.com/neuvector/prometheus-exporter.git
-      tag: v${{package.version}}
+      tag: v${{vars.mangled-package-version}}
 
   - runs: |
       install -Dm755 nv_exporter.py "${{targets.destdir}}"/usr/bin/nv_exporter.py
@@ -65,8 +72,11 @@ test:
 
 update:
   enabled: true
+  version-transform:
+    - match: '-'
+      replace: '.'
   github:
     identifier: neuvector/prometheus-exporter
+    tag-filter: v1
     strip-prefix: v
-    tag-filter: v
     use-tag: true

--- a/neuvector-scanner.yaml
+++ b/neuvector-scanner.yaml
@@ -30,13 +30,6 @@ pipeline:
       output: ${{package.name}}
       vendor: true
 
-  - runs: |
-      # Retrieve certs
-      mkdir -p ${{targets.contextdir}}/etc/neuvector/certs/internal/
-      wget https://raw.githubusercontent.com/neuvector/manifests/main/build/share/etc/neuvector/certs/internal/ca.cert -P ${{targets.contextdir}}/etc/neuvector/certs/internal/
-      wget https://raw.githubusercontent.com/neuvector/manifests/main/build/share/etc/neuvector/certs/internal/cert.pem -P ${{targets.contextdir}}/etc/neuvector/certs/internal/
-      wget https://raw.githubusercontent.com/neuvector/manifests/main/build/share/etc/neuvector/certs/internal/cert.key -P ${{targets.contextdir}}/etc/neuvector/certs/internal/
-
   - uses: strip
 
 subpackages:

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,3 +1,4 @@
+neuvector-prometheus-exporter-5.3.0-r0.apk
 neuvector-controller-5.3-5.3.2-r0.apk
 neuvector-controller-5.3-5.3.2-r1.apk
 neuvector-controller-5.3-5.3.2-r2.apk

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,3 +1,13 @@
+neuvector-controller-5.3-5.3.2-r0.apk
+neuvector-controller-5.3-5.3.2-r1.apk
+neuvector-controller-5.3-5.3.2-r2.apk
+neuvector-manager-5.3-5.3.2-r0.apk
+neuvector-manager-5.3-cli-5.3.2-r0.apk
+neuvector-monitor-5.3-5.3.2-r0.apk
+neuvector-monitor-5.3-5.3.2-r1.apk
+neuvector-monitor-5.3-compat-5.3.2-r0.apk
+neuvector-nstools-5.3-5.3.2-r0.apk
+neuvector-nstools-5.3-5.3.2-r1.apk
 xz-5.6.0-r0.apk
 xz-dev-5.6.0-r0.apk
 xz-doc-5.6.0-r0.apk


### PR DESCRIPTION
- Removes certs from manager and scanner, these should be generated
- Filters out nonstandard releases
- Use new versioning scheme for nv promotheus exporter
- Drop 5.3 from package name, NeuVector doesn't appear to support prior versions