### PR TITLE
add mattermost-9

### DIFF
--- a/mattermost-9.yaml
+++ b/mattermost-9.yaml
@@ -1,0 +1,225 @@
+package:
+  name: mattermost-9
+  version: 9.9.0
+  epoch: 0
+  description: "Mattermost is an open source platform for secure collaboration across the entire software development lifecycle."
+  copyright:
+    - license: MIT
+    - license: Apache-2.0
+    - license: AGPL-3.0-only
+  dependencies:
+    runtime:
+      - bash
+      - tzdata
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
+      - ca-certificates-bundle
+      - curl
+      - gnupg-scdaemon
+      - go
+      - gpg
+      - libimagequant-dev
+      - libpng-dev
+      - libtool
+      - nodejs-20
+      - npm
+      - pkgconf-dev
+      - posix-libc-utils
+      - wolfi-base
+      - xmlsec-openssl
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/mattermost/mattermost
+      tag: v${{package.version}}
+      expected-commit: 4179e17b491ec5292ca6e157d7b216b464bce397
+
+  # Properly append cppflags
+  - uses: patch
+    with:
+      patches: fix_cppflags.patch
+
+  - runs: |
+      mkdir -p ${{targets.contextdir}}/usr/bin
+      for dir in bin data logs config plugins fonts i18n templates client test; do
+        mkdir -p ${{targets.contextdir}}/etc/mattermost/$dir
+      done
+
+  - working-directory: server
+    pipeline:
+      - uses: go/bump
+        with:
+          deps: golang.org/x/net@v0.23.0 google.golang.org/protobuf@v1.33.0
+          modroot: .
+          tidy: false # https://github.com/mattermost/mattermost/issues/26221
+      - runs: make modules-tidy
+      - runs: |
+          # Our global LDFLAGS conflict with a Makefile parameter: `flag provided but not defined: -Wl,--as-needed,-O1,--sort-common`
+          unset LDFLAGS
+
+          make GOFLAGS="" config-reset
+          make BUILD_ENTERPRISE=false BUILD_ENTERPRISE_READY=false BUILD_NUMBER=chainguard build-cmd
+          make BUILD_ENTERPRISE=false BUILD_ENTERPRISE_READY=false package-linux
+
+          mv ./bin/mattermost ${{targets.contextdir}}/usr/bin/
+          mv ./bin/mmctl ${{targets.contextdir}}/usr/bin/
+          mv ./dist/mattermost/* ${{targets.contextdir}}/etc/mattermost/
+          cp -a ./i18n/* ${{targets.contextdir}}/etc/mattermost/i18n/
+
+          mkdir -p ${{targets.contextdir}}/etc/mattermost/client/plugins
+
+          cp ./config/config.json ${{targets.contextdir}}/etc/mattermost/config/config.json
+          cp ./build/MIT-COMPILED-LICENSE.md ${{targets.contextdir}}/etc/mattermost/MIT-COMPILED-LICENSE.md
+          cp ../LICENSE.txt ${{targets.contextdir}}/etc/mattermost/LICENSE.txt
+          cp ./build/entrypoint.sh ${{targets.contextdir}}/usr/bin/entrypoint.sh
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: Compatibility package to place binaries in the location expected by upstream Dockerfile
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/mattermost
+          for dir in data logs config plugins fonts i18n templates client; do
+            ln -sf /etc/mattermost/$dir ${{targets.contextdir}}/mattermost/$dir
+          done
+          mkdir -p ${{targets.contextdir}}/mattermost/bin
+          ln -sf /usr/bin/mattermost ${{targets.contextdir}}/mattermost/bin/mattermost
+          ln -sf /usr/bin/mmctl ${{targets.contextdir}}/mattermost/bin/mmctl
+          ln -sf /usr/bin/entrypoint.sh ${{targets.contextdir}}/entrypoint.sh
+
+update:
+  enabled: true
+  github:
+    identifier: mattermost/mattermost
+    strip-prefix: v
+    tag-filter: v9.
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+        - postgresql
+        - postgresql-client
+        - wolfi-base
+        - shadow
+        - sudo-rs
+        - glibc-locales
+        - ${{package.name}}-compat
+        - exim
+    environment:
+      PGDATA: /tmp/test_db
+      PGUSER: mmuser
+      PGPASS: mostest
+      PGDB: mattermost_test
+  pipeline:
+    - name: "Check binaries"
+      runs: |
+        mattermost version
+        mmctl version
+    - name: "Fetch database dump"
+      runs: |
+        curl https://raw.githubusercontent.com/mattermost/mattermost/v${{package.version}}/server/scripts/mattermost-postgresql-6.0.0.sql -o /etc/mattermost/test/mattermost-postgresql-6.0.0.sql
+    - name: "Prepare database"
+      runs: |
+        useradd postgres
+        sudo -u postgres initdb -D ${PGDATA}
+        sudo -u postgres pg_ctl -D ${PGDATA} -l /tmp/logfile start
+        sudo -u postgres createdb ${PGDB}
+        sudo -u postgres psql -d postgres -c "CREATE USER ${PGUSER} WITH PASSWORD '${PGPASS}';"
+        sudo -u postgres psql -d ${PGDB} -c "GRANT ALL PRIVILEGES ON SCHEMA public TO ${PGUSER};"
+        sudo -u postgres psql -U $PGUSER -d $PGDB -f /etc/mattermost/test/mattermost-postgresql-6.0.0.sql
+    - name: "Prepare mailserver on port 10025"
+      runs: |
+        cat <<EOF > /etc/exim/exim.conf
+        # Minimal Exim configuration
+
+        # Main configuration
+        primary_hostname = localhost
+        daemon_smtp_ports = 10025
+        spool_directory = /var/spool/exim
+        log_file_path = /var/log/exim/%s
+
+        # Routers
+        begin routers
+        localuser:
+          driver = accept
+          check_local_user
+          transport = local_delivery
+
+        # Transports
+        begin transports
+        remote_smtp:
+          driver = smtp
+
+        local_delivery:
+          driver = appendfile
+          file = /var/mail/\${local_part}
+          delivery_date_add
+          envelope_to_add
+          return_path_add
+        EOF
+        mkdir -p /var/spool/exim /var/log/exim /var/mail
+        addgroup -S exim
+        adduser -S -G exim exim
+        chown -R exim:exim /var/spool/exim /var/log/exim /var/mail
+        exim -bd -oX 10025 &
+    - name: "Run application"
+      runs: |
+        cd /mattermost # Set working directory
+
+        /entrypoint.sh mattermost > /tmp/logs.txt 2>&1 &
+        PID=$!
+
+        sleep 15 # ensure that enough time is given for the logs to get written
+
+        logs_to_expect="
+        Server is initializing...
+        Starting websocket hubs
+        Loaded system translations
+        Loaded config
+        Starting workers
+        Starting schedulers.
+        Starting up plugins
+        Server is listening on
+        "
+
+        echo "$logs_to_expect" | while IFS= read -r log; do
+          if [ -z "$log" ]; then
+            continue
+          fi
+          if ! grep -F -i "$log" /tmp/logs.txt; then
+            cat /tmp/logs.txt
+            echo "Expected log '$log' not found!"
+            exit 1
+          fi
+        done
+
+        logs_to_not_expect="
+        connection refused
+        unable to load
+        "
+
+        # Use a while loop with a read command to handle multi-line strings
+        echo "$logs_to_not_expect" | while IFS= read -r log; do
+          if [ -z "$log" ]; then
+            continue
+          fi
+          if grep -F -i "$log" /tmp/logs.txt; then
+            cat /tmp/logs.txt
+            echo "Unexpected log '$log' found!"
+            exit 1
+          fi
+        done
+
+        kill $PID

--- a/mattermost-9/fix_cppflags.patch
+++ b/mattermost-9/fix_cppflags.patch
@@ -1,0 +1,19 @@
+diff --git a/webapp/Makefile b/webapp/Makefile
+index da56ad1..390690d 100644
+--- a/webapp/Makefile
++++ b/webapp/Makefile
+@@ -8,12 +8,12 @@ CI ?= false
+ # please see optipng-bin Linux arm64 support issue (https://github.com/imagemin/optipng-bin/issues/118) for details:
+ ifeq ($(shell uname)/$(shell uname -m),Linux/aarch64)
+   LINUX_ARM64 = true
+-  CPPFLAGS += " -DPNG_ARM_NEON_OPT=0"
++  CPPFLAGS += -DPNG_ARM_NEON_OPT=0
+ endif
+ # Exact same issue but for Linux/PPC64
+ ifeq ($(findstring Linux/ppc64,$(shell uname)/$(shell uname -m)),Linux/ppc64)
+   LINUX_PPC64 = true
+-  CPPFLAGS += " -DPNG_POWERPC_VSX_OPT=0"
++  CPPFLAGS += -DPNG_POWERPC_VSX_OPT=0
+ endif
+ 
+ .PHONY: run


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
