### PR TITLE
go clean ups May 30

### DIFF
--- a/terraform-provider-aws.yaml
+++ b/terraform-provider-aws.yaml
@@ -14,10 +14,6 @@ package:
       - terraform-compat
       - terraform-local-provider-config
 
-environment:
-  environment:
-    CGO_ENABLED: 0
-
 pipeline:
   - uses: git-checkout
     with:
@@ -29,7 +25,6 @@ pipeline:
     with:
       packages: .
       output: terraform-provider-aws
-      ldflags: -s -w
 
   - runs: |
       GOARCH=$(go env GOARCH)

--- a/terraform-provider-azurerm.yaml
+++ b/terraform-provider-azurerm.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-azurerm
   version: 3.105.0
-  epoch: 0
+  epoch: 1
   description: Terraform provider for Azure Resource Manager
   copyright:
     - license: MPL-2.0
@@ -10,10 +10,6 @@ package:
       - terraform
       - terraform-compat
       - terraform-local-provider-config
-
-environment:
-  environment:
-    CGO_ENABLED: 0
 
 pipeline:
   - uses: git-checkout
@@ -24,7 +20,6 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w
       output: terraform-provider-azurerm
       packages: .
       vendor: "true"

--- a/terraform-provider-google.yaml
+++ b/terraform-provider-google.yaml
@@ -1,7 +1,7 @@
 package:
   name: terraform-provider-google
   version: 5.31.1
-  epoch: 0
+  epoch: 1
   description: Terraform GCP provider
   copyright:
     - license: MPL-2.0
@@ -10,10 +10,6 @@ package:
       - terraform
       - terraform-compat
       - terraform-local-provider-config
-
-environment:
-  environment:
-    CGO_ENABLED: 0
 
 pipeline:
   - uses: git-checkout
@@ -26,7 +22,6 @@ pipeline:
     with:
       packages: .
       output: terraform-provider-google
-      ldflags: -s -w
 
   - runs: |
       GOARCH=$(go env GOARCH)

--- a/terraform.yaml
+++ b/terraform.yaml
@@ -1,13 +1,9 @@
 package:
   name: terraform
   version: 1.5.7
-  epoch: 10
+  epoch: 11
   copyright:
     - license: MPL-2.0
-
-environment:
-  environment:
-    CGO_ENABLED: 0
 
 pipeline:
   - uses: git-checkout
@@ -24,9 +20,6 @@ pipeline:
     with:
       packages: .
       output: terraform
-      ldflags: -s -w
-
-  - uses: strip
 
 subpackages:
   - name: terraform-compat

--- a/vcluster.yaml
+++ b/vcluster.yaml
@@ -1,7 +1,7 @@
 package:
   name: vcluster
   version: 0.19.5
-  epoch: 0
+  epoch: 1
   description: Create fully functional virtual Kubernetes clusters
   copyright:
     - license: Apache-2.0
@@ -12,12 +12,7 @@ package:
 environment:
   contents:
     packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
       - helm
-  environment:
-    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout
@@ -47,8 +42,6 @@ pipeline:
       packages: ./cmd/vclusterctl
       output: vcluster
       ldflags: -X=main.version=${{package.version}}
-
-  - uses: strip
 
 subpackages:
   - name: ${{package.name}}-syncer

--- a/wolfictl.yaml
+++ b/wolfictl.yaml
@@ -1,14 +1,10 @@
 package:
   name: wolfictl
   version: 0.16.14
-  epoch: 0
+  epoch: 1
   description: Helper CLI for managing Wolfi
   copyright:
     - license: Apache-2.0
-
-environment:
-  environment:
-    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout
@@ -16,19 +12,16 @@ pipeline:
       repository: https://github.com/wolfi-dev/wolfictl
       tag: v${{package.version}}
       expected-commit: 2b43fb0dae170699a6e9410c6da4172df09638ea
-      destination: wolfictl
 
   - uses: go/bump
     with:
       deps: github.com/mholt/archiver/v3@v3.5.1
       replaces: github.com/mholt/archiver/v3=github.com/anchore/archiver/v3@v3.5.2
-      modroot: wolfictl
 
   - uses: go/build
     with:
       packages: .
       output: wolfictl
-      modroot: wolfictl
 
   - uses: strip
 


### PR DESCRIPTION
Update packaging to conform to latest best practice of go/build
pipeline.

- Do not use nested checkouts
- Do not specify explicit CGO_ENABLED setting
- Do not specify default ldflags
- Do not specify pipeline dependencies in runtime environment

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
