### PR TITLE
Revert "libdrm/2.4.121 package update"

### DIFF
--- a/libdrm.yaml
+++ b/libdrm.yaml
@@ -1,7 +1,7 @@
 # Generated from https://git.alpinelinux.org/aports/plain/main/libdrm/APKBUILD
 package:
   name: libdrm
-  version: 2.4.121
+  version: 2.4.120
   epoch: 0
   description: Userspace interface to kernel DRM services
   copyright:
@@ -24,7 +24,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: a733c691080f13da94d830060e5139b6e3099a413f919a6b152c0f5020099dcb
+      expected-sha256: 66b40c776704145d8550c294bcea357ca2dafcc814aa5b48cff0dc57af174b16
       uri: https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-${{package.version}}/drm-libdrm-${{package.version}}.tar.gz
 
   - runs: |


### PR DESCRIPTION
Reverts wolfi-dev/os#21158

Gitlab is currently under maintenance