### PR TITLE
go: enable symbols tables

### DIFF
--- a/actions-runner-controller.yaml
+++ b/actions-runner-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: actions-runner-controller
   version: 0.9.2
-  epoch: 1
+  epoch: 2
   description: Kubernetes controller for GitHub Actions self-hosted runners
   copyright:
     - license: Apache-2.0
@@ -42,19 +42,16 @@ pipeline:
     with:
       packages: ./cmd/githubwebhookserver
       output: github-webhook-server
-      ldflags: -s -w
 
   - uses: go/build
     with:
       packages: ./cmd/actionsmetricsserver
       output: actions-metrics-server
-      ldflags: -s -w
 
   - uses: go/build
     with:
       packages: ./cmd/sleep
       output: sleep
-      ldflags: -s -w
 
   - uses: strip
 

--- a/bincapz.yaml
+++ b/bincapz.yaml
@@ -1,7 +1,7 @@
 package:
   name: bincapz
   version: 0.13.0
-  epoch: 0
+  epoch: 1
   description: enumerate binary capabilities, including malicious behaviors
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,6 @@ pipeline:
   - uses: go/build
     with:
       packages: .
-      ldflags: -s -w
       output: bincapz
 
   - uses: strip

--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: caddy
   version: 2.8.4
-  epoch: 1
+  epoch: 2
   description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
   copyright:
     - license: Apache-2.0
@@ -29,7 +29,6 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w
       output: caddy
       packages: ./cmd/caddy
 

--- a/capslock.yaml
+++ b/capslock.yaml
@@ -1,7 +1,7 @@
 package:
   name: capslock
   version: 0.2.2
-  epoch: 3
+  epoch: 4
   description: Capslock is a capability analysis CLI for Go packages that informs users of which privileged operations a given package can access
   copyright:
     - license: BSD-3-Clause
@@ -23,7 +23,6 @@ pipeline:
     with:
       packages: ./cmd/capslock
       output: capslock
-      ldflags: -s -w
 
   - uses: strip
 

--- a/cluster-api-controller.yaml
+++ b/cluster-api-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-api-controller
   version: 1.7.2
-  epoch: 1
+  epoch: 2
   description: Cluster API core controller
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,6 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w
       output: cluster-api-controller
       packages: .
 

--- a/cluster-autoscaler-1.25.yaml
+++ b/cluster-autoscaler-1.25.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.25
   version: 1.25.3
-  epoch: 15
+  epoch: 16
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,6 @@ pipeline:
       modroot: cluster-autoscaler
       packages: .
       output: cluster-autoscaler
-      ldflags: -s -w
 
   - uses: strip
 

--- a/cluster-autoscaler-1.29.yaml
+++ b/cluster-autoscaler-1.29.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.29
   version: 1.29.3
-  epoch: 1
+  epoch: 2
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -37,7 +37,6 @@ pipeline:
       modroot: cluster-autoscaler
       packages: .
       output: cluster-autoscaler
-      ldflags: -s -w
       vendor: true
 
   - uses: strip

--- a/croc.yaml
+++ b/croc.yaml
@@ -1,7 +1,7 @@
 package:
   name: croc
   version: 10.0.7
-  epoch: 1
+  epoch: 2
   description: Easily and securely send things from one computer to another
   copyright:
     - license: MIT
@@ -28,7 +28,6 @@ pipeline:
     with:
       packages: .
       output: croc
-      ldflags: -s -w
 
   - uses: strip
 

--- a/dockerize.yaml
+++ b/dockerize.yaml
@@ -1,7 +1,7 @@
 package:
   name: dockerize
   version: 0.7.0
-  epoch: 9
+  epoch: 10
   description: Utility to simplify running applications in docker containers
   copyright:
     - license: MIT
@@ -29,7 +29,6 @@ pipeline:
     with:
       packages: .
       output: dockerize
-      ldflags: -s -w
 
   - uses: strip
 

--- a/ferretdb.yaml
+++ b/ferretdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: ferretdb
   version: 1.21.0
-  epoch: 4
+  epoch: 5
   description: "A truly Open Source MongoDB alternative"
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,6 @@ pipeline:
       packages: ./cmd/ferretdb
       output: ferretdb
       tags: ferretdb_tigris
-      ldflags: -s -w
 
   - uses: strip
 

--- a/flux-image-reflector-controller.yaml
+++ b/flux-image-reflector-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-image-reflector-controller
   version: 0.32.0
