### PR TITLE
cilium: Add support for cilium v1.16.x

### DIFF
--- a/cilium-1.16.yaml
+++ b/cilium-1.16.yaml
@@ -1,0 +1,231 @@
+#nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
+package:
+  name: cilium-1.16
+  version: 1.16.0-rc.2
+  epoch: 0
+  description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
+  copyright:
+    - license: Apache-2.0
+  resources:
+    cpu: 20
+    memory: 64Gi
+  dependencies:
+    runtime:
+      - bpftool
+      # cilium does compilations at runtime on the node.
+      - clang
+      - cni-plugins-loopback
+      # iptables packages are needed at build time because cilium-iptables
+      # has a script that changes based on the presences of these packages
+      # at build time.
+      - ip6tables
+      - iproute2
+      - ipset
+      - iptables
+      - kmod
+      - llvm17
+    provides:
+      - cilium=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - bash
+      - bazel-6
+      - binutils
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang-17
+      - clang-17-dev
+      - cmake
+      - coreutils # for GNU install
+      # We need to stick to gcc 12 for now, envoy doesn't build with gcc >= 13
+      - gcc-12-default
+      - git
+      - go
+      - grep
+      - ip6tables
+      - iptables # for cilium-iptables
+      - isl-dev
+      - libtool
+      - llvm-lld-17
+      - llvm17
+      - llvm17-dev
+      - mpc-dev
+      - openjdk-11
+      - patch
+      - python3-dev
+      - samurai
+      - wolfi-baselayout
+
+vars:
+  # https://github.com/cilium/cilium/blob/v1.16.0-rc.2/images/cilium/Dockerfile
+  CILIUM_PROXY_COMMIT: "39a2a56bbd5b3a591f69dbca51d3e30ef97e0e51"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cilium/cilium
+      tag: v${{package.version}}
+      expected-commit: 359f47803540c5a91130e88c6c0d8bbb67202e3e
+
+  - uses: patch
+    with:
+      patches: loopback-location.patch
+
+  - runs: |
+      # Bazel errors out on toolchain stanza
+      sed -i '/$toolchain /d' go.mod
+      # Bazel errors out on go point release
+      sed -i 's|^\(go 1\.[0-9]*\)\.[0-9]*|\1|' go.mod
+
+  - runs: |
+      # Remove groupadd from Makefile: it's not doing anything useful in
+      # a package build anyway, and it's not available in busybox.
+      find . -name Makefile -exec sed -i '/groupadd/d' {} \;
+
+      DESTDIR=${{targets.destdir}} DISABLE_ENVOY_INSTALLATION=1 make build-container
+      DESTDIR=${{targets.destdir}} DISABLE_ENVOY_INSTALLATION=1 make install-container
+
+  - runs: |
+      # Check the Dockerfile for a SHA and match against the proxy SHA
+      ENVOY_SHA=$(grep 'ARG.*cilium-envoy' ./images/cilium/Dockerfile \
+        | sed "s/^ARG.*:v[0-9.]\+-//g" | cut -d@ -f1)
+
+      if [ "$ENVOY_SHA" != "${{vars.CILIUM_PROXY_COMMIT}}" ]; then
+        echo "Expected vars.CILIUM_PROXY_COMMIT to be $ENVOY_SHA. Please update" 1>&2
+        exit 1
+      fi
+
+  - uses: git-checkout
+    with:
+      repository: https://github.com/cilium/proxy
+      # Branch from https://github.com/cilium/cilium/blob/v1.16.0-rc.2/images/cilium/Dockerfile
+      # Note often the branch is updated with dependencies updates, no tags
+      # See CILIUM_PROXY_COMMIT for anchor point
+      branch: v1.29
+      depth: 1000
+      destination: envoy
+
+  - runs: |
+      git -C envoy reset --hard ${{vars.CILIUM_PROXY_COMMIT}}
+
+  - uses: patch
+    with:
+      patches: toolchains-paths.patch
+
+  - runs: |
+      # Bazel errors out on toolchain stanza
+      sed -i '/$toolchain /d' go.mod
+      # Bazel errors out on go point release
+      sed -i 's|^\(go 1\.[0-9]*\)\.[0-9]*|\1|' go.mod
+
+  - runs: |
+      cd /home/build/envoy/proxylib
+      make
+      mkdir -p ${{targets.destdir}}/usr/lib
+      cp -v libcilium.so ${{targets.destdir}}/usr/lib/libcilium.so
+
+      cd /home/build/envoy
+      # The Python interpreter complains about being run as root, there's a flag to pass to disable that warning.
+      sed -i 's/envoy_dependencies_extra()/envoy_dependencies_extra(ignore_root_user_error=True)/g' WORKSPACE
+      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+      mkdir -p .cache/bazel/_bazel_root
+
+      ./bazel/setup_clang.sh /usr
+
+      mkdir -p ${{targets.destdir}}/usr/bin
+
+      for target in cilium-envoy-starter cilium-envoy; do
+        bazel build --fission=no --config=clang \
+          --discard_analysis_cache \
+          --nokeep_state_after_build \
+          --notrack_incremental_state \
+          --conlyopt="-Wno-strict-prototypes" \
+          --verbose_failures -c opt //:${target}
+        cp -v bazel-bin/${target} ${{targets.destdir}}/usr/bin/${target}
+      done
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-container-init
+    description: init scripts for cilium
+    dependencies:
+      provides:
+        - cilium-container-init=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          cp images/cilium/init-container.sh \
+             plugins/cilium-cni/install-plugin.sh \
+             plugins/cilium-cni/cni-uninstall.sh \
+            ${{targets.subpkgdir}}/usr/bin
+
+  - name: ${{package.name}}-container-init-compat
+    description: init scripts for cilium
+    dependencies:
+      runtime:
+        - ${{package.name}}-container-init
+      provides:
+        - cilium-container-init-compat=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}
+          ln -sf /usr/bin/init-container.sh ${{targets.subpkgdir}}/init-container.sh
+          ln -sf /usr/bin/install-plugin.sh ${{targets.subpkgdir}}/install-plugin.sh
+          ln -sf /usr/bin/cni-uninstall.sh ${{targets.subpkgdir}}/cni-uninstall.sh
+
+  - name: ${{package.name}}-iptables
+    description: iptables compatibility package for cilium
+    dependencies:
+      runtime:
+        - iptables
+      provides:
+        - cilium-iptables=${{package.full-version}}
+    pipeline:
+      - runs: |
+          # This script generates a wrapper based on the version
+          # of iptables provided by the build environment.
+          ./images/runtime/iptables-wrapper-installer.sh
+          mkdir -p ${{targets.subpkgdir}}/sbin
+          mv /sbin/iptables-wrapper ${{targets.subpkgdir}}/sbin/iptables-wrapper
+      - uses: strip
+
+  - name: ${{package.name}}-operator-generic
+    description: Generic operator for cilium
+    dependencies:
+      runtime:
+        - gops
+      provides:
+        - cilium-operator-generic=${{package.full-version}}
+    pipeline:
+      - runs: |
+          cd /home/build/operator
+          make cilium-operator-generic
+          DESTDIR=${{targets.subpkgdir}} make install-generic
+      - uses: strip
+
+  - name: ${{package.name}}-hubble-relay
+    description: Hubble relay
+    dependencies:
+      provides:
+        - cilium-hubble-relay=${{package.full-version}}
+    pipeline:
+      - runs: |
+          cd /home/build/hubble-relay
+          make hubble-relay
+          DESTDIR=${{targets.subpkgdir}} make install
+      - uses: strip
+
+test:
+  pipeline:
+    - runs: cilium version
+
+update:
+  enabled: true
+  github:
+    identifier: cilium/cilium
+    strip-prefix: v
+    tag-filter-prefix: v1.16.

