### PR TITLE
clang 18

### DIFF
--- a/clang-18.yaml
+++ b/clang-18.yaml
@@ -126,7 +126,7 @@ subpackages:
     description: "Clang 18 runtime library"
     pipeline:
       - runs: |
-          sonamefull="libclang-cpp.so.18"
+          sonamefull="libclang-cpp.so.18.1"
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/
           mv "${{targets.destdir}}"/usr/lib/$sonamefull "${{targets.subpkgdir}}"/usr/lib/
     dependencies:

--- a/clang-18.yaml
+++ b/clang-18.yaml
@@ -1,0 +1,224 @@
+package:
+  name: clang-18
+  version: 18.1.6
+  epoch: 0
+  description: "C language family frontend for LLVM"
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: 32
+    memory: 64Gi
+  dependencies:
+    runtime:
+      - libLLVM-18
+
+environment:
+  contents:
+    packages:
+      - binutils-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - help2man
+      - libLLVM-18
+      - libffi-dev
+      - libxml2-dev
+      - llvm-18
+      - llvm-18-dev
+      - llvm-cmake-18
+      - pkgconf
+      - python3
+      - samurai
+      - wolfi-base
+      - zlib-dev
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/clang-${{package.version}}.src.tar.xz
+      expected-sha256: 54e0817f918b90b5f94684e9729ac2f9d3820fce040d6395d71c1f19ffa3b03c
+
+  - uses: fetch
+    with:
+      uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/clang-tools-extra-${{package.version}}.src.tar.xz
+      expected-sha256: d78732ec6d55b7374abe14b97c9529a7b56a1fe19929a5bf4c3802b69f77764e
+      strip-components: 0
+
+  - runs: |
+      mv clang-tools-extra-${{package.version}}.src tools/extra
+
+  - runs: |
+      python_version=$(python3 -V | sed 's/.*\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*/\1/')
+
+      cmake -B build -G Ninja -Wno-dev \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_MODULE_PATH=/usr/lib/llvm-${{vars.major-version}}/share/cmake/Modules \
+        -DCLANG_BUILT_STANDALONE=TRUE \
+        -DLLVM_COMMON_CMAKE_UTILS="/usr/lib/llvm-${{vars.major-version}}/share/cmake" \
+        -DCLANG_CONFIG_FILE_SYSTEM_DIR=/etc/clang-${{vars.major-version}} \
+        -DLLVM_CONFIG=/usr/lib/llvm-${{vars.major-version}}/bin/llvm-config \
+        -DCLANG_ENABLE_ARCMT=ON \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DCLANG_ENABLE_STATIC_ANALYZER=ON \
+        -DCLANG_LINK_CLANG_DYLIB=ON \
+        -DCLANG_PLUGIN_SUPPORT=ON \
+        -DCLANG_PYTHON_BINDINGS_VERSIONS="$python_version" \
+        -DCLANG_VENDOR=Wolfi \
+        -DENABLE_LINKER_BUILD_ID=ON \
+        -DLIBCLANG_BUILD_STATIC=ON \
+        -DLLVM_INCLUDE_DIRS=/usr/lib/llvm-${{vars.major-version}}/include
+
+  - runs: |
+      cmake --build build --target clang-tblgen
+
+  - runs: |
+      cmake --build build
+
+  - runs: |
+      help2man --no-info \
+        --source "Wolfi" \
+        --name "Wolfi Clang ${{package.version}}-r${{package.epoch}}" \
+        --version-string "${{package.version}}-r${{package.epoch}}" \
+        --help-option "--help-hidden" \
+        ./build/bin/clang > clang.1
+
+  - runs: |
+      DESTDIR="${{targets.destdir}}" cmake --install build
+
+      install -Dm644 build/lib/libclang.a -t "${{targets.destdir}}"/usr/lib/
+
+  - runs: |
+      rm "${{targets.destdir}}"/usr/share/clang/clang-format-bbedit.applescript \
+         "${{targets.destdir}}"/usr/share/clang/clang-doc-default-stylesheet.css \
+         "${{targets.destdir}}"/usr/share/clang/index.js
+
+      install -Dm644 clang.1 -t "${{targets.destdir}}"/usr/share/man/man1/
+
+      mkdir -p "${{targets.destdir}}"/usr/share/bash-completion/completions
+      mv "${{targets.destdir}}"/usr//share/clang/bash-autocomplete.sh \
+         "${{targets.destdir}}"/usr/share/bash-completion/completions/clang
+
+      mkdir -p "${{targets.destdir}}"/usr/share/emacs/site-lisp
+      mv "${{targets.destdir}}"/usr/share/clang/clang-*.el \
+         "${{targets.destdir}}"/usr/share/emacs/site-lisp
+
+  - uses: strip
+
+subpackages:
+  - name: "clang-18-dev"
+    description: "headers for clang-18"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - libLLVM-18
+        - libclang-cpp-18
+
+  - name: "libclang-cpp-18"
+    description: "Clang 18 runtime library"
+    pipeline:
+      - runs: |
+          sonamefull="libclang-cpp.so.18"
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/
+          mv "${{targets.destdir}}"/usr/lib/$sonamefull "${{targets.subpkgdir}}"/usr/lib/
+    dependencies:
+      runtime:
+        - libLLVM-18
+
+  - name: "clang-18-analyzer"
+    description: "Clang 18 analyzer"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/scan* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/analyze-build* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/intercept-build* "${{targets.subpkgdir}}"/usr/bin/
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/libexec
+          mv "${{targets.destdir}}"/usr/libexec/*-analyzer* "${{targets.subpkgdir}}"/usr/libexec/
+          mv "${{targets.destdir}}"/usr/libexec/analyze-* "${{targets.subpkgdir}}"/usr/libexec/
+          mv "${{targets.destdir}}"/usr/libexec/intercept-* "${{targets.subpkgdir}}"/usr/libexec/
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/share
+          mv "${{targets.destdir}}"/usr/share/scan-* "${{targets.subpkgdir}}"/usr/share/
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libear* "${{targets.subpkgdir}}"/usr/lib/
+    dependencies:
+      runtime:
+        - perl
+        - python3
+
+  - name: "clang-18-extras"
+    description: "Clang 18 extras"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/clang-apply-replacements* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-change-namespace* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-check* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-doc* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-extdef-mapping* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-format* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-include-fixer* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-move* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-offload-bundler* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-offload-packager* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-query* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-refactor* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-rename* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-reorder-fields* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-repl* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-scan-deps* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clang-tidy* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/clangd* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/c-index-test* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/diagtool* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/find-all-symbols* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/git-clang-format* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/hmaptool* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/modularize* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/pp-trace* "${{targets.subpkgdir}}"/usr/bin/
+          mv "${{targets.destdir}}"/usr/bin/run-clang-tidy* "${{targets.subpkgdir}}"/usr/bin/
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/clang
+          mv "${{targets.destdir}}"/usr/share/clang/clang-include-fixer* "${{targets.subpkgdir}}"/usr/share/clang/
+          mv "${{targets.destdir}}"/usr/share/clang/clang-format*.py "${{targets.subpkgdir}}"/usr/share/clang/
+          mv "${{targets.destdir}}"/usr/share/clang/*clang-tidy* "${{targets.subpkgdir}}"/usr/share/clang/
+          mv "${{targets.destdir}}"/usr/share/clang/run-find-all-symbols.py "${{targets.subpkgdir}}"/usr/share/clang/
+
+          mv "${{targets.destdir}}"/usr/share/emacs "${{targets.subpkgdir}}"/usr/share/
+
+  - name: "py3-clang-18"
+    description: "Clang 18 Python bindings"
+    pipeline:
+      - runs: |
+          sitedir=$(python3 -c "import site; print(site.getsitepackages()[0])")
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/python* "${{targets.subpkgdir}}"/usr/lib/
+
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/clang
+          mv "${{targets.destdir}}"/usr/share/clang/clang-rename.py "${{targets.subpkgdir}}"/usr/share/clang/
+
+          mv "${{targets.destdir}}"/usr/lib/libscanbuild "${{targets.subpkgdir}}"/"$sitedir"
+    dependencies:
+      runtime:
+        - libLLVM-18
+        - libclang-cpp-18
+
+update:
+  enabled: true
+  github:
+    identifier: llvm/llvm-project
+    strip-prefix: llvmorg-
+    tag-filter: llvmorg-18
+    use-tag: true

--- a/llvm-lld-18.yaml
+++ b/llvm-lld-18.yaml
@@ -1,0 +1,82 @@
+package:
+  name: llvm-lld-18
+  version: 18.1.6
+  epoch: 0
+  description: The LLVM Linker
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - llvm-lld=18
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang-18
+      - cmake
+      - curl
+      - git
+      - libedit-dev
+      - llvm-18
+      - llvm-18-dev
+      - llvm-cmake-18
+      - llvm-libunwind-dev
+      - samurai
+      - zlib-dev
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 4ac13125616dc44905b85820aa403d27ec1226329b7f674daeb5f5584c6f0b22
+      uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/lld-${{package.version}}.src.tar.xz
+
+  - runs: |
+      cmake -B build -G Ninja -Wno-dev \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_MODULE_PATH=/usr/lib/llvm-${{vars.major-version}}/share/cmake/Modules \
+        -DLLVM_COMMON_CMAKE_UTILS="/usr/lib/llvm-${{vars.major-version}}/share/cmake" \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_SKIP_INSTALL_RPATH=ON \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLD_BUILT_STANDALONE=ON \
+        -DLLVM_CONFIG=/usr/lib/llvm-${{vars.major-version}}/bin/llvm-config \
+        -DLLVM_INCLUDE_DIRS=/usr/lib/llvm-${{vars.major-version}}/include
+
+  - runs: |
+      cmake --build build
+
+  - runs: |
+      DESTDIR=${{targets.destdir}} cmake --install build
+
+subpackages:
+  - name: llvm-lld-18-static
+    pipeline:
+      - uses: split/static
+
+  - name: llvm-lld-18-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - llvm-lld-18
+    description: llvm-lld dev
+
+update:
+  enabled: true
+  github:
+    identifier: llvm/llvm-project
+    use-tag: true
+    tag-filter: llvmorg-18.1.
+    strip-prefix: llvmorg-

--- a/llvm-lld-18.yaml
+++ b/llvm-lld-18.yaml
@@ -38,7 +38,7 @@ var-transforms:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 4ac13125616dc44905b85820aa403d27ec1226329b7f674daeb5f5584c6f0b22
+      expected-sha256: f1f059c2bf98ffa558cd0c48ea568736c41f0c8029dabb53147d48b9efdaa802
       uri: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{package.version}}/lld-${{package.version}}.src.tar.xz
 
   - runs: |


### PR DESCRIPTION
most of llvm-18 updates landed without clang, but now fixed that up too, so landing remaining two components of the llvm-18 collection of tools.

- **Revert "Build without clang-18"**
  This reverts commit 7b6846ec551809c2b32c4c4497c283e9685768bd.
  
- **Fix libclang-cpp soname**

- **llvm-lld-18: fix tarball checksum (copied from 17 previously)**
  