### PR TITLE
Bump `loki-3.0` package for `promtail`

### DIFF
--- a/loki-3.0.yaml
+++ b/loki-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: loki-3.0
   version: 3.0.0
-  epoch: 3
+  epoch: 4
   description: Like Prometheus, but for logs.
   copyright:
     - license: AGPL-3.0-or-later


### PR DESCRIPTION
Today we have a `promtail` package with version `3.0.0-r3` and this package now provides it at the same version.

This change bumps the epoch mainly to create an unambiguous solution and ensure we pick up the right package moving forwards.
