### PR TITLE
util-linux: bump to 2.40 and fix the source path

### DIFF
--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -25,11 +25,17 @@ environment:
       - sqlite-dev
       - zlib-dev
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+)\.(\d+).(\d+)$
+    replace: $1.$2
+    to: major-minor
+
 pipeline:
   - uses: fetch
     with:
       expected-sha256: 59e676aa53ccb44b6c39f0ffe01a8fa274891c91bef1474752fad92461def24f
-      uri: https://www.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-${{package.version}}.tar.xz
+      uri: https://www.kernel.org/pub/linux/utils/util-linux/v${{vars.major-minor}}/util-linux-${{package.version}}.tar.xz
 
   - runs: |
       cp ttydefaults.h include/

--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -12,14 +12,17 @@ environment:
     packages:
       - autoconf
       - automake
+      - bash
       - build-base
       - busybox
       - ca-certificates-bundle
       - libcap-ng-dev
       - libeconf-dev
       - libtool
+      - linux-headers
       - linux-pam-dev
       - ncurses-dev
+      - sqlite-dev
       - zlib-dev
 
 pipeline:

--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -1,7 +1,7 @@
 package:
   name: util-linux
-  version: 2.39.3
-  epoch: 4
+  version: 2.40.1
+  epoch: 0
   description: Random collection of Linux utilities
   copyright:
     - license: |-
@@ -25,8 +25,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 7b6605e48d1a49f43cc4b4cfc59f313d0dd5402fa40b96810bd572e167dfed0f
-      uri: https://www.kernel.org/pub/linux/utils/util-linux/v2.39/util-linux-${{package.version}}.tar.xz
+      expected-sha256: 8e396eececae2b3b68db232c33b8810faa7c31f6df19f98f512739293d5829b7
+      uri: https://www.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-${{package.version}}.tar.xz
 
   - runs: |
       cp ttydefaults.h include/

--- a/util-linux.yaml
+++ b/util-linux.yaml
@@ -25,7 +25,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 8e396eececae2b3b68db232c33b8810faa7c31f6df19f98f512739293d5829b7
+      expected-sha256: 59e676aa53ccb44b6c39f0ffe01a8fa274891c91bef1474752fad92461def24f
       uri: https://www.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-${{package.version}}.tar.xz
 
   - runs: |


### PR DESCRIPTION
fixes #21644