### PR TITLE
Make ruby version streams provide ruby

### DIFF
--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -1,11 +1,14 @@
 package:
   name: ruby-3.0
   version: 3.0.7
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
     - license: BSD-2-Clause
+  dependencies:
+    provides:
+      - ruby=${{package.full-version}}
 
 environment:
   contents:

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,11 +1,14 @@
 package:
   name: ruby-3.1
   version: 3.1.6
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
     - license: BSD-2-Clause
+  dependencies:
+    provides:
+      - ruby=${{package.full-version}}
 
 environment:
   contents:

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,11 +1,14 @@
 package:
   name: ruby-3.2
   version: 3.2.4
-  epoch: 4
+  epoch: 5
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
     - license: BSD-2-Clause
+  dependencies:
+    provides:
+      - ruby=${{package.full-version}}
 
 environment:
   contents:

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,11 +1,14 @@
 package:
   name: ruby-3.3
   version: 3.3.3
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
     - license: BSD-2-Clause
+  dependencies:
+    provides:
+      - ruby=${{package.full-version}}
 
 environment:
   contents:


### PR DESCRIPTION
This gives us a "ruby" virtual that allows wolfictl to properly construct a graph and make ruby-3.2 and ruby-3.3 conflict with each other more explicitly to help the apko solver when it struggles.
