### PR TITLE
Drop invalid inputs from shadowsocks-rust

### DIFF
--- a/shadowsocks-rust.yaml
+++ b/shadowsocks-rust.yaml
@@ -67,13 +67,11 @@ test:
         - shadowsocks-rust-ssserver
   pipeline:
     - uses: test/daemon-check-output
-      name: "test sslocal"
       with:
         start: sslocal
         expected_output: "listening on"
     - uses: test/daemon-check-output
       with:
-        name: "test sslocal"
         start: ssserver
         expected_output: "listening on"
 


### PR DESCRIPTION
We'll need to force this through because there's a newer version.