### PR TITLE
Git checkout pkgs 6

### DIFF
--- a/ipset.yaml
+++ b/ipset.yaml
@@ -1,7 +1,7 @@
 package:
   name: ipset
   version: "7.22"
-  epoch: 0
+  epoch: 1
   description: Manage Linux IP sets
   copyright:
     - license: GPL-2.0-only
@@ -17,12 +17,18 @@ environment:
       - libmnl-dev
       - libtool
       - linux-headers
+      - pkgconf-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ipset.netfilter.org/ipset-${{package.version}}.tar.bz2
-      expected-sha512: e375a9110eb7974480147c57eb2cff4bdd03c7704cdae006a3d254cc80fada587aa8aee25a86f7cab29db83f5e283c5f9a47a314297317660ebba5097f623d79
+      repository: https://git.netfilter.org/ipset
+      tag: v${{package.version}}
+      expected-commit: 715a01d1942fca674d87e5b3081f2c0e4d8cba24
+      depth: "-1"
+
+  - runs: |
+      ./autogen.sh
 
   - uses: autoconf/configure
     with:

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables
   version: 1.8.10
-  epoch: 3
+  epoch: 4
   description: Linux kernel firewall, NAT and packet mangling tools
   copyright:
     - license: GPL-2.0-or-later
@@ -9,6 +9,8 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
       - bash
       - bison
       - build-base
@@ -17,13 +19,20 @@ environment:
       - flex
       - libmnl-dev
       - libnftnl-dev
+      - libtool
       - linux-headers
+      - pkgconf-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://www.netfilter.org/projects/iptables/files/iptables-${{package.version}}.tar.xz
-      expected-sha256: 5cc255c189356e317d070755ce9371eb63a1b783c34498fb8c30264f3cc59c9c
+      repository: https://git.netfilter.org/iptables
+      tag: v${{package.version}}
+      expected-commit: 9b9d9a1b0c9ec85d406d7475961068628074ddcf
+      depth: "-1"
+
+  - runs: |
+      ./autogen.sh
 
   - runs: |
       export CFLAGS="$CFLAGS -D_GNU_SOURCE"

--- a/ipvsadm.yaml
+++ b/ipvsadm.yaml
@@ -1,7 +1,7 @@
 package:
   name: ipvsadm
   version: 1.31
-  epoch: 0
+  epoch: 1
   description: The IP Virtual Server administration utility
   copyright:
     - license: GPL-2.0-or-later
@@ -19,10 +19,11 @@ environment:
       - popt-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 1a0a5e25b5a1226435d2fb76341656f83a710183aebb0d204db39c0ec3bedfdb
-      uri: https://kernel.org/pub/linux/utils/kernel/ipvsadm/ipvsadm-${{package.version}}.tar.xz
+      repository: https://git.kernel.org/pub/scm/utils/kernel/ipvsadm/ipvsadm.git
+      tag: v${{package.version}}
+      expected-commit: 73468692914a1b23301f83a27f55130ab8ff1fb1
 
   - runs: |
       make libs && make BUILD_ROOT="${{targets.destdir}}" \

--- a/isl.yaml
+++ b/isl.yaml
@@ -1,7 +1,7 @@
 package:
   name: isl
   version: 0.26
-  epoch: 3
+  epoch: 4
   description: "an integer set library for the polyhedral model"
   copyright:
     - license: MIT
@@ -9,17 +9,24 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
+      - automake
       - build-base
       - busybox
       - ca-certificates-bundle
       - gmp-dev
+      - libtool
       - wolfi-baselayout
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://libisl.sourceforge.io/isl-${{package.version}}.tar.gz
-      expected-sha256: b10473024cbf17d7db85323121eff0e50f03de14342a03738b4d384b587ce212
+      repository: https://repo.or.cz/isl.git
+      tag: isl-${{package.version}}
+      expected-commit: e58af07f91c94db81627fb801fa6f52c3a7201a8
+
+  - runs: |
+      autoreconf -vfi
 
   - runs: |
       ./configure \

--- a/jansson.yaml
+++ b/jansson.yaml
@@ -1,7 +1,7 @@
 package:
   name: jansson
   version: "2.14"
-  epoch: 1
+  epoch: 2
   description: lightweight JSON library
   copyright:
     - license: MIT
@@ -14,12 +14,17 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 5798d010e41cf8d76b66236cfb2f2543c8d082181d16bc3085ab49538d4b9929
-      uri: https://github.com/akheron/jansson/releases/download/v${{package.version}}/jansson-${{package.version}}.tar.gz
+      repository: https://github.com/akheron/jansson.git
+      tag: v${{package.version}}
+      expected-commit: 684e18c927e89615c2d501737e90018f4930d6c5
+
+  - runs: |
+      autoreconf -vfi
 
   - uses: autoconf/configure
 


### PR DESCRIPTION
Updates 5 packages to use git-checkout instead of fetch:
* ipset
* iptables
* ipvsadm
* isl
* jansson