### PR TITLE
chore(gitlab-cng): Unify package naming

### DIFF
--- a/gitlab-cng-17.1.yaml
+++ b/gitlab-cng-17.1.yaml
@@ -150,7 +150,7 @@ subpackages:
               fi
             done
 
-  - name: ${{package.name}}-gitlab-container-registry
+  - name: ${{package.name}}-container-registry
     description: The GitLab Container Registry originated as a fork of the Docker Distribution Registry, now CNCF Distribution, both distributed under Apache License Version 2.0.
     dependencies:
       provides:
@@ -233,7 +233,7 @@ subpackages:
             # Stop the registry
             kill $PID
 
-  - name: ${{package.name}}-gitlab-container-registry-compat
+  - name: ${{package.name}}-container-registry-compat
     dependencies:
       provides:
         - gitlab-cng-gitlab-container-registry-compat=${{package.full-version}}
@@ -243,7 +243,7 @@ subpackages:
           mkdir -p "${{targets.contextdir}}"/bin
           ln -sf /usr/bin/registry "${{targets.contextdir}}"/bin/registry
 
-  - name: ${{package.name}}-gitlab-elasticsearch-indexer
+  - name: ${{package.name}}-elasticsearch-indexer
     description: Elasticsearch indexer for GitLab EE, written in Go
     dependencies:
       provides:
@@ -270,7 +270,7 @@ subpackages:
             gitlab-elasticsearch-indexer --version
             gitlab-elasticsearch-indexer --help
 
-  - name: ${{package.name}}-gitlab-elasticsearch-indexer-compat
+  - name: ${{package.name}}-elasticsearch-indexer-compat
     dependencies:
       provides:
         - gitlab-cng-gitlab-elasticsearch-indexer-compat=${{package.full-version}}
@@ -279,7 +279,7 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
           ln -sf /usr/bin/gitlab-elasticsearch-indexer ${{targets.subpkgdir}}/usr/local/bin/gitlab-elasticsearch-indexer
 
-  - name: ${{package.name}}-gitlab-exporter
+  - name: ${{package.name}}-exporter
     description: GitLab Exporter is a Prometheus Web exporter.
     dependencies:
       provides:
@@ -355,7 +355,7 @@ subpackages:
               exit 1
             fi
 
-  - name: ${{package.name}}-gitlab-logger
+  - name: ${{package.name}}-logger
     description: GitLab Logger provides a means of wrapping non-structured log files within structure JSON.
     dependencies:
       provides:
@@ -377,7 +377,7 @@ subpackages:
         - runs: |
             gitlab-logger -h
 
-  - name: ${{package.name}}-gitlab-logger-compat
+  - name: ${{package.name}}-logger-compat
     dependencies:
       provides:
         - gitlab-cng-gitlab-logger-compat=${{package.full-version}}
@@ -387,7 +387,7 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
           ln -s /usr/bin/gitlab-logger "${{targets.subpkgdir}}"/usr/local/bin/gitlab-logger
 
-  - name: ${{package.name}}-gitlab-mailroom
+  - name: ${{package.name}}-mailroom
     description: GitLab mail_room contains some merged functionality that GitLab requires, so this mirror fork is to help us release custom functionality.
     dependencies:
       provides:
@@ -426,7 +426,7 @@ subpackages:
           dir: ./mailroom
       - uses: ruby/clean
 
-  - name: ${{package.name}}-gitlab-shell
+  - name: ${{package.name}}-shell
     description: SSH access for GitLab
     dependencies:
       provides:

--- a/gitlab-cng-17.1.yaml
+++ b/gitlab-cng-17.1.yaml
@@ -24,6 +24,12 @@ vars:
   shell-commit: 29bb5c68e7bdbfc2f7690e28f2a693da437bb323
   shell-tag: 14.36.0
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+
 package:
   name: gitlab-cng-17.1
   version: 17.1.2
@@ -79,10 +85,10 @@ data:
 
 subpackages:
   - range: scripts
-    name: "${{package.name}}-${{range.key}}-scripts"
+    name: gitlab-${{range.key}}-scripts-${{vars.major-minor-version}}
     dependencies:
       provides:
