### PR TITLE
Git-Checkout updates (batch 13)

### DIFF
--- a/libxrender.yaml
+++ b/libxrender.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxrender
   version: 0.9.11
-  epoch: 6
+  epoch: 7
   description: X Rendering Extension client library
   copyright:
     - license: XFree86-1.1
@@ -14,15 +14,20 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
       - libx11-dev
+      - pkgconf-dev
       - util-macros
       - xorgproto
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 6aec3ca02e4273a8cbabf811ff22106f641438eb194a12c0ae93c7e08474b667
-      uri: https://www.x.org/releases/individual/lib/libXrender-${{package.version}}.tar.gz
+      repository: https://gitlab.freedesktop.org/xorg/lib/libxrender.git
+      tag: libXrender-${{package.version}}
+      expected-commit: e5e23272394c90731debd7e18dd167e8c25b5c15
+
+  - runs: ./autogen.sh
 
   - uses: autoconf/configure
 

--- a/libxslt.yaml
+++ b/libxslt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxslt
   version: 1.1.41
-  epoch: 0
+  epoch: 1
   description: XML stylesheet transformation library
   copyright:
     - license: MIT
@@ -18,12 +18,16 @@ environment:
       - libgpg-error-dev
       - libtool
       - libxml2-dev
+      - pkgconf-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 3ad392af91115b7740f7b50d228cc1c5fc13afc1da7f16cb0213917a37f71bda
-      uri: https://download.gnome.org/sources/libxslt/1.1/libxslt-${{package.version}}.tar.xz
+      repository: https://gitlab.gnome.org/GNOME/libxslt.git
+      tag: v${{package.version}}
+      expected-commit: f156f9b9838b8ad389e5c6527dbe2e0582134ef8
+
+  - runs: ./autogen.sh
 
   - uses: autoconf/configure
     with:

--- a/libxt.yaml
+++ b/libxt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxt
   version: 1.3.0
-  epoch: 1
+  epoch: 2
   description: X11 toolkit intrinsics library
   copyright:
     - license: MIT-open-group
@@ -16,15 +16,20 @@ environment:
       - ca-certificates-bundle
       - libice-dev
       - libsm-dev
+      - libtool
       - libx11-dev
+      - pkgconf-dev
       - util-macros
       - xorgproto
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: de4a80c4cc7785b9620e572de71026805f68e85a2bf16c386009ef0e50be3f77
-      uri: https://www.x.org/releases/individual/lib/libXt-${{package.version}}.tar.gz
+      repository: https://gitlab.freedesktop.org/xorg/lib/libxt.git
+      tag: libXt-${{package.version}}
+      expected-commit: 64fca6a2d7cf4fee28ca2277ca6a8b7b32aee66e
+
+  - runs: ./autogen.sh
 
   - uses: autoconf/configure
     with:

--- a/libxtst.yaml
+++ b/libxtst.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxtst
   version: 1.2.4
-  epoch: 7
+  epoch: 8
   description: X11 Testing -- Resource extension library
   copyright:
     - license: XFree86-1.1
@@ -14,17 +14,22 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - libtool
       - libx11-dev
       - libxext-dev
       - libxi-dev
+      - pkgconf-dev
       - util-macros
       - xorgproto
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 84f5f30b9254b4ffee14b5b0940e2622153b0d3aed8286a3c5b7eeb340ca33c8
-      uri: https://www.x.org/releases/individual/lib/libXtst-${{package.version}}.tar.xz
+      repository: https://gitlab.freedesktop.org/xorg/lib/libxtst.git
+      tag: libXtst-${{package.version}}
+      expected-commit: 99b89c3bcb0ebb0b6dd86bfdc9d276715eaea889
+
+  - runs: ./autogen.sh
 
   - uses: autoconf/configure
     with:

--- a/lmdb.yaml
+++ b/lmdb.yaml
@@ -1,7 +1,7 @@
 # Generated from https://git.alpinelinux.org/aports/plain/main/lmdb/APKBUILD
 package:
   name: lmdb
-  version: 0.9.30
+  version: 0.9.31
   epoch: 0
   description: Lightning Memory-Mapped Database
   copyright:
@@ -17,14 +17,14 @@ environment:
       - ca-certificates-bundle
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 8c5a93ac3cc97427c54571ad5a6140b7469389d01e6d2f43df39f96d3a4ccef7
-      uri: https://git.openldap.org/openldap/openldap/-/archive/LMDB_${{package.version}}/openldap-LMDB_${{package.version}}.tar.gz
-      strip-components: 0
+      repository: https://github.com/LMDB/lmdb.git
+      tag: LMDB_${{package.version}}
+      expected-commit: ce201088de95d26fc0da36ba805bf2ddc2ba74ff
 
   - runs: |
