### PR TITLE
libreoffice: use build flags tested with ppt

### DIFF
--- a/libreoffice-24.2.yaml
+++ b/libreoffice-24.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libreoffice-24.2
-  version: 24.2.5.1
-  epoch: 0
+  version: 24.2.5.2
+  epoch: 1
   description:
   # https://www.libreoffice.org/about-us/licenses
   copyright:
@@ -107,8 +107,6 @@ environment:
       - python-3.11
       - python-3.11-dev
       - zip
-  environment:
-    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 pipeline:
   - uses: git-checkout
@@ -123,7 +121,6 @@ pipeline:
 
   - runs: |
       cat > autogen.input <<EOF
-      --with-jdk-home=$JAVA_HOME
       --enable-python=system
       --enable-split-debug
       --prefix=/usr
@@ -137,10 +134,18 @@ pipeline:
       --with-system-zlib
       --with-system-boost
       --with-system-curl
-      --host=${{host.triplet.gnu}}
-      --build=${{host.triplet.gnu}}
+      --disable-gui
+      --disable-cups
+      --disable-lotuswordpro
       --without-junit
       --without-galleries
+      --without-lxml
+      --without-system-libxml
+      --without-java
+      --without-krb5
+      --without-system-dicts
+      --without-system-nss
+
       EOF
       ./autogen.sh
       sed -i 's/bootstrap: check-if-root/bootstrap: /g' Makefile.in


### PR DESCRIPTION
 https://github.com/wolfi-dev/os/issues/22069 noted that `libreoffice` cannot convert PowerPoint files. We had the same issue and built `libreoffice` locally with the build flags in this PR. PowerPoint files convert successfully when building `libreoffice` with these flags.

Note, while this build works for our purposes (headless file conversion with `soffice`), I'm unsure if changing the flags would impact functionality other users may need.

Fixes:
- https://github.com/wolfi-dev/os/issues/22069

Related:

### Pre-review Checklist

After building the `.apk` locally with `melange`, we did the following to test.

```
docker run -it --platform linux/amd64 cgr.dev/chainguard/wolfi-base
```

```
apk add libreoffice-24-24.2.4.2-r1.apk  --allow-untrusted
ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/libreoffice
ln -s /usr/lib/libreoffice/program/soffice.bin /usr/bin/soffice
chmod +x /usr/lib/libreoffice/program/soffice.bin
chmod +x /usr/bin/libreoffice
chmod +x /usr/bin/soffice
```

```
5288451bdb34:/app# soffice --headless --convert-to docx --outdir /app fake.doc
convert /app/fake.doc as a Writer document -> /app/fake.docx using filter : MS Word 2007 XML
5288451bdb34:/app# ls
fake-power-point.ppt            fake.docx
fake.doc                        libreoffice-24-24.2.4.2-r1.apk
5288451bdb34:/app# soffice --headless --convert-to pptx --outdir /app fake-power-point.ppt
convert /app/fake-power-point.ppt as a Impress document -> /app/fake-power-point.pptx using filter : Impress Office Open XML
5288451bdb34:/app# ls
fake-power-point.ppt            fake.doc                        libreoffice-24-24.2.4.2-r1.apk
fake-power-point.pptx           fake.docx
```
