### PR TITLE
Add lshw

### DIFF
--- a/lshw.yaml
+++ b/lshw.yaml
@@ -1,0 +1,33 @@
+package:
+  name: lshw
+  version: "02.20"
+  epoch: 0
+  description: "Provide detailed information about a machine's hardware configuration"
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - gettext
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://ezix.org/src/pkg/lshw.git
+      tag: "B.${{package.version}}"
+      expected-commit: 4c6497c8b0a67cd9fa9693e9101a7cafd3297e81
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 6701


### PR DESCRIPTION
`lshw` prints out details about harware like cpu, memory, storage etc:

```
[sdk] ❯ lshw
465093c7b33d
    description: Computer
    width: 64 bits
    capabilities: smp tagged_addr_disabled
  *-core
       description: Motherboard
       physical id: 0
     *-cpu:0
          description: CPU
          product: cpu
          physical id: 0
          bus info: cpu@0
          capabilities: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 asimddp sha512 asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp flagm2 frint
```

### Pre-review Checklist

#### For new package PRs only
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates