### PR TITLE
fix(bazelisk): add version to compiled binary

### DIFF
--- a/bazelisk.yaml
+++ b/bazelisk.yaml
@@ -1,7 +1,7 @@
 package:
   name: bazelisk
   version: 1.20.0
-  epoch: 1
+  epoch: 2
   description: A user-friendly launcher for Bazel.
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,7 @@ pipeline:
     with:
       packages: .
       output: bazelisk
+      ldflags: -s -w -X github.com/bazelbuild/bazelisk/core.BazeliskVersion=${{package.version}}
 
   - uses: strip
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

From [this discussion[(https://github.com/orgs/wolfi-dev/discussions/21663), it came to light that Bazelisk is not compiled with a version set.  This PR tries to solve that.

```
f471be81c286:/work/packages# bazelisk version
Bazelisk version: 1.20.0
```

Fixes: https://github.com/orgs/wolfi-dev/discussions/21663

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
