### PR TITLE
fix trivy

### DIFF
--- a/harbor-scanner-trivy.yaml
+++ b/harbor-scanner-trivy.yaml
@@ -1,13 +1,14 @@
 package:
   name: harbor-scanner-trivy
   version: 0.31.2
-  epoch: 0
+  epoch: 1
   description: Use Trivy as a plug-in vulnerability scanner in the Harbor registry
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - ca-certificates-bundle
+      - trivy
 
 pipeline:
   - uses: git-checkout

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,17 +1,10 @@
 package:
   name: trivy
   version: 0.52.0
-  epoch: 0
+  epoch: 1
   description: Simple and comprehensive vulnerability scanner for containers
   copyright:
     - license: Apache-2.0
-
-environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
 
 pipeline:
   - uses: git-checkout
@@ -20,12 +13,11 @@ pipeline:
       repository: https://github.com/aquasecurity/trivy
       tag: v${{package.version}}
 
-  - runs: |
-      CGO_ENABLED=0 go build \
-        -ldflags "-w -X github.com/aquasecurity/trivy/pkg/version.ver=${{package.version}}" \
-        -o "${{targets.contextdir}}/usr/bin/trivy" ./cmd/trivy
-
-  - uses: strip
+  - uses: go/build
+    with:
+      packages: ./cmd/trivy
+      output: trivy
+      ldflags: -X github.com/aquasecurity/trivy/pkg/version.ver=${{package.version}}
 
 test:
   environment:


### PR DESCRIPTION
- **trivy: switch from manual build to go/build pipeline**
  Remove redundant dependencies and flags, already provided by the
  go/build pipeline.
  
  Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
  

- **harbor-scanner-trivy: depend on trivy**
  harbor-scanner-trivy executes trivy binary, thus ensure it depends on
  it.
  
  Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
  