### PR TITLE
revert recent commit around /etc/localtime in wolfi-baselayout

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "256.2"
-  epoch: 3
+  epoch: 4
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -65,10 +65,12 @@ subpackages:
     dependencies:
       runtime:
         - ${{package.name}}
+        - tzdata
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}
+          mkdir -p ${{targets.subpkgdir}}/etc
           ln -s /usr/lib/systemd/systemd ${{targets.subpkgdir}}/init
+          ln -sf /usr/share/zoneinfo/UTC ${{targets.subpkgdir}}/etc/localtime
 
 update:
   enabled: true

--- a/wolfi-baselayout.yaml
+++ b/wolfi-baselayout.yaml
@@ -1,7 +1,7 @@
 package:
   name: wolfi-baselayout
   version: 20230201
-  epoch: 14
+  epoch: 15
   description: "baselayout data for Wolfi"
   copyright:
     - license: MIT
@@ -49,7 +49,6 @@ pipeline:
       for i in etc/passwd etc/group etc/shadow etc/services etc/hosts etc/profile etc/shells etc/protocols etc/profile.d/locale.sh etc/nsswitch.conf etc/os-release etc/secfixes.d/wolfi; do
         install -m644 vendor/${i} "${{targets.destdir}}"/${i}
       done
-      touch "${{targets.destdir}}"/etc/localtime
 
       install -m600 vendor/etc/shadow "${{targets.destdir}}"/etc/shadow
 


### PR DESCRIPTION
Sorry for the back and forth....

As it turns out, the recent commit touching /etc/localtime broke some users.  As it turns out, this can't just be an empty file, but rather must be a symlink to the right timezone data.  That data is provided by the tzdata package.  We probably don't want / need that in our base image (I mean, hey, we've gotten this far without it).  So let's move this timezone configuration back to systemd-init and there we can depend on tzdata.