### PR TITLE
Add exclude-reason field to existing configs with comments. 2/9

### DIFF
--- a/font-ipafont.yaml
+++ b/font-ipafont.yaml
@@ -37,4 +37,5 @@ subpackages:
           install -D -m644 ${{range.value}}*.ttf -t "${{targets.subpkgdir}}"/usr/share/fonts/${{package.name}}
 
 update:
-  enabled: false # No releases or tags
+  enabled: false
+  exclude-reason: No releases or tags

--- a/font-lklug.yaml
+++ b/font-lklug.yaml
@@ -32,4 +32,5 @@ pipeline:
       install -D -m644 lklug.ttf "${{targets.destdir}}"/usr/share/fonts/
 
 update:
-  enabled: false # No source to watch for the new versions
+  enabled: false
+  exclude-reason: No source to watch for the new versions

--- a/font-lohit-beng-assamese.yaml
+++ b/font-lohit-beng-assamese.yaml
@@ -46,4 +46,5 @@ pipeline:
       install -Dm644 lohit-master/assamese/66-lohit-assamese.conf -t ${{targets.destdir}}/etc/fonts/conf.avail
 
 update:
-  enabled: false # The project seems to be inactive
+  enabled: false
+  exclude-reason: The project seems to be inactive

--- a/font-lohit-beng-bengali.yaml
+++ b/font-lohit-beng-bengali.yaml
@@ -46,4 +46,5 @@ pipeline:
       install -Dm644 lohit-master/bengali/66-lohit-bengali.conf -t ${{targets.destdir}}/etc/fonts/conf.avail
 
 update:
-  enabled: false # The project seems to be inactive
+  enabled: false
+  exclude-reason: The project seems to be inactive

--- a/font-lohit-guru.yaml
+++ b/font-lohit-guru.yaml
@@ -35,4 +35,5 @@ pipeline:
       install -D -m644 *.ttf "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
 
 update:
-  enabled: false # No source to watch for the new versions
+  enabled: false
+  exclude-reason: No source to watch for the new versions

--- a/font-lohit-knda.yaml
+++ b/font-lohit-knda.yaml
@@ -35,4 +35,5 @@ pipeline:
       install -D -m644 *.ttf "${{targets.destdir}}"/usr/share/fonts/${pkgname#font-}
 
 update:
-  enabled: false # No source to watch for the new versions
+  enabled: false
+  exclude-reason: No source to watch for the new versions

--- a/font-noto-cjk.yaml
+++ b/font-noto-cjk.yaml
@@ -40,6 +40,6 @@ pipeline:
       		-t "${{targets.destdir}}"/usr/share/fonts/noto/
       done
 
-# they use a different versioning scheme
 update:
   enabled: false
+  exclude-reason: they use a different versioning scheme

--- a/font-opensans.yaml
+++ b/font-opensans.yaml
@@ -26,6 +26,8 @@ pipeline:
 
 update:
   enabled: false
-  # they don't publish releases or tags :(
+  exclude-reason: >
+    they don't publish releases or tags :(
+
   github:
     identifier: googlefonts/opensans

--- a/font-samyak.yaml
+++ b/font-samyak.yaml
@@ -41,4 +41,5 @@ subpackages:
           install -D -m644 *.ttf -t "${{targets.subpkgdir}}"/usr/share/fonts/samyak
 
 update:
-  enabled: false # No releases or tags
+  enabled: false
+  exclude-reason: No releases or tags

--- a/font-ubuntu.yaml
+++ b/font-ubuntu.yaml
@@ -35,4 +35,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # No source to watch for the new versions
+  enabled: false
+  exclude-reason: No source to watch for the new versions


### PR DESCRIPTION
Moves existing update field comments into new exclude-reason field. This is intented to track why auto-update is disabled for a particular package.

Related: chainguard-dev/mono#18290, wolfi-dev/wolfictl#1060, #23885

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
