### PR TITLE
Use test/daemon-check-output in jupyterhub-k8s-hub and shadowsocks-rust

### DIFF
--- a/jupyterhub-k8s-hub.yaml
+++ b/jupyterhub-k8s-hub.yaml
@@ -79,20 +79,22 @@ test:
         - openssl # Fixes: RuntimeError: OpenSSL 3.0's legacy provider failed to load.
         - curl
   pipeline:
-    - runs: |
-        nohup /usr/bin/jupyterhub > $bin.out 2> $bin.err < /dev/null &
-        pid=$!
-        sleep 3
-
-        if ! (cat $bin.out $bin.err | grep -i "JupyterHub is now running"); then
-          echo "Could not find expected 'JupyterHub is now running' log message in the output!"
-          cat $bin.out
-          cat $bin.err
-          exit 1
-        fi
-
-        curl http://localhost:8000/_chp_healthz | grep -qi "OK"
-
-        echo "Stopping..."
-        kill $pid
-        sleep 3
+    - name: Jupyterhub daemon test.
+      uses: test/daemon-check-output
+      with:
+        start: /usr/bin/jupyterhub
+        setup: echo "127.0.0.1 $(hostname)" >> /etc/hosts
+        expected_output: "JupyterHub is now running"
+        post: |
+          #!/bin/sh -e
+          url=http://127.0.0.1:8000/_chp_healthz
+          response=$(curl -s "$url") || {
+            echo "curl ${url} failed $?"
+            exit 1
+          }
+          echo "$response" | grep -qi OK || {
+            echo "response from $url did not contain \"OK\""
+            echo "response: $response"
+            exit 1
+          }
+          echo "$url had expected output: $response"

--- a/shadowsocks-rust.yaml
+++ b/shadowsocks-rust.yaml
@@ -66,24 +66,16 @@ test:
         - shadowsocks-rust-sslocal
         - shadowsocks-rust-ssserver
   pipeline:
-    - runs: |
-        for bin in sslocal ssserver; do
-          echo "Starting $bin"
-          nohup $bin > $bin.out 2> $bin.err < /dev/null &
-          pid=$!
-          sleep 3
-
-          if ! (cat $bin.out $bin.err | grep "listening on"); then
-            echo "Could not find expected 'listening on' log message in '$bin' output!"
-            cat $bin.out
-            cat $bin.err
-            exit 1
-          fi
-
-          echo "Stopping $bin"
-          kill $pid
-          sleep 3
-        done
+    - uses: test/daemon-check-output
+      name: "test sslocal"
+      with:
+        start: sslocal
+        expected_output: "listening on"
+    - uses: test/daemon-check-output
+      with:
+        name: "test sslocal"
+        start: ssserver
+        expected_output: "listening on"
 
 update:
   enabled: true


### PR DESCRIPTION
These two packages tested daemon output, make them use the test/daemon-check-output pipeline instead.

