### PR TITLE
Fix compat link

### DIFF
--- a/multus-cni.yaml
+++ b/multus-cni.yaml
@@ -1,7 +1,7 @@
 package:
   name: multus-cni
   version: 4.0.2
-  epoch: 8
+  epoch: 9
   description: A CNI meta-plugin for multi-homed pods in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -62,9 +62,9 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/src/multus-cni/bin
           ln -sf /usr/bin/multus ${{targets.contextdir}}/usr/src/multus-cni/bin/multus
-          ln -sf /usr/bin/install_multus ${{targets.contextdir}}/usr/src/multus-cni/bin/install_multus
           ln -sf /usr/bin/multus-shim ${{targets.contextdir}}/usr/src/multus-cni/bin/multus-shim
           ln -sf /usr/bin/multus-daemon ${{targets.contextdir}}/usr/src/multus-cni/bin/multus-daemon
+          ln -sf /usr/bin/install_multus ${{targets.contextdir}}/install_multus
           ln -s /usr/bin/thin_entrypoint ${{targets.contextdir}}/thin_entrypoint
 
 update:
@@ -89,3 +89,4 @@ test:
         /usr/src/multus-cni/bin/multus-shim -version
         /usr/src/multus-cni/bin/multus-daemon -help
         /thin_entrypoint --multus-log-level info
+        /install_multus -h


### PR DESCRIPTION
One of the compat links added earlier in this PR: https://github.com/wolfi-dev/os/pull/23244 was actually not in the directory that a chart expects, this should fix it