### PR TITLE
chore: Bump ruby packages 4 of 6

### DIFF
--- a/ruby3.2-faraday.yaml
+++ b/ruby3.2-faraday.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-faraday
   version: 2.10.0
-  epoch: 0
+  epoch: 1
   description: HTTP/REST API client library.
   copyright:
     - license: MIT

--- a/ruby3.2-fluent-config-regexp-type.yaml
+++ b/ruby3.2-fluent-config-regexp-type.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-fluent-config-regexp-type
   version: 1.0.0
-  epoch: 1
+  epoch: 2
   description: Backport regex type for fluentd
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-i18n.yaml
+++ b/ruby3.2-i18n.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-i18n
   version: 1.14.5
-  epoch: 0
+  epoch: 1
   description: New wave Internationalization support for Ruby.
   copyright:
     - license: MIT

--- a/ruby3.2-jruby-openssl.yaml
+++ b/ruby3.2-jruby-openssl.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-jruby-openssl
   version: 0.15.0
-  epoch: 0
+  epoch: 1
   description: JRuby-OpenSSL is an add-on gem for JRuby that emulates the Ruby OpenSSL native library.
   copyright:
     - license: GPL-2.0-or-later AND EPL-1.0 AND LGPL-2.1-or-later

--- a/ruby3.2-json-jwt.yaml
+++ b/ruby3.2-json-jwt.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-json-jwt
   version: 1.16.6
-  epoch: 0
+  epoch: 1
   description: JSON Web Token and its family (JSON Web Signature, JSON Web Encryption and JSON Web Key) in Ruby
   copyright:
     - license: MIT

--- a/ruby3.2-logstash-mixin-ecs_compatibility_support.yaml
+++ b/ruby3.2-logstash-mixin-ecs_compatibility_support.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-logstash-mixin-ecs_compatibility_support
   version: 1.3.0
-  epoch: 1
+  epoch: 2
   description: Support for the ECS-Compatibility mode targeting Logstash 7.7, for plugins wishing to use this API on older Logstashes
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-mail.yaml
+++ b/ruby3.2-mail.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-mail
   version: 2.8.1
-  epoch: 2
+  epoch: 3
   description: A really Ruby Mail handler.
   copyright:
     - license: MIT

--- a/ruby3.2-manticore.yaml
+++ b/ruby3.2-manticore.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-manticore
   version: 0.9.1
-  epoch: 0
+  epoch: 1
   description: Manticore is an HTTP client built on the Apache HttpCore components
   copyright:
     - license: MIT

--- a/ruby3.2-mustermann.yaml
+++ b/ruby3.2-mustermann.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-mustermann
   version: 3.0.0
-  epoch: 1
+  epoch: 2
   description: A library implementing patterns that behave like regular expressions.
   copyright:
     - license: MIT


### PR DESCRIPTION
Bump Ruby packages so that they pick up the correct Ruby version at runtime (fixed in SCA)