### PR TITLE
chore(nginx-mainline): bump version to latest mainline

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-mainline
-  version: 1.25.5
-  epoch: 2
+  version: 1.27.0
+  epoch: 0
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause
@@ -51,7 +51,7 @@ data:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 2fe2294f8af4144e7e842eaea884182a84ee7970e11046ba98194400902bbec0
+      expected-sha512: 251bfe65c717a8027ef05caae2ab2ea73b9b544577f539a1d419fe6adf0bcc846b73b58f54ea3f102df79aaf340e4fa56793ddadea3cd61bcbbe2364ef94bacb
       uri: https://nginx.org/download/nginx-${{package.version}}.tar.gz
   - name: configure
     runs: |
@@ -216,5 +216,5 @@ update:
   github:
     identifier: nginx/nginx
     use-tag: true
-    tag-filter: release-1.25
+    tag-filter: release-1.27
     strip-prefix: release-


### PR DESCRIPTION
Latest mainline is currently 1.27, ensure that our package follows suit.