### PR TITLE
Add jre runtime packages

### DIFF
--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-3.5
   version: 3.5.1
-  epoch: 4
+  epoch: 5
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0
@@ -11,6 +11,8 @@ package:
     runtime:
       - bash
       - busybox
+      - openjdk-17
+      - openjdk-17-default-jvm
       - procps
 
 environment:
@@ -117,13 +119,9 @@ update:
 
 test:
   environment:
-    contents:
-      packages:
-        - openjdk-8
-        - openjdk-8-default-jvm
     environment:
       LANG: en_US.UTF-8
-      JAVA_HOME: /usr/lib/jvm/java-1.8-openjdk
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk
   pipeline:
     - runs: |
         /usr/lib/spark/bin/spark-submit --version


### PR DESCRIPTION
Previously we where defining the JRE runtime packages at the image level - but for consistency with other packages, moving to runtime dependencies in the package instead. We originally believed we may need to switch out the JDKs, but this hasn't been the case.