### PR TITLE
pgbouncer-cloudnative-pg

### DIFF
--- a/pgbouncer-cloudnative-pg.yaml
+++ b/pgbouncer-cloudnative-pg.yaml
@@ -1,0 +1,51 @@
+package:
+  name: pgbouncer-cloudnative-pg
+  version: 1.22.1.15
+  epoch: 0
+  description: CloudNativePG containing PgBouncer
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - pgbouncer
+
+var-transforms:
+  - from: ${{package.version}}
+    match: '\.(\d+)$'
+    replace: '-$1'
+    to: mangled-package-version
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cloudnative-pg/pgbouncer-containers
+      expected-commit: d1bcb28762f25d48330cd2de9375cdb4c488a393
+      tag: v${{vars.mangled-package-version}}
+
+  - runs: |
+      mkdir -p "${{targets.contextdir}}"/var/log/pgbouncer
+      mkdir -p "${{targets.contextdir}}"/var/run/pgbouncer
+      mkdir -p "${{targets.contextdir}}"/etc/pgbouncer
+
+      mv /etc/pgbouncer/pgbouncer.ini "${{targets.contextdir}}"/etc/pgbouncer/pgbouncer.ini.example
+      mv /etc/pgbouncer/userlist.txt "${{targets.contextdir}}"/etc/pgbouncer/userlist.txt.example
+
+      touch "${{targets.contextdir}}"/etc/pgbouncer/pgbouncer.ini "${{targets.contextdir}}"/etc/pgbouncer/userlist.txt
+
+      # https://github.com/cloudnative-pg/pgbouncer-containers/blob/d1bcb28762f25d48330cd2de9375cdb4c488a393/Dockerfile#L78
+      # we are going to call the script from /t to be able to use it as "./entrypoint.sh" in the entrypoint of the container image
+      mkdir -p "${{targets.contextdir}}"/
+      install -Dm755 entrypoint.sh "${{targets.contextdir}}"/entrypoint.sh
+
+update:
+  # Doesn't work with var transforms
+  enabled: false
+  manual: true
+  github:
+    identifier: cloudnative-pg/pgbouncer-containers
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

- [x] It needs https://github.com/wolfi-dev/os/pull/22282 to be merged first.

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
