### PR TITLE
updates packages to use git-checkout (batch 12)

### DIFF
--- a/libwebp.yaml
+++ b/libwebp.yaml
@@ -1,7 +1,7 @@
 package:
   name: libwebp
   version: 1.4.0
-  epoch: 1
+  epoch: 2
   description: Libraries for working with WebP images
   copyright:
     - license: BSD-3-Clause
@@ -20,10 +20,13 @@ environment:
       - libtool
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 61f873ec69e3be1b99535634340d5bde750b2e4447caa1db9f61be3fd49ab1e5
-      uri: https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${{package.version}}.tar.gz
+      repository: https://chromium.googlesource.com/webm/libwebp
+      tag: v${{package.version}}
+      expected-commit: a443170fc0ebdfc3abbf89ac81f35e7eb656a3da
+
+  - runs: ./autogen.sh
 
   - uses: autoconf/configure
 

--- a/libx11.yaml
+++ b/libx11.yaml
@@ -1,7 +1,7 @@
 package:
   name: libx11
   version: 1.8.9
-  epoch: 2
+  epoch: 3
   description: X11 client-side library
   copyright:
     - license: XFree86-1.1
@@ -14,17 +14,24 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gtk-doc
+      - intltool
+      - libtool
       - libxcb-dev
+      - pkgconf-dev
       - util-macros
       - xmlto
       - xorgproto
       - xtrans
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 779d8f111d144ef93e2daa5f23a762ce9555affc99592844e71c4243d3bd3262
-      uri: https://www.x.org/releases/individual/lib/libX11-${{package.version}}.tar.xz
+      repository: https://gitlab.freedesktop.org/xorg/lib/libx11.git
+      tag: libX11-${{package.version}}
+      expected-commit: a465588218c1643eedc35b3c24409cb775454eee
+
+  - runs: ./autogen.sh
 
   - uses: autoconf/configure
     with:

--- a/libxau.yaml
+++ b/libxau.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxau
   version: 1.0.11
-  epoch: 6
+  epoch: 7
   description: X11 authorisation library
   copyright:
     - license: MIT
@@ -14,14 +14,19 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
+      - pkgconf-dev
       - util-macros
       - xorgproto
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: f3fa3282f5570c3f6bd620244438dbfbdd580fc80f02f549587a0f8ab329bbeb
-      uri: https://www.x.org/releases/individual/lib/libXau-${{package.version}}.tar.xz
+      repository: https://gitlab.freedesktop.org/xorg/lib/libxau.git
+      tag: libXau-${{package.version}}
+      expected-commit: 14fdf25db9f21c8f3ad37f0d32a5b8e726efdc0d
+
+  - runs: ./autogen.sh
 
   - uses: autoconf/configure
     with:

--- a/libxcb.yaml
+++ b/libxcb.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcb
   version: 1.17.0
-  epoch: 2
+  epoch: 3
   description: X11 client-side library
   copyright:
     - license: MIT
@@ -15,17 +15,23 @@ environment:
       - busybox
       - ca-certificates-bundle
       - libpthread-stubs
+      - libtool
       - libxau-dev
       - libxdmcp-dev
       - libxslt
+      - pkgconf-dev
       - python3
+      - util-macros
       - xcb-proto
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 599ebf9996710fea71622e6e184f3a8ad5b43d0e5fa8c4e407123c88a59a6d55
-      uri: https://xorg.freedesktop.org/archive/individual/lib/libxcb-${{package.version}}.tar.xz
+      repository: https://gitlab.freedesktop.org/xorg/lib/libxcb.git
+      tag: libxcb-${{package.version}}
+      expected-commit: 622152ee42a310876f10602601206954b8d0613e
+
+  - runs: ./autogen.sh
 
   - uses: autoconf/configure
     with:

--- a/libxcomposite.yaml
+++ b/libxcomposite.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcomposite
   version: 0.4.6
-  epoch: 2
+  epoch: 3
   description: X11 Composite extension library
   copyright:
     - license: MIT
@@ -14,17 +14,22 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
       - libx11-dev
       - libxext-dev
       - libxfixes-dev
+      - pkgconf-dev
       - util-macros
       - xorgproto
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: fe40bcf0ae1a09070eba24088a5eb9810efe57453779ec1e20a55080c6dc2c87
-      uri: https://www.x.org/releases/individual/lib/libXcomposite-${{package.version}}.tar.xz
+      repository: https://gitlab.freedesktop.org/xorg/lib/libxcomposite.git
+      tag: libXcomposite-${{package.version}}
+      expected-commit: cecff847395deb553b6331f31776f9cbfc809add
+
+  - runs: ./autogen.sh
 
   - uses: autoconf/configure
 

--- a/libxdmcp.yaml
+++ b/libxdmcp.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxdmcp
   version: 1.1.5
