### PR TITLE
fix(gitlab-exporter-17.1): Unlock gemspec

### DIFF
--- a/gitlab-cng-17.1.yaml
+++ b/gitlab-cng-17.1.yaml
@@ -33,7 +33,7 @@ var-transforms:
 package:
   name: gitlab-cng-17.1
   version: 17.1.2
-  epoch: 5
+  epoch: 6
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -336,6 +336,7 @@ subpackages:
           expected-commit: ${{vars.exporter-commit}}
           destination: ./exporter
       # GitLab-Exporter Runtime Dependencies
+      - uses: ruby/unlock-spec
       - working-directory: ./exporter
         runs: |
           cat gitlab-exporter.gemspec


### PR DESCRIPTION
Needed to substitute expected gems with ours