### PR TITLE
Add exclude-reason field to existing configs with comments. 7/9

### DIFF
--- a/php-8.2-pecl-sqlsrv.yaml
+++ b/php-8.2-pecl-sqlsrv.yaml
@@ -45,9 +45,8 @@ pipeline:
 
   - uses: strip
 
-# TODO(vaikas): I can find the releases in github but building it does not work
-# with fetching from there like it does when you use fetch.
-# Also seems like I can't watch the github repo for new releases, yet use
-# the fetch above together?
 update:
   enabled: false
+  exclude-reason: >
+    TODO(vaikas): I can find the releases in github but building it does not work with fetching from there like it does when you use fetch. Also seems like I can't watch the github repo for new releases, yet use the fetch above together?
+

--- a/pnpm-stage0.yaml
+++ b/pnpm-stage0.yaml
@@ -37,7 +37,8 @@ pipeline:
       ln -sf /usr/lib/node_modules/pnpm/bin/pnpx.cjs  "${{targets.destdir}}"/usr/bin/pnpx
 
 update:
-  enabled: false # don't auto update stage 0 packages
+  enabled: false
+  exclude-reason: "don't auto update stage 0 packages"
   github:
     identifier: pnpm/pnpm
     strip-prefix: v

--- a/py3-alembic.yaml
+++ b/py3-alembic.yaml
@@ -46,7 +46,8 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # This requires manual updates because of the strange tagging scheme.
+  enabled: false
   manual: true
+  exclude-reason: This requires manual updates because of the strange tagging scheme.
   github:
     identifier: sqlalchemy/alembic

--- a/py3-ffwd.yaml
+++ b/py3-ffwd.yaml
@@ -33,6 +33,6 @@ test:
         imports: |
           import ffwd
 
-#archived but needed by cassandra-medussa
 update:
   enabled: false
+  exclude-reason: archived but needed by cassandra-medussa

--- a/py3-keras-applications.yaml
+++ b/py3-keras-applications.yaml
@@ -36,6 +36,7 @@ pipeline:
   - uses: strip
 
 update:
-  # The modular keras-preprocessing package has been retired upstream in favor of monolithic
-  # "keras" package, but Tensorflow itself has not made the jump yet.
   enabled: false
+  exclude-reason: >
+    The modular keras-preprocessing package has been retired upstream in favor of monolithic "keras" package, but Tensorflow itself has not made the jump yet.
+

--- a/py3-keras-preprocessing.yaml
+++ b/py3-keras-preprocessing.yaml
@@ -36,6 +36,7 @@ pipeline:
   - uses: strip
 
 update:
-  # The modular keras-preprocessing package has been retired upstream in favor of monolithic
-  # "keras" package, but Tensorflow itself has not made the jump yet.
   enabled: false
+  exclude-reason: >
+    The modular keras-preprocessing package has been retired upstream in favor of monolithic "keras" package, but Tensorflow itself has not made the jump yet.
+

--- a/py3-mdit-plain.yaml
+++ b/py3-mdit-plain.yaml
@@ -32,4 +32,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # Neither Release Monitor nor GitHub branches/tags are available for this package
+  enabled: false
+  exclude-reason: Neither Release Monitor nor GitHub branches/tags are available for this package

--- a/py3-onetimepass.yaml
+++ b/py3-onetimepass.yaml
@@ -33,4 +33,5 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # No releases since 2015
+  enabled: false
+  exclude-reason: No releases since 2015

--- a/py3-ply.yaml
+++ b/py3-ply.yaml
@@ -1,27 +1,18 @@
 package:
   name: py3-ply
   version: 3.11_git20180215
-  epoch: 4
+  epoch: 3
   description: Python Lex & Yacc
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    provider-priority: 0
-
-vars:
-  pypi-package: ply
-
-data:
-  - name: py-versions
-    items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+    runtime:
+      - python3
 
 var-transforms:
   - from: ${{package.version}}
     match: _git(.*)
-    replace: ''
+    replace: ""
     to: mangled-package-version
 
 environment:
@@ -29,10 +20,10 @@ environment:
     packages:
       - build-base
       - busybox
-      - py3-supported-build
-      - py3-supported-pip
-      - py3-supported-python
-      - py3-supported-wheel
+      - ca-certificates-bundle
+      - py3-setuptools
+      - python3
+      - wolfi-base
 
 pipeline:
   - uses: git-checkout
@@ -41,26 +32,14 @@ pipeline:
       tag: ${{vars.mangled-package-version}}
       expected-commit: 0f398b72618c1564d71f7dc0558e6722b241875a
 
-subpackages:
-  - range: py-versions
-    name: py${{range.key}}-${{vars.pypi-package}}
-    description: ${{vars.pypi-package}} installed for python${{range.key}}
-    dependencies:
-      provides:
-        - py3-${{vars.pypi-package}}
-      provider-priority: ${{range.value}}
-    pipeline:
-      - uses: py/pip-build-install
-        with:
-          python: python${{range.key}}
-      - uses: strip
-    test:
-      pipeline:
-        - uses: python/import
-          with:
-            python: python${{range.key}}
-            import: ${{vars.pypi-package}}
+  - name: Python Build
+    runs: python setup.py build
 
-# some sort of a deprecated project
+  - name: Python Install
+    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+
+  - uses: strip
+
 update:
   enabled: false
+  exclude-reason: some sort of a deprecated project

--- a/py3-pyfarmhash.yaml
+++ b/py3-pyfarmhash.yaml
@@ -34,4 +34,5 @@ pipeline:
 
 update:
   enabled: false
-  manual: true # no releases, tags, and release-monitor id
+  manual: true
+  exclude-reason: no releases, tags, and release-monitor id


### PR DESCRIPTION
Moves existing update field comments into new exclude-reason field. This is intented to track why auto-update is disabled for a particular package.

Related: chainguard-dev/mono#18290, wolfi-dev/wolfictl#1060, #23885

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->
### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
