### PR TITLE
fix(multus-cni): include compat package

### DIFF
--- a/multus-cni.yaml
+++ b/multus-cni.yaml
@@ -1,10 +1,13 @@
 package:
   name: multus-cni
   version: 4.0.2
-  epoch: 4
+  epoch: 5
   description: A CNI meta-plugin for multi-homed pods in Kubernetes
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - busybox
 
 environment:
   contents:
@@ -56,6 +59,14 @@ pipeline:
 
   - uses: strip
 
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/src/multus-cni/bin
+          ln -sf /usr/bin/multus-shim ${{targets.contextdir}}/usr/src/multus-cni/bin/multus-shim
+          ln -sf /usr/bin/multus-daemon ${{targets.contextdir}}/usr/src/multus-cni/bin/multus-daemon
+
 update:
   enabled: true
   github:
@@ -63,8 +74,16 @@ update:
     strip-prefix: v
 
 test:
+  environment:
+    contents:
+      packages:
+        - multus-cni-compat
   pipeline:
     - runs: |
         multus -version
         multus-daemon -h
         multus-shim -h
+    - name: "Check compat paths"
+      runs: |
+        stat /usr/src/multus-cni/bin/multus-shim
+        stat /usr/src/multus-cni/bin/multus-daemon


### PR DESCRIPTION
Include a compat package for `multus-cni` so that it works with the upstream Helm chart.