### PR TITLE
revert symlink change

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -157,7 +157,6 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
           install -m644 -D nginx.conf ${{targets.subpkgdir}}/etc/nginx/
 
-          # Should be exported as conf.d/default.conf as per https://hg.nginx.org/pkg-oss/file/tip/alpine/alpine/APKBUILD-base.in#l87
           install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/default.conf
           install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d
 

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -157,7 +157,6 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
           install -m644 -D nginx.conf ${{targets.subpkgdir}}/etc/nginx/
 
-          install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/default.conf
           install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d
 
           # Follow Docker Image and link logs to to stdout/stderr

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -222,6 +222,30 @@ subpackages:
           cp -r ./nginx-mainline/* ${{targets.contextdir}}/usr/src/nginx
           ls -latr ${{targets.contextdir}}/usr/src/nginx
 
+  - name: ${{package.name}}-config-compat
+    description: Nginx config compatibility with upstream image
+    dependencies:
+      runtime:
+        - nginx-mainline
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
+          install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/
+          ln -s /etc/nginx/conf.d/nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/default.conf
+
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-config
+        - ${{package.name}}-config-compat
+  pipeline:
+    - runs: |
+        nginx -v
+        head -n 5 /etc/nginx/nginx.conf
+        head -n 5 /etc/nginx/conf.d/nginx.default.conf
+        head -n 5 /etc/nginx/conf.d/default.conf
+
 update:
   enabled: true
   github:

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-mainline
   version: 1.27.0
-  epoch: 5
+  epoch: 6
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause
@@ -156,10 +156,10 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
           install -m644 -D nginx.conf ${{targets.subpkgdir}}/etc/nginx/
-          install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/
 
           # Should be exported as conf.d/default.conf as per https://hg.nginx.org/pkg-oss/file/tip/alpine/alpine/APKBUILD-base.in#l87
-          ln -s /etc/nginx/conf.d/nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/default.conf
+          install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/default.conf
+          install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d
 
           # Follow Docker Image and link logs to to stdout/stderr
           # https://github.com/nginxinc/docker-nginx/blob/73a5acae6945b75b433cafd0c9318e4378e72cbb/mainline/alpine-slim/Dockerfile#L106-L107

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-stable
   version: 1.26.1
-  epoch: 5
+  epoch: 6
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause
@@ -214,6 +214,30 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/src/nginx
           cp -r ./nginx-stable/* ${{targets.contextdir}}/usr/src/nginx
           ls -latr ${{targets.contextdir}}/usr/src/nginx
+
+  - name: ${{package.name}}-config-compat
+    description: Nginx config compatibility with upstream image
+    dependencies:
+      runtime:
+        - nginx-stable
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
+          install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/
+          ln -s /etc/nginx/conf.d/nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/default.conf
+
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-config
+        - ${{package.name}}-config-compat
+  pipeline:
+    - runs: |
+        nginx -v
+        head -n 5 /etc/nginx/nginx.conf
+        head -n 5 /etc/nginx/conf.d/nginx.default.conf
+        head -n 5 /etc/nginx/conf.d/default.conf
 
 update:
   enabled: true

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -157,7 +157,6 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
           install -m644 -D nginx.conf ${{targets.subpkgdir}}/etc/nginx/
 
-          # Should be exported as conf.d/default.conf as per https://hg.nginx.org/pkg-oss/file/tip/alpine/alpine/APKBUILD-base.in#l87
           install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/default.conf
           install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d
 

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -157,7 +157,6 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
           install -m644 -D nginx.conf ${{targets.subpkgdir}}/etc/nginx/
 
-          install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/default.conf
           install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d
 
           # Follow Docker Image and link logs to to stdout/stderr

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -156,10 +156,10 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/etc/nginx/conf.d
           install -m644 -D nginx.conf ${{targets.subpkgdir}}/etc/nginx/
-          install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/
 
           # Should be exported as conf.d/default.conf as per https://hg.nginx.org/pkg-oss/file/tip/alpine/alpine/APKBUILD-base.in#l87
-          ln -s /etc/nginx/conf.d/nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/default.conf
+          install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d/default.conf
+          install -m644 -D nginx.default.conf ${{targets.subpkgdir}}/etc/nginx/conf.d
 
           # Follow Docker Image and link logs to to stdout/stderr
           # https://github.com/nginxinc/docker-nginx/blob/73a5acae6945b75b433cafd0c9318e4378e72cbb/stable/alpine-slim/Dockerfile#L106-L107


### PR DESCRIPTION
https://github.com/wolfi-dev/os/commit/3fac15ee0dac0f6c02e4ff16fc869b53ce81a662 was recently committed, as part of a batch of other changes to try and make our image behave closer to the upstream image. Unfortunately, it has caused some unexpected issues, so we're rolling back this change.