### PR TITLE
add a subpackage for gitaly's config

### DIFF
--- a/gitlab-cng-17.1.yaml
+++ b/gitlab-cng-17.1.yaml
@@ -33,7 +33,7 @@ var-transforms:
 package:
   name: gitlab-cng-17.1
   version: 17.1.2
-  epoch: 3
+  epoch: 4
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -476,6 +476,16 @@ subpackages:
           install -d ${{targets.contextdir}}/etc/ssh
           install -d ${{targets.contextdir}}/var/log/gitlab-shell
           touch ${{targets.contextdir}}/var/log/gitlab-shell/gitlab-shell.log
+
+  - name: gitaly-config-${{vars.major-minor-version}}
+    dependencies:
+      provides:
+        - gitaly-config=${{package.full-version}}
+    pipeline:
+      - working-directory: ./gitaly
+        runs: |
+          mkdir -p "${{targets.contextdir}}/etc/gitaly"
+          cp config.toml "${{targets.contextdir}}/etc/gitaly/config.toml.tpl"
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

We @Aditvil-Dev were working on the gitaly CNG package, then we noticed this line where they copied the config.toml https://gitlab.com/gitlab-org/build/CNG/-/blob/master/gitaly/Dockerfile#L113, so accordingly I think we should create a subpackage for this in the CNG package, but at the same time I am not sure if this is correct, we could also do this in the gitaly package where we put the same content in the folder and copy it from that folder to the package, but this would cause the file (config.toml) to be differentiated from the upstream CNG package.

Any thoughts on this? @EyeCantCU 

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