--- a/cilium-1.16/loopback-location.patch
+++ b/cilium-1.16/loopback-location.patch
@@ -1,0 +1,15 @@
+Update the loopback binary location to be /usr/bin
+
+diff --git a/plugins/cilium-cni/install-plugin.sh b/plugins/cilium-cni/install-plugin.sh
+index f3d589acc8..9cd4673fbf 100755
+--- a/plugins/cilium-cni/install-plugin.sh
++++ b/plugins/cilium-cni/install-plugin.sh
+@@ -30,7 +30,7 @@ install_cni() {
+ # Install the CNI loopback driver if not installed already
+ if [ ! -f "${CNI_DIR}/bin/loopback" ]; then
+ 	# Don't fail hard if this fails as it is usually not required
+-	install_cni /cni/loopback || true
++	install_cni /usr/bin/loopback || true
+ fi
+ 
+ install_cni "/opt/cni/bin/${BIN_NAME}"

--- a/cilium-1.16/toolchains-paths.patch
+++ b/cilium-1.16/toolchains-paths.patch
@@ -1,0 +1,87 @@
+diff --git a/envoy/bazel/toolchains/BUILD b/envoy/bazel/toolchains/BUILD
+index b806112b6..024d8882e 100644
+--- a/envoy/bazel/toolchains/BUILD
++++ b/envoy/bazel/toolchains/BUILD
+@@ -48,6 +48,11 @@ cc_toolchain_config(
+     coverage_link_flags = ["--coverage"],
+     cpu = "aarch64",
+     cxx_builtin_include_directories = [
++        # These aren't how we configure where to look, but which files
++        # Bazel allows us to use in the build. So we don't have to be
++        # super exact and specify the version in the path.
++        "/usr/lib64/gcc/aarch64-unknown-linux-gnu",
++        "/usr/lib/clang",
+         "/usr/lib/llvm-17",
+         "/usr/aarch64-linux-gnu/include",
+         "/usr/include",
+@@ -76,18 +81,18 @@ cc_toolchain_config(
+     target_libc = "glibc",
+     target_system_name = "aarch64-linux-gnu",
+     tool_paths = {
+-        "ar": "/usr/bin/llvm-ar-17",
+-        "compat-ld": "/usr/bin/lld-17",
+-        "ld": "/usr/bin/lld-17",
+-        "gold": "/usr/bin/lld-17",
++        "ar": "/usr/bin/llvm-ar",
++        "compat-ld": "/usr/bin/lld",
++        "ld": "/usr/bin/lld",
++        "gold": "/usr/bin/lld",
+         "cpp": "/usr/bin/clang-cpp-17",
+         "gcc": "/usr/bin/clang-17",
+-        "dwp": "/usr/bin/llvm-dwp-17",
+-        "gcov": "/usr/bin/llvmcov-17",
+-        "nm": "/usr/bin/llvm-nm-17",
+-        "objcopy": "/usr/bin/llvm-objcopy-17",
+-        "objdump": "/usr/bin/llvm-objdump-17",
+-        "strip": "/usr/bin/llvm-strip-17",
++        "dwp": "/usr/bin/llvm-dwp",
++        "gcov": "/usr/bin/llvmcov",
++        "nm": "/usr/bin/llvm-nm",
++        "objcopy": "/usr/bin/llvm-objcopy",
++        "objdump": "/usr/bin/llvm-objdump",
++        "strip": "/usr/bin/llvm-strip",
+     },
+     toolchain_identifier = "linux_aarch64",
+     unfiltered_compile_flags = [
+@@ -146,6 +151,11 @@ cc_toolchain_config(
+     coverage_link_flags = ["--coverage"],
+     cpu = "k8",
+     cxx_builtin_include_directories = [
++        # These aren't how we configure where to look, but which files
++        # Bazel allows us to use in the build. So we don't have to be
++        # super exact and specify the version in the path.
++        "/usr/lib64/gcc/x86_64-pc-linux-gnu",
++        "/usr/lib/clang",
+         "/usr/lib/llvm-17",
+         "/usr/x86_64-linux-gnu/include",
+         "/usr/include",
+@@ -174,18 +184,18 @@ cc_toolchain_config(
+     target_libc = "unknown",
+     target_system_name = "unknown",
+     tool_paths = {
+-        "ar": "/usr/bin/llvm-ar-17",
+-        "compat-ld": "/usr/bin/lld-17",
+-        "ld": "/usr/bin/lld-17",
+-        "gold": "/usr/bin/lld-17",
+-        "cpp": "/usr/bin/clang-cpp-17",
++        "ar": "/usr/bin/llvm-ar",
++        "compat-ld": "/usr/bin/lld",
++        "ld": "/usr/bin/lld",
++        "gold": "/usr/bin/lld",
++        "cpp": "/usr/bin/clang-cpp",
+         "gcc": "/usr/bin/clang-17",
+-        "dwp": "/usr/bin/llvm-dwp-17",
+-        "gcov": "/usr/bin/llvmcov-17",
+-        "nm": "/usr/bin/llvm-nm-17",
+-        "objcopy": "/usr/bin/llvm-objcopy-17",
+-        "objdump": "/usr/bin/llvm-objdump-17",
+-        "strip": "/usr/bin/llvm-strip-17",
++        "dwp": "/usr/bin/llvm-dwp",
++        "gcov": "/usr/bin/llvmcov",
++        "nm": "/usr/bin/llvm-nm",
++        "objcopy": "/usr/bin/llvm-objcopy",
++        "objdump": "/usr/bin/llvm-objdump",
++        "strip": "/usr/bin/llvm-strip",
+     },
+     toolchain_identifier = "linux_x86_64",
+     unfiltered_compile_flags = [


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

This commit is to add the support for cilium v1.16 (will be released soon). The current version v1.16.0-rc.2 is used for testing purpose.

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: NA

Related: NA

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
