### PR TITLE
Fix provides for rabbitmq-server-compat-3.13 subpackage

### DIFF
--- a/rabbitmq-server-3.13.yaml
+++ b/rabbitmq-server-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-server-3.13
   version: 3.13.3
-  epoch: 0
+  epoch: 1
   description: Open source RabbitMQ. core server and tier 1 (built-in) plugins
   copyright:
     - license: MPL-2.0
@@ -126,7 +126,7 @@ subpackages:
           ln -sf /opt/bitnami/rabbitmq/etc/rabbitmq ${{targets.contextdir}}/etc/
     dependencies:
       provides:
-        - rabbitmq-bitnami-compat=${{package.full-version}}
+        - rabbitmq-server-compat=${{package.full-version}}
 
 update:
   enabled: true


### PR DESCRIPTION
In https://github.com/wolfi-dev/os/pull/21269 we modified the package name `rabbitmq-server-compat` to be `rabbitmq-server-compat-3.13`. Now when we try to install `rabbitmq-server-compat`, there was nothing that provides it because it was always incorrectly providing `rabbitmq-bitnami-compat=${{package.full-version}}`. It does not appear that the `rabbitmq-bitnami-compat` package (virtual package) is used anywhere.