### PR TITLE
gcc cleanups

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -61,7 +61,7 @@ pipeline:
         --enable-default-pie \
         --enable-default-ssp \
         --with-system-zlib \
-        --enable-languages=c,c++,objc,fortran,jit,go \
+        --enable-languages=c,c++,fortran,jit,go \
         --enable-bootstrap \
         --enable-gnu-indirect-function \
         --enable-gnu-unique-object \
@@ -146,28 +146,6 @@ subpackages:
       runtime:
         - gcc
         - libgfortran
-
-  - name: "libobjc"
-    description: "GNU Objective-C runtime"
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          mv "${{targets.destdir}}"/usr/lib64/libobjc.so.* "${{targets.subpkgdir}}"/usr/lib64
-
-  - name: "gcc-objc"
-    description: "GNU Objective-C compiler"
-    pipeline:
-      - runs: |
-          _libexecdir=/usr/libexec/gcc/${{host.triplet.gnu}}/${{package.version}}
-          _libdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
-
-          for i in "$_libexecdir" "$_libdir"/include usr/lib64; do
-            mkdir -p "${{targets.subpkgdir}}"/$i
-          done
-
-          mv "${{targets.destdir}}"/$_libexecdir/cc1obj "${{targets.subpkgdir}}"/$_libexecdir
-          mv "${{targets.destdir}}"/$_libdir/include/objc "${{targets.subpkgdir}}"/$_libdir/include/
-          mv "${{targets.destdir}}"/usr/lib64/libobjc.* "${{targets.subpkgdir}}"/usr/lib64
 
   - name: "libgccjit"
     description: "GCC JIT library"

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -45,6 +45,21 @@ pipeline:
 
   - name: 'Configure GCC'
     runs: |
+      # Check https://aws.amazon.com/ec2/instance-types/ and
+      # https://cloud.google.com/compute/docs/general-purpose-machines
+      # for most current CPU types on arm64 and x86 to set mtune to
+      # the current generation of CPUs. Other clouds are typically
+      # roughly at the same level (Azure, Oracle, IBM, Linode, etc).
+      case "${{build.arch}}" in
+        "aarch64")
+          march=armv8-a+crc+crypto
+          mtune=neoverse-v2
+          ;;
+        "x86_64")
+          march=x86-64-v2
+          mtune=sapphirerapids
+          ;;
+      esac
       cd build
       ../configure \
         --prefix=/usr \
@@ -62,6 +77,8 @@ pipeline:
         --enable-default-pie \
         --enable-default-ssp \
         --with-system-zlib \
+        --with-arch=$march \
+        --with-tune=$mtune \
         --enable-languages=c,c++,fortran,jit,go \
         --enable-bootstrap \
         --enable-gnu-indirect-function \

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -129,11 +129,11 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/* \
             "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/
 
-  - if: ${{build.arch}} == 'x86_64'
-    name: "libquadmath"
+  - name: "libquadmath"
     description: "128-bit math library provided by GCC"
     pipeline:
-      - runs: |
+      - if: ${{build.arch}} == 'x86_64'
+        runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib64
           mv "${{targets.destdir}}"/usr/lib64/libquadmath.so.* "${{targets.subpkgdir}}"/usr/lib64/
 

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -50,6 +50,7 @@ pipeline:
         --prefix=/usr \
         --disable-nls \
         --disable-werror \
+        --with-pkgversion='Wolfi ${{package.full-version}}' \
         --with-glibc-version=2.35 \
         --enable-initfini-array \
         --disable-nls \

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -110,12 +110,13 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/* \
             "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/
 
-  - name: "libquadmath"
+  - if: ${{build.arch}} == 'x86_64'
+    name: "libquadmath"
     description: "128-bit math library provided by GCC"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          [ -f "${{targets.destdir}}"/usr/lib64/libquadmath.so.* ] && mv "${{targets.destdir}}"/usr/lib64/libquadmath.so.* "${{targets.subpkgdir}}"/usr/lib64/
+          mv "${{targets.destdir}}"/usr/lib64/libquadmath.so.* "${{targets.subpkgdir}}"/usr/lib64/
 
   - name: "libgfortran"
     description: "Fortran runtime library provided by GCC"

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -84,6 +84,7 @@ pipeline:
         --enable-gnu-indirect-function \
         --enable-gnu-unique-object \
         --enable-cet=auto \
+        --enable-link-mutex \
         --with-linker-hash-style=gnu
 
   - runs: |

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 13.3.0
-  epoch: 0
+  epoch: 1
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1


### PR DESCRIPTION
- **gcc: provide runtime libquadmath.so in a subpackage**
  Currently libquadmath subpackage is empty, but should contain runtime
  libquadmath library, as used by boost and hdf5 on x86 only.
  
  aarch64 supports 128 precision without need for libquadmath runtime
  library.

```console
# apk info -L libquadmath
libquadmath-13.3.0-r1 contains:
usr/lib64/libquadmath.so.0
usr/lib64/libquadmath.so.0.0.0
var/lib/db/sbom/libquadmath-13.3.0-r1.spdx.json
```

- **gcc: stop building objc**
  objc compiler typically requires gnustep libraries to be usable, which
  Wolfi does not package. Unused by any of the packages in Wolfi and not
  shipped in any Chainguard Images.
  

- **gcc: set full pkgversion like clang**

```console
# gcc --version
gcc (Wolfi 13.3.0-r1) 13.3.0
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

- **gcc: set with-arch & with-mtune**  
  Use current settings of march from build-flags. Bump mtune to
  current/latest generation of silicon available in the public clouds.

```console
# gcc -Q --help=target | grep -e march= -e mtune= | head -n2
  -march=                     		x86-64-v2
  -mtune=                     		sapphirerapids

# gcc -Q --help=target | grep -e march= -e mtune=
  -march=                     		armv8-a+crc+crypto
  -mtune=                     		neoverse-v2
```

- **gcc: (build) avoid linking compilers at the same time**
  
- **gcc: bump epoch**
  