### PR TITLE
kyverno-1.12: version stream for subpackages

### DIFF
--- a/kyverno-1.12.yaml
+++ b/kyverno-1.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-1.12
   version: 1.12.4
-  epoch: 2
+  epoch: 3
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0
@@ -40,35 +40,50 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: kyverno-init-container
+  - name: kyverno-init-container-1.12
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           install -Dm755 cmd/kyverno-init/kyvernopre ${{targets.subpkgdir}}/usr/bin/kyvernopre
+    dependencies:
+      provides:
+        - kyverno-init-container=${{package.full-version}}
 
-  - name: kyverno-reports-controller
+  - name: kyverno-reports-controller-1.12
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           install -Dm755 cmd/reports-controller/reports-controller ${{targets.subpkgdir}}/usr/bin/reports-controller
+    dependencies:
+      provides:
+        - kyverno-reports-controller=${{package.full-version}}
 
-  - name: kyverno-background-controller
+  - name: kyverno-background-controller-1.12
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           install -Dm755 cmd/background-controller/background-controller ${{targets.subpkgdir}}/usr/bin/background-controller
+    dependencies:
+      provides:
+        - kyverno-background-controller=${{package.full-version}}
 
-  - name: kyverno-cleanup-controller
+  - name: kyverno-cleanup-controller-1.12
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           install -Dm755 cmd/cleanup-controller/cleanup-controller ${{targets.subpkgdir}}/usr/bin/cleanup-controller
+    dependencies:
+      provides:
+        - kyverno-cleanup-controller=${{package.full-version}}
 
-  - name: kyverno-cli
+  - name: kyverno-cli-1.12
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           install -Dm755 cmd/cli/kubectl-kyverno/kubectl-kyverno ${{targets.subpkgdir}}/usr/bin/kubectl-kyverno
+    dependencies:
+      provides:
+        - kyverno-cli=${{package.full-version}}
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
