### PR TITLE
Add concurrency to test-world.

### DIFF
--- a/.github/workflows/test-world.yaml
+++ b/.github/workflows/test-world.yaml
@@ -9,6 +9,11 @@ on:
 
   workflow_dispatch:
 
+
+# Only run one test at a time to curtail costs
+concurrency:
+  group: test-world-${{ github.ref }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
As-is, we are spinning up 64c runners for every PR were merge.  We merge a lot.  This is expensive.
