### PR TITLE
Update the ACL package to use git-checkout instead of fetch

### DIFF
--- a/acl.yaml
+++ b/acl.yaml
@@ -1,7 +1,7 @@
 package:
   name: acl
   version: 2.3.2
-  epoch: 1
+  epoch: 2
   description: "access control list utilities"
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -10,16 +10,24 @@ environment:
   contents:
     packages:
       - attr-dev
+      - autoconf
+      - automake
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gettext-dev
+      - libtool
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://download.savannah.nongnu.org/releases/acl/acl-${{package.version}}.tar.gz
-      expected-sha256: 5f2bdbad629707aa7d85c623f994aa8a1d2dec55a73de5205bac0bf6058a2f7c
+      repository: https://git.savannah.nongnu.org/git/acl.git
+      tag: v${{package.version}}
+      expected-commit: cefe1c17f20448b7a0ca53ac9cf8a46d444a8cca
+
+  - runs: |
+      ./autogen.sh
 
   - runs: |
       ./configure \


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:  Updates ACL to use git-checkout vs fetch, as a means to bias away fetching compiled tars, which is related the xz backdoor exploit earlier this year

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
