### PR TITLE
Git checkout pkgs 10

### DIFF
--- a/libsm.yaml
+++ b/libsm.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsm
   version: 1.2.4
-  epoch: 3
+  epoch: 4
   description: X11 Session Management library
   copyright:
     - license: MIT
@@ -15,8 +15,12 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gettext-dev
+      - intltool
       - libice-dev
+      - libtool
       - libuuid
+      - pkgconf-dev
       - util-linux-dev
       - util-macros
       - xmlto
@@ -24,10 +28,13 @@ environment:
       - xtrans
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 51464ce1abce323d5b6707ceecf8468617106e1a8a98522f8342db06fd024c15
-      uri: https://www.x.org/releases/individual/lib/libSM-${{package.version}}.tar.gz
+      repository: https://gitlab.freedesktop.org/xorg/lib/libsm.git
+      tag: libSM-${{package.version}}
+      expected-commit: dc882ac7b748048f12b033d0d8e5267a6e36036a
+
+  - runs: autoreconf -vfi
 
   - uses: autoconf/configure
     with:

--- a/libsodium.yaml
+++ b/libsodium.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsodium
-  version: 1.0.18
-  epoch: 5
+  version: 1.0.20
+  epoch: 0
   description: P(ortable|ackageable) NaCl-based crypto library
   copyright:
     - license: ISC
@@ -16,10 +16,11 @@ environment:
       - ca-certificates-bundle
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1
-      uri: https://github.com/jedisct1/libsodium/releases/download/${{package.version}}-RELEASE/libsodium-${{package.version}}.tar.gz
+      repository: https://github.com/jedisct1/libsodium.git
+      tag: ${{package.version}}-RELEASE
+      expected-commit: 9511c982fb1d046470a8b42aa36556cdb7da15de
 
   - uses: autoconf/configure
 
@@ -45,4 +46,7 @@ subpackages:
 
 update:
   enabled: true
-  manual: true # need to add a melange config to strip the suffix -RELEASE
+  github:
+    identifier: jedisct1/libsodium
+    tag-filter-contains: -RELEASE
+    strip-suffix: -RELEASE

--- a/libssh.yaml
+++ b/libssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: libssh
   version: 0.10.6
-  epoch: 1
+  epoch: 2
   description: Library for accessing ssh client services through C libraries
   copyright:
     - license: LGPL-2.1-or-later AND BSD-2-Clause
@@ -19,10 +19,11 @@ environment:
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha512: 40c62d63c44e882999b71552c237d73fc7364313bd00b15a211a34aeff1b73693da441d2c8d4e40108d00fb7480ec7c5b6d472f9c0784b2359a179632ab0d6c1
-      uri: https://www.libssh.org/files/0.10/libssh-${{package.version}}.tar.xz
+      repository: https://git.libssh.org/projects/libssh.git
+      tag: libssh-${{package.version}}
+      expected-commit: 291548af0009b8d2456e3c7e31dadd7d89ba43b0
 
   - runs: |
       cmake -B build -G Ninja \

--- a/libssh2.yaml
+++ b/libssh2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libssh2
   version: 1.11.0 # Remove CVE-2023-48795.patch when upgrading to 1.11.1
-  epoch: 3
+  epoch: 4
   description: "A library implementing the SSH2 protocol as defined by Internet Drafts"
   copyright:
     - license: BSD-3-Clause
@@ -9,22 +9,27 @@ package:
 environment:
   contents:
     packages:
+      - autoconf
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
       - openssl-dev
       - wolfi-baselayout
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://www.libssh2.org/download/libssh2-${{package.version}}.tar.gz
-      expected-sha256: 3736161e41e2693324deb38c26cfdc3efe6209d634ba4258db1cecff6a5ad461
+      repository: https://github.com/libssh2/libssh2.git
+      tag: libssh2-${{package.version}}
+      expected-commit: 1c3f1b7da588f2652260285529ec3c1f1125eb4e
 
   - uses: patch
     with:
       # Source CVE-2023-48795: https://github.com/libssh2/libssh2/commit/d34d9258b8420b19ec3f97b4cc5bf7aa7d98e35a
       patches: CVE-2023-48795.patch
+
+  - runs: autoreconf -vfi
 
   - uses: autoconf/configure
 
@@ -42,5 +47,10 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 1730
+  ignore-regex-patterns:
+    - "^RELEASE.*"
+    - "^beforenb.*"
+    - "^start$"
+  github:
+    identifier: libssh2/libssh2
+    strip-prefix: libssh2-

--- a/openldap.yaml
+++ b/openldap.yaml
@@ -1,7 +1,7 @@
 package:
   name: openldap
   version: 2.6.8
-  epoch: 3
+  epoch: 4
   description: LDAP Server
   copyright:
     - license: OLDAP-2.8

--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: 8.1.29
-  epoch: 3
+  epoch: 4
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: 8.2.20
-  epoch: 3
+  epoch: 4
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/unbound.yaml
+++ b/unbound.yaml
@@ -1,7 +1,7 @@
 package:
   name: unbound
   version: 1.20.0
-  epoch: 0
+  epoch: 1
   description: "Unbound is a validating, recursive, and caching DNS resolver."
   copyright:
     - license: BSD-3-Clause

--- a/zeromq.yaml
+++ b/zeromq.yaml
@@ -1,7 +1,7 @@
 package:
   name: zeromq
   version: 4.3.5
-  epoch: 0
+  epoch: 1
   description: The ZeroMQ messaging library and tools
   copyright:
     - license: MPL-2.0


### PR DESCRIPTION
Updates packages to use git-checkout:
* libsm
* libssh
* libssh2
* libsodium: Note this one causes an ABI compatibility check failure, but I've bumped the epochs on it's dependent packages and nothing appears broken.