### PR TITLE
Remove pombump as build time dependency for spark-3.5

### DIFF
--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -29,7 +29,6 @@ environment:
       - openjdk-8
       - openjdk-8-default-jvm
       - perl-utils
-      - pombump
       - procps
       - py3.11-pip
       - python-3.11


### PR DESCRIPTION
If the pipeline from the ``uses: foo/bar`` itself has an environment build dependency then there’s no need to include it in the main package. It's included here already: https://github.com/chainguard-dev/melange/blob/main/pkg/build/pipelines/maven/pombump.yaml
