### PR TITLE
kustomize: build with default settings

### DIFF
--- a/kustomize.yaml
+++ b/kustomize.yaml
@@ -1,22 +1,13 @@
 package:
   name: kustomize
   version: 5.4.2
-  epoch: 0
+  epoch: 1
   description: Customization of kubernetes YAML configurations
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - ca-certificates-bundle
-
-environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
-  environment:
-    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout
@@ -29,9 +20,7 @@ pipeline:
     with:
       packages: ./kustomize
       output: kustomize
-      ldflags: -s -w -X sigs.k8s.io/kustomize/api/provenance.version=kustomize/${{package.version}} -X 'sigs.k8s.io/kustomize/api/provenance.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')'
-
-  - uses: strip
+      ldflags: -X sigs.k8s.io/kustomize/api/provenance.version=kustomize/${{package.version}} -X 'sigs.k8s.io/kustomize/api/provenance.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')'
 
 update:
   enabled: true


### PR DESCRIPTION
Do not strip symbols table (for determination if fips is needed, and
vulnerability scanning). Do not set CGO_ENABLED - as it is
automatically used as needed.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
