### PR TITLE
Update py3-rfc3339-validator.yaml

### DIFF
--- a/py3-rfc3339-validator.yaml
+++ b/py3-rfc3339-validator.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-rfc3339-validator
   version: 0.1.4
-  epoch: 2
+  epoch: 3
   description: A pure python RFC3339 validator
   copyright:
     - license: MIT


### PR DESCRIPTION
The previous change to this updated its license to be a valid identifier, but didn't bump the epoch to rebuild.
