### PR TITLE
[dnm] build mono

### DIFF
--- a/mono.yaml
+++ b/mono.yaml
@@ -1,0 +1,43 @@
+package:
+  name: sonarr
+  version: 6.12.0.206
+  epoch: 0
+  description: "Mono is a software platform designed to allow developers to easily create cross platform applications."
+  copyright:
+    - license: MIT
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - clang-17
+      - cmake
+      - curl
+      - gettext
+      - libtool
+      - python3
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/mono/mono
+      tag: mono-${{package.version}}
+      expected-commit: 0cbf0e290c31adb476f9de0fa44b1d8829affa40
+
+  - runs: |
+      ./autogen.sh --prefix=/usr
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: mono/mono
+    use-tag: true
+    strip-prefix: mono-


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

build mono from latest tag

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
