### PR TITLE
Bump pip higher

### DIFF
--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pip
   version: "24.0"
-  epoch: 2
+  epoch: 3
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT


### PR DESCRIPTION
To ensure the new py3-pip replaces all previous builds of pip,
i.e. py3.12-pip the epoch on py3-pip has to be higher than any
previous epoch.

Bump pip to epoch 3.

This will need a force merge as well.