### PR TITLE
Fixing wordpress entrypoint script

### DIFF
--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -1,7 +1,7 @@
 package:
   name: wordpress
   version: 6.5.5
-  epoch: 0
+  epoch: 1
   description: "The Open Source Publishing Platform"
   copyright:
     - license: GPL-2.0-only

--- a/wordpress/docker-entrypoint.sh
+++ b/wordpress/docker-entrypoint.sh
@@ -48,10 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 			--extract
 			--file -
 		)
-		if [ "$uid" != '0' ]; then
-			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
-		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)
 		for contentPath in \


### PR DESCRIPTION
The entrypoint script comes from the official WP Alpine / FPM build, which uses GNU tar, and a few options are different from Busybox tar. The  option `--no-overwrite-dir` does not exist and is not necessary in Busybox tar because it behaves differently as far as I understood.

It passed unnoticed because the `make local-wolfi` dev env runs as root, which doesn't trigger that flag. I only detected the issue now while testing in an image running as `nonroot`.