### PR TITLE
Find yaml files without 'find' and avoid searching .git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ define get-source-dir
 endef
 
 package/%:
-	$(eval yamlfile := $(shell find . -type f \( -name "$*.yaml" -o -path "*/$*/$*.melange.yaml" \) -not -path "*.melangecache/*" | head -n 1))
+	$(eval yamlfile=$(firstword $(wildcard $*.yaml */$*/$*.melange.yaml)))
 	@if [ -z "$(yamlfile)" ]; then \
 		echo "Error: could not find yaml file for $*"; exit 1; \
 	else \
@@ -149,8 +149,9 @@ packages/$(ARCH)/%.apk: $(KEY)
 	$(info @SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) $(srcdirflag))
 	@SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) $(srcdirflag)
 
+
 debug/%:
-	$(eval yamlfile := $(shell find . -type f \( -name "$*.yaml" -o -path "*/$*/$*.melange.yaml" \) | head -n 1))
+	$(eval yamlfile=$(firstword $(wildcard $*.yaml */$*/$*.melange.yaml)))
 	@if [ -z "$(yamlfile)" ]; then \
 		echo "Error: could not find yaml file for $*"; exit 1; \
 	else \
@@ -169,7 +170,7 @@ debug/%:
 
 test/%:
 	@mkdir -p ./$(*)/
-	$(eval yamlfile := $(shell find . -type f \( -name "$*.yaml" -o -path "*/$*/$*.melange.yaml" \) -not -path "*.melangecache/*" | head -n 1))
+	$(eval yamlfile=$(firstword $(wildcard $*.yaml */$*/$*.melange.yaml)))
 	@if [ -z "$(yamlfile)" ]; then \
 		echo "Error: could not find yaml file for $*"; exit 1; \
 	else \


### PR DESCRIPTION
This fixes a DOS attack that ajay made on me when he added named branches 'refactor/zstd.yaml' and I added his git repo to my known remotes lists.

    $ find . -name zstd.yaml
    ./.git/refs/remotes/ajay/refactor/zstd.yaml
    ./.git/logs/refs/remotes/ajay/refactor/zstd.yaml
    ./zstd.yaml

    $ make debug/zstd
    yamlfile is .git/refs/remotes/ajay/refactor/zstd.yaml
    ...