-      cd openldap-LMDB_${{package.version}}/libraries/liblmdb
+      cd libraries/liblmdb
 
       cat > lmdb.pc << EOF
       prefix=/usr

--- a/lua-resty-http.yaml
+++ b/lua-resty-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-http
-  version: 0.0_git20210806
-  epoch: 3
+  version: 0.17.2
+  epoch: 0
   description: "Lua HTTP client cosocket driver for OpenResty / ngx_lua."
   copyright:
     - license: BSD-3-Clause
@@ -17,13 +17,16 @@ environment:
     PREFIX: /usr
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/ledgetech/lua-resty-http/archive/0ce55d6d15da140ecc5966fa848204c6fd9074e8.tar.gz
-      expected-sha256: 9fcb6db95bc37b6fce77d3b3dc740d593f9d90dce0369b405eb04844d56ac43f
-      strip-components: 1
+      repository: https://github.com/ledgetech/lua-resty-http.git
+      tag: v${{package.version}}
+      expected-commit: 183310324026120ab7eaf5dd82b9be90ae63aadf
 
   - uses: autoconf/make-install
 
 update:
-  enabled: false
+  enabled: true
+  github:
+    identifier: ledgetech/lua-resty-http
+    strip-prefix: v

--- a/lua-resty-ipmatcher.yaml
+++ b/lua-resty-ipmatcher.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-ipmatcher
   version: 0.6.1
-  epoch: 3
+  epoch: 4
   description: "High-performance match IP address for Nginx + Lua"
   copyright:
     - license: Apache-2.0
@@ -16,11 +16,11 @@ environment:
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/api7/lua-resty-ipmatcher/archive/v${{package.version}}.tar.gz
-      expected-sha256: efb767487ea3f6031577b9b224467ddbda2ad51a41c5867a47582d4ad85d609e
-      strip-components: 1
+      repository: https://github.com/api7/lua-resty-ipmatcher.git
+      tag: v${{package.version}}
+      expected-commit: 62d4c44d67227e8f3fe02331c2f8b90fe0d7ccd1
 
   - name: "Configure lua-resty-ipmatcher"
     runs: |

--- a/lua-resty-redis.yaml
+++ b/lua-resty-redis.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-redis
   version: 0.30
-  epoch: 3
+  epoch: 4
   description: "Lua redis client driver for the ngx_lua based on the cosocket API"
   copyright:
     - license: BSD-3-Clause
@@ -17,11 +17,11 @@ environment:
     PREFIX: /usr
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openresty/lua-resty-redis/archive/v${{package.version}}.tar.gz
-      expected-sha256: c15aed1a01c88a3a6387d9af67a957dff670357f5fdb4ee182beb44635eef3f1
-      strip-components: 1
+      repository: https://github.com/openresty/lua-resty-redis.git
+      tag: v${{package.version}}
+      expected-commit: d7c25f1b339d79196ff67f061c547a73a920b580
 
   - uses: autoconf/make-install
 

--- a/lua-resty-upload.yaml
+++ b/lua-resty-upload.yaml
@@ -1,7 +1,7 @@
 package:
   name: lua-resty-upload
-  version: 0.10
-  epoch: 3
+  version: 0.11
+  epoch: 0
   description: "Streaming reader and parser for http file uploading based on ngx_lua cosocket"
   copyright:
     - license: BSD-3-Clause
@@ -24,13 +24,17 @@ environment:
     PREFIX: /usr
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/openresty/lua-resty-upload/archive/v${{package.version}}.tar.gz
-      expected-sha256: 5d16e623d17d4f42cc64ea9cfb69ca960d313e12f5d828f785dd227cc483fcbd
-      strip-components: 1
+      repository: https://github.com/openresty/lua-resty-upload.git
+      tag: v${{package.version}}
+      expected-commit: 03704aee42f7135e7782688d8a9af63a16015edc
 
   - uses: autoconf/make-install
 
 update:
-  enabled: false
+  enabled: true
+  github:
+    identifier: openresty/lua-resty-upload
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
Updates several packages to use git-checkout over fetch:
* libxslt
* libxrender
* libxt
* libxtst
* lmdb
* lua-resty-http
* lua-resty-ipmatcher
* lua-resty-redis
* lua-resty-upload