### PR TITLE
Updates jenkins-entrypoint, jq, keyutils, kmod, krb5 to use git-checkout

### DIFF
--- a/jenkins-entrypoint.yaml
+++ b/jenkins-entrypoint.yaml
@@ -4,7 +4,7 @@
 package:
   name: jenkins-entrypoint
   version: "2.463"
-  epoch: 0
+  epoch: 1
   description: Fetches the jenkins entrypoint script from upstream docker repository.
   copyright:
     - license: MIT
@@ -15,11 +15,11 @@ environment:
       - busybox
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://raw.githubusercontent.com/jenkinsci/docker/${{package.version}}/jenkins.sh
-      expected-sha256: faf757d5ae6f70f59e3adcf025b9881f7b45aaf4b7a9e64aaf7c04d8d353d53f
-      extract: false
+      repository: https://github.com/jenkinsci/docker.git
+      tag: ${{package.version}}
+      expected-commit: 6f8d9e3925d6fd9256a761a159ae69f622807308
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/local/bin/

--- a/jq.yaml
+++ b/jq.yaml
@@ -1,7 +1,7 @@
 package:
   name: jq
   version: 1.7.1
-  epoch: 1
+  epoch: 2
   description: "a lightweight and flexible JSON processor"
   copyright:
     - license: MIT
@@ -9,17 +9,23 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
       - oniguruma-dev
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/jqlang/jq/releases/download/jq-${{package.version}}/jq-${{package.version}}.tar.gz
-      expected-sha256: 478c9ca129fd2e3443fe27314b455e211e0d8c60bc8ff7df703873deeee580c2
+      repository: https://github.com/jqlang/jq.git
+      tag: jq-${{package.version}}
+      expected-commit: 71c2ab509a8628dbbad4bc7b3f98a64aa90d3297
+
+  - runs: |
+      autoreconf -vfi
 
   - uses: autoconf/configure
 

--- a/keyutils.yaml
+++ b/keyutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: keyutils
   version: 1.6.3
-  epoch: 2
+  epoch: 3
   description: Linux Key Management Utilities
   copyright:
     - license: GPL-2.0-or-later OR LGPL-2.0-or-later
@@ -18,10 +18,11 @@ environment:
       - linux-headers
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: a61d5706136ae4c05bd48f86186bcfdbd88dd8bd5107e3e195c924cfc1b39bb4
-      uri: https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git/snapshot/keyutils-${{package.version}}.tar.gz
+      repository: https://kernel.googlesource.com/pub/scm/linux/kernel/git/dhowells/keyutils.git
+      tag: v${{package.version}}
+      expected-commit: 5678a1aae8834b5c16b5ed7dc72ef8836a29e122
 
   - uses: autoconf/make
     with:

--- a/kmod.yaml
+++ b/kmod.yaml
@@ -1,7 +1,7 @@
 package:
   name: kmod
   version: "32"
-  epoch: 2
+  epoch: 3
   description: Linux kernel module management utilities
   copyright:
     - license: GPL-2.0-or-later
@@ -14,8 +14,11 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gtk-doc
+      - libtool
       - libxslt
       - openssl-dev
+      - pkgconf-dev
       - sed
       - tree
       - xz-dev
@@ -23,10 +26,14 @@ environment:
       - zstd-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 630ed0d92275a88cb9a7bf68f5700e911fdadaf02e051cf2e4680ff8480bd492
-      uri: https://kernel.org/pub/linux/utils/kernel/kmod/kmod-${{package.version}}.tar.xz
+      repository: https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git
+      tag: v${{package.version}}
+      expected-commit: af14bd8afa15e3a348b50352816517a07e315117
+    
+  - runs: |
+      ./autogen.sh
 
   - uses: autoconf/configure
     with:

--- a/kmod.yaml
+++ b/kmod.yaml
@@ -31,7 +31,7 @@ pipeline:
       repository: https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git
       tag: v${{package.version}}
       expected-commit: af14bd8afa15e3a348b50352816517a07e315117
-    
+
   - runs: |
       ./autogen.sh
 

--- a/krb5.yaml
+++ b/krb5.yaml
@@ -1,7 +1,7 @@
 package:
   name: krb5
   version: 1.21.2
-  epoch: 2
+  epoch: 3
   description: The Kerberos network authentication system
   copyright:
     - license: MIT
@@ -25,10 +25,15 @@ environment:
       - perl
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 9560941a9d843c0243a71b17a7ac6fe31c7cebb5bce3983db79e52ae7e850491
-      uri: https://web.mit.edu/kerberos/dist/krb5/1.21/krb5-${{package.version}}.tar.gz
+      repository: https://github.com/krb5/krb5.git
+      tag: krb5-${{package.version}}-final
+      expected-commit: 835f6e3d819beb7ee1046f01afb284b54ad54c5f
+
+  - working-directory: src
+    runs: |
+      autoreconf -vfi
 
   - uses: autoconf/configure
     with:
@@ -126,6 +131,8 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 13287
+  github:
+    identifier: krb5/krb5
+    use-tag: true
+    strip-prefix: krb5-
     strip-suffix: -final


### PR DESCRIPTION
Updates packages to use git-checkout over fetch:
* jenkins-entrypoint
* jq
* keyutils
* kmod
* krb5