### PR TITLE
wihdraw: remove openjdk-11-jre-headless-17.0.5.8-r4 from the apk's as…

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -70,3 +70,4 @@ valkey-cli-7.2.5-r0.apk
 valkey-benchmark-7.2.5-r0.apk
 istio-install-cni-1.21-1.22.0-r0.apk
 istio-install-cni-1.21-1.22.0-r1.apk
+openjdk-11-jre-headless-17.0.5.8-r4.apk


### PR DESCRIPTION
… it was reverted

fixes https://github.com/wolfi-dev/os/issues/20445
