### PR TITLE
add package: fluent-bit-docker-image

### DIFF
--- a/fluent-bit-docker-image.yaml
+++ b/fluent-bit-docker-image.yaml
@@ -1,0 +1,28 @@
+package:
+  name: fluent-bit-docker-image
+  version: 20220322
+  epoch: 0
+  description: Docker image for Fluent Bit
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+vars:
+  FLB_DOCKER_BRANCH: "1.8"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/fluent/fluent-bit-docker-image
+      destination: ${{targets.destdir}}/fluent-bit-docker-image
+      branch: ${{vars.FLB_DOCKER_BRANCH}}
+      expected-commit: 98ce3316ea93751ddd33bc319a8f9d177493155b
+
+  - runs: rm -rf ${{targets.destdir}}/fluent-bit-docker-image/.git ${{targets.destdir}}/fluent-bit-docker-image/.github
+
+update:
+  enabled: false # this repository is no longer maintained

--- a/fluent-bit-docker-image.yaml
+++ b/fluent-bit-docker-image.yaml
@@ -1,3 +1,4 @@
+#nolint:valid-pipeline-git-checkout-tag
 package:
   name: fluent-bit-docker-image
   version: 20220322


### PR DESCRIPTION
New package: fluent-bit-docker-image

Attempting to migrate https://github.com/chainguard-dev/enterprise-packages/blob/main/aws-for-fluent-bit-1.9.yaml#L58,  https://github.com/chainguard-dev/enterprise-packages/blob/main/aws-for-fluent-bit-fips.yaml#L58, and https://github.com/wolfi-dev/os/blob/a887e75fbd958082ae9075a662a478ed8cef87b8/aws-for-fluent-bit.yaml#L58 away from using those second git-checkouts steps, which will enable auto-updates to work properly.

Though this repo is not being maintained upstream, there is no code (so security updates shouldn't be an issue) and this is needed for a wolfi-os package, so being placed here.

