### PR TITLE
Add explicit ruby-3.2 deps to gitlab-exporter deps

### DIFF
--- a/gitlab-exporter.yaml
+++ b/gitlab-exporter.yaml
@@ -5,7 +5,7 @@
 package:
   name: gitlab-exporter
   version: 15.0.0
-  epoch: 0
+  epoch: 1
   description: GitLab Exporter is a Prometheus Web exporter.
   copyright:
     - license: MIT

--- a/ruby3.2-puma.yaml
+++ b/ruby3.2-puma.yaml
@@ -2,13 +2,14 @@
 package:
   name: ruby3.2-puma
   version: 6.4.2
-  epoch: 2
+  epoch: 3
   description: Puma is a simple, fast, threaded, and highly parallel HTTP 1.1 server for Ruby/Rack applications. Puma is intended for use in both development and production environments. It's great for highly parallel Ruby implementations such as Rubinius and JRuby as well as as providing process worker support to support CRuby well.
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
       - ruby3.2-nio4r
+      - ruby-3.2
 
 environment:
   contents:

--- a/ruby3.2-sidekiq.yaml
+++ b/ruby3.2-sidekiq.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-sidekiq
   version: 7.3.0
-  epoch: 0
+  epoch: 1
   description: Simple, efficient background processing for Ruby.
   copyright:
     - license: LGPL-3.0-or-later
@@ -12,6 +12,7 @@ package:
       - ruby3.2-connection_pool
       - ruby3.2-rack-2.2
       - ruby3.2-redis-client
+      - ruby-3.2
 
 environment:
   contents:

--- a/ruby3.2-tilt.yaml
+++ b/ruby3.2-tilt.yaml
@@ -2,10 +2,13 @@
 package:
   name: ruby3.2-tilt
   version: 2.4.0
-  epoch: 0
+  epoch: 1
   description: Generic interface to multiple Ruby template engines
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      - ruby-3.2
 
 environment:
   contents:


### PR DESCRIPTION
These were getting SCA-d cmd:ruby but pulling in ruby-3.3 because the apko solver is not great. This adds explicit deps on ruby-3.2 for ruby3.2* packages that need ruby to workaround this.

Also bump gitlab-exporter to make sure the tests run.