### PR TITLE
keycloak: fix not-exist symlink

### DIFF
--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak
   version: 25.0.2
-  epoch: 1
+  epoch: 2
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0
@@ -128,7 +128,6 @@ subpackages:
           find ${{targets.contextdir}}/opt/bitnami -type f -exec sed 's#${{targets.contextdir}}##g' -i {} \;
 
           # Link binaries used by Bitnami config
-          ln -sf /usr/bin/keycloak ${{targets.contextdir}}/opt/bitnami/keycloak/bin/keycloak
           ln -sf /opt/bitnami/scripts/keycloak/entrypoint.sh ${{targets.contextdir}}/entrypoint.sh
           ln -sf /opt/bitnami/scripts/keycloak/run.sh ${{targets.contextdir}}/run.sh
     test:


### PR DESCRIPTION
https://apk.dag.dev/https/packages.wolfi.dev/os/aarch64/keycloak-bitnami-compat-25.0.2-r1.apk@sha1:4df393652fa2da06086bac0f9153989787a6d75a/opt/bitnami/keycloak/bin/

There is no such `/usr/bin/keycloak` so `/opt/bitnami/keycloak/bin/keycloak` doesn't exist at all.