### PR TITLE
Adds 5 more packages that now use git-checkout instead of fetch

### DIFF
--- a/gnutls.yaml
+++ b/gnutls.yaml
@@ -116,6 +116,8 @@ subpackages:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - "^gnutls.*"
   github:
     identifier: gnutls/gnutls
     use-tag: true

--- a/gnutls.yaml
+++ b/gnutls.yaml
@@ -33,13 +33,13 @@ environment:
       - libev-dev
       - libkcapi-dev
       - libtasn1-dev
-      - libunistring-dev
       - libtool
+      - libunistring-dev
       - linux-headers
       - nettle-dev
+      - p11-kit-dev
       - patch
       - pkgconf-dev
-      - p11-kit-dev
       - texinfo
       - wget
       - zlib-dev

--- a/gnutls.yaml
+++ b/gnutls.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnutls
   version: 3.8.5
-  epoch: 0
+  epoch: 1
   description: TLS protocol implementation
   copyright:
     - license: LGPL-2.1-or-later
@@ -22,23 +22,37 @@ environment:
     packages:
       - autoconf
       - automake
+      - bison
       - build-base
       - busybox
       - ca-certificates-bundle
+      - coreutils
+      - gettext-dev
+      - gperf
+      - gtk-doc
+      - libev-dev
       - libkcapi-dev
       - libtasn1-dev
       - libunistring-dev
+      - libtool
       - linux-headers
       - nettle-dev
+      - patch
+      - pkgconf-dev
       - p11-kit-dev
       - texinfo
+      - wget
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 66269a2cfe0e1c2dabec87bdbbd8ab656f396edd9a40dd006978e003cfa52bfc
-      uri: https://www.gnupg.org/ftp/gcrypt/gnutls/v${{vars.mangled-package-version}}/gnutls-${{package.version}}.tar.xz
+      repository: https://github.com/gnutls/gnutls.git
+      tag: ${{package.version}}
+      expected-commit: 49f4ae2109b7cc969539b90be92a5844bbe7b322
+
+  - runs: |
+      ./bootstrap
 
   - runs: |
       LIBS="-lgmp"  \
@@ -102,5 +116,6 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 1221
+  github:
+    identifier: gnutls/gnutls
+    use-tag: true

--- a/gzip.yaml
+++ b/gzip.yaml
@@ -1,7 +1,7 @@
 package:
   name: gzip
   version: "1.13"
-  epoch: 1
+  epoch: 2
   description: "GNU data compression program"
   copyright:
     - license: GPL-3.0-or-later
@@ -9,15 +9,25 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
       - build-base
       - busybox
       - ca-certificates-bundle
+      - coreutils
+      - gettext-dev
+      - texinfo
+      - xz
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ftp.gnu.org/gnu/gzip/gzip-${{package.version}}.tar.gz
-      expected-sha256: 20fc818aeebae87cdbf209d35141ad9d3cf312b35a5e6be61bfcfbf9eddd212a
+      repository: https://git.savannah.gnu.org/git/gzip.git
+      tag: v${{package.version}}
+      expected-commit: ec1a0b1af679e252839ef4996e92f69d3ee8b3d2
+
+  - runs: |
+      ./bootstrap
 
   - name: Configure
     runs: |

--- a/haproxy-2.9.yaml
+++ b/haproxy-2.9.yaml
@@ -80,5 +80,17 @@ subpackages:
 
 update:
   enabled: true
+  # This is a hack to ignore all valid semantic versions greater than version 2.9
+  #   Explanation
+  #     \b: Word boundary to ensure we are matching whole semantic versions, not parts of longer strings.
+  #     (3\.\d+\.\d+|[4-9]\.\d+\.\d+|[1-9]\d+\.\d+\.\d+):
+  #       3\.\d+\.\d+: Matches versions starting with 3 and any minor/patch version.
+  #       [4-9]\.\d+\.\d+: Matches versions starting with 4 to 9 with any minor/patch version.
+  #       [1-9]\d+\.\d+\.\d+: Matches versions starting with 10 or higher with any minor/patch version.
+  #     (?:-[\w\.-]+)?: Non-capturing group to optionally match the pre-release identifier (e.g., -alpha, -beta.1).
+  #     (?:\+[\w\.-]+)?: Non-capturing group to optionally match the build metadata identifier (e.g., +build1, +001).
+  #     \b: Another word boundary to ensure the match is complete and not part of a larger string.
+  ignore-regex-patterns:
+    - "\\b(3\\.\\d+\\.\\d+|[4-9]\\.\\d+\\.\\d+|[1-9]\\d+\\.\\d+\\.\\d+)(?:-[\\w\\.-]+)?(?:\\+[\\w\\.-]+)?\\b"
   release-monitor:
     identifier: 1298

--- a/haproxy-2.9.yaml
+++ b/haproxy-2.9.yaml
@@ -79,18 +79,6 @@ subpackages:
           chmod +x ${{targets.subpkgdir}}/usr/local/bin/docker-entrypoint.sh
 
 update:
