### PR TITLE
fix: subject due to a redeploy of the bincapz-check service

### DIFF
--- a/.github/chainguard/lifecycle-bincapz-check.sts.yaml
+++ b/.github/chainguard/lifecycle-bincapz-check.sts.yaml
@@ -1,7 +1,7 @@
 issuer: https://accounts.google.com
 
 # prod-images: bot-bincapz-check@prod-images-c6e5.iam.gserviceaccount.com
-subject: "111257172661272935124"
+subject: "100391373612188354572"
 
 permissions:
   contents: read


### PR DESCRIPTION
We redeployed bincapz services that changed the service account id for the respective sts policy.