### PR TITLE
Add symlink for entrypoint binary, for compat with upstream image and charts

### DIFF
--- a/multus-cni.yaml
+++ b/multus-cni.yaml
@@ -85,3 +85,5 @@ test:
       runs: |
         stat /usr/src/multus-cni/bin/multus-shim
         stat /usr/src/multus-cni/bin/multus-daemon
+        /usr/bin/thin_entrypoint --help
+        /thin_entrypoint --help

--- a/multus-cni.yaml
+++ b/multus-cni.yaml
@@ -1,7 +1,7 @@
 package:
   name: multus-cni
   version: 4.0.2
-  epoch: 7
+  epoch: 8
   description: A CNI meta-plugin for multi-homed pods in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -63,6 +63,7 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/src/multus-cni/bin
           ln -sf /usr/bin/multus-shim ${{targets.contextdir}}/usr/src/multus-cni/bin/multus-shim
           ln -sf /usr/bin/multus-daemon ${{targets.contextdir}}/usr/src/multus-cni/bin/multus-daemon
+          ln -s /usr/bin/thin_entrypoint ${{targets.contextdir}}/thin_entrypoint
 
 update:
   enabled: true

--- a/multus-cni.yaml
+++ b/multus-cni.yaml
@@ -61,6 +61,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/src/multus-cni/bin
+          ln -sf /usr/bin/multus ${{targets.contextdir}}/usr/src/multus-cni/bin/multus
           ln -sf /usr/bin/multus-shim ${{targets.contextdir}}/usr/src/multus-cni/bin/multus-shim
           ln -sf /usr/bin/multus-daemon ${{targets.contextdir}}/usr/src/multus-cni/bin/multus-daemon
           ln -s /usr/bin/thin_entrypoint ${{targets.contextdir}}/thin_entrypoint
@@ -83,7 +84,7 @@ test:
         multus-shim -h
     - name: "Check compat paths"
       runs: |
-        stat /usr/src/multus-cni/bin/multus-shim
-        stat /usr/src/multus-cni/bin/multus-daemon
-        /usr/bin/thin_entrypoint --help
-        /thin_entrypoint --help
+        /usr/src/multus-cni/bin/multus -version
+        /usr/src/multus-cni/bin/multus-shim -version
+        /usr/src/multus-cni/bin/multus-daemon -help
+        /thin_entrypoint --multus-log-level info

--- a/multus-cni.yaml
+++ b/multus-cni.yaml
@@ -62,6 +62,7 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/src/multus-cni/bin
           ln -sf /usr/bin/multus ${{targets.contextdir}}/usr/src/multus-cni/bin/multus
+          ln -sf /usr/bin/install_multus ${{targets.contextdir}}/usr/src/multus-cni/bin/install_multus
           ln -sf /usr/bin/multus-shim ${{targets.contextdir}}/usr/src/multus-cni/bin/multus-shim
           ln -sf /usr/bin/multus-daemon ${{targets.contextdir}}/usr/src/multus-cni/bin/multus-daemon
           ln -s /usr/bin/thin_entrypoint ${{targets.contextdir}}/thin_entrypoint


### PR DESCRIPTION
Add missing symlinks for compatibility with upstream image, as well as any charts depending on these files being present. 