### PR TITLE
Add exclude-reason field to existing configs with comments.

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -63,7 +63,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib "${{targets.subpkgdir}}"/usr/lib
 
 update:
-  # setting the update to false until the latest apk tools fails for previously built packages
   enabled: false
+  exclude-reason: setting the update to false until the latest apk tools fails for previously built packages
   release-monitor:
     identifier: 20466

--- a/armadillo.yaml
+++ b/armadillo.yaml
@@ -38,4 +38,5 @@ subpackages:
       - uses: split/dev
 
 update:
-  enabled: false # Release monitor is broken here
+  enabled: false
+  exclude-reason: Release monitor is broken here

--- a/berg.yaml
+++ b/berg.yaml
@@ -30,4 +30,7 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false #hosted on codeberg and not present at release-monitoring.org. but #1566 is open to provide support for it in the future.
+  enabled: false
+  exclude-reason: >
+    hosted on codeberg and not present at release-monitoring.org. but #1566 is open to provide support for it in the future.
+

--- a/confluent-common-docker.yaml
+++ b/confluent-common-docker.yaml
@@ -56,7 +56,10 @@ subpackages:
       - uses: strip
 
 update:
-  enabled: false # Upstream repo doesn't provide any jars/poms past 7.6.0: https://packages.confluent.io/maven/io/confluent/common/
+  enabled: false
+  exclude-reason: >
+    Upstream repo doesn't provide any jars/poms past 7.6.0: https://packages.confluent.io/maven/io/confluent/common/
+
 
 test:
   environment:

--- a/db.yaml
+++ b/db.yaml
@@ -82,6 +82,9 @@ subpackages:
     description: C++ binding for libdb
 
 update:
-  enabled: false # we can only track major 5.* versions due to licensing and currently cannot filter for release monitor
+  enabled: false
+  exclude-reason: >
+    we can only track major 5.* versions due to licensing and currently cannot filter for release monitor
+
   release-monitor:
     identifier: 1587

--- a/dhcping.yaml
+++ b/dhcping.yaml
@@ -38,4 +38,7 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # doesn't exist in release monitor, not sure how to get the latest version
+  enabled: false
+  exclude-reason: >
+    doesn't exist in release monitor, not sure how to get the latest version
+

--- a/dieharder.yaml
+++ b/dieharder.yaml
@@ -41,7 +41,8 @@ subpackages:
       - uses: split/manpages
     description: dieharder manpages
 
-# Since release monitor latest version is of the form 3.31.1_20110601-1,
-# we are for now going for manual update till we can have gitlab identifier
 update:
   enabled: false
+  exclude-reason: >
+    Since release monitor latest version is of the form 3.31.1_20110601-1, we are for now going for manual update till we can have gitlab identifier
+

--- a/fluent-bit-docker-image.yaml
+++ b/fluent-bit-docker-image.yaml
@@ -26,4 +26,5 @@ pipeline:
   - runs: rm -rf ${{targets.destdir}}/fluent-bit-docker-image/.git ${{targets.destdir}}/fluent-bit-docker-image/.github
 
 update:
-  enabled: false # this repository is no longer maintained
+  enabled: false
+  exclude-reason: this repository is no longer maintained

--- a/fluxbox.yaml
+++ b/fluxbox.yaml
@@ -41,7 +41,7 @@ pipeline:
   - runs: |
       ./autogen.sh
 
-  - name: 'Configure binutils'
+  - name: "Configure binutils"
     runs: |
       ./configure \
         --prefix=/usr \
@@ -55,9 +55,8 @@ pipeline:
 
   - uses: strip
 
-# Upstream repository no longer cuts any tags or releases (since 2015). The
-# last tag cut was v1.3.7 back in 2015, but there have been several commits
-# since then, including fixes to compile against gcc 11+. This is why updates
-# are disabled, as we're fixing to a given commit ID in the main branch.
 update:
   enabled: false
+  exclude-reason: >
+    Upstream repository no longer cuts any tags or releases (since 2015). The last tag cut was v1.3.7 back in 2015, but there have been several commits since then, including fixes to compile against gcc 11+. This is why updates are disabled, as we're fixing to a given commit ID in the main branch.
+

--- a/font-ipa.yaml
+++ b/font-ipa.yaml
@@ -32,4 +32,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # Non-semanic versioning and 3rd party hosting
+  enabled: false
+  exclude-reason: Non-semanic versioning and 3rd party hosting

