### PR TITLE
fix: cloudnative-pg use build.goarch

### DIFF
--- a/cloudnative-pg.yaml
+++ b/cloudnative-pg.yaml
@@ -56,6 +56,6 @@ test:
     - name: "Verify Installation"
       runs: |
         cd /
-        manager_${{vars.build.goarch}} version | grep "${{package.version}}"
+        manager_${{build.goarch}} version | grep "${{package.version}}"
         /manager version | grep "${{package.version}}"
         /manager debug show-architectures | grep ${{build.goarch}}

--- a/cloudnative-pg.yaml
+++ b/cloudnative-pg.yaml
@@ -1,21 +1,10 @@
 package:
   name: cloudnative-pg
   version: 1.23.2
-  epoch: 5
+  epoch: 6
   description: CloudNativePG is a comprehensive platform designed to seamlessly manage PostgreSQL databases
   copyright:
     - license: Apache-2.0
-
-# Replace aarch64/x86_64 with arm64/amd64
-var-transforms:
-  - from: ${{build.arch}}
-    match: 'aarch64'
-    replace: 'arm64'
-    to: mangled-arch
-  - from: ${{build.arch}}
-    match: 'x86_64'
-    replace: 'amd64'
-    to: mangled-arch
 
 pipeline:
   - uses: git-checkout
@@ -31,7 +20,7 @@ pipeline:
   - uses: go/build
     with:
       modroot: ./cmd/manager
-      output: manager_${{vars.mangled-arch}}
+      output: manager_${{build.goarch}}
       prefix: /
       ldflags: |
         -X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildVersion=${{package.version}}
@@ -39,7 +28,7 @@ pipeline:
         -X github.com/cloudnative-pg/cloudnative-pg/pkg/versions.buildDate=$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%Y-%m-%dT%H:%M:%SZ")
       packages: .
 
-  - runs: ln -sf /bin/manager_${{vars.mangled-arch}} ${{targets.contextdir}}/manager
+  - runs: ln -sf /bin/manager_${{build.goarch}} ${{targets.contextdir}}/manager
 
 subpackages:
   - name: ${{package.name}}-plugins
@@ -67,6 +56,6 @@ test:
     - name: "Verify Installation"
       runs: |
         cd /
-        manager_${{vars.mangled-arch}} version | grep "${{package.version}}"
+        manager_${{vars.build.goarch}} version | grep "${{package.version}}"
         /manager version | grep "${{package.version}}"
-        /manager debug show-architectures | grep ${{vars.mangled-arch}}
+        /manager debug show-architectures | grep ${{build.goarch}}


### PR DESCRIPTION
This didn't work the way it was intended before, and newer versions of `melange` detect and fail in this case.

As it was, only the first one was used, so it worked as expected on `x86_64`, producing `manager_amd64`. `aarch64` was unaffected, and produced `manager_aarch64`. Because the var followed that behavior, the test didn't detect it.

It turns out we have `${{build.goarch}}` for this, which we can use directly instead of mangling vars.