### PR TITLE
py3-tomli: revert py3-tomli git-checkout

### DIFF
--- a/py3-tomli.yaml
+++ b/py3-tomli.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tomli
   version: 2.0.1
-  epoch: 6
+  epoch: 7
   description: "TOML parser"
   copyright:
     - license: MIT
@@ -15,26 +15,26 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-pip
+      - py3-installer
       - python3
       - wolfi-base
 
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://github.com/hukkin/tomli.git
-      tag: ${{package.version}}
-      expected-commit: 36ef51d6a5a55e0eca077b58695390d041061bd4
+      uri: https://files.pythonhosted.org/packages/py3/t/tomli/tomli-${{package.version}}-py3-none-any.whl
+      expected-sha256: 939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc
+      extract: false
 
   - runs: |
-      pip install --prefix=/usr --root="${{targets.contextdir}}" .
+      python3 -m installer -d "${{targets.destdir}}" tomli-${{package.version}}-py3-none-any.whl
 
   - uses: strip
 
 update:
   enabled: true
-  github:
-    identifier: hukkin/tomli
+  release-monitor:
+    identifier: 207408
 
 test:
   pipeline:


### PR DESCRIPTION
Reverts checkout/build changes just to py3-tomli.yaml from #21523

Preserves the test pipeline from #21523

Bump epoch

To unblock #20318 additional tracking in #22159 as many uses of py3-tomli are redundant (upstreams use only on  python 3.10 and below, and use python stdlib tomllib on 3.11+)