-  enabled: true
-  # This is a hack to ignore all valid semantic versions greater than version 2.9
-  #   Explanation
-  #     \b: Word boundary to ensure we are matching whole semantic versions, not parts of longer strings.
-  #     (3\.\d+\.\d+|[4-9]\.\d+\.\d+|[1-9]\d+\.\d+\.\d+):
-  #       3\.\d+\.\d+: Matches versions starting with 3 and any minor/patch version.
-  #       [4-9]\.\d+\.\d+: Matches versions starting with 4 to 9 with any minor/patch version.
-  #       [1-9]\d+\.\d+\.\d+: Matches versions starting with 10 or higher with any minor/patch version.
-  #     (?:-[\w\.-]+)?: Non-capturing group to optionally match the pre-release identifier (e.g., -alpha, -beta.1).
-  #     (?:\+[\w\.-]+)?: Non-capturing group to optionally match the build metadata identifier (e.g., +build1, +001).
-  #     \b: Another word boundary to ensure the match is complete and not part of a larger string.
-  ignore-regex-patterns:
-    - "\\b(3\\.\\d+\\.\\d+|[4-9]\\.\\d+\\.\\d+|[1-9]\\d+\\.\\d+\\.\\d+)(?:-[\\w\\.-]+)?(?:\\+[\\w\\.-]+)?\\b"
+  enabled: false
   release-monitor:
     identifier: 1298

--- a/haproxy-2.9.yaml
+++ b/haproxy-2.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-2.9
-  version: 2.9.7
-  epoch: 1
+  version: 2.9.9
+  epoch: 0
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: GPL-2.0-or-later
@@ -10,14 +10,6 @@ package:
       - libgcc
     provides:
       - haproxy=${{package.full-version}}
-
-# creates a new var that contains only the major and minor version to be used in the fetch URL
-# e.g. 2.6.11 will create a new var mangled-package-version=2.6
-var-transforms:
-  - from: ${{package.version}}
-    match: (\d+\.\d+)\.\d+
-    replace: $1
-    to: mangled-package-version
 
 environment:
   contents:
@@ -32,10 +24,12 @@ environment:
       - pcre2-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://www.haproxy.org/download/${{vars.mangled-package-version}}/src/haproxy-${{package.version}}.tar.gz
-      expected-sha256: d1a0a56f008a8d2f007bc0c37df6b2952520d1f4dde33b8d3802710e5158c131
+      repository: https://git.haproxy.org/git/haproxy-2.9.git/
+      tag: v${{package.version}}
+      expected-commit: ad75c480c019cf1522049cbe8f654807d434743f
+      depth: "-1"
 
   - uses: autoconf/make
     with:

--- a/iperf.yaml
+++ b/iperf.yaml
@@ -1,3 +1,4 @@
+#nolint:valid-pipeline-git-checkout-tag
 package:
   name: iperf
   version: 2.2.0
@@ -27,7 +28,6 @@ pipeline:
     with:
       repository: https://git.code.sf.net/p/iperf2/code
       # The iperf2 code doesn't seem to track using tags
-      #nolint:valid-pipeline-git-checkout-tag
       branch: ${{vars.mangled-package-version}}
       expected-commit: 59ccf3c5aac51873cd99f0e423f7ac3023aa9c2a
 

--- a/iperf.yaml
+++ b/iperf.yaml
@@ -1,10 +1,16 @@
 package:
   name: iperf
   version: 2.2.0
-  epoch: 0
+  epoch: 1
   description: A tool to measure IP bandwidth using UDP or TCP
   copyright:
     - license: NCSA
+
+var-transforms:
+  - from: ${{package.version}}
+    match: \.
+    replace: "-"
+    to: mangled-package-version
 
 environment:
   contents:
@@ -17,10 +23,11 @@ environment:
       - linux-headers
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 16810a9575e4c6dd65e4a18ab5df3cdac6730b3c832cf080a8990f132f68364a
-      uri: https://sourceforge.net/projects/iperf2/files/iperf-${{package.version}}.tar.gz
+      repository: https://git.code.sf.net/p/iperf2/code
+      branch: ${{vars.mangled-package-version}}
+      expected-commit: 59ccf3c5aac51873cd99f0e423f7ac3023aa9c2a
 
   - uses: autoconf/configure
     with:

--- a/iperf.yaml
+++ b/iperf.yaml
@@ -26,6 +26,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://git.code.sf.net/p/iperf2/code
+      # The iperf2 code doesn't seem to track using tags
+      #nolint:valid-pipeline-git-checkout-tag
       branch: ${{vars.mangled-package-version}}
       expected-commit: 59ccf3c5aac51873cd99f0e423f7ac3023aa9c2a
 

--- a/iproute2.yaml
+++ b/iproute2.yaml
@@ -1,7 +1,7 @@
 package:
   name: iproute2
   version: 6.9.0
-  epoch: 0
+  epoch: 1
   description: IP Routing Utilities
   copyright:
     - license: GPL-2.0-or-later
@@ -19,10 +19,11 @@ environment:
       - iptables-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://kernel.org/pub/linux/utils/net/iproute2/iproute2-${{package.version}}.tar.xz
-      expected-sha256: 2f643d09ea11a4a2a043c92e2b469b5f73228cbf241ae806760296ed0ec413d0
+      repository: https://git.kernel.org/pub/scm/network/iproute2/iproute2.git
+      tag: v${{package.version}}
+      expected-commit: 3724f17a4be32d89044c6967846eb20ce5bed383
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
Updates 5 packages to use git-checkout over fetch:
* gnutls
* gzip
* haproxy-2.9
* iperf
* iproute2

Note haproxy we disable update for.