### PR TITLE
poppler:24.06.1 new package

### DIFF
--- a/poppler.yaml
+++ b/poppler.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: Poppler is a PDF rendering library based on the xpdf-3.0 code base.
   copyright:
-    - license: GNU General Public License v2.0 or later
+    - license: GPL-2.0-or-later
  
 environment:
   contents:

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -67,8 +67,3 @@ update:
   enabled: true
   release-monitor:
     identifier: 3686
-    
-test:
-  pipeline:
-    - runs: |
-        pdfinfo -v

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -5,31 +5,31 @@ package:
   description: Poppler is a PDF rendering library based on the xpdf-3.0 code base.
   copyright:
     - license: GPL-2.0-or-later
- 
+
 environment:
   contents:
     packages:
       - bash
+      - boost-dev
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cairo-dev 
-      - boost-dev 
-      - cmake 
-      - libfontconfig1 
-      - gobject-introspection-dev 
+      - cairo-dev
+      - cmake
+      - expat-dev
+      - gobject-introspection-dev
       - lcms2-dev
-      - libjpeg-turbo-dev 
-      - libpng-dev 
-      - libxml2-dev 
-      - libnss-dev 
-      - openjpeg-dev 
-      - openjpeg-tools 
-      - samurai 
-      - tiff-dev 
-      - zlib-dev 
-      - expat-dev 
+      - libfontconfig1
+      - libjpeg-turbo-dev
       - libnspr-dev
+      - libnss-dev
+      - libpng-dev
+      - libxml2-dev
+      - openjpeg-dev
+      - openjpeg-tools
+      - samurai
+      - tiff-dev
+      - zlib-dev
 
 pipeline:
   - uses: git-checkout
@@ -58,11 +58,11 @@ subpackages:
   - name: poppler-glib
     pipeline:
       - uses: split/dev
-      
+
   - name: poppler-utils
     pipeline:
       - uses: split/dev
-  
+
 update:
   enabled: true
   release-monitor:

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -67,4 +67,4 @@ subpackages:
 update:
   enabled: true
   release-monitor:
-    identifier: 2573
+    identifier: 3686

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -37,13 +37,18 @@ pipeline:
       tag: poppler-${{package.version}}
       expected-commit: c670e8e1fd8cc4630b8e02f195681027edd4c19a
 
-  - runs: |
-      #!/bin/sh
-      set -x
-      mkdir build && cd build
-      cmake -DENABLE_GPGME=OFF -DENABLE_LIBCURL=OFF -DENABLE_QT5=OFF -DENABLE_QT6=OFF ..
-      make -j$(nproc)
-      make install
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DENABLE_GPGME=OFF \
+        -DENABLE_LIBCURL=OFF \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DENABLE_QT5=OFF \
+        -DENABLE_QT6=OFF
+
+  - uses: cmake/build
+
+  - uses: cmake/install  
 
 subpackages:
   - name: poppler-dev

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -9,7 +9,6 @@ package:
 environment:
   contents:
     packages:
-      - bash
       - boost-dev
       - build-base
       - busybox

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -48,7 +48,7 @@ pipeline:
 
   - uses: cmake/build
 
-  - uses: cmake/install  
+  - uses: cmake/install
 
 subpackages:
   - name: poppler-dev

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -1,0 +1,70 @@
+package:
+  name: poppler
+  version: 24.06.1
+  epoch: 0
+  description: Poppler is a PDF rendering library based on the xpdf-3.0 code base.
+  copyright:
+    - license: GNU General Public License v2.0 or later
+ 
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cairo-dev 
+      - boost-dev 
+      - cmake 
+      - build-base 
+      - libfontconfig1 
+      - gobject-introspection-dev 
+      - lcms2-dev
+      - libjpeg-turbo-dev 
+      - libpng-dev 
+      - libxml2-dev 
+      - libnss-dev 
+      - openjpeg-dev 
+      - openjpeg-tools 
+      - samurai 
+      - tiff-dev 
+      - zlib-dev 
+      - expat-dev 
+      - libnspr-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.freedesktop.org/poppler/poppler.git
+      tag: poppler-${{package.version}}
+      expected-commit: c670e8e1fd8cc4630b8e02f195681027edd4c19a
+
+  - runs: |
+      #!/bin/sh
+      set -x
+      mkdir build && cd build
+      cmake -DENABLE_GPGME=OFF -DENABLE_LIBCURL=OFF -DENABLE_QT5=OFF -DENABLE_QT6=OFF ..
+      make -j$(nproc)
+      make install
+
+subpackages:
+  - name: poppler-dev
+    pipeline:
+      - uses: split/dev
+
+  - name: poppler-doc
+    pipeline:
+      - uses: split/dev
+
+  - name: poppler-glib
+    pipeline:
+      - uses: split/dev
+      
+  - name: poppler-utils
+    pipeline:
+      - uses: split/dev
+  
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2573

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -16,7 +16,6 @@ environment:
       - cairo-dev 
       - boost-dev 
       - cmake 
-      - build-base 
       - libfontconfig1 
       - gobject-introspection-dev 
       - lcms2-dev

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -68,3 +68,8 @@ update:
   enabled: true
   release-monitor:
     identifier: 3686
+    
+test:
+  pipeline:
+    - runs: |
+        pdfinfo -v


### PR DESCRIPTION
Adding Poppler Package.
Poppler support for rendering PDF documents, including features like anti-aliasing of vector graphics, transparent objects, and minification filtering of bitmaps. Command-line utilities built on Poppler's library API to manage PDF documents and extract contents, such as pdftocairo, pdftotext, pdfimages, etc.

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
