### PR TITLE
Add exclude-reason field to existing configs with comments. 6/9

### DIFF
--- a/perl-algorithm-diff.yaml
+++ b/perl-algorithm-diff.yaml
@@ -43,4 +43,5 @@ subpackages:
     description: perl-algorithm-diff manpages
 
 update:
-  enabled: false # latest releases mismatches in release monitor and github release is not maintained to latest version
+  enabled: false
+  exclude-reason: latest releases mismatches in release monitor and github release is not maintained to latest version

--- a/pgbouncer.yaml
+++ b/pgbouncer.yaml
@@ -57,9 +57,9 @@ subpackages:
     description: pgbouncer manpages
 
 update:
-  # Doesn't work with var transforms
   enabled: false
   manual: true
+  exclude-reason: Doesn't work with var transforms
   github:
     identifier: pgbouncer/pgbouncer
     strip-prefix: pgbouncer_

--- a/php-8.1-pecl-pdosqlsrv.yaml
+++ b/php-8.1-pecl-pdosqlsrv.yaml
@@ -45,9 +45,8 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can find the releases in github but building it does not work
-# with fetching from there like it does when you use fetch.
-# Also seems like I can't watch the github repo for new releases, yet use
-# the fetch above together?
 update:
   enabled: false
+  exclude-reason: >
+    TODO(vaikas): I can find the releases in github but building it does not work with fetching from there like it does when you use fetch. Also seems like I can't watch the github repo for new releases, yet use the fetch above together?
+

--- a/php-8.1-pecl-raphf.yaml
+++ b/php-8.1-pecl-raphf.yaml
@@ -51,6 +51,8 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can't find in release-monitoring, or github.
 update:
   enabled: false
+  exclude-reason: >
+    TODO(vaikas): I can't find in release-monitoring, or github.
+

--- a/php-8.1-pecl-sqlsrv.yaml
+++ b/php-8.1-pecl-sqlsrv.yaml
@@ -45,9 +45,8 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can find the releases in github but building it does not work
-# with fetching from there like it does when you use fetch.
-# Also seems like I can't watch the github repo for new releases, yet use
-# the fetch above together?
 update:
   enabled: false
+  exclude-reason: >
+    TODO(vaikas): I can find the releases in github but building it does not work with fetching from there like it does when you use fetch. Also seems like I can't watch the github repo for new releases, yet use the fetch above together?
+

--- a/php-8.2-pecl-pdosqlsrv.yaml
+++ b/php-8.2-pecl-pdosqlsrv.yaml
@@ -45,9 +45,8 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can find the releases in github but building it does not work
-# with fetching from there like it does when you use fetch.
-# Also seems like I can't watch the github repo for new releases, yet use
-# the fetch above together?
 update:
   enabled: false
+  exclude-reason: >
+    TODO(vaikas): I can find the releases in github but building it does not work with fetching from there like it does when you use fetch. Also seems like I can't watch the github repo for new releases, yet use the fetch above together?
+

--- a/php-8.2-pecl-raphf.yaml
+++ b/php-8.2-pecl-raphf.yaml
@@ -51,6 +51,8 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can't find in release-monitoring, or github.
 update:
   enabled: false
+  exclude-reason: >
+    TODO(vaikas): I can't find in release-monitoring, or github.
+


### PR DESCRIPTION
Moves existing update field comments into new exclude-reason field. This is intented to track why auto-update is disabled for a particular package.

Related: chainguard-dev/mono#18290, wolfi-dev/wolfictl#1060, #23885

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
