### PR TITLE
add chainguard security guide

### DIFF
--- a/chainguard-security-guide.yaml
+++ b/chainguard-security-guide.yaml
@@ -1,0 +1,41 @@
+package:
+  name: chainguard-security-guide
+  version: 0.1.1
+  epoch: 0
+  description: Security automation content for Chainguard Images
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/chainguard-dev/stigs
+      expected-commit: f558960a0d2656e1110ca8c531f0f9c7a977b3cd
+      tag: v${{package.version}}
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share
+      cp -r gpos/* ${{targets.destdir}}/usr/share/
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: chainguard-dev/stigs
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - openscap
+  pipeline:
+    - name: Verify gpos content is recognized by oscap
+      runs: |
+        oscap info /usr/share/xml/scap/ssg/content/ssg-chainguard-gpos-ds.xml


### PR DESCRIPTION
add chainguard-security-guide (the STIG SRGs content).

the naming of this package is meant to mimic the complianceascode project (`scap-security-guide`), I understand its a little confusing in isolation.