### PR TITLE
udns

### DIFF
--- a/udns.yaml
+++ b/udns.yaml
@@ -1,0 +1,59 @@
+package:
+  name: udns
+  version: "0.5"
+  epoch: 0
+  description: DNS Resolver Library
+  copyright:
+    - license: LGPL-2.1-or-later
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 035bfc12e3819d0aba8f40ee8220a974b7e9b29c3259d310970cc4b2d1c203c0
+      uri: https://www.corpit.ru/mjt/udns/udns-${{package.version}}.tar.gz
+
+  - runs: |
+      mkdir -p "${{targets.contextdir}}"/usr/bin
+      mkdir -p "${{targets.contextdir}}"/usr/include
+      mkdir -p "${{targets.contextdir}}"/usr/lib
+      ./configure
+      make
+      make sharedlib
+      install -Dm755 dnsget rblcheck ex-rdns -t "${{targets.contextdir}}"/usr/bin
+      install -Dm644 udns.h -t "${{targets.contextdir}}"/usr/include
+      install -Dm755 libudns.so.0 -t "${{targets.contextdir}}"/usr/lib
+      ln -s libudns.so.0 "${{targets.contextdir}}"/usr/lib/libudns.so
+
+  - uses: strip
+
+subpackages:
+  - name: udns-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - udns
+    description: udns dev
+
+  - name: udns-doc
+    pipeline:
+      - uses: split/manpages
+    description: udns manpages
+
+test:
+  pipeline:
+    - runs: |
+        dnsget -h
+        rblcheck -h
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5031


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
