### PR TITLE
Package: gitlab-runner-17.1 bumped epoch and added compat for gitlab-…

### DIFF
--- a/gitlab-runner-17.1.yaml
+++ b/gitlab-runner-17.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitlab-runner-17.1
   version: 17.1.0
-  epoch: 3
+  epoch: 4
   description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
   copyright:
     - license: MIT
@@ -49,6 +49,15 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"
           cp dockerfiles/runner/alpine/entrypoint "${{targets.subpkgdir}}"/entrypoint
           chmod 755 "${{targets.subpkgdir}}"/entrypoint
+
+  - name: "gitlab-runner-helper-compat-${{vars.short-package-version}}"
+    description: "Gitlab-runner-helper Compat package for alpine"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          cp dockerfiles/runner-helper/scripts/gitlab-runner-build "${{targets.subpkgdir}}"/usr/bin/gitlab-runner-build
+          ls -alh packaging/root/usr/bin
+          cp packaging/root/usr/bin/gitlab-runner "${{targets.subpkgdir}}"/usr/bin/gitlab-ci-multi-runner
 
 update:
   enabled: true

--- a/gitlab-runner-17.1.yaml
+++ b/gitlab-runner-17.1.yaml
@@ -57,7 +57,7 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           cp dockerfiles/runner-helper/scripts/gitlab-runner-build "${{targets.subpkgdir}}"/usr/bin/gitlab-runner-build
           ls -alh packaging/root/usr/bin
-          cp packaging/root/usr/bin/gitlab-runner "${{targets.subpkgdir}}"/usr/bin/gitlab-ci-multi-runner
+          ln -sf /usr/bin/gitlab-runner "${{targets.subpkgdir}}"/usr/bin/gitlab-ci-multi-runner
 
 update:
   enabled: true

--- a/gitlab-runner-17.1.yaml
+++ b/gitlab-runner-17.1.yaml
@@ -35,6 +35,9 @@ pipeline:
 subpackages:
   - name: gitlab-runner-helper-${{vars.short-package-version}}
     description: GitLab Runner Helper
+    dependencies:
+      provides:
+        - gitlab-runner-helper=${{package.full-version}}
     pipeline:
       - uses: go/build
         with:
@@ -44,6 +47,9 @@ subpackages:
 
   - name: "gitlab-runner-compat-${{vars.short-package-version}}"
     description: "Gitlab-runner Compat package for alpine"
+    dependencies:
+      provides:
+        - gitlab-runner-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"
@@ -52,6 +58,9 @@ subpackages:
 
   - name: "gitlab-runner-helper-compat-${{vars.short-package-version}}"
     description: "Gitlab-runner-helper Compat package for alpine"
+    dependencies:
+      provides:
+        - gitlab-runner-helper-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin


### PR DESCRIPTION
…runner-helper

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
