### PR TITLE
fix(postgresql-16): Remove gosu as entrypoint dep

### DIFF
--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.3"
-  epoch: 3
+  epoch: 4
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -162,7 +162,7 @@ subpackages:
     dependencies:
       runtime:
         - bash
-        - gosu
+        # Needs gosu, added at image level
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/libexec/${{vars.mangled-package-name}}


### PR DESCRIPTION
Allows dropping in gosu-fips at the image level