### PR TITLE
Fix version for subpackages, make sure its appended on end

### DIFF
--- a/calico-3.28.yaml
+++ b/calico-3.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico-3.28
   version: 3.28.0
-  epoch: 6
+  epoch: 7
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0
@@ -14,6 +14,12 @@ package:
   checks:
     disabled:
       - empty
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: short-package-version
 
 environment:
   contents:
@@ -125,7 +131,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "${{package.name}}-node"
+  - name: "calico-node-${{vars.short-package-version}}"
     dependencies:
       provides:
         - calico-node=${{package.full-version}}
@@ -229,7 +235,7 @@ subpackages:
           rm -f "${{targets.subpkgdir}}"/etc/nsswitch.conf
 
   # The felix binaries aren't actually shipped, but they contain some useful testing utilities
-  - name: "${{package.name}}-felix"
+  - name: "calico-felix-${{vars.short-package-version}}"
     dependencies:
       provides:
         - calico-felix=${{package.full-version}}
@@ -304,7 +310,7 @@ subpackages:
             -o "${{targets.subpkgdir}}"/usr/bin/test-workload \
             ./felix/fv/test-workload
 
-  - name: "${{package.name}}-cni"
+  - name: "calico-cni-${{vars.short-package-version}}"
     dependencies:
       provides:
         - calico-cni=${{package.full-version}}
@@ -344,7 +350,7 @@ subpackages:
 
           install -Dm755 cni-plugin/out/install "${{targets.subpkgdir}}"/usr/bin/calico-cni-install
 
-  - name: "${{package.name}}-cni-compat"
+  - name: "calico-cni-compat-${{vars.short-package-version}}"
     dependencies:
       provides:
         - calico-cni-compat=${{package.full-version}}
@@ -363,7 +369,7 @@ subpackages:
           ln -s /usr/bin/calico "${{targets.subpkgdir}}"/opt/cni/bin/calico-ipam
           ln -s /usr/bin/calico-cni-install "${{targets.subpkgdir}}"/opt/cni/bin/install
 
-  - name: "${{package.name}}-apiserver"
+  - name: "calico-apiserver-${{vars.short-package-version}}"
     dependencies:
       provides:
         - calico-apiserver=${{package.full-version}}
@@ -377,7 +383,7 @@ subpackages:
           output: calico-apiserver
           ldflags: "-X github.com/projectcalico/calico/cmd/apiserver/server.VERSION=${{package.version}}) -X github.com/projectcalico/calico/cmd/apiserver/server.BUILD_DATE=$(date -u +'%FT%T%z') -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_DESCRIPTION=$(git describe --tags) -X github.com/projectcalico/calico/cmd/apiserver/server.GIT_REVISION=$(git rev-parse --short HEAD)"
 
-  - name: "${{package.name}}-key-cert-provisioner"
+  - name: "calico-key-cert-provisioner-${{vars.short-package-version}}"
     dependencies:
       provides:
         - calico-key-cert-provisioner=${{package.full-version}}
@@ -390,7 +396,7 @@ subpackages:
           packages: ./key-cert-provisioner/cmd/
           output: calico-key-cert-provisioner
 
-  - name: "${{package.name}}-app-policy"
+  - name: "calico-app-policy-${{vars.short-package-version}}"
     dependencies:
       provides:
         - calico-app-policy=${{package.full-version}}
@@ -409,7 +415,7 @@ subpackages:
           packages: ./app-policy/cmd/healthz
           output: calico-healthz
 
-  - name: "${{package.name}}-kube-controllers"
+  - name: "calico-kube-controllers-${{vars.short-package-version}}"
     dependencies:
       provides:
         - calico-kube-controllers=${{package.full-version}}
@@ -429,7 +435,7 @@ subpackages:
           output: check-status # keep naming convention as "check-status" is usually harded to /usr/bin/check-status
           ldflags: "-X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
 
