### PR TITLE
hunspell: add missing dictionaries

### DIFF
--- a/hunspell-dict.yaml
+++ b/hunspell-dict.yaml
@@ -1,0 +1,163 @@
+package:
+  name: hunspell-dictionaries-all
+  version: 0.1_git20240709
+  epoch: 0
+  description: Dictionaries for spell checker and morphological analyzer library and program
+  copyright:
+    - license: GPL-2.0-or-later OR LGPL-2.1-or-later OR MPL-1.1
+  dependencies:
+    runtime:
+      - hunspell-dictionary-af
+      - hunspell-dictionary-an
+      - hunspell-dictionary-ar
+      - hunspell-dictionary-bg
+      - hunspell-dictionary-bn
+      - hunspell-dictionary-bo
+      - hunspell-dictionary-br
+      - hunspell-dictionary-bs
+      - hunspell-dictionary-ca
+      - hunspell-dictionary-ckb
+      - hunspell-dictionary-cs
+      - hunspell-dictionary-da
+      - hunspell-dictionary-de
+      - hunspell-dictionary-el
+      - hunspell-dictionary-en
+      - hunspell-dictionary-eo
+      - hunspell-dictionary-es
+      - hunspell-dictionary-et
+      - hunspell-dictionary-fr
+      - hunspell-dictionary-gd
+      - hunspell-dictionary-gl
+      - hunspell-dictionary-gu
+      - hunspell-dictionary-gug
+      - hunspell-dictionary-he
+      - hunspell-dictionary-hi
+      - hunspell-dictionary-hr
+      - hunspell-dictionary-hu
+      - hunspell-dictionary-id
+      - hunspell-dictionary-is
+      - hunspell-dictionary-it
+      - hunspell-dictionary-kmr
+      - hunspell-dictionary-ko
+      - hunspell-dictionary-lo
+      - hunspell-dictionary-lt
+      - hunspell-dictionary-lv
+      - hunspell-dictionary-mn
+      - hunspell-dictionary-nb
+      - hunspell-dictionary-ne
+      - hunspell-dictionary-nl
+      - hunspell-dictionary-nn
+      - hunspell-dictionary-oc
+      - hunspell-dictionary-pl
+      - hunspell-dictionary-pt
+      - hunspell-dictionary-ro
+      - hunspell-dictionary-ru
+      - hunspell-dictionary-si
+      - hunspell-dictionary-sk
+      - hunspell-dictionary-sl
+      - hunspell-dictionary-sq
+      - hunspell-dictionary-sr
+      - hunspell-dictionary-sv
+      - hunspell-dictionary-sw
+      - hunspell-dictionary-te
+      - hunspell-dictionary-th
+      - hunspell-dictionary-tr
+      - hunspell-dictionary-uk
+      - hunspell-dictionary-vi
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gettext-dev
+      - ncurses-dev
+      - readline-dev
+      - git
+
+pipeline:
+  - runs: |
+      # libreoffice git repos don't provide stable download URLs, and this project doesn't use tags for versioning.
+      # our git-checkout pipeline requires a tag to checkout, so we need to do it this way...
+      git clone  https://anongit.freedesktop.org/git/libreoffice/dictionaries.git
+      cd dictionaries
+
+      # Bump this commit when updating
+      git checkout fc2dc383a40e56c0118866c9110954bebc6ea41d
+
+data:
+  - name: _dictionaries
+    items:
+      af:
+      an:
+      ar:
+      bg:
+      bn:
+      bo:
+      br:
+      bs:
+      ca:
+      ckb:
+      cs:
+      da:
+      de:
+      el:
+      en:
+      eo:
+      es:
+      et:
+      fr:
+      gd:
+      gl:
+      gu:
+      gug:
+      he:
+      hi:
+      hr:
+      hu:
+      id:
+      is:
+      it:
+      kmr:
+      ko:
+      lo:
+      lt:
+      lv:
+      mn:
+      nb:
+      ne:
+      nl:
+      nn:
+      oc:
+      pl:
+      pt:
+      ro:
+      ru:
+      si:
+      sk:
+      sl:
+      sq:
+      sr:
+      sv:
+      sw:
+      te:
+      th:
+      tr:
+      uk:
+      vi:
+
+
+subpackages:
+  - range: _dictionaries
+    name: hunspell-dictionary-${{range.key}}
+    description: hunspell dictionaries
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share/hunspell
+          find dictionaries/  \( -iname ${{range.key}}*.dic -o -iname ${{range.key}}*.aff \) -exec cp {} ${{targets.subpkgdir}}/usr/share/hunspell \;
+
+update:
+  enabled: false

--- a/hunspell-dict.yaml
+++ b/hunspell-dict.yaml
@@ -74,9 +74,9 @@ environment:
       - busybox
       - ca-certificates-bundle
       - gettext-dev
+      - git
       - ncurses-dev
       - readline-dev
-      - git
 
 pipeline:
   - runs: |
@@ -148,7 +148,6 @@ data:
       tr:
       uk:
       vi:
-
 
 subpackages:
   - range: _dictionaries

--- a/hunspell.yaml
+++ b/hunspell.yaml
@@ -1,7 +1,7 @@
 package:
   name: hunspell
   version: 1.7.2
-  epoch: 0
+  epoch: 1
   description: Spell checker and morphological analyzer library and program
   copyright:
     - license: GPL-2.0-or-later OR LGPL-2.1-or-later OR MPL-1.1
@@ -48,11 +48,6 @@ subpackages:
     pipeline:
       - uses: split/manpages
     description: hunspell manpages
-
-  - name: hunspell-lang
-    pipeline:
-      - uses: split/locales
-    description: hunspell FIXME
 
 update:
   enabled: true


### PR DESCRIPTION
Related: https://github.com/chainguard-dev/image-requests/issues/3637

Fixing subpackages creation for dictinaries, needed for spellchecking to actually work
