### PR TITLE
chore: Bump ruby packages 6 of 6

### DIFF
--- a/ruby3.2-redis-client.yaml
+++ b/ruby3.2-redis-client.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-redis-client
   version: 0.22.2
-  epoch: 0
+  epoch: 1
   description: Simple low-level client for Redis 6+
   copyright:
     - license: MIT

--- a/ruby3.2-redis-namespace.yaml
+++ b/ruby3.2-redis-namespace.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-redis-namespace
   version: 1.11.0
-  epoch: 2
+  epoch: 3
   description: Adds a Redis::Namespace class which can be used to namespace calls to Redis. This is useful when using a single instance of Redis with multiple, different applications.
   copyright:
     - license: MIT

--- a/ruby3.2-redis.yaml
+++ b/ruby3.2-redis.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-redis
   version: 5.2.0
-  epoch: 0
+  epoch: 1
   description: A Ruby client that tries to match Redis API one-to-one, while still providing an idiomatic interface.
   copyright:
     - license: MIT

--- a/ruby3.2-sinatra.yaml
+++ b/ruby3.2-sinatra.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-sinatra
   version: 4.0.0
-  epoch: 0
+  epoch: 1
   description: Sinatra is a DSL for quickly creating web applications in Ruby with minimal effort.
   copyright:
     - license: MIT

--- a/ruby3.2-snaky_hash.yaml
+++ b/ruby3.2-snaky_hash.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-snaky_hash
   version: 2.0.0
-  epoch: 0
+  epoch: 1
   description: 'A Hashie::Mash joint to make #snakelife better'
   copyright:
     - license: MIT

--- a/ruby3.2-swd.yaml
+++ b/ruby3.2-swd.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-swd
   version: 2.0.3
-  epoch: 0
+  epoch: 1
   description: SWD (Simple Web Discovery) Client Library
   copyright:
     - license: MIT

--- a/ruby3.2-treetop.yaml
+++ b/ruby3.2-treetop.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-treetop
   version: 1.6.12
-  epoch: 0
+  epoch: 1
   description: A Parsing Expression Grammar (PEG) Parser generator DSL for Ruby
   copyright:
     - license: MIT

--- a/ruby3.2-validate_email.yaml
+++ b/ruby3.2-validate_email.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-validate_email
   version: 0.1.6
-  epoch: 2
+  epoch: 3
   description: Library for validating email addresses in Rails 3 models.
   dependencies:
     runtime:

--- a/ruby3.2-validate_url.yaml
+++ b/ruby3.2-validate_url.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-validate_url
   version: 1.0.15
-  epoch: 3
+  epoch: 4
   description: Library for validating urls in Rails.
   dependencies:
     runtime:

--- a/ruby3.2-webfinger.yaml
+++ b/ruby3.2-webfinger.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-webfinger
   version: 2.1.2
-  epoch: 3
+  epoch: 4
   description: Ruby WebFinger client library
   copyright:
     - license: MIT

--- a/selenium.yaml
+++ b/selenium.yaml
@@ -1,7 +1,7 @@
 package:
   name: selenium
   version: 4.23.0
-  epoch: 0
+  epoch: 1
   description: A browser automation framework and ecosystem.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Bump Ruby packages so that they pick up the correct Ruby version at runtime (fixed in SCA)