### PR TITLE
go bump php-fpm_exporter to get go1.22 goodies

### DIFF
--- a/php-fpm_exporter.yaml
+++ b/php-fpm_exporter.yaml
@@ -34,7 +34,7 @@ pipeline:
 
   - uses: goreleaser/build
     with:
-      args: --skip-validate
+      skip: "docker,ok,publish,validate"
 
   - uses: strip
 

--- a/php-fpm_exporter.yaml
+++ b/php-fpm_exporter.yaml
@@ -34,7 +34,7 @@ pipeline:
 
   - uses: goreleaser/build
     with:
-      skip: "docker,ok,publish,validate"
+      skip: "docker,ko,publish,validate"
 
   - uses: strip
 

--- a/php-fpm_exporter.yaml
+++ b/php-fpm_exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-fpm_exporter
   version: 2.2.0
-  epoch: 5
+  epoch: 6
   description: A prometheus exporter for PHP-FPM.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
We need to bump the epoch of this package too.