### PR TITLE
clang-18: add more runtime dependencies

### DIFF
--- a/clang-18.yaml
+++ b/clang-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-18
   version: 18.1.8
-  epoch: 0
+  epoch: 1
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,13 @@ package:
     memory: 64Gi
   dependencies:
     runtime:
+      - gcc
+      - glibc-dev
       - libLLVM-18
+      - libclang-cpp-18
+      - llvm-18
+    provides:
+      - clang-18-dev=${{package.full-version}}
 
 environment:
   contents:
@@ -113,15 +119,6 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "clang-18-dev"
-    description: "headers for clang-18"
-    pipeline:
-      - uses: split/dev
-    dependencies:
-      runtime:
-        - libLLVM-18
-        - libclang-cpp-18
-
   - name: "libclang-cpp-18"
     description: "Clang 18 runtime library"
     pipeline:


### PR DESCRIPTION
It is a very confusing experience when installing clang-18 doesn't
result in ability to compile trivial c++ applications. clang needs a
gcc installation and libstdc++-dev and glibc-dev to ensure it can
dynamically locate internal gcc headers, and thus discover all the
proper include paths to find headers like stddef.h, features.h,
iostream and so on. Without all of these things installed debugging
those failures is quite non-trivial.

Also not sure if our package splits are correct, or worth the effort,
given one typically needs all the things at runtime.

Also not sure why llvm stack is split into so many packages, given
that LLVM supports checking out all the source code side by side, and
build all the things in one go.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
