### PR TITLE
paxmark: new package

### DIFF
--- a/paxmark.yaml
+++ b/paxmark.yaml
@@ -1,0 +1,35 @@
+package:
+  name: paxmark
+  version: 0.1.0
+  epoch: 0
+  description: "update PaX markings on binaries run under PaX-capable kernels"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - rust
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/edera-dev/paxmark
+      tag: v${{package.version}}
+      expected-commit: 7e69813989b5f78975c0fa43f32fd582544c3a31
+
+  - runs: |
+      cargo build --release
+      install -Dm755 target/release/paxmark "${{targets.destdir}}"/usr/sbin/paxmark
+
+update:
+  enabled: true
+  github:
+    identifier: edera-dev/paxmark
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
paxmark allows for the adjustment of PaX markings on binaries which need special privileges to run correctly under PaX environments such as Edera Protect.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)