### PR TITLE
py3-zipp - fix issue where version was reported as 0.0.0

### DIFF
--- a/py3-zipp.yaml
+++ b/py3-zipp.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-zipp
   version: 3.19.2
-  epoch: 2
+  epoch: 3
   description: Backport of pathlib-compatible object wrapper for zip files
   copyright:
     - license: MIT
@@ -26,6 +26,8 @@ environment:
       - busybox
       - py3-supported-pip
       - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-setuptools-scm
       - py3-supported-wheel
 
 pipeline:
@@ -48,6 +50,17 @@ subpackages:
         with:
           python: python${{range.key}}
       - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            imports: |
+              import zipp
+        - runs: |
+            python${{range.key}} <<"ENDVERCHECK"
+            from importlib.metadata import version
+            assert version('zipp') == "${{package.version}}"
+            ENDVERCHECK
 
 update:
   enabled: true


### PR DESCRIPTION
py3-zipp - fix issue where version was reported as 0.0.0

Without setuptools-scm, py3-zipp was being installed as
version 0.0.0 per metadata.

Add a test that ensures the install has the expected version.
