### PR TITLE
s3cmd: use explicit python3.12 for now

### DIFF
--- a/s3cmd.yaml
+++ b/s3cmd.yaml
@@ -1,7 +1,7 @@
 package:
   name: s3cmd
   version: 2.4.0
-  epoch: 2
+  epoch: 3
   description: Command-line tool for managing Amazon S3 and CloudFront services
   copyright:
     - license: GPL-2.0-or-later
@@ -18,6 +18,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - py3-setuptools
+      - python-3.12
 
 pipeline:
   - uses: fetch


### PR DESCRIPTION
Fix breaking build