### PR TITLE
feat(packages): Add pg_failover_slots library for Postgres 16

### DIFF
--- a/pg-failover-slots-16.yaml
+++ b/pg-failover-slots-16.yaml
@@ -1,0 +1,44 @@
+package:
+  name: pg-failover-slots-16
+  version: 1.0.1
+  epoch: 0
+  description: PG Failover Slots extension for PostgreSQL 16
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - automake
+      - build-base
+      - busybox
+      - postgresql-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/EnterpriseDB/pg_failover_slots
+      expected-commit: 4ac7afc0603e805693a23046afa607ab60586c6f
+      tag: v${{package.version}}
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+test:
+  pipeline:
+    - runs: |
+        if [[ -f /usr/lib/postgresql16/pg_failover_slots.so ]]; then
+          echo "pg_failover_slots library found!"
+        else
+          echo "pg_failover_slots library not found!"
+          exit 1
+        fi
+
+update:
+  enabled: true
+  github:
+    identifier: EnterpriseDB/pg_failover_slots
+    strip-prefix: v


### PR DESCRIPTION
#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)