### PR TITLE
openjdk-8: build with SunPKCS11 provider enabled

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.412.08 # this corresponds to same release as jdk8u412-ga / jdk8u412-b08
-  epoch: 1
+  epoch: 2
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later
@@ -40,6 +40,8 @@ environment:
       - libffi-dev
       - libice-dev
       - libjpeg-turbo-dev
+      - libnspr-dev
+      - libnss-dev
       - libpng-dev
       - libtool
       - libx11-dev
@@ -107,6 +109,7 @@ pipeline:
         --disable-docs \
         --disable-system-pcsc \
         --disable-system-sctp \
+        --enable-nss \
         --with-openjdk-src-zip=/home/build/icedtea-drops/openjdk-git.tar.xz \
         --with-hotspot-src-zip=/home/build/icedtea-drops/hotspot.tar.xz \
         --with-jdk-home=/usr/lib/jvm/java-1.7-openjdk \


### PR DESCRIPTION
Currently SunPKCS11 provider is enabled in jdk 11..22, but not 8.

Pass configure option to include SunPKCS11 on jdk 8 as well.

```console
2024/07/17 00:58:15 INFO checking whether to enable the PKCS11 crypto provider using NSS... enabled by default (edit java.security to disable)
2024/07/17 00:58:15 INFO checking for nss... yes
```


```diff
# diff -u /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/java.security /work/packages/x86_64/java.security 
--- /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/java.security
+++ /work/packages/x86_64/java.security
@@ -74,10 +74,7 @@
 security.provider.7=com.sun.security.sasl.Provider
 security.provider.8=org.jcp.xml.dsig.internal.dom.XMLDSigRI
 security.provider.9=sun.security.smartcardio.SunPCSC
-# the NSS security provider was not enabled for this build; it can be enabled
-# if NSS (libnss3) is available on the machine. The nss.cfg file may need
-# editing to reflect the location of the NSS installation.
-#security.provider.10=sun.security.pkcs11.SunPKCS11 ${java.home}/lib/security/nss.cfg
+security.provider.10=sun.security.pkcs11.SunPKCS11 ${java.home}/lib/security/nss.cfg
 
 #
 # Sun Provider SecureRandom seed source.
```

```diff
# diff /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/nss.cfg /work/packages/x86_64/nss.cfg 
--- /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/nss.cfg
+++ /work/packages/x86_64/nss.cfg
@@ -1,5 +1,5 @@
 name = NSS
-nssLibraryDirectory = 
+nssLibraryDirectory = /usr/lib
 nssDbMode = noDb
 attributes = compatibility
 handleStartupErrors = ignoreMultipleInitialisation
```

This corrects java.security & nss.cfg files.