### PR TITLE
move /etc/localtime touch from systemd-init to wolfi-baselayout

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -67,6 +67,7 @@ subpackages:
         - ${{package.name}}
     pipeline:
       - runs: |
+          mkdir -p ${{targets.subpkgdir}}
           ln -s /usr/lib/systemd/systemd ${{targets.subpkgdir}}/init
 
 update:

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "256.2"
-  epoch: 2
+  epoch: 3
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -67,9 +67,7 @@ subpackages:
         - ${{package.name}}
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/etc
           ln -s /usr/lib/systemd/systemd ${{targets.subpkgdir}}/init
-          touch ${{targets.subpkgdir}}/etc/localtime
 
 update:
   enabled: true

--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 13
+  epoch: 14
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
@@ -49,6 +49,7 @@ pipeline:
       for i in etc/passwd etc/group etc/shadow etc/services etc/hosts etc/profile etc/shells etc/protocols etc/profile.d/locale.sh etc/nsswitch.conf etc/os-release etc/secfixes.d/wolfi; do
         install -m644 vendor/${i} "${{targets.destdir}}"/${i}
       done
+      touch "${{targets.destdir}}"/etc/localtime
 
       install -m600 vendor/etc/shadow "${{targets.destdir}}"/etc/shadow
 


### PR DESCRIPTION
Yesterday, I put this in systemd-init.  Actually, I think this should generally be in wolfi-baselayout.  Sorry for the back and forth...