### PR TITLE
extract the sshd-session binary in the server subpackage

### DIFF
--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssh
   version: 9.8_p1
-  epoch: 0
+  epoch: 1
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC
@@ -128,6 +128,8 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/sbin
           mv "${{targets.destdir}}"/usr/sbin/sshd "${{targets.subpkgdir}}"/usr/sbin/
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/ssh
+          mv "${{targets.destdir}}"/usr/lib/ssh/sshd-session "${{targets.subpkgdir}}"/usr/lib/ssh/
     dependencies:
       runtime:
         - openssh-keygen


### PR DESCRIPTION
The `sshd` binary in the `openssh-server` package was broken because it was missing the `sshd-session` binary. This PR just extracts the `sshd-session binary as part of the `openssh-server` subpackage so it is individually installable.

Release Notes: https://www.openssh.com/releasenotes.html
```
* [sshd(8)](https://man.openbsd.org/sshd.8): the server has been split into a listener binary, [sshd(8)](https://man.openbsd.org/sshd.8),
   and a per-session binary "sshd-session". This allows for a much
   smaller listener binary, as it no longer needs to support the SSH
   protocol. As part of this work, support for disabling privilege
   separation (which previously required code changes to disable) and
   disabling re-execution of [sshd(8)](https://man.openbsd.org/sshd.8) has been removed. Further
   separation of sshd-session into additional, minimal binaries is
   planned for the future.
```