### PR TITLE
new package: vscode-skip-server-requirements-check

### DIFF
--- a/vscode-skip-server-requirements-check.yaml
+++ b/vscode-skip-server-requirements-check.yaml
@@ -1,0 +1,18 @@
+package:
+  name: vscode-skip-server-requirements-check
+  version: 20240628
+  epoch: 0
+  description: Sentinel file to skip vscode server requirements check
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - runs: touch /tmp/vscode-skip-server-requirements-check
+
+update:
+  enabled: false


### PR DESCRIPTION
This empty sentinel file is used by VSCode server checks to skip the requirements check, which currently fails for Wolfi-based remote environments.*

https://github.com/microsoft/vscode/blob/5bece9e46a005096f4b137b292327d4af1b57073/resources/server/bin/helpers/check-requirements-linux.sh#L21

In Wolfi-based Workstations we have a startup command to touch this file, but having it in a package means it'll be reflected in the SBOM and we can avoid relying on startup commands.

\* For the morbidly curious, the image fails because `/sbin/ldconfig` isn't run before the check, so libstdc++ isn't found. The requirements check tries to ensure the libstdc++ version is sufficient, which it is, but the check fails. Another way to solve this might be to run `/sbin/ldconfig` before the check, but I haven't figured out how to do that yet. If we can get rid of this package in time, we will.