### PR TITLE
gcc: stop building go and objc

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 13.3.0
-  epoch: 0
+  epoch: 1
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -61,7 +61,7 @@ pipeline:
         --enable-default-pie \
         --enable-default-ssp \
         --with-system-zlib \
-        --enable-languages=c,c++,objc,fortran,jit,go \
+        --enable-languages=c,c++,fortran,jit \
         --enable-bootstrap \
         --enable-gnu-indirect-function \
         --enable-gnu-unique-object \
@@ -146,28 +146,6 @@ subpackages:
         - gcc
         - libgfortran
 
-  - name: "libobjc"
-    description: "GNU Objective-C runtime"
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          mv "${{targets.destdir}}"/usr/lib64/libobjc.so.* "${{targets.subpkgdir}}"/usr/lib64
-
-  - name: "gcc-objc"
-    description: "GNU Objective-C compiler"
-    pipeline:
-      - runs: |
-          _libexecdir=/usr/libexec/gcc/${{host.triplet.gnu}}/${{package.version}}
-          _libdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
-
-          for i in "$_libexecdir" "$_libdir"/include usr/lib64; do
-            mkdir -p "${{targets.subpkgdir}}"/$i
-          done
-
-          mv "${{targets.destdir}}"/$_libexecdir/cc1obj "${{targets.subpkgdir}}"/$_libexecdir
-          mv "${{targets.destdir}}"/$_libdir/include/objc "${{targets.subpkgdir}}"/$_libdir/include/
-          mv "${{targets.destdir}}"/usr/lib64/libobjc.* "${{targets.subpkgdir}}"/usr/lib64
-
   - name: "libgccjit"
     description: "GCC JIT library"
     pipeline:
@@ -212,41 +190,6 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib64
           mv "${{targets.destdir}}"/usr/lib64/libatomic.so.* "${{targets.subpkgdir}}"/usr/lib64/
-
-  - name: "libgo"
-    description: "GCC go runtime library"
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          mv "${{targets.destdir}}"/usr/lib64/libgo.so.* "${{targets.subpkgdir}}"/usr/lib64/
-
-  - name: "gcc-go"
-    description: "GCC go compiler"
-    dependencies:
-      provides:
-        - go-bootstrap=1.18
-    pipeline:
-      - runs: |
-          _libexecdir=/usr/libexec/gcc/${{host.triplet.gnu}}/${{package.version}}
-
-          for i in "$_libexecdir" usr/lib64 usr/bin; do
-            mkdir -p "${{targets.subpkgdir}}"/$i
-          done
-
-          mv "${{targets.destdir}}"/usr/bin/${{host.triplet.gnu}}-gccgo "${{targets.subpkgdir}}"/usr/bin/
-          for i in go gofmt gccgo; do
-            mv "${{targets.destdir}}"/usr/bin/$i "${{targets.subpkgdir}}"/usr/bin/
-          done
-
-          mv "${{targets.destdir}}"/usr/lib64/go "${{targets.subpkgdir}}"/usr/lib64/
-          mv "${{targets.destdir}}"/usr/lib64/libgo.a "${{targets.subpkgdir}}"/usr/lib64/
-          mv "${{targets.destdir}}"/usr/lib64/libgobegin.a "${{targets.subpkgdir}}"/usr/lib64/
-          mv "${{targets.destdir}}"/usr/lib64/libgolibbegin.a "${{targets.subpkgdir}}"/usr/lib64/
-          mv "${{targets.destdir}}"/usr/lib64/libgo.so "${{targets.subpkgdir}}"/usr/lib64/
-
-          for i in cgo go1; do
-            mv "${{targets.destdir}}"/"$_libexecdir"/$i "${{targets.subpkgdir}}"/"$_libexecdir"/
-          done
 
 update:
   enabled: true


### PR DESCRIPTION
gccgo only supports EOL golang 1.18 without generics, it is thus not
useful to build up to date golang code. Unused by any of the packages
in Wolfi and not shipped in any Chainguard Images. It is holding up
shipping EOL go-1.18 in Wolfi.

objc compiler typically requires gnustep libraries to be usable, which
Wolfi does not package. Unused by any of the packages in Wolfi and not
shipped in any Chainguard Images.

These compilers can be reintroduced if popular software starts to
require these toolchains, or if there is demand to ship them as
Chainguard Images. In the meantime, building these toolchains is a
waste of resources.
