### PR TITLE
New package hardening-check

### DIFF
--- a/hardening-check.yaml
+++ b/hardening-check.yaml
@@ -1,0 +1,31 @@
+package:
+  name: hardening-check
+  version: 2.23.7
+  epoch: 0
+  description: "Debian devscripts hardening-check"
+  copyright:
+    - license: GPL-2.0-or-later
+  dependencies:
+    runtime:
+      - binutils
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://salsa.debian.org/debian/devscripts.git
+      tag: v${{package.version}}
+      expected-commit: eb7dc80e72486f7955ec6793a8067fe69fda7883
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/usr/bin
+      mv scripts/hardening-check.pl "${{targets.destdir}}"/usr/bin/hardening-check
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5419


### PR DESCRIPTION
A useful script to determine hardening features enabled in a given ELF
binary by parsing and creating summary out of readelf/objdump output.

This is packaged and widely used in Debian, Ubuntu, SUSE, Fedora.