### PR TITLE
glibc: enable hardening options

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.39
-  epoch: 6
+  epoch: 7
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -47,6 +47,9 @@ environment:
       - texinfo
       - wolfi-baselayout
       - zlib
+  # glibc manages FORTIFY_SOURCE on per-file basis
+  environment:
+    CPPFLAGS: ""
 
 pipeline:
   - uses: fetch
@@ -77,9 +80,6 @@ pipeline:
       echo "build-programs=no" > configparms
       cat configparms.base >> configparms
 
-      # We remove fortify when building the libraries
-      export CPPFLAGS=${CPPFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
-
       ../configure \
         --prefix=/usr \
         --libdir=/usr/lib \
@@ -87,18 +87,22 @@ pipeline:
         --includedir=/usr/include \
         --host=${{host.triplet.gnu}} \
         --build=${{host.triplet.gnu}} \
+        --enable-bind-now \
+        --enable-fortify-source \
+        --enable-stackguard-randomization \
+        --enable-stack-protector=strong \
+        --enable-cet \
+        --with-pkgversion="glibc-${{package.full-version}}" \
         --disable-werror \
         --disable-crypt \
         --enable-kernel=4.9
 
   - runs: |
-      export CPPFLAGS=${CPPFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
       make -C build -j$(nproc)
 
   - runs: |
       # Build the programs with fortify
       echo "build-programs=yes" > build/configparms
-      echo "CPPFLAGS += -Wp,-D_FORTIFY_SOURCE=3" >> build/configparms
       cat build/configparms.base >> build/configparms
       make -C build -j$(nproc)
 


### PR DESCRIPTION
Enable multiple hardening options at configure time, to be sure (some of these are toolchain built-in defaults anyway).
Embed the full package version in the build.

With these changes, `hardening-check` reports that "Control flow integrity" is now enabled on `libc.so.6` like it is on other distributions.

However, "Stack clash protection" is still reported as unknown/no, instead of "yes" like it is on other distributions. Will investigate that separately.

