### PR TITLE
Update google-cloud-sdk.yaml

### DIFF
--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -1,6 +1,6 @@
 package:
   name: google-cloud-sdk
-  version: 475.0.0
+  version: 483.0.0
   epoch: 0
   description: "Google Cloud Command Line Interface"
   copyright:
@@ -36,14 +36,14 @@ pipeline:
     uses: fetch
     with:
       uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-x86_64.tar.gz
-      expected-sha256: dd5e035fb0ce7afeede98081ae808b9cfd0d3cc94279d202599b67b29ff2c386
+      expected-sha256: dd3ebdbd13bffa1997232ab5a68af7797594079b062fd41474c666b84165cc35
       strip-components: 0
 
   - if: ${{build.arch}} == "aarch64"
     uses: fetch
     with:
       uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-arm.tar.gz
-      expected-sha256: 45cde176a3a00b6bd98bcb9838b249a6628a010029ef9a0820ac859869fac53d
+      expected-sha256: 7b9a628f2551cecc14a9da2f80b157195150e59ae481e4ec4aec5876651a5b37
       strip-components: 0
 
   - runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
