### PR TITLE
go/build drop subpackage

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -362,7 +362,6 @@ subpackages:
           modroot: .
           packages: ./apiserver/cmd/apiserver
           output: calico-apiserver
-          subpackage: "true"
           ldflags: "-X github.com/projectcalico/calico/cmd/apiserver/server.VERSION=${{package.version}}) -X github.com/projectcalico/calico/cmd/apiserver/server.BUILD_DATE=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_DESCRIPTION=$(git describe --tags) -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_REVISION=$(git rev-parse --short HEAD)"
 
   - name: "calico-key-cert-provisioner"
@@ -375,7 +374,6 @@ subpackages:
           modroot: .
           packages: ./key-cert-provisioner/cmd/
           output: calico-key-cert-provisioner
-          subpackage: "true"
 
   - name: "calico-app-policy"
     dependencies:
@@ -387,14 +385,12 @@ subpackages:
           modroot: .
           packages: ./app-policy/cmd/dikastes
           output: calico-dikastes
-          subpackage: "true"
           ldflags: "-X github.com/projectcalico/calico/app-policy/buildinfo.GitVersion=$(git describe --tags --dirty --always --abbrev=12 || echo '<unknown>') -X github.com/projectcalico/calico/app-policy/buildinfo.BuildDate=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/app-policy/GitRevision=$(git rev-parse HEAD || echo '<unknown>') -B 0x$(git rev-parse HEAD || uuidgen | sed 's/-//g')"
       - uses: go/build
         with:
           modroot: .
           packages: ./app-policy/cmd/healthz
           output: calico-healthz
-          subpackage: "true"
 
   - name: "calico-kube-controllers"
     dependencies:
@@ -406,14 +402,12 @@ subpackages:
           modroot: .
           packages: ./kube-controllers/cmd/kube-controllers
           output: calico-kube-controllers
-          subpackage: "true"
           ldflags: "-X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
       - uses: go/build
         with:
           modroot: .
           packages: ./kube-controllers/cmd/check-status
           output: check-status # keep naming convention as "check-status" is usually harded to /usr/bin/check-status
-          subpackage: "true"
           ldflags: "-X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
 
   - name: "calico-pod2daemon"
@@ -427,19 +421,16 @@ subpackages:
           modroot: .
           packages: ./pod2daemon/flexvol
           output: calico-pod2daemon-flexvol
-          subpackage: "true"
       - uses: go/build
         with:
           modroot: .
           packages: ./pod2daemon/csidriver
           output: calico-pod2daemon-csidriver
-          subpackage: "true"
       - uses: go/build
         with:
           modroot: .
           packages: ./pod2daemon/nodeagent
           output: calico-pod2daemon-nodeagent
-          subpackage: "true"
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           install -m755 ./pod2daemon/flexvol/docker-image/flexvol.sh "${{targets.subpkgdir}}"/usr/bin/flexvol.sh
@@ -458,7 +449,6 @@ subpackages:
           modroot: .
           packages: ./calicoctl/calicoctl
           output: calicoctl
-          subpackage: "true"
           ldflags: "-X github.com/projectcalico/calico/calicoctl/commands.VERSION=$(git describe --tags --dirty --always --abbrev=12) -X github.com/projectcalico/calico/calicoctl/commands.GIT_REVISION=$(git rev-parse --short HEAD) -X github.com/projectcalico/calico/calicoctl/commands/common.VERSION=$(git describe --tags --dirty --always --abbrev=12) -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
 
   - name: "calico-typhad"

--- a/confluent-common-docker.yaml
+++ b/confluent-common-docker.yaml
@@ -52,7 +52,6 @@ subpackages:
           modroot: ./base-lite/ub
           packages: .
           output: ub
-          subpackage: "true"
           ldflags: "-s -w"
       - uses: strip
 

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -41,7 +41,6 @@ subpackages:
         with:
           output: crank
           packages: ./cmd/crank
-          subpackage: "true"
       - uses: strip
 
 update:

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -364,7 +364,6 @@ subpackages:
             with:
               packages: ./cmd/server
               output: fakeintake
-              subpackage: "true"
 
   # The datadog-agent image uses a deprecated version of s6-overlay from 2020
   # we don't want to maintain a package for. Instead, include the

--- a/hubble-ui.yaml
+++ b/hubble-ui.yaml
@@ -60,7 +60,6 @@ subpackages:
           modroot: backend
           packages: .
           output: backend
-          subpackage: "true"
           ldflags: "-w"
       - uses: strip
 

--- a/k3d.yaml
+++ b/k3d.yaml
@@ -42,7 +42,6 @@ subpackages:
           modroot: ./tools
           packages: .
           output: k3d-tools
-          subpackage: "true"
           ldflags: "-w"
       - uses: strip
 
@@ -74,7 +73,6 @@ subpackages:
           modroot: /home/confd
           packages: .
           output: confd
-          subpackage: "true"
           ldflags: "-w -X main.GitSHA=$(git rev-parse --short HEAD)"
       - uses: strip
 

--- a/logstash.yaml
+++ b/logstash.yaml
@@ -174,7 +174,6 @@ subpackages:
               packages: .
               output: env2yaml
               ldflags: -s -w
-              subpackage: "true"
       - uses: strip
 
   # Due to the way logstash implements their plugin system, this is a full

--- a/rekor.yaml
+++ b/rekor.yaml
@@ -32,7 +32,6 @@ subpackages:
       - uses: go/build
         with:
           modroot: .
-          subpackage: "true"
           packages: ./cmd/rekor-server
           output: rekor-server
           ldflags: -w
@@ -43,7 +42,6 @@ subpackages:
       - uses: go/build
         with:
           modroot: .
-          subpackage: "true"
           packages: ./cmd/rekor-cli
           output: rekor-cli
           ldflags: -w
@@ -54,7 +52,6 @@ subpackages:
       - uses: go/build
         with:
           modroot: .
-          subpackage: "true"
           packages: ./cmd/backfill-redis
           output: backfill-redis
           ldflags: -w

--- a/sigstore-scaffolding.yaml
+++ b/sigstore-scaffolding.yaml
@@ -47,7 +47,6 @@ subpackages:
       - uses: go/build
         with:
           modroot: .
-          subpackage: "true"
           packages: ${{range.value}}
           output: ${{range.key}}
           ldflags: -w
@@ -58,7 +57,6 @@ subpackages:
       - uses: go/build
         with:
           modroot: .
-          subpackage: "true"
           packages: ./cmd/cloudsqlproxy
           output: cloudsqlproxy
           ldflags: -w

--- a/tekton-pipelines.yaml
+++ b/tekton-pipelines.yaml
@@ -51,7 +51,6 @@ subpackages:
           packages: ./cmd/${{range.key}}
           output: tekton-pipelines-${{range.key}}
           modroot: tekton
-          subpackage: "true"
 
 update:
   enabled: true

--- a/trillian.yaml
+++ b/trillian.yaml
@@ -32,7 +32,6 @@ subpackages:
       - uses: go/build
         with:
           modroot: .
-          subpackage: "true"
           packages: ./cmd/trillian_log_server
           output: trillian_log_server
       - uses: strip
@@ -42,7 +41,6 @@ subpackages:
       - uses: go/build
         with:
           modroot: .
-          subpackage: "true"
           packages: ./cmd/trillian_log_signer
           output: trillian_log_signer
       - uses: strip


### PR DESCRIPTION
Drop subpackage from go/build pipleine, as it is unused since
https://github.com/chainguard-dev/melange/commit/ea789dfe794d84c8890208cb71905940c91d2c50

No epoch bumps as the change is noop.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
