### PR TITLE
pytorch update to 2.3.1

### DIFF
--- a/pytorch.yaml
+++ b/pytorch.yaml
@@ -1,6 +1,6 @@
 package:
   name: pytorch
-  version: 2.3.0
+  version: 2.3.1
   epoch: 0
   description: Tensors and Dynamic neural networks in Python with strong GPU acceleration
   copyright:
@@ -33,7 +33,7 @@ pipeline:
     with:
       repository: https://github.com/pytorch/pytorch.git
       tag: v${{package.version}}
-      expected-commit: 97ff6cfd9c86c5c09d7ce775ab64ec5c99230f5d
+      expected-commit: 63d5e9221bedd1546b7d364b5ce4171547db12a9
 
   - runs: git submodule update --init --recursive
 


### PR DESCRIPTION
* pytorch update to 2.3.1 

- [x] The `epoch` field is reset to 0


