### PR TITLE
Add exclude-reason field to existing configs with comments. 4/9

### DIFF
--- a/libedit.yaml
+++ b/libedit.yaml
@@ -49,6 +49,7 @@ subpackages:
 
 update:
   enabled: false
-  manual: true # version contains a date in the fetch URL
+  manual: true
+  exclude-reason: version contains a date in the fetch URL
   release-monitor:
     identifier: 1599

--- a/libid3tag.yaml
+++ b/libid3tag.yaml
@@ -48,4 +48,7 @@ subpackages:
 
 update:
   enabled: false
-  manual: true # we need to manually update because it does not use GitHub. Release Monitor (id: 21478) is outdated or wrong.
+  manual: true
+  exclude-reason: >
+    we need to manually update because it does not use GitHub. Release Monitor (id: 21478) is outdated or wrong.
+

--- a/libspf2.yaml
+++ b/libspf2.yaml
@@ -61,4 +61,5 @@ subpackages:
           rm -fr "${{targets.destdir}}"/usr/bin
 
 update:
-  enabled: false # no tags or releases
+  enabled: false
+  exclude-reason: no tags or releases

--- a/lua-haproxy-auth-request.yaml
+++ b/lua-haproxy-auth-request.yaml
@@ -26,4 +26,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # no releases or tags available
+  enabled: false
+  exclude-reason: no releases or tags available

--- a/luajit.yaml
+++ b/luajit.yaml
@@ -42,4 +42,5 @@ subpackages:
     description: luajit dev
 
 update:
-  enabled: false # package uses special versioning
+  enabled: false
+  exclude-reason: package uses special versioning

--- a/marzano.yaml
+++ b/marzano.yaml
@@ -38,8 +38,8 @@ pipeline:
   - uses: strip
 
 update:
-  # Until this project does releases we'll have to update these manually
   enabled: false
+  exclude-reason: Until this project does releases we'll have to update these manually
 
 test:
   pipeline:

--- a/maven-stage0.yaml
+++ b/maven-stage0.yaml
@@ -45,4 +45,5 @@ pipeline:
       ln -sf /usr/share/java/maven/bin/mvnyjp ${{targets.destdir}}/usr/bin/mvnyjp
 
 update:
-  enabled: false # don't auto update stage 0 packages
+  enabled: false
+  exclude-reason: don't auto update stage 0 packages

--- a/mc.yaml
+++ b/mc.yaml
@@ -36,4 +36,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # odd versions which cannot be compared and automated
+  enabled: false
+  exclude-reason: odd versions which cannot be compared and automated

--- a/neuvector-db.yaml
+++ b/neuvector-db.yaml
@@ -38,4 +38,5 @@ test:
         fi
 
 update:
-  manual: true # No releases or tags
+  manual: true
+  exclude-reason: No releases or tags

--- a/neuvector-dbgen.yaml
+++ b/neuvector-dbgen.yaml
@@ -59,4 +59,5 @@ test:
         fi
 
 update:
-  manual: true # No releases or tags
+  manual: true
+  exclude-reason: No releases or tags


### PR DESCRIPTION
Moves existing update field comments into new exclude-reason field. This is intented to track why auto-update is disabled for a particular package.

Related: chainguard-dev/mono#18290, wolfi-dev/wolfictl#1060, #23885

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
