### PR TITLE
chore(gitaly-17.2): Create subpackage for backup utility

### DIFF
--- a/gitaly-17.2.yaml
+++ b/gitaly-17.2.yaml
@@ -1,13 +1,21 @@
 package:
   name: gitaly-17.2
   version: 17.2.0
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: MIT
   dependencies:
     provides:
       - gitaly=${{package.full-version}}
+    runtime:
+      - gitaly-backup-${{vars.major-minor-version}}
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
 
 environment:
   contents:
@@ -33,7 +41,17 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: gitaly-init-cgroups-17.2
+  - name: gitaly-backup-${{vars.major-minor-version}}
+    description: Git repository backup tool
+    dependencies:
+      provides:
+        - gitaly-backup=${{vars.major-minor-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/gitaly-backup ${{targets.contextdir}}/usr/bin/
+
+  - name: gitaly-init-cgroups-${{vars.major-minor-version}}
     # https://gitlab.com/gitlab-org/build/CNG/-/blob/master/gitaly-init-cgroups/Dockerfile
     description: gitaly-init-cgroups
     dependencies:
@@ -46,7 +64,7 @@ subpackages:
           modroot: ./tools/gitaly-init-cgroups/
           output: setup_cgroups
 
-  - name: gitaly-init-cgroups-17.2-compat
+  - name: gitaly-init-cgroups-compat-${{vars.major-minor-version}}
     description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
     dependencies:
       provides:


### PR DESCRIPTION
Creates a subpackage for Gitaly's Git repository backup tool
