### PR TITLE
fix vscode skip package, add test

### DIFF
--- a/vscode-skip-server-requirements-check.yaml
+++ b/vscode-skip-server-requirements-check.yaml
@@ -1,10 +1,13 @@
 package:
   name: vscode-skip-server-requirements-check
   version: 20240628
-  epoch: 0
+  epoch: 1
   description: Sentinel file to skip vscode server requirements check
   copyright:
     - license: Apache-2.0
+  checks:
+    disabled:
+      - tempdir
 
 environment:
   contents:
@@ -12,7 +15,13 @@ environment:
       - busybox
 
 pipeline:
-  - runs: touch /tmp/vscode-skip-server-requirements-check
+  - runs: |
+      mkdir -p ${{targets.destdir}}/tmp
+      touch ${{targets.destdir}}/tmp/vscode-skip-server-requirements-check
 
 update:
   enabled: false
+
+test:
+  pipeline:
+    - runs: test -f /tmp/vscode-skip-server-requirements-check


### PR DESCRIPTION
Need to disable the tempdir check, which is expected.

I'm not sure why the empty package lint check didn't trip on this, I'll figure that out too.