### PR TITLE
Update the GCC package to use git-checkout instead of fetch

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -38,7 +38,7 @@ pipeline:
     with:
       repository: git://gcc.gnu.org/git/gcc.git
       tag: releases/gcc-${{package.version}}
-      expected-commit: c891d8dc23e1a46ad9f3e757d09e57b500d40044
+      expected-commit: cd0059a1976303638cea95f216de129334fc04d1
 
   - uses: patch
     with:

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -34,10 +34,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ftp.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.gz
-      expected-sha256: 8cb4be3796651976f94b9356fa08d833524f62420d6292c5033a9a26af315078
+      repository: git://gcc.gnu.org/git/gcc.git
+      tag: releases/gcc-${{package.version}}
+      expected-commit: c891d8dc23e1a46ad9f3e757d09e57b500d40044
 
   - uses: patch
     with:

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
-  version: 13.2.0
-  epoch: 7
+  version: 14.1.0
+  epoch: 0
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
