### PR TITLE
Git checkout pkgs 3

### DIFF
--- a/attr.yaml
+++ b/attr.yaml
@@ -1,7 +1,7 @@
 package:
   name: attr
   version: 2.5.2
-  epoch: 1
+  epoch: 2
   description: "utilities for managing filesystem extended attributes"
   copyright:
     - license: GPL-2.0-or-later
@@ -9,16 +9,24 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gettext-dev
+      - libtool
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://download.savannah.nongnu.org/releases/attr/attr-${{package.version}}.tar.gz
-      expected-sha256: 39bf67452fa41d0948c2197601053f48b3d78a029389734332a6309a680c6c87
+      repository: https://git.savannah.nongnu.org/git/attr.git
+      tag: v${{package.version}}
+      expected-commit: cba99e6932f7d532460011a25f413c61aefaa872
+
+  - runs: |
+      ./autogen.sh
 
   - runs: |
       ./configure \

--- a/bash.yaml
+++ b/bash.yaml
@@ -1,10 +1,17 @@
 package:
   name: bash
   version: 5.2.21
-  epoch: 4
+  epoch: 5
   description: "GNU bourne again shell"
   copyright:
     - license: GPL-3.0-or-later
+
+# The bash git repository only tags using major.minor version numbers
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d+\.\d+).*
+    replace: $1
+    to: mangled-package-version
 
 environment:
   contents:
@@ -15,10 +22,11 @@ environment:
       - ncurses-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ftp.gnu.org/gnu/bash/bash-${{package.version}}.tar.gz
-      expected-sha256: c8e31bdc59b69aaffc5b36509905ba3e5cbb12747091d27b4b977f078560d5b8
+      repository: https://git.savannah.gnu.org/git/bash.git
+      tag: bash-${{vars.mangled-package-version}}
+      expected-commit: 74091dd4e8086db518b30df7f222691524469998
 
   - runs: |
       ./configure \
@@ -83,3 +91,10 @@ update:
   enabled: true
   release-monitor:
     identifier: 166
+
+test:
+  pipeline:
+    - runs: |
+        /bin/bash --version || exit 1
+    - runs: |
+        /bin/bash -c "echo 'hello world'" || exit 1

--- a/bind.yaml
+++ b/bind.yaml
@@ -1,7 +1,7 @@
 package:
   name: bind
   version: 9.18.27
-  epoch: 0
+  epoch: 1
   description: The ISC DNS server
   copyright:
     - license: MPL-2.0
@@ -20,20 +20,26 @@ environment:
       - fstrm-dev
       - krb5-dev
       - libcap-dev
+      - libtool
       - libuv-dev
       - libxml2-dev
       - nghttp2-dev
       - openldap-dev
       - openssl-dev
       - perl
+      - pkgconf-dev
       - protobuf-c-dev
       - protoc
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: ea3f3d8cfa2f6ae78c8722751d008f54bc17a3aed2be3f7399eb7bf5f4cda8f1
-      uri: https://downloads.isc.org/isc/bind9/${{package.version}}/bind-${{package.version}}.tar.xz
+      repository: https://gitlab.isc.org/isc-projects/bind9.git
+      tag: v${{package.version}}
+      expected-commit: 663e6d969c8dc6a59cbaf1dbe26b47407c5717fb
+
+  - runs: |
+      autoreconf -fi
 
   - uses: autoconf/configure
     with:

--- a/bird.yaml
+++ b/bird.yaml
@@ -1,7 +1,7 @@
 package:
   name: bird
   version: 2.15.1
-  epoch: 0
+  epoch: 1
   description: BIRD Internet Routing Daemon
   copyright:
     - license: GPL-2.0-or-later
@@ -22,10 +22,14 @@ environment:
       - readline-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 48e85c622de164756c132ea77ad1a8a95cc9fd0137ffd0d882746589ce75c75d
-      uri: https://bird.network.cz/download/bird-${{package.version}}.tar.gz
+      repository: https://gitlab.nic.cz/labs/bird.git
+      tag: v${{package.version}}
+      expected-commit: 0b684a43bd7ce4a32c9cd7754b88286bcd1815bb
+
+  - runs: |
+      autoreconf -fi
 
   - uses: autoconf/configure
     with:

--- a/brotli.yaml
+++ b/brotli.yaml
@@ -1,7 +1,7 @@
 package:
   name: brotli
   version: 1.1.0
-  epoch: 2
+  epoch: 3
   description: "a generic lossless compression algorithm"
   copyright:
     - license: MIT
@@ -17,10 +17,11 @@ environment:
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/google/brotli/archive/v${{package.version}}.tar.gz
-      expected-sha256: e720a6ca29428b803f4ad165371771f5398faba397edf6778837a18599ea13ff
+      repository: https://github.com/google/brotli.git
+      tag: v${{package.version}}
+      expected-commit: ed738e842d2fbdf2d6459e39267a633c4a9b2f5d
 
   - uses: cmake/configure
 
@@ -59,5 +60,8 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 15235
+  ignore-regex-patterns:
+    - "^dev\\/null$"
+  github:
+    identifier: google/brotli
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
