### PR TITLE
py3-cassandra-medusa-compat: remove grpc-health-probe dep

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: 0.21.0
-  epoch: 0
+  epoch: 1
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
@@ -52,6 +52,8 @@ pipeline:
 
   - runs: |
       .venv/bin/pip install -I -r requirements.txt --no-compile
+      # CVE-2024-35195: requests
+      .venv/bin/pip install --upgrade requests=2.32.0
       .venv/bin/pip install -I --no-compile dist/*.whl
 
   - runs: |

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -83,7 +83,6 @@ subpackages:
     description: "Compatibility package to place binaries and docker entrypoints in the location expected by upstream helm charts"
     dependencies:
       runtime:
-        - grpc-health-probe
         # The entrypoint script fails to start without bash and sleep (which comes from busybox)
         - bash
         - busybox

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -53,7 +53,7 @@ pipeline:
   - runs: |
       .venv/bin/pip install -I -r requirements.txt --no-compile
       # CVE-2024-35195: requests
-      .venv/bin/pip install --upgrade requests=2.32.0
+      .venv/bin/pip install --upgrade requests==2.32.0
       .venv/bin/pip install -I --no-compile dist/*.whl
 
   - runs: |


### PR DESCRIPTION
Remove explicit dep for symlink only compat subpackage