### PR TITLE
teleport: use rustup stable triplet

### DIFF
--- a/teleport.yaml
+++ b/teleport.yaml
@@ -1,7 +1,7 @@
 package:
   name: teleport
   version: 16.0.1
-  epoch: 0
+  epoch: 1
   description: The easiest, and most secure way to access and protect all of your infrastructure.
   copyright:
     - license: AGPL-3.0-only
@@ -43,7 +43,7 @@ pipeline:
       rustup target add wasm32-unknown-unknown
 
       # This is a bit of a hack, but it's the easiest way to get the right version of rustc and cargo in the path.
-      export PATH="$HOME/.rustup/toolchains/stable-${{host.triplet.rust}}/bin:$PATH"
+      export PATH="$HOME/.rustup/toolchains/stable-${{build.arch}}-unknown-linux-gnu/bin:$PATH"
 
       make full
 


### PR DESCRIPTION
The melange triple does not match rustup stable channel so the path is incorrect

Discovered in issue with wasm rustup packages in #22375