### PR TITLE
Adding WordPress package (new)

### DIFF
--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -43,3 +43,4 @@ update:
   enabled: true
   github:
     identifier: wordpress/wordpress
+    use-tag: true  

--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -26,17 +26,6 @@ pipeline:
       expected-commit: e67e9caef43512751aae60f37d91cf589dce78b0
       destination: "${{targets.destdir}}/usr/share/wordpress"
 
-subpackages:
-  - name: wordpress-config
-    description: Creates WordPress config subpackage that can be overwritten by users.
-    dependencies:
-      runtime:
-        - wordpress
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/share/wordpress
-          cp ${{targets.destdir}}/usr/share/wordpress/wp-config-sample.php ${{targets.subpkgdir}}/usr/share/wordpress/wp-config.php
-
 update:
   enabled: true
   github:

--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -6,8 +6,6 @@ package:
   copyright:
     - license: GPL-2.0
   dependencies:
-    provides:
-      - wordpress=${{package.full-version}}
     runtime:
       - php
 

--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: "The Open Source Publishing Platform"
   copyright:
-    - license: GPL-2.0
+    - license: GPL-2.0-only
   dependencies:
     runtime:
       - php

--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -32,8 +32,6 @@ subpackages:
     dependencies:
       runtime:
         - wordpress
-      provides:
-        - wordpress-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/share/wordpress

--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -43,4 +43,4 @@ update:
   enabled: true
   github:
     identifier: wordpress/wordpress
-    use-tag: true  
+    use-tag: true

--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -1,0 +1,45 @@
+package:
+  name: wordpress
+  version: 6.5.4
+  epoch: 0
+  description: "The Open Source Publishing Platform"
+  copyright:
+    - license: GPL-2.0
+  dependencies:
+    provides:
+      - wordpress=${{package.full-version}}
+    runtime:
+      - php
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - git
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/wordpress/wordpress
+      tag: ${{package.version}}
+      expected-commit: e67e9caef43512751aae60f37d91cf589dce78b0
+      destination: "${{targets.destdir}}/usr/share/wordpress"
+
+subpackages:
+  - name: wordpress-config
+    description: Creates WordPress config subpackage that can be overwritten by users.
+    dependencies:
+      runtime:
+        - wordpress
+      provides:
+        - wordpress-config=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share/wordpress
+          cp ${{targets.destdir}}/usr/share/wordpress/wp-config-sample.php ${{targets.subpkgdir}}/usr/share/wordpress/wp-config.php
+
+update:
+  enabled: true
+  github:
+    identifier: wordpress/wordpress


### PR DESCRIPTION
In preparation for a new PHP image request we are working on at the moment.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

## CVE Scan Results
When running `wolfictl scan`, I got a few results:
```
🔎 Scanning "./packages/x86_64/wordpress-6.5.4-r0.apk"
└── 📄 /.PKGINFO
        📦 wordpress 6.5.4-r0 (apk)
            Medium CVE-2007-2627
            High CVE-2011-5216
            Medium CVE-2012-4271
            Low CVE-2012-6527
            Medium CVE-2013-7240
```

These are pretty old CVEs in plugins that aren't even being developed anymore and are not included within the wordpress package. Let me know if there's something extra I should do to clear these up.