### PR TITLE
Add sniff test to tomcat-10.1.

### DIFF
--- a/tomcat-10.1.yaml
+++ b/tomcat-10.1.yaml
@@ -70,6 +70,44 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/share/tomcat/webapps.dist
           cp -r output/build/webapps/* ${{targets.subpkgdir}}/usr/share/tomcat/webapps.dist/
 
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-webapps
+        - curl
+        - default-jvm
+        - tomcat-native
+    environment:
+      LD_LIBRARY_PATH: "/usr/lib/tomcat-native"
+  pipeline:
+    - name: Start tomcat
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          #!/bin/sh -ex
+          cp /usr/share/tomcat/webapps.dist/docs/appdev/sample/sample.war /usr/share/tomcat/webapps/
+        start: "env JAVA_HOME=/usr/lib/jvm/default-jvm /usr/share/tomcat/bin/catalina.sh run"
+        timeout: 30
+        expected_output: |
+          Deploying.*sample.war
+          Server startup in
+        post: |
+          #!/bin/sh -e
+          url=http://localhost:8080/sample/
+          echo "testing $url"
+          response=$(curl -s "$url") || {
+            echo "curl $url failed $?"
+            exit 1
+          }
+          expected="Sample.*Hello.*World.*Application"
+          echo "$response" | grep -q "$expected" || {
+            echo "response from $url did not contain \"$expected\""
+            echo "response: $response"
+            exit 1
+          }
+          echo "found \"$expected\" in output of curl $url"
+
 update:
   enabled: true
   ignore-regex-patterns:


### PR DESCRIPTION
The test is similar to that found in the current image test for tomcat. It verifies tomcat starts and can run the sample webapp.
