### PR TITLE
jupyterhub-k8s-hub: fix for py3-jupyterhub 5.0.0 dependency

### DIFF
--- a/configurable-http-proxy.yaml
+++ b/configurable-http-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: configurable-http-proxy
   version: 4.6.1
-  epoch: 2
+  epoch: 3
   description: "HTTP parser written against llparse"
   copyright:
     - license: BSD-3-Clause
@@ -39,8 +39,17 @@ pipeline:
           npm ci --production
       - uses: strip
 
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      ln -sf /srv/${{package.name}}/bin/${{package.name}} ${{targets.destdir}}/usr/bin/${{package.name}}
+
 update:
   enabled: true
   github:
     identifier: jupyterhub/configurable-http-proxy
     use-tag: true
+
+test:
+  pipeline:
+    - runs: |
+        configurable-http-proxy --version

--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -1,7 +1,7 @@
 package:
   name: jupyterhub-k8s-hub
   version: 3.3.7
-  epoch: 0
+  epoch: 1
   description: Zero to JupyterHub with Kubernetes
   copyright:
     - license: BSD-3-Clause
@@ -71,3 +71,28 @@ update:
   enabled: true
   github:
     identifier: jupyterhub/zero-to-jupyterhub-k8s
+
+test:
+  environment:
+    contents:
+      packages:
+        - openssl # Fixes: RuntimeError: OpenSSL 3.0's legacy provider failed to load.
+        - curl
+  pipeline:
+    - runs: |
+        nohup /usr/bin/jupyterhub > $bin.out 2> $bin.err < /dev/null &
+        pid=$!
+        sleep 3
+
+        if ! (cat $bin.out $bin.err | grep -i "JupyterHub is now running"); then
+          echo "Could not find expected 'JupyterHub is now running' log message in the output!"
+          cat $bin.out
+          cat $bin.err
+          exit 1
+        fi
+
+        curl http://localhost:8000/_chp_healthz | grep -qi "OK"
+
+        echo "Stopping..."
+        kill $pid
+        sleep 3

--- a/py3-jupyterhub.yaml
+++ b/py3-jupyterhub.yaml
@@ -2,8 +2,8 @@
 package:
   name: py3-jupyterhub
   version: 5.0.0
-  epoch: 0
-  description: 'JupyterHub: A multi-user server for Jupyter notebooks'
+  epoch: 1
+  description: "JupyterHub: A multi-user server for Jupyter notebooks"
   copyright:
     - license: BSD-3-Clause
   dependencies:
@@ -24,6 +24,9 @@ package:
       - py3-importlib-metadata
       - py3-pamela
       - py3-psutil
+      - linux-pam
+      - py3-jupyter-events
+      - py3-pydantic
       - python-3
 
 environment:


### PR DESCRIPTION
* Added test for `jupyterhub-k8s-hub`
* Fixed path for `configurable-http-proxy`
* Added missing dependencies to `py3-jupyterhub`