### PR TITLE
openssl: add patches for CVE-2024-5535

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.3.1
-  epoch: 2
+  epoch: 3
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,8 @@ pipeline:
       repository: https://github.com/openssl/openssl.git
       tag: openssl-${{package.version}}
       expected-commit: db2ac4f6ebd8f3d7b2a60882992fbea1269114e2
+      cherry-picks: |
+        openssl-3.3/e86ac436f0bd54d4517745483e2315650fae7b2c: CVE-2024-5535
 
   - uses: patch
     with:


### PR DESCRIPTION
https://www.openssl.org/news/secadv/20240627.txt

Due to the low severity of this issue we are not issuing new releases of
OpenSSL at this time. The fix will be included in the next releases when they
become available. The fix is also available in commit e86ac436f0 (for 3.3),
commit 99fb785a5f (for 3.2), commit 4ada436a19 (for 3.1) and commit cf6f91f612
(for 3.0) in the OpenSSL git repository. It is available to premium support
customers in commit b78ec0824d (for 1.1.1) and commit 99472514130 for (1.0.2).