### PR TITLE
Bump py3-installer to higher than py3.12-installer

### DIFF
--- a/py3-installer.yaml
+++ b/py3-installer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-installer
   version: 0.7.0
-  epoch: 6
+  epoch: 7
   description: A library for installing Python wheels.
   copyright:
     - license: "MIT"


### PR DESCRIPTION
Bump py3-installer to 7, such that it is higher than py3.12-installer
which it supersedes.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
