### PR TITLE
gcc: stop building objc

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 13.3.0
-  epoch: 0
+  epoch: 1
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -61,7 +61,7 @@ pipeline:
         --enable-default-pie \
         --enable-default-ssp \
         --with-system-zlib \
-        --enable-languages=c,c++,objc,fortran,jit,go \
+        --enable-languages=c,c++,fortran,jit,go \
         --enable-bootstrap \
         --enable-gnu-indirect-function \
         --enable-gnu-unique-object \
@@ -145,28 +145,6 @@ subpackages:
       runtime:
         - gcc
         - libgfortran
-
-  - name: "libobjc"
-    description: "GNU Objective-C runtime"
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          mv "${{targets.destdir}}"/usr/lib64/libobjc.so.* "${{targets.subpkgdir}}"/usr/lib64
-
-  - name: "gcc-objc"
-    description: "GNU Objective-C compiler"
-    pipeline:
-      - runs: |
-          _libexecdir=/usr/libexec/gcc/${{host.triplet.gnu}}/${{package.version}}
-          _libdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
-
-          for i in "$_libexecdir" "$_libdir"/include usr/lib64; do
-            mkdir -p "${{targets.subpkgdir}}"/$i
-          done
-
-          mv "${{targets.destdir}}"/$_libexecdir/cc1obj "${{targets.subpkgdir}}"/$_libexecdir
-          mv "${{targets.destdir}}"/$_libdir/include/objc "${{targets.subpkgdir}}"/$_libdir/include/
-          mv "${{targets.destdir}}"/usr/lib64/libobjc.* "${{targets.subpkgdir}}"/usr/lib64
 
   - name: "libgccjit"
     description: "GCC JIT library"


### PR DESCRIPTION
objc compiler typically requires gnustep libraries to be usable, which
Wolfi does not package. Unused by any of the packages in Wolfi and not
shipped in any Chainguard Images.
