### PR TITLE
Fix CVE GHSA-5jpm-x58v-624v in management-api-for-apache-cassandra

### DIFF
--- a/management-api-for-apache-cassandra.yaml
+++ b/management-api-for-apache-cassandra.yaml
@@ -29,7 +29,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: upgrade-deps.patch
+      patches: upgrade-deps.patch GHSA-5jpm-x58v-624v.patch
 
   - runs: |
       MAAC_PATH="${{targets.contextdir}}"/opt/management-api

--- a/management-api-for-apache-cassandra/GHSA-5jpm-x58v-624v.patch
+++ b/management-api-for-apache-cassandra/GHSA-5jpm-x58v-624v.patch
@@ -1,0 +1,13 @@
+diff --git a/management-api-agent-5.0.x/pom.xml b/management-api-agent-5.0.x/pom.xml
+index 5bcba36..8fe40e8 100644
+--- a/management-api-agent-5.0.x/pom.xml
++++ b/management-api-agent-5.0.x/pom.xml
+@@ -17,7 +17,7 @@
+   <artifactId>datastax-mgmtapi-agent-5.0.x</artifactId>
+   <properties>
+     <cassandra5.version>5.0-beta1</cassandra5.version>
+-    <netty.http.codec.version>4.1.96.Final</netty.http.codec.version>
++    <netty.http.codec.version>4.1.108.Final</netty.http.codec.version>
+   </properties>
+   <dependencies>
+     <dependency>


### PR DESCRIPTION
Fixes: https://github.com/chainguard-dev/CVE-Dashboard/issues/36