### PR TITLE
Add required runtime dependency

### DIFF
--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-3.5
   version: 3.5.1
-  epoch: 3
+  epoch: 4
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0

--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -11,6 +11,7 @@ package:
     runtime:
       - bash
       - busybox
+      - procps
 
 environment:
   contents:


### PR DESCRIPTION
[load-spark-env.sh](https://github.com/apache/spark/blob/master/bin/load-spark-env.sh) has a dependency on `ps`, without it this error was observed in the logs:

```bash
/opt/bitnami/spark/bin/load-spark-env.sh: line 68: /usr/bin/ps: No such file or directory
```

It wasn't causing the application to halt, but it would mean that the conditonal checked would not append additional Java args to an environment variable, when the condition is met.
