### PR TITLE
add entrypoint script for helm and expand tests

### DIFF
--- a/minio.yaml
+++ b/minio.yaml
@@ -1,7 +1,7 @@
 package:
   name: minio
-  version: 0.20240629.012047
-  epoch: 1
+  version: 0.20240704.142545
+  epoch: 0
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0-or-later
@@ -26,12 +26,13 @@ pipeline:
     with:
       repository: https://github.com/minio/minio
       tag: ${{vars.mangled-package-version}}
-      expected-commit: 91faaa13877df0e2989b1eb3821f0e82fcbbfe80
+      expected-commit: 107d951893c3e02982f200dcbb09d9e953c2b73f
 
   - runs: |
       make build
       mkdir -p ${{targets.destdir}}/usr/bin
       mv minio ${{targets.destdir}}/usr/bin
+      mv dockerscripts/docker-entrypoint.sh ${{targets.destdir}}/usr/bin/docker-entrypoint.sh
 
   - uses: strip
 
@@ -43,3 +44,96 @@ update:
   github:
     identifier: minio/minio
     use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - mc
+        - curl
+        - posix-libc-utils
+  pipeline:
+    - runs: |
+        #!/bin/bash
+
+        # Variables
+        MINIO_ALIAS="myminio"
+        BUCKET_NAME="test-bucket"
+        TEST_FILE="testfile.txt"
+        MINIO_BINARY="minio"
+        MINIO_DATA_DIR="/data/minio"
+        MINIO_SERVER_URL="http://localhost:9000"
+        MINIO_ACCESS_KEY="minioadmin"
+        MINIO_SECRET_KEY="minioadmin"
+
+        # Function to start MinIO server
+        start_minio() {
+            echo "Starting MinIO server..."
+            MINIO_ROOT_USER=$MINIO_ACCESS_KEY MINIO_ROOT_PASSWORD=$MINIO_SECRET_KEY $MINIO_BINARY server $MINIO_DATA_DIR &
+            MINIO_PID=$!
+
+            sleep 10
+        }
+
+        # Function to stop MinIO server
+        stop_minio() {
+            echo "Stopping MinIO server..."
+            kill $MINIO_PID
+            wait $MINIO_PID
+        }
+
+        # Function to check if MinIO is running
+        check_minio() {
+            echo "Checking if MinIO server is running..."
+            if mc alias list | grep -q "$MINIO_ALIAS"; then
+                echo "MinIO server is accessible."
+                return 0
+            else
+                echo "MinIO server is not accessible."
+                return 1
+            fi
+        }
+
+        # Configure mc with default credentials
+        configure_mc() {
+            echo "Configuring mc with default credentials..."
+            mc alias set "$MINIO_ALIAS" $MINIO_SERVER_URL "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+        }
+
+        # Main script
+        if start_minio; then
+            configure_mc
+
+            if check_minio; then
+                # Create a test file
+                echo "Creating a test file..."
+                echo "This is a test file." > $TEST_FILE
+
+                # Create a bucket
+                echo "Creating a bucket named $BUCKET_NAME..."
+                mc mb "$MINIO_ALIAS/$BUCKET_NAME"
+
+                # Upload the test file to the bucket
+                echo "Uploading the test file to the bucket..."
+                mc cp $TEST_FILE "$MINIO_ALIAS/$BUCKET_NAME"
+
+                # List the contents of the bucket
+                echo "Listing the contents of the bucket..."
+                mc ls "$MINIO_ALIAS/$BUCKET_NAME"
+
+                # Clean up
+                echo "Cleaning up..."
+                rm $TEST_FILE
+                mc rb --force "$MINIO_ALIAS/$BUCKET_NAME"
+
+                echo "MinIO test completed."
+            else
+                echo "MinIO server failed to respond. Exiting."
+                exit 1
+            fi
+
+            stop_minio
+        else
+            echo "MinIO server failed to start. Exiting."
+            exit 1
+        fi


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: Duplicates with https://github.com/wolfi-dev/os/pull/23188

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
