### PR TITLE
enable updates, some minor improvements

### DIFF
--- a/gitlab-logger.yaml
+++ b/gitlab-logger.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitlab-logger
   version: 3.0.0
-  epoch: 9
+  epoch: 10
   description: GitLab Logger provides a means of wrapping non-structured log files within structure JSON.
   copyright:
     - license: MIT
@@ -11,24 +11,20 @@ environment:
     CGO_ENABLED: "0"
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      # https://gitlab.com/gitlab-org/cloud-native/gitlab-logger
-      uri: https://gitlab.com/gitlab-org/cloud-native/gitlab-logger/-/archive/v${{package.version}}/gitlab-logger-v${{package.version}}.tar.gz
-      expected-sha256: b6bca21e3eba525334f4b140d9d9405181a25821365ccd9065402fa050af78d5
+      repository: https://gitlab.com/gitlab-org/cloud-native/gitlab-logger
+      expected-commit: 61e76054e898803f7c2408e7e54dfba96a5085fc
+      tag: v${{package.version}}
 
   - uses: go/build
     with:
       packages: ./cmd/gitlab-logger
       output: gitlab-logger
-
-  - uses: strip
+      ldflags: -X main.version=${{package.version}} -X main.buildtime=$(date +%F-%T)
 
 subpackages:
   - name: gitlab-logger-compat
-    dependencies:
-      runtime:
-        - gitlab-logger
     pipeline:
       - runs: |
           # GitLab helm chart mostly hardcodes multiple executables path to /usr/local/bin/*
@@ -36,4 +32,15 @@ subpackages:
           ln -s /usr/bin/gitlab-logger "${{targets.subpkgdir}}"/usr/local/bin/gitlab-logger
 
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 373223
+
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-compat
+  pipeline:
+    - runs: |
+        gitlab-logger -h


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
