### PR TITLE
Refactor: aws-for-fluent-bit

### DIFF
--- a/aws-for-fluent-bit.yaml
+++ b/aws-for-fluent-bit.yaml
@@ -22,9 +22,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-
-vars:
-  FLB_DOCKER_BRANCH: "1.8"
+      - fluent-bit-docker-image
 
 pipeline:
   - uses: git-checkout
@@ -53,16 +51,9 @@ pipeline:
         configs/plugin-metrics-parser.conf \
         "${{targets.destdir}}"/etc/fluent-bit/configs/
 
-  - working-directory: fluent-bit-docker-image
-    pipeline:
-      - uses: git-checkout
-        with:
-          repository: https://github.com/fluent/fluent-bit-docker-image
-          branch: ${{vars.FLB_DOCKER_BRANCH}}
-          expected-commit: 98ce3316ea93751ddd33bc319a8f9d177493155b
-      - runs: |
-          cp conf/parsers*.conf "${{targets.destdir}}"/etc/fluent-bit/etc
-          cp conf/parsers*.conf "${{targets.destdir}}"/etc/fluent-bit/parsers/
+  - runs: |
+      cp /fluent-bit-docker-image/conf/parsers*.conf "${{targets.destdir}}"/etc/fluent-bit/etc
+      cp /fluent-bit-docker-image/conf/parsers*.conf "${{targets.destdir}}"/etc/fluent-bit/parsers/
 
   - uses: strip
 


### PR DESCRIPTION
Attempting to decouple this package from https://github.com/wolfi-dev/os/blob/a887e75fbd958082ae9075a662a478ed8cef87b8/aws-for-fluent-bit.yaml#L58 to enable auto-updates. Waiting on https://github.com/wolfi-dev/os/pull/23220.