### PR TITLE
withdrawn-packges: remaining obsolete python-*-default packages

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -102,3 +102,13 @@ bun-1.1.0-r2.apk
 bun-bootstrap-1.0.20-r0.apk
 bun-bootstrap-1.0.23-r0.apk
 bun-bootstrap-1.0.23-r0.apk
+python-3.10-default-3.10.13-r6.apk
+python-3.11-default-3.11.8-r2.apk
+python-3.11-default-3.11.8-r3.apk
+python-3.12-default-3.12.2-r2.apk
+python-3.12-default-3.12.2-r3.apk
+python-3.12-default-3.12.2-r4.apk
+python-3.12-default-3.12.2-r5.apk
+python-3.12-default-3.12.2-r6.apk
+python-3.12-dev-default-3.12.2-r5.apk
+python-3.12-dev-default-3.12.2-r6.apk


### PR DESCRIPTION
The switch to ship python3/python3-dev symlinks in -default packages
was unsuccessful and reverted back to python-3.N{-dev}
packages. However, -default packages remained published, and remain
discoverable that can confuse users.

Withdraw this packages, to remove any ambiguity.

Fixes: https://github.com/wolfi-dev/os/issues/22273
