### PR TITLE
Fixing evaluation of load order in php extensions

### DIFF
--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: 8.1.29
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -225,7 +225,10 @@ subpackages:
           [ -f "ext/${{range.key}}/config.w32" ] && \
             deps=`sed -En "s/.*ADD_EXTENSION_DEP\('${{range.key}}', ([^)]+)\).*/\1/p" "ext/${{range.key}}/config.w32" \
                 | tr -d "'," | tr ' ' '\n' \
-                | sort -u | wc -w`
+                | sort -u \
+                | while read -r dep; do
+                  [ "$dep" = "true" ] || echo $dep
+                done | wc -w`
           echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"$((order+order*deps))-${{range.key}}.ini"
 
   - name: ${{package.name}}-dev

--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -15,6 +15,7 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
       - bison
       - build-base
       - busybox
@@ -43,25 +44,22 @@ environment:
       - openssl-dev
       - patch
       - postgresql-dev
+      - re2c
       - readline-dev
       - sqlite-dev
       - unixodbc-dev
+      - wget
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://www.php.net/distributions/php-${{package.version}}.tar.gz
-      expected-sha256: 8b2609bf1d3173aa38269a9af21532c65f730aadd3051f9aae011eea9e246de5
-      extract: false
-
-  - name: Prepare Build Folder
-    runs: |
-      mv php-${{package.version}}.tar.gz $HOME
-      tar zxf $HOME/php-${{package.version}}.tar.gz
+      repository: https://github.com/php/php-src
+      tag: php-${{package.version}}
+      expected-commit: fc4973fb0dfae6085742868b8f0f05163e150a0c
 
   - name: Configure
     runs: |
-      cd $HOME/php-${{package.version}}
+      ./buildconf --force
       EXTENSION_DIR=/usr/lib/php/modules ./configure \
         --prefix=/usr \
         --libdir=/usr/lib/php \
@@ -128,12 +126,9 @@ pipeline:
         --with-zip=shared
 
   - uses: autoconf/make
-    with:
-      dir: $HOME/php-${{package.version}}
 
   - name: Make Install
     runs: |
-      cd $HOME/php-${{package.version}}
       INSTALL_ROOT=${{targets.destdir}} DESTDIR=${{targets.destdir}} make install
       mkdir -p "${{targets.destdir}}/bin" && ln -s /usr/bin/php "${{targets.destdir}}/bin/php"
 
@@ -191,7 +186,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
-          mv $HOME/php-${{package.version}}/php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
+          mv $HOME/php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
 
   - range: extensions
     name: "${{package.name}}-${{range.key}}"

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -15,6 +15,7 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
       - bison
       - build-base
       - busybox
@@ -43,25 +44,22 @@ environment:
       - openssl-dev
       - patch
       - postgresql-dev
+      - re2c
       - readline-dev
       - sqlite-dev
       - unixodbc-dev
+      - wget
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://www.php.net/distributions/php-${{package.version}}.tar.gz
-      expected-sha256: 05a4365f7bc6475ac4fef65dde13886913dbc0036e63895d369c1fc6e8206107
-      extract: false
-
-  - name: Prepare Build Folder
-    runs: |
-      mv php-${{package.version}}.tar.gz $HOME
-      tar zxf $HOME/php-${{package.version}}.tar.gz
+      repository: https://github.com/php/php-src
+      tag: php-${{package.version}}
+      expected-commit: 40298a988fca728ddc47316938da61e0f768c872
 
   - name: Configure
     runs: |
-      cd $HOME/php-${{package.version}}
+      ./buildconf --force
       EXTENSION_DIR=/usr/lib/php/modules ./configure \
         --prefix=/usr \
         --libdir=/usr/lib/php \
@@ -128,12 +126,9 @@ pipeline:
         --with-zip=shared
 
   - uses: autoconf/make
-    with:
-      dir: $HOME/php-${{package.version}}
 
   - name: Make Install
     runs: |
-      cd $HOME/php-${{package.version}}
       INSTALL_ROOT=${{targets.destdir}} DESTDIR=${{targets.destdir}} make install
       mkdir -p "${{targets.destdir}}/bin" && ln -s /usr/bin/php "${{targets.destdir}}/bin/php"
 
@@ -191,7 +186,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
-          mv $HOME/php-${{package.version}}/php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
+          mv $HOME/php.ini-production ${{targets.subpkgdir}}/etc/php/php.ini
 
   - range: extensions
     name: "${{package.name}}-${{range.key}}"

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: 8.2.20
-  epoch: 1
+  epoch: 2
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -225,7 +225,10 @@ subpackages:
           [ -f "ext/${{range.key}}/config.w32" ] && \
             deps=`sed -En "s/.*ADD_EXTENSION_DEP\('${{range.key}}', ([^)]+)\).*/\1/p" "ext/${{range.key}}/config.w32" \
                 | tr -d "'," | tr ' ' '\n' \
-                | sort -u | wc -w`
+                | sort -u \
+                | while read -r dep; do
+                  [ "$dep" = "true" ] || echo $dep
+                done | wc -w`
           echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"$((order+order*deps))-${{range.key}}.ini"
 
   - name: ${{package.name}}-dev

--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: 8.3.8
-  epoch: 2
+  epoch: 3
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -219,7 +219,10 @@ subpackages:
           [ -f "ext/${{range.key}}/config.w32" ] && \
             deps=`sed -En "s/.*ADD_EXTENSION_DEP\('${{range.key}}', ([^)]+)\).*/\1/p" "ext/${{range.key}}/config.w32" \
                 | tr -d "'," | tr ' ' '\n' \
-                | sort -u | wc -w`
+                | sort -u \
+                | while read -r dep; do
+                  [ "$dep" = "true" ] || echo $dep
+                done | wc -w`
           echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"$((order+order*deps))-${{range.key}}.ini"
 
   - name: ${{package.name}}-dev


### PR DESCRIPTION
The PR has fixes for the PR #22229 where the evaluation of dependencies was faulty. I also detected another issue where PHP 8.2 and 8.1 where not evaluating anything because the build paths where different and the extension config files could not be found.

I updated the 8.2 and 8.1 builds to mirror what we have for 8.3, using Github as source and default build dirs. Tested adding the packages in a local wolfi env and the configuration files are now in correct order. Confirmed same result in 8.3, 8.2, and 8.1.

Epochs bumped accordingly.
