### PR TITLE
refactor cfssl to use go/build pipeline

### DIFF
--- a/cfssl.yaml
+++ b/cfssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: cfssl
   version: 1.6.5
-  epoch: 5
+  epoch: 6
   description: Cloudflare's PKI and TLS toolkit
   copyright:
     - license: BSD-2-Clause
@@ -20,37 +20,36 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 96259aa29c9cc9b2f4e04bad7d4bc152e5405dda
 
-  - uses: go/bump
-    with:
-      deps: google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0
-
-  - runs: |
-      make all
-
-  - runs: |
-      mkdir -p "${{targets.destdir}}"/usr/bin/
-      install -Dm755 bin/cfssl "${{targets.destdir}}"/usr/bin/
-
-  - uses: strip
-
 data:
-  - name: components
+  - name: binaries
     items:
-      bundle: cfssl-bundle
-      certinfo: cfssl-certinfo
-      newkey: cfssl-newkey
-      scan: cfssl-scan
-      json: cfssljson
-      mkbundle: mkbundle
-      multirootca: multirootca
+      cfssl-bundle:
+      cfssl-certinfo:
+      cfssl-newkey:
+      cfssl-scan:
+      cfssljson:
+      mkbundle:
+      multirootca:
 
 subpackages:
-  - range: components
-    name: "${{package.name}}-${{range.key}}"
+  - range: binaries
+    name: ${{package.name}}-${{range.key}}
     pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin/
-          install -Dm755 bin/${{range.value}} "${{targets.subpkgdir}}"/usr/bin/
+      - uses: go/bump
+        with:
+          deps: google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0
+      - uses: go/build
+        with:
+          packages: ./cmd/${{range.key}}
+          output: ${{range.key}}
+          ldflags: -s -w -X github.com/cloudflare/cfssl/cli/version.version=${{package.version}}
+          vendor: true
+          subpackage: true
+    test:
+      pipeline:
+        - runs: |
+            echo "Testing ${{range.key}}"
+            ${{range.key}} -h
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
