### PR TITLE
git: fix test

### DIFF
--- a/git.yaml
+++ b/git.yaml
@@ -110,6 +110,9 @@ update:
     identifier: 5350
 
 test:
+  environment:
+    environment:
+      HOME: /tmp
   pipeline:
     - name: Verify git installation
       runs: |
@@ -134,5 +137,5 @@ test:
         git fetch || exit 1
     - name: Check git configuration
       runs: |
-        git config --list | grep 'user.name=Wolfi' || exit 1config --list | grep 'user.name=Test User' || exit 1
-        git config --list | grep 'user.email=wolf@wolfi.dev' || exit 1ist | grep 'user.email=test@example.com' || exit 1
+        git config --list | grep 'user.name=Wolfi' || exit 1
+        git config --list | grep 'user.email=wolf@wolfi.dev' || exit 1


### PR DESCRIPTION
In case `HOME` is not set, set one.

Fix weird errors when tests do fail, I'm not sure where these came from. Introduced in https://github.com/wolfi-dev/os/commit/377e1829466451476d740e0a013a891dfa368456