### PR TITLE
Change semgrep to be 'pip install'.

### DIFF
--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1,14 +1,13 @@
 package:
   name: semgrep
   version: 1.81.0
-  epoch: 0
+  epoch: 1
   description: "Lightweight static analysis for many languages. Find bug variants with patterns that look like source code."
   copyright:
     - license: LGPL-2.1-or-later
   dependencies:
     runtime:
-      - py3-semgrep
-      - python3
+      - py3-semgrep=${{package.full-version}}
 
 environment:
   contents:
@@ -61,7 +60,7 @@ pipeline:
   - runs: |
       install -Dm755 _build/default/src/main/Main.exe \
         "${{targets.destdir}}"/usr/bin/osemgrep
-      ln -sf /usr/bin/osemgrep "${{targets.destdir}}"/usr/bin/semgrep-core
+      ln -sf osemgrep "${{targets.destdir}}"/usr/bin/semgrep-core
       install -Dm644 LICENSE \
         "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
 
@@ -70,43 +69,47 @@ pipeline:
 subpackages:
   - name: py3-semgrep
     description: "Python bindings for semgrep"
-    dependencies:
-      runtime:
-        - python3
-        - py3-boltons
-        - py3-click
-        - py3-click-option-group
-        - py3-colorama
-        - py3-glom
-        - py3-defusedxml
-        - py3-attrs
-        - py3-jsonschema
-        - py3-packaging
-        - py3-peewee
-        - py3-python-lsp-jsonrpc
-        - py3-requests
-        - py3-rich
-        - py3-ruamel-yaml
-        - py3-tomli
-        - py3-typing-extensions
-        - py3-wcmatch
     pipeline:
       - runs: |
           cd cli
           git submodule update --init -- src/semgrep/semgrep_interfaces
-          python3 -m gpep517 build-wheel \
+          python3=$(readlink -f `which python3`)
+          $python3 -m gpep517 build-wheel \
             --wheel-dir dist \
             --output-fd 3 3>&1 >&2
-          python3 -m installer -d "${{targets.contextdir}}" \
-            dist/*.whl
+          $python3 -m pip install --verbose \
+            --prefix=/usr "--root=${{targets.contextdir}}" dist/*.whl
+          $python3 -m compileall --invalidation-mode=unchecked-hash -r100 "${{targets.contextdir}}"
+      - runs: |
+          # opentelemetry uses pkg_resources but does not declare a dep.
+          python3=$(readlink -f `which python3`)
+          $python3 -m pip install --verbose \
+            --ignore-installed \
+            --prefix=/usr "--root=${{targets.contextdir}}" setuptools
+      - runs: |
+          # clean out any bins other than semgrep and pysemgrep.
+          d=$(mktemp -d)
+          cd ${{targets.contextdir}}/usr/bin
+          mv semgrep pysemgrep "$d"
+          # there is a __pycache__ dir here, so -R
+          rm -Rf *
+          mv $d/* .
       - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            imports: |
+              import semgrep
+        - name: "run pysemgrep --help"
+          runs: |
+            pysemgrep --help
 
 test:
   pipeline:
-    - uses: python/import
-      with:
-        imports: |
-          import semgrep
+    - name: "run osemgrep --help"
+      runs: |
+        osemgrep --help
 
 update:
   enabled: true


### PR DESCRIPTION
Semgrep update to 1.80.0 added opentelemetry dependency. We do not have that packaged.
The opentelemetry dependency caused immediate failure of 'pysemgrep', and made me look at other dependencies.  Pip check said:

    # pip check
    semgrep 1.81.0 req exceptiongroup - not installed.
    semgrep 1.81.0 req opentelemetry-api - not installed.
    semgrep 1.81.0 req opentelemetry-exporter-otlp-proto-http - not installed
    semgrep 1.81.0 req opentelemetry-instrumentation-requests - not installed
    semgrep 1.81.0 req opentelemetry-sdk - not installed
    glom 23.5.0 has req face==20.1.1, but you have face 22.0.0.
    semgrep 1.81.0 has req boltons~=21.0, but you have boltons 24.0.0.
    semgrep 1.81.0 has req glom~=22.1, but you have glom 23.5.0.
    semgrep 1.81.0 has req ruamel.yaml<0.18,>=0.16.0,
       but you have ruamel-yaml 0.18.6.

The short path to getting all of that resolved is to move to 'pip install' sytle package.

Also here:
 * use relative symlink for osemgrep -> semgrep-core
 * make 'semgrep' depend on specific version of pysemgrep, rather than the unversioned one.
