### PR TITLE
fix(gitlab-cng-17.1): Don't bundle CNG scripts/config with components…

### DIFF
--- a/gitlab-cng-17.1.yaml
+++ b/gitlab-cng-17.1.yaml
@@ -27,7 +27,7 @@ vars:
 package:
   name: gitlab-cng-17.1
   version: 17.1.2
-  epoch: 1
+  epoch: 2
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -82,7 +82,7 @@ subpackages:
     name: "${{package.name}}-${{range.key}}-scripts"
     dependencies:
       provides:
-        - "gitlab-cng-${{range.key}}-scripts=${{package.full-version}}"
+        - gitlab-cng-${{range.key}}-scripts=${{package.full-version}}
     pipeline:
       - runs: |
           cd ${{range.value}}
@@ -134,7 +134,6 @@ subpackages:
     dependencies:
       runtime:
         - ca-certificates
-        - gitlab-cng-base
     test:
       pipeline:
         - name: Test bundle-certificates script
@@ -178,7 +177,6 @@ subpackages:
         contents:
           packages:
             - crane
-            - gitlab-cng-gitlab-container-registry-compat
       pipeline:
         - runs: |
             #!/bin/bash
@@ -217,7 +215,7 @@ subpackages:
             EOL
 
             # Run the Docker registry with the configuration file
-            /bin/registry serve /etc/docker/registry/config.yml &
+            registry serve /etc/docker/registry/config.yml &
             PID=$!
 
             # Wait for the registry to start
@@ -291,8 +289,6 @@ subpackages:
         - ruby-3.2
         - libpq-16
         - busybox
-        - ${{package.name}}-base
-        - ${{package.name}}-exporter-scripts
         - ruby3.2-webrick
         - ruby3.2-faraday
         - ruby3.2-faraday-excon
@@ -351,11 +347,6 @@ subpackages:
           dir: ./exporter
       - uses: ruby/clean
     test:
-      environment:
-        contents:
-          packages:
-            - wolfi-base
-        environment:
       pipeline:
         - name: "Test gitlab-exporter"
           runs: |
@@ -382,10 +373,6 @@ subpackages:
           ldflags: -X main.version=${component_version} -X main.buildtime=$(date +%F-%T)
           modroot: ./logger
     test:
-      environment:
-        contents:
-          packages:
-            - gitlab-cng-gitlab-logger-compat
       pipeline:
         - runs: |
             gitlab-logger -h
@@ -409,8 +396,6 @@ subpackages:
         - jemalloc
         - ruby-3.2
         - busybox
-        - ${{package.name}}-base
-        - ${{package.name}}-mailroom-scripts
         - ruby3.2-webrick
         - ruby3.2-bundler
         - ruby3.2-oauth2
@@ -447,9 +432,6 @@ subpackages:
       provides:
         - gitlab-cng-gitlab-shell=${{package.full-version}}
       runtime:
-        - ${{package.name}}-base
-        - ${{package.name}}-shell-scripts
-        - ${{package.name}}-gitlab-logger-compat
         - openssh
     pipeline:
       - uses: git-checkout


### PR DESCRIPTION
… at runtime

Allows us to drop in either CE or EE CNG scripts/configuration at runtime without creating duplicate packages to accomodate this. While I'd expect no differences between the scripts/config shipped in CNG anyway (as the compoennts themselves are not different between versions), it's better we handle this at the image level in case there are