### PR TITLE
WIP: new package: gvisor

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -256,3 +256,7 @@ update:
   enabled: true
   release-monitor:
     identifier: 6502
+
+test:
+  pipeline:
+    - runs: gcc --version

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -256,7 +256,3 @@ update:
   enabled: true
   release-monitor:
     identifier: 6502
-
-test:
-  pipeline:
-    - runs: gcc --version

--- a/gvisor.yaml
+++ b/gvisor.yaml
@@ -1,0 +1,39 @@
+package:
+  name: gvisor
+  version: 20240617.0
+  epoch: 0
+  description: Application Kernel for Containers
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - bash
+      - bazel-6
+      - build-base
+      - busybox
+      - go
+      - openjdk-11
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-11-openjdk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: a1352e9079e50901d393d4bc4466ea42a3ff1d65
+      repository: https://github.com/google/gvisor
+      tag: release-${{package.version}}
+
+  # The build expects to find gcc at /usr/bin/${arch}-linux-gnu-gcc so symlink ours there.
+  - runs: ln -s /usr/bin/gcc /usr/bin/${{build.arch}}-linux-gnu-gcc
+
+  - runs: bazel build //runsc:runsc --config=${{build.arch}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: google/gvisor
+    strip-prefix: release-

--- a/gvisor.yaml
+++ b/gvisor.yaml
@@ -13,6 +13,7 @@ environment:
       - bazel-6
       - build-base
       - busybox
+      - clang
       - go
       - openjdk-11
   environment:

--- a/gvisor.yaml
+++ b/gvisor.yaml
@@ -15,6 +15,7 @@ environment:
       - busybox
       - clang
       - go
+      - libbpf-dev
       - openjdk-11
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
@@ -38,3 +39,4 @@ update:
   github:
     identifier: google/gvisor
     strip-prefix: release-
+    use-tag: true

--- a/gvisor.yaml
+++ b/gvisor.yaml
@@ -30,7 +30,7 @@ pipeline:
   # The build expects to find gcc at /usr/bin/${arch}-linux-gnu-gcc so symlink ours there.
   - runs: ln -s /usr/bin/gcc /usr/bin/${{build.arch}}-linux-gnu-gcc
 
-  - runs: bazel build //runsc:runsc --config=${{build.arch}}
+  - runs: bazel build -c opt --sandbox_debug --config=${{build.arch}} //runsc
 
   - uses: strip
 


### PR DESCRIPTION
Also add a basic test for `gcc`.

gvisor currently fails with:

```
2024/06/24 12:56:26 WARN /bin/bash: line 1: /usr/bin/aarch64-linux-gnu-gcc: No such file or directory
```
...when building on x86_64 (and vice versa). The bazel target seems to want to build both platforms, and we don't want that. 🤔 


This doesn't build for me at all locally with the docker builder (on Arm M1 Mac):

```
2024/06/24 09:04:41 WARN ERROR: /home/build/pkg/sentry/seccheck/points/BUILD:10:14 GoCompilePkg pkg/sentry/seccheck/points/points_go_proto.a failed: undeclared inclusion(s) in rule '@com_google_absl//absl/base:log_severity':
2024/06/24 09:04:41 WARN this rule is missing dependency declarations for the following files included by 'absl/base/log_severity.cc':
2024/06/24 09:04:41 WARN   '/usr/lib/gcc/aarch64-unknown-linux-gnu/13.2.0/include/stddef.h'
2024/06/24 09:04:41 WARN   '/usr/lib/gcc/aarch64-unknown-linux-gnu/13.2.0/include/stdarg.h'
2024/06/24 09:04:41 WARN   '/usr/lib/gcc/aarch64-unknown-linux-gnu/13.2.0/include-fixed/pthread.h'
2024/06/24 09:04:41 WARN   '/usr/lib/gcc/aarch64-unknown-linux-gnu/13.2.0/include/limits.h'
2024/06/24 09:04:41 WARN   '/usr/lib/gcc/aarch64-unknown-linux-gnu/13.2.0/include/syslimits.h'
```