### PR TITLE
kubeflow-pipelines: remediate GHSA-9wx4-h78v-vm56

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: 2.2.0
-  epoch: 1
+  epoch: 2
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -47,9 +47,9 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: dd59f48cdd0f6cd7fac40306277ef5f3dad6e263
 
-  - runs: |
-      #fix idna CVE
-      sed -i 's/idna==3\.4/idna==3.7/g' backend/requirements.txt
+  - uses: patch
+    with:
+      patches: py-backend-cves.patch
 
   - uses: go/bump
     with:

--- a/kubeflow-pipelines/py-backend-cves.patch
+++ b/kubeflow-pipelines/py-backend-cves.patch
@@ -1,0 +1,22 @@
+diff --git a/backend/requirements.txt b/backend/requirements.txt
+index 68cfc0f33..889feb4c4 100644
+--- a/backend/requirements.txt
++++ b/backend/requirements.txt
+@@ -39,7 +39,7 @@ google-resumable-media==2.6.0
+     # via google-cloud-storage
+ googleapis-common-protos==1.60.0
+     # via google-api-core
+-idna==3.4
++idna==3.7
+     # via requests
+ importlib-metadata==6.7.0
+     # via click
+@@ -73,7 +73,7 @@ pyyaml==6.0.1
+     # via
+     #   kfp
+     #   kubernetes
+-requests==2.31.0
++requests==2.32.0
+     # via
+     #   google-api-core
+     #   google-cloud-storage


### PR DESCRIPTION
also move idna from a sed in the pipeline into the patch so it's easier to know when upstream updates this and we can remove our patch
