### PR TITLE
mattermost-9: fix CVE GHSA-3669-72x9-r9p3

### DIFF
--- a/mattermost-9.yaml
+++ b/mattermost-9.yaml
@@ -57,7 +57,7 @@ pipeline:
     pipeline:
       - uses: go/bump
         with:
-          deps: google.golang.org/protobuf@v1.33.0 golang.org/x/image@v0.18.0
+          deps: google.golang.org/protobuf@v1.33.0 golang.org/x/image@v0.18.0 github.com/gorilla/schema@v1.4.1
           modroot: .
           tidy: false # https://github.com/mattermost/mattermost/issues/26221
       - runs: make modules-tidy


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-3669-72x9-r9p3