### PR TITLE
chore: Bump ruby packages 1 of 6

### DIFF
--- a/fluent-plugin-cloudwatch-logs.yaml
+++ b/fluent-plugin-cloudwatch-logs.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-cloudwatch-logs
   version: 0.14.3
-  epoch: 1
+  epoch: 2
   description: CloudWatch Logs Plugin for Fluentd
   copyright:
     - license: MIT

--- a/fluent-plugin-detect-exceptions.yaml
+++ b/fluent-plugin-detect-exceptions.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-detect-exceptions
   version: 0.0.15
-  epoch: 0
+  epoch: 1
   description: Fluentd output plugin which detects exception stack traces in a stream of JSON log messages and combines all single-line messages that belong to the same stack trace into one multi-line message. This is an official Google Ruby gem.
   copyright:
     - license: Apache-2.0

--- a/fluent-plugin-elasticsearch.yaml
+++ b/fluent-plugin-elasticsearch.yaml
@@ -2,7 +2,7 @@
 package:
   name: fluent-plugin-elasticsearch
   version: 5.4.3
-  epoch: 0
+  epoch: 1
   description: Elasticsearch output plugin for Fluent event collector
   copyright:
     - license: Apache-2.0

--- a/fluent-plugin-kubernetes_metadata_filter.yaml
+++ b/fluent-plugin-kubernetes_metadata_filter.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-kubernetes_metadata_filter
   version: 3.5.0
-  epoch: 0
+  epoch: 1
   description: This is the Filter plugin to add Kubernetes metadata
   copyright:
     - license: Apache-2.0

--- a/fluent-plugin-label-router.yaml
+++ b/fluent-plugin-label-router.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-label-router
   version: "0.2.10_git20230928"
-  epoch: 2
+  epoch: 3
   description: Label-Router helps routing log messages based on their labels and namespace tag in a Kubernetes environment.
   copyright:
     - license: Apache-2.0

--- a/fluent-plugin-newrelic.yaml
+++ b/fluent-plugin-newrelic.yaml
@@ -2,7 +2,7 @@
 package:
   name: fluent-plugin-newrelic
   version: "1.2.2_git20230928"
-  epoch: 1
+  epoch: 2
   description: Sends FluentD events to New Relic
   copyright:
     - license: Apache-2.0

--- a/fluent-plugin-out-http.yaml
+++ b/fluent-plugin-out-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-out-http
   version: 1.3.4
-  epoch: 2
+  epoch: 3
   description: This is the Fluentd output plugin for enabling http access to the container
   copyright:
     - license: Apache-2.0

--- a/fluent-plugin-prometheus.yaml
+++ b/fluent-plugin-prometheus.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-prometheus
   version: 2.1.0
-  epoch: 1
+  epoch: 2
   description: A fluent plugin that collects metrics and exposes for Prometheus.
   copyright:
     - license: Apache-2.0

--- a/fluent-plugin-record-modifier.yaml
+++ b/fluent-plugin-record-modifier.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-record-modifier
   version: 2.2.0
-  epoch: 1
+  epoch: 2
   description: Filter plugin for modifying event record
   copyright:
     - license: MIT


### PR DESCRIPTION
Bump Ruby packages so that they pick up the correct Ruby version at runtime (fixed in SCA)