### PR TITLE
Updates packages to use git-checkout (batch 14)

### DIFF
--- a/lvm2.yaml
+++ b/lvm2.yaml
@@ -2,10 +2,16 @@
 package:
   name: lvm2
   version: 2.03.24
-  epoch: 0
+  epoch: 1
   description: Logical Volume Manager 2 utilities
   copyright:
     - license: GPL-2.0-only AND LGPL-2.1-only
+
+var-transforms:
+  - from: ${{package.version}}
+    match: '\.'
+    replace: '_'
+    to: mangled-package-version
 
 environment:
   contents:
@@ -20,10 +26,11 @@ environment:
       - util-linux-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 593c5503ba00faab1c6e0b4a597b9605ec7b5881845c04bf412ebf9d1bbfa13c
-      uri: https://mirrors.kernel.org/sourceware/lvm2/LVM2.${{package.version}}.tgz
+      repository: https://gitlab.com/lvmteam/lvm2.git
+      tag: v${{vars.mangled-package-version}}
+      expected-commit: 90ec2cd92f6367c431dd8dae55d0cbe7e196734f
 
   - runs: |
       # during cross-compilation malloc test goes wrong

--- a/mariadb-10.11.yaml
+++ b/mariadb-10.11.yaml
@@ -2,7 +2,7 @@ package:
   name: mariadb-10.11
   # Latest LTS
   version: 10.11.8
-  epoch: 0
+  epoch: 1
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -18,6 +18,7 @@ package:
 environment:
   contents:
     packages:
+      - bison
       - build-base
       - busybox
       - ca-certificates-bundle
@@ -34,10 +35,11 @@ environment:
       - xz-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ftp.osuosl.org/pub/mariadb/mariadb-${{package.version}}/source/mariadb-${{package.version}}.tar.gz
-      expected-sha256: 5f04f3e33d9f1cbeff05e79c54d41d302630500c995aee72b0638e2f9dfcdf0f
+      repository: https://github.com/MariaDB/server.git
+      tag: mariadb-${{package.version}}
+      expected-commit: 3a069644682e336e445039e48baae9693f9a08ee
 
   - name: "Cmake"
     runs: |

--- a/mariadb-11.2.yaml
+++ b/mariadb-11.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-11.2
   version: 11.2.4
-  epoch: 0
+  epoch: 1
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -17,6 +17,7 @@ package:
 environment:
   contents:
     packages:
+      - bison
       - build-base
       - busybox
       - ca-certificates-bundle
@@ -33,10 +34,11 @@ environment:
       - xz-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://archive.mariadb.org/mariadb-${{package.version}}/source/mariadb-${{package.version}}.tar.gz
-      expected-sha256: e16f152a6b60bec0938051a8340e410d33e0708d1f84a2cf38f1b04e4133bf19
+      repository: https://github.com/MariaDB/server.git
+      tag: mariadb-${{package.version}}
+      expected-commit: db06c5dd07e6ffd6a569afe6950fa77c2f02f811
 
   - name: "Cmake"
     runs: |


### PR DESCRIPTION
Updates packages to use git-checkout over fetch:
* lvm2
* mariadb-10.11
* mariadb-11.2