### PR TITLE
java-cacerts: enable automatic updates

### DIFF
--- a/java-cacerts.yaml
+++ b/java-cacerts.yaml
@@ -2,19 +2,20 @@ package:
   name: java-cacerts
   # Update this when ca-certificates is updated.
   version: 20230106
-  epoch: 5
+  epoch: 6
   description: "default certificate authorities for Java"
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - ca-certificates
+      - ca-certificates~${{package.version}}
       - p11-kit-trust
 
 environment:
   contents:
     packages:
-      - ca-certificates
+      - ca-certificates~${{package.version}}
+      - ca-certificates-bundle~${{package.version}}
       - p11-kit-trust
       - wolfi-base
 
@@ -36,4 +37,6 @@ pipeline:
       chmod +x "${{targets.destdir}}"/etc/ca-certificates/update.d/java-cacerts
 
 update:
-  enabled: false
+  enabled: true
+  release-monitor:
+    identifier: 332224


### PR DESCRIPTION
Enable update tracker of ca-certificates bundle. Ensure that matching
package-version is used for the build-time and runtime-time
dependencies. This way automatic update will pass CI, once
ca-certificates package update lands and a retry is performed.