-  epoch: 2
+  epoch: 3
   description: GitOps Toolkit controller that scans container registries
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,6 @@ pipeline:
     with:
       packages: .
       output: image-reflector-controller
-      ldflags: -s -w
 
   - uses: strip
 

--- a/flyte.yaml
+++ b/flyte.yaml
@@ -1,7 +1,7 @@
 package:
   name: flyte
   version: 1.12.0
-  epoch: 2
+  epoch: 3
   description: Scalable and flexible workflow orchestration platform that seamlessly unifies data, ML and analytics stacks.
   copyright:
     - license: Apache-2.0
@@ -31,7 +31,6 @@ pipeline:
       modroot: .
       packages: ./cmd
       output: flyte
-      ldflags: -s -w
 
   - uses: strip
 

--- a/fulcio.yaml
+++ b/fulcio.yaml
@@ -1,7 +1,7 @@
 package:
   name: fulcio
   version: 1.4.5
-  epoch: 3
+  epoch: 4
   description: Sigstore OIDC PKI
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,6 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w
       modroot: .
       output: fulcio
       packages: ./

--- a/ghaudit.yaml
+++ b/ghaudit.yaml
@@ -1,7 +1,7 @@
 package:
   name: ghaudit
   version: 0.4.0
-  epoch: 4
+  epoch: 5
   description: Experimental tool for evaluating Chainguard's GitHub policies.
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,6 @@ pipeline:
   - uses: go/build
     with:
       packages: .
-      ldflags: -s -w
       output: ghaudit
 
   - uses: strip

--- a/gke-gcloud-auth-plugin.yaml
+++ b/gke-gcloud-auth-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: gke-gcloud-auth-plugin
   version: 0.0.2
-  epoch: 11
+  epoch: 12
   description: "kubectl plugin for GKE authentication"
   copyright:
     - license: Apache-2.0
@@ -34,7 +34,6 @@ pipeline:
       output: gke-gcloud-auth-plugin
       # TODO(mattmoor): Consider adding all of these:
       # https://github.com/kubernetes/cloud-provider-gcp/blob/e64cf3b0fcb1958cee1fe55d7e30f4573c34bf4e/defs/version.bzl#L38
-      ldflags: -s -w
 
   - uses: strip
 

--- a/go-licenses.yaml
+++ b/go-licenses.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-licenses
   version: 1.6.0
-  epoch: 14
+  epoch: 15
   description: A lightweight tool to report on the licenses used by a Go package and its dependencies. Highlight! Versioned external URL to licenses can be found at the same time.
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,6 @@ pipeline:
       modroot: .
       packages: .
       output: go-licenses
-      ldflags: -s -w
 
   - uses: strip
 

--- a/go-md2man.yaml
+++ b/go-md2man.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-md2man
   version: 2.0.4
-  epoch: 4
+  epoch: 5
   description: Utility to convert markdown to man pages
   copyright:
     - license: MIT
@@ -25,7 +25,6 @@ pipeline:
     with:
       packages: .
       output: go-md2man
-      ldflags: -s -w
 
   - runs: |
       ${{targets.destdir}}/usr/bin/go-md2man -in go-md2man.1.md -out go-md2man.1

--- a/gosu.yaml
+++ b/gosu.yaml
@@ -1,7 +1,7 @@
 package:
   name: gosu
   version: "1.17"
-  epoch: 6
+  epoch: 7
   description: Simple Go-based setuid+setgid+setgroups+exec
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,6 @@ pipeline:
     with:
       packages: .
       output: gosu
-      ldflags: -s -w
 
   - uses: strip
 

--- a/grafana-agent-operator.yaml
+++ b/grafana-agent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-agent-operator
   version: 0.41.0
-  epoch: 1
+  epoch: 2
   description: Grafana Agent Operator is a Kubernetes operator for the static mode of Grafana Agent. It makes it easier to deploy and configure static mode to collect telemetry data from Kubernetes resources.
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,6 @@ pipeline:
     with:
       packages: ./cmd/grafana-agent-operator
       output: grafana-agent-operator
-      ldflags: -s -w
 
   - uses: strip
 

--- a/hivemind.yaml
+++ b/hivemind.yaml
@@ -1,7 +1,7 @@
 package:
   name: hivemind
   version: 1.1.0
-  epoch: 1
+  epoch: 2
   description: "Process manager for Procfile-based applications"
   copyright:
     - license: MIT
