### PR TITLE
velero: clean up build pipelines

### DIFF
--- a/restic.yaml
+++ b/restic.yaml
@@ -1,17 +1,10 @@
 package:
   name: restic
   version: 0.16.4
-  epoch: 11
+  epoch: 12
   description: restic is a backup program which allows saving multiple revisions of files and directories in an encrypted repository stored on different backends
   copyright:
     - license: BSD-2-Clause
-
-environment:
-  contents:
-    packages:
-      - busybox
-      - ca-certificates-bundle
-      - go
 
 pipeline:
   - uses: git-checkout
@@ -28,9 +21,7 @@ pipeline:
     with:
       packages: ./cmd/restic
       output: restic
-      ldflags: "-s -w -X main.version=${{package.version}} -extldflags '-static'"
-
-  - uses: strip
+      ldflags: "-X main.version=${{package.version}}"
 
 subpackages:
   - name: ${{package.name}}-compat

--- a/velero.yaml
+++ b/velero.yaml
@@ -1,23 +1,13 @@
 package:
   name: velero
   version: 1.14.0
-  epoch: 0
+  epoch: 1
   description: Backup and migrate Kubernetes applications and their persistent volumes
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - restic
-      - wolfi-base
-
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - git
-      - go
 
 pipeline:
   - uses: git-checkout
@@ -34,15 +24,13 @@ pipeline:
     with:
       packages: ./cmd/velero
       output: velero
-      ldflags: "-s -w -X main.version=v${{package.version}} -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=v${{package.version}} -extldflags '-static'"
+      ldflags: "-X main.version=v${{package.version}} -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=v${{package.version}}"
 
   - uses: go/build
     with:
       packages: ./cmd/velero-restore-helper
       output: velero-restore-helper
-      ldflags: "-s -w -X main.version=v${{package.version}} -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=v${{package.version}} -extldflags '-static'"
-
-  - uses: strip
+      ldflags: "-X main.version=v${{package.version}} -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=v${{package.version}}"
 
 subpackages:
   - name: "velero-restore-helper"


### PR DESCRIPTION
Drop wolfi-base runtime dependency, as apk-utils should not be pulled in.

go/build defaults build stripped (-w) binaries, with symbols table enabled (no -s) and with user tags that result in staticaly linked binaries (no need for external ldflags).

This enables govulncheck support.
