### PR TITLE
Revert "Merge pull request #22192 from dakaneye/git-checkout-pkgs-2"

### DIFF
--- a/gnutls.yaml
+++ b/gnutls.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnutls
   version: 3.8.5
-  epoch: 1
+  epoch: 0
   description: TLS protocol implementation
   copyright:
     - license: LGPL-2.1-or-later
@@ -22,37 +22,23 @@ environment:
     packages:
       - autoconf
       - automake
-      - bison
       - build-base
       - busybox
       - ca-certificates-bundle
-      - coreutils
-      - gettext-dev
-      - gperf
-      - gtk-doc
-      - libev-dev
       - libkcapi-dev
       - libtasn1-dev
-      - libtool
       - libunistring-dev
       - linux-headers
       - nettle-dev
       - p11-kit-dev
-      - patch
-      - pkgconf-dev
       - texinfo
-      - wget
       - zlib-dev
 
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://github.com/gnutls/gnutls.git
-      tag: ${{package.version}}
-      expected-commit: 49f4ae2109b7cc969539b90be92a5844bbe7b322
-
-  - runs: |
-      ./bootstrap
+      expected-sha256: 66269a2cfe0e1c2dabec87bdbbd8ab656f396edd9a40dd006978e003cfa52bfc
+      uri: https://www.gnupg.org/ftp/gcrypt/gnutls/v${{vars.mangled-package-version}}/gnutls-${{package.version}}.tar.xz
 
   - runs: |
       LIBS="-lgmp"  \
@@ -116,8 +102,5 @@ subpackages:
 
 update:
   enabled: true
-  ignore-regex-patterns:
-    - "^gnutls.*"
-  github:
-    identifier: gnutls/gnutls
-    use-tag: true
+  release-monitor:
+    identifier: 1221

--- a/gzip.yaml
+++ b/gzip.yaml
@@ -1,7 +1,7 @@
 package:
   name: gzip
   version: "1.13"
-  epoch: 2
+  epoch: 1
   description: "GNU data compression program"
   copyright:
     - license: GPL-3.0-or-later
@@ -9,25 +9,15 @@ package:
 environment:
   contents:
     packages:
-      - autoconf
-      - automake
       - build-base
       - busybox
       - ca-certificates-bundle
-      - coreutils
-      - gettext-dev
-      - texinfo
-      - xz
 
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://git.savannah.gnu.org/git/gzip.git
-      tag: v${{package.version}}
-      expected-commit: ec1a0b1af679e252839ef4996e92f69d3ee8b3d2
-
-  - runs: |
-      ./bootstrap
+      uri: https://ftp.gnu.org/gnu/gzip/gzip-${{package.version}}.tar.gz
+      expected-sha256: 20fc818aeebae87cdbf209d35141ad9d3cf312b35a5e6be61bfcfbf9eddd212a
 
   - name: Configure
     runs: |

--- a/haproxy-2.9.yaml
+++ b/haproxy-2.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-2.9
-  version: 2.9.9
-  epoch: 0
+  version: 2.9.7
+  epoch: 1
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: GPL-2.0-or-later
@@ -10,6 +10,14 @@ package:
       - libgcc
     provides:
       - haproxy=${{package.full-version}}
+
+# creates a new var that contains only the major and minor version to be used in the fetch URL
+# e.g. 2.6.11 will create a new var mangled-package-version=2.6
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d+\.\d+)\.\d+
+    replace: $1
+    to: mangled-package-version
 
 environment:
   contents:
@@ -24,12 +32,10 @@ environment:
       - pcre2-dev
 
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://git.haproxy.org/git/haproxy-2.9.git/
-      tag: v${{package.version}}
-      expected-commit: ad75c480c019cf1522049cbe8f654807d434743f
-      depth: "-1"
+      uri: https://www.haproxy.org/download/${{vars.mangled-package-version}}/src/haproxy-${{package.version}}.tar.gz
+      expected-sha256: d1a0a56f008a8d2f007bc0c37df6b2952520d1f4dde33b8d3802710e5158c131
 
   - uses: autoconf/make
     with:
@@ -79,6 +85,6 @@ subpackages:
           chmod +x ${{targets.subpkgdir}}/usr/local/bin/docker-entrypoint.sh
 
 update:
-  enabled: false
+  enabled: true
   release-monitor:
     identifier: 1298

--- a/iperf.yaml
+++ b/iperf.yaml
@@ -1,17 +1,10 @@
-#nolint:valid-pipeline-git-checkout-tag
 package:
   name: iperf
   version: 2.2.0
-  epoch: 1
+  epoch: 0
   description: A tool to measure IP bandwidth using UDP or TCP
   copyright:
     - license: NCSA
-
-var-transforms:
-  - from: ${{package.version}}
-    match: \.
-    replace: "-"
-    to: mangled-package-version
 
 environment:
   contents:
@@ -24,12 +17,10 @@ environment:
       - linux-headers
 
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://git.code.sf.net/p/iperf2/code
-      # The iperf2 code doesn't seem to track using tags
-      branch: ${{vars.mangled-package-version}}
-      expected-commit: 59ccf3c5aac51873cd99f0e423f7ac3023aa9c2a
+      expected-sha256: 16810a9575e4c6dd65e4a18ab5df3cdac6730b3c832cf080a8990f132f68364a
+      uri: https://sourceforge.net/projects/iperf2/files/iperf-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:

--- a/iproute2.yaml
+++ b/iproute2.yaml
@@ -1,7 +1,7 @@
 package:
   name: iproute2
   version: 6.9.0
-  epoch: 1
+  epoch: 0
   description: IP Routing Utilities
   copyright:
     - license: GPL-2.0-or-later
@@ -19,11 +19,10 @@ environment:
       - iptables-dev
 
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://git.kernel.org/pub/scm/network/iproute2/iproute2.git
-      tag: v${{package.version}}
-      expected-commit: 3724f17a4be32d89044c6967846eb20ce5bed383
+      uri: https://kernel.org/pub/linux/utils/net/iproute2/iproute2-${{package.version}}.tar.xz
+      expected-sha256: 2f643d09ea11a4a2a043c92e2b469b5f73228cbf241ae806760296ed0ec413d0
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
This reverts commit c398e65ad6a4852bac99329832458108374c752e, reversing changes made to d905760613c70702b4fd993451ca8fddfc82caff.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
