### PR TITLE
Updating Wordpress package to include entrypoint script

### DIFF
--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -1,7 +1,7 @@
 package:
   name: wordpress
   version: 6.5.4
-  epoch: 0
+  epoch: 1
   description: "The Open Source Publishing Platform"
   copyright:
     - license: GPL-2.0-only
@@ -22,7 +22,44 @@ pipeline:
       repository: https://github.com/wordpress/wordpress
       tag: ${{package.version}}
       expected-commit: e67e9caef43512751aae60f37d91cf589dce78b0
-      destination: "${{targets.destdir}}/usr/share/wordpress"
+      destination: "${{targets.destdir}}/usr/src/wordpress"
+
+subpackages:
+  - name: ${{package.name}}-oci-entrypoint
+    description: Entrypoint for configuring WordPress in OCI containers
+    dependencies:
+      runtime:
+        - bash
+        - busybox
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin/
+          cp wp-config-docker.php "${{targets.destdir}}/usr/src/wordpress"
+          cp docker-entrypoint.sh ${{targets.subpkgdir}}/usr/local/bin/
+          chmod +x ${{targets.subpkgdir}}/usr/local/bin/docker-entrypoint.sh
+
+test:
+  environment:
+    contents:
+      packages:
+        - wordpress
+        - wordpress-oci-entrypoint
+        - php-fpm
+        - shadow
+    environment:
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DB_USER: wolfi
+      WORDPRESS_DB_PASSWORD: wolfi
+  pipeline:
+    - name: Run Entrypoint Script
+      runs: |
+        useradd -U nonroot
+        mkdir -p /var/www/html && cd /var/www/html
+        timeout 5s /usr/local/bin/docker-entrypoint.sh php-fpm
+    - name: Check Configuration
+      runs: |
+        test -f /var/www/html/wp-config.php
+        test $WORDPRESS_DB_NAME = "wordpress"
 
 update:
   enabled: true

--- a/wordpress/docker-entrypoint.sh
+++ b/wordpress/docker-entrypoint.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+# This script comes from https://github.com/docker-library/wordpress/blob/c37f27433bb26ea3ec3154fcb1f546d855afcff6/latest/php8.3/fpm-alpine/docker-entrypoint.sh
+# It is used to set up the WordPress environment and configuration files.
+
+set -Eeuo pipefail
+
+if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
+	uid="$(id -u)"
+	gid="$(id -g)"
+	if [ "$uid" = '0' ]; then
+		case "$1" in
+			apache2*)
+				user="${APACHE_RUN_USER:-nonroot}"
+				group="${APACHE_RUN_GROUP:-nonroot}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
+				;;
+			*) # php-fpm
+				user='nonroot'
+				group='nonroot'
+				;;
+		esac
+	else
+		user="$uid"
+		group="$gid"
+	fi
+
+	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
+		# if the directory exists and WordPress doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
+		if [ "$uid" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
+			chown "$user:$group" .
+		fi
+
+		echo >&2 "WordPress not found in $PWD - copying now..."
+		if [ -n "$(find -mindepth 1 -maxdepth 1 -not -name wp-content)" ]; then
+			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
+		fi
+		sourceTarArgs=(
+			--create
+			--file -
+			--directory /usr/src/wordpress
+		)
+		targetTarArgs=(
+			--extract
+			--file -
+		)
+		if [ "$uid" != '0' ]; then
+			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+			targetTarArgs+=( --no-overwrite-dir )
+		fi
+		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
+		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)
+		for contentPath in \
+			/usr/src/wordpress/.htaccess \
+			/usr/src/wordpress/wp-content/*/*/ \
+		; do
+			contentPath="${contentPath%/}"
+			[ -e "$contentPath" ] || continue
+			contentPath="${contentPath#/usr/src/wordpress/}" # "wp-content/plugins/akismet", etc.
+			if [ -e "$PWD/$contentPath" ]; then
+				echo >&2 "WARNING: '$PWD/$contentPath' exists! (not copying the WordPress version)"
+				sourceTarArgs+=( --exclude "./$contentPath" )
+			fi
+		done
+		tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
+	fi
+
+	wpEnvs=( "${!WORDPRESS_@}" )
+	if [ ! -s wp-config.php ] && [ "${#wpEnvs[@]}" -gt 0 ]; then
+		for wpConfigDocker in \
+			wp-config-docker.php \
+			/usr/src/wordpress/wp-config-docker.php \
+		; do
+			if [ -s "$wpConfigDocker" ]; then
+				echo >&2 "No 'wp-config.php' found in $PWD, but 'WORDPRESS_...' variables supplied; copying '$wpConfigDocker' (${wpEnvs[*]})"
+				# using "awk" to replace all instances of "put your unique phrase here" with a properly unique string (for AUTH_KEY and friends to have safe defaults if they aren't specified with environment variables)
+				awk '
+					/put your unique phrase here/ {
+						cmd = "head -c1m /dev/urandom | sha1sum | cut -d\\  -f1"
+						cmd | getline str
+						close(cmd)
+						gsub("put your unique phrase here", str)
+					}
+					{ print }
+				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
+				break
+			fi
+		done
+	fi
+fi
+
+exec "$@"