-        - gitlab-cng-${{range.key}}-scripts=${{package.full-version}}
+        - gitlab-${{range.key}}-scripts=${{package.full-version}}
     pipeline:
       - runs: |
           cd ${{range.value}}
@@ -91,7 +97,7 @@ subpackages:
             cp -r $x ${{targets.subpkgdir}}/$x
           done
 
-  - name: "${{package.name}}-base"
+  - name: gitlab-base-${{vars.major-minor-version}}
     pipeline:
       - runs: |
           cd ./gitlab-base
@@ -101,18 +107,18 @@ subpackages:
           done
     dependencies:
       provides:
-        - gitlab-cng-base=${{package.full-version}}
+        - gitlab-base=${{package.full-version}}
       runtime:
         - bash
         - busybox
         - ca-certificates-bundle
         - curl
-        - gitlab-logger
+        - gitlab-logger-${{vars.major-minor-version}}
         - gomplate
         - procps
         - xtail
 
-  - name: "${{package.name}}-webservice-config"
+  - name: gitlab-webservice-config-${{vars.major-minor-version}}
     pipeline:
       - runs: |
           cd ./gitlab-webservice
@@ -120,9 +126,9 @@ subpackages:
           cp configuration/puma.rb ${{targets.subpkgdir}}/srv/gitlab/config
     dependencies:
       provides:
-        - gitlab-cng-webservice-config=${{package.full-version}}
+        - gitlab-webservice-config=${{package.full-version}}
 
-  - name: "${{package.name}}-certificates"
+  - name: gitlab-certificates-${{vars.major-minor-version}}
     pipeline:
       - runs: |
           cd ./certificates
@@ -132,6 +138,8 @@ subpackages:
           done
           ./scripts/bundle-certificates
     dependencies:
+      provides:
+        - gitlab-certificates=${{package.full-version}}
       runtime:
         - ca-certificates
     test:
@@ -150,11 +158,11 @@ subpackages:
               fi
             done
 
-  - name: ${{package.name}}-container-registry
+  - name: gitlab-container-registry-${{vars.major-minor-version}}
     description: The GitLab Container Registry originated as a fork of the Docker Distribution Registry, now CNCF Distribution, both distributed under Apache License Version 2.0.
     dependencies:
       provides:
-        - gitlab-cng-gitlab-container-registry=${{package.full-version}}
+        - gitlab-container-registry=${{package.full-version}}
     pipeline:
       - uses: git-checkout
         with:
@@ -237,21 +245,21 @@ subpackages:
             # Stop the registry
             kill $PID
 
-  - name: ${{package.name}}-container-registry-compat
+  - name: gitlab-container-registry-compat-${{vars.major-minor-version}}
     dependencies:
       provides:
-        - gitlab-cng-gitlab-container-registry-compat=${{package.full-version}}
+        - gitlab-container-registry-compat=${{package.full-version}}
     pipeline:
       - runs: |
           # https://gitlab.com/gitlab-org/build/CNG/-/blob/master/gitlab-container-registry/scripts/process-wrapper?ref_type=heads#L3
           mkdir -p "${{targets.contextdir}}"/bin
           ln -sf /usr/bin/registry "${{targets.contextdir}}"/bin/registry
 
-  - name: ${{package.name}}-elasticsearch-indexer
+  - name: gitlab-elasticsearch-indexer-${{vars.major-minor-version}}
     description: Elasticsearch indexer for GitLab EE, written in Go
     dependencies:
       provides:
-        - gitlab-cng-gitlab-elasticsearch-indexer=${{package.full-version}}
+        - gitlab-elasticsearch-indexer=${{package.full-version}}
     pipeline:
       - uses: git-checkout
         with:
@@ -274,20 +282,20 @@ subpackages:
             gitlab-elasticsearch-indexer --version
             gitlab-elasticsearch-indexer --help
 
-  - name: ${{package.name}}-elasticsearch-indexer-compat
+  - name: gitlab-elasticsearch-indexer-compat-${{vars.major-minor-version}}
     dependencies:
       provides:
