### PR TITLE
fix(neuvector): Add CIS benchmarks to enforcer and controller

### DIFF
--- a/neuvector.yaml
+++ b/neuvector.yaml
@@ -1,10 +1,15 @@
 package:
   name: neuvector
   version: 5.3.3
-  epoch: 8
+  epoch: 9
   description: "NeuVector Full Lifecycle Container Security Platform"
   copyright:
     - license: Apache-2.0
+  # CIS benchmarks hardcoded to /tmp
+  # In 5.4, these will be moved to a scripts folder in /usr/local/bin/...
+  checks:
+    disabled:
+      - tempdir
 
 environment:
   contents:
@@ -64,6 +69,18 @@ subpackages:
           make -C tools/nstools
           install -Dm755 tools/nstools/nstools ${{targets.contextdir}}/usr/local/bin/nstools
 
+  - name: neuvector-cis-benchmarks
+    description: "CIS benchmarks for NeuVector"
+    pipeline:
+      - runs: |
+          # Copy CIS benchmarks to /tmp - yes, /tmp
+          mkdir -p ${{targets.contextdir}}/tmp
+          cp -r agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/ ${{targets.contextdir}}/tmp/
+          cp -r agent/nvbench/kubernetes-cis-benchmark/cis-1.23/ ${{targets.contextdir}}/tmp/
+          cp -r agent/nvbench/kubernetes-cis-benchmark/cis-1.24/ ${{targets.contextdir}}/tmp/
+          cp -r agent/nvbench/kubernetes-cis-benchmark/cis-1.8.0/ ${{targets.contextdir}}/tmp/
+          cp -r agent/nvbench/ocp/rh-1.4.0/ ${{targets.contextdir}}/tmp/
+
   - name: neuvector-enforcer
     description: "NeuVector Enforcer"
     dependencies:
@@ -76,6 +93,7 @@ subpackages:
         - iproute2
         - iptables
         - jq
+        - neuvector-cis-benchmarks
         - neuvector-monitor
         - neuvector-nstools
         - yq
@@ -138,6 +156,7 @@ subpackages:
         - consul
         - ethtool
         - iproute2
+        - neuvector-cis-benchmarks
         - neuvector-monitor
         - neuvector-nstools
         - opa

--- a/neuvector.yaml
+++ b/neuvector.yaml
@@ -195,6 +195,7 @@ update:
   enabled: true
   ignore-regex-patterns:
     - '.*\-.*'
+    - '.*fnb.*'
   github:
     identifier: neuvector/neuvector
     tag-filter: v


### PR DESCRIPTION
These are thrown in /tmp at the moment. In 5.4, the location will change to a scripts directory in /usr/local/bin, but for now, we have to disable the tempdir check