### PR TITLE
Drop the mariadb-test package from mariadb-10.11

### DIFF
--- a/mariadb-10.11.yaml
+++ b/mariadb-10.11.yaml
@@ -2,7 +2,7 @@ package:
   name: mariadb-10.11
   # Latest LTS
   version: 10.11.8
-  epoch: 1
+  epoch: 2
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -148,6 +148,16 @@ pipeline:
       rm -rf "${{targets.destdir}}"/usr/lib/libmariadb.so*
       rm -rf "${{targets.destdir}}"/usr/lib/pkgconfig/libmariadb.pc
 
+      rm -rf "${{targets.destdir}}"/usr/bin/mysql_client_test \
+        "${{targets.destdir}}"/usr/bin/mysql_client_test_embedded \
+        "${{targets.destdir}}"/usr/bin/mariadb-client-test \
+        "${{targets.destdir}}"/usr/bin/mariadb-client-test-embedded \
+        "${{targets.destdir}}"/usr/bin/mariadb-test \
+        "${{targets.destdir}}"/usr/bin/mariadb-test-embedded \
+        "${{targets.destdir}}"/usr/bin/mysqltest \
+        "${{targets.destdir}}"/usr/bin/mysqltest_embedded \
+        "${{targets.destdir}}"/usr/mysql-test
+
   - name: "make mysql data dir "
     runs: |
       mkdir -p "${{targets.destdir}}"/var/lib/mysql
@@ -164,23 +174,6 @@ subpackages:
   - name: "mariadb-10.11-doc"
     pipeline:
       - uses: split/manpages
-
-  - name: "mariadb-test"
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/mysql_client_test \
-            "${{targets.destdir}}"/usr/bin/mysql_client_test_embedded \
-            "${{targets.destdir}}"/usr/bin/mariadb-client-test \
-            "${{targets.destdir}}"/usr/bin/mariadb-client-test-embedded \
-            "${{targets.destdir}}"/usr/bin/mariadb-test \
-            "${{targets.destdir}}"/usr/bin/mariadb-test-embedded \
-            "${{targets.destdir}}"/usr/bin/mysqltest \
-            "${{targets.destdir}}"/usr/bin/mysqltest_embedded \
-            "${{targets.subpkgdir}}"/usr/bin/
-
-          mv "${{targets.destdir}}"/usr/mysql-test \
-            "${{targets.subpkgdir}}"/usr/
 
   - name: "mariadb-10.11-bench"
     dependencies:


### PR DESCRIPTION
This package was
1. shipping some out of date jar files with CVEs https://github.com/wolfi-dev/advisories/pull/6072
2. not used at all to our knowledge
3. not present in mariadb-10.6 or mariadb-11.2

Good bye.
