### PR TITLE
calico: fix FTBFS and rebuild with new golang

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico
   version: 3.28.0
-  epoch: 3
+  epoch: 4
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0
@@ -147,7 +147,7 @@ subpackages:
         - glibc
     pipeline:
       - assertions:
-          required-steps: 1
+          required-steps: 2
         pipeline:
           # Equivalent to target: "$(NODE_CONTAINER_BINARY)"
           - if: ${{build.arch}} == 'x86_64' || ${{build.arch}} == 'aarch64' # Essentially a guard to make sure we never try to build beyond x86_64 and aarch64


### PR DESCRIPTION
Recently melange has updated how it calculates required steps, and it
seems that number of required pipelines to execute has always been two
yet incorrectly asserted as one. Update the assertion to the new
currently expected value.

Also this rebuilds calico with new golang for CVE remediation.
