### PR TITLE
keycloak-operator 24.0.4-r1: fix CVE-2024-29857, CVE-2024-30172 and CVE-2024-30171

### DIFF
--- a/keycloak-operator.yaml
+++ b/keycloak-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-operator
   version: 24.0.4
-  epoch: 1
+  epoch: 2
   description: A Kubernetes Operator based on the Operator SDK for installing and managing Keycloak.
   copyright:
     - license: Apache-2.0

--- a/keycloak-operator/pombump-deps.yaml
+++ b/keycloak-operator/pombump-deps.yaml
@@ -10,3 +10,9 @@ patches:
     version: 1.78
     scope: import
     type: jar
+  # Fixes CVE-2024-29857, CVE-2024-30172 and CVE-2024-30171
+  - groupId: org.bouncycastle
+    artifactId: bcpkix-jdk18on
+    version: 1.78
+    scope: import
+    type: jar


### PR DESCRIPTION
keycloak-operator 24.0.4-r1: fix CVE-2024-29857, CVE-2024-30172 and CVE-2024-30171

Related: https://github.com/chainguard-dev/CVE-Dashboard/issues/3#event-12989237018

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo (Note: fixed advisories are automatically recorded these days)

