### PR TITLE
fix version streams for loki and pass dependencies.provides to other packages

### DIFF
--- a/jruby-9.4.yaml
+++ b/jruby-9.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: jruby-9.4
   version: 9.4.8.0
-  epoch: 0
+  epoch: 1
   description: JRuby, an implementation of Ruby on the JVM
   copyright:
     - license: Apache-2.0

--- a/jruby-9.4.yaml
+++ b/jruby-9.4.yaml
@@ -5,6 +5,9 @@ package:
   description: JRuby, an implementation of Ruby on the JVM
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - jruby=${{package.full-version}}
 
 environment:
   contents:

--- a/loki-3.yaml
+++ b/loki-3.yaml
@@ -63,7 +63,7 @@ subpackages:
           mv clients/cmd/promtail/promtail ${{targets.contextdir}}/usr/bin/promtail
 
           mkdir -p ${{targets.contextdir}}/etc/promtail
-          mv promtail-local-config.yaml ${{targets.contextdir}}/etc/promtail/config.yml
+          mv clients/cmd/promtail/promtail-local-config.yaml ${{targets.contextdir}}/etc/promtail/config.yml
     dependencies:
       provides:
         - promtail=${{package.full-version}}

--- a/loki-3.yaml
+++ b/loki-3.yaml
@@ -38,7 +38,7 @@ pipeline:
 
       # Add the default config
       mkdir -p ${{targets.contextdir}}/etc/loki
-      mv local-config.yaml ${{targets.contextdir}}/etc/loki
+      mv cmd/loki/loki-local-config.yaml ${{targets.contextdir}}/etc/loki/local-config.yaml
 
   - uses: strip
 

--- a/loki-3.yaml
+++ b/loki-3.yaml
@@ -1,5 +1,5 @@
 package:
-  name: loki-3.0
+  name: loki-3
   version: 3.1.0
   epoch: 0
   description: Like Prometheus, but for logs.

--- a/percona-server-8.3.yaml
+++ b/percona-server-8.3.yaml
@@ -6,6 +6,9 @@ package:
   copyright:
     - license: GPL-3.0-or-later
     - license: BSD-3-Clause
+  dependencies:
+    provides:
+      - percona-server=${{package.full-version}}
 
 environment:
   contents:

--- a/percona-server-8.3.yaml
+++ b/percona-server-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-server-8.3
   version: 8.3.0
-  epoch: 1
+  epoch: 2
   description: "Percona Server for MySQL is a free, fully compatible, enhanced, and open source drop-in replacement for any MySQL database. It provides superior performance, scalability, and instrumentation."
   copyright:
     - license: GPL-3.0-or-later

--- a/percona-server-8.3.yaml
+++ b/percona-server-8.3.yaml
@@ -31,6 +31,7 @@ environment:
       - pcre2-dev
       - perl
       - readline-dev
+      - rpcgen
       - samurai
       - sed
       - wolfi-baselayout

--- a/ruby3.2-openid_connect-1.1.8.yaml
+++ b/ruby3.2-openid_connect-1.1.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-openid_connect-1.1.8
   version: 1.1.8
-  epoch: 2
+  epoch: 3
   description: OpenID Connect Server & Client Library
   copyright:
     - license: MIT

--- a/ruby3.2-openid_connect-1.1.8.yaml
+++ b/ruby3.2-openid_connect-1.1.8.yaml
@@ -18,6 +18,8 @@ package:
       - ruby3.2-validate_email
       - ruby3.2-validate_url
       - ruby3.2-webfinger
+    provides:
+      - ruby3.2-openid_connect=${{package.full-version}}
 
 environment:
   contents:

--- a/ruby3.2-rack-2.2.yaml
+++ b/ruby3.2-rack-2.2.yaml
@@ -5,6 +5,9 @@ package:
   description: Rack provides a minimal, modular and adaptable interface for developing web applications in Ruby
   copyright:
     - license: MIT
+  dependencies:
+    provides:
+      - ruby3.2-rack=${{package.full-version}}
 
 environment:
   contents:

--- a/ruby3.2-rack-2.2.yaml
+++ b/ruby3.2-rack-2.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-rack-2.2
   version: 2.2.8.1
-  epoch: 0
+  epoch: 1
   description: Rack provides a minimal, modular and adaptable interface for developing web applications in Ruby
   copyright:
     - license: MIT


### PR DESCRIPTION
* rename `loki-3.0` to `loki-3`
* add missing `dependencies.provides` for some packages
* fixes `loki-3` build due to missing config file