### PR TITLE
Updates to compat package for redis

### DIFF
--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -84,7 +84,7 @@ subpackages:
           image: redis
           version-path: 7.2/debian-12
       - runs: |
-          # The postgres-bitnami startup scripts expect these directories to be
+          # The bitnami startup scripts expect these directories to be
           # in place. If not, redis will fail to launch.
           mkdir -p "${{targets.subpkgdir}}"/bitnami/redis/data
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc.default

--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -89,7 +89,10 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/bitnami/redis/data
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc.default
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc
-          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis/etc/redis.conf
+
+          # Moves in the default redis configuration. Note the bitnami scripts
+          # create a copy of this later and make some modifications.
+          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis/etc/redis-default.conf
 
           ln -s /opt/bitnami/scripts/redis/entrypoint.sh ${{targets.subpkgdir}}/entrypoint.sh
           ln -s /opt/bitnami/scripts/redis/run.sh ${{targets.subpkgdir}}/run.sh

--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis-7.2
   version: 7.2.5
-  epoch: 0
+  epoch: 1
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
@@ -84,9 +84,12 @@ subpackages:
           image: redis
           version-path: 7.2/debian-12
       - runs: |
-          # Bitnami startup scripts _require_ the redis-default.conf to exist
+          # The postgres-bitnami startup scripts expect these directories to be
+          # in place. If not, redis will fail to launch.
+          mkdir -p "${{targets.subpkgdir}}"/bitnami/redis/data
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc.default
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc
-          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis/etc/redis-default.conf
+          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis/etc/redis.conf
 
           ln -s /opt/bitnami/scripts/redis/entrypoint.sh ${{targets.subpkgdir}}/entrypoint.sh
           ln -s /opt/bitnami/scripts/redis/run.sh ${{targets.subpkgdir}}/run.sh


### PR DESCRIPTION
Upon testing the later versions of the bitnami scripts for redis, there where a few additional directories required 