### PR TITLE
Rename rabbitmq-server to rabbitmq-server-3.13

### DIFF
--- a/rabbitmq-server-3.13.yaml
+++ b/rabbitmq-server-3.13.yaml
@@ -21,9 +21,9 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - elixir-1.15
-      - erlang
-      - erlang-dev
+      - elixir
+      - erlang-26
+      - erlang-26-dev
       - libxslt
       - python3
       - rsync

--- a/rabbitmq-server-3.13.yaml
+++ b/rabbitmq-server-3.13.yaml
@@ -1,6 +1,6 @@
 package:
   name: rabbitmq-server-3.13
-  version: 3.13.2
+  version: 3.13.3
   epoch: 0
   description: Open source RabbitMQ. core server and tier 1 (built-in) plugins
   copyright:
@@ -31,7 +31,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: e391e0f90db71a1664cf10e116fab0c85f895f53f03b0ab5e7fda0278e9013bc
+      expected-sha256: 08f9e83caded04a2a6228f088a8502516930ebeb1dbf345a02782c79167c7943
       uri: https://github.com/rabbitmq/rabbitmq-server/releases/download/v${{package.version}}/rabbitmq-server-${{package.version}}.tar.xz
 
   - runs: |

--- a/rabbitmq-server-3.13.yaml
+++ b/rabbitmq-server-3.13.yaml
@@ -27,6 +27,9 @@ environment:
       - libxslt
       - python3
       - rsync
+  environment:
+    # This is needed to work around the error "the VM is running with native name encoding of latin1 which may cause Elixir to malfunction..."
+    ELIXIR_ERL_OPTIONS: "+fnu"
 
 pipeline:
   - uses: fetch

--- a/rabbitmq-server-3.13.yaml
+++ b/rabbitmq-server-3.13.yaml
@@ -75,12 +75,15 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "rabbitmq-doc"
+  - name: rabbitmq-doc-3.13
     description: "rabbitmq documentation"
     pipeline:
       - uses: split/manpages
+    dependencies:
+      provides:
+        - rabbitmq-doc=${{package.full-version}}
 
-  - name: rabbitmq-server-compat
+  - name: rabbitmq-server-compat-3.13
     description: Compat package for the Bitnami Rabbitmq Helm chart
     pipeline:
       - uses: bitnami/compat
@@ -130,3 +133,4 @@ update:
   github:
     identifier: rabbitmq/rabbitmq-server
     strip-prefix: v
+    tag-filter-prefix: v3.13.

--- a/rabbitmq-server-3.13.yaml
+++ b/rabbitmq-server-3.13.yaml
@@ -21,7 +21,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - elixir
+      - elixir~1.15
       - erlang
       - erlang-dev
       - libxslt

--- a/rabbitmq-server-3.13.yaml
+++ b/rabbitmq-server-3.13.yaml
@@ -86,7 +86,7 @@ subpackages:
       provides:
         - rabbitmq-doc=${{package.full-version}}
 
-  - name: rabbitmq-server-compat-3.13
+  - name:  ${{package.name}}-compat
     description: Compat package for the Bitnami Rabbitmq Helm chart
     pipeline:
       - uses: bitnami/compat

--- a/rabbitmq-server-3.13.yaml
+++ b/rabbitmq-server-3.13.yaml
@@ -86,7 +86,7 @@ subpackages:
       provides:
         - rabbitmq-doc=${{package.full-version}}
 
-  - name:  ${{package.name}}-compat
+  - name: ${{package.name}}-compat
     description: Compat package for the Bitnami Rabbitmq Helm chart
     pipeline:
       - uses: bitnami/compat

--- a/rabbitmq-server-3.13.yaml
+++ b/rabbitmq-server-3.13.yaml
@@ -11,7 +11,7 @@ package:
     runtime:
       # rabbitmq-server is a wrapper shell script.
       - busybox
-      - erlang
+      - erlang-26
 
 environment:
   contents:

--- a/rabbitmq-server-3.13.yaml
+++ b/rabbitmq-server-3.13.yaml
@@ -27,9 +27,6 @@ environment:
       - libxslt
       - python3
       - rsync
-  environment:
-    # This is needed to work around the error "the VM is running with native name encoding of latin1 which may cause Elixir to malfunction..."
-    ELIXIR_ERL_OPTIONS: "+fnu"
 
 pipeline:
   - uses: fetch

--- a/rabbitmq-server-3.13.yaml
+++ b/rabbitmq-server-3.13.yaml
@@ -21,7 +21,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - elixir~1.15
+      - elixir-1.15
       - erlang
       - erlang-dev
       - libxslt

--- a/rabbitmq-server-3.13.yaml
+++ b/rabbitmq-server-3.13.yaml
@@ -1,11 +1,13 @@
 package:
-  name: rabbitmq-server
+  name: rabbitmq-server-3.13
   version: 3.13.2
-  epoch: 2
+  epoch: 0
   description: Open source RabbitMQ. core server and tier 1 (built-in) plugins
   copyright:
     - license: MPL-2.0
   dependencies:
+    provides:
+      - rabbitmq-server=${{package.full-version}}
     runtime:
       # rabbitmq-server is a wrapper shell script.
       - busybox


### PR DESCRIPTION
replaces https://github.com/wolfi-dev/os/pull/16029 and https://github.com/wolfi-dev/os/pull/20756