-  epoch: 2
+  epoch: 3
   description: X11 Display Manager Control Protocol library
   copyright:
     - license: MIT
@@ -15,15 +15,20 @@ environment:
       - busybox
       - ca-certificates-bundle
       - libbsd-dev
+      - libtool
+      - pkgconf-dev
       - util-macros
       - xmlto
       - xorgproto
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 31a7abc4f129dcf6f27ae912c3eedcb94d25ad2e8f317f69df6eda0bc4e4f2f3
-      uri: https://www.x.org/releases/individual/lib/libXdmcp-${{package.version}}.tar.gz
+      repository: https://gitlab.freedesktop.org/xorg/lib/libxdmcp.git
+      tag: libXdmcp-${{package.version}}
+      expected-commit: 1192d3bc407348ff316bd3bffc791b3ac73f591b
+
+  - runs: ./autogen.sh
 
   - uses: autoconf/configure
 

--- a/libxext.yaml
+++ b/libxext.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxext
   version: 1.3.6
-  epoch: 2
+  epoch: 3
   description: X11 miscellaneous extensions library
   copyright:
     - license: MIT
@@ -14,17 +14,22 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
       - libx11-dev
       - libxau-dev
+      - pkgconf-dev
       - util-macros
       - xmlto
       - xorgproto
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 1a0ac5cd792a55d5d465ced8dbf403ed016c8e6d14380c0ea3646c4415496e3d
-      uri: https://www.x.org/releases/individual/lib/libXext-${{package.version}}.tar.gz
+      repository: https://gitlab.freedesktop.org/xorg/lib/libxext.git
+      tag: libXext-${{package.version}}
+      expected-commit: 3826a58d190c2d8093d3586cb33867668cbb4553
+
+  - runs: ./autogen.sh
 
   - uses: autoconf/configure
 

--- a/libxi.yaml
+++ b/libxi.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxi
   version: 1.8.1
-  epoch: 3
+  epoch: 4
   description: X11 Input extension library
   copyright:
     - license: MIT AND X11
@@ -15,18 +15,23 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
       - libx11-dev
       - libxext-dev
       - libxfixes-dev
+      - pkgconf-dev
       - util-macros
       - xmlto
       - xorgproto
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 89bfc0e814f288f784202e6e5f9b362b788ccecdeb078670145eacd8749656a7
-      uri: https://www.x.org/releases/individual/lib/libXi-${{package.version}}.tar.xz
+      repository: https://gitlab.freedesktop.org/xorg/lib/libxi.git
+      tag: libXi-${{package.version}}
+      expected-commit: 3a7503ec7703f10de17c622ea22b7bff736cea74
+
+  - runs: ./autogen.sh
 
   - uses: autoconf/configure
     with:

--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxml2
   version: 2.13.1
-  epoch: 0
+  epoch: 1
   description: XML parsing library, version 2
   copyright:
     - license: MIT
@@ -22,15 +22,20 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
+      - pkgconf-dev
       - python3-dev
       - xz-dev
       - zlib-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 25239263dc37f5f55a5393eff27b35f0b7d9ea4b2a7653310598ea8299e3b741
-      uri: https://download.gnome.org/sources/libxml2/${{vars.mangled-package-version}}/libxml2-${{package.version}}.tar.xz
+      repository: https://gitlab.gnome.org/GNOME/libxml2.git
+      tag: v${{package.version}}
+      expected-commit: 48dba1e21f8f1a7d8a817eaf65831396e74b78d2
+
+  - runs: ./autogen.sh
 
   - uses: autoconf/configure
     with:

--- a/libxpm.yaml
+++ b/libxpm.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxpm
   version: 3.5.17
-  epoch: 2
+  epoch: 3
   description: X11 pixmap library
   copyright:
     - license: MIT
@@ -14,17 +14,22 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
       - libx11-dev
       - libxext-dev
       - libxt-dev
+      - pkgconf-dev
       - util-linux-dev
       - util-macros
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 64b31f81019e7d388c822b0b28af8d51c4622b83f1f0cb6fa3fc95e271226e43
-      uri: https://www.x.org/releases/individual/lib/libXpm-${{package.version}}.tar.xz
+      repository: https://gitlab.freedesktop.org/xorg/lib/libxpm.git
+      tag: libXpm-${{package.version}}
+      expected-commit: a154f12b6e56f131bd5880fc96f11615ff940b29
+
+  - runs: ./autogen.sh
 
   - runs: |
       ac_cv_search_gettext=no \


### PR DESCRIPTION
Updates packages to use git-checkout
* libwebp
* libx11
* libxau
* libxcb
* libxcomposite
* libxdmcp
* libext
* libxi
* libxml2
* libxpm