### PR TITLE
gcc: provide runtime libquadmath.so in a subpackage

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 13.3.0
-  epoch: 0
+  epoch: 1
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -113,9 +113,10 @@ subpackages:
   - name: "libquadmath"
     description: "128-bit math library provided by GCC"
     pipeline:
-      - runs: |
+      - if: ${{build.arch}} == 'x86_64'
+        runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          [ -f "${{targets.destdir}}"/usr/lib64/libquadmath.so.* ] && mv "${{targets.destdir}}"/usr/lib64/libquadmath.so.* "${{targets.subpkgdir}}"/usr/lib64/
+          mv "${{targets.destdir}}"/usr/lib64/libquadmath.so.* "${{targets.subpkgdir}}"/usr/lib64/
 
   - name: "libgfortran"
     description: "Fortran runtime library provided by GCC"


### PR DESCRIPTION
Currently libquadmath subpackage is empty, but should contain runtime libquadmath library, as used by boost and hdf5 on x86 only.

aarch64 supports 128 precision without need for libquadmath runtime library.