### PR TITLE
gcc-12: openssf integration

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent
   version: 7.55.2
-  epoch: 0
+  epoch: 1
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0

--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-no-driver
   version: 0.38.1
-  epoch: 1
+  epoch: 2
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -124,6 +124,10 @@ pipeline:
       mv lib64/libgcc_s.* ${{vars.major-version}}/
       rmdir lib64/
 
+  # Remove stray gcc-tmp (which used to be gcc-M.N.P)
+  - runs: |
+      rm ${{targets.destdir}}/usr/bin/${{host.triplet.gnu}}-gcc-tmp
+
   - name: 'Clean up documentation'
     runs: |
       rm -rf ${{targets.destdir}}/usr/share/info

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -34,6 +34,12 @@ environment:
       - zip
       - zlib-dev
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
 pipeline:
   - uses: fetch
     with:
@@ -92,6 +98,7 @@ pipeline:
             --enable-cet=auto \
             --enable-link-mutex \
             --enable-version-specific-runtime-libs \
+            --with-gcc-major-version-only \
             --with-linker-hash-style=gnu \
             --disable-libcc1
 
@@ -114,7 +121,7 @@ pipeline:
   - name: 'Fix libgcc_s.so location'
     runs: |
       cd "${{targets.destdir}}"/usr/lib/gcc/${{host.triplet.gnu}}
-      mv lib64/libgcc_s.* ${{package.version}}/
+      mv lib64/libgcc_s.* ${{vars.major-version}}/
       rmdir lib64/
 
   - name: 'Clean up documentation'
@@ -131,7 +138,7 @@ subpackages:
   - name: 'libstdc++-12'
     pipeline:
       - runs: |
