### PR TITLE
Create a package for using `systemd` for `/init`

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "256.1"
-  epoch: 0
+  epoch: 1
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -57,6 +57,16 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/lib
           mv ${{targets.destdir}}/lib/libsystemd.so.* ${{targets.subpkgdir}}/lib
+
+  - name: "systemd-init"
+    description: "Configure systemd for use as an init system"
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/
+          ln -s /usr/lib/systemd/systemd ${{targets.subpkgdir}}/init
 
 update:
   enabled: true


### PR DESCRIPTION
This just creates a package to install `systemd` with a symlink to `/init`

