### PR TITLE
CI: Fix orphan adoption

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,6 +97,11 @@ jobs:
           set -e
           set -o pipefail
 
+          # Overwrite the APKINDEX.tar.gz we just generated with the original one.
+          # Since we use a temporary key during the build, we need to re-sign the APKs later.
+          # We don't want to keep the newly indexed stuff because the size field is probably wrong.
+          cp /gcsfuse/wolfi-registry/${{ matrix.arch }}/APKINDEX.* ./packages/${{ matrix.arch }}/
+
           # Pick up any stragglers that didn't get uploaded in previous builds.
           cat ./packages/${{ matrix.arch }}/APKINDEX.tar.gz | tar -Oxz APKINDEX | awk -F':' '$1 == "P" {printf "%s-", $2} $1 == "V" {printf "%s.apk\n", $2}' | sort > indexed.txt
           # TODO: Figure out why ls through gcsfuse is so slow.
@@ -107,11 +112,6 @@ jobs:
 
           # Clean up the symlinks to keep only packages we built.
           find ./packages/${{ matrix.arch }} -type l -exec rm -f {} \;
-
-          # Overwrite the APKINDEX.tar.gz we just generated with the original one.
-          # Since we use a temporary key during the build, we need to re-sign the APKs later.
-          # We don't want to keep the newly indexed stuff because the size field is probably wrong.
-          cp /gcsfuse/wolfi-registry/${{ matrix.arch }}/APKINDEX.* ./packages/${{ matrix.arch }}/
 
           # Merge any missing APKs into our new index.
           for missed in $(cat missing.txt); do


### PR DESCRIPTION
Fixing a separate issue in #22814 broke the orphan adoption because we were adopting the orphans into the APKINDEX that gets thrown away.

This moves the overwriting up to before we compute the missing APKs so that we fix that in yamlbash instead of in the wolfictl build go code.
