### PR TITLE
withdrawn-packages: renamed LLVM libraries

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -151,3 +151,9 @@ gitlab-cng-base-17.1.0-r0.apk
 gitlab-cng-base-17.1.1-r0.apk
 gitlab-cng-base-17.1.1-r1.apk
 gitlab-cng-certificates-17.1.1-r1.apk
+llvm18.1-18.1.5-r0.apk
+llvm18.1-dev-18.1.5-r0.apk
+libLLVM-18.1-18.1.5-r0.apk
+llvm18.1-18.1.6-r0.apk
+llvm18.1-dev-18.1.6-r0.apk
+libLLVM-18.1-18.1.6-r0.apk


### PR DESCRIPTION
libllvm18.1/libLLVM18.1 got renamed to libllvm-18/libLLVM-18
(corrected stream name). However, both obsolete and new packages have
the same `so:` provides and may result in missmatched builds getting
installed.

Remove obsolete package names to prevent this.
