### PR TITLE
gcc-12 explicitly add deps for libexec binaries

### DIFF
--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.4.0
-  epoch: 0
+  epoch: 2
   description: "the GNU compiler collection - version 12"
   resources:
     cpu: 16

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.4.0
-  epoch: 2
+  epoch: 1
   description: "the GNU compiler collection - version 12"
   resources:
     cpu: 16

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -15,6 +15,10 @@ package:
       - binutils
       - libstdc++-12-dev
       - posix-cc-wrappers
+      - gmp
+      - isl
+      - mpc
+      - mpfr
 
 environment:
   contents:

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -13,12 +13,12 @@ package:
   dependencies:
     runtime:
       - binutils
-      - libstdc++-12-dev
-      - posix-cc-wrappers
       - gmp
       - isl
+      - libstdc++-12-dev
       - mpc
       - mpfr
+      - posix-cc-wrappers
 
 environment:
   contents:


### PR DESCRIPTION
tested by apk add gcc-12 and ldd

Fix compiler issues after 12.4.0 release 

```
/usr/libexec/gcc/x86_64-pc-linux-gnu/12.4.0 # ldd cc1
        linux-vdso.so.1 (0x00007ffcca3f5000)
        libisl.so.23 => not found
        libmpc.so.3 => not found
        libmpfr.so.6 => not found
        libgmp.so.10 => not found
        libz.so.1 => /lib/libz.so.1 (0x00007f7ac1109000)
        libm.so.6 => /lib/libm.so.6 (0x00007f7ac1028000)
        libc.so.6 => /lib/libc.so.6 (0x00007f7ac0e3f000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f7ac1126000)
```