### PR TITLE
Removed Package Check

### DIFF
--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -54,8 +54,6 @@ pipeline:
       mkdir -p "${{targets.destdir}}/app"
       mv * "${{targets.destdir}}/app"
 
-      # https://github.com/browserify/resolve/issues/288
-      sed -i 's/monorepo-symlink-test/false-positive/g' ${{targets.destdir}}/app/node_modules/resolve/test/resolver/multirepo/package.json
 
 update:
   enabled: true


### PR DESCRIPTION
* This package check test was to see if monorepo-symlink-test false-positive is still an issue. The file no longer exists there and is causing the builds to fail. 


Related: https://github.com/browserify/resolve/issues/288

