### PR TITLE
fix(gitlab): Fix tag filters for KAS and runner

### DIFF
--- a/gitlab-kas-17.1.yaml
+++ b/gitlab-kas-17.1.yaml
@@ -38,4 +38,4 @@ update:
     identifier: gitlabhq/gitlabhq
     strip-prefix: v
     use-tag: true
-    tag-filter: v17
+    tag-filter: v17.1

--- a/gitlab-runner-17.1.yaml
+++ b/gitlab-runner-17.1.yaml
@@ -56,4 +56,4 @@ update:
     identifier: gitlabhq/gitlab-runner
     strip-prefix: v
     use-tag: true
-    tag-filter: v17
+    tag-filter: v17.1


### PR DESCRIPTION
Filters to 17.1 instead of 17