### PR TITLE
google-cloud-sdk: bump to 475.0.0

### DIFF
--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: google-cloud-sdk
   version: 475.0.0
-  epoch: 1
+  epoch: 0
   description: "Google Cloud Command Line Interface"
   copyright:
     - license: Apache-2.0

--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -55,7 +55,6 @@ pipeline:
       rm -rf google-cloud-sdk/deb
       rm -rf google-cloud-sdk/rpm
       rm google-cloud-sdk/install.bat
-      rm google-cloud-sdk/data/cli/gcloud.json
 
       # Remove any third party tests that bloat up the package
       find google-cloud-sdk -type d \( -name 'tests' -o -name 'test' \) -path '*/third_party/*' -exec rm -rf {} +

--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -61,9 +61,6 @@ pipeline:
       find google-cloud-sdk -type d \( -name 'tests' -o -name 'test' \) -path '*/third_party/*' -exec rm -rf {} +
 
       # This is a large binary with vulnerabilities in it, users can add it back later.
-      google-cloud-sdk/bin/gcloud components remove anthoscli
-
-      # This is a large binary with vulnerabilities in it, users can add it back later.
       google-cloud-sdk/bin/gcloud components remove gcloud-crc32c
 
       # Running gcloud adds a bunch of pyc files, remove those
@@ -77,7 +74,7 @@ pipeline:
       mv google-cloud-sdk ${{targets.destdir}}/usr/share/
 
       mkdir -p ${{targets.destdir}}/usr/bin
-      for f in anthoscli bq docker-credential-gcloud gcloud gcloud-crc32c git-credential-gcloud.sh gsutil java_dev_appserver.sh; do
+      for f in bq docker-credential-gcloud gcloud gcloud-crc32c git-credential-gcloud.sh gsutil java_dev_appserver.sh; do
         ln -sf /usr/share/google-cloud-sdk/bin/$f ${{targets.destdir}}/usr/bin/$f
       done
 

--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,6 +1,6 @@
 package:
   name: google-cloud-sdk
-  version: 469.0.0
+  version: 475.0.0
   epoch: 1
   description: "Google Cloud Command Line Interface"
   copyright:
@@ -36,14 +36,14 @@ pipeline:
     uses: fetch
     with:
       uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-x86_64.tar.gz
-      expected-sha256: 896151e0ff30820c0e448bf5656be77d4888ced8edc1e9405fc21368f97dbea5
+      expected-sha256: dd5e035fb0ce7afeede98081ae808b9cfd0d3cc94279d202599b67b29ff2c386
       strip-components: 0
 
   - if: ${{build.arch}} == "aarch64"
     uses: fetch
     with:
       uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-arm.tar.gz
-      expected-sha256: 10d52ed535c5586fca51179637f0a3aa9cea184371183b9f531b416fcc95fb52
+      expected-sha256: 45cde176a3a00b6bd98bcb9838b249a6628a010029ef9a0820ac859869fac53d
       strip-components: 0
 
   - runs: |


### PR DESCRIPTION
Bump version of google-cloud-sdk to 475.0.0

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
