### PR TITLE
fix: don't use range for postgresql-16

### DIFF
--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.3"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -83,26 +83,8 @@ pipeline:
 
   - uses: strip
 
-data:
-  - name: client-tools
-    items:
-      clusterdb: ""
-      createdb: ""
-      createuser: ""
-      dropdb: ""
-      dropuser: ""
-      pg_amcheck: ""
-      pg_basebackup: ""
-      pg_dump: ""
-      pg_dumpall: ""
-      pg_isready: ""
-      pg_receivewal: ""
-      pg_recvlogical: ""
-      pg_restore: ""
-      pg_verifybackup: ""
-      psql: ""
-      reindexdb: ""
-      vacuumdb: ""
+vars:
+  client-tools: clusterdb createdb createuser dropdb dropuser pg_amcheck pg_basebackup pg_dump pg_dumpall pg_isready pg_receivewal pg_recvlogical pg_restore pg_verifybackup psql reindexdb vacuumdb
 
 subpackages:
   - name: ${{package.name}}-dev
@@ -120,11 +102,12 @@ subpackages:
 
   - name: ${{package.name}}-client-base
     description: PostgreSQL client base
-    range: client-tools
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}
-          mv ${{targets.destdir}}/usr/libexec/${{vars.mangled-package-name}}/${{range.key}} ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/${{range.key}}
+          for binary in ${{vars.client-tools}}; do
+            mv ${{targets.destdir}}/usr/libexec/${{vars.mangled-package-name}}/${binary} ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}/${binary}
+          done
 
   - name: ${{package.name}}-client
     description: PostgreSQL client
@@ -133,11 +116,12 @@ subpackages:
         - ${{package.name}}-client-base=${{package.full-version}}
       provides:
         - postgresql-client=${{package.full-version}}
-    range: client-tools
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
-          ln -sf /usr/libexec/${{vars.mangled-package-name}}/${{range.key}} ${{targets.subpkgdir}}/usr/bin/${{range.key}}
+          for binary in ${{vars.client-tools}}; do
+            ln -sf /usr/libexec/${{vars.mangled-package-name}}/${binary} ${{targets.subpkgdir}}/usr/bin/${binary}
+          done
 
   - name: ${{package.name}}-contrib
     dependencies:


### PR DESCRIPTION
`range:` isn't the right way to run the same pipeline step repeatedly in a subpackage. Due to confusing behavior of melange, this worked by accident, but we shouldn't rely on this bug. Future versions of melange will fail in this case.