### PR TITLE
Fix path in compat package

### DIFF
--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: redis-7.2
   version: 7.2.5
-  epoch: 1
+  epoch: 2
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
@@ -145,8 +145,8 @@ subpackages:
           version-path: 7.2/debian-12
       - runs: |
           # Bitnami startup scripts _require_ the redis-default.conf to exist
-          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis-cluster/etc
-          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis-cluster/etc/redis-default.conf
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc
+          cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis/etc/redis-default.conf
 
 update:
   enabled: true


### PR DESCRIPTION
Fixes following issue:

```bash
cp: cannot stat '/opt/bitnami/redis/etc/redis-default.conf': No such file or directory
```

Reason - we where placing into `/opt/bitnami/redis-cluster/etc/redis-default.conf`, but upstream expects it under `/opt/bitnami/redis/etc/redis-default.conf`

