### PR TITLE
Update non LTS openjdk packages to use git-checkout instead of fetch

### DIFF
--- a/openjdk-14.yaml
+++ b/openjdk-14.yaml
@@ -46,10 +46,11 @@ var-transforms:
     to: mangled-package-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openjdk/jdk14u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
-      expected-sha512: 6b328c0930d2aff79f2c5cd1a11a33be5fdd1f548770b6d4093e930447022109dc49104795f04aa8282f654a2475c8dcab052650ea3f9ca9201526487d042c87
+      repository: https://github.com/openjdk/jdk14u
+      tag: jdk-${{vars.mangled-package-version}}
+      expected-commit: a718f22fc087a923ccb873ee76d8f0b2e6a16863
 
   - uses: patch
     with:

--- a/openjdk-14.yaml
+++ b/openjdk-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-14
   version: 14.0.2.12
-  epoch: 5
+  epoch: 6
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-15
   version: 15.0.10.5
-  epoch: 5
+  epoch: 6
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -46,10 +46,11 @@ var-transforms:
     to: mangled-package-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openjdk/jdk15u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
-      expected-sha512: 24c8324ebf05d37efaf573d17d5fcbba19b3164fce0a226190a0c9864adda06b5ca8020911ea677a6abfa37bd3000c50eb07cc1f00fa99f4a1d5f588501f1276
+      repository: https://github.com/openjdk/jdk15u
+      tag: jdk-${{vars.mangled-package-version}}
+      expected-commit: 2357372439135daf40d69b34bf9a48d16768b666
 
   - working-directory: /home/build/googletest
     pipeline:

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-16
   version: 16.0.2.7
-  epoch: 5
+  epoch: 6
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -46,10 +46,11 @@ var-transforms:
     to: mangled-package-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openjdk/jdk16u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
-      expected-sha512: 78af6dfddda1d6de1a82c8f792eb634dd2c3646395cc875524abf0804402120d2baedbac19b79cd80c16a3e89469857e5c7aa000a0bf67f6eae5f4099c8be180
+      repository: https://github.com/openjdk/jdk16u
+      tag: jdk-${{vars.mangled-package-version}}
+      expected-commit: 3b56f0b15cee132d6366e8ec03e05c918a42b4f1
 
   - working-directory: /home/build/googletest
     pipeline:

--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-18
   version: 18.0.2.1.0
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -49,10 +49,11 @@ var-transforms:
     to: mangled-package-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openjdk/jdk18u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
-      expected-sha512: da9ce83bd46c806b6fea626f2dc7e921ada3e67ed19fd4ecaacd48ba8c7f30ef49add695394c6299471876a03a3e734237b31f0e0a60ef2c6401a60f376442fb
+      repository: https://github.com/openjdk/jdk18u
+      tag: jdk-${{vars.mangled-package-version}}
+      expected-commit: 0e73b3911f20169607e8836d38f532fe51d577f9
 
   - working-directory: /home/build/googletest
     pipeline:

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -49,10 +49,11 @@ var-transforms:
     to: mangled-package-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openjdk/jdk19u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
-      expected-sha512: f25f2fe1f835854bfbe0cfabde092aed3b883a5448b30be5a9e5788e79723bf2f6fca9d41383a99dcd980bed04e7f18cfef3d0f3044b245d32b5cb1ff351eefd
+      repository: https://github.com/openjdk/jdk19u
+      tag: jdk-${{vars.mangled-package-version}}
+      expected-commit: 1d3871afcd30214ed6a5e6732b775ead3297aae5
 
   - working-directory: /home/build/googletest
     pipeline:

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-19
   version: 19.0.2.7
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-20
   version: 20.0.2.9
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -49,10 +49,11 @@ var-transforms:
     to: mangled-package-version
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openjdk/jdk20u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
-      expected-sha512: 18a352ad5474b8499b7fcdacdfbf7392ff16681e3a47c925dcb4edd7a326c690fdfd5a40977783c2c85cb2b55c9fd70d70e7cf37357cd44e02383f96fb9df8f4
+      repository: https://github.com/openjdk/jdk20u
+      tag: jdk-${{vars.mangled-package-version}}
+      expected-commit: 9ced461a4d8cb2ecfe2d6a74ec218ec589dcd617
 
   - working-directory: /home/build/googletest
     pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Using git-checkout vs fetch 
* Noting that there _are_ vulnerabilities in these packages, but nothing new here.
* openjdk was already pulling tar archives from github, so this was pretty easy to cut over.

Related: 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
