### PR TITLE
nss: enable library self-tests and checksums

### DIFF
--- a/nss.yaml
+++ b/nss.yaml
@@ -1,7 +1,7 @@
 package:
   name: nss
   version: "3.102"
-  epoch: 0
+  epoch: 1
   description: "Network Security Services (NSS) is a set of libraries designed to support cross-platform development of security-enabled client and server applications."
   copyright:
     - license: MPL-2.0
@@ -35,13 +35,14 @@ pipeline:
 
   - runs: |
       cd nss
-      ./build.sh -c --disable-tests --opt --system-nspr --system-sqlite
+      ./build.sh -c --disable-tests --opt --system-nspr --system-sqlite --enable-fips
 
       mkdir -p "${{targets.destdir}}"/usr/lib
       mkdir -p "${{targets.destdir}}"/usr/bin
       mkdir -p "${{targets.destdir}}"/usr/include/nss
 
       mv ../dist/Release/lib/*.so "${{targets.destdir}}"/usr/lib
+      mv ../dist/Release/lib/*.chk "${{targets.destdir}}"/usr/lib
       mv ../dist/Release/bin/* "${{targets.destdir}}"/usr/bin
       mv ../dist/public/nss/* "${{targets.destdir}}"/usr/include/nss
 
@@ -63,12 +64,22 @@ pipeline:
 
   - uses: strip
 
+  - name: Recompute checksums after strip
+    runs: |
+      export LD_LIBRARY_PATH="${{targets.destdir}}"/usr/lib
+      export PATH="${{targets.destdir}}"/usr/bin:$PATH
+      cd "${{targets.destdir}}"/usr/lib
+      shlibsign -v -i libsoftokn3.so
+      shlibsign -v -i libfreebl3.so
+      shlibsign -v -i libfreeblpriv3.so
+
 subpackages:
   - name: libnss
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/*.so "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/*.chk "${{targets.subpkgdir}}"/usr/lib
     dependencies:
       runtime:
         - libnspr
@@ -88,6 +99,18 @@ subpackages:
     dependencies:
       runtime:
         - libnss
+
+test:
+  environment:
+    contents:
+      packages:
+        - libnss-tools
+  pipeline:
+    - name: Check one can create nssdb in various modes
+      runs: |
+        mkdir -p /tmp/nssdb
+        modutil -dbdir /tmp/nssdb -create < /dev/null
+        modutil -dbdir /tmp/nssdb -fips true < /dev/null
 
 update:
   enabled: true


### PR DESCRIPTION
Enable library self-tests and checksums. Note there is no
certification for this build.

This is on parity with what other community distributions do without
any certification (Debian, Fedora, devel releases).
