### PR TITLE
gcc: add C and C++ tests

### DIFF
--- a/gcc-10.yaml
+++ b/gcc-10.yaml
@@ -147,6 +147,23 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           ln -sf libgcc_s.so.1 "${{targets.subpkgdir}}"/usr/lib/libgcc_s.so
 
+test:
+  pipeline:
+    - name: Check basic usage of top level & libexec binaries
+      runs: |
+        # Check C frontend compiler
+        gcc-10 --version | grep ${{package.version}}
+        # Check C++ frontend compiler
+        g++-10 --version | grep ${{package.version}}
+        # Check C empty translation unit compilation
+        rm -f empty.c
+        touch empty.c
+        gcc-10 -c empty.c
+        # Check C++ empty translation unit compilation
+        rm -f empty.cpp
+        touch empty.cpp
+        g++-10 -c empty.cpp
+
 update:
   enabled: false
   manual: true

--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -147,6 +147,23 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           ln -sf libgcc_s.so.1 "${{targets.subpkgdir}}"/usr/lib/libgcc_s.so
 
+test:
+  pipeline:
+    - name: Check basic usage of top level & libexec binaries
+      runs: |
+        # Check C frontend compiler
+        gcc-11 --version | grep ${{package.version}}
+        # Check C++ frontend compiler
+        g++-11 --version | grep ${{package.version}}
+        # Check C empty translation unit compilation
+        rm -f empty.c
+        touch empty.c
+        gcc-11 -c empty.c
+        # Check C++ empty translation unit compilation
+        rm -f empty.cpp
+        touch empty.cpp
+        g++-11 -c empty.cpp
+
 update:
   enabled: false
   manual: true

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -150,6 +150,23 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           ln -sf libgcc_s.so.1 "${{targets.subpkgdir}}"/usr/lib/libgcc_s.so
 
+test:
+  pipeline:
+    - name: Check basic usage of top level & libexec binaries
+      runs: |
+        # Check C frontend compiler
+        gcc-12 --version | grep ${{package.version}}
+        # Check C++ frontend compiler
+        g++-12 --version | grep ${{package.version}}
+        # Check C empty translation unit compilation
+        rm -f empty.c
+        touch empty.c
+        gcc-12 -c empty.c
+        # Check C++ empty translation unit compilation
+        rm -f empty.cpp
+        touch empty.cpp
+        g++-12 -c empty.cpp
+
 update:
   enabled: false
   manual: true

--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -242,6 +242,23 @@ subpackages:
              "${{targets.destdir}}"/$gcclibdir/libgcj.spec \
              "${{targets.subpkgdir}}"/$gcclibdir/
 
+test:
+  pipeline:
+    - name: Check basic usage of top level & libexec binaries
+      runs: |
+        # Check C frontend compiler
+        gcc-6.5 --version | grep ${{package.version}}
+        # Check C++ frontend compiler
+        g++-6.5 --version | grep ${{package.version}}
+        # Check C empty translation unit compilation
+        rm -f empty.c
+        touch empty.c
+        gcc-6.5 -c empty.c
+        # Check C++ empty translation unit compilation
+        rm -f empty.cpp
+        touch empty.cpp
+        g++-6.5 -c empty.cpp
+
 update:
   # EOL upstream, needed for Java 8 bootstrap only.
   enabled: false

--- a/gcc-9.yaml
+++ b/gcc-9.yaml
@@ -147,6 +147,23 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           ln -sf libgcc_s.so.1 "${{targets.subpkgdir}}"/usr/lib/libgcc_s.so
 
+test:
+  pipeline:
+    - name: Check basic usage of top level & libexec binaries
+      runs: |
+        # Check C frontend compiler
+        gcc-9 --version | grep ${{package.version}}
+        # Check C++ frontend compiler
+        g++-9 --version | grep ${{package.version}}
+        # Check C empty translation unit compilation
+        rm -f empty.c
+        touch empty.c
+        gcc-9 -c empty.c
+        # Check C++ empty translation unit compilation
+        rm -f empty.cpp
+        touch empty.cpp
+        g++-9 -c empty.cpp
+
 update:
   enabled: false
   manual: true

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -248,6 +248,23 @@ subpackages:
             mv "${{targets.destdir}}"/"$_libexecdir"/$i "${{targets.subpkgdir}}"/"$_libexecdir"/
           done
 
+test:
+  pipeline:
+    - name: Check basic usage of top level & libexec binaries
+      runs: |
+        # Check C frontend compiler
+        gcc --version | grep ${{package.version}}
+        # Check C++ frontend compiler
+        g++ --version | grep ${{package.version}}
+        # Check C empty translation unit compilation
+        rm -f empty.c
+        touch empty.c
+        gcc -c empty.c
+        # Check C++ empty translation unit compilation
+        rm -f empty.cpp
+        touch empty.cpp
+        g++ -c empty.cpp
+
 update:
   enabled: true
   release-monitor:


### PR DESCRIPTION
A recent update of gcc-12 resulted in incorrect runtime SCA
dependencies which caused compilers to not work at all. Add tests that
exercise both frontend and underlying compiler binaries to ensure they
are operation and are able to compile C and C++ code.

This is a smoketest, but would have caught the breakage in gcc-12
update.

Explicitely not doing epoch bump, as tests are executed anyway against
existing builds, and epoch bumps of old gcc toolchains likely result
in SCA runtime library breaks. Thus these tests should be landed prior
to future gcc epoch bumps.
