### PR TITLE
Bump the epoch of apache-nifi

### DIFF
--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi
   version: 1.26.0
-  epoch: 2
+  epoch: 3
   description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Attempt scanning apache-nifi and rebuild this image again. We've detected a long list of CVEs.