### PR TITLE
Fix issue with generated APKINDEX

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,6 +108,11 @@ jobs:
           # Clean up the symlinks to keep only packages we built.
           find ./packages/${{ matrix.arch }} -type l -exec rm -f {} \;
 
+          # Overwrite the APKINDEX.tar.gz we just generated with the original one.
+          # Since we use a temporary key during the build, we need to re-sign the APKs later.
+          # We don't want to keep the newly indexed stuff because the size field is probably wrong.
+          cp /gcsfuse/wolfi-registry/${{ matrix.arch }}/APKINDEX.* ./packages/${{ matrix.arch }}/
+
           # Merge any missing APKs into our new index.
           for missed in $(cat missing.txt); do
             # We could do this in one command instead of a loop, but it takes things on argv, which is a bit annoying.
@@ -232,14 +237,19 @@ jobs:
             # Consolidate with the built artifacts
             tar xvf /tmp/artifacts/packages-${arch}.tar.gz
 
-            # Sign the APK index
-            melange sign-index -f --signing-key ./wolfi-signing.rsa packages/${arch}/APKINDEX.tar.gz
-
             # Only attempt to sign when *.apk's exist.
             apks=$(ls ./packages/${arch}/*.apk 2>/dev/null || true)
             if [ -n "$apks" ]; then
               melange sign --signing-key ./wolfi-signing.rsa ./packages/${arch}/*.apk
+
+              melange index --merge \
+                --source ./packages/${arch}/APKINDEX.tar.gz \
+                --output ./packages/${arch}/APKINDEX.tar.gz \
+                ./packages/${arch}/*.apk
             fi
+
+            # Sign the APK index
+            melange sign-index -f --signing-key ./wolfi-signing.rsa packages/${arch}/APKINDEX.tar.gz
           done
 
       # Clean up the signing key before uploading to storage out

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins
   version: "2.464"
-  epoch: 0
+  epoch: 1
   description: Open-source CI/CD application.
   copyright:
     - license: MIT


### PR DESCRIPTION
I haven't confirmed this theory because it only really happens in CI, but it seems to make sense.

If you run `apk fetch jenkins` for x86_64, you'll get: BAD archive

Checking the APKINDEX:

  C:Q1Ba0snWqTgKOO85yaQvTH8Z1o6uU=
  P:jenkins
  V:2.464-r0
  A:x86_64
  S:92957609

The size should be "92957609".

Looking at the actual APK:

  wc -c jenkins-2.464-r0.apk
   92957605 jenkins-2.464-r0.apk

We have 4 bytes too many in the APKINDEX. That's odd.

That can probably be explained by this 4 byte difference:

local-melange.rsa.pub
wolfi-signing.rsa

With `wolfictl build`, we (intentionally) re-generate the APKINDEX as we go so that subsequent package builds use the up-to-date version of anything that came before it. Unfortunately, the APKINDEX we generate includes sizes based on the signed APKs, which use "local-melange.rsa" instead of "wolfi-signing.rsa". We don't want the builds to have access to the "wolfi-signing.rsa" key, so we only use that later on in the pipeline, but that means the APKINDEX that we upload for built packages is (usually, gzip affects this) wrong by 1-4 bytes for every size field.

We didn't notice this forever because `apk add` and `apko` don't check this size (they just use the checksum), but apparently `apk fetch` does care about the size matching.

The root cause of (my) confusion here was this:
https://github.com/wolfi-dev/os/blob/c12db62b778952a372afe005a9df4d9f0711be55/Makefile#L20

When implementing `wolfictl build`, I wanted the `--generate-index` behavior to match what we already doing, but what we were already doing was a mistake (which is why I left a comment there). I didn't want to change it, because I didn't want to break anything, but I do think we've been doing this accidentally ~forever.