-        - gitlab-cng-gitlab-elasticsearch-indexer-compat=${{package.full-version}}
+        - gitlab-elasticsearch-indexer-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
           ln -sf /usr/bin/gitlab-elasticsearch-indexer ${{targets.subpkgdir}}/usr/local/bin/gitlab-elasticsearch-indexer
 
-  - name: ${{package.name}}-exporter
+  - name: gitlab-exporter-${{vars.major-minor-version}}
     description: GitLab Exporter is a Prometheus Web exporter.
     dependencies:
       provides:
-        - gitlab-cng-gitlab-exporter=${{package.full-version}}
+        - gitlab-exporter=${{package.full-version}}
       runtime:
         - jemalloc
         - ruby-3.2
@@ -359,11 +367,11 @@ subpackages:
               exit 1
             fi
 
-  - name: ${{package.name}}-logger
+  - name: gitlab-logger-${{vars.major-minor-version}}
     description: GitLab Logger provides a means of wrapping non-structured log files within structure JSON.
     dependencies:
       provides:
-        - gitlab-cng-gitlab-logger=${{package.full-version}}
+        - gitlab-logger=${{package.full-version}}
     pipeline:
       - uses: git-checkout
         with:
@@ -381,21 +389,21 @@ subpackages:
         - runs: |
             gitlab-logger -h
 
-  - name: ${{package.name}}-logger-compat
+  - name: gitlab-logger-compat-${{vars.major-minor-version}}
     dependencies:
       provides:
-        - gitlab-cng-gitlab-logger-compat=${{package.full-version}}
+        - gitlab-logger-compat=${{package.full-version}}
     pipeline:
       - runs: |
           # GitLab helm chart mostly hardcodes multiple executables path to /usr/local/bin/*
           mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
           ln -s /usr/bin/gitlab-logger "${{targets.subpkgdir}}"/usr/local/bin/gitlab-logger
 
-  - name: ${{package.name}}-mailroom
+  - name: gitlab-mailroom-${{vars.major-minor-version}}
     description: GitLab mail_room contains some merged functionality that GitLab requires, so this mirror fork is to help us release custom functionality.
     dependencies:
       provides:
-        - gitlab-cng-gitlab-mailroom=${{package.full-version}}
+        - gitlab-mailroom=${{package.full-version}}
       runtime:
         - jemalloc
         - ruby-3.2
@@ -430,11 +438,11 @@ subpackages:
           dir: ./mailroom
       - uses: ruby/clean
 
-  - name: ${{package.name}}-shell
+  - name: gitlab-shell-${{vars.major-minor-version}}
     description: SSH access for GitLab
     dependencies:
       provides:
-        - gitlab-cng-gitlab-shell=${{package.full-version}}
+        - gitlab-shell=${{package.full-version}}
       runtime:
         - openssh
     pipeline:

--- a/gitlab-cng-17.1.yaml
+++ b/gitlab-cng-17.1.yaml
@@ -27,7 +27,7 @@ vars:
 package:
   name: gitlab-cng-17.1
   version: 17.1.2
-  epoch: 2
+  epoch: 3
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT

--- a/gitlab-cng-17.1.yaml
+++ b/gitlab-cng-17.1.yaml
@@ -165,6 +165,10 @@ subpackages:
       - working-directory: ./container-registry
         runs: |
           mkdir -p "${{targets.contextdir}}"/etc/docker/registry
+      - uses: go/bump
+        with:
+          deps: github.com/jackc/pgx/v5@v5.5.4 google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0
+          modroot: ./container-registry
       - uses: go/build
         with:
           packages: ./cmd/registry

--- a/gitlab-pages.yaml
+++ b/gitlab-pages.yaml
@@ -3,19 +3,19 @@
 package:
   name: gitlab-pages
   version: 17.1.2
-  epoch: 0
+  epoch: 1
   description: GitLab Pages daemon used to serve static websites for GitLab users.
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - gitlab-cng-base
-      - gitlab-cng-pages-scripts
+      - gitlab-base
+      - gitlab-pages-scripts
 
 environment:
   contents:
     packages:
-      - gitlab-cng-base
+      - gitlab-base
       - go
 
 pipeline:


### PR DESCRIPTION
Remove gitlab-cng from package names and append <major>.<minor> version to the end