### PR TITLE
chore: Bump ruby packages 3 of 6

### DIFF
--- a/ruby3.2-aws-sdk-s3.yaml
+++ b/ruby3.2-aws-sdk-s3.yaml
@@ -26,7 +26,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: fe91b01cddb6acac9b083706a1c61c2904a7c946
+      expected-commit: 0ea8ece30f9dd8a4e80ec4c82f56348d27e94460
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
 

--- a/ruby3.2-aws-sdk-s3.yaml
+++ b/ruby3.2-aws-sdk-s3.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-aws-sdk-s3
   version: 1.156.0
-  epoch: 0
+  epoch: 1
   description: Official AWS Ruby gem for Amazon Simple Storage Service (Amazon S3). This gem is part of the AWS SDK for Ruby.
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-aws-sdk-sqs.yaml
+++ b/ruby3.2-aws-sdk-sqs.yaml
@@ -24,7 +24,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: fe91b01cddb6acac9b083706a1c61c2904a7c946
+      expected-commit: 0ea8ece30f9dd8a4e80ec4c82f56348d27e94460
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
 

--- a/ruby3.2-aws-sdk-sqs.yaml
+++ b/ruby3.2-aws-sdk-sqs.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-aws-sdk-sqs
   version: 1.80.0
-  epoch: 0
+  epoch: 1
   description: Official AWS Ruby gem for Amazon Simple Queue Service (Amazon SQS). This gem is part of the AWS SDK for Ruby.
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-aws-sigv4.yaml
+++ b/ruby3.2-aws-sigv4.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-aws-sigv4
   version: 1.8.0
-  epoch: 1
+  epoch: 2
   description: Amazon Web Services Signature Version 4 signing library. Generates sigv4 signature for HTTP requests.
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-aws-sigv4.yaml
+++ b/ruby3.2-aws-sigv4.yaml
@@ -24,7 +24,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: fe91b01cddb6acac9b083706a1c61c2904a7c946
+      expected-commit: 0ea8ece30f9dd8a4e80ec4c82f56348d27e94460
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
 

--- a/ruby3.2-chronic_duration.yaml
+++ b/ruby3.2-chronic_duration.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-chronic_duration
   version: 0.10.6
-  epoch: 0
+  epoch: 1
   description: A simple Ruby natural language parser for elapsed time. (For example, 4 hours and 30 minutes, 6 minutes 4 seconds, 3 days, etc.) Returns all results in seconds. Will return an integer unless you get tricky and need a float. (4 minutes and 13.47 seconds, for example.) The reverse can also be performed via the output method.
   copyright:
     - license: MIT

--- a/ruby3.2-elastic-transport.yaml
+++ b/ruby3.2-elastic-transport.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-elastic-transport
   version: 8.3.5
-  epoch: 0
+  epoch: 1
   description: |
     Low level Ruby client for Elastic. See the `elasticsearch` or `elastic-enterprise-search` gems for full integration.
   copyright:

--- a/ruby3.2-elasticsearch-api.yaml
+++ b/ruby3.2-elasticsearch-api.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-elasticsearch-api
   version: 8.14.0
-  epoch: 0
+  epoch: 1
   description: |
     Ruby API for Elasticsearch. See the `elasticsearch` gem for full integration.
   copyright:

--- a/ruby3.2-elasticsearch.yaml
+++ b/ruby3.2-elasticsearch.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-elasticsearch
   version: 8.14.0
-  epoch: 0
+  epoch: 1
   description: |
     Ruby integrations for Elasticsearch (client, API, etc.)
   copyright:

--- a/ruby3.2-faraday-excon.yaml
+++ b/ruby3.2-faraday-excon.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-faraday-excon
   version: 2.1.0
-  epoch: 1
+  epoch: 2
   description: Faraday adapter for Excon
   copyright:
     - license: MIT

--- a/ruby3.2-faraday-follow_redirects.yaml
+++ b/ruby3.2-faraday-follow_redirects.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-faraday-follow_redirects
   version: 0.3.0
-  epoch: 4
+  epoch: 5
   description: |
     Faraday 2.x compatible extraction of FaradayMiddleware::FollowRedirects.
   copyright:


### PR DESCRIPTION
Bump Ruby packages so that they pick up the correct Ruby version at runtime (fixed in SCA)