### PR TITLE
Revert "updatebot: remove old updatebot GHA's as infra is now hosted on GCP"

### DIFF
--- a/.github/workflows/wolfictl-update-gh.yaml
+++ b/.github/workflows/wolfictl-update-gh.yaml
@@ -1,0 +1,43 @@
+name: Wolfictl Update From GitHub
+
+on:
+  workflow_dispatch:
+  # Triggers the workflow every hour
+  schedule:
+    - cron: "0 * * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  GIT_AUTHOR_NAME: wolfi-bot
+  GIT_AUTHOR_EMAIL: 121097084+wolfi-bot@users.noreply.github.com
+
+jobs:
+  update:
+    name: Wolfictl Update
+    if: github.repository == 'wolfi-dev/os'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+      id: octo-sts
+      with:
+        scope: ${{ github.repository }}
+        identity: github-updates
+
+    # this need to point to main to always get the latest action
+    - uses: wolfi-dev/actions/wolfictl-update-gh@main # main
+      with:
+        repository: ${{github.repository}}
+        token: ${{ steps.octo-sts.outputs.token }}
+        git_author_name: ${{ env.GIT_AUTHOR_NAME }}
+        git_author_email: ${{ env.GIT_AUTHOR_EMAIL }}

--- a/.github/workflows/wolfictl-update-rm.yaml
+++ b/.github/workflows/wolfictl-update-rm.yaml
@@ -1,0 +1,44 @@
+name: Wolfictl Update From Release Monitor
+
+on:
+  workflow_dispatch:
+  # Triggers the workflow every hour
+  schedule:
+    - cron: "0 * * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  GIT_AUTHOR_NAME: wolfi-bot
+  GIT_AUTHOR_EMAIL: 121097084+wolfi-bot@users.noreply.github.com
+
+jobs:
+  update:
+    name: Wolfictl Update
+    if: github.repository == 'wolfi-dev/os'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+      id: octo-sts
+      with:
+        scope: ${{ github.repository }}
+        identity: release-monitoring-updates
+
+    # this need to point to main to always get the latest action
+    - uses: wolfi-dev/actions/wolfictl-update-rm@main # main
+      with:
+        repository: ${{github.repository}}
+        release_monitor_token: ${{ secrets.RELEASE_MONITOR_TOKEN }}
+        token: ${{ steps.octo-sts.outputs.token }}
+        git_author_name: ${{ env.GIT_AUTHOR_NAME }}
+        git_author_email: ${{ env.GIT_AUTHOR_EMAIL }}


### PR DESCRIPTION
Reverts wolfi-dev/os#24469

Need to investigate an issue with git pushes