### PR TITLE
touch /etc/localtime to get systemd-init to work

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "256.2"
-  epoch: 1
+  epoch: 2
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -67,8 +67,9 @@ subpackages:
         - ${{package.name}}
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/
+          mkdir -p ${{targets.subpkgdir}}/etc
           ln -s /usr/lib/systemd/systemd ${{targets.subpkgdir}}/init
+          touch ${{targets.subpkgdir}}/etc/localtime
 
 update:
   enabled: true


### PR DESCRIPTION
Trivial change, required to get systemd-init to boot a system unattended