### PR TITLE
Break autoconf/configure cycle for git-bootstrap

### DIFF
--- a/git-bootstrap.yaml
+++ b/git-bootstrap.yaml
@@ -86,9 +86,18 @@ pipeline:
         with:
           uri: https://curl.se/download/curl-${{vars.curl-version}}.tar.xz
           expected-sha256: 6fea2aac6a4610fbd0400afb0bcddbe7258a64c63f1f68e5855ebc0c659710cd
-      - uses: autoconf/configure
-        with:
-          opts: --with-openssl --disable-docs --disable-manual --disable-shared
+      - runs: |
+          # NB: Intentionally not using autoconf/configure to avoid dependency cycle.
+          ./configure \
+            --host=${{host.triplet.gnu}} \
+            --build=${{host.triplet.gnu}} \
+            --prefix=/usr \
+            --sysconfdir=/etc \
+            --libdir=/usr/lib \
+            --mandir=/usr/share/man \
+            --infodir=/usr/share/info \
+            --localstatedir=/var \
+            --with-openssl --disable-docs --disable-manual --disable-shared
       - runs: |
           make -C lib/ -j$(nproc)
           make -C src/ -j$(nproc)


### PR DESCRIPTION
Since we added autoreconf as a dependency for autoconf/configure, attempting to build git-bootstrap introduces a dependency cycle. This inlines the previous implementation to break that cycle.