### PR TITLE
Add openssh-server test

### DIFF
--- a/openssh.yaml
+++ b/openssh.yaml
@@ -138,6 +138,11 @@ subpackages:
       post-install: |
         #!/bin/sh
         ssh-keygen -A -q -N ""
+    test:
+      pipeline:
+        - runs: |
+            ssh-keygen -A -q -N ""    # This is unfortunate, but scriplets don't run in test environments, so force this here
+            /usr/sbin/sshd
 
   - name: "openssh-server-config"
     description: "OpenSSH server configuration"
@@ -152,10 +157,6 @@ update:
     identifier: 2565
 
 test:
-  environment:
-    contents:
-      packages:
-        - openssh-server
   pipeline:
     - runs: |
         ssh-keygen -A -q -N ""    # This is unfortunate, but scriplets don't run in test environments, so force this here


### PR DESCRIPTION
This is a follow-up to https://github.com/wolfi-dev/os/pull/22942

The old test _looked_ like it was testing `openssh-server` and it technically was. The test pipeline was tied to the `openssh` package though which means the `openssh` package was implicitly installed in the environment so the `sshd-session` binary was picked up. I took the same test and added it under the `openssh-server` subpackage so it gets tested without the extra packages.

I confirmed this test catches the breakage for the 9.8 r0 package