### PR TITLE
gcc: add C and C++ tests (gcc-13)

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -249,6 +249,10 @@ subpackages:
           done
 
 test:
+  environment:
+    contents:
+      packages:
+        - glibc-dev
   pipeline:
     - name: Check basic usage of top level & libexec binaries
       runs: |

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -265,6 +265,34 @@ test:
         : > empty.cpp
         g++ -c empty.cpp
 
+    - name: hello world c
+      runs: |
+        cat >hello.c <<"EOF"
+        #include <stdio.h>
+        int main(int argc, char* argv[]) {
+            printf("hello-c");
+            return 0;
+        }
+        EOF
+
+        gcc -o hello-c hello.c
+        out=$(./hello-c)
+        [ "$out" = "hello-c" ]
+
+    - name: hello world c++
+      runs: |
+        cat >hello.cpp <<"EOF"
+        #include <iostream>
+        int main() {
+            std::cout << "hello-c++";
+            return 0;
+        }
+        EOF
+
+        g++ -o hello-c++ hello.cpp
+        out=$(./hello-c++)
+        [ "$out" = "hello-c++" ]
+
 update:
   enabled: true
   release-monitor:

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -257,12 +257,12 @@ test:
         # Check C++ frontend compiler
         g++ --version | grep ${{package.version}}
         # Check C empty translation unit compilation
-        rm -f empty.c
-        touch empty.c
+        : > empty.c
         gcc -c empty.c
+
         # Check C++ empty translation unit compilation
         rm -f empty.cpp
-        touch empty.cpp
+        : > empty.cpp
         g++ -c empty.cpp
 
 update:

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -248,6 +248,23 @@ subpackages:
             mv "${{targets.destdir}}"/"$_libexecdir"/$i "${{targets.subpkgdir}}"/"$_libexecdir"/
           done
 
+test:
+  pipeline:
+    - name: Check basic usage of top level & libexec binaries
+      runs: |
+        # Check C frontend compiler
+        gcc --version | grep ${{package.version}}
+        # Check C++ frontend compiler
+        g++ --version | grep ${{package.version}}
+        # Check C empty translation unit compilation
+        rm -f empty.c
+        touch empty.c
+        gcc -c empty.c
+        # Check C++ empty translation unit compilation
+        rm -f empty.cpp
+        touch empty.cpp
+        g++ -c empty.cpp
+
 update:
   enabled: true
   release-monitor:

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -264,7 +264,6 @@ test:
         rm -f empty.cpp
         : > empty.cpp
         g++ -c empty.cpp
-
     - name: hello world c
       runs: |
         cat >hello.c <<"EOF"
@@ -278,7 +277,6 @@ test:
         gcc -o hello-c hello.c
         out=$(./hello-c)
         [ "$out" = "hello-c" ]
-
     - name: hello world c++
       runs: |
         cat >hello.cpp <<"EOF"


### PR DESCRIPTION
A recent update of gcc-12 resulted in incorrect runtime SCA
dependencies which caused compilers to not work at all. Add tests that
exercise both frontend and underlying compiler binaries to ensure they
are operation and are able to compile C and C++ code.

This is a smoketest, but would have caught the equivalent breakage
seen in the gcc-12 update.

Epoch bump not needed for test only change, as presubmit will rebuild
and tests will be executed against current builds.
