### PR TITLE
build flags: enable frame-pointers by default

### DIFF
--- a/build-aarch64.env
+++ b/build-aarch64.env
@@ -1,5 +1,5 @@
 # Ampere Altra, the CPU used by most cloud providers, is Neoverse N1.
-export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv8-a+crc+crypto -mtune=neoverse-n1"
+export CFLAGS="-O2 -Wall -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -march=armv8-a+crc+crypto -mtune=neoverse-n1"
 export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack"

--- a/build-armv7l.env
+++ b/build-armv7l.env
@@ -1,7 +1,0 @@
-# We target the BCM2836 which is Cortex-A7 with the SIMD unit.
-export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=armv7-a+simd -mtune=cortex-a7"
-export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
-export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack"
-export GOFLAGS=""
-export GOTOOLCHAIN=local

--- a/build-x86_64.env
+++ b/build-x86_64.env
@@ -1,4 +1,4 @@
-export CFLAGS="-O2 -Wall -fomit-frame-pointer -march=x86-64-v2 -mtune=broadwell"
+export CFLAGS="-O2 -Wall -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -march=x86-64-v2 -mtune=broadwell"
 export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack"


### PR DESCRIPTION
The consensus is that this is low risk. Once enough packages are built
with this feature on, benchmarking should be performed to demonstrate
that it is usable with our binaries.

Drop obsolete and unused armv7l build flags.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
