### PR TITLE
fix(neuvector-cis-benchmarks): Add utils

### DIFF
--- a/neuvector.yaml
+++ b/neuvector.yaml
@@ -1,7 +1,7 @@
 package:
   name: neuvector
   version: 5.3.3
-  epoch: 9
+  epoch: 10
   description: "NeuVector Full Lifecycle Container Security Platform"
   copyright:
     - license: Apache-2.0
@@ -75,6 +75,7 @@ subpackages:
       - runs: |
           # Copy CIS benchmarks to /tmp - yes, /tmp
           mkdir -p ${{targets.contextdir}}/tmp
+          cp -r agent/nvbench/kubernetes-cis-benchmark/utils/ ${{targets.contextdir}}/tmp/
           cp -r agent/nvbench/kubernetes-cis-benchmark/cis-1.6.0/ ${{targets.contextdir}}/tmp/
           cp -r agent/nvbench/kubernetes-cis-benchmark/cis-1.23/ ${{targets.contextdir}}/tmp/
           cp -r agent/nvbench/kubernetes-cis-benchmark/cis-1.24/ ${{targets.contextdir}}/tmp/


### PR DESCRIPTION
Missed these when adding the CIS benchmarks