### PR TITLE
Add exclude-reason field to existing configs with comments. 8/9

### DIFF
--- a/py3-pykube-ng.yaml
+++ b/py3-pykube-ng.yaml
@@ -39,4 +39,5 @@ pipeline:
 
 update:
   enabled: false
-  manual: true # we need to manually update because it does not use github
+  manual: true
+  exclude-reason: we need to manually update because it does not use github

--- a/py3-pytz.yaml
+++ b/py3-pytz.yaml
@@ -39,7 +39,7 @@ pipeline:
   - uses: strip
 
 update:
-  # releases have an odd structure
   enabled: false
+  exclude-reason: releases have an odd structure
   release-monitor:
     identifier: 6537

--- a/py3-sqlalchemy.yaml
+++ b/py3-sqlalchemy.yaml
@@ -42,7 +42,8 @@ pipeline:
   - uses: strip
 
 update:
-  enabled: false # This requires manual updates because of the strange tagging scheme.
+  enabled: false
   manual: true
+  exclude-reason: This requires manual updates because of the strange tagging scheme.
   github:
     identifier: sqlalchemy/sqlalchemy

--- a/ragel.yaml
+++ b/ragel.yaml
@@ -49,5 +49,5 @@ test:
         ragel --version
 
 update:
-  # RM tracks development releases instead of stable
   manual: true
+  exclude-reason: RM tracks development releases instead of stable

--- a/rlwrap.yaml
+++ b/rlwrap.yaml
@@ -42,5 +42,5 @@ pipeline:
   - uses: strip
 
 update:
-  # very inconsistent release versions v0.46, 0.46.1
   enabled: false
+  exclude-reason: very inconsistent release versions v0.46, 0.46.1

--- a/rstudio.yaml
+++ b/rstudio.yaml
@@ -95,8 +95,8 @@ pipeline:
   - uses: strip
 
 update:
-  # Doesn't work with the tagging scheme.
   enabled: false
+  exclude-reason: Doesn't work with the tagging scheme.
   github:
     identifier: rstudio/rstudio
     use-tag: true

--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -102,7 +102,8 @@ subpackages:
 
 update:
   enabled: false
-  manual: true # be careful with auto updates as we don't want to include 3.3, we currently don't offer a filter on release monitor versions
+  manual: true
+  exclude-reason: be careful with auto updates as we don't want to include 3.3, we currently don't offer a filter on release monitor versions
   release-monitor:
     identifier: 4223
 


### PR DESCRIPTION
Moves existing update field comments into new exclude-reason field. This is intented to track why auto-update is disabled for a particular package.

Related: chainguard-dev/mono#18290, wolfi-dev/wolfictl#1060, #23885

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
