### PR TITLE
mailpit: init at 1.19.2

### DIFF
--- a/mailpit.yaml
+++ b/mailpit.yaml
@@ -1,0 +1,48 @@
+package:
+  name: mailpit
+  version: 1.19.2
+  epoch: 0
+  description: An email and SMTP testing tool with API for developers
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - nodejs-20
+      - npm
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/axllent/mailpit
+      tag: v${{package.version}}
+      expected-commit: 1f7a60452e4655cc463b069cc1308c4fa5e52156
+
+  - runs: |
+      npm install
+      npm run package
+
+  - runs: |
+      CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/axllent/mailpit/config.Version=${{package.version}}" -o mailpit
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv mailpit ${{targets.destdir}}/usr/bin/
+
+  - uses: strip
+
+test:
+  pipeline:
+    - name: Verify mailpit binary
+      runs: |
+        mailpit version || exit 1
+
+update:
+  enabled: true
+  github:
+    identifier: axllent/mailpit
+    tag-filter: v
+    strip-prefix: v


### PR DESCRIPTION
Mailhog alternative for local email testing

https://mailpit.axllent.org/

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
