### PR TITLE
fluentbit-watcher

### DIFF
--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-operator
   version: 2.9.0
-  epoch: 0
+  epoch: 1
   description: Operate Fluent Bit and Fluentd in the Kubernetes way - Previously known as FluentBit Operator
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,55 @@ pipeline:
       packages: .
 
   - uses: strip
+
+subpackages:
+  - name: fluent-watcher
+    pipeline:
+      - runs: |
+          # https://github.com/fluent/fluent-operator/blob/v2.8.0/cmd/fluent-watcher/fluentbit/main.go#L24
+          mkdir -p "${{targets.contextdir}}"/fluent-bit/config
+      - uses: go/build
+        with:
+          packages: ./cmd/fluent-watcher/fluentbit
+          output: fluent-watcher
+          ldflags: -s -w
+          subpackage: true
+    test:
+      environment:
+        contents:
+          packages:
+            - fluent-bit
+            - fluent-bit-compat
+            - fluent-watcher-compat
+      pipeline:
+        - runs: |
+            echo "Testing fluent-watcher"
+            fluent-watcher -h
+            # Run fluent-watcher in the background and redirect its output to a temporary file
+            tempfile=$(mktemp)
+            fluent-watcher > "$tempfile" 2>&1 &
+
+            # Capture the PID of fluent-watcher
+            FLUENT_WATCHER_PID=$!
+
+            sleep 5
+
+            cat "$tempfile"
+
+            # Use grep to filter the output
+            cat "$tempfile" | grep -i "fluent-bit started"
+
+            # Wait for fluent-watcher to finish (optional)
+            kill $FLUENT_WATCHER_PID
+
+            # Clean up the temporary file
+            rm "$tempfile"
+
+  - name: fluent-watcher-compat
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/fluent-bit/bin/
+          ln -s /usr/bin/fluent-watcher "${{targets.contextdir}}"/fluent-bit/bin/fluent-watcher
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
