### PR TITLE
PHP Extensions Load Order

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: 8.1.29
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -218,9 +218,15 @@ subpackages:
       - runs: |
           export CONF_DIR="${{targets.subpkgdir}}/etc/php/conf.d"
           mkdir -p $CONF_DIR
+          order=10
           prefix=
           [ "${{range.key}}" != "opcache" ] || prefix="zend_"
-          echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"${{range.key}}.ini"
+          # Determine load order based on number of dependencies found in config.w32
+          [ -f "ext/${{range.key}}/config.w32" ] && \
+            deps=`sed -En "s/.*ADD_EXTENSION_DEP\('${{range.key}}', ([^)]+)\).*/\1/p" "ext/${{range.key}}/config.w32" \
+                | tr -d "'," | tr ' ' '\n' \
+                | sort -u | wc -w`
+          echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"$((order+order*deps))-${{range.key}}.ini"
 
   - name: ${{package.name}}-dev
     description: PHP 8.1 development headers

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -324,7 +324,7 @@ test:
         - shadow
         - sudo-rs
         - glibc-locales
-        - php-pgsql
+        - php-8.2-pgsql
     environment:
       PGDATA: /tmp/test_db
       PGUSER: wolfi

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: 8.2.20
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -218,9 +218,15 @@ subpackages:
       - runs: |
           export CONF_DIR="${{targets.subpkgdir}}/etc/php/conf.d"
           mkdir -p $CONF_DIR
+          order=10
           prefix=
           [ "${{range.key}}" != "opcache" ] || prefix="zend_"
-          echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"${{range.key}}.ini"
+          # Determine load order based on number of dependencies found in config.w32
+          [ -f "ext/${{range.key}}/config.w32" ] && \
+            deps=`sed -En "s/.*ADD_EXTENSION_DEP\('${{range.key}}', ([^)]+)\).*/\1/p" "ext/${{range.key}}/config.w32" \
+                | tr -d "'," | tr ' ' '\n' \
+                | sort -u | wc -w`
+          echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"$((order+order*deps))-${{range.key}}.ini"
 
   - name: ${{package.name}}-dev
     description: PHP 8.2 development headers

--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: 8.3.8
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -212,9 +212,15 @@ subpackages:
       - runs: |
           export CONF_DIR="${{targets.subpkgdir}}/etc/php/conf.d"
           mkdir -p $CONF_DIR
+          order=10
           prefix=
           [ "${{range.key}}" != "opcache" ] || prefix="zend_"
-          echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"${{range.key}}.ini"
+          # Determine load order based on number of dependencies found in config.w32
+          [ -f "ext/${{range.key}}/config.w32" ] && \
+            deps=`sed -En "s/.*ADD_EXTENSION_DEP\('${{range.key}}', ([^)]+)\).*/\1/p" "ext/${{range.key}}/config.w32" \
+                | tr -d "'," | tr ' ' '\n' \
+                | sort -u | wc -w`
+          echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"$((order+order*deps))-${{range.key}}.ini"
 
   - name: ${{package.name}}-dev
     description: PHP 8.3 development headers


### PR DESCRIPTION
This PR should work as a long-term fix for the issue with the order in which PHP extensions are loaded within images.

I am currently working on a WordPress image and it is not possible to use some of the extensions as they are loaded in alphabetical order, even though they have dependencies between each other. So anyone trying to build a PHP image today with the `mysqli` extension will get errors because `mysqli` depends on `mysqlnd`, which is loaded later because of the extension name. The issue is specifically with extension configuration files (.ini), they work like Nginx configuration files, can be renamed to force a specific load order.

This PR does **not** change any extension or package names. Only the configuration files are affected, which should not cause any disruption.

The change uses the file `config.w32` which is present in most extensions and defines other extensions in which this depends on. The script then creates a prefix for the `.ini` files based on the number of deps they have (more deps, higher number, loads later). This is what Alpine does to fix the same problem in the [Alpine PHP build](https://git.alpinelinux.org/aports/tree/community/php82/APKBUILD) (see the [resolve_extension_deps()](https://git.alpinelinux.org/aports/tree/community/php82/APKBUILD#n596) function).

With the change, this is how the configuration files will look like:

```
552b5d2d572f:/work/packages# ls /etc/php/conf.d/
10-mbstring.ini   10-mysqlnd.ini    20-xmlwriter.ini  30-mysqli.ini     30-xmlreader.ini
```

Related: https://github.com/chainguard-dev/internal/issues/3826

