### PR TITLE
Try adding a simple semgrep test

### DIFF
--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1,7 +1,7 @@
 package:
   name: semgrep
   version: 1.80.0
-  epoch: 0
+  epoch: 1
   description: "Lightweight static analysis for many languages. Find bug variants with patterns that look like source code."
   copyright:
     - license: LGPL-2.1-or-later
@@ -100,6 +100,13 @@ subpackages:
           python3 -m installer -d "${{targets.contextdir}}" \
             dist/*.whl
       - uses: strip
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import semgrep
 
 update:
   enabled: true


### PR DESCRIPTION
We're seeing this in our downstream image builds:
```
  Traceback (most recent call last):
    File "/usr/bin/pysemgrep", line 51, in <module>
      import semgrep.main
    File "/usr/lib/python3.12/site-packages/semgrep/main.py", line 1, in <module>
      from semgrep.cli import cli
    File "/usr/lib/python3.12/site-packages/semgrep/cli.py", line 5, in <module>
      from semgrep.commands.ci import ci
    File "/usr/lib/python3.12/site-packages/semgrep/commands/ci.py", line 22, in <module>
      import semgrep.run_scan
    File "/usr/lib/python3.12/site-packages/semgrep/run_scan.py", line 34, in <module>
      import semgrep.scan_report as scan_report
    File "/usr/lib/python3.12/site-packages/semgrep/scan_report.py", line 16, in <module>
      from semgrep.app import auth
    File "/usr/lib/python3.12/site-packages/semgrep/app/auth.py", line 7, in <module>
      from semgrep import tracing
    File "/usr/lib/python3.12/site-packages/semgrep/tracing.py", line 11, in <module>
      from opentelemetry import context
  ModuleNotFoundError: No module named 'opentelemetry'
```