### PR TITLE
chore: Bump ruby packages 5 of 6

### DIFF
--- a/ruby3.2-net-http-persistent.yaml
+++ b/ruby3.2-net-http-persistent.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-net-http-persistent
   version: 4.0.2
-  epoch: 3
+  epoch: 4
   description: Manages persistent connections using Net::HTTP including a thread pool for connecting to multiple hosts.
   copyright:
     - license: MIT

--- a/ruby3.2-net-imap.yaml
+++ b/ruby3.2-net-imap.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-net-imap
   version: 0.4.14
-  epoch: 0
+  epoch: 1
   description: Ruby client api for Internet Message Access Protocol
   copyright:
     - license: Ruby

--- a/ruby3.2-net-protocol.yaml
+++ b/ruby3.2-net-protocol.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-net-protocol
   version: 0.2.2
-  epoch: 3
+  epoch: 4
   description: The abstract interface for net-* client.
   copyright:
     - license: Ruby

--- a/ruby3.2-oauth2.yaml
+++ b/ruby3.2-oauth2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-oauth2
   version: 2.0.9
-  epoch: 0
+  epoch: 1
   description: A Ruby wrapper for the OAuth 2.0 protocol built with a similar style to the original OAuth spec.
   copyright:
     - license: MIT

--- a/ruby3.2-openid_connect-1.1.8.yaml
+++ b/ruby3.2-openid_connect-1.1.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-openid_connect-1.1.8
   version: 1.1.8
-  epoch: 3
+  epoch: 4
   description: OpenID Connect Server & Client Library
   copyright:
     - license: MIT

--- a/ruby3.2-openid_connect.yaml
+++ b/ruby3.2-openid_connect.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-openid_connect
   version: 2.3.0
-  epoch: 2
+  epoch: 3
   description: OpenID Connect Server & Client Library
   copyright:
     - license: MIT

--- a/ruby3.2-pry.yaml
+++ b/ruby3.2-pry.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-pry
   version: 0.14.2
-  epoch: 0
+  epoch: 1
   description: A runtime developer console and IRB alternative with powerful introspection capabilities
   copyright:
     - license: MIT

--- a/ruby3.2-rack-oauth2.yaml
+++ b/ruby3.2-rack-oauth2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-rack-oauth2
   version: 2.2.1
-  epoch: 0
+  epoch: 1
   description: OAuth 2.0 Server & Client Library. Both Bearer token type are supported.
   copyright:
     - license: MIT

--- a/ruby3.2-rack-protection.yaml
+++ b/ruby3.2-rack-protection.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-rack-protection
   version: 4.0.0
-  epoch: 0
+  epoch: 1
   description: Protect against typical web attacks, works with all Rack apps, including Rails
   copyright:
     - license: MIT


### PR DESCRIPTION
Bump Ruby packages so that they pick up the correct Ruby version at runtime (fixed in SCA)