### PR TITLE
spello: add spello package

### DIFF
--- a/py3-spello.yaml
+++ b/py3-spello.yaml
@@ -41,3 +41,4 @@ update:
   github:
     identifier: hellohaptik/spello
     use-tag: true
+    strip-suffix: .post0

--- a/py3-spello.yaml
+++ b/py3-spello.yaml
@@ -25,7 +25,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/hellohaptik/spello
-      tag: ${{package.version}}
+      tag: ${{package.version}}.post0
       expected-commit: 6aeb68a55c81b9627434e08cc6adb4f464c7419b
 
   - name: Python Build

--- a/py3-spello.yaml
+++ b/py3-spello.yaml
@@ -1,0 +1,43 @@
+package:
+  name: py3-spello
+  version: 1.3.0.post0
+  epoch: 0
+  description: Fast and accurate spell correction library
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - python3
+      - py3-nltk
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-setuptools
+      - py3-wheel
+      - python3-dev
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hellohaptik/spello
+      tag: ${{package.version}}
+      expected-commit: 6aeb68a55c81b9627434e08cc6adb4f464c7419b
+
+  - name: Python Build
+    runs: python setup.py build
+
+  - name: Python Install
+    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: hellohaptik/spello
+    use-tag: true

--- a/py3-spello.yaml
+++ b/py3-spello.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-spello
-  version: 1.3.0.post0
+  version: 1.3.0
   epoch: 0
   description: Fast and accurate spell correction library
   copyright:


### PR DESCRIPTION
Related: https://github.com/chainguard-dev/image-requests/issues/3637

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
