### PR TITLE
pip-zipapp: New package for bootstrapping python pipeline

### DIFF
--- a/pip-zipapp.yaml
+++ b/pip-zipapp.yaml
@@ -63,8 +63,9 @@ pipeline:
       cp *.whl "$destd/$sdir/wheels/"
 
 update:
-  ignore-regex-patterns:
-    - b
   enabled: true
+  ignore-regex-patterns:
+    - 'b'
   github:
     identifier: pypa/pip
+    use-tag: true

--- a/pip-zipapp.yaml
+++ b/pip-zipapp.yaml
@@ -26,37 +26,31 @@ pipeline:
       uri: https://bootstrap.pypa.io/pip/zipapp/pip-${{package.version}}.pyz
       expected-sha256: 1af141650f2b1e71bf9d856db74324042b4bfe3a36c37f8c2b3e2d8d6b3da411
       extract: false
-
   - uses: fetch
     with:
       uri: "https://files.pythonhosted.org/packages/e5/ca/1172b6638d52f2d6caa2dd262ec4c811ba59eee96d54a7701930726bce18/installer-0.7.0-py3-none-any.whl"
       expected-sha256: "05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53"
       extract: false
-
   - uses: fetch
     with:
       uri: "https://files.pythonhosted.org/packages/de/88/70c5767a0e43eb4451c2200f07d042a4bcd7639276003a9c54a68cfcc1f8/setuptools-70.0.0-py3-none-any.whl"
       expected-sha256: "54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4"
       extract: false
-
   - uses: fetch
     with:
       uri: "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl"
       expected-sha256: "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"
       extract: false
-
   - uses: fetch
     with:
       uri: "https://files.pythonhosted.org/packages/7d/cd/d7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce/wheel-0.43.0-py3-none-any.whl"
       expected-sha256: "55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81"
       extract: false
-
   - uses: fetch
     with:
       uri: "https://files.pythonhosted.org/packages/38/45/618e84e49a6c51e5dd15565ec2fcd82ab273434f236b8f108f065ded517a/flit_core-3.9.0-py3-none-any.whl"
       expected-sha256: "7aada352fb0c7f5538c4fafeddf314d3a6a92ee8e2b1de70482329e42de70301"
       extract: false
-
   - runs: |
       destd=${{targets.destdir}}
       sdir=usr/share/${{package.name}}

--- a/pip-zipapp.yaml
+++ b/pip-zipapp.yaml
@@ -11,6 +11,15 @@ environment:
     packages:
       - busybox
 
+# See https://pip.pypa.io/en/stable/installation/#standalone-zip-application
+# Wheels for installer, setuptools, tomli, wheel, flit-core
+#
+# Hashes available from pypi (built distribution is the wheel)
+# https://pypi.org/project/installer/0.7.0/#files
+# https://pypi.org/project/setuptools/70.0.0/#files
+# https://pypi.org/project/tomli/2.0.1/#files
+# https://pypi.org/project/wheel/#files
+# https://pypi.org/project/flit-core/#files
 pipeline:
   - uses: fetch
     with:
@@ -60,6 +69,8 @@ pipeline:
       cp *.whl "$destd/$sdir/wheels/"
 
 update:
+  ignore-regex-patterns:
+    - b
   enabled: true
   github:
     identifier: pypa/pip

--- a/pip-zipapp.yaml
+++ b/pip-zipapp.yaml
@@ -1,0 +1,65 @@
+package:
+  name: pip-zipapp
+  version: 24.0
+  epoch: 0
+  description: "Pip as a python zipapp"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://bootstrap.pypa.io/pip/zipapp/pip-${{package.version}}.pyz
+      expected-sha256: 1af141650f2b1e71bf9d856db74324042b4bfe3a36c37f8c2b3e2d8d6b3da411
+      extract: false
+
+  - uses: fetch
+    with:
+      uri: "https://files.pythonhosted.org/packages/e5/ca/1172b6638d52f2d6caa2dd262ec4c811ba59eee96d54a7701930726bce18/installer-0.7.0-py3-none-any.whl"
+      expected-sha256: "05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53"
+      extract: false
+
+  - uses: fetch
+    with:
+      uri: "https://files.pythonhosted.org/packages/de/88/70c5767a0e43eb4451c2200f07d042a4bcd7639276003a9c54a68cfcc1f8/setuptools-70.0.0-py3-none-any.whl"
+      expected-sha256: "54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4"
+      extract: false
+
+  - uses: fetch
+    with:
+      uri: "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl"
+      expected-sha256: "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"
+      extract: false
+
+  - uses: fetch
+    with:
+      uri: "https://files.pythonhosted.org/packages/7d/cd/d7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce/wheel-0.43.0-py3-none-any.whl"
+      expected-sha256: "55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81"
+      extract: false
+
+  - uses: fetch
+    with:
+      uri: "https://files.pythonhosted.org/packages/38/45/618e84e49a6c51e5dd15565ec2fcd82ab273434f236b8f108f065ded517a/flit_core-3.9.0-py3-none-any.whl"
+      expected-sha256: "7aada352fb0c7f5538c4fafeddf314d3a6a92ee8e2b1de70482329e42de70301"
+      extract: false
+
+  - runs: |
+      destd=${{targets.destdir}}
+      sdir=usr/share/${{package.name}}
+      fname=${{package.name}}.pyz
+      mkdir -p "$destd/$sdir"
+      cp "pip-${{package.version}}.pyz" "$destd/$sdir/$fname"
+      chmod 0644 "$destd/$sdir/$fname"
+
+      mkdir -p "$destd/$sdir/wheels"
+      cp *.whl "$destd/$sdir/wheels/"
+
+update:
+  enabled: true
+  github:
+    identifier: pypa/pip


### PR DESCRIPTION
See #20318 needed to bootstrap python pipeline

#### For new package PRs only

- [ ] This PR is part of python toolchain improvements
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ x REQUIRED - The version of the package is still receiving security updates
- [ n/a ] This PR links to the upstream project's support policy (e.g. `endoflife.date`) (see main pip package)

