### PR TITLE
minify: build with symbols & universal compat package

### DIFF
--- a/minify.yaml
+++ b/minify.yaml
@@ -1,18 +1,10 @@
 package:
   name: minify
   version: 2.20.32
-  epoch: 0
+  epoch: 1
   description: "Go minifiers for web formats"
   copyright:
     - license: MIT
-
-environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
-      - wolfi-base
 
 pipeline:
   - uses: git-checkout
@@ -24,10 +16,7 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cmd/minify
-      ldflags: -s -w
       output: minify
-
-  - uses: strip
 
 subpackages:
   - name: minify-bash-completion
@@ -37,9 +26,6 @@ subpackages:
           _out="${{targets.subpkgdir}}"/usr/share/bash-completion/completions
           mkdir -p $_out
           install -Dm644 ./cmd/minify/bash_completion $_out
-    dependencies:
-      runtime:
-        - minify
 
 update:
   enabled: true


### PR DESCRIPTION
Prepare minify for fips build. Build with symbols enabled, without
redundant environment packages. Also make bash completion package not
depend on minify, such that it can be used with future minify-fips as
well.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
