### PR TITLE
py3-jinja2: cve remediation

### DIFF
--- a/py3-jinja2.yaml
+++ b/py3-jinja2.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-jinja2
-  version: 3.1.3
+  version: 3.1.4
   epoch: 1
   description: "A small but fast and easy to use stand-alone python template engine"
   copyright:
@@ -15,27 +15,32 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - py3-flit-core
+      - py3-gpep517
+      - py3-pip
       - py3-setuptools
+      - py3-wheel
       - python3-dev
       - wolfi-base
 
 pipeline:
   - uses: fetch
     with:
-      uri: https://files.pythonhosted.org/packages/source/J/Jinja2/Jinja2-${{package.version}}.tar.gz
-      expected-sha512: 5c36d0cd094b40626511f30c561176c095c49ef4066c2752a9edc3e6feb2430dafa866c17deebddcd0168aa1f0fd3944916d592c5c999639b8152e7c1009c700
+      uri: https://files.pythonhosted.org/packages/source/j/jinja2/jinja2-${{package.version}}.tar.gz
+      expected-sha512: d07d68a2687af68c705d3b7f5a2c67aca7b9d125316b15085888b9d0d6e769981af76f6f524728b89b5501bd671d518fcb2638f9ae112e57ca2bf2a53482cd89
 
   - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3 -m gpep517 build-wheel --wheel-dir .dist --output-fd 3 3>&1 >&2
+      python3 -m installer -d "${{targets.destdir}}" .dist/*.whl
 
       docdir="/usr/share/doc/${{package.name}}"
       # Note: The documentation in the docs directory needs to be generated
       # by py-sphinx, however, this package (py-jinja2) is a dependency of
       # Sphinx itself!
       mkdir -p "$docdir"
-      cp -R docs examples "$docdir"/
+      cp -R docs "$docdir"/
 
-      install -m 644 -D LICENSE.rst /usr/share/licenses/${{package.name}}/LICENSE.rst
+      install -m 644 -D LICENSE.txt /usr/share/licenses/${{package.name}}/LICENSE.txt
 
   - uses: strip
 


### PR DESCRIPTION
Fix couple of CVEs by upgrading jinja2 and updating the version to a higher one with less vulnerable code.