### PR TITLE
Updates the nodejs images to use git-checkout instead of fetch

### DIFF
--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-16
   version: 16.20.2
-  epoch: 5
+  epoch: 6
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -34,10 +34,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://nodejs.org/dist/v${{package.version}}/node-v${{package.version}}.tar.gz
-      expected-sha256: 33188eb11b977113adb65b2e09d71bddd63f12168ba73ceadae6c27938dc9e93
+      repository: https://github.com/nodejs/node.git
+      tag: v${{package.version}}
+      expected-commit: dadbde963fd37a637316c875f8c3e9bbf6e6a393
 
   - name: Configure and build
     runs: |

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-18
   version: 18.20.3
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT
@@ -34,10 +34,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://nodejs.org/dist/v${{package.version}}/node-v${{package.version}}.tar.gz
-      expected-sha256: f35c9b9923c7b2e9243e7e2d10cd9ae61fbd5b925df3debbb72d5a70dbff555d
+      repository: https://github.com/nodejs/node.git
+      tag: v${{package.version}}
+      expected-commit: 64903b1ca04dbe182b0abc36deb7437a49bf1881
 
   - name: Configure and build
     runs: |

--- a/nodejs-19.yaml
+++ b/nodejs-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-19
   version: 19.9.0
-  epoch: 7
+  epoch: 8
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -33,10 +33,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://nodejs.org/dist/v${{package.version}}/node-v${{package.version}}.tar.gz
-      expected-sha256: c9293eb40dff8e5f55ef8da7cf1b9fd71b4a6a513620d02bbd158936e85216f2
+      repository: https://github.com/nodejs/node.git
+      tag: v${{package.version}}
+      expected-commit: 8085bcf88277cf2b474af008e1e150ce72af5b03
 
   - name: Configure and build
     runs: |

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-20
   version: 20.14.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   dependencies:
     provides:
@@ -34,10 +34,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://nodejs.org/dist/v${{package.version}}/node-v${{package.version}}.tar.gz
-      expected-sha256: f01109d3102754ac360fcf25aa588f3bef5c090a8eed3fb1d0be194149c46cf2
+      repository: https://github.com/nodejs/node.git
+      tag: v${{package.version}}
+      expected-commit: fe0f08a5dd68fd72b1652adaa51ab07a4b09f847
 
   - name: Configure and build
     runs: |

--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-21
   version: 21.7.3
-  epoch: 1
+  epoch: 2
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -33,10 +33,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://nodejs.org/dist/v${{package.version}}/node-v${{package.version}}.tar.gz
-      expected-sha256: ce1f61347671ef219d9c2925313d629d3fef98fc8d7f5ef38dd4656f7d0f58e7
+      repository: https://github.com/nodejs/node.git
+      tag: v${{package.version}}
+      expected-commit: 97297e91febe3b49b50b22f0bea8ed21189a9e53
 
   - name: Configure and build
     runs: |

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -33,10 +33,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://nodejs.org/dist/v${{package.version}}/node-v${{package.version}}.tar.gz
-      expected-sha256: 2210ce0a40aa6aec3cc118228fdad6536607002319b1fde24260d179118c1055
+      repository: https://github.com/nodejs/node.git
+      tag: v${{package.version}}
+      expected-commit: d57af10d1be390f4e33e6efe596133de9da36c86
 
   - name: Configure and build
     runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Use official nodejs github instead of source download
* Note: several existing nodejs versions appear to have vulnerabilities unrelated to this change.

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
