### PR TITLE
Switch heimdal to git-checkout

### DIFF
--- a/heimdal.yaml
+++ b/heimdal.yaml
@@ -25,16 +25,21 @@ environment:
       - sqlite-dev
       - texinfo
       - wolfi-base
-
+      - perl-json
+      - gcc
+      
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://github.com/heimdal/heimdal/releases/download/heimdal-${{package.version}}/heimdal-${{package.version}}.tar.gz
-      expected-sha512: 0167345aca77d65b7a1113874eee5b65ec6e1fec1f196d57e571265409fa35ef95a673a4fd4aafbb0ab5fb5b246b97412353a68d6613a8aff6393a9f1e72999e
+      repository: https://github.com/heimdal/heimdal
+      tag: heimdal-${{package.version}}
+      expected-commit: a6cf94577c0d1e5bca5304342e4ddffb18255afe
 
   - uses: patch
     with:
       patches: CVE-2022-45142.patch
+    
+  - uses: autoconf/configure
 
   - runs: |
       ./configure \

--- a/heimdal.yaml
+++ b/heimdal.yaml
@@ -16,18 +16,18 @@ environment:
       - busybox
       - ca-certificates-bundle
       - gawk
+      - gcc
       - gdbm-dev
       - libtool
       - ncurses-dev
       - perl
+      - perl-json
       - python3
       - readline-dev
       - sqlite-dev
       - texinfo
       - wolfi-base
-      - perl-json
-      - gcc
-      
+
 pipeline:
   - uses: git-checkout
     with:
@@ -38,7 +38,7 @@ pipeline:
   - uses: patch
     with:
       patches: CVE-2022-45142.patch
-    
+
   - uses: autoconf/configure
 
   - runs: |

--- a/perl-json.yaml
+++ b/perl-json.yaml
@@ -1,31 +1,38 @@
 # Generated from https://git.alpinelinux.org/aports/plain/main/perl-json/APKBUILD
 package:
-    name: perl-json
-    version: "4.10"
-    epoch: 0
-    description: Perl module implementing a JSON encoder/decoder
-    copyright:
-        - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  name: perl-json
+  version: "4.10"
+  epoch: 0
+  description: Perl module implementing a JSON encoder/decoder
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
 environment:
-    contents:
-        packages:
-            - build-base
-            - busybox
-            - ca-certificates-bundle
-            - perl
-            - gcc
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gcc
+      - perl
+
 pipeline:
-    - uses: fetch
-      with:
-        expected-sha256: df8b5143d9a7de99c47b55f1a170bd1f69f711935c186a6dc0ab56dd05758e35
-        uri: https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-${{package.version}}.tar.gz
-    - runs: |
-        PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
-    - uses: autoconf/make
-    - uses: autoconf/make-install
-    - uses: strip
+  - uses: fetch
+    with:
+      expected-sha256: df8b5143d9a7de99c47b55f1a170bd1f69f711935c186a6dc0ab56dd05758e35
+      uri: https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-${{package.version}}.tar.gz
+
+  - runs: |
+      PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
 subpackages:
-    - name: perl-json-doc
-      pipeline:
-        - uses: split/manpages
-      description: perl-json manpages
+  - name: perl-json-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-json manpages

--- a/perl-json.yaml
+++ b/perl-json.yaml
@@ -1,0 +1,31 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/perl-json/APKBUILD
+package:
+    name: perl-json
+    version: "4.10"
+    epoch: 0
+    description: Perl module implementing a JSON encoder/decoder
+    copyright:
+        - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+environment:
+    contents:
+        packages:
+            - build-base
+            - busybox
+            - ca-certificates-bundle
+            - perl
+            - gcc
+pipeline:
+    - uses: fetch
+      with:
+        expected-sha256: df8b5143d9a7de99c47b55f1a170bd1f69f711935c186a6dc0ab56dd05758e35
+        uri: https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-${{package.version}}.tar.gz
+    - runs: |
+        PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+    - uses: autoconf/make
+    - uses: autoconf/make-install
+    - uses: strip
+subpackages:
+    - name: perl-json-doc
+      pipeline:
+        - uses: split/manpages
+      description: perl-json manpages


### PR DESCRIPTION
Signed-off-by: Krish Jain <krish.jain@chainguard.dev>

TODO(Krish) move perl-json (added dependency) to git-checkout

cc/ @smoser 

`make package/heimdal`

```
...
...
...
2024/06/28 19:41:05 INFO checking for x86_64-pc-linux-gnu-gcc  options needed to detect all undeclared functions... cannot detect
2024/06/28 19:41:05 WARN configure: error: in '/home/build':
2024/06/28 19:41:05 WARN configure: error: cannot make x86_64-pc-linux-gnu-gcc  report undeclared builtins
```

Scott says its a result of botched configure. It's probably missing something in the dependencies. Maybe https://src.fedoraproject.org/rpms/heimdal/blob/rawhide/f/heimdal.spec helps find the right dependency?
