### PR TITLE
fix(gitaly-17.2): Build bundled Git

### DIFF
--- a/gitaly-17.2.yaml
+++ b/gitaly-17.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitaly-17.2
   version: 17.2.0
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: MIT
@@ -20,9 +20,16 @@ var-transforms:
 environment:
   contents:
     packages:
+      - build-base
       - busybox
-      - go
-      - make
+      - curl-dev
+      - expat-dev
+      - openssl-dev
+      - pcre2-dev
+      - wolfi-base
+      - zlib-dev
+  environment:
+    WITH_BUNDLED_GIT: YesPlease
 
 pipeline:
   - uses: git-checkout
@@ -41,6 +48,16 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: gitaly-git-${{vars.major-minor-version}}
+    description: Bundled Git for Gitaly
+    dependencies:
+      provides:
+        - gitaly-git=${{vars.major-minor-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/bin
+          mv ${{targets.destdir}}/usr/bin/gitaly-git-* ${{targets.contextdir}}/usr/bin
+
   - name: gitaly-backup-${{vars.major-minor-version}}
     description: Git repository backup tool
     dependencies:


### PR DESCRIPTION
Adds subpackage containing Git revisions supported by Gitaly
