### PR TITLE
Add exclude-reason field to existing configs with comments. 1/9

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -63,7 +63,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib "${{targets.subpkgdir}}"/usr/lib
 
 update:
-  # setting the update to false until the latest apk tools fails for previously built packages
   enabled: false
+  exclude-reason: setting the update to false until the latest apk tools fails for previously built packages
   release-monitor:
     identifier: 20466

--- a/armadillo.yaml
+++ b/armadillo.yaml
@@ -38,4 +38,5 @@ subpackages:
       - uses: split/dev
 
 update:
-  enabled: false # Release monitor is broken here
+  enabled: false
+  exclude-reason: Release monitor is broken here

--- a/berg.yaml
+++ b/berg.yaml
@@ -30,4 +30,7 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false #hosted on codeberg and not present at release-monitoring.org. but #1566 is open to provide support for it in the future.
+  enabled: false
+  exclude-reason: >
+    hosted on codeberg and not present at release-monitoring.org. but #1566 is open to provide support for it in the future.
+

--- a/confluent-common-docker.yaml
+++ b/confluent-common-docker.yaml
@@ -56,7 +56,10 @@ subpackages:
       - uses: strip
 
 update:
-  enabled: false # Upstream repo doesn't provide any jars/poms past 7.6.0: https://packages.confluent.io/maven/io/confluent/common/
+  enabled: false
+  exclude-reason: >
+    Upstream repo doesn't provide any jars/poms past 7.6.0: https://packages.confluent.io/maven/io/confluent/common/
+
 
 test:
   environment:

--- a/db.yaml
+++ b/db.yaml
@@ -82,6 +82,9 @@ subpackages:
     description: C++ binding for libdb
 
 update:
-  enabled: false # we can only track major 5.* versions due to licensing and currently cannot filter for release monitor
+  enabled: false
+  exclude-reason: >
+    we can only track major 5.* versions due to licensing and currently cannot filter for release monitor
+
   release-monitor:
     identifier: 1587

--- a/db.yaml
+++ b/db.yaml
@@ -4,7 +4,8 @@ package:
   epoch: 0
   description: The Berkeley DB embedded database system
   copyright:
-    - license: custom
+    - license: LicenseRef-berkeley-db
+      license-path: LICENSE
 
 environment:
   contents:

--- a/dhcping.yaml
+++ b/dhcping.yaml
@@ -38,4 +38,7 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # doesn't exist in release monitor, not sure how to get the latest version
+  enabled: false
+  exclude-reason: >
+    doesn't exist in release monitor, not sure how to get the latest version
+

--- a/dieharder.yaml
+++ b/dieharder.yaml
@@ -41,7 +41,8 @@ subpackages:
       - uses: split/manpages
     description: dieharder manpages
 
-# Since release monitor latest version is of the form 3.31.1_20110601-1,
-# we are for now going for manual update till we can have gitlab identifier
 update:
   enabled: false
+  exclude-reason: >
+    Since release monitor latest version is of the form 3.31.1_20110601-1, we are for now going for manual update till we can have gitlab identifier
+

--- a/fluent-bit-docker-image.yaml
+++ b/fluent-bit-docker-image.yaml
@@ -26,4 +26,5 @@ pipeline:
   - runs: rm -rf ${{targets.destdir}}/fluent-bit-docker-image/.git ${{targets.destdir}}/fluent-bit-docker-image/.github
 
 update:
-  enabled: false # this repository is no longer maintained
+  enabled: false
+  exclude-reason: this repository is no longer maintained

--- a/fluxbox.yaml
+++ b/fluxbox.yaml
@@ -41,7 +41,7 @@ pipeline:
   - runs: |
       ./autogen.sh
 
-  - name: 'Configure binutils'
+  - name: "Configure binutils"
     runs: |
       ./configure \
         --prefix=/usr \
@@ -55,9 +55,8 @@ pipeline:
 
   - uses: strip
 
-# Upstream repository no longer cuts any tags or releases (since 2015). The
-# last tag cut was v1.3.7 back in 2015, but there have been several commits
-# since then, including fixes to compile against gcc 11+. This is why updates
-# are disabled, as we're fixing to a given commit ID in the main branch.
 update:
   enabled: false
+  exclude-reason: >
+    Upstream repository no longer cuts any tags or releases (since 2015). The last tag cut was v1.3.7 back in 2015, but there have been several commits since then, including fixes to compile against gcc 11+. This is why updates are disabled, as we're fixing to a given commit ID in the main branch.
+

--- a/font-ipa.yaml
+++ b/font-ipa.yaml
@@ -32,4 +32,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # Non-semanic versioning and 3rd party hosting
+  enabled: false
+  exclude-reason: Non-semanic versioning and 3rd party hosting


### PR DESCRIPTION
Moves existing update field comments into new exclude-reason field. This is intented to track why auto-update is disabled for a particular package.

Related: chainguard-dev/mono#18290, https://github.com/wolfi-dev/wolfictl/pull/1060, https://github.com/wolfi-dev/os/pull/23885

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
