### PR TITLE
git-checkout hotfix for submodule checkouts

### DIFF
--- a/neon.yaml
+++ b/neon.yaml
@@ -1,7 +1,7 @@
 package:
   name: neon
   version: "5733"
-  epoch: 0
+  epoch: 1
   description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
   copyright:
     - license: Apache-2.0

--- a/pipelines/git-checkout.yaml
+++ b/pipelines/git-checkout.yaml
@@ -1,0 +1,148 @@
+name: Check out sources from git
+
+needs:
+  packages:
+    - git
+
+inputs:
+  repository:
+    description: |
+      The repository to check out sources from.
+    required: true
+
+  destination:
+    description: |
+      The path to check out the sources to.
+    default: .
+
+  depth:
+    description: |
+      The depth to use when cloning. Set to -1 to not specify depth when cloning.
+    default: 1
+
+  branch:
+    description: |
+      The branch to check out, otherwise HEAD is checked out.
+
+  tag:
+    description: |
+      The tag to check out.
+
+  expected-commit:
+    description: |
+      The expected commit hash
+
+  recurse-submodules:
+    description: |
+      Indicates whether --recurse-submodules should be passed to git clone.
+    default: false
+
+pipeline:
+  - runs: |
+      #!/bin/sh
+      set -e
+
+      msg() { echo "[git checkout]" "$@" 1>&2; }
+      fail() { msg FAIL "$@"; exit 1; }
+      vr() { msg "execute:" "$@"; "$@"; }
+
+      main() {
+          local repo=$1 dest=${2:-.} depth=${3:-"-1"} branch=$4
+          local tag=$5 expcommit=$6 recurse=${7:-false}
+          msg "repo='$repo' dest='$dest' depth='$depth' branch='$branch'" \
+              "tag='$tag' expcommit='$expcommit' recurse='$recurse'"
+
+          case "$recurse" in
+              true|false) :;;
+              *) fail "recurse must be true or false, not '$recurse'"
+          esac
+
+          [ -n "$repo" ] || fail "repository not provided"
+
+          if [ -z "$branch" ] && [ -z "$tag" ]; then
+              msg "Warning: you have not specified a branch or tag."
+          fi
+
+          [ -n "$expcommit" ] ||
+              msg "Warning: no expected-commit"
+
+          local flags="" depthflag="" dest_fullpath="" workdir=""
+          local remote="origin" rcfile="" rc=""
+          [ -n "$branch" ] && flags="--branch=$branch"
+          [ -n "$tag" ] && flags="--branch=$tag"
+          [ "$recurse" = "true" ] && flags="$flags --recurse-submodules"
+
+          [ "$depth" = "-1" ] || depthflag="--depth=$depth"
+
+          workdir=$(mktemp -d)
+          rcfile=$(mktemp)
+          mkdir -p "$dest"
+          dest_fullpath=$(realpath "$dest")
+
+          vr git config --global --add safe.directory "$workdir"
+          vr git config --global --add safe.directory "$dest_fullpath"
+
+          vr git clone "--origin=$remote" $flags \
+              ${depthflag:+"$depthflag"} "$repo" "$workdir"
+
+          vr cd "$workdir"
+          msg "tar -c . | tar -C \"$dest_fullpath\" -x"
+          ( tar -c . ; echo $? > "$rcfile") | tar -C "$dest_fullpath" -x
+          read rc < "$rcfile" || fail "failed to read rc file"
+          [ $rc -eq 0 ] || fail "tar creation in $workdir failed"
+
+          rm -rf "$workdir"
+          vr cd "$dest_fullpath"
+          vr git config --global --add safe.directory "$dest_fullpath"
+
+          local foundcommit="" tagobj=""
+          vr git config --global advice.detachedHead false
+          if [ -z "$tag" ]; then
+              foundcommit=$(git rev-parse --verify HEAD)
+              if [ -n "$expcommit" ] && [ "$expcommit" != "$foundcommit" ]; then
+                  fail "expected commit $expcommit on ${branch:-HEAD}," \
+                      " got $foundcommit"
+              fi
+              msg "tip of ${branch:-HEAD} is commit $foundcommit"
+              return 0
+          fi
+
+          # git clone --branch=X will pick the branch X if there
+          # exists both a tag and a branch by that name.
+          # since a tag was given, we want the tag.
+          vr git fetch $remote ${depthflag:+"$depthflag"} --no-tags \
+              "+refs/tags/$tag:refs/$remote/tags/$tag"
+          vr git checkout "$remote/tags/$tag"
+
+          foundcommit=$(git rev-parse --verify HEAD)
+          if [ -z "$expcommit" ] || [ "$expcommit" = "$foundcommit" ]; then
+              msg "tag $tag is $foundcommit"
+              return 0
+          fi
+
+          # If it's a tag, then it could be a lightweight or annotated tag.
+          # Lightweight tags point directly to the commit and do not have
+          # any messages, signatures, or other data.  Annotated tags point
+          # to its own git object containing the tag data, with a reference
+          # to the underlying commit.  We expect most tags to be using
+          # annotated tags.
+          tagobj=$(git rev-parse --verify --end-of-options \
+              "refs/$remote/tags/$tag")
+          if [ "$expcommit" != "$tagobj" ]; then
+              [ "$tagobj" != "$expcommit" ] &&
+                  msg "tag object hash was $tagobj"
+              fail "Expected commit $expcommit for $tag, found $foundcommit"
+          fi
+
+          msg "Warning: The provided expected-commit ($expcommit)"
+          msg "was the hash of the annotated tag object for $tag."
+          msg "Update to set expected-commit to $foundcommit"
+
+          return 0
+      }
+
+      main \
+          "${{inputs.repository}}" "${{inputs.destination}}" \
+          "${{inputs.depth}}" "${{inputs.branch}}" \
+          "${{inputs.tag}}" "${{inputs.expected-commit}}" \
+          "${{inputs.recurse-submodules}}"


### PR DESCRIPTION
Fast track https://github.com/chainguard-dev/melange/pull/1310 whilst
updates to wolfictl to new melange & apko are failing.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
