### PR TITLE
new pkg: iptables-wrappers

### DIFF
--- a/iptables-wrappers.yaml
+++ b/iptables-wrappers.yaml
@@ -12,8 +12,8 @@ package:
 environment:
   contents:
     packages:
-      - ip6tables # this pulls in iptables as well
       - busybox
+      - ip6tables # this pulls in iptables as well
 
 pipeline:
   - uses: git-checkout

--- a/iptables-wrappers.yaml
+++ b/iptables-wrappers.yaml
@@ -1,0 +1,36 @@
+package:
+  name: iptables-wrappers
+  version: 2
+  epoch: 0
+  description: Wrapper scripts for using iptables in containers
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - ip6tables # this pulls in iptables as well
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/iptables-wrappers
+      tag: v${{package.version}}
+      expected-commit: e139a115350974aac8a82ec4b815d2845f86997e
+
+  - runs: |
+      # This script generates a wrapper based on the version
+      # of iptables provided by the build environment.
+      ./iptables-wrapper-installer.sh
+
+      mkdir -p ${{targets.contextdir}}/sbin
+      mv /sbin/iptables-wrapper ${{targets.contextdir}}/sbin/iptables-wrapper
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/iptables-wrappers
+    strip-prefix: v

--- a/iptables-wrappers.yaml
+++ b/iptables-wrappers.yaml
@@ -5,6 +5,9 @@ package:
   description: Wrapper scripts for using iptables in containers
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ip6tables # this pulls in iptables as well
 
 environment:
   contents:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/24440

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