@@ -24,7 +24,6 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w
       output: hivemind
       packages: .
 

--- a/kubeadm-bootstrap-controller.yaml
+++ b/kubeadm-bootstrap-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeadm-bootstrap-controller
   version: 1.7.2
-  epoch: 1
+  epoch: 2
   description: Cluster API kubeadm bootstrap controller
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,6 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w
       output: kubeadm-bootstrap-controller
       packages: ./bootstrap/kubeadm
 

--- a/kubeadm-controlplane-controller.yaml
+++ b/kubeadm-controlplane-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeadm-controlplane-controller
   version: 1.7.2
-  epoch: 1
+  epoch: 2
   description: Cluster API kubeadm controlplane controller
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,6 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w
       output: kubeadm-controlplane-controller
       packages: ./controlplane/kubeadm
 

--- a/kubernetes-ingress-defaultbackend.yaml
+++ b/kubernetes-ingress-defaultbackend.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-ingress-defaultbackend
   version: 1.29.1
-  epoch: 1
+  epoch: 2
   description: 'A simple web server that respond 404 common used in kubernetes ingress, serve pages 404 at root and 200 at /healthz'
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,6 @@ pipeline:
     with:
       packages: ./cmd/404-server
       output: defaultbackend
-      ldflags: -s -w
       vendor: true
 
   - uses: strip

--- a/logstash.yaml
+++ b/logstash.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash
   version: 8.13.4
-  epoch: 2
+  epoch: 3
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -173,7 +173,6 @@ subpackages:
             with:
               packages: .
               output: env2yaml
-              ldflags: -s -w
       - uses: strip
 
   # Due to the way logstash implements their plugin system, this is a full

--- a/memcached-exporter.yaml
+++ b/memcached-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached-exporter
   version: 0.14.3
-  epoch: 6
+  epoch: 7
   description: Exports metrics from memcached servers for consumption by Prometheus.
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,6 @@ pipeline:
     with:
       packages: ./cmd/memcached_exporter
       output: memcached_exporter
-      ldflags: -s -w
 
   - uses: strip
 

--- a/metallb.yaml
+++ b/metallb.yaml
@@ -1,7 +1,7 @@
 package:
   name: metallb
   version: 0.14.5
-  epoch: 3
+  epoch: 4
   description: "A network load-balancer implementation for Kubernetes using standard routing protocols"
   copyright:
     - license: Apache-2.0
@@ -24,19 +24,16 @@ pipeline:
   - uses: go/build
     with:
       packages: ./controller
-      ldflags: -s -w
       output: metallb-controller
 
   - uses: go/build
     with:
       packages: ./frr-tools/metrics
-      ldflags: -s -w
       output: metallb-frr-metrics
 
   - uses: go/build
     with:
       packages: ./speaker
-      ldflags: -s -w
       output: metallb-speaker
 
   - uses: strip

--- a/nri-couchbase.yaml
+++ b/nri-couchbase.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-couchbase
   version: 2.6.5
-  epoch: 1
+  epoch: 2
   description: New Relic Infrastructure Couchbase Integration
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,6 @@ pipeline:
       modroot: .
       packages: ./src/
       output: nri-couchbase
-      ldflags: -s -w
 
   - uses: strip
 

--- a/nri-discovery-kubernetes.yaml
+++ b/nri-discovery-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-discovery-kubernetes
   version: 1.9.1
-  epoch: 1
+  epoch: 2
   description: New Relic Kubernetes Auto-Discovery
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,6 @@ pipeline:
       modroot: .
       packages: ./cmd/discovery/
       output: nri-discovery-kubernetes
-      ldflags: -s -w
 
   - uses: strip
 

--- a/nri-f5.yaml
+++ b/nri-f5.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-f5
   version: 2.7.5
-  epoch: 1
+  epoch: 2
   description: New Relic Infrastructure F5 Integration
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,6 @@ pipeline:
       modroot: .
       packages: ./src/
       output: nri-f5
-      ldflags: -s -w
 
   - uses: strip
 

--- a/nri-mssql.yaml
+++ b/nri-mssql.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-mssql
   version: 2.12.4
-  epoch: 1
+  epoch: 2
   description: New Relic Infrastructure Mssql Integration
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,6 @@ pipeline:
       modroot: .
       packages: ./src/
       output: nri-mssql
-      ldflags: -s -w
 
   - uses: strip
 