--- a/font-ipafont.yaml
+++ b/font-ipafont.yaml
@@ -37,4 +37,5 @@ subpackages:
           install -D -m644 ${{range.value}}*.ttf -t "${{targets.subpkgdir}}"/usr/share/fonts/${{package.name}}
 
 update:
-  enabled: false # No releases or tags
+  enabled: false
+  exclude-reason: No releases or tags

--- a/font-lklug.yaml
+++ b/font-lklug.yaml
@@ -32,4 +32,5 @@ pipeline:
       install -D -m644 lklug.ttf "${{targets.destdir}}"/usr/share/fonts/
 
 update:
-  enabled: false # No source to watch for the new versions
+  enabled: false
+  exclude-reason: No source to watch for the new versions

--- a/font-lohit-beng-assamese.yaml
+++ b/font-lohit-beng-assamese.yaml
@@ -46,4 +46,5 @@ pipeline:
       install -Dm644 lohit-master/assamese/66-lohit-assamese.conf -t ${{targets.destdir}}/etc/fonts/conf.avail
 
 update:
-  enabled: false # The project seems to be inactive
+  enabled: false
+  exclude-reason: The project seems to be inactive

--- a/font-lohit-beng-bengali.yaml
+++ b/font-lohit-beng-bengali.yaml
@@ -46,4 +46,5 @@ pipeline:
       install -Dm644 lohit-master/bengali/66-lohit-bengali.conf -t ${{targets.destdir}}/etc/fonts/conf.avail
 
 update:
-  enabled: false # The project seems to be inactive
+  enabled: false
+  exclude-reason: The project seems to be inactive

--- a/font-lohit-guru.yaml
+++ b/font-lohit-guru.yaml
@@ -35,4 +35,5 @@ pipeline:
       install -D -m644 *.ttf "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
 
 update:
-  enabled: false # No source to watch for the new versions
+  enabled: false
+  exclude-reason: No source to watch for the new versions

--- a/font-lohit-knda.yaml
+++ b/font-lohit-knda.yaml
@@ -35,4 +35,5 @@ pipeline:
       install -D -m644 *.ttf "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
 
 update:
-  enabled: false # No source to watch for the new versions
+  enabled: false
+  exclude-reason: No source to watch for the new versions

--- a/font-noto-cjk.yaml
+++ b/font-noto-cjk.yaml
@@ -40,6 +40,6 @@ pipeline:
       		-t "${{targets.destdir}}"/usr/share/fonts/noto/
       done
 
-# they use a different versioning scheme
 update:
   enabled: false
+  exclude-reason: they use a different versioning scheme

--- a/font-opensans.yaml
+++ b/font-opensans.yaml
@@ -26,6 +26,8 @@ pipeline:
 
 update:
   enabled: false
-  # they don't publish releases or tags :(
+  exclude-reason: >
+    they don't publish releases or tags :(
+
   github:
     identifier: googlefonts/opensans

--- a/font-samyak.yaml
+++ b/font-samyak.yaml
@@ -41,4 +41,5 @@ subpackages:
           install -D -m644 *.ttf -t "${{targets.subpkgdir}}"/usr/share/fonts/samyak
 
 update:
-  enabled: false # No releases or tags
+  enabled: false
+  exclude-reason: No releases or tags

--- a/font-ubuntu.yaml
+++ b/font-ubuntu.yaml
@@ -35,4 +35,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # No source to watch for the new versions
+  enabled: false
+  exclude-reason: No source to watch for the new versions

--- a/font-unfonts-core.yaml
+++ b/font-unfonts-core.yaml
@@ -29,4 +29,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # No releases or tags
+  enabled: false
+  exclude-reason: No releases or tags

--- a/font-wqy-zenhei.yaml
+++ b/font-wqy-zenhei.yaml
@@ -46,4 +46,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # No source to watch for the new versions
+  enabled: false
+  exclude-reason: No source to watch for the new versions

--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -243,5 +243,5 @@ subpackages:
              "${{targets.subpkgdir}}"/$gcclibdir/
 
 update:
-  # EOL upstream, needed for Java 8 bootstrap only.
   enabled: false
+  exclude-reason: EOL upstream, needed for Java 8 bootstrap only.

--- a/govulncheck.yaml
+++ b/govulncheck.yaml
@@ -18,6 +18,8 @@ pipeline:
       output: govulncheck
       packages: ./cmd/govulncheck
 
