### PR TITLE
Revert "openjdk-8: build with SunPKCS11 provider enabled"

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.412.08 # this corresponds to same release as jdk8u412-ga / jdk8u412-b08
-  epoch: 2
+  epoch: 3
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later
@@ -40,8 +40,6 @@ environment:
       - libffi-dev
       - libice-dev
       - libjpeg-turbo-dev
-      - libnspr-dev
-      - libnss-dev
       - libpng-dev
       - libtool
       - libx11-dev
@@ -109,7 +107,6 @@ pipeline:
         --disable-docs \
         --disable-system-pcsc \
         --disable-system-sctp \
-        --enable-nss \
         --with-openjdk-src-zip=/home/build/icedtea-drops/openjdk-git.tar.xz \
         --with-hotspot-src-zip=/home/build/icedtea-drops/hotspot.tar.xz \
         --with-jdk-home=/usr/lib/jvm/java-1.7-openjdk \


### PR DESCRIPTION
This caused stack trace when tomcat-jdk8 was run.

This reverts commit 9a4cc332b590cf6cbae6c1e67b21081eafbb9d80.
