### PR TITLE
shadow: remove duplicate range subpackages

### DIFF
--- a/shadow.yaml
+++ b/shadow.yaml
@@ -2,7 +2,7 @@
 package:
   name: shadow
   version: 4.15.1
-  epoch: 0
+  epoch: 1
   description: PAM login and passwd utilities
   copyright:
     - license: BSD-3-Clause
@@ -91,23 +91,9 @@ pipeline:
 
   - uses: strip
 
-data:
-  - name: login-utils
-    items:
-      faillog: faillog
-      lastlog: lastlog
-      login: login
-      newgrp: newgrp
-      nologin: nologin
-      sg: sg
-      su: su
-
-  - name: conv-utils
-    items:
-      pwconv: pwconv
-      pwunconv: pwunconv
-      grpconv: grpconv
-      grpunconv: grpunconv
+vars:
+  login-utils: faillog lastlog login newgrp nologin sg su
+  conv-utils: pwconv pwunconv grpconv grpunconv
 
 subpackages:
   - name: shadow-dev
@@ -119,15 +105,16 @@ subpackages:
     description: shadow dev
 
   - name: shadow-login
-    range: login-utils
     pipeline:
       - runs: |
           cd ${{targets.destdir}}
-          for dir in bin sbin usr/bin usr/sbin; do
-            if [ -e $dir/${{range.key}} ] || [ -L $dir/${{range.key}} ]; then
-              mkdir -p ${{targets.subpkgdir}}/$dir
-              mv ${{targets.destdir}}/$dir/${{range.key}} ${{targets.subpkgdir}}/$dir/
-            fi
+          for bin in ${{vars.login-utils}}; do
+            for dir in bin sbin usr/bin usr/sbin; do
+              if [ -e $dir/$bin ] || [ -L $dir/$bin ]; then
+                mkdir -p ${{targets.subpkgdir}}/$dir
+                mv ${{targets.destdir}}/$dir/$bin ${{targets.subpkgdir}}/$dir/
+              fi
+            done
           done
     description: Login utils from shadow
 
@@ -137,11 +124,12 @@ subpackages:
     description: shadow manpages
 
   - name: shadow-conv
-    range: conv-utils
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/sbin
-          mv ${{targets.destdir}}/usr/sbin/${{range.key}} ${{targets.subpkgdir}}/usr/sbin/
+          for bin in ${{vars.conv-utils}}; do
+            mv ${{targets.destdir}}/usr/sbin/$bin ${{targets.subpkgdir}}/usr/sbin/
+          done
     description: Utilities for converting to and from shadow passwords and groups
 
   - name: shadow-subids


### PR DESCRIPTION
Pipelines can do for-loops without templating whole package.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
