### PR TITLE
gitlab-container-registry revert back to 4.4.0 and withdrawn the 4.5.0

### DIFF
--- a/gitlab-container-registry.yaml
+++ b/gitlab-container-registry.yaml
@@ -1,6 +1,6 @@
 package:
   name: gitlab-container-registry
-  version: 4.5.0
+  version: 4.4.0
   epoch: 0
   description: The GitLab Container Registry originated as a fork of the Docker Distribution Registry, now CNCF Distribution, both distributed under Apache License Version 2.0.
   copyright:
@@ -15,7 +15,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://gitlab.com/gitlab-org/container-registry
-      expected-commit: 96e8efda4e5837182a93e62aab2de89991d762bf
+      expected-commit: 7365a280a92c88c187d1dbdfd5f9f3d99d7014c5
       tag: v${{package.version}}-gitlab
 
   - uses: go/bump

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -112,3 +112,5 @@ python-3.12-default-3.12.2-r5.apk
 python-3.12-default-3.12.2-r6.apk
 python-3.12-dev-default-3.12.2-r5.apk
 python-3.12-dev-default-3.12.2-r6.apk
+gitlab-container-registry-4.5.0-r0.apk
+gitlab-container-registry-compat-4.5.0-r0.apk


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
