### PR TITLE
bincapz: bump version to v0.15.0

### DIFF
--- a/bincapz.yaml
+++ b/bincapz.yaml
@@ -1,6 +1,6 @@
 package:
   name: bincapz
-  version: 0.14.0
+  version: 0.15.0
   epoch: 0
   description: enumerate binary capabilities, including malicious behaviors
   copyright:
@@ -21,7 +21,7 @@ pipeline:
     with:
       repository: https://github.com/chainguard-dev/bincapz
       tag: v${{package.version}}
-      expected-commit: e22cb16c1e313516413c7d35f6b2ec66a6f00a6f
+      expected-commit: dd4080a6b7cd23da29f98fac6d8e23c38b7282eb
 
   - uses: go/build
     with:


### PR DESCRIPTION
Bump bincapz to v0.15.0 so we can use it on our pipelines.