-# This isn't on GitHub and it's not in release-monitor
 update:
   enabled: false
+  exclude-reason: >
+    This isn't on GitHub and it's not in release-monitor
+

--- a/gradle-stage0.yaml
+++ b/gradle-stage0.yaml
@@ -41,4 +41,5 @@ pipeline:
       ln -sf /usr/share/java/gradle/bin/gradle ${{targets.destdir}}/usr/bin/gradle
 
 update:
-  enabled: false # don't auto update stage 0 packages
+  enabled: false
+  exclude-reason: don't auto update stage 0 packages

--- a/grafana-grafonnet.yaml
+++ b/grafana-grafonnet.yaml
@@ -36,4 +36,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # no releases or tags available
+  enabled: false
+  exclude-reason: no releases or tags available

--- a/harbor-registry.yaml
+++ b/harbor-registry.yaml
@@ -67,8 +67,8 @@ test:
         test $(curl -LI localhost:5000 -o /dev/null -w '%{http_code}\n' -s) == "200"
 
 update:
-  # Re-enable when v3.x.x lands a stable release
   manual: true
+  exclude-reason: Re-enable when v3.x.x lands a stable release
   github:
     identifier: distribution/distribution
     strip-prefix: v

--- a/jackson-json.yaml
+++ b/jackson-json.yaml
@@ -32,10 +32,11 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/share/java
       mv build/*.jar ${{targets.destdir}}/usr/share/java
 
-# the only time this repo gets updated is when there's a CVE
-# if a scanner picks up this package, update the fetched URI above manually
 update:
   enabled: false
   manual: true
+  exclude-reason: >
+    The only time this repo gets updated is when there's a CVE. If a scanner picks up this package, update the fetched URI above manually.
+
   github:
     identifier: FasterXML/jackson-1

--- a/kube-downscaler.yaml
+++ b/kube-downscaler.yaml
@@ -42,4 +42,5 @@ pipeline:
 
 update:
   enabled: false
-  manual: true # we need to manually update because it does not use github
+  manual: true
+  exclude-reason: we need to manually update because it does not use github

--- a/kubernetes-latest.yaml
+++ b/kubernetes-latest.yaml
@@ -91,6 +91,7 @@ subpackages:
           ln -s kube-apiserver-${{vars.kubernetes-version}} ${{targets.subpkgdir}}/usr/bin/kube-apiserver
 
 update:
-  # This package and it's references to "latest" must be bumped manually
-  # when a new latest is dropped.
   enabled: false
+  exclude-reason: >
+    This package and it's references to "latest" must be bumped manually when a new latest is dropped.
+

--- a/libedit.yaml
+++ b/libedit.yaml
@@ -49,6 +49,7 @@ subpackages:
 
 update:
   enabled: false
-  manual: true # version contains a date in the fetch URL
+  manual: true
+  exclude-reason: version contains a date in the fetch URL
   release-monitor:
     identifier: 1599

--- a/libid3tag.yaml
+++ b/libid3tag.yaml
@@ -48,4 +48,7 @@ subpackages:
 
 update:
   enabled: false
-  manual: true # we need to manually update because it does not use GitHub. Release Monitor (id: 21478) is outdated or wrong.
+  manual: true
+  exclude-reason: >
+    we need to manually update because it does not use GitHub. Release Monitor (id: 21478) is outdated or wrong.
+

--- a/libspf2.yaml
+++ b/libspf2.yaml
@@ -61,4 +61,5 @@ subpackages:
           rm -fr "${{targets.destdir}}"/usr/bin
 
 update:
-  enabled: false # no tags or releases
+  enabled: false
+  exclude-reason: no tags or releases

--- a/lua-haproxy-auth-request.yaml
+++ b/lua-haproxy-auth-request.yaml
@@ -26,4 +26,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # no releases or tags available
+  enabled: false
+  exclude-reason: no releases or tags available

--- a/luajit.yaml
+++ b/luajit.yaml
@@ -42,4 +42,5 @@ subpackages:
     description: luajit dev
 
 update:
-  enabled: false # package uses special versioning
+  enabled: false
+  exclude-reason: package uses special versioning

--- a/marzano.yaml
+++ b/marzano.yaml
@@ -38,8 +38,8 @@ pipeline:
   - uses: strip
 
 update:
-  # Until this project does releases we'll have to update these manually
   enabled: false
+  exclude-reason: Until this project does releases we'll have to update these manually
 
 test:
   pipeline:

--- a/maven-stage0.yaml
+++ b/maven-stage0.yaml
@@ -45,4 +45,5 @@ pipeline:
       ln -sf /usr/share/java/maven/bin/mvnyjp ${{targets.destdir}}/usr/bin/mvnyjp
 
 update:
-  enabled: false # don't auto update stage 0 packages
+  enabled: false
+  exclude-reason: don't auto update stage 0 packages

--- a/mc.yaml
+++ b/mc.yaml
@@ -36,4 +36,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # odd versions which cannot be compared and automated
+  enabled: false
+  exclude-reason: odd versions which cannot be compared and automated

--- a/neuvector-db.yaml
+++ b/neuvector-db.yaml
@@ -38,4 +38,5 @@ test:
         fi
 
 update:
-  manual: true # No releases or tags
+  manual: true
+  exclude-reason: No releases or tags

--- a/neuvector-dbgen.yaml
+++ b/neuvector-dbgen.yaml
@@ -59,4 +59,5 @@ test:
         fi
 
 update:
-  manual: true # No releases or tags
+  manual: true
+  exclude-reason: No releases or tags

--- a/neuvector-scanner.yaml
+++ b/neuvector-scanner.yaml
@@ -70,4 +70,5 @@ test:
         fi
 
 update:
-  manual: true # No releases or tags
+  manual: true
+  exclude-reason: No releases or tags

--- a/neuvector-sigstore-interface.yaml
+++ b/neuvector-sigstore-interface.yaml
@@ -39,4 +39,5 @@ test:
         sigstore-interface --help
 
 update:
-  manual: true # No releases or tags
+  manual: true
+  exclude-reason: No releases or tags

--- a/openjdk-10.yaml
+++ b/openjdk-10.yaml
@@ -224,5 +224,5 @@ subpackages:
         - default-jdk=1.10
 
 update:
-  # OpenJDK 10 is EOL.
   enabled: false
+  exclude-reason: OpenJDK 10 is EOL.

--- a/openjdk-12.yaml
+++ b/openjdk-12.yaml
@@ -232,5 +232,5 @@ subpackages:
         - default-jdk=1.12
 
 update:
-  # OpenJDK 12 is EOL
   enabled: false
+  exclude-reason: OpenJDK 12 is EOL.

--- a/openjdk-13.yaml
+++ b/openjdk-13.yaml
@@ -228,5 +228,5 @@ subpackages:
         - default-jdk=1.13
 
 update:
-  # OpenJDK 13 is EOL
   enabled: false
+  exclude-reason: OpenJDK 13 is EOL.

--- a/openjdk-14.yaml
+++ b/openjdk-14.yaml
@@ -224,5 +224,5 @@ subpackages:
         - default-jdk=1.14
 
 update:
-  # OpenJDK 14 is EOL
   enabled: false
+  exclude-reason: OpenJDK 14 is EOL.

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -228,5 +228,5 @@ subpackages:
         - default-jdk=1.15
 
 update:
-  # OpenJDK 15 is EOL
   enabled: false
+  exclude-reason: OpenJDK 15 is EOL.

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -231,5 +231,5 @@ subpackages:
         - default-jdk=1.16
 
 update:
-  # OpenJDK 16 is EOL
   enabled: false
+  exclude-reason: OpenJDK 16 is EOL.

--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -235,5 +235,5 @@ subpackages:
         - default-jdk=1.18
 
 update:
-  # OpenJDK 18 is EOL
   enabled: false
+  exclude-reason: OpenJDK 18 is EOL.

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -232,5 +232,5 @@ subpackages:
         - default-jdk=1.19
 
 update:
-  # OpenJDK 19 is EOL
   enabled: false
+  exclude-reason: OpenJDK 19 is EOL.

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -238,4 +238,5 @@ subpackages:
         - default-jdk=1.20
 
 update:
-  enabled: false # JDK 20 is EOL
+  enabled: false
+  exclude-reason: OpenJDK 20 is EOL.

--- a/openjdk-7.yaml
+++ b/openjdk-7.yaml
@@ -265,7 +265,7 @@ subpackages:
              "${{targets.subpkgdir}}"/usr/lib/jvm/java-1.7-openjdk
 
   - name: "openjdk-7-default-jvm"
-    description: 'Use the openjdk-7 JVM as the default JVM'
+    description: "Use the openjdk-7 JVM as the default JVM"
     dependencies:
       runtime:
         - openjdk-7-jre-base
@@ -286,5 +286,5 @@ subpackages:
         - default-jdk=1.7
 
 update:
-  # OpenJDK 7 is EOL.
   enabled: false
+  exclude-reason: "OpenJDK 7 is EOL"

--- a/openjdk-9.yaml
+++ b/openjdk-9.yaml
@@ -219,5 +219,5 @@ subpackages:
         - default-jdk=1.9
 
 update:
-  # OpenJDK 9 is EOL.
   enabled: false
+  exclude-reason: OpenJDK 9 is EOL.

--- a/perl-algorithm-diff.yaml
+++ b/perl-algorithm-diff.yaml
@@ -43,4 +43,5 @@ subpackages:
     description: perl-algorithm-diff manpages
 
 update:
-  enabled: false # latest releases mismatches in release monitor and github release is not maintained to latest version
+  enabled: false
+  exclude-reason: latest releases mismatches in release monitor and github release is not maintained to latest version

--- a/pgbouncer.yaml
+++ b/pgbouncer.yaml
@@ -57,9 +57,9 @@ subpackages:
     description: pgbouncer manpages
 
 update:
-  # Doesn't work with var transforms
   enabled: false
   manual: true
+  exclude-reason: Doesn't work with var transforms
   github:
     identifier: pgbouncer/pgbouncer
     strip-prefix: pgbouncer_

--- a/php-8.1-pecl-pdosqlsrv.yaml
+++ b/php-8.1-pecl-pdosqlsrv.yaml
@@ -45,9 +45,8 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can find the releases in github but building it does not work
-# with fetching from there like it does when you use fetch.
-# Also seems like I can't watch the github repo for new releases, yet use
-# the fetch above together?
 update:
   enabled: false
+  exclude-reason: >
+    TODO(vaikas): I can find the releases in github but building it does not work with fetching from there like it does when you use fetch. Also seems like I can't watch the github repo for new releases, yet use the fetch above together?
+

--- a/php-8.1-pecl-raphf.yaml
+++ b/php-8.1-pecl-raphf.yaml
@@ -51,6 +51,8 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can't find in release-monitoring, or github.
 update:
   enabled: false
+  exclude-reason: >
+    TODO(vaikas): I can't find in release-monitoring, or github.
+

--- a/php-8.1-pecl-sqlsrv.yaml
+++ b/php-8.1-pecl-sqlsrv.yaml
@@ -45,9 +45,8 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can find the releases in github but building it does not work
-# with fetching from there like it does when you use fetch.
-# Also seems like I can't watch the github repo for new releases, yet use
-# the fetch above together?
 update:
   enabled: false
+  exclude-reason: >
+    TODO(vaikas): I can find the releases in github but building it does not work with fetching from there like it does when you use fetch. Also seems like I can't watch the github repo for new releases, yet use the fetch above together?
+

--- a/php-8.2-pecl-pdosqlsrv.yaml
+++ b/php-8.2-pecl-pdosqlsrv.yaml
@@ -45,9 +45,8 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can find the releases in github but building it does not work
-# with fetching from there like it does when you use fetch.
-# Also seems like I can't watch the github repo for new releases, yet use
-# the fetch above together?
 update:
   enabled: false
+  exclude-reason: >
+    TODO(vaikas): I can find the releases in github but building it does not work with fetching from there like it does when you use fetch. Also seems like I can't watch the github repo for new releases, yet use the fetch above together?
+

--- a/php-8.2-pecl-raphf.yaml
+++ b/php-8.2-pecl-raphf.yaml
@@ -51,6 +51,8 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can't find in release-monitoring, or github.
 update:
   enabled: false
+  exclude-reason: >
+    TODO(vaikas): I can't find in release-monitoring, or github.
+

--- a/php-8.2-pecl-sqlsrv.yaml
+++ b/php-8.2-pecl-sqlsrv.yaml
@@ -45,9 +45,8 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can find the releases in github but building it does not work
-# with fetching from there like it does when you use fetch.
-# Also seems like I can't watch the github repo for new releases, yet use
-# the fetch above together?
 update:
   enabled: false
+  exclude-reason: >
+    TODO(vaikas): I can find the releases in github but building it does not work with fetching from there like it does when you use fetch. Also seems like I can't watch the github repo for new releases, yet use the fetch above together?
+

--- a/pnpm-stage0.yaml
+++ b/pnpm-stage0.yaml
@@ -37,7 +37,8 @@ pipeline:
       ln -sf /usr/lib/node_modules/pnpm/bin/pnpx.cjs  "${{targets.destdir}}"/usr/bin/pnpx
 
 update:
-  enabled: false # don't auto update stage 0 packages
+  enabled: false
+  exclude-reason: "don't auto update stage 0 packages"
   github:
     identifier: pnpm/pnpm
     strip-prefix: v

--- a/py3-alembic.yaml
+++ b/py3-alembic.yaml
@@ -46,7 +46,8 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # This requires manual updates because of the strange tagging scheme.
+  enabled: false
   manual: true
+  exclude-reason: This requires manual updates because of the strange tagging scheme.
   github:
     identifier: sqlalchemy/alembic

--- a/py3-ffwd.yaml
+++ b/py3-ffwd.yaml
@@ -33,6 +33,6 @@ test:
         imports: |
           import ffwd
 
-#archived but needed by cassandra-medussa
 update:
   enabled: false
+  exclude-reason: archived but needed by cassandra-medussa

--- a/py3-keras-applications.yaml
+++ b/py3-keras-applications.yaml
@@ -36,6 +36,7 @@ pipeline:
   - uses: strip
 
 update:
-  # The modular keras-preprocessing package has been retired upstream in favor of monolithic
-  # "keras" package, but Tensorflow itself has not made the jump yet.
   enabled: false
+  exclude-reason: >
+    The modular keras-preprocessing package has been retired upstream in favor of monolithic "keras" package, but Tensorflow itself has not made the jump yet.
+

--- a/py3-keras-preprocessing.yaml
+++ b/py3-keras-preprocessing.yaml
@@ -36,6 +36,7 @@ pipeline:
   - uses: strip
 
 update:
-  # The modular keras-preprocessing package has been retired upstream in favor of monolithic
-  # "keras" package, but Tensorflow itself has not made the jump yet.
   enabled: false
+  exclude-reason: >
+    The modular keras-preprocessing package has been retired upstream in favor of monolithic "keras" package, but Tensorflow itself has not made the jump yet.
+

--- a/py3-mdit-plain.yaml
+++ b/py3-mdit-plain.yaml
@@ -32,4 +32,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # Neither Release Monitor nor GitHub branches/tags are available for this package
+  enabled: false
+  exclude-reason: Neither Release Monitor nor GitHub branches/tags are available for this package

--- a/py3-onetimepass.yaml
+++ b/py3-onetimepass.yaml
@@ -33,4 +33,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # No releases since 2015
+  enabled: false
+  exclude-reason: No releases since 2015

--- a/py3-ply.yaml
+++ b/py3-ply.yaml
@@ -12,7 +12,7 @@ package:
 var-transforms:
   - from: ${{package.version}}
     match: _git(.*)
-    replace: ''
+    replace: ""
     to: mangled-package-version
 
 environment:
@@ -40,6 +40,6 @@ pipeline:
 
   - uses: strip
 
-# some sort of a deprecated project
 update:
   enabled: false
+  exclude-reason: some sort of a deprecated project

--- a/py3-pyfarmhash.yaml
+++ b/py3-pyfarmhash.yaml
@@ -34,4 +34,5 @@ pipeline:
 
 update:
   enabled: false
-  manual: true # no releases, tags, and release-monitor id
+  manual: true
+  exclude-reason: no releases, tags, and release-monitor id

--- a/py3-pykube-ng.yaml
+++ b/py3-pykube-ng.yaml
@@ -39,4 +39,5 @@ pipeline:
 
 update:
   enabled: false
-  manual: true # we need to manually update because it does not use github
+  manual: true
+  exclude-reason: we need to manually update because it does not use github

--- a/py3-pytz.yaml
+++ b/py3-pytz.yaml
@@ -39,7 +39,7 @@ pipeline:
   - uses: strip
 
 update:
-  # releases have an odd structure
   enabled: false
+  exclude-reason: releases have an odd structure
   release-monitor:
     identifier: 6537

--- a/py3-sqlalchemy.yaml
+++ b/py3-sqlalchemy.yaml
@@ -42,7 +42,8 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # This requires manual updates because of the strange tagging scheme.
+  enabled: false
   manual: true
+  exclude-reason: This requires manual updates because of the strange tagging scheme.
   github:
     identifier: sqlalchemy/sqlalchemy

--- a/ragel.yaml
+++ b/ragel.yaml
@@ -49,5 +49,5 @@ test:
         ragel --version
 
 update:
-  # RM tracks development releases instead of stable
   manual: true
+  exclude-reason: RM tracks development releases instead of stable

--- a/rlwrap.yaml
+++ b/rlwrap.yaml
@@ -42,5 +42,5 @@ pipeline:
   - uses: strip
 
 update:
-  # very inconsistent release versions v0.46, 0.46.1
   enabled: false
+  exclude-reason: very inconsistent release versions v0.46, 0.46.1

--- a/rstudio.yaml
+++ b/rstudio.yaml
@@ -95,8 +95,8 @@ pipeline:
   - uses: strip
 
 update:
-  # Doesn't work with the tagging scheme.
   enabled: false
+  exclude-reason: Doesn't work with the tagging scheme.
   github:
     identifier: rstudio/rstudio
     use-tag: true

--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -102,7 +102,8 @@ subpackages:
 
 update:
   enabled: false
-  manual: true # be careful with auto updates as we don't want to include 3.3, we currently don't offer a filter on release monitor versions
+  manual: true
+  exclude-reason: be careful with auto updates as we don't want to include 3.3, we currently don't offer a filter on release monitor versions
   release-monitor:
     identifier: 4223
 

--- a/ruby3.2-aws-eventstream.yaml
+++ b/ruby3.2-aws-eventstream.yaml
@@ -42,6 +42,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-partitions.yaml
+++ b/ruby3.2-aws-partitions.yaml
@@ -42,6 +42,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-sdk-cloudwatchlogs.yaml
+++ b/ruby3.2-aws-sdk-cloudwatchlogs.yaml
@@ -44,6 +44,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-sdk-core.yaml
+++ b/ruby3.2-aws-sdk-core.yaml
@@ -48,6 +48,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-sdk-kms.yaml
+++ b/ruby3.2-aws-sdk-kms.yaml
@@ -46,6 +46,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-sdk-s3.yaml
+++ b/ruby3.2-aws-sdk-s3.yaml
@@ -48,6 +48,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-sdk-sqs.yaml
+++ b/ruby3.2-aws-sdk-sqs.yaml
@@ -46,6 +46,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-sigv4.yaml
+++ b/ruby3.2-aws-sigv4.yaml
@@ -46,6 +46,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-filesize.yaml
+++ b/ruby3.2-filesize.yaml
@@ -39,4 +39,5 @@ vars:
   gem: filesize
 
 update:
-  enabled: false # unmaintained, latest tag cut in 2018
+  enabled: false
+  exclude-reason: unmaintained, latest tag cut in 2018

--- a/rust-stage0.yaml
+++ b/rust-stage0.yaml
@@ -53,4 +53,5 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
 
 update:
-  enabled: false # don't auto update stage 0 packages
+  enabled: false
+  exclude-reason: don't auto update stage 0 packages

--- a/sbt-stage0.yaml
+++ b/sbt-stage0.yaml
@@ -38,4 +38,5 @@ pipeline:
       install -m644 -Dt ${{targets.destdir}}/usr/share/java/sbt/bin ./bin/sbtn-${{build.arch}}-pc-linux
 
 update:
-  enabled: false # don't auto update stage 0 packages
+  enabled: false
+  exclude-reason: don't auto update stage 0 packages

--- a/ssh-import-id.yaml
+++ b/ssh-import-id.yaml
@@ -41,7 +41,8 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # Need support for git.launchpad.net
+  enabled: false
+  exclude-reason: Need support for git.launchpad.net
 
 test:
   pipeline:

--- a/wildfly-openssl.yaml
+++ b/wildfly-openssl.yaml
@@ -49,7 +49,8 @@ pipeline:
 
 update:
   enabled: false
-  manual: true #  two unrelated source artifacts that do not use the same version, we need to manually handle updates here.
+  manual: true
+  exclude-reason: two unrelated source artifacts that do not use the same version, we need to manually handle updates here.
   github:
     identifier: wildfly-security/wildfly-openssl
     strip-suffix: .FINAL


### PR DESCRIPTION
Moves existing update field comments into new exclude-reason field. This is intented to track why auto-update is disabled for a particular package.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/chainguard-dev/mono/issues/18290, https://github.com/wolfi-dev/wolfictl/pull/1060/files

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
