### PR TITLE
airflow - Add missing dependency on python3, fix test.

### DIFF
--- a/airflow.yaml
+++ b/airflow.yaml
@@ -66,6 +66,14 @@ pipeline:
       python -m build --wheel
       pip install dist/*.whl
 
+  - runs: |
+      # CVE-2024-6345 GHSA-cx63-2mw6-8hw5
+      # setuptools comes from airflow/providers/google/provider.yaml having
+      # gcloud-aio-auth>=4.0.0,<5.0.0 . gcloud-aio-auth 4 is backlevel and has
+      # setuptools in it's pyproject.toml 'tool.poetry.dependencies'
+      # The tldr; For that case it is not needed in runtime.
+      ./venv/bin/pip uninstall --yes setuptools
+
   - working-directory: venv/lib/python3.12/site-packages/airflow/www
     runs: |
       # front-end build

--- a/airflow.yaml
+++ b/airflow.yaml
@@ -1,13 +1,16 @@
 package:
   name: airflow
   version: 2.9.3
-  epoch: 0
+  epoch: 1
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
     #  is provided in the virtual environment. Enabling no-depends
     #  works around this
     no-depends: true
+  dependencies:
+    runtime:
+      - python3
   copyright:
     - license: Apache-2.0
 
@@ -117,4 +120,4 @@ test:
   pipeline:
     - runs: |
         export PATH=/opt/airflow/venv/bin:$PATH
-        airflow version
+        HOME=/home/build airflow version


### PR DESCRIPTION
airflow has 'no-depends', so it didn't even know that it depends on python3 (the venv's python3 has a dynamic depends on python)

> (venv) f206c35a9154:/# ldd /opt/airflow/venv/bin/python
>        linux-vdso.so.1 (0x00007ffc89361000)
>        libpython3.12.so.1.0 => not found
>        libc.so.6 => /lib/libc.so.6 (0x00007d072f5d1000)
>        /lib64/ld-linux-x86-64.so.2 (0x00007d072f7c2000)

I'm not actually sure how that ever worked.

Then, add HOME to test's environment fix a problem with
>
>  File "/opt/airflow/venv/lib/python3.12/site-packages/airflow/settings.py", line 238, in configure_orm
>     raise AirflowConfigException(
> airflow.exceptions.AirflowConfigException: Cannot use relative path: `sqlite:///~/airflow/airflow.db` to connect to sqlite. Please use absolute path such as `sqlite:////tmp/airflow.db`.
> ERROR: failed to test package. the test environment has been preserved:
>   workspace dir: /home/user/tmp/melange-workspace-2227873862
