### PR TITLE
build multus-cni with the latest commit until a new version is released

### DIFF
--- a/multus-cni.yaml
+++ b/multus-cni.yaml
@@ -1,7 +1,7 @@
 package:
   name: multus-cni
-  version: 4.0.2
-  epoch: 9
+  version: 4.0.2_git20240710
+  epoch: 10
   description: A CNI meta-plugin for multi-homed pods in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -14,11 +14,11 @@ environment:
       - ca-certificates-bundle
 
 pipeline:
-  - uses: git-checkout
-    with:
-      repository: https://github.com/k8snetworkplumbingwg/multus-cni
-      tag: v${{package.version}}
-      expected-commit: f03765681fe81ee1e0633ee1734bf48ab3bccf2b
+  - runs: |
+      # Hack until they cut a release
+      git clone https://github.com/k8snetworkplumbingwg/multus-cni
+      cd multus-cni
+      git checkout 41013e7580396629a02213019baad1d0c84a6a2c
 
   - uses: go/bump
     with:
@@ -54,6 +54,18 @@ pipeline:
       ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
       output: thin_entrypoint
 
+  - uses: go/build
+    with:
+      packages: ./cmd/kubeconfig_generator
+      ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
+      output: kubeconfig_generator
+
+  - uses: go/build
+    with:
+      packages: ./cmd/cert-approver
+      ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
+      output: cert-approver
+
   - uses: strip
 
 subpackages:
@@ -64,14 +76,13 @@ subpackages:
           ln -sf /usr/bin/multus ${{targets.contextdir}}/usr/src/multus-cni/bin/multus
           ln -sf /usr/bin/multus-shim ${{targets.contextdir}}/usr/src/multus-cni/bin/multus-shim
           ln -sf /usr/bin/multus-daemon ${{targets.contextdir}}/usr/src/multus-cni/bin/multus-daemon
+          ln -sf /usr/bin/cert-approver ${{targets.contextdir}}/usr/src/multus-cni/bin/cert-approver
+          ln -sf /usr/bin/kubeconfig_generator ${{targets.contextdir}}/usr/src/multus-cni/bin/kubeconfig_generator
           ln -sf /usr/bin/install_multus ${{targets.contextdir}}/install_multus
           ln -s /usr/bin/thin_entrypoint ${{targets.contextdir}}/thin_entrypoint
 
 update:
-  enabled: true
-  github:
-    identifier: k8snetworkplumbingwg/multus-cni
-    strip-prefix: v
+  enabled: false
 
 test:
   environment:

--- a/multus-cni.yaml
+++ b/multus-cni.yaml
@@ -20,53 +20,47 @@ pipeline:
       cd multus-cni
       git checkout 41013e7580396629a02213019baad1d0c84a6a2c
 
-  - uses: go/bump
-    with:
-      deps: google.golang.org/grpc@v1.56.3 google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0
-
-  - uses: go/build
-    with:
-      packages: ./cmd/multus
-      ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
-      output: multus
-
-  - uses: go/build
-    with:
-      packages: ./cmd/multus-daemon
-      ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
-      output: multus-daemon
-
-  - uses: go/build
-    with:
-      packages: ./cmd/multus-shim
-      ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
-      output: multus-shim
-
-  - uses: go/build
-    with:
-      packages: ./cmd/install_multus
-      ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
-      output: install_multus
-
-  - uses: go/build
-    with:
-      packages: ./cmd/thin_entrypoint
-      ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
-      output: thin_entrypoint
-
-  - uses: go/build
-    with:
-      packages: ./cmd/kubeconfig_generator
-      ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
-      output: kubeconfig_generator
-
-  - uses: go/build
-    with:
-      packages: ./cmd/cert-approver
-      ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
-      output: cert-approver
-
-  - uses: strip
+  - working-directory: multus-cni
+    pipeline:
+      - uses: go/bump
+        with:
+          deps: google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0
+      - uses: go/build
+        with:
+          packages: ./cmd/multus
+          ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
+          output: multus
+      - uses: go/build
+        with:
+          packages: ./cmd/multus-daemon
+          ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
+          output: multus-daemon
+      - uses: go/build
+        with:
+          packages: ./cmd/multus-shim
+          ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
+          output: multus-shim
+      - uses: go/build
+        with:
+          packages: ./cmd/install_multus
+          ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
+          output: install_multus
+      - uses: go/build
+        with:
+          packages: ./cmd/thin_entrypoint
+          ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
+          output: thin_entrypoint
+      - uses: go/build
+        with:
+          packages: ./cmd/kubeconfig_generator
+          ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
+          output: kubeconfig_generator
+      - uses: go/build
+        with:
+          packages: ./cmd/cert-approver
+          ldflags: -X 'gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus.version=${{package.version}}'
+          output: cert-approver
+      - uses: strip
 
 subpackages:
   - name: ${{package.name}}-compat


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
