### PR TITLE
imagemagick: fix shared library usage

### DIFF
--- a/imagemagick.yaml
+++ b/imagemagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: imagemagick
   version: 7.1.1.33
-  epoch: 0
+  epoch: 1
   description: Tools and libraries for manipulating common image formats
   copyright:
     - license: ImageMagick


### PR DESCRIPTION
```
apk add --no-cache php-8.3-imagick
```

gives this error

````
PHP Warning:  PHP Startup: Unable to load dynamic library 'imagick.so' (tried: /usr/lib/php/modules/imagick.so (/usr/lib/libMagickCore-7.Q16HDRI.so.10: undefined symbol: xmlNanoHTTPMethod, version LIBXML2_2.4.30), /usr/lib/php/modules/imagick.so.so (/usr/lib/php/modules/imagick.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
````

After recompiling Imagemagick the error is in php fixed
