### PR TITLE
esbuild: convert to go/build

### DIFF
--- a/esbuild.yaml
+++ b/esbuild.yaml
@@ -1,7 +1,7 @@
 package:
   name: esbuild
   version: 0.21.4
-  epoch: 1
+  epoch: 2
   description: An extremely fast bundler for the web
   copyright:
     - license: MIT
@@ -9,11 +9,6 @@ package:
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - git
-      - go
       - nodejs
 
 pipeline:
@@ -24,11 +19,12 @@ pipeline:
       expected-commit: 67cbf87a4909d87a902ca8c3b69ab5330defab0a
 
   - runs: |
-      make esbuild
-      mkdir -p ${{targets.destdir}}/usr/bin
-      mv esbuild ${{targets.destdir}}/usr/bin/
+      node scripts/esbuild.js --update-version-go
 
-  - uses: strip
+  - uses: go/build
+    with:
+      packages: ./cmd/esbuild
+      output: esbuild
 
 update:
   enabled: true


### PR DESCRIPTION
This introduces x86-64-v2 optimisation, and adds symbols table, and
makes it easier to create a fips build.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
