### PR TITLE
Add exclude-reason field to existing configs with comments. 3/9

### DIFF
--- a/font-unfonts-core.yaml
+++ b/font-unfonts-core.yaml
@@ -29,4 +29,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # No releases or tags
+  enabled: false
+  exclude-reason: No releases or tags

--- a/font-wqy-zenhei.yaml
+++ b/font-wqy-zenhei.yaml
@@ -46,4 +46,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # No source to watch for the new versions
+  enabled: false
+  exclude-reason: No source to watch for the new versions

--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -243,5 +243,5 @@ subpackages:
              "${{targets.subpkgdir}}"/$gcclibdir/
 
 update:
-  # EOL upstream, needed for Java 8 bootstrap only.
   enabled: false
+  exclude-reason: EOL upstream, needed for Java 8 bootstrap only.

--- a/govulncheck.yaml
+++ b/govulncheck.yaml
@@ -18,6 +18,8 @@ pipeline:
       output: govulncheck
       packages: ./cmd/govulncheck
 
-# This isn't on GitHub and it's not in release-monitor
 update:
   enabled: false
+  exclude-reason: >
+    This isn't on GitHub and it's not in release-monitor
+

--- a/gradle-stage0.yaml
+++ b/gradle-stage0.yaml
@@ -41,4 +41,5 @@ pipeline:
       ln -sf /usr/share/java/gradle/bin/gradle ${{targets.destdir}}/usr/bin/gradle
 
 update:
-  enabled: false # don't auto update stage 0 packages
+  enabled: false
+  exclude-reason: don't auto update stage 0 packages

--- a/grafana-grafonnet.yaml
+++ b/grafana-grafonnet.yaml
@@ -36,4 +36,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # no releases or tags available
+  enabled: false
+  exclude-reason: no releases or tags available

--- a/harbor-registry.yaml
+++ b/harbor-registry.yaml
@@ -67,8 +67,8 @@ test:
         test $(curl -LI localhost:5000 -o /dev/null -w '%{http_code}\n' -s) == "200"
 
 update:
-  # Re-enable when v3.x.x lands a stable release
   manual: true
+  exclude-reason: Re-enable when v3.x.x lands a stable release
   github:
     identifier: distribution/distribution
     strip-prefix: v

--- a/jackson-json.yaml
+++ b/jackson-json.yaml
@@ -32,10 +32,11 @@ pipeline:
       mkdir -p ${{targets.destdir}}/usr/share/java
       mv build/*.jar ${{targets.destdir}}/usr/share/java
 
-# the only time this repo gets updated is when there's a CVE
-# if a scanner picks up this package, update the fetched URI above manually
 update:
   enabled: false
   manual: true
+  exclude-reason: >
+    The only time this repo gets updated is when there's a CVE. If a scanner picks up this package, update the fetched URI above manually.
+
   github:
     identifier: FasterXML/jackson-1

--- a/kube-downscaler.yaml
+++ b/kube-downscaler.yaml
@@ -42,4 +42,5 @@ pipeline:
 
 update:
   enabled: false
-  manual: true # we need to manually update because it does not use github
+  manual: true
+  exclude-reason: we need to manually update because it does not use github

--- a/kubernetes-latest.yaml
+++ b/kubernetes-latest.yaml
@@ -91,6 +91,7 @@ subpackages:
           ln -s kube-apiserver-${{vars.kubernetes-version}} ${{targets.subpkgdir}}/usr/bin/kube-apiserver
 
 update:
-  # This package and it's references to "latest" must be bumped manually
-  # when a new latest is dropped.
   enabled: false
+  exclude-reason: >
+    This package and it's references to "latest" must be bumped manually when a new latest is dropped.
+


### PR DESCRIPTION
Moves existing update field comments into new exclude-reason field. This is intented to track why auto-update is disabled for a particular package.

Related: chainguard-dev/mono#18290, wolfi-dev/wolfictl#1060, #23885

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
