### PR TITLE
Update symlink in compat package

### DIFF
--- a/cassandra-4.1.yaml
+++ b/cassandra-4.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-4.1
   version: 4.1.5
-  epoch: 0
+  epoch: 1
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0
@@ -65,7 +65,8 @@ subpackages:
         - cassandra-compat=${{package.full-version}}
     pipeline:
       - runs: |
-          install -d ${{targets.subpkgdir}}/etc/cassandra
+          mkdir -p ${{targets.subpkgdir}}/etc
+          ln -sf /opt/cassandra/conf ${{targets.subpkgdir}}/etc/cassandra
           mkdir -p ${{targets.subpkgdir}}/opt
           ln -sf /usr/share/java/cassandra ${{targets.subpkgdir}}/opt/cassandra
 

--- a/management-api-for-apache-cassandra.yaml
+++ b/management-api-for-apache-cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: management-api-for-apache-cassandra
   version: 0.1.78
-  epoch: 0
+  epoch: 1
   description: RESTful / Secure Management Sidecar for Apache Cassandra
   copyright:
     - license: Apache-2.0
@@ -55,6 +55,12 @@ subpackages:
           ln -s /usr/bin/ps ${{targets.contextdir}}/bin/ps
           # the reason why we need to do this is because the java code hard-codes /bin/which
           ln -s /usr/bin/which ${{targets.contextdir}}/bin/which
+
+          # Expects this symlink to exist. If not, when deploying this image
+          # with k8s-operator, it'll throw an error:
+          # https://github.com/k8ssandra/management-api-for-apache-cassandra/blob/504b78406a48b1ad597197a3f321dc208ebe7a09/Dockerfile-5_0.ubi8#L142
+          mkdir -p ${{targets.contextdir}}/etc/cassandra
+          ln -sf /opt/cassandra/conf/ ${{targets.contextdir}}/etc/cassandra
 
 update:
   enabled: true

--- a/management-api-for-apache-cassandra.yaml
+++ b/management-api-for-apache-cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: management-api-for-apache-cassandra
   version: 0.1.78
-  epoch: 1
+  epoch: 0
   description: RESTful / Secure Management Sidecar for Apache Cassandra
   copyright:
     - license: Apache-2.0
@@ -55,12 +55,6 @@ subpackages:
           ln -s /usr/bin/ps ${{targets.contextdir}}/bin/ps
           # the reason why we need to do this is because the java code hard-codes /bin/which
           ln -s /usr/bin/which ${{targets.contextdir}}/bin/which
-
-          # Expects this symlink to exist. If not, when deploying this image
-          # with k8s-operator, it'll throw an error:
-          # https://github.com/k8ssandra/management-api-for-apache-cassandra/blob/504b78406a48b1ad597197a3f321dc208ebe7a09/Dockerfile-5_0.ubi8#L142
-          mkdir -p ${{targets.contextdir}}/etc/cassandra
-          ln -sf /opt/cassandra/conf/ ${{targets.contextdir}}/etc/cassandra
 
 update:
   enabled: true


### PR DESCRIPTION
The compat package places files under /etc/cassandra, which are expected by by some helm charts and operators. Previously we where creating an empty directory. However this actually needs to be symlinked to /opt/cassandra/conf.

Example from upstream image:

```bash
# ls /etc/cassandra
cassandra-env.sh		       commitlog_archiving.properties  jvm11-server.options  logback-tools.xml
cassandra-jaas.config		       cqlshrc.sample		       jvm8-clients.options  logback.xml
cassandra-rackdc.properties	       credentials.sample	       jvm8-server.options   metrics-reporter-config-sample.yaml
cassandra-topology.properties.example  hotspot_compiler		       jvm-clients.options   README.txt
cassandra.yaml			       jvm11-clients.options	       jvm-server.options    triggers
```

whereas with our compat package before this change:

```bash
$ ls /etc/cassandra/
/ $
```