### PR TITLE
Fix gitlab-exporter troubles with apko

### DIFF
--- a/gitlab-exporter.yaml
+++ b/gitlab-exporter.yaml
@@ -5,7 +5,7 @@
 package:
   name: gitlab-exporter
   version: 15.0.0
-  epoch: 0
+  epoch: 1
   description: GitLab Exporter is a Prometheus Web exporter.
   copyright:
     - license: MIT
@@ -13,6 +13,7 @@ package:
     runtime:
       - jemalloc
       - ruby-3.2
+      - cmd:ruby~3.2 # Work around solver picking 3.3 for cmd:ruby
       - libpq-16
       - busybox
       - gitlab-cng-base


### PR DESCRIPTION
Before:

```
make test/gitlab-exporter
...

2024/07/03 16:32:41 INFO   adding package "busybox" for pipeline "Unlock ruby dependencies"
2024/07/03 16:32:41 INFO   adding package "busybox" for pipeline "Build a ruby gem"
2024/07/03 16:32:41 INFO   adding package "ca-certificates-bundle" for pipeline "Build a ruby gem"
2024/07/03 16:32:41 INFO   adding package "busybox" for pipeline "Install a ruby gem"
2024/07/03 16:32:41 INFO   adding package "ca-certificates-bundle" for pipeline "Install a ruby gem"
2024/07/03 16:32:41 INFO   adding package "busybox" for pipeline "Clean a ruby gem"
2024/07/03 16:32:41 INFO   adding package "ca-certificates-bundle" for pipeline "Clean a ruby gem"
2024/07/03 16:32:41 INFO building test workspace in: '/var/folders/96/3cdgttts3698hyjg_tydpw5c0000gn/T/melange-guest-1711846124-main' with apko
2024/07/03 16:32:41 INFO setting apk repositories: [/Users/jonjohnson/src/github.com/wolfi-dev/os/packages https://packages.wolfi.dev/os]
2024/07/03 16:32:41 INFO image configuration:
2024/07/03 16:32:41 INFO   contents:
2024/07/03 16:32:41 INFO     build repositories: []
2024/07/03 16:32:41 INFO     runtime repositories: []
2024/07/03 16:32:41 INFO     keyring:      []
2024/07/03 16:32:41 INFO     packages:     [wolfi-base gitlab-exporter]
2024/07/03 16:32:41 INFO ERROR: failed to test package. the test environment has been preserved:
2024/07/03 16:32:41 INFO   workspace dir: /var/folders/96/3cdgttts3698hyjg_tydpw5c0000gn/T/melange-workspace-2531140463
2024/07/03 16:32:41 INFO   guest dir: /var/folders/96/3cdgttts3698hyjg_tydpw5c0000gn/T/melange-guest-1711846124
2024/07/03 16:32:41 ERRO failed to build package: unable to build guest: unable to generate image: installing apk packages: error getting package dependencies: solving "gitlab-exporter" constraint: resolving "gitlab-exporter-15.0.0-r0.apk" deps:
solving "ruby-3.2" constraint:   ruby-3.2-3.2.0-r0.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.0-r1.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.0-r2.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.0-r3.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.0-r4.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.0-r5.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.0-r6.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.1-r0.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.1-r1.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.2-r0.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.2-r1.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.2-r2.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.2-r3.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.2-r4.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.3-r0.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.3-r1.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.3-r2.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.3-r3.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.4-r0.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.4-r1.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.4-r2.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.4-r3.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
  ruby-3.2-3.2.4-r4.apk disqualified because ruby-3.3-3.3.3-r0.apk already provides cmd:erb
make: *** [test/gitlab-exporter] Error 1
```

After:

