### PR TITLE
py3-hatchling: py3 versioned and build deps

### DIFF
--- a/py3-hatchling.yaml
+++ b/py3-hatchling.yaml
@@ -1,39 +1,87 @@
 package:
   name: py3-hatchling
   version: 1.25.0
-  epoch: 0
+  epoch: 1
   description: "Modern, extensible Python build backend"
   copyright:
     - license: BSD-3-Clause
-  dependencies:
-    runtime:
-      - py3-pathspec
-      - py3-pluggy
-      - python3
+
+vars:
+  pypi-package: hatchling
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 environment:
   contents:
     packages:
       - busybox
       - ca-certificates-bundle
-      - py3-installer
-      - python3
+      - py3-supported-build
+      - py3-supported-installer
+      - py3-supported-pathspec
+      - py3-supported-pip
+      - py3-supported-pluggy
+      - py3-supported-python
+      - py3-supported-tomli
+      - py3-supported-trove-classifiers
+      - py3-supported-wheel
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://files.pythonhosted.org/packages/py3/h/hatchling/hatchling-${{package.version}}-py3-none-any.whl
-      expected-sha512: 337892f0b647a20f43b8fbc46575166b0a051d8cdd3e7a36771ddb66b3666cb53301c5b992ce9c6df1ccf7faee011e1df888b7e5eb5e85c97f76277665aed630
-      extract: false
-      delete: false
+      expected-commit: 6fdb66d16f91f3ce80b705e266674f74c83c987a
+      repository: https://github.com/pypa/hatch
+      tag: hatchling-v${{package.version}}
 
-  - runs: |
-      python3 -m installer -d "${{targets.destdir}}" ./hatchling-${{package.version}}-py3-none-any.whl
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-packaging
+        - py${{range.key}}-pathspec
+        - py${{range.key}}-pluggy
+        - py${{range.key}}-tomli
+        - py${{range.key}}-trove-classifiers
+      provider-priority: ${{range.value}}
+    pipeline:
+      - runs: |
+          # TODO(pnasrat): refactor when melange fix subpackage with range working-dir 
+          # This is inline stripped down from pipelines/py/pip-build-install.yaml
+          cd backend
+          export SOURCE_DATE_EPOCH=315532800
+          mkdir dist
+          python${{range.key}} -m pip wheel -w dist --no-index --no-build-isolation --no-deps .
+          python${{range.key}} -m pip install --no-index --no-build-isolation --no-deps \
+            --force-reinstall --no-compile --prefix=/usr --root=${{targets.subpkgdir}} dist/*.whl
+      - runs: rm -rf backend/dist
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 185085
+  github:
+    identifier: pypa/hatch
+    strip-prefix: hatchling-v
+    tag-filter: hatchling-v

--- a/py3-hatchling.yaml
+++ b/py3-hatchling.yaml
@@ -55,7 +55,7 @@ subpackages:
       provider-priority: ${{range.value}}
     pipeline:
       - runs: |
-          # TODO(pnasrat): refactor when melange fix subpackage with range working-dir 
+          # TODO(pnasrat): refactor when melange fix subpackage with range working-dir
           # This is inline stripped down from pipelines/py/pip-build-install.yaml
           cd backend
           export SOURCE_DATE_EPOCH=315532800

--- a/py3-hatchling.yaml
+++ b/py3-hatchling.yaml
@@ -71,6 +71,20 @@ subpackages:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
 
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr
+          mv ${{targets.contextdir}}/../py${{range.key}}-${{vars.pypi-package}}/usr/bin ${{targets.contextdir}}/usr
+
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
     dependencies:

--- a/py3-pathspec.yaml
+++ b/py3-pathspec.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pathspec
   version: 0.12.1
-  epoch: 1
+  epoch: 2
   description: "Utility library for gitignore style pattern matching of file paths"
   copyright:
     - license: MPL-2.0
@@ -48,6 +48,14 @@ subpackages:
   - name: py3-wheels-${{vars.pypi-package}}
     pipeline:
       - uses: py/collect-wheels
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-pluggy.yaml
+++ b/py3-pluggy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pluggy
   version: 1.5.0
-  epoch: 1
+  epoch: 2
   description: "Plugin management and hook calling for Python"
   copyright:
     - license: MIT
@@ -50,6 +50,14 @@ subpackages:
           with:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-trove-classifiers.yaml
+++ b/py3-trove-classifiers.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-trove-classifiers
   version: 2024.7.2
-  epoch: 1
+  epoch: 2
   description: Canonical source for classifiers on PyPI (pypi.org).
   copyright:
     - license: Apache-2.0
@@ -48,6 +48,14 @@ subpackages:
         with:
           python: python${{range.key}}
       - uses: strip
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
 
 update:
   enabled: true


### PR DESCRIPTION
Build backend for hatch

- Move to git-checkout
- Use versioned python
-  Make build deps available as py3-supported meta packages