### PR TITLE
flannel: switch to go/build pipeline

### DIFF
--- a/flannel-cni-plugin.yaml
+++ b/flannel-cni-plugin.yaml
@@ -1,18 +1,10 @@
 package:
   name: flannel-cni-plugin
   version: 1.4.1
-  epoch: 2
+  epoch: 3
   description: flannel cni plugin
   copyright:
     - license: Apache-2.0
-
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - go
 
 pipeline:
   - uses: git-checkout
@@ -21,17 +13,11 @@ pipeline:
       tag: v${{package.version}}-flannel1
       expected-commit: 85206d1cdc253d9a3720e2248b4959fb5acce6d2
 
-  - runs: |
-      # Ensure we build statically since CNI plugins often get moved onto the
-      # host machine where we can't guarantee GLIBC verion compatibility
-      # `-extldflags "-static"` is included by default
-      CGO_ENABLED=0 \
-      EXTRA_LDFLAGS="-s -w" \
-      scripts/build_flannel.sh
-
-      install -Dm755 dist/flannel-$(go env GOARCH) "${{targets.destdir}}"/usr/bin/flannel
-
-  - uses: strip
+  - uses: go/build
+    with:
+      output: flannel
+      packages: .
+      ldflags: -X main.Version=v${{package.version}}-flannel1 -X main.Commit=$(git rev-parse --short=8 HEAD) -X main.Program=flannel -X main.buildDate=$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%Y-%m-%dT%H:%M:%SZ")
 
 subpackages:
   - name: flannel-cni-plugin-compat


### PR DESCRIPTION
Ensure version ldtags remain the same. The binary remains static, by
virtue of netgo,osusergo tags.

no_stage,static_build tags removed - as no source appears to use them.

ARM64 and AMD64 builds now use identical configuration.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