--- a/nri-prometheus.yaml
+++ b/nri-prometheus.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-prometheus
   version: 2.21.2
-  epoch: 1
+  epoch: 2
   description: Fetch metrics in the Prometheus metrics inside or outside Kubernetes and send them to the New Relic Metrics platform.
   copyright:
     - license: Apache-2.0
@@ -30,7 +30,6 @@ pipeline:
     with:
       packages: ./cmd/nri-prometheus
       output: nri-prometheus
-      ldflags: -s -w
 
   - uses: strip
 

--- a/osv-scanner.yaml
+++ b/osv-scanner.yaml
@@ -1,7 +1,7 @@
 package:
   name: osv-scanner
   version: 1.7.4
-  epoch: 1
+  epoch: 2
   description: Vulnerability scanner written in Go which uses the data provided by https://osv.dev
   copyright:
     - license: Apache-2.0
@@ -24,13 +24,11 @@ pipeline:
     with:
       packages: ./cmd/osv-scanner/
       output: osv-scanner
-      ldflags: -s -w
 
   - uses: go/build
     with:
       packages: ./cmd/osv-reporter/
       output: osv-reporter
-      ldflags: -s -w
 
   - uses: strip
 

--- a/overmind.yaml
+++ b/overmind.yaml
@@ -1,7 +1,7 @@
 package:
   name: overmind
   version: 2.5.1
-  epoch: 2
+  epoch: 3
   description: "Process manager for Procfile-based applications"
   copyright:
     - license: MIT
@@ -23,7 +23,6 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w
       output: overmind
       packages: .
 

--- a/speedtest-go.yaml
+++ b/speedtest-go.yaml
@@ -1,7 +1,7 @@
 package:
   name: speedtest-go
   version: 1.7.7
-  epoch: 1
+  epoch: 2
   description: CLI and Go API to Test Internet Speed using speedtest.net
   copyright:
     - license: MIT
@@ -17,7 +17,6 @@ pipeline:
     with:
       packages: .
       output: speedtest-go
-      ldflags: -s -w
 
 test:
   pipeline:

--- a/stakater-reloader.yaml
+++ b/stakater-reloader.yaml
@@ -1,7 +1,7 @@
 package:
   name: stakater-reloader
   version: 1.0.105
-  epoch: 0
+  epoch: 1
   description: A Kubernetes controller to watch changes in ConfigMap and Secrets and do rolling upgrades on Pods
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,6 @@ pipeline:
     with:
       packages: .
       output: manager
-      ldflags: -s -w
 
   - uses: strip
 

--- a/temporal-ui-server.yaml
+++ b/temporal-ui-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal-ui-server
   version: 2.27.2
-  epoch: 1
+  epoch: 2
   description: Golang Server for https://github.com/temporalio/ui
   copyright:
     - license: MIT
@@ -25,7 +25,6 @@ pipeline:
     with:
       packages: ./cmd/server
       output: ui-server
-      ldflags: -s -w
 
   - uses: strip
 

--- a/wgcf.yaml
+++ b/wgcf.yaml
@@ -1,7 +1,7 @@
 package:
   name: wgcf
   version: 2.2.22
-  epoch: 2
+  epoch: 3
   description: Cross-platform, unofficial CLI for Cloudflare Warp
   copyright:
     - license: MIT
@@ -23,7 +23,6 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w
       output: wgcf
       packages: .
 

--- a/wire-go.yaml
+++ b/wire-go.yaml
@@ -1,7 +1,7 @@
 package:
   name: wire-go
   version: 0.6.0
-  epoch: 4
+  epoch: 5
   description: Compile-time Dependency Injection for Go
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,6 @@ pipeline:
     with:
       packages: ./cmd/wire
       output: wire
-      ldflags: -s -w
 
   - uses: strip
 

--- a/wireguard-go.yaml
+++ b/wireguard-go.yaml
@@ -1,7 +1,7 @@
 package:
   name: wireguard-go
   version: 0.0.20230223
-  epoch: 12
+  epoch: 13
   description: "Go Implementation of WireGuard"
   copyright:
     - license: GPL-2.0-only
@@ -30,7 +30,6 @@ pipeline:
     with:
       packages: .
       output: wireguard-go
-      ldflags: -s -w
 
   - uses: strip
 


### PR DESCRIPTION
go/build pipeline already strips debug symbols (built-in flag
controled with strip: key) and we also want symbols tables on by
default, for govuln checker to work.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
