### PR TITLE
adds contour 1.29 compat and bitnami-compat

### DIFF
--- a/contour-1.29.yaml
+++ b/contour-1.29.yaml
@@ -1,7 +1,7 @@
 package:
   name: contour-1.29
   version: 1.29.1
-  epoch: 1
+  epoch: 2
   description: Contour is a Kubernetes ingress controller using Envoy proxy.
   copyright:
     - license: Apache-2.0
@@ -37,6 +37,32 @@ pipeline:
         -X github.com/projectcontour/contour/internal/build.Branch=$(git rev-parse --abbrev-ref HEAD)
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "compat package for contour as expected by envoy"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/bin
+          ln -s /usr/bin/contour "${{targets.subpkgdir}}"/bin/contour
+    dependencies:
+      provides:
+        - contour-compat=${{package.full-version}}
+
+  - name: ${{package.name}}-bitnami-compat
+    description: "compat package with bitnami/contour image"
+    dependencies:
+      provides:
+        - contour-bitnami-compat=${{package.full-version}}
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: contour
+          version-path: 1.29/debian-12
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/contour/bin/
+          chmod g+rwX ${{targets.subpkgdir}}/opt/bitnami
+          ln -sf /usr/bin/contour ${{targets.subpkgdir}}/opt/bitnami/contour/bin/contour
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
