### PR TITLE
hivemind: init at 1.1.0

### DIFF
--- a/hivemind.yaml
+++ b/hivemind.yaml
@@ -1,0 +1,37 @@
+package:
+  name: hivemind
+  version: 1.1.0
+  epoch: 0
+  description: "Process manager for Procfile-based applications"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - gobump
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/DarthSim/hivemind
+      tag: "v${{package.version}}"
+      expected-commit: 580abe5b3faf585c450604227e40e960cdbb21bd
+
+  - runs: gobump --packages golang.org/x/sys@v0.0.0-20220412211240-33da011f77ad
+
+  - uses: go/build
+    with:
+      ldflags: -s -w
+      output: hivemind
+      packages: .
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: DarthSim/hivemind
+    strip-prefix: v
+    tag-filter: v

--- a/hivemind.yaml
+++ b/hivemind.yaml
@@ -19,7 +19,9 @@ pipeline:
       tag: "v${{package.version}}"
       expected-commit: 580abe5b3faf585c450604227e40e960cdbb21bd
 
-  - runs: gobump --packages golang.org/x/sys@v0.0.0-20220412211240-33da011f77ad
+      - uses: go/bump
+        with:
+          deps: golang.org/x/sys@v0.0.0-20220412211240-33da011f77ad
 
   - uses: go/build
     with:

--- a/hivemind.yaml
+++ b/hivemind.yaml
@@ -10,7 +10,6 @@ environment:
   contents:
     packages:
       - busybox
-      - gobump
 
 pipeline:
   - uses: git-checkout
@@ -19,9 +18,9 @@ pipeline:
       tag: "v${{package.version}}"
       expected-commit: 580abe5b3faf585c450604227e40e960cdbb21bd
 
-      - uses: go/bump
-        with:
-          deps: golang.org/x/sys@v0.0.0-20220412211240-33da011f77ad
+  - uses: go/bump
+    with:
+      deps: golang.org/x/sys@v0.0.0-20220412211240-33da011f77ad
 
   - uses: go/build
     with:


### PR DESCRIPTION
Simple Procfile based process manager can be used in entrypoint to run two programs at once

https://github.com/DarthSim/hivemind

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
