### PR TITLE
python-dev PR missed bump on wheel and six

### DIFF
--- a/py3-six.yaml
+++ b/py3-six.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-six
   version: 1.16.0
-  epoch: 8
+  epoch: 9
   description: "python 2 and 3 compatibility library"
   copyright:
     - license: MIT

--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wheel
   version: 0.43.0
-  epoch: 1
+  epoch: 2
   description: "built-package format for Python"
   copyright:
     - license: MIT


### PR DESCRIPTION
Whilst this passes the `wolfictl text` build cycle check, it doesn't
actually attempt to build wheel and the new packages it provides.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
