### PR TITLE
erlang-27: add odbc subpackage

### DIFF
--- a/erlang-27.yaml
+++ b/erlang-27.yaml
@@ -1,7 +1,7 @@
 package:
   name: erlang-27
   version: 27.0
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -20,9 +20,11 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - freetds-dev
       - ncurses-dev
       - openssl-dev
       - perl-dev
+      - unixodbc-dev
       - zlib-dev
 
 pipeline:
@@ -63,6 +65,20 @@ subpackages:
         - erlang
       provides:
         - erlang-dev=${{package.full-version}}
+
+  - name: ${{package.name}}-odbc
+    description: "Erlang odbc library"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/erlang/lib
+          mv "${{targets.destdir}}"/usr/lib/erlang/lib/odbc-* "${{targets.subpkgdir}}"/usr/lib/erlang/lib
+    dependencies:
+      runtime:
+        - erlang
+        - freetds
+        - unixodbc
+      provides:
+        - erlang-odbc=${{package.full-version}}
 
 update:
   enabled: true


### PR DESCRIPTION
### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

This adds the erlang-odbc library to the build outcomes, which was previously not included. I bundled it as a subpackage to not increase the erlang base package. 

For a project I need the erlang-odbc library, currently I am recompiling erlang including the two missing build dependencies. This subpackage would make it irrelevant :) 

P.S. This may be also interesting to "backport" to erlang-25 and erlang-26 packages.

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
