### PR TITLE
Add no-depends to datadog-agent-s6-overlay

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent
   version: 7.55.1
-  epoch: 0
+  epoch: 1
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -371,6 +371,7 @@ subpackages:
     options:
       # Hide this from our SCA and dag, this package should _only_ ever be used by datadog-agent
       no-provides: true
+      no-depends: true
     pipeline:
       - runs: |
           S6_OVERLAY_VERSION=v2.2.0.3


### PR DESCRIPTION
datadog-agent-s6-overlay-fips vendors a 's6 overlay'.
melange's SCA identifies that several programs in usr/bin
(fix-attrs, fixcontenv) used '#!/bin/execlineb', and added
a depends on 'cmd:execlineb'.

We had 'no-provides', which meant other packages would not see
that we provided execlineb, but also meant that we couldn't provide
it to ourselves.

There were no other listed dependencies, so just turn off depends.

This problem did _not_ exist in the last build of datadog-agent,
but with the current melange
(v0.11.1/a52edcc075ebf1dc89aea87893e3821944171ee3)
it would gain the dependency if it were updated.