--- a/wordpress/wp-config-docker.php
+++ b/wordpress/wp-config-docker.php
@@ -1,0 +1,136 @@
+<?php
+
+# This Script comes from https://github.com/docker-library/wordpress/blob/c37f27433bb26ea3ec3154fcb1f546d855afcff6/latest/php8.3/fpm-alpine/wp-config-docker.php
+
+/**
+ * The base configuration for WordPress
+ *
+ * The wp-config.php creation script uses this file during the installation.
+ * You don't have to use the website, you can copy this file to "wp-config.php"
+ * and fill in the values.
+ *
+ * This file contains the following configurations:
+ *
+ * * Database settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * This has been slightly modified (to read environment variables) for use in Docker.
+ *
+ * @link https://developer.wordpress.org/advanced-administration/wordpress/wp-config/
+ *
+ * @package WordPress
+ */
+
+// IMPORTANT: this file needs to stay in-sync with https://github.com/WordPress/WordPress/blob/master/wp-config-sample.php
+// (it gets parsed by the upstream wizard in https://github.com/WordPress/WordPress/blob/f27cb65e1ef25d11b535695a660e7282b98eb742/wp-admin/setup-config.php#L356-L392)
+
+// a helper function to lookup "env_FILE", "env", then fallback
+if (!function_exists('getenv_docker')) {
+    // https://github.com/docker-library/wordpress/issues/588 (WP-CLI will load this file 2x)
+    function getenv_docker($env, $default) {
+        if ($fileEnv = getenv($env . '_FILE')) {
+            return rtrim(file_get_contents($fileEnv), "\r\n");
+        }
+        else if (($val = getenv($env)) !== false) {
+            return $val;
+        }
+        else {
+            return $default;
+        }
+    }
+}
+
+// ** Database settings - You can get this info from your web host ** //
+/** The name of the database for WordPress */
+define( 'DB_NAME', getenv_docker('WORDPRESS_DB_NAME', 'wordpress') );
+
+/** Database username */
+define( 'DB_USER', getenv_docker('WORDPRESS_DB_USER', 'example username') );
+
+/** Database password */
+define( 'DB_PASSWORD', getenv_docker('WORDPRESS_DB_PASSWORD', 'example password') );
+
+/**
+ * Docker image fallback values above are sourced from the official WordPress installation wizard:
+ * https://github.com/WordPress/WordPress/blob/1356f6537220ffdc32b9dad2a6cdbe2d010b7a88/wp-admin/setup-config.php#L224-L238
+ * (However, using "example username" and "example password" in your database is strongly discouraged.  Please use strong, random credentials!)
+ */
+
+/** Database hostname */
+define( 'DB_HOST', getenv_docker('WORDPRESS_DB_HOST', 'mysql') );
+
+/** Database charset to use in creating database tables. */
+define( 'DB_CHARSET', getenv_docker('WORDPRESS_DB_CHARSET', 'utf8') );
+
+/** The database collate type. Don't change this if in doubt. */
+define( 'DB_COLLATE', getenv_docker('WORDPRESS_DB_COLLATE', '') );
+
+/**#@+
+ * Authentication unique keys and salts.
+ *
+ * Change these to different unique phrases! You can generate these using
+ * the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}.
+ *
+ * You can change these at any point in time to invalidate all existing cookies.
+ * This will force all users to have to log in again.
+ *
+ * @since 2.6.0
+ */
+define( 'AUTH_KEY',         getenv_docker('WORDPRESS_AUTH_KEY',         'put your unique phrase here') );
+define( 'SECURE_AUTH_KEY',  getenv_docker('WORDPRESS_SECURE_AUTH_KEY',  'put your unique phrase here') );
+define( 'LOGGED_IN_KEY',    getenv_docker('WORDPRESS_LOGGED_IN_KEY',    'put your unique phrase here') );
+define( 'NONCE_KEY',        getenv_docker('WORDPRESS_NONCE_KEY',        'put your unique phrase here') );
+define( 'AUTH_SALT',        getenv_docker('WORDPRESS_AUTH_SALT',        'put your unique phrase here') );
+define( 'SECURE_AUTH_SALT', getenv_docker('WORDPRESS_SECURE_AUTH_SALT', 'put your unique phrase here') );
+define( 'LOGGED_IN_SALT',   getenv_docker('WORDPRESS_LOGGED_IN_SALT',   'put your unique phrase here') );
+define( 'NONCE_SALT',       getenv_docker('WORDPRESS_NONCE_SALT',       'put your unique phrase here') );
+// (See also https://wordpress.stackexchange.com/a/152905/199287)
+
+/**#@-*/
+
+/**
+ * WordPress database table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix = getenv_docker('WORDPRESS_TABLE_PREFIX', 'wp_');
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the documentation.
+ *
+ * @link https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/
+ */
+define( 'WP_DEBUG', !!getenv_docker('WORDPRESS_DEBUG', '') );
+
+/* Add any custom values between this line and the "stop editing" line. */
+
+// If we're behind a proxy server and using HTTPS, we need to alert WordPress of that fact
+// see also https://wordpress.org/support/article/administration-over-ssl/#using-a-reverse-proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strpos($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false) {
+    $_SERVER['HTTPS'] = 'on';
+}
+// (we include this by default because reverse proxying is extremely common in container environments)
+
+if ($configExtra = getenv_docker('WORDPRESS_CONFIG_EXTRA', '')) {
+    eval($configExtra);
+}
+
+/* That's all, stop editing! Happy publishing. */
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once ABSPATH . 'wp-settings.php';


### PR DESCRIPTION
This PR updates the WordPress package to include an oci entrypoint as subpackage (wordpress-oci-entrypoint), reproducing the behavior of the default WordPress FPM/Alpine image [on Docker Hub](https://github.com/docker-library/wordpress/blob/c37f27433bb26ea3ec3154fcb1f546d855afcff6/latest/php8.3/fpm-alpine/Dockerfile) and following the example of our MariaDB image which also creates a subpackage to share the entrypoint script.

I also added a couple tests to check that the wp-config file is successfully created when database ENV vars are provided.

