### PR TITLE
add: Cloudnative-pg(CloudNativePG is designed to seamlessly manage PostgreSQL databases)

### DIFF
--- a/cloudnative-pg.yaml
+++ b/cloudnative-pg.yaml
@@ -35,6 +35,7 @@ subpackages:
           packages: ./cmd/kubectl-cnpg
           output: plugins
           subpackage: true
+
   - name: ${{package.name}}-compat
     pipeline:
       - runs: |
@@ -53,7 +54,9 @@ test:
     contents:
       packages:
         - busybox
-  pipeline:
-    - name: "Test cloudnative-pg"
+  pipeline
+  # - Testing observability requires helm installation
+  # - Testing backup and Recovery requires using BarmanObjectStorage:
+    - name: "Verify Installation"
       runs: |
-        manager version
+        manager version | grep "${{package.version}}"

--- a/cloudnative-pg.yaml
+++ b/cloudnative-pg.yaml
@@ -54,9 +54,9 @@ test:
     contents:
       packages:
         - busybox
-  pipeline
-  # - Testing observability requires helm installation
-  # - Testing backup and Recovery requires using BarmanObjectStorage:
+  pipeline:
+    # - Testing observability requires helm installation
+    # - Testing backup and Recovery requires using BarmanObjectStorage:
     - name: "Verify Installation"
       runs: |
         manager version | grep "${{package.version}}"

--- a/cloudnative-pg.yaml
+++ b/cloudnative-pg.yaml
@@ -1,0 +1,59 @@
+package:
+  name: cloudnative-pg
+  version: 1.23.2
+  epoch: 0
+  description: CloudNativePG is a comprehensive platform designed to seamlessly manage PostgreSQL databases
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cloudnative-pg/cloudnative-pg
+      tag: v${{package.version}}
+      expected-commit: 4bef841286ef84c4b435a6204a7ee632e1d4fb57
+
+  - uses: go/build
+    with:
+      modroot: ./cmd/manager
+      output: manager
+      packages: .
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-plugins
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/kubectl-cnpg
+          output: plugins
+          subpackage: true
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}/manager"
+          ln -s /usr/bin/manager "${{targets.contextdir}}"/manager
+
+update:
+  enabled: true
+  github:
+    identifier: cloudnative-pg/cloudnative-pg
+    strip-prefix: v
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - name: "Test cloudnative-pg"
+      runs: |
+        manager version

--- a/cloudnative-pg.yaml
+++ b/cloudnative-pg.yaml
@@ -6,12 +6,6 @@ package:
   copyright:
     - license: Apache-2.0
 
-environment:
-  contents:
-    packages:
-      - busybox
-      - go
-
 pipeline:
   - uses: git-checkout
     with:
@@ -35,12 +29,6 @@ subpackages:
           packages: ./cmd/kubectl-cnpg
           output: plugins
           subpackage: true
-
-  - name: ${{package.name}}-compat
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.contextdir}}/manager"
-          ln -s /usr/bin/manager "${{targets.contextdir}}"/manager
 
 update:
   enabled: true


### PR DESCRIPTION
…ge PostgreSQL databases

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
