### PR TITLE
adds sonar-scanner-cli-entrypoint and compat packages

### DIFF
--- a/sonar-scanner-cli-entrypoint.yaml
+++ b/sonar-scanner-cli-entrypoint.yaml
@@ -23,8 +23,7 @@ pipeline:
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin/
-      chmod +x entrypoint.sh
-      install -m755 entrypoint.sh ${{targets.destdir}}/usr/bin/
+      install -m755 bin/entrypoint.sh ${{targets.destdir}}/usr/bin/
 
 update:
   manual: true

--- a/sonar-scanner-cli-entrypoint.yaml
+++ b/sonar-scanner-cli-entrypoint.yaml
@@ -3,7 +3,7 @@
 # code, we need to fetch it and be able to auto-update.
 package:
   name: sonar-scanner-cli-entrypoint
-  version: "10.0.3.1430_5.0.1"
+  version: "10.0.3.1430.5.0.1"
   epoch: 0
   description: Fetches the sonar-scanner-cli entrypoint script from upstream docker repository.
   copyright:
@@ -14,12 +14,18 @@ environment:
     packages:
       - busybox
 
+var-transforms:
+  - from: ${{package.version}}
+    match: '^(\d+\.\d+\.\d+\.\d+)\.(\d+\.\d+\.\d+)$'
+    replace: '$1_$2'
+    to: mangled-package-version
+
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/SonarSource/sonar-scanner-cli-docker
       expected-commit: 8ee21641b014850a1c50d0635aa337bf9a6ba369
-      tag: ${{package.version}}
+      tag: ${{vars.mangled-package-version}}
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin/

--- a/sonar-scanner-cli-entrypoint.yaml
+++ b/sonar-scanner-cli-entrypoint.yaml
@@ -1,3 +1,4 @@
+#nolint:valid-pipeline-git-checkout-tag
 # Fetches the sonar-scanner-cli entrypoint script used in the upstream docker image. We
 # need this for our image, but as it's stored in a different repo vs the source
 # code, we need to fetch it and be able to auto-update.

--- a/sonar-scanner-cli-entrypoint.yaml
+++ b/sonar-scanner-cli-entrypoint.yaml
@@ -15,18 +15,18 @@ environment:
       - busybox
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://raw.githubusercontent.com/SonarSource/sonar-scanner-cli-docker/${{package.version}}/bin/entrypoint.sh
-      expected-sha256: d93310f2a96b766e0c96de33b519d0e414d863e28a433d2ca7832fcaa5926979
-      extract: false
+      repository: https://github.com/SonarSource/sonar-scanner-cli-docker
+      expected-commit: 8ee21641b014850a1c50d0635aa337bf9a6ba369
+      tag: ${{package.version}}
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin/
       chmod +x entrypoint.sh
-      cp entrypoint.sh ${{targets.destdir}}/usr/bin/
+      install -m755 entrypoint.sh ${{targets.destdir}}/usr/bin/
 
 update:
-  enabled: true
+  manual: true
   github:
     identifier: SonarSource/sonar-scanner-cli-docker

--- a/sonar-scanner-cli-entrypoint.yaml
+++ b/sonar-scanner-cli-entrypoint.yaml
@@ -3,7 +3,7 @@
 # code, we need to fetch it and be able to auto-update.
 package:
   name: sonar-scanner-cli-entrypoint
-  version: 10.0.3.1430_5.0.1
+  version: "10.0.3.1430_5.0.1"
   epoch: 0
   description: Fetches the sonar-scanner-cli entrypoint script from upstream docker repository.
   copyright:

--- a/sonar-scanner-cli-entrypoint.yaml
+++ b/sonar-scanner-cli-entrypoint.yaml
@@ -14,18 +14,11 @@ environment:
     packages:
       - busybox
 
-var-transforms:
-  - from: ${{package.version}}
-    match: '^(\d+\.\d+\.\d+\.\d+)\.(\d+\.\d+\.\d+)$'
-    replace: '$1_$2'
-    to: mangled-package-version
-
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/SonarSource/sonar-scanner-cli-docker
       expected-commit: 8ee21641b014850a1c50d0635aa337bf9a6ba369
-      tag: ${{vars.mangled-package-version}}
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin/

--- a/sonar-scanner-cli-entrypoint.yaml
+++ b/sonar-scanner-cli-entrypoint.yaml
@@ -1,0 +1,32 @@
+# Fetches the sonar-scanner-cli entrypoint script used in the upstream docker image. We
+# need this for our image, but as it's stored in a different repo vs the source
+# code, we need to fetch it and be able to auto-update.
+package:
+  name: sonar-scanner-cli-entrypoint
+  version: 10.0.3.1430_5.0.1
+  epoch: 0
+  description: Fetches the sonar-scanner-cli entrypoint script from upstream docker repository.
+  copyright:
+    - license: LGPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://raw.githubusercontent.com/SonarSource/sonar-scanner-cli-docker/${{package.version}}/bin/entrypoint.sh
+      expected-sha256: d93310f2a96b766e0c96de33b519d0e414d863e28a433d2ca7832fcaa5926979
+      extract: false
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin/
+      chmod +x entrypoint.sh
+      cp entrypoint.sh ${{targets.destdir}}/usr/bin/
+
+update:
+  enabled: true
+  github:
+    identifier: SonarSource/sonar-scanner-cli-docker

