### PR TITLE
src-fingerprint: build with symbols tables

### DIFF
--- a/src-fingerprint.yaml
+++ b/src-fingerprint.yaml
@@ -1,14 +1,10 @@
 package:
   name: src-fingerprint
   version: 0.19.0
-  epoch: 13
+  epoch: 14
   description: Extract git related information (file shas, commit shas) from your hosted source version control system
   copyright:
     - license: Apache-2.0
-
-environment:
-  environment:
-    CGO_ENABLED: '0'
 
 pipeline:
   - uses: git-checkout
@@ -29,7 +25,7 @@ pipeline:
     with:
       packages: ./cmd/src-fingerprint
       output: src-fingerprint
-      ldflags: '-s -w -X main.version=${{package.version}}'
+      ldflags: '-X main.version=${{package.version}}'
 
   - uses: strip
 


### PR DESCRIPTION
Enable symbols table, and drop redundant stripping of debug symbols, and redundant cgo_enabled=0 specification.