### PR TITLE
ingress-nginx-controller: apply all patches from upstream

### DIFF
--- a/ingress-nginx-controller.yaml
+++ b/ingress-nginx-controller.yaml
@@ -325,11 +325,10 @@ pipeline:
 
       cd "$BUILD_PATH/nginx-${{vars.NGINX_VERSION}}"
 
-      # CVE 2023-44487
-      #
-      # The filename is confusing because upstream uses nginx-1.21.4 while
-      # Wolfi uses 1.25.2 but it is the same patch.
-      patch -p1 $BUILD_PATH/images/nginx/rootfs/patches/nginx-1.21.4-http2.patch
+      for p in $(ls $BUILD_PATH/images/nginx-1.25/rootfs/patches/*.patch); do
+        echo "Patching $p..."
+        patch -p1 $p
+      done
 
       WITH_FLAGS="--with-debug \
       --with-compat \


### PR DESCRIPTION
Two changes:
* Use patches from https://github.com/kubernetes/ingress-nginx/tree/controller-v1.10.1/images/nginx-1.25/rootfs/patches
* Apply all of them (which is actually only one file for 1.10.1)