### PR TITLE
Drop sourcedir logic from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,95 +93,48 @@ list-yaml:
 	$(info $(addsuffix .yaml,$(shell $(PKGLISTCMD))))
 	@printf ''
 
-# This function parses the path from the package file. It's used to figure out
-# what to mount to the container image as supporting files (patches, tests,
-# etc.)
-# Returns the directory of the package in the first variable passed in. In
-# example below this would be ret-variable-in-calling-function. You do not need
-# to explicitly declare this variable in the calling function, just add to
-# argument list and it will be populated and usable.
-#
-# $(call get-package-dir,ret-variable-in-calling-function,package-file)
-define get-package-dir
-	$(info getting package dir for $(2))
-	$(eval pkgdir := $(shell dirname $(2)))
-	$(info For package $(1) found dir: $(pkgdir))
-	$(1) := ${pkgdir}
-endef
-
-# This function tries to figure out what the 'source-dir' is for the package.
-# It's complicated by the fact that it can either be './<package-name>' for
-# packages before the refactoring, or it can be a relative path
-# './<module>/package/', and in some cases it may not exist.
-# To make it easier on the caller, it returns the entire:
-# `--source-dir ./<package-name>`, or `--source-dir ./<module>/package/`, or ""
-# as the first variable passed in, and this is meant to be directly passed
-# to the melange build/test command.
-#
-#$(call get-source-dir,ret-variable-for-source-dir,package-dir,package-name)
-define get-source-dir
-	$(info getting source dir for package $(3) with dir $(2))
-	$(1) := $(shell if [ "." = "$(2)" ]; then \
-		echo "--source-dir ./$(3)"; \
-	else \
-		echo "--source-dir $(2)"; \
-	fi)
-endef
-
 package/%:
-	$(eval yamlfile := $(shell find . -type f \( -name "$*.yaml" -o -path "*/$*/$*.melange.yaml" \) -not -path "*.melangecache/*" | head -n 1))
+	$(eval yamlfile := $*.yaml)
 	@if [ -z "$(yamlfile)" ]; then \
 		echo "Error: could not find yaml file for $*"; exit 1; \
 	else \
 		echo "yamlfile is $(yamlfile)"; \
 	fi
-	$(eval $(call get-package-dir,pkgdir,$(yamlfile)))
-	$(info found package dir as $(pkgdir))
-	$(eval $(call get-source-dir,sourcedir,$(pkgdir),$*))
-	$(info found source dir as $(sourcedir))
 	$(eval pkgver := $(shell $(MELANGE) package-version $(yamlfile)))
 	@printf "Building package $* with version $(pkgver) from file $(yamlfile)\n"
-	$(MAKE) yamlfile=$(yamlfile) srcdirflag="$(sourcedir)" pkgname=$* packages/$(ARCH)/$(pkgver).apk
+	$(MAKE) yamlfile=$(yamlfile) pkgname=$* packages/$(ARCH)/$(pkgver).apk
 
 packages/$(ARCH)/%.apk: $(KEY)
 	@mkdir -p ./$(pkgname)/
 	$(eval SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct --follow $(yamlfile)))
-	$(info @SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) $(srcdirflag))
-	@SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) $(srcdirflag)
+	$(info @SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS))
+	@SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) --source-dir ./$(pkgname)/
 
 debug/%:
-	$(eval yamlfile := $(shell find . -type f \( -name "$*.yaml" -o -path "*/$*/$*.melange.yaml" \) | head -n 1))
+	$(eval yamlfile := $*.yaml)
 	@if [ -z "$(yamlfile)" ]; then \
 		echo "Error: could not find yaml file for $*"; exit 1; \
 	else \
 		echo "yamlfile is $(yamlfile)"; \
 	fi
-	$(eval $(call get-package-dir,pkgdir,$(yamlfile)))
-	$(info found package dir as $(pkgdir))
-	$(eval $(call get-source-dir,sourcedir,$(pkgdir),$*))
-	$(info found source dir as $(sourcedir))
 	$(eval pkgver := $(shell $(MELANGE) package-version $(yamlfile)))
 	@printf "Building package $* with version $(pkgver) from file $(yamlfile)\n"
 	@mkdir -p ./"$*"/
 	$(eval SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct --follow $(yamlfile)))
-	$(info @SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS) $(sourcedir))
-	@SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_DEBUG_OPTS) $(sourcedir)
+	$(info @SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_OPTS))
+	@SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(MELANGE) build $(yamlfile) $(MELANGE_DEBUG_OPTS) --source-dir ./$(*)/
 
 test/%:
 	@mkdir -p ./$(*)/
-	$(eval yamlfile := $(shell find . -type f \( -name "$*.yaml" -o -path "*/$*/$*.melange.yaml" \) -not -path "*.melangecache/*" | head -n 1))
+	$(eval yamlfile := $*.yaml)
 	@if [ -z "$(yamlfile)" ]; then \
 		echo "Error: could not find yaml file for $*"; exit 1; \
 	else \
 		echo "yamlfile is $(yamlfile)"; \
 	fi
-	$(eval $(call get-package-dir,pkgdir,$(yamlfile)))
-	$(info found package dir as $(pkgdir))
-	$(eval $(call get-source-dir,sourcedir,$(pkgdir),$*))
-	$(info found source dir as $(sourcedir))
 	$(eval pkgver := $(shell $(MELANGE) package-version $(yamlfile)))
 	@printf "Testing package $* with version $(pkgver) from file $(yamlfile)\n"
-	$(MELANGE) test $(yamlfile) $(sourcedir) $(MELANGE_TEST_OPTS)
+	$(MELANGE) test $(yamlfile) $(MELANGE_TEST_OPTS) --source-dir ./$(*)/
 
 dev-container:
 	docker run --privileged --rm -it \

--- a/crane.yaml
+++ b/crane.yaml
@@ -1,7 +1,7 @@
 package:
   name: crane
   version: 0.19.2
-  epoch: 0
+  epoch: 1
   description: Tool for interacting with remote images and registries.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
We don't have any configs in nonstandard locations, so let's stop trying to support it.

Bump crane to make sure I haven't broken the Makefile.
