### PR TITLE
rebuild keycloak

### DIFF
--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak
   version: 25.0.2
-  epoch: 0
+  epoch: 1
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
For some reason, `keycloak-bitnami-compat` [doesn't exist](https://apk.dag.dev/https/packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz@etag:035712c683f23e3ccdfbe28b52fbb684/APKINDEX?full=false&search=keycloak-bitnami&depend=&provide=) on the registry, so re-triggering the build.