### PR TITLE
Fix rabbitmq-server-3.13-doc

### DIFF
--- a/rabbitmq-server-3.13.yaml
+++ b/rabbitmq-server-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-server-3.13
   version: 3.13.3
-  epoch: 1
+  epoch: 2
   description: Open source RabbitMQ. core server and tier 1 (built-in) plugins
   copyright:
     - license: MPL-2.0
@@ -75,7 +75,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: ${{package.name}}-doc-3.13
+  - name: ${{package.name}}-doc
     description: "rabbitmq documentation"
     pipeline:
       - uses: split/manpages

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -80,3 +80,4 @@ valkey-benchmark-7.2.5-r0.apk
 istio-install-cni-1.21-1.22.0-r0.apk
 istio-install-cni-1.21-1.22.0-r1.apk
 openjdk-11-jre-headless-17.0.5.8-r4.apk
+rabbitmq-server-3.13-doc-3.13-3.13.3-r1.apk


### PR DESCRIPTION
This was rabbitmq-server-3.13-doc-3.13, which doesn't seem right.