-  - name: "${{package.name}}-pod2daemon"
+  - name: "calico-pod2daemon-${{vars.short-package-version}}"
     description: "The calico pod2daemon components"
     dependencies:
       provides:
@@ -456,7 +462,7 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           install -m755 ./pod2daemon/flexvol/docker-image/flexvol.sh "${{targets.subpkgdir}}"/usr/bin/flexvol.sh
 
-  - name: "${{package.name}}-pod2daemon-flexvol-compat"
+  - name: "calico-pod2daemon-flexvol-compat-${{vars.short-package-version}}"
     dependencies:
       provides:
         - calico-pod2daemon-flexvol-compat=${{package.full-version}}
@@ -466,7 +472,7 @@ subpackages:
           ln -sf /usr/bin/calico-pod2daemon-flexvol "${{targets.subpkgdir}}"/usr/local/bin/flexvol
           ln -sf /usr/bin/flexvol.sh "${{targets.subpkgdir}}"/usr/local/bin/flexvol.sh
 
-  - name: "${{package.name}}-calicoctl"
+  - name: "calicoctl-${{vars.short-package-version}}"
     dependencies:
       provides:
         - calicoctl=${{package.full-version}}
@@ -478,7 +484,7 @@ subpackages:
           output: calicoctl
           ldflags: "-X github.com/projectcalico/calico/calicoctl/commands.VERSION=$(git describe --tags --dirty --always --abbrev=12) -X github.com/projectcalico/calico/calicoctl/commands.GIT_REVISION=$(git rev-parse --short HEAD) -X github.com/projectcalico/calico/calicoctl/commands/common.VERSION=$(git describe --tags --dirty --always --abbrev=12) -X main.VERSION=$(git describe --tags --dirty --always --abbrev=12)"
 
-  - name: "${{package.name}}-typhad"
+  - name: "calico-typhad-${{vars.short-package-version}}"
     description: "The calico typha daemon"
     dependencies:
       provides:
@@ -506,7 +512,7 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/licenses
           cp ./typha/LICENSE "${{targets.subpkgdir}}"/licenses
 
-  - name: "${{package.name}}-typha-client"
+  - name: "calico-typha-client-${{vars.short-package-version}}"
     description: "The calico typha client"
     dependencies:
       provides:

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -123,3 +123,16 @@ pytorch-2.2.1-r1.apk
 pytorch-2.3.0-r0.apk
 gitlab-container-registry-4.5.0-r0.apk
 gitlab-container-registry-compat-4.5.0-r0.apk
+calico-3.28-apiserver-3.28.0-r6.apk
+calico-3.28-app-policy-3.28.0-r6.apk
+calico-3.28-calicoctl-3.28.0-r6.apk
+calico-3.28-cni-3.28.0-r6.apk
+calico-3.28-cni-compat-3.28.0-r6.apk
+calico-3.28-felix-3.28.0-r6.apk
+calico-3.28-key-cert-provisioner-3.28.0-r6.apk
+calico-3.28-kube-controllers-3.28.0-r6.apk
+calico-3.28-node-3.28.0-r6.apk
+calico-3.28-pod2daemon-3.28.0-r6.apk
+calico-3.28-pod2daemon-flexvol-compat-3.28.0-r6.apk
+calico-3.28-typha-client-3.28.0-r6.apk
+calico-3.28-typhad-3.28.0-r6.apk


### PR DESCRIPTION
Attempted to tidy-up subpackage names for version stream in: https://github.com/wolfi-dev/os/pull/23887

version was not appended onto end of subpackage names, this should resolve:

```bash
% ls packages/aarch64 | grep "calico"
calico-3.28-3.28.0-r7.apk
calico-apiserver-3.28-3.28.0-r7.apk
calico-app-policy-3.28-3.28.0-r7.apk
calico-cni-3.28-3.28.0-r7.apk
calico-cni-compat-3.28-3.28.0-r7.apk
calico-felix-3.28-3.28.0-r7.apk
calico-key-cert-provisioner-3.28-3.28.0-r7.apk
...
```