### PR TITLE
add `wv` and `unrtf`

### DIFF
--- a/unrtf.yaml
+++ b/unrtf.yaml
@@ -1,0 +1,37 @@
+# Generated from https://git.alpinelinux.org/aports/plain/community/unrtf/APKBUILD
+package:
+  name: unrtf
+  version: 0.21.10
+  epoch: 0
+  description: Command-line program which converts RTF documents to other formats
+  copyright:
+    - license: GPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: b49f20211fa69fff97d42d6e782a62d7e2da670b064951f14bbff968c93734ae
+      uri: https://ftp.gnu.org/gnu/unrtf/unrtf-${{package.version}}.tar.gz
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: unrtf-doc
+    pipeline:
+      - uses: split/manpages
+    description: unrtf manpages

--- a/unrtf.yaml
+++ b/unrtf.yaml
@@ -35,3 +35,8 @@ subpackages:
     pipeline:
       - uses: split/manpages
     description: unrtf manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5052

--- a/unrtf.yaml
+++ b/unrtf.yaml
@@ -40,3 +40,13 @@ update:
   enabled: true
   release-monitor:
     identifier: 5052
+
+test:
+  pipeline:
+    - name: Verify installation
+      runs: |
+        unrtf --version
+    - name: Convert
+      runs: |
+        echo '{\\rtf1\\ansi This is a test.}' > test.rtf
+        unrtf --text test.rtf | grep -i "Translation from RTF performed by UnRTF"

--- a/wv.yaml
+++ b/wv.yaml
@@ -1,0 +1,56 @@
+# Generated from https://git.alpinelinux.org/aports/plain/community/wv/APKBUILD
+package:
+  name: wv
+  version: 1.2.9
+  epoch: 0
+  description: A library that can load and parse Word 2000, 97, 95 and 6 file formats
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - bzip2-dev
+      - ca-certificates-bundle
+      - coreutils
+      - glib-dev
+      - libgsf-dev
+      - libpng-dev
+      - libxml2-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 4c730d3b325c0785450dd3a043eeb53e1518598c4f41f155558385dd2635c19d
+      uri: https://distfiles.alpinelinux.org/distfiles/edge/wv-${{package.version}}.tar.gz
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: wv-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - wv
+    description: wv dev
+
+  - name: wv-doc
+    pipeline:
+      - uses: split/manpages
+    description: wv manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5113


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