--- a/sonar-scanner-cli.yaml
+++ b/sonar-scanner-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: sonar-scanner-cli
   version: 6.0.0.4432
-  epoch: 0
+  epoch: 1
   description: Scanner CLI for SonarQube and SonarCloud
   copyright:
     - license: LGPL-3.0-or-later
@@ -37,8 +37,24 @@ pipeline:
     runs: |
       mvn clean package
       mkdir -p ${{targets.destdir}}/usr/bin/sonarqube
+      mkdir -p "${{targets.destdir}}"/opt/sonar-scanner/conf
       cp target/sonar-scanner-cli-*.jar ${{targets.destdir}}/usr/bin/sonarqube/sonarscanner-cli.jar
       chmod +x sonar-scanner-cli && cp sonar-scanner-cli ${{targets.destdir}}/usr/bin/
+      chmod +x sonar-scanner-cli-debug && cp sonar-scanner-cli-debug ${{targets.destdir}}/usr/bin/
+      cp src/main/assembly/conf/sonar-scanner.properties "${{targets.destdir}}"/opt/sonar-scanner/conf/
+
+subpackages:
+  - name: sonar-scanner-cli-compat
+    dependencies:
+      runtime:
+        - sonar-scanner-cli
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/opt/sonar-scanner/bin
+          mkdir -p "${{targets.subpkgdir}}"/opt/sonar-scanner/lib
+          ln -s /usr/bin/sonar-scanner-cli "${{targets.subpkgdir}}"/opt/sonar-scanner/bin/
+          ln -s /usr/bin/sonar-scanner-cli-debug "${{targets.subpkgdir}}"/opt/sonar-scanner/bin/
+          ln -s /usr/bin/sonarqube/sonarscanner-cli.jar "${{targets.subpkgdir}}"/opt/sonar-scanner/lib/sonar-scanner-cli-${{package.version}}.jar
 
 update:
   enabled: true

--- a/sonar-scanner-cli.yaml
+++ b/sonar-scanner-cli.yaml
@@ -53,6 +53,8 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/opt/sonar-scanner/bin
           mkdir -p "${{targets.subpkgdir}}"/opt/sonar-scanner/lib
           ln -s /usr/bin/sonar-scanner-cli "${{targets.subpkgdir}}"/opt/sonar-scanner/bin/
+          ln -s /usr/bin/sonar-scanner-cli "${{targets.subpkgdir}}"/opt/sonar-scanner/bin/sonar-scanner # entrypoint.sh script expects this
+
           ln -s /usr/bin/sonar-scanner-cli-debug "${{targets.subpkgdir}}"/opt/sonar-scanner/bin/
           ln -s /usr/bin/sonarqube/sonarscanner-cli.jar "${{targets.subpkgdir}}"/opt/sonar-scanner/lib/sonar-scanner-cli-${{package.version}}.jar
 

--- a/sonar-scanner-cli/sonar-scanner-cli-debug
+++ b/sonar-scanner-cli/sonar-scanner-cli-debug
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+#
+# SonarScanner CLI Startup Script for Unix
+#
+# Required ENV vars:
+#   JAVA_HOME - Location of Java's installation, optional if use_embedded_jre is set
+#
+# Optional ENV vars:
+#   SONAR_SCANNER_OPTS - parameters passed to the Java VM when running the SonarScanner
+
+SONAR_SCANNER_DEBUG_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000"
+SONAR_SCANNER_JAVA_DEBUG_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8001"
+SONAR_SCANNER_JAVA_OPTS="$SONAR_SCANNER_JAVA_OPTS $SONAR_SCANNER_JAVA_DEBUG_OPTS"
+
+echo "Executing SonarScanner CLI in Debug Mode"
+echo "SONAR_SCANNER_DEBUG_OPTS=\"$SONAR_SCANNER_DEBUG_OPTS\""
+echo "SONAR_SCANNER_JAVA_OPTS=\"$SONAR_SCANNER_JAVA_OPTS\""
+
+env SONAR_SCANNER_OPTS="$SONAR_SCANNER_OPTS" SONAR_SCANNER_DEBUG_OPTS="$SONAR_SCANNER_DEBUG_OPTS" SONAR_SCANNER_JAVA_OPTS="$SONAR_SCANNER_JAVA_OPTS" "`dirname "$0"`"/sonar-scanner "$@"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
