### PR TITLE
mariadb-10.6: drop duplicate subpackage -test

### DIFF
--- a/mariadb-10.6.yaml
+++ b/mariadb-10.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-10.6
   version: 10.6.18
-  epoch: 0
+  epoch: 1
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -184,6 +184,7 @@ subpackages:
 
           mv "${{targets.destdir}}"/usr/mysql-test \
             "${{targets.subpkgdir}}"/usr/
+          mv mysql-test "${{targets.subpkgdir}}"/usr/mariadb-test
 
   - name: "mariadb-10.6-bench"
     dependencies:
@@ -229,15 +230,6 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/mariadb-embedded  "${{targets.subpkgdir}}"/usr/bin
-
-  - name: mariadb-10.6-test
-    dependencies:
-      provides:
-        - mariadb-test=10.6.999
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr
-          mv mysql-test "${{targets.subpkgdir}}"/usr/mariadb-test
 
 update:
   enabled: true


### PR DESCRIPTION
Note -test subpackage is already created earlier on. Merge the two into one:

From file diffs:

> Package mariadb-10.6-test:
> Unchanged