### PR TITLE
envoy-ratelimit: include commit data in package

### DIFF
--- a/envoy-ratelimit.yaml
+++ b/envoy-ratelimit.yaml
@@ -34,6 +34,8 @@ pipeline:
       output: ratelimit
       packages: ./src/service_cmd
 
+  - runs: echo "${var.commit}" > /var/envoy-ratelimit-commit
+
 subpackages:
   - name: envoy-ratelimit-compat
     pipeline:

--- a/envoy-ratelimit.yaml
+++ b/envoy-ratelimit.yaml
@@ -34,9 +34,7 @@ test:
       packages:
         - go
   pipeline:
-    - runs: |
-       go version -m /usr/bin/ratelimit
-       go version -m /usr/bin/ratelimit | grep "vcs.revision=${{vars.commit}}$"
+    - runs: go version -m /usr/bin/ratelimit | grep "vcs.revision=${{vars.commit}}$"
 
 subpackages:
   - name: envoy-ratelimit-compat

--- a/envoy-ratelimit.yaml
+++ b/envoy-ratelimit.yaml
@@ -12,16 +12,10 @@ vars:
   commit: f3b67307a53c3979783bef4de8bfa655167b0807
 
 pipeline:
-  - uses: fetch
-    with:
-      expected-sha256: 2683c2445371506ca8689530276f830bc54d0c9c5169007849b6e1871d2bf174
-      extract: "false"
-      uri: https://github.com/envoyproxy/ratelimit/archive/${{vars.commit}}.zip
-
   - runs: |
-      unzip -q ${{vars.commit}}.zip
-      mv ratelimit-${{vars.commit}} ratelimit
-      rm *.zip
+      git clone https://github.com/envoyproxy/ratelimit ratelimit/
+      cd ratelimit/
+      git checkout ${{vars.commit}}
 
   - uses: go/bump
     with:
@@ -34,7 +28,15 @@ pipeline:
       output: ratelimit
       packages: ./src/service_cmd
 
-  - runs: mkdir -p /var && echo "${var.commit}" > /var/envoy-ratelimit-commit
+test:
+  environment:
+    contents:
+      packages:
+        - go
+  pipeline:
+    - runs: |
+       go version -m /usr/bin/ratelimit
+       go version -m /usr/bin/ratelimit | grep "vcs.revision=${{vars.commit}}$"
 
 subpackages:
   - name: envoy-ratelimit-compat

--- a/envoy-ratelimit.yaml
+++ b/envoy-ratelimit.yaml
@@ -3,7 +3,7 @@ package:
   # This project doesn't do releases and everything is commit based.
   # This corresponds to commit f3b67307a53c3979783bef4de8bfa655167b0807
   version: 0.0_git20240220
-  epoch: 9
+  epoch: 10
   description: Go/gRPC service designed to enable generic rate limit scenarios from different types of applications.
   copyright:
     - license: Apache-2.0
@@ -34,7 +34,7 @@ pipeline:
       output: ratelimit
       packages: ./src/service_cmd
 
-  - runs: echo "${var.commit}" > /var/envoy-ratelimit-commit
+  - runs: mkdir -p /var && echo "${var.commit}" > /var/envoy-ratelimit-commit
 
 subpackages:
   - name: envoy-ratelimit-compat


### PR DESCRIPTION
This project doesn't do upstream releases, and we'd like a way to be able to determine the version being used from image contents. This is a cheap and cheerful way to accomplish that.
