### PR TITLE
Whereabouts package

### DIFF
--- a/whereabouts.yaml
+++ b/whereabouts.yaml
@@ -15,8 +15,8 @@ pipeline:
       repository: https://github.com/k8snetworkplumbingwg/whereabouts
       tag: v${{package.version}}
       expected-commit: c599b3c211fecd0c46460a10a81876ce447f6720
-  - uses: go/build
 
+  - uses: go/build
     with:
       modroot: .
       packages: cmd/whereabouts.go
@@ -24,10 +24,14 @@ pipeline:
 
   - uses: strip
 
+test:
+  pipeline:
+    - runs: |
+        whereabouts
+
 update:
   enabled: true
   github:
     identifier: k8snetworkplumbingwg/whereabouts
     strip-prefix: v
     use-tag: true
-

--- a/whereabouts.yaml
+++ b/whereabouts.yaml
@@ -1,0 +1,33 @@
+package:
+  name: whereabouts
+  version: 0.7.0
+  epoch: 0
+  description: A CNI IPAM plugin that assigns IP addresses cluster-wide
+
+environment:
+  contents:
+    packages:
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/k8snetworkplumbingwg/whereabouts
+      tag: v${{package.version}}
+      expected-commit: c599b3c211fecd0c46460a10a81876ce447f6720
+  - uses: go/build
+
+    with:
+      modroot: .
+      packages: cmd/whereabouts.go
+      output: whereabouts
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: k8snetworkplumbingwg/whereabouts
+    strip-prefix: v
+    use-tag: true
+

--- a/whereabouts.yaml
+++ b/whereabouts.yaml
@@ -3,11 +3,14 @@ package:
   version: 0.7.0
   epoch: 0
   description: A CNI IPAM plugin that assigns IP addresses cluster-wide
+  dependencies:
+    runtime:
+      # https://github.com/k8snetworkplumbingwg/whereabouts/blob/4a6fc53afbc7c888dc803517e9eed8cb8d400214/script/install-cni.sh
+      - busybox
 
 environment:
-  contents:
-    packages:
-      - go
+  environment:
+    CGO_ENABLED: "0"
 
 pipeline:
   - uses: git-checkout
@@ -16,22 +19,35 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: c599b3c211fecd0c46460a10a81876ce447f6720
 
+  - uses: go/bump
+    with:
+      deps: golang.org/x/net@v0.23.0
+
   - uses: go/build
     with:
       modroot: .
+      ldflags: -w -X github.com/k8snetworkplumbingwg/whereabouts/pkg/version.Version=${{package.version}} -X github.com/k8snetworkplumbingwg/whereabouts/pkg/version.GitSHA=$(git rev-parse HEAD) -X github.com/k8snetworkplumbingwg/whereabouts/pkg/version.GitTreeState=clean -X github.com/k8snetworkplumbingwg/whereabouts/pkg/version.ReleaseStatus=released
       packages: cmd/whereabouts.go
       output: whereabouts
 
-  - uses: strip
+  - uses: go/build
+    with:
+      modroot: .
+      ldflags: -w -X github.com/k8snetworkplumbingwg/whereabouts/pkg/version.Version=${{package.version}} -X github.com/k8snetworkplumbingwg/whereabouts/pkg/version.GitSHA=$(git rev-parse HEAD) -X github.com/k8snetworkplumbingwg/whereabouts/pkg/version.GitTreeState=clean -X github.com/k8snetworkplumbingwg/whereabouts/pkg/version.ReleaseStatus=released
+      packages: cmd/controlloop/controlloop.go
+      output: controlloop
+
+  - runs: |
+      mkdir -p "${{targets.contextdir}}"/
+      install -Dm755 script/install-cni.sh "${{targets.contextdir}}"/install-cni.sh
 
 test:
   pipeline:
     - runs: |
-        whereabouts
+        whereabouts -h
 
 update:
   enabled: true
   github:
     identifier: k8snetworkplumbingwg/whereabouts
     strip-prefix: v
-    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
