### PR TITLE
new pkg: seaweedfs

### DIFF
--- a/seaweedfs.yaml
+++ b/seaweedfs.yaml
@@ -18,6 +18,10 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: ac6fd36c06f9cd6740cb2ff7e97c1ba92d55bf2c
 
+  - uses: go/bump
+    with:
+      deps: google.golang.org/grpc@v1.64.1
+
   - uses: go/build
     with:
       packages: ./weed

--- a/seaweedfs.yaml
+++ b/seaweedfs.yaml
@@ -1,0 +1,38 @@
+package:
+  name: seaweedfs
+  version: 3.69
+  epoch: 0
+  description: SeaweedFS is a fast distributed storage system for blobs, objects, files.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  environment:
+    CGO_ENABLED: "0"
+    GODEBUG: http2client=0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/seaweedfs/seaweedfs
+      tag: ${{package.version}}
+      expected-commit: ac6fd36c06f9cd6740cb2ff7e97c1ba92d55bf2c
+
+  - uses: go/build
+    with:
+      packages: ./weed
+      output: weed
+      ldflags: |
+        -s -w -extldflags -static -X github.com/seaweedfs/seaweedfs/weed/util.COMMIT=$(git rev-parse HEAD)
+
+  - uses: strip
+
+test:
+  pipeline:
+    - name: "version command"
+      runs: weed version
+
+update:
+  enabled: true
+  github:
+    identifier: seaweedfs/seaweedfs


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/24217

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
