### PR TITLE
fix(cloudnative-pg): Fix architecture detection

### DIFF
--- a/cloudnative-pg.yaml
+++ b/cloudnative-pg.yaml
@@ -1,10 +1,21 @@
 package:
   name: cloudnative-pg
   version: 1.23.2
-  epoch: 3
+  epoch: 4
   description: CloudNativePG is a comprehensive platform designed to seamlessly manage PostgreSQL databases
   copyright:
     - license: Apache-2.0
+
+# Replace aarch64/x86_64 with arm64/amd64
+var-transforms:
+  - from: ${{build.arch}}
+    match: 'aarch64'
+    replace: 'arm64'
+    to: mangled-arch
+  - from: ${{build.arch}}
+    match: 'x86_64'
+    replace: 'amd64'
+    to: mangled-arch
 
 pipeline:
   - uses: git-checkout
@@ -20,12 +31,15 @@ pipeline:
   - uses: go/build
     with:
       modroot: ./cmd/manager
-      output: manager
+      output: manager_${{vars.mangled-arch}}
+      prefix: /
       ldflags: |
         -X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildVersion=${{package.version}}
         -X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildCommit=$(git rev-parse --short=8 HEAD)
         -X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildDate=$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%Y-%m-%dT%H:%M:%SZ")
       packages: .
+
+  - runs: ln -sf /bin/manager_${{vars.mangled-arch}} ${{targets.contextdir}}/manager
 
 subpackages:
   - name: ${{package.name}}-plugins
@@ -40,12 +54,6 @@ subpackages:
             -X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildDate=$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%Y-%m-%dT%H:%M:%SZ")
           subpackage: true
 
-  - name: ${{package.name}}-compat
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.contextdir}}"
-          ln -sf /usr/bin/manager "${{targets.contextdir}}"/manager
-
 update:
   enabled: true
   github:
@@ -54,15 +62,12 @@ update:
     use-tag: true
 
 test:
-  environment:
-    contents:
-      packages:
-        - busybox
-        - cloudnative-pg-compat
   pipeline:
     # - Testing observability requires helm installation
     # - Testing backup and Recovery requires using BarmanObjectStorage:
     - name: "Verify Installation"
       runs: |
-        manager version | grep "${{package.version}}"
+        cd /
+        manager_${{vars.mangled-arch}} version | grep "${{package.version}}"
         /manager version | grep "${{package.version}}"
+        /manager debug show-architectures | grep ${{vars.mangled-arch}}


### PR DESCRIPTION
Fix architecture detection. This is determined by the binary name which must have the arch appended at the end, and must reside in bin

Also add a package test to catch this in the future

Additionally, drop the compat package and create the symlink in the main package as this path is expected anyway