```
make test/gitlab-exporter
...

2024/07/03 16:33:20 INFO   adding package "busybox" for pipeline "Unlock ruby dependencies"
2024/07/03 16:33:20 INFO   adding package "busybox" for pipeline "Build a ruby gem"
2024/07/03 16:33:20 INFO   adding package "ca-certificates-bundle" for pipeline "Build a ruby gem"
2024/07/03 16:33:20 INFO   adding package "busybox" for pipeline "Install a ruby gem"
2024/07/03 16:33:20 INFO   adding package "ca-certificates-bundle" for pipeline "Install a ruby gem"
2024/07/03 16:33:20 INFO   adding package "busybox" for pipeline "Clean a ruby gem"
2024/07/03 16:33:20 INFO   adding package "ca-certificates-bundle" for pipeline "Clean a ruby gem"
2024/07/03 16:33:20 INFO building test workspace in: '/var/folders/96/3cdgttts3698hyjg_tydpw5c0000gn/T/melange-guest-2923703009-main' with apko
2024/07/03 16:33:20 INFO setting apk repositories: [/Users/jonjohnson/src/github.com/wolfi-dev/os/packages https://packages.wolfi.dev/os]
2024/07/03 16:33:20 INFO image configuration:
2024/07/03 16:33:20 INFO   contents:
2024/07/03 16:33:20 INFO     build repositories: []
2024/07/03 16:33:20 INFO     runtime repositories: []
2024/07/03 16:33:20 INFO     keyring:      []
2024/07/03 16:33:20 INFO     packages:     [wolfi-base gitlab-exporter]
2024/07/03 16:33:21 INFO installing ruby3.2-deep_merge (1.2.2-r0)
2024/07/03 16:33:21 INFO installing ruby3.2-excon (0.110.0-r0)
2024/07/03 16:33:21 INFO installing ruby3.2-ruby2_keywords (0.0.5-r2)
2024/07/03 16:33:21 INFO installing ruby3.2-faraday-net_http (3.1.0-r1)
2024/07/03 16:33:21 INFO installing ruby3.2-faraday (2.9.2-r0)
2024/07/03 16:33:21 INFO installing ruby3.2-faraday-excon (2.1.0-r1)
2024/07/03 16:33:21 INFO installing ruby3.2-rack-2.2 (2.2.8.1-r0)
2024/07/03 16:33:21 INFO installing ruby3.2-mustermann (3.0.0-r1)
2024/07/03 16:33:21 INFO installing ruby3.2-quantile (0.2.1-r1)
2024/07/03 16:33:21 INFO installing ca-certificates-bundle (20240315-r4)
2024/07/03 16:33:21 INFO installing wolfi-baselayout (20230201-r12)
2024/07/03 16:33:21 INFO installing ld-linux (2.39-r6)
2024/07/03 16:33:21 INFO installing glibc-locale-posix (2.39-r6)
2024/07/03 16:33:21 INFO installing glibc (2.39-r6)
2024/07/03 16:33:21 INFO installing libgcc (13.2.0-r7)
2024/07/03 16:33:21 INFO installing libstdc++ (13.2.0-r7)
2024/07/03 16:33:21 INFO installing jemalloc (5.3.0-r2)
2024/07/03 16:33:21 INFO installing ruby3.2-connection_pool (2.4.1-r4)
2024/07/03 16:33:21 INFO installing ruby3.2-redis-client (0.22.2-r0)
2024/07/03 16:33:21 INFO installing ruby3.2-redis (5.2.0-r0)
2024/07/03 16:33:21 INFO installing ruby3.2-redis-namespace (1.11.0-r2)
2024/07/03 16:33:21 INFO installing ruby3.2-rack-protection (4.0.0-r0)
2024/07/03 16:33:21 INFO installing yaml (0.2.5-r4)
2024/07/03 16:33:21 INFO installing ncurses-terminfo-base (6.5_p20240629-r0)
2024/07/03 16:33:21 INFO installing ncurses (6.5_p20240629-r0)
2024/07/03 16:33:21 INFO installing readline (8.2-r7)
2024/07/03 16:33:21 INFO installing libffi (3.4.6-r3)
2024/07/03 16:33:21 INFO installing zlib (1.3.1-r3)
2024/07/03 16:33:21 INFO installing libxcrypt (4.4.36-r7)
2024/07/03 16:33:21 INFO installing libcrypt1 (2.39-r6)
2024/07/03 16:33:21 INFO installing libcrypto3 (3.3.1-r3)
2024/07/03 16:33:21 INFO installing libssl3 (3.3.1-r3)
2024/07/03 16:33:21 INFO installing ruby-3.2 (3.2.4-r4)
2024/07/03 16:33:21 INFO installing ruby3.2-tilt (2.4.0-r0)
2024/07/03 16:33:21 INFO installing ruby3.2-sinatra (4.0.0-r0)
2024/07/03 16:33:21 INFO installing libpq-16 (16.3-r4)
2024/07/03 16:33:21 INFO installing ruby3.2-pg (1.5.6-r3)
2024/07/03 16:33:21 INFO installing ruby3.2-nio4r (2.7.1-r2)
2024/07/03 16:33:21 INFO installing ruby3.2-puma (6.4.2-r2)
2024/07/03 16:33:21 INFO installing ruby3.2-concurrent-ruby (1.3.1-r0)
2024/07/03 16:33:21 INFO installing ruby3.2-sidekiq (7.3.0-r0)
2024/07/03 16:33:21 INFO installing ruby3.2-webrick (1.8.1-r6)
2024/07/03 16:33:21 INFO installing xtail (2.1.9-r1)
2024/07/03 16:33:21 INFO installing libproc-2-0 (4.0.4-r2)
2024/07/03 16:33:21 INFO installing procps (4.0.4-r2)
2024/07/03 16:33:21 INFO installing bash (5.2.21-r5)
2024/07/03 16:33:21 INFO installing gitlab-logger (3.0.0-r10)
2024/07/03 16:33:21 INFO installing libunistring (1.2-r2)
2024/07/03 16:33:21 INFO installing libidn2 (2.3.7-r2)
2024/07/03 16:33:21 INFO installing libpsl (0.21.5-r3)
2024/07/03 16:33:21 INFO installing libbrotlicommon1 (1.1.0-r3)
2024/07/03 16:33:21 INFO installing libbrotlidec1 (1.1.0-r3)
2024/07/03 16:33:21 INFO installing libnghttp2-14 (1.62.1-r1)
2024/07/03 16:33:21 INFO installing libcurl-openssl4 (8.8.0-r0)
2024/07/03 16:33:21 INFO installing curl (8.8.0-r0)
2024/07/03 16:33:21 INFO installing gomplate (4.0.1-r1)
2024/07/03 16:33:21 INFO installing busybox (1.36.1-r10)
2024/07/03 16:33:21 INFO installing gitlab-cng-base (17.1.1-r1)
2024/07/03 16:33:21 INFO installing gitlab-cng-exporter-scripts (17.1.1-r1)
2024/07/03 16:33:21 INFO installing ruby3.2-bundler (2.5.14-r0)
2024/07/03 16:33:21 INFO installing gitlab-exporter (15.0.0-r1)
2024/07/03 16:33:21 INFO installing wolfi-keys (1-r8)
2024/07/03 16:33:21 INFO installing apk-tools (2.14.4-r0)
2024/07/03 16:33:21 INFO installing wolfi-base (1-r6)
...
2024/07/03 16:33:23 INFO running the main test pipeline
2024/07/03 16:33:23 INFO running step "Test gitlab-exporter"
2024/07/03 16:33:23 WARN + export 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
2024/07/03 16:33:23 WARN + '[' -d /home/build ]
2024/07/03 16:33:23 WARN + cd /home/build
2024/07/03 16:33:23 WARN + command -v gitlab-exporter
2024/07/03 16:33:23 WARN + exit 0
```