### PR TITLE
update pgbouncer 1.22.1

### DIFF
--- a/pgbouncer.yaml
+++ b/pgbouncer.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgbouncer
-  version: 1.21.0
-  epoch: 2
+  version: 1.22.1
+  epoch: 0
   description: lightweight connection pooler for PostgreSQL
   copyright:
     - license: ISC
@@ -32,7 +32,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/pgbouncer/pgbouncer/releases/download/pgbouncer_${{vars.mangled-package-version}}/pgbouncer-${{package.version}}.tar.gz
-      expected-sha256: 7e1dd620c8d85a8490aff25061d5055d7aef9cf3e8bfe2d9e7719b8ee59114e2
+      expected-sha256: 2b018aa6ce7f592c9892bb9e0fd90262484eb73937fd2af929770a45373ba215
 
   - uses: autoconf/configure
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
