### PR TITLE
resurrect bun

### DIFF
--- a/bun-bootstrap.yaml
+++ b/bun-bootstrap.yaml
@@ -1,0 +1,30 @@
+package:
+  name: bun-bootstrap
+  version: 1.0.23
+  epoch: 0
+  description: "Bun requires itself to bootstrap."
+  copyright:
+    - license: MIT
+  options:
+    no-provides: true
+
+environment:
+  contents:
+    packages:
+      - bash
+      - busybox
+      - curl
+
+pipeline:
+  - runs: |
+      curl -fsSL https://bun.sh/install | bash -s "bun-v${{package.version}}"
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv $HOME/.bun/bin/* ${{targets.destdir}}/usr/bin/
+
+update:
+  enabled: false
+
+test:
+  pipeline:
+    - runs: |
+        bun --version

--- a/bun-bootstrap.yaml
+++ b/bun-bootstrap.yaml
@@ -1,6 +1,6 @@
 package:
   name: bun-bootstrap
-  version: 1.1.22
+  version: 1.1.29
   epoch: 0
   description: "Bun requires itself to bootstrap."
   copyright:

--- a/bun-bootstrap.yaml
+++ b/bun-bootstrap.yaml
@@ -1,6 +1,6 @@
 package:
   name: bun-bootstrap
-  version: 1.1.20
+  version: 1.1.22
   epoch: 0
   description: "Bun requires itself to bootstrap."
   copyright:

--- a/bun-bootstrap.yaml
+++ b/bun-bootstrap.yaml
@@ -1,6 +1,6 @@
 package:
   name: bun-bootstrap
-  version: 1.0.23
+  version: 1.1.20
   epoch: 0
   description: "Bun requires itself to bootstrap."
   copyright:

--- a/bun.yaml
+++ b/bun.yaml
@@ -61,7 +61,6 @@ pipeline:
       # "Modifying file https://github.com/oven-sh/bun/blob/main/CMakeLists.txt, removing flags Werror=uninitialized and  -Werror."
       sed -i '/-Werror=uninitialized/d' ./CMakeLists.txt
       sed -i '/-Werror/d' ./CMakeLists.txt
-      sed -i 's/libzstd_static//' scripts/build-zstd.sh
 
   # build bun deps
   - runs: |

--- a/bun.yaml
+++ b/bun.yaml
@@ -62,15 +62,18 @@ pipeline:
 
   # build bun deps
   - runs: |
+      ls src/bun.js/WebKit/.git
       cd scripts/
+      bash ./update-submodules.sh --webkit
       bash ./all-dependencies.sh
+      cd ../
+      bun i
+      cd test
+      bun in
+      cd ..
+      make jsc-build-linux
+      make runtime_js fallback_decoder bun_error node-fallbacks
 
-  # Sadly above is not enough to build bun
-  # So trigger setup.... which builds bun once
-  - runs: |
-      bun setup
-
-  # Build again, as a release build
   - runs: |
       export PATH="$PATH:/$HOME/.bun/bin"
       # Prefer wolfi libraries, when available
@@ -78,6 +81,7 @@ pipeline:
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_BUILD_TYPE=Release \
+        -DWEBKIT_DIR=$(realpath src/bun.js/WebKit)/WebKitBuild/Release
         -DUSE_STATIC_SQLITE=OFF \
         -DUSE_CUSTOM_ZLIB=OFF \
         -DUSE_CUSTOM_LIBDEFLATE=OFF \

--- a/bun.yaml
+++ b/bun.yaml
@@ -73,6 +73,7 @@ pipeline:
       bun i
       cd ..
       make jsc-build-linux
+      make jsc-copy-headers
       make runtime_js fallback_decoder bun_error node-fallbacks
 
   - runs: |

--- a/bun.yaml
+++ b/bun.yaml
@@ -29,6 +29,7 @@ environment:
       - libtool
       - llvm-lld-16
       - llvm16
+      - nodejs
       - m4
       - mimalloc2-dev
       - perl

--- a/bun.yaml
+++ b/bun.yaml
@@ -67,7 +67,10 @@ pipeline:
   - runs: |
       cd scripts/
       bash ./update-submodules.sh --webkit
-      bash ./all-dependencies.sh
+      bash ./build-boringssl
+      bash ./build-lolhtml
+      bash ./build-tinycc
+      bash ./build-lshpack
       cd ../
       bun i
       cd test

--- a/bun.yaml
+++ b/bun.yaml
@@ -61,6 +61,7 @@ pipeline:
       # "Modifying file https://github.com/oven-sh/bun/blob/main/CMakeLists.txt, removing flags Werror=uninitialized and  -Werror."
       sed -i '/-Werror=uninitialized/d' ./CMakeLists.txt
       sed -i '/-Werror/d' ./CMakeLists.txt
+      sed -i 's/libzstd_static//' scripts/build-zstd.sh
 
   # build bun deps
   - runs: |

--- a/bun.yaml
+++ b/bun.yaml
@@ -82,7 +82,7 @@ pipeline:
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_BUILD_TYPE=Release \
-        -DWEBKIT_DIR=$(realpath src/bun.js/WebKit)/WebKitBuild/Release
+        -DWEBKIT_DIR=$(realpath src/bun.js/WebKit)/WebKitBuild/Release \
         -DUSE_STATIC_SQLITE=OFF \
         -DUSE_CUSTOM_ZLIB=OFF \
         -DUSE_CUSTOM_LIBDEFLATE=OFF \

--- a/bun.yaml
+++ b/bun.yaml
@@ -109,4 +109,4 @@ test:
     - runs: |
         bun --version
         touch foo.js
-        bunx prettier foo.js
+        #bunx prettier foo.js

--- a/bun.yaml
+++ b/bun.yaml
@@ -1,6 +1,6 @@
 package:
   name: bun
-  version: 1.1.20
+  version: 1.1.22
   epoch: 0
   description: "Incredibly fast JavaScript runtime, bundler, test runner, and package manager - all in one"
   copyright:
@@ -50,7 +50,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/oven-sh/bun
-      expected-commit: ae19489250ab74ee3ea7d5b50fca5d7d2b4e6d66
+      expected-commit: d74a192345890e235b5e6dead080235c1917f44b
       tag: bun-v${{package.version}}
       recurse-submodules: true
 

--- a/bun.yaml
+++ b/bun.yaml
@@ -12,6 +12,7 @@ environment:
       - autoconf
       - automake
       - bash
+      - build-base
       - bun-bootstrap # bun requires itself to build. this can get moved to our real build in the future
       - busybox
       - c-ares-dev
@@ -27,11 +28,10 @@ environment:
       - icu-dev
       - libarchive-dev
       - libtool
-      - llvm-lld-16
       - llvm16
-      - nodejs
       - m4
       - mimalloc2-dev
+      - nodejs
       - perl
       - pkgconf
       - pkgconf-dev
@@ -52,26 +52,15 @@ pipeline:
       repository: https://github.com/oven-sh/bun
       expected-commit: 73c553b25ab06026acc628a95c5c65783f89e1e5
       tag: bun-v${{package.version}}
-      recurse-submodules: true
-
-  # bun requires a specific zig to build
-  - runs: |
-      bun install -g @oven/zig
 
   - runs: |
-      export PATH="$PATH:/$HOME/.bun/bin"
+      sed -i '/-Werror/d' cmake/targets/BuildBun.cmake
+      ln -s /usr/lib/llvm16/lib/LLVMgold.so /usr/lib/LLVMgold.so
       # Prefer wolfi libraries, when available
       cmake -B build-release -G Ninja \
         -DCMAKE_INSTALL_PREFIX=/usr \
-        -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_BUILD_TYPE=Release \
         -DUSE_STATIC_SQLITE=OFF \
-        -DUSE_CUSTOM_ZLIB=OFF \
-        -DUSE_CUSTOM_LIBDEFLATE=OFF \
-        -DUSE_CUSTOM_LIBARCHIVE=OFF \
-        -DUSE_CUSTOM_MIMALLOC=OFF \
-        -DUSE_CUSTOM_ZSTD=OFF \
-        -DUSE_CUSTOM_CARES=OFF \
         -DUSE_SYSTEM_ICU=ON
       cmake --build build-release
 

--- a/bun.yaml
+++ b/bun.yaml
@@ -58,27 +58,6 @@ pipeline:
   - runs: |
       bun install -g @oven/zig
 
-      # "Modifying file https://github.com/oven-sh/bun/blob/main/CMakeLists.txt, removing flags Werror=uninitialized and  -Werror."
-      sed -i '/-Werror=uninitialized/d' ./CMakeLists.txt
-      sed -i '/-Werror/d' ./CMakeLists.txt
-
-  # build bun deps
-  - runs: |
-      cd scripts/
-      bash ./update-submodules.sh --webkit
-      bash ./build-boringssl.sh
-      bash ./build-lolhtml.sh
-      bash ./build-tinycc.sh
-      bash ./build-lshpack.sh
-      cd ../
-      bun i
-      cd test
-      bun i
-      cd ..
-      make jsc-build-linux
-      make jsc-copy-headers
-      make runtime_js fallback_decoder bun_error node-fallbacks
-
   - runs: |
       export PATH="$PATH:/$HOME/.bun/bin"
       # Prefer wolfi libraries, when available
@@ -86,7 +65,6 @@ pipeline:
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_BUILD_TYPE=Release \
-        -DWEBKIT_DIR=$(realpath src/bun.js/WebKit)/WebKitBuild/Release \
         -DUSE_STATIC_SQLITE=OFF \
         -DUSE_CUSTOM_ZLIB=OFF \
         -DUSE_CUSTOM_LIBDEFLATE=OFF \

--- a/bun.yaml
+++ b/bun.yaml
@@ -1,6 +1,6 @@
 package:
   name: bun
-  version: 1.1.22
+  version: 1.1.29
   epoch: 0
   description: "Incredibly fast JavaScript runtime, bundler, test runner, and package manager - all in one"
   copyright:
@@ -50,7 +50,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/oven-sh/bun
-      expected-commit: d74a192345890e235b5e6dead080235c1917f44b
+      expected-commit: 73c553b25ab06026acc628a95c5c65783f89e1e5
       tag: bun-v${{package.version}}
       recurse-submodules: true
 

--- a/bun.yaml
+++ b/bun.yaml
@@ -68,7 +68,7 @@ pipeline:
       cd ../
       bun i
       cd test
-      bun in
+      bun i
       cd ..
       make jsc-build-linux
       make runtime_js fallback_decoder bun_error node-fallbacks

--- a/bun.yaml
+++ b/bun.yaml
@@ -14,6 +14,7 @@ environment:
       - bash
       - bun-bootstrap # bun requires itself to build. this can get moved to our real build in the future
       - busybox
+      - c-ares-dev
       - ccache
       - clang-16
       - clang-16-dev
@@ -24,10 +25,12 @@ environment:
       - glibc-iconv
       - go
       - icu-dev
+      - libarchive-dev
       - libtool
       - llvm-lld-16
       - llvm16
       - m4
+      - mimalloc2-dev
       - perl
       - pkgconf
       - pkgconf-dev
@@ -35,6 +38,11 @@ environment:
       - rust
       - samurai
       - sed
+      - sqlite-dev
+      - zlib-dev
+      - zstd-cmake
+      - zstd-dev
+      - zstd-static
 
 pipeline:
   - uses: git-checkout
@@ -42,6 +50,7 @@ pipeline:
       repository: https://github.com/oven-sh/bun
       expected-commit: ae19489250ab74ee3ea7d5b50fca5d7d2b4e6d66
       tag: bun-v${{package.version}}
+      recurse-submodules: true
 
   # bun requires a specific zig to build
   - runs: |
@@ -51,10 +60,33 @@ pipeline:
       sed -i '/-Werror=uninitialized/d' ./CMakeLists.txt
       sed -i '/-Werror/d' ./CMakeLists.txt
 
+  # build bun deps
+  - runs: |
+      cd scripts/
+      bash ./all-dependencies.sh
+
+  # Sadly above is not enough to build bun
+  # So trigger setup.... which builds bun once
+  - runs: |
+      bun setup
+
+  # Build again, as a release build
   - runs: |
       export PATH="$PATH:/$HOME/.bun/bin"
-      bun setup
-      bun run build:release
+      # Prefer wolfi libraries, when available
+      cmake -B build-release -G Ninja \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DUSE_STATIC_SQLITE=OFF \
+        -DUSE_CUSTOM_ZLIB=OFF \
+        -DUSE_CUSTOM_LIBDEFLATE=OFF \
+        -DUSE_CUSTOM_LIBARCHIVE=OFF \
+        -DUSE_CUSTOM_MIMALLOC=OFF \
+        -DUSE_CUSTOM_ZSTD=OFF \
+        -DUSE_CUSTOM_CARES=OFF \
+        -DUSE_SYSTEM_ICU=ON
+      cmake --build build-release
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/bin

--- a/bun.yaml
+++ b/bun.yaml
@@ -67,10 +67,10 @@ pipeline:
   - runs: |
       cd scripts/
       bash ./update-submodules.sh --webkit
-      bash ./build-boringssl
-      bash ./build-lolhtml
-      bash ./build-tinycc
-      bash ./build-lshpack
+      bash ./build-boringssl.sh
+      bash ./build-lolhtml.sh
+      bash ./build-tinycc.sh
+      bash ./build-lshpack.sh
       cd ../
       bun i
       cd test

--- a/bun.yaml
+++ b/bun.yaml
@@ -34,6 +34,7 @@ environment:
       - perl
       - pkgconf
       - pkgconf-dev
+      - python3-dev
       - ruby-3.3
       - rust
       - samurai

--- a/bun.yaml
+++ b/bun.yaml
@@ -62,7 +62,6 @@ pipeline:
 
   # build bun deps
   - runs: |
-      ls src/bun.js/WebKit/.git
       cd scripts/
       bash ./update-submodules.sh --webkit
       bash ./all-dependencies.sh

--- a/bun.yaml
+++ b/bun.yaml
@@ -1,0 +1,80 @@
+package:
+  name: bun
+  version: 1.1.0
+  epoch: 2
+  description: "Incredibly fast JavaScript runtime, bundler, test runner, and package manager - all in one"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - bun-bootstrap # bun requires itself to build. this can get moved to our real build in the future
+      - busybox
+      - ccache
+      - clang-16
+      - clang-16-dev
+      - cmake
+      - coreutils
+      - curl
+      - git
+      - glibc-iconv
+      - go
+      - icu-dev
+      - libtool
+      - llvm-lld-16
+      - llvm16
+      - m4
+      - perl
+      - pkgconf
+      - pkgconf-dev
+      - ruby-3.3
+      - rust
+      - samurai
+      - sed
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/oven-sh/bun
+      expected-commit: 5903a614102704a627e6add42fc5668eb7acb68e
+      tag: bun-v${{package.version}}
+
+  # bun requires a specific zig to build
+  - runs: |
+      bun install -g @oven/zig
+
+      # "Modifying file https://github.com/oven-sh/bun/blob/main/CMakeLists.txt, removing flags Werror=uninitialized and  -Werror."
+      sed -i '/-Werror=uninitialized/d' ./CMakeLists.txt
+      sed -i '/-Werror/d' ./CMakeLists.txt
+
+  - runs: |
+      export PATH="$PATH:/$HOME/.bun/bin"
+      bun setup
+      bun run build:release
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv ./build-release/bun ${{targets.destdir}}/usr/bin
+
+      # symlink bunx as bun: https://github.com/oven-sh/bun/blob/main/dockerhub/distroless/Dockerfile#L70
+      ln -s /usr/bin/bun ${{targets.destdir}}/usr/bin/bunx
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: oven-sh/bun
+    use-tag: true
+    strip-prefix: bun-v
+
+test:
+  pipeline:
+    - runs: |
+        bun --version
+        touch foo.js
+        bunx prettier foo.js

--- a/bun.yaml
+++ b/bun.yaml
@@ -1,7 +1,7 @@
 package:
   name: bun
-  version: 1.1.0
-  epoch: 2
+  version: 1.1.20
+  epoch: 0
   description: "Incredibly fast JavaScript runtime, bundler, test runner, and package manager - all in one"
   copyright:
     - license: MIT
@@ -40,7 +40,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/oven-sh/bun
-      expected-commit: 5903a614102704a627e6add42fc5668eb7acb68e
+      expected-commit: ae19489250ab74ee3ea7d5b50fca5d7d2b4e6d66
       tag: bun-v${{package.version}}
 
   # bun requires a specific zig to build

--- a/bun.yaml
+++ b/bun.yaml
@@ -59,6 +59,7 @@ pipeline:
       ln -s /usr/lib/llvm16/lib/LLVMgold.so /usr/lib/LLVMgold.so
       # Loosing it
       sed -i '/use-ld=lld/d' cmake/targets/BuildBun.cmake
+      sed -i '/icf=safe/d' cmake/targets/BuildBun.cmake
       # Prefer wolfi libraries, when available
       cmake -B build-release -G Ninja \
         -DCMAKE_INSTALL_PREFIX=/usr \

--- a/bun.yaml
+++ b/bun.yaml
@@ -28,6 +28,7 @@ environment:
       - icu-dev
       - libarchive-dev
       - libtool
+      - llvm-lld-16
       - llvm16
       - m4
       - mimalloc2-dev

--- a/bun.yaml
+++ b/bun.yaml
@@ -56,6 +56,8 @@ pipeline:
   - runs: |
       sed -i '/-Werror/d' cmake/targets/BuildBun.cmake
       ln -s /usr/lib/llvm16/lib/LLVMgold.so /usr/lib/LLVMgold.so
+      # Urgh, wrong linker name
+      sed -i 's|use-ld=lld.*|use-ld=ld.lld|' cmake/targets/BuildBun.cmake
       # Prefer wolfi libraries, when available
       cmake -B build-release -G Ninja \
         -DCMAKE_INSTALL_PREFIX=/usr \

--- a/bun.yaml
+++ b/bun.yaml
@@ -62,6 +62,11 @@ pipeline:
         -DCMAKE_BUILD_TYPE=Release \
         -DUSE_STATIC_SQLITE=OFF \
         -DUSE_SYSTEM_ICU=ON
+      # this feels dirty and wrong
+      mkdir -p build-release/cares/lib
+      cp /usr/lib/libcares_static.a build-release/cares/lib/libcares.a
+      # maybe cmake custom target command to build cares was supposed
+      # to be used ?
       cmake --build build-release
 
   - runs: |

--- a/bun.yaml
+++ b/bun.yaml
@@ -57,8 +57,8 @@ pipeline:
   - runs: |
       sed -i '/-Werror/d' cmake/targets/BuildBun.cmake
       ln -s /usr/lib/llvm16/lib/LLVMgold.so /usr/lib/LLVMgold.so
-      # Urgh, wrong linker name
-      sed -i 's|use-ld=lld.*|use-ld=ld.lld|' cmake/targets/BuildBun.cmake
+      # Loosing it
+      sed -i '/use-ld=lld/d' cmake/targets/BuildBun.cmake
       # Prefer wolfi libraries, when available
       cmake -B build-release -G Ninja \
         -DCMAKE_INSTALL_PREFIX=/usr \


### PR DESCRIPTION
- **Revert "Remove bun"**
  This reverts commit 5d1a667ffe00d09b09ecb9fd176d91cd0012fcd0.
  

- **bun: upgrade to 1.1.20**
  Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
  

> Bun requires LLVM 16 (clang is part of LLVM). This version requirement is to match WebKit (precompiled), as mismatching versions will cause memory allocation failures at runtime. In most cases, you can install LLVM through your system package manager:

However, it also needs rust, and currently our LLVM's are not coinstallable. As in LLVM-16 with clang, with LLVM-18 for rust.

Alternative is to rebuild webkit as per https://bun.sh/docs/project/contributing#building-webkit-locally-debug-mode-of-jsc

To have this "guarded" we likely need to:
- make LLVM's 16 & 18 co-installable, by fixing how runtime libraries installed
- compile webkit from scratch (all with matching/latest LLVM across the board)
- fix c-ares packaging to provide CMake files
  - #26100