### PR TITLE
ruby3.2-aws: bump commit, add exclude-reason.

### DIFF
--- a/ruby3.2-aws-eventstream.yaml
+++ b/ruby3.2-aws-eventstream.yaml
@@ -20,7 +20,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 0ea8ece30f9dd8a4e80ec4c82f56348d27e94460
+      expected-commit: 34308c3e89d723067eabd5f952a34bc6b55f17ae
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
 
@@ -42,6 +42,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-partitions.yaml
+++ b/ruby3.2-aws-partitions.yaml
@@ -20,7 +20,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 0ea8ece30f9dd8a4e80ec4c82f56348d27e94460
+      expected-commit: 34308c3e89d723067eabd5f952a34bc6b55f17ae
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
 
@@ -42,6 +42,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-sdk-cloudwatchlogs.yaml
+++ b/ruby3.2-aws-sdk-cloudwatchlogs.yaml
@@ -24,7 +24,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 0ea8ece30f9dd8a4e80ec4c82f56348d27e94460
+      expected-commit: 34308c3e89d723067eabd5f952a34bc6b55f17ae
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
 
@@ -44,6 +44,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-sdk-core.yaml
+++ b/ruby3.2-aws-sdk-core.yaml
@@ -26,7 +26,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: fe91b01cddb6acac9b083706a1c61c2904a7c946
+      expected-commit: 34308c3e89d723067eabd5f952a34bc6b55f17ae
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
 
@@ -48,6 +48,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-sdk-kms.yaml
+++ b/ruby3.2-aws-sdk-kms.yaml
@@ -24,7 +24,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 0ea8ece30f9dd8a4e80ec4c82f56348d27e94460
+      expected-commit: 34308c3e89d723067eabd5f952a34bc6b55f17ae
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
 
@@ -46,6 +46,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-sdk-s3.yaml
+++ b/ruby3.2-aws-sdk-s3.yaml
@@ -26,7 +26,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 0ea8ece30f9dd8a4e80ec4c82f56348d27e94460
+      expected-commit: 34308c3e89d723067eabd5f952a34bc6b55f17ae
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
 
@@ -48,6 +48,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-sdk-sqs.yaml
+++ b/ruby3.2-aws-sdk-sqs.yaml
@@ -24,7 +24,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 0ea8ece30f9dd8a4e80ec4c82f56348d27e94460
+      expected-commit: 34308c3e89d723067eabd5f952a34bc6b55f17ae
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
 
@@ -46,6 +46,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496

--- a/ruby3.2-aws-sigv4.yaml
+++ b/ruby3.2-aws-sigv4.yaml
@@ -24,7 +24,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 0ea8ece30f9dd8a4e80ec4c82f56348d27e94460
+      expected-commit: 34308c3e89d723067eabd5f952a34bc6b55f17ae
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
 
@@ -46,6 +46,7 @@ vars:
 
 update:
   enabled: false
-  manual: true # the library we fetch uses a different version then the package version
+  manual: true
+  exclude-reason: the library we fetch uses a different version then the package version
   release-monitor:
     identifier: 174496


### PR DESCRIPTION
Want to add exclude-reason, but these packages won't build unless the commit matches the current branch head.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

Related: #23885 

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
