### PR TITLE
add jenkins-plugin-manager and jenkins-docker

### DIFF
--- a/jenkins-docker.yaml
+++ b/jenkins-docker.yaml
@@ -1,0 +1,45 @@
+package:
+  name: jenkins-docker
+  version: "2.460"
+  epoch: 0
+  description: Docker compatbility scripts and tooling for Jenkins
+  copyright:
+    - license: MIT
+  dependencies:
+    # https://github.com/jenkinsci/docker/blob/5575a3c8fe959449570de9eb03e6cb3127d8f389/alpine/hotspot/Dockerfile#L42
+    runtime:
+      - bash
+      - coreutils
+      - curl
+      - git
+      - git-lfs
+      - gnupg
+      - openssh-client
+      - tini
+      - ttf-dejavu
+      - tzdata
+      - unzip
+      - jenkins-plugin-manager-compat
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/jenkinsci/docker
+      tag: ${{package.version}}
+      expected-commit: 5575a3c8fe959449570de9eb03e6cb3127d8f389
+
+  # https://github.com/jenkinsci/docker/blob/master/alpine/hotspot/Dockerfile#L136
+  - runs: |
+      install -Dm755 jenkins-support ${{targets.destdir}}/usr/local/bin/jenkins-support
+      install -Dm755 jenkins.sh ${{targets.destdir}}/usr/local/bin/jenkins.sh
+      install -Dm755 jenkins-plugin-cli.sh ${{targets.destdir}}/bin/jenkins-plugin-cli
+
+update:
+  enabled: true
+  github:
+    identifier: jenkinsci/docker

--- a/jenkins-plugin-manager.yaml
+++ b/jenkins-plugin-manager.yaml
@@ -1,0 +1,44 @@
+package:
+  name: jenkins-plugin-manager
+  version: 2.13.0
+  epoch: 0
+  description: Plugin Manager CLI tool for Jenkins
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - maven
+      - openjdk-17
+      - openjdk-17-default-jvm
+      - wolfi-base
+      - wolfi-baselayout
+  environment:
+    LANG: en_US.UTF-8
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/jenkinsci/plugin-installation-manager-tool
+      tag: ${{package.version}}
+      expected-commit: f9bd96d7be42052fb29c25a3cafbdd7a90d72962
+
+  - runs: |
+      mvn clean package -DskipTests
+
+      mkdir -p ${{targets.destdir}}/usr/share/java/jenkins-plugin-manager
+      cp plugin-management-cli/target/jenkins-plugin-manager*.jar ${{targets.destdir}}/usr/share/java/${{package.name}}/jenkins-plugin-manager.jar
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/opt
+          ln -s /usr/share/java/${{package.name}}/jenkins-plugin-manager.jar ${{targets.subpkgdir}}/opt/jenkins-plugin-manager.jar
+
+update:
+  enabled: true
+  github:
+    identifier: jenkinsci/plugin-installation-manager-tool


### PR DESCRIPTION
`jenkins-docker` is intended to replace `jenkins-entrypoint`. I'm adding it as a separate origin to remain compatible with the sole user (the jenkins image).

when that is updated I'll withdraw `jenkins-entrypoint`.

ref: https://github.com/chainguard-images/images/pull/2763