### PR TITLE
Update gitlab packages to use version streams and gitlab mirror for u…

### DIFF
--- a/gitlab-cng-17.1.yaml
+++ b/gitlab-cng-17.1.yaml
@@ -5,6 +5,9 @@ package:
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
+  dependencies:
+    provides:
+      - gitlab-cng=${{package.version}}
 
 environment:
   contents:

--- a/gitlab-cng-17.1.yaml
+++ b/gitlab-cng-17.1.yaml
@@ -1,11 +1,7 @@
-# source is gitlab so we can't use github updates to get expected commit
-# let's still auto create the PR, it will fail as expected commit will be wrong
-# however it will be easy to fix
-#nolint:git-checkout-must-use-github-updates
 package:
-  name: gitlab-cng
+  name: gitlab-cng-17.1
   version: 17.1.1
-  epoch: 1
+  epoch: 0
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -43,6 +39,9 @@ data:
 subpackages:
   - range: scripts
     name: "${{package.name}}-${{range.key}}-scripts"
+    dependencies:
+      provides:
+        - "gitlab-cng-${{range.key}}-scripts==${{package.version}}"
     pipeline:
       - runs: |
           cd ${{range.value}}
@@ -60,6 +59,8 @@ subpackages:
             cp -r $x ${{targets.subpkgdir}}/$x
           done
     dependencies:
+      provides:
+        - gitlab-cng-base==${{package.version}}
       runtime:
         - bash
         - busybox
@@ -101,5 +102,8 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 10037
+  github:
+    identifier: gitlabhq/gitlabhq
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v17

--- a/gitlab-kas-17.1.yaml
+++ b/gitlab-kas-17.1.yaml
@@ -1,5 +1,5 @@
 package:
-  name: gitlab-kas
+  name: gitlab-kas-17.1
   version: 17.1.1
   epoch: 0
   description: GitLab Kas is a component installed together with GitLab. It is required to manage the GitLab agent for Kubernetes.
@@ -11,11 +11,11 @@ environment:
     CGO_ENABLED: "0"
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      # https://gitlab.com/gitlab-org/build/CNG/-/tree/master/gitlab-kas
-      uri: https://gitlab.com/gitlab-org/cluster-integration/gitlab-agent/-/archive/v${{package.version}}/gitlab-agent-v${{package.version}}.tar.gz
-      expected-sha256: 73da3b3d2dc46665483290964da5bc50f549fea19ea3a7599cdba282afa530ad
+      repository: https://gitlab.com/gitlab-org/cluster-integration/gitlab-agent
+      tag: v${{package.version}}
+      expected-commit: df7295ddc0ca049221c174e9f8f204b399422131
 
   - uses: go/bump
     with:
@@ -31,5 +31,8 @@ pipeline:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 369632
+  github:
+    identifier: gitlabhq/gitlabhq
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v17

--- a/gitlab-kas-17.1.yaml
+++ b/gitlab-kas-17.1.yaml
@@ -5,6 +5,9 @@ package:
   description: GitLab Kas is a component installed together with GitLab. It is required to manage the GitLab agent for Kubernetes.
   copyright:
     - license: MIT
+  dependencies:
+    provides:
+      - gitlab-kas=${{package.version}}
 
 environment:
   environment:

--- a/gitlab-runner-17.1.yaml
+++ b/gitlab-runner-17.1.yaml
@@ -5,6 +5,9 @@ package:
   description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
   copyright:
     - license: MIT
+  dependencies:
+    provides:
+      - gitlab-runner=${{package.version}}
 
 environment:
   contents:

--- a/gitlab-runner-17.1.yaml
+++ b/gitlab-runner-17.1.yaml
@@ -1,11 +1,7 @@
-# source is gitlab so we can't use github updates to get expected commit
-# let's still auto create the PR, it will fail as expected commit will be wrong
-# however it will be easy to fix
-#nolint:git-checkout-must-use-github-updates
 package:
-  name: gitlab-runner
+  name: gitlab-runner-17.1
   version: 17.1.0
-  epoch: 2
+  epoch: 0
   description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
   copyright:
     - license: MIT
@@ -45,5 +41,8 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 11337
+  github:
+    identifier: gitlabhq/gitlab-runner
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v17


### PR DESCRIPTION
This PR version streams existing gitlab packages. It also uses the gitlabhq mirror to check for updates.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new version streams
<!-- remove if unrelated -->
- [X] The upstream project actually supports multiple concurrent versions.
- [X] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [X] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))
