### PR TITLE
jenkins: 2.460 update with patch fix

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -1,6 +1,6 @@
 package:
   name: jenkins
-  version: "2.459"
+  version: "2.460"
   epoch: 0
   description: Open-source CI/CD application.
   copyright:
@@ -44,7 +44,7 @@ pipeline:
     with:
       repository: https://github.com/jenkinsci/jenkins
       tag: jenkins-${{package.version}}
-      expected-commit: 4cb317d870a86150237b2024dd31a855e2e5efcb
+      expected-commit: ff4367f8d14bdf9e295941c8fd79c4d2043a30dc
 
   - uses: patch
     with:

--- a/jenkins/ignoreArchiveNotReadableTest.patch
+++ b/jenkins/ignoreArchiveNotReadableTest.patch
@@ -1,18 +1,10 @@
 # Disabling single test which fails.  Manually checked that Java does set the read only file permissions correctly
 # Requires more investigation, early thoughts could be related to the jenkins test harness coming from maven central and the test not using the one built from source
 diff --git a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
-index 92dee288b4..cdc4235c0b 100644
+index 6ceca40aba..0306fb8f77 100644
 --- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
 +++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
-@@ -60,6 +60,7 @@ import jenkins.util.VirtualFile;
- import org.hamcrest.Matchers;
- import org.jenkinsci.plugins.structs.describable.DescribableModel;
- import org.junit.ClassRule;
-+import org.junit.Ignore;
- import org.junit.Rule;
- import org.junit.Test;
- import org.jvnet.hudson.test.BuildWatcher;
-@@ -382,6 +383,7 @@ public class ArtifactArchiverTest {
+@@ -480,6 +480,7 @@ public class ArtifactArchiverTest {
      }
  
      @Test @Issue("JENKINS-21905")


### PR DESCRIPTION
Jenkins project released 2.460 an 2.461 on same day.  Manually updating and repairing patch file to get a 2.460 image tag built before automation builds 2.461.