### PR TITLE
Drop the mariadb-test package from mariadb-10.6, 11.2; update 10.11

### DIFF
--- a/mariadb-10.11.yaml
+++ b/mariadb-10.11.yaml
@@ -2,7 +2,7 @@ package:
   name: mariadb-10.11
   # Latest LTS
   version: 10.11.8
-  epoch: 2
+  epoch: 3
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -148,15 +148,10 @@ pipeline:
       rm -rf "${{targets.destdir}}"/usr/lib/libmariadb.so*
       rm -rf "${{targets.destdir}}"/usr/lib/pkgconfig/libmariadb.pc
 
-      rm -rf "${{targets.destdir}}"/usr/bin/mysql_client_test \
-        "${{targets.destdir}}"/usr/bin/mysql_client_test_embedded \
-        "${{targets.destdir}}"/usr/bin/mariadb-client-test \
-        "${{targets.destdir}}"/usr/bin/mariadb-client-test-embedded \
-        "${{targets.destdir}}"/usr/bin/mariadb-test \
-        "${{targets.destdir}}"/usr/bin/mariadb-test-embedded \
-        "${{targets.destdir}}"/usr/bin/mysqltest \
-        "${{targets.destdir}}"/usr/bin/mysqltest_embedded \
-        "${{targets.destdir}}"/usr/mysql-test
+      rm ${{targets.destdir}}/usr/bin/mariadb*-test*
+      rm ${{targets.destdir}}/usr/bin/mysql*test*
+      rm ${{targets.destdir}}/usr/bin/test-connect-t
+      rm -r ${{targets.destdir}}/usr/mysql-test/
 
   - name: "make mysql data dir "
     runs: |
@@ -219,15 +214,6 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/mariadb-embedded  "${{targets.subpkgdir}}"/usr/bin
-
-  - name: mariadb-10.11-test
-    dependencies:
-      provides:
-        - mariadb-test=10.11.999
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr
-          mv mysql-test "${{targets.subpkgdir}}"/usr/mariadb-test
 
 update:
   enabled: true

--- a/mariadb-10.6.yaml
+++ b/mariadb-10.6.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-10.6
   version: 10.6.18
-  epoch: 1
+  epoch: 2
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -145,6 +145,11 @@ pipeline:
       rm -rf "${{targets.destdir}}"/usr/lib/libmariadb.so*
       rm -rf "${{targets.destdir}}"/usr/lib/pkgconfig/libmariadb.pc
 
+      rm ${{targets.destdir}}/usr/bin/mariadb*-test*
+      rm ${{targets.destdir}}/usr/bin/mysql*test*
+      rm ${{targets.destdir}}/usr/bin/test-connect-t
+      rm -r ${{targets.destdir}}/usr/mysql-test/
+
   - name: "make mysql data dir "
     runs: |
       mkdir -p "${{targets.destdir}}"/var/lib/mysql
@@ -164,27 +169,6 @@ subpackages:
     dependencies:
       provides:
         - mariadb-doc=10.6.999
-
-  - name: "mariadb-10.6-test"
-    dependencies:
-      provides:
-        - mariadb-test=10.6.999
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/mysql_client_test \
-            "${{targets.destdir}}"/usr/bin/mysql_client_test_embedded \
-            "${{targets.destdir}}"/usr/bin/mariadb-client-test \
-            "${{targets.destdir}}"/usr/bin/mariadb-client-test-embedded \
-            "${{targets.destdir}}"/usr/bin/mariadb-test \
-            "${{targets.destdir}}"/usr/bin/mariadb-test-embedded \
-            "${{targets.destdir}}"/usr/bin/mysqltest \
-            "${{targets.destdir}}"/usr/bin/mysqltest_embedded \
-            "${{targets.subpkgdir}}"/usr/bin/
-
-          mv "${{targets.destdir}}"/usr/mysql-test \
-            "${{targets.subpkgdir}}"/usr/
-          mv mysql-test "${{targets.subpkgdir}}"/usr/mariadb-test
 
   - name: "mariadb-10.6-bench"
     dependencies:

--- a/mariadb-11.2.yaml
+++ b/mariadb-11.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-11.2
   version: 11.2.4
-  epoch: 1
+  epoch: 2
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -147,6 +147,11 @@ pipeline:
       rm -rf "${{targets.destdir}}"/usr/lib/libmariadb.so*
       rm -rf "${{targets.destdir}}"/usr/lib/pkgconfig/libmariadb.pc
 
+      rm ${{targets.destdir}}/usr/bin/mariadb*-test*
+      rm ${{targets.destdir}}/usr/bin/mysql*test*
+      rm ${{targets.destdir}}/usr/bin/test-connect-t
+      rm -r ${{targets.destdir}}/usr/mariadb-test/
+
   - name: "make mysql data dir "
     runs: |
       mkdir -p "${{targets.destdir}}"/var/lib/mysql
@@ -211,15 +216,6 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin/
           mv "${{targets.destdir}}"/usr/bin/mariadb-embedded  "${{targets.subpkgdir}}"/usr/bin
-
-  - name: "${{package.name}}-test"
-    dependencies:
-      provides:
-        - mariadb-test=${{package.full-version}}
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr
-          mv "${{targets.destdir}}"/usr/mariadb-test "${{targets.subpkgdir}}"/usr/
 
 update:
   enabled: true


### PR DESCRIPTION
This package was
1. shipping some out of date jar files with CVEs https://github.com/wolfi-dev/advisories/pull/6072
2. not used at all to our knowledge
3. not present in mariadb-10.6 or mariadb-11.2

Good bye.

https://github.com/wolfi-dev/os/pull/22730 landed the change only to 10.11, so this commit fixes up the 3 mariadb to be similar.

