### PR TITLE
Fix preexisting poppler package

### DIFF
--- a/poppler.yaml
+++ b/poppler.yaml
@@ -56,10 +56,6 @@ subpackages:
     pipeline:
       - uses: split/dev
 
-  - name: poppler-doc
-    pipeline:
-      - uses: split/man
-
 update:
   enabled: true
   release-monitor:

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -1,7 +1,7 @@
 package:
   name: poppler
   version: 24.07.0
-  epoch: 0
+  epoch: 1
   description: Poppler is a PDF rendering library based on the xpdf-3.0 code base.
   copyright:
     - license: GPL-2.0-or-later

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -14,8 +14,9 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cairo-dev
-      - cmake
       - expat-dev
+      - glib-dev
+      - glib-gir
       - gobject-introspection-dev
       - lcms2-dev
       - libfontconfig1
@@ -26,7 +27,6 @@ environment:
       - libxml2-dev
       - openjpeg-dev
       - openjpeg-tools
-      - samurai
       - tiff-dev
       - zlib-dev
 
@@ -44,7 +44,8 @@ pipeline:
         -DENABLE_LIBCURL=OFF \
         -DCMAKE_BUILD_TYPE=Release \
         -DENABLE_QT5=OFF \
-        -DENABLE_QT6=OFF
+        -DENABLE_QT6=OFF \
+        -DENABLE_GLIB=ON
 
   - uses: cmake/build
 
@@ -57,15 +58,7 @@ subpackages:
 
   - name: poppler-doc
     pipeline:
-      - uses: split/dev
-
-  - name: poppler-glib
-    pipeline:
-      - uses: split/dev
-
-  - name: poppler-utils
-    pipeline:
-      - uses: split/dev
+      - uses: split/man
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
Adds support for glib on poppler and removes poppler-glib subpackage which didn't provide any packages

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
