### PR TITLE
vertical-pod-autoscaler: go cleanups

### DIFF
--- a/vertical-pod-autoscaler.yaml
+++ b/vertical-pod-autoscaler.yaml
@@ -1,18 +1,10 @@
 package:
   name: vertical-pod-autoscaler
   version: 1.1.2
-  epoch: 1
+  epoch: 2
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
-
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - go
 
 pipeline:
   - uses: git-checkout
@@ -32,38 +24,23 @@ pipeline:
       packages: ./pkg/admission-controller
       output: admission-controller
 
-  - uses: go/bump
-    with:
-      deps: google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0
-      modroot: vertical-pod-autoscaler
-
-  - uses: go/build
-    with:
-      modroot: vertical-pod-autoscaler
-      packages: ./pkg/updater
-      output: updater
-
-  - uses: go/build
-    with:
-      modroot: vertical-pod-autoscaler
-      packages: ./pkg/recommender
-      output: recommender
-      vendor: "true"
-
-  - uses: strip
-
 subpackages:
   - name: vertical-pod-autoscaler-updater
     pipeline:
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv ${{targets.destdir}}/usr/bin/updater ${{targets.subpkgdir}}/usr/bin
+      - uses: go/build
+        with:
+          modroot: vertical-pod-autoscaler
+          packages: ./pkg/updater
+          output: updater
 
   - name: vertical-pod-autoscaler-recommender
     pipeline:
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv ${{targets.destdir}}/usr/bin/recommender ${{targets.subpkgdir}}/usr/bin
+      - uses: go/build
+        with:
+          modroot: vertical-pod-autoscaler
+          packages: ./pkg/recommender
+          output: recommender
+          vendor: "true"
 
 update:
   enabled: true


### PR DESCRIPTION
Remove duplicate go/bump.

Remove duplicate copies of dependencies, which pipelines self-declare.

Move go/build pipelines from main package to their respective
subpackages, instead of moving binaries to subpackages by hand.

Drop strip pipeline, as go/build builds go binaries stripped already.

This will make it easier to maintain fips version of the package.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
