### PR TITLE
calico: clean ups and fix ups

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -1,10 +1,13 @@
 package:
   name: calico
   version: 3.28.0
-  epoch: 2
+  epoch: 3
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0
+  resources:
+    cpu: 4
+    memory: 12Gi
   checks:
     disabled:
       - empty
@@ -116,6 +119,7 @@ pipeline:
           # make -C ../felix build-bpf ARCH=$(ARCH)
           cp -r ../felix/bpf-gpl/bin/* $_target
           cp -r ../felix/bpf-apache/bin/* $_target
+  - uses: strip
 
 subpackages:
   - name: "calico-node"
@@ -156,7 +160,7 @@ subpackages:
               CGO_LDFLAGS="-L$LIBBPF_CONTAINER_PATH/$_arch -lbpf -lelf -lz"
               CGO_CFLAGS="-I$LIBBPF_CONTAINER_PATH -I$BPFGPL_CONTAINER_PATH"
 
-              LDFLAGS="-s -w"
+              LDFLAGS="-w"
               LDFLAGS="$LDFLAGS -X node/pkg/lifecycle/startup.VERSION=${{package.version}}"
               LDFLAGS="$LDFLAGS -X node/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>')"
               LDFLAGS="$LDFLAGS -X node/buildinfo.BuildDate=$(date -u +'%FT%T%z')"
@@ -239,7 +243,7 @@ subpackages:
           CGO_LDFLAGS="-L$LIBBPF_CONTAINER_PATH/$_arch -lbpf -lelf -lz"
           CGO_CFLAGS="-I$LIBBPF_CONTAINER_PATH -I$BPFGPL_CONTAINER_PATH"
 
-          LDFLAGS="-s -w"
+          LDFLAGS="-w"
           LDFLAGS="$LDFLAGS -X node/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>')"
           LDFLAGS="$LDFLAGS -X node/buildinfo.BuildDate=$(date -u +'%FT%T%z')"
           LDFLAGS="$LDFLAGS -X node/buildinfo.GitRevision=$(git rev-parse HEAD || echo '<unknown>')"
@@ -311,17 +315,18 @@ subpackages:
           # the host, we explicitly statically compile this to ensure it doesn't
           # conflict with the hosts GLIBC, which is often a much more outdated
           # version than what we build with.
-          LDFLAGS="-s -w -extldflags '-static'"
-          LDFLAGS="$LDFLAGS -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>')"
-          CGO_ENABLED=0 \
+          LDFLAGS="-w -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>')"
+          CGO_ENABLED=1 \
             go build -v -buildvcs=false \
             -ldflags "$LDFLAGS" \
+            -tags osusergo,netgo \
             -o cni-plugin/out/calico \
             ./cni-plugin/cmd/calico
 
-          CGO_ENABLED=0 \
+          CGO_ENABLED=1 \
             go build -v -buildvcs=false \
             -ldflags "$LDFLAGS" \
+            -tags osusergo,netgo \
             -o cni-plugin/out/install \
             ./cni-plugin/cmd/install
       - runs: |
@@ -358,7 +363,7 @@ subpackages:
           packages: ./apiserver/cmd/apiserver
           output: calico-apiserver
           subpackage: "true"
-          ldflags: "-s -w -X github.com/projectcalico/calico/cmd/apiserver/server.VERSION=${{package.version}}) -X github.com/projectcalico/calico/cmd/apiserver/server.BUILD_DATE=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_DESCRIPTION=$(git describe --tags) -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_REVISION=$(git rev-parse --short HEAD)"
+          ldflags: "-X github.com/projectcalico/calico/cmd/apiserver/server.VERSION=${{package.version}}) -X github.com/projectcalico/calico/cmd/apiserver/server.BUILD_DATE=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_DESCRIPTION=$(git describe --tags) -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_REVISION=$(git rev-parse --short HEAD)"
 
   - name: "calico-key-cert-provisioner"
     dependencies:
@@ -371,7 +376,6 @@ subpackages:
           packages: ./key-cert-provisioner/cmd/
           output: calico-key-cert-provisioner
           subpackage: "true"
-          ldflags: "-s -w"
 
   - name: "calico-app-policy"
     dependencies:
@@ -384,7 +388,7 @@ subpackages:
           packages: ./app-policy/cmd/dikastes
           output: calico-dikastes
           subpackage: "true"
-          ldflags: "-s -w -X github.com/projectcalico/calico/app-policy/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>') -X github.com/projectcalico/calico/app-policy/buildinfo.BuildDate=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/app-policy/GitRevision=$(git rev-parse HEAD || echo '<unknown>') -B 0x$(git rev-parse HEAD || uuidgen | sed 's/-//g')"
+          ldflags: "-X github.com/projectcalico/calico/app-policy/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>') -X github.com/projectcalico/calico/app-policy/buildinfo.BuildDate=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/app-policy/GitRevision=$(git rev-parse HEAD || echo '<unknown>') -B 0x$(git rev-parse HEAD || uuidgen | sed 's/-//g')"
       - uses: go/build
         with:
           modroot: .
@@ -403,14 +407,14 @@ subpackages:
           packages: ./kube-controllers/cmd/kube-controllers
           output: calico-kube-controllers
           subpackage: "true"
-          ldflags: "-s -w -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
+          ldflags: "-X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
       - uses: go/build
         with:
           modroot: .
           packages: ./kube-controllers/cmd/check-status
           output: check-status # keep naming convention as "check-status" is usually harded to /usr/bin/check-status
           subpackage: "true"
-          ldflags: "-s -w -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
+          ldflags: "-X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
 
   - name: "calico-pod2daemon"
     description: "The calico pod2daemon components"
@@ -424,21 +428,18 @@ subpackages:
           packages: ./pod2daemon/flexvol
           output: calico-pod2daemon-flexvol
           subpackage: "true"
-          ldflags: "-s -w"
       - uses: go/build
         with:
           modroot: .
           packages: ./pod2daemon/csidriver
           output: calico-pod2daemon-csidriver
           subpackage: "true"
-          ldflags: "-s -w"
       - uses: go/build
         with:
           modroot: .
           packages: ./pod2daemon/nodeagent
           output: calico-pod2daemon-nodeagent
           subpackage: "true"
-          ldflags: "-s -w"
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           install -m755 ./pod2daemon/flexvol/docker-image/flexvol.sh "${{targets.subpkgdir}}"/usr/bin/flexvol.sh
@@ -458,7 +459,7 @@ subpackages:
           packages: ./calicoctl/calicoctl
           output: calicoctl
           subpackage: "true"
-          ldflags: "-s -w -X github.com/projectcalico/calico/calicoctl/commands.VERSION=$(git describe --tags --dirty --always --abbrev=12) -X github.com/projectcalico/calico/calicoctl/commands.GIT_REVISION=$(git rev-parse --short HEAD) -X github.com/projectcalico/calico/calicoctl/commands/common.VERSION=$(git describe --tags --dirty --always --abbrev=12) -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
+          ldflags: "-X github.com/projectcalico/calico/calicoctl/commands.VERSION=$(git describe --tags --dirty --always --abbrev=12) -X github.com/projectcalico/calico/calicoctl/commands.GIT_REVISION=$(git rev-parse --short HEAD) -X github.com/projectcalico/calico/calicoctl/commands/common.VERSION=$(git describe --tags --dirty --always --abbrev=12) -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
 
   - name: "calico-typhad"
     description: "The calico typha daemon"
@@ -468,7 +469,7 @@ subpackages:
     pipeline:
       # TODO: I'm not sure yet if this actually needs CGO, or is just enabled upstream because of go-fips
       - runs: |
-          LDFLAGS="-s -w"
+          LDFLAGS="-w"
           LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/typha/pkg/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>')"
           LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/typha/pkg/buildinfo.BuildDate=$(date -u +'%FT%T%z')"
           LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/typha/pkg/buildinfo.GitRevision=$(git rev-parse HEAD || echo '<unknown>')"
@@ -494,14 +495,14 @@ subpackages:
     pipeline:
       # TODO: I'm not sure yet if this actually needs CGO, or is just enabled upstream because of go-fips
       - runs: |
-          LDFLAGS="-s -w"
+          LDFLAGS="-w"
           LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/typha/pkg/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>')"
           LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/typha/pkg/buildinfo.BuildDate=$(date -u +'%FT%T%z')"
           LDFLAGS="$LDFLAGS -X github.com/projectcalico/calico/typha/pkg/buildinfo.GitRevision=$(git rev-parse HEAD || echo '<unknown>')"
           LDFLAGS="$LDFLAGS -B 0x$(git rev-parse HEAD || uuidgen | sed 's/-//g')"
 
           CGO_ENABLED=1 \
-            go build -v -tags cgo -v -buildvcs=false \
+            go build -v -tags osusergo,netgo,cgo -v -buildvcs=false \
             -o "${{targets.subpkgdir}}"/usr/bin/typha-client \
             ./typha/cmd/typha-client
 


### PR DESCRIPTION
Make improvements and consolidate changes with versioned and fips
packaging of calico, to ensure these builds are easier to maintain in
the future.

When using go/build pipeline '-w -s' settings are already
pre-selected, and do not need to be specified again.

Also osusergo,netgo already results in static binaries with regular go
toolchain, thus forcing cgo off is not needed.

There are many other redundant things to clean up here, but this is
already a tangible improvement.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
