### PR TITLE
feat(package): add python-gitlab 4.6.0

### DIFF
--- a/py3-python-gitlab.yaml
+++ b/py3-python-gitlab.yaml
@@ -1,0 +1,57 @@
+# Generated from https://pypi.org/project/python-gitlab/
+package:
+  name: py3-python-gitlab
+  version: 4.6.0
+  epoch: 0
+  description: A python wrapper for the GitLab API
+  url: https://python-gitlab.readthedocs.io
+  copyright:
+    - license: LGPL-3.0-or-later
+  dependencies:
+    runtime:
+      - py3-requests
+      - py3-requests-toolbelt
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-setuptools
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 9c1c210c058dda9177dd6c54f0ac10a698ca94f7
+      repository: https://github.com/python-gitlab/python-gitlab
+      tag: v${{package.version}}
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: python-gitlab/python-gitlab
+    strip-prefix: v
+
+test:
+  pipeline:
+    - name: Verify getting GitLab project
+      runs: |
+        cat <<EOF> python-gitlab-test.py
+        import gitlab
+
+        gl = gitlab.Gitlab()
+
+        # This ID is for the upstream project containing the GitLab source code.
+        project = gl.projects.get(278964)
+
+        assert project.attributes.get("web_url") == "https://gitlab.com/gitlab-org/gitlab"
+        EOF
+
+        python python-gitlab-test.py


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

I've until now been manually installing via `requirements.txt` file.  But why not include it with Wolfi. 🤷🏻‍♂️ 

Used the built-in tool from Melange, but ended up with adding some tweaks for stripping `v` and added spaces between the sections.

```
$ melange convert python python-gitlab
```

How I've tested it:

```
$ docker run --privileged -v "$PWD":/work cgr.dev/chainguard/melange build --pipeline-dir ./pipelines/  --repository-append https://packages.wolfi.dev/os \
                  --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub py3-python-gitlab.yaml

$ docker run --rm -it -v (pwd):/extra cgr.dev/chainguard/wolfi-base /bin/sh
/ # apk add --allow-untrusted /extra/packages/aarch64/py3-python-gitlab-4.6.0-r0.apk
```

Wrote a small script for testing it:

```py
#!/usr/bin/env python

import gitlab
import json

gl = gitlab.Gitlab()

project = gl.projects.get(278964)
print(json.dumps(project.attributes, indent=2))
```
This gives the following:

```json
{
  "id": 278964,
  "description": "GitLab is an open source end-to-end software development platform with built-in version control, issue tracking, code review, CI/CD, and more. Self-host GitLab on your own servers, in a container, or on a cloud provider.",
  "name": "GitLab",
  "name_with_namespace": "GitLab.org / GitLab",
  "path": "gitlab",
  "path_with_namespace": "gitlab-org/gitlab",
  "created_at": "2015-05-20T10:47:11.949Z",
  "default_branch": "master",
  "tag_list": [
    "hacktoberfest",
    "javascript",
    "ruby",
    "vue.js"
  ],
  "topics": [
    "hacktoberfest",
    "javascript",
    "ruby",
    "vue.js"
  ],
  "ssh_url_to_repo": "git@gitlab.com:gitlab-org/gitlab.git",
  "http_url_to_repo": "https://gitlab.com/gitlab-org/gitlab.git",
  "web_url": "https://gitlab.com/gitlab-org/gitlab",
  "readme_url": "https://gitlab.com/gitlab-org/gitlab/-/blob/master/README.md",
  "forks_count": 9798,
  "avatar_url": "https://gitlab.com/uploads/-/system/project/avatar/278964/project_avatar.png",
  "star_count": 5058,
  "last_activity_at": "2024-06-10T15:06:34.525Z",
  "namespace": {
    "id": 9970,
    "name": "GitLab.org",
    "path": "gitlab-org",
    "kind": "group",
    "full_path": "gitlab-org",
    "parent_id": null,
    "avatar_url": "/uploads/-/system/group/avatar/9970/project_avatar.png",
    "web_url": "https://gitlab.com/groups/gitlab-org"
  }
}
```

So I was able to create a client and pull data from GitLab.com.

Is it allowed to write a test that connects to the internet, like the one that I used above?  I'm not sure how to else write a test without setting up some mock, or something. 🤔   Maybe it has some offline helper functions I can test.

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
