### PR TITLE
openssl: add CVE-2024-4741 patch

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.3.0
-  epoch: 8
+  epoch: 9
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: CVE-2024-4603.patch
+      patches: CVE-2024-4603.patch CVE-2024-4741.patch
 
   - name: Configure and build
     runs: |

--- a/openssl/CVE-2024-4741.patch
+++ b/openssl/CVE-2024-4741.patch
@@ -1,0 +1,36 @@
+From e5093133c35ca82874ad83697af76f4b0f7e3bd8 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Tue, 23 Apr 2024 16:34:46 +0100
+Subject: [PATCH] Only free the read buffers if we're not using them
+
+If we're part way through processing a record, or the application has
+not released all the records then we should not free our buffer because
+they are still needed.
+
+CVE-2024-4741
+
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/24395)
+
+(cherry picked from commit 38690cab18de88198f46478565fab423cf534efa)
+---
+ ssl/record/methods/tls_common.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/ssl/record/methods/tls_common.c b/ssl/record/methods/tls_common.c
+index b7481c071f746..01cf3012b8c2c 100644
+--- a/ssl/record/methods/tls_common.c
++++ b/ssl/record/methods/tls_common.c
+@@ -2124,7 +2124,10 @@ int tls_free_buffers(OSSL_RECORD_LAYER *rl)
+     /* Read direction */
+ 
+     /* If we have pending data to be read then fail */
+-    if (rl->curr_rec < rl->num_recs || TLS_BUFFER_get_left(&rl->rbuf) != 0)
++    if (rl->curr_rec < rl->num_recs
++            || rl->curr_rec != rl->num_released
++            || TLS_BUFFER_get_left(&rl->rbuf) != 0
++            || rl->rstate == SSL_ST_READ_BODY)
+         return 0;
+ 
+     return tls_release_read_buffer(rl);


### PR DESCRIPTION
Adds patches for https://www.cve.org/CVERecord?id=CVE-2024-4741 https://www.openssl.org/news/secadv/20240528.txt
with [(git commit)](https://github.com/openssl/openssl/commit/e5093133c35ca82874ad83697af76f4b0f7e3bd8)