-          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
 
           mkdir -p "${{targets.subpkgdir}}"/$gcclibdir
           mv "${{targets.destdir}}"/$gcclibdir/*++.so.* "${{targets.subpkgdir}}"/$gcclibdir
@@ -141,16 +148,16 @@ subpackages:
   - name: 'libstdc++-12-dev'
     pipeline:
       - runs: |
-          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
 
           mkdir -p "${{targets.subpkgdir}}"/$gcclibdir
           mkdir -p "${{targets.subpkgdir}}"/$gcclibdir/include
-          mkdir -p "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx
           mv "${{targets.destdir}}"/$gcclibdir/*++.a "${{targets.subpkgdir}}"/$gcclibdir/
           mv "${{targets.destdir}}"/$gcclibdir/libstdc++.so* "${{targets.subpkgdir}}"/$gcclibdir/
           mv "${{targets.destdir}}"/$gcclibdir/include/*++* "${{targets.subpkgdir}}"/$gcclibdir/include/
-          mv "${{targets.destdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/* \
-            "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/
+          mv "${{targets.destdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/* \
+            "${{targets.subpkgdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/
 
   - name: 'gcc-12-default'
     description: 'Use GCC 12 as system gcc'

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,24 +1,17 @@
 package:
   name: gcc-12
   version: 12.4.0
-  epoch: 2
+  epoch: 3
   description: "the GNU compiler collection - version 12"
+  copyright:
+    - license: GPL-3.0-or-later WITH GCC-exception-3.1
   resources:
     cpu: 16
     memory: 16Gi
-  copyright:
-    - license: GPL-3.0-or-later
-  options:
-    no-provides: true
   dependencies:
     runtime:
       - binutils
-      - gmp
-      - isl
-      - libgcc
       - libstdc++-12-dev
-      - mpc
-      - mpfr
       - posix-cc-wrappers
 
 environment:
@@ -35,6 +28,7 @@ environment:
       - make
       - mpc-dev
       - mpfr-dev
+      - patch
       - texinfo
       - wolfi-baselayout
       - zip
@@ -50,17 +44,27 @@ pipeline:
     pipeline:
       - name: 'Configure GCC'
         runs: |
-          # We use generic CFLAGS, because GCC 6 is older than the CFLAGS we normally use.
-          CFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
-          CXXFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
-          CPPFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
-          export CFLAGS CXXFLAGS CPPFLAGS
-
+          # Check https://aws.amazon.com/ec2/instance-types/ and
+          # https://cloud.google.com/compute/docs/general-purpose-machines
+          # for most current CPU types on arm64 and x86 to set mtune to
+          # the current generation of CPUs. Other clouds are typically
+          # roughly at the same level (Azure, Oracle, IBM, Linode, etc).
+          case "${{build.arch}}" in
+            "aarch64")
+              march=armv8-a+crc+crypto
+              mtune=neoverse-v2
+              ;;
+            "x86_64")
+              march=x86-64-v2
+              mtune=sapphirerapids
+              ;;
+          esac
           ../configure \
             --prefix=/usr \
             --program-suffix="-12" \
             --disable-nls \
             --disable-werror \
+            --with-pkgversion='Wolfi ${{package.full-version}}' \
             --with-glibc-version=2.35 \
             --enable-initfini-array \
             --disable-nls \
@@ -74,10 +78,14 @@ pipeline:
             --enable-default-pie \
             --enable-default-ssp \
             --with-system-zlib \
+            --with-arch=$march \
+            --with-tune=$mtune \
             --enable-languages=c,c++ \
             --enable-bootstrap \
             --enable-gnu-indirect-function \
             --enable-gnu-unique-object \
+            --enable-cet=auto \
+            --enable-link-mutex \
             --enable-version-specific-runtime-libs \
             --with-linker-hash-style=gnu \
             --disable-libcc1

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -40,6 +40,11 @@ pipeline:
       uri: https://ftp.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
       expected-sha512: 5bd29402cad2deb5d9388d0236c7146414d77e5b8d5f1c6c941c7a1f47691c3389f08656d5f6e8e2d6717bf2c81f018d326f632fb468f42925b40bd217fc4853
 
+  - name: Fix false invalid march extension crc on arm64
+    uses: patch
+    with:
+      patches: 1be715f31605976d8e4336973d3b81c5b7cea79f.patch
+
   - working-directory: /home/build/build
     pipeline:
       - name: 'Configure GCC'

--- a/gcc-12/1be715f31605976d8e4336973d3b81c5b7cea79f.patch
+++ b/gcc-12/1be715f31605976d8e4336973d3b81c5b7cea79f.patch
@@ -1,0 +1,331 @@
+From https://github.com/gcc-mirror/gcc/commit/1be715f31605976d8e4336973d3b81c5b7cea79f.patch
+From 1be715f31605976d8e4336973d3b81c5b7cea79f Mon Sep 17 00:00:00 2001
+From: Wilco Dijkstra <wilco.dijkstra@arm.com>
+Date: Wed, 18 May 2022 16:02:12 +0100
+Subject: [PATCH] AArch64: Cleanup CPU option processing code
+
+The --with-cpu/--with-arch configure option processing not only checks valid
+arguments but also sets TARGET_CPU_DEFAULT with a CPU and extension bitmask.
+This isn't used however since a --with-cpu is translated into a -mcpu option
+which is processed as if written on the command-line (so TARGET_CPU_DEFAULT
+is never accessed).
+
+So remove all the complex processing and bitmask, and just validate the
+option. Fix a bug that always reports valid architecture extensions as invalid.
+As a result the CPU processing in aarch64.c can be simplified.
+
+gcc/
+	* config.gcc (aarch64*-*-*): Simplify --with-cpu and --with-arch
+	processing.  Add support for architectural extensions.
+	* config/aarch64/aarch64.h (TARGET_CPU_DEFAULT): Remove
+	AARCH64_CPU_DEFAULT_FLAGS.
+	(TARGET_CPU_NBITS): Remove.
+	(TARGET_CPU_MASK): Remove.
+	* config/aarch64/aarch64.cc (AARCH64_CPU_DEFAULT_FLAGS): Remove define.
+	(get_tune_cpu): Assert CPU is always valid.
+	(get_arch): Assert architecture is always valid.
+	(aarch64_override_options): Cleanup CPU selection code and simplify logic.
+	(aarch64_option_restore): Remove unnecessary checks on tune.
+---
+ gcc/config.gcc                |  43 +------------
+ gcc/config/aarch64/aarch64.cc | 115 +++++++++-------------------------
+ gcc/config/aarch64/aarch64.h  |   9 +--
+ 3 files changed, 32 insertions(+), 135 deletions(-)
+
+diff --git a/gcc/config.gcc b/gcc/config.gcc
+index c5064dd376660..b48d5451e8027 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -4178,8 +4178,6 @@ case "${target}" in
+ 			  pattern=AARCH64_CORE
+ 			fi
+ 
+-			ext_mask=AARCH64_CPU_DEFAULT_FLAGS
+-
+ 			# Find the base CPU or ARCH id in aarch64-cores.def or
+ 			# aarch64-arches.def
+ 			if [ x"$base_val" = x ] \
+@@ -4187,23 +4185,6 @@ case "${target}" in
+ 				    ${srcdir}/config/aarch64/$def \
+ 				    > /dev/null; then
+ 
+-			  if [ $which = arch ]; then
+-				base_id=`grep "^$pattern(\"$base_val\"," \
+-				  ${srcdir}/config/aarch64/$def | \
+-				  sed -e 's/^[^,]*,[ 	]*//' | \
+-				  sed -e 's/,.*$//'`
+-				# Extract the architecture flags from aarch64-arches.def
+-				ext_mask=`grep "^$pattern(\"$base_val\"," \
+-				   ${srcdir}/config/aarch64/$def | \
+-				   sed -e 's/)$//' | \
+-				   sed -e 's/^.*,//'`
+-			  else
+-				base_id=`grep "^$pattern(\"$base_val\"," \
+-				  ${srcdir}/config/aarch64/$def | \
+-				  sed -e 's/^[^,]*,[ 	]*//' | \
+-				  sed -e 's/,.*$//'`
+-			  fi
+-
+ 			  # Disallow extensions in --with-tune=cortex-a53+crc.
+ 			  if [ $which = tune ] && [ x"$ext_val" != x ]; then
+ 			    echo "Architecture extensions not supported in --with-$which=$val" 1>&2
+@@ -4234,25 +4215,7 @@ case "${target}" in
+ 					grep "^\"$base_ext\""`
+ 
+ 				if [ x"$base_ext" = x ] \
+-				    || [[ -n $opt_line ]]; then
+-
+-				  # These regexp extract the elements based on
+-				  # their group match index in the regexp.
+-				  ext_canon=`echo -e "$opt_line" | \
+-					sed -e "s/$sed_patt/\2/"`
+-				  ext_on=`echo -e "$opt_line" | \
+-					sed -e "s/$sed_patt/\3/"`
+-				  ext_off=`echo -e "$opt_line" | \
+-					sed -e "s/$sed_patt/\4/"`
+-
+-				  if [ $ext = $base_ext ]; then
+-					# Adding extension
+-					ext_mask="("$ext_mask") | ("$ext_on" | "$ext_canon")"
+-				  else
+-					# Removing extension
+-					ext_mask="("$ext_mask") & ~("$ext_off" | "$ext_canon")"
+-				  fi
+-
++				    || [ x"$opt_line" != x ]; then
+ 				  true
+ 				else
+ 				  echo "Unknown extension used in --with-$which=$val" 1>&2
+@@ -4261,10 +4224,6 @@ case "${target}" in
+ 				ext_val=`echo $ext_val | sed -e 's/[a-z0-9]\+//'`
+ 			  done
+ 
+-			  ext_mask="(("$ext_mask") << TARGET_CPU_NBITS)"
+-			  if [ x"$base_id" != x ]; then
+-				target_cpu_cname="TARGET_CPU_$base_id | $ext_mask"
+-			  fi
+ 			  true
+ 			else
+ 			  # Allow --with-$which=native.
+diff --git a/gcc/config/aarch64/aarch64.cc b/gcc/config/aarch64/aarch64.cc
+index 4aad14cc8d380..ba5b6be850a27 100644
+--- a/gcc/config/aarch64/aarch64.cc
++++ b/gcc/config/aarch64/aarch64.cc
+@@ -2760,8 +2760,6 @@ static const struct attribute_spec aarch64_attribute_table[] =
+   { NULL,                 0, 0, false, false, false, false, NULL, NULL }
+ };
+ 
+-#define AARCH64_CPU_DEFAULT_FLAGS ((selected_cpu) ? selected_cpu->flags : 0)
+-
+ /* An ISA extension in the co-processor and main instruction set space.  */
+ struct aarch64_option_extension
+ {
+@@ -18067,39 +18065,24 @@ aarch64_validate_mtune (const char *str, const struct processor **res)
+   return false;
+ }
+ 
+-static_assert (TARGET_CPU_generic < TARGET_CPU_MASK,
+-	       "TARGET_CPU_NBITS is big enough");
+-
+-/* Return the CPU corresponding to the enum CPU.
+-   If it doesn't specify a cpu, return the default.  */
++/* Return the CPU corresponding to the enum CPU.  */
+ 
+ static const struct processor *
+ aarch64_get_tune_cpu (enum aarch64_processor cpu)
+ {
+-  if (cpu != aarch64_none)
+-    return &all_cores[cpu];
++  gcc_assert (cpu != aarch64_none);
+ 
+-  /* The & TARGET_CPU_MASK is to extract the bottom TARGET_CPU_NBITS bits that
+-     encode the default cpu as selected by the --with-cpu GCC configure option
+-     in config.gcc.
+-     ???: The whole TARGET_CPU_DEFAULT and AARCH64_CPU_DEFAULT_FLAGS
+-     flags mechanism should be reworked to make it more sane.  */
+-  return &all_cores[TARGET_CPU_DEFAULT & TARGET_CPU_MASK];
++  return &all_cores[cpu];
+ }
+ 
+-/* Return the architecture corresponding to the enum ARCH.
+-   If it doesn't specify a valid architecture, return the default.  */
++/* Return the architecture corresponding to the enum ARCH.  */
+ 
+ static const struct processor *
+ aarch64_get_arch (enum aarch64_arch arch)
+ {
+-  if (arch != aarch64_no_arch)
+-    return &all_architectures[arch];
+-
+-  const struct processor *cpu
+-    = &all_cores[TARGET_CPU_DEFAULT & TARGET_CPU_MASK];
++  gcc_assert (arch != aarch64_no_arch);
+ 
+-  return &all_architectures[cpu->arch];
++  return &all_architectures[arch];
+ }
+ 
+ /* Return the VG value associated with -msve-vector-bits= value VALUE.  */
+@@ -18137,10 +18120,6 @@ aarch64_override_options (void)
+   uint64_t arch_isa = 0;
+   aarch64_isa_flags = 0;
+ 
+-  bool valid_cpu = true;
+-  bool valid_tune = true;
+-  bool valid_arch = true;
+-
+   selected_cpu = NULL;
+   selected_arch = NULL;
+   selected_tune = NULL;
+@@ -18155,77 +18134,56 @@ aarch64_override_options (void)
+      If either of -march or -mtune is given, they override their
+      respective component of -mcpu.  */
+   if (aarch64_cpu_string)
+-    valid_cpu = aarch64_validate_mcpu (aarch64_cpu_string, &selected_cpu,
+-					&cpu_isa);
++    aarch64_validate_mcpu (aarch64_cpu_string, &selected_cpu, &cpu_isa);
+ 
+   if (aarch64_arch_string)
+-    valid_arch = aarch64_validate_march (aarch64_arch_string, &selected_arch,
+-					  &arch_isa);
++    aarch64_validate_march (aarch64_arch_string, &selected_arch, &arch_isa);
+ 
+   if (aarch64_tune_string)
+-    valid_tune = aarch64_validate_mtune (aarch64_tune_string, &selected_tune);
++    aarch64_validate_mtune (aarch64_tune_string, &selected_tune);
+ 
+ #ifdef SUBTARGET_OVERRIDE_OPTIONS
+   SUBTARGET_OVERRIDE_OPTIONS;
+ #endif
+ 
+-  /* If the user did not specify a processor, choose the default
+-     one for them.  This will be the CPU set during configuration using
+-     --with-cpu, otherwise it is "generic".  */
+-  if (!selected_cpu)
+-    {
+-      if (selected_arch)
+-	{
+-	  selected_cpu = &all_cores[selected_arch->ident];
+-	  aarch64_isa_flags = arch_isa;
+-	  explicit_arch = selected_arch->arch;
+-	}
+-      else
+-	{
+-	  /* Get default configure-time CPU.  */
+-	  selected_cpu = aarch64_get_tune_cpu (aarch64_none);
+-	  aarch64_isa_flags = TARGET_CPU_DEFAULT >> TARGET_CPU_NBITS;
+-	}
+-
+-      if (selected_tune)
+-	explicit_tune_core = selected_tune->ident;
+-    }
+-  /* If both -mcpu and -march are specified check that they are architecturally
+-     compatible, warn if they're not and prefer the -march ISA flags.  */
+-  else if (selected_arch)
++  if (selected_cpu && selected_arch)
+     {
++      /* If both -mcpu and -march are specified, warn if they are not
++	 architecturally compatible and prefer the -march ISA flags.  */
+       if (selected_arch->arch != selected_cpu->arch)
+ 	{
+ 	  warning (0, "switch %<-mcpu=%s%> conflicts with %<-march=%s%> switch",
+ 		       aarch64_cpu_string,
+ 		       aarch64_arch_string);
+ 	}
++
+       aarch64_isa_flags = arch_isa;
+-      explicit_arch = selected_arch->arch;
+-      explicit_tune_core = selected_tune ? selected_tune->ident
+-					  : selected_cpu->ident;
+     }
+-  else
++  else if (selected_cpu)
+     {
+-      /* -mcpu but no -march.  */
+-      aarch64_isa_flags = cpu_isa;
+-      explicit_tune_core = selected_tune ? selected_tune->ident
+-					  : selected_cpu->ident;
+-      gcc_assert (selected_cpu);
+       selected_arch = &all_architectures[selected_cpu->arch];
+-      explicit_arch = selected_arch->arch;
++      aarch64_isa_flags = cpu_isa;
+     }
+-
+-  /* Set the arch as well as we will need it when outputing
+-     the .arch directive in assembly.  */
+-  if (!selected_arch)
++  else if (selected_arch)
+     {
+-      gcc_assert (selected_cpu);
++      selected_cpu = &all_cores[selected_arch->ident];
++      aarch64_isa_flags = arch_isa;
++    }
++  else
++    {
++      /* No -mcpu or -march specified, so use the default CPU.  */
++      selected_cpu = &all_cores[TARGET_CPU_DEFAULT];
+       selected_arch = &all_architectures[selected_cpu->arch];
++      aarch64_isa_flags = selected_cpu->flags;
+     }
+ 
++  explicit_arch = selected_arch->arch;
+   if (!selected_tune)
+     selected_tune = selected_cpu;
++  explicit_tune_core = selected_tune->ident;
++
++  gcc_assert (explicit_tune_core != aarch64_none);
++  gcc_assert (explicit_arch != aarch64_no_arch);
+ 
+   if (aarch64_enable_bti == 2)
+     {
+@@ -18261,15 +18219,6 @@ aarch64_override_options (void)
+   if (aarch64_ra_sign_scope != AARCH64_FUNCTION_NONE && TARGET_ILP32)
+     sorry ("return address signing is only supported for %<-mabi=lp64%>");
+ 
+-  /* Make sure we properly set up the explicit options.  */
+-  if ((aarch64_cpu_string && valid_cpu)
+-       || (aarch64_tune_string && valid_tune))
+-    gcc_assert (explicit_tune_core != aarch64_none);
+-
+-  if ((aarch64_cpu_string && valid_cpu)
+-       || (aarch64_arch_string && valid_arch))
+-    gcc_assert (explicit_arch != aarch64_no_arch);
+-
+   /* The pass to insert speculation tracking runs before
+      shrink-wrapping and the latter does not know how to update the
+      tracking status.  So disable it in this case.  */
+@@ -18375,11 +18324,7 @@ aarch64_option_restore (struct gcc_options *opts,
+   opts->x_explicit_arch = ptr->x_explicit_arch;
+   selected_arch = aarch64_get_arch (ptr->x_explicit_arch);
+   opts->x_explicit_tune_core = ptr->x_explicit_tune_core;
+-  if (opts->x_explicit_tune_core == aarch64_none
+-      && opts->x_explicit_arch != aarch64_no_arch)
+-    selected_tune = &all_cores[selected_arch->ident];
+-  else
+-    selected_tune = aarch64_get_tune_cpu (ptr->x_explicit_tune_core);
++  selected_tune = aarch64_get_tune_cpu (ptr->x_explicit_tune_core);
+   opts->x_aarch64_override_tune_string = ptr->x_aarch64_override_tune_string;
+   opts->x_aarch64_branch_protection_string
+     = ptr->x_aarch64_branch_protection_string;
+diff --git a/gcc/config/aarch64/aarch64.h b/gcc/config/aarch64/aarch64.h
+index 359b6e8561faa..f835da33b72f3 100644
+--- a/gcc/config/aarch64/aarch64.h
++++ b/gcc/config/aarch64/aarch64.h
+@@ -813,16 +813,9 @@ enum target_cpus
+   TARGET_CPU_generic
+ };
+ 
+-/* Define how many bits are used to represent the CPU in TARGET_CPU_DEFAULT.
+-   This needs to be big enough to fit the value of TARGET_CPU_generic.
+-   All bits after this are used to represent the AARCH64_CPU_DEFAULT_FLAGS.  */
+-#define TARGET_CPU_NBITS 8
+-#define TARGET_CPU_MASK ((1 << TARGET_CPU_NBITS) - 1)
+-
+ /* If there is no CPU defined at configure, use generic as default.  */
+ #ifndef TARGET_CPU_DEFAULT
+-#define TARGET_CPU_DEFAULT \
+-  (TARGET_CPU_generic | (AARCH64_CPU_DEFAULT_FLAGS << TARGET_CPU_NBITS))
++# define TARGET_CPU_DEFAULT TARGET_CPU_generic
+ #endif
+ 
+ /* If inserting NOP before a mult-accumulate insn remember to adjust the

--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: 2.7.0
-  epoch: 1
+  epoch: 2
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT

--- a/llvm-libunwind-15.yaml
+++ b/llvm-libunwind-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-libunwind-15
   version: 15.0.7
-  epoch: 0
+  epoch: 1
   description: LLVM version of libunwind library
   copyright:
     - license: MIT

--- a/llvm-libunwind-16.yaml
+++ b/llvm-libunwind-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-libunwind-16
   version: 16.0.6
-  epoch: 3
+  epoch: 4
   description: LLVM version of libunwind library
   copyright:
     - license: MIT

--- a/llvm-libunwind-17.yaml
+++ b/llvm-libunwind-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-libunwind-17
   version: 17.0.6
-  epoch: 0
+  epoch: 1
   description: LLVM version of libunwind library
   copyright:
     - license: MIT

--- a/nfs-ganesha.yaml
+++ b/nfs-ganesha.yaml
@@ -1,7 +1,7 @@
 package:
   name: nfs-ganesha
   version: "5.9"
-  epoch: 0
+  epoch: 1
   description: NFS-Ganesha is an NFSv3,v4,v4.1 fileserver that runs in user mode on most UNIX/Linux systems
   copyright:
     - license: GPL-3.0-or-later

--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: opensearch-dashboards-2
   version: 2.15.0 # when updating please check if we can remove the patched package.json for the reporting plugin
-  epoch: 1
+  epoch: 2
   description: Open source visualization dashboards for OpenSearch
   copyright:
     - license: Apache-2.0

--- a/pnpm-stage0.yaml
+++ b/pnpm-stage0.yaml
@@ -1,7 +1,7 @@
 package:
   name: pnpm-stage0
   version: 8.7.4
-  epoch: 0
+  epoch: 1
   description: "Fast, disk space efficient package manager"
   copyright:
     - license: MIT

--- a/pnpm.yaml
+++ b/pnpm.yaml
@@ -1,7 +1,7 @@
 package:
   name: pnpm
   version: 9.6.0
-  epoch: 0
+  epoch: 1
   description: "Fast, disk space efficient package manager"
   copyright:
     - license: MIT

--- a/rethinkdb.yaml
+++ b/rethinkdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: rethinkdb
   version: 2.4.4
-  epoch: 3
+  epoch: 4
   description: The open-source database for the realtime web.
   copyright:
     - license: Apache-2.0

--- a/zetasql.yaml
+++ b/zetasql.yaml
@@ -1,7 +1,7 @@
 package:
   name: zetasql
   version: 2024.06.1
-  epoch: 0
+  epoch: 1
   description: ZetaSQL - Analyzer Framework for SQL
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bring in relevant improvements from #23949 and #24194:

- set default march & mtune settings
- set package version information
- drop manual runtime dependencies, as `no-provides` issues were all fixed
- enable Intel CET automatically
- do not link mutliple compilers simultaneously (should reduce peak RAM usage)
- install internal binaries into major number subpaths, thus making spec files locations predictable

Bumped reverse-build dependencies to test rebuilds of them.

