### PR TITLE
Adding compat subpackages

### DIFF
--- a/gitaly-17.2.yaml
+++ b/gitaly-17.2.yaml
@@ -91,6 +91,26 @@ subpackages:
           mkdir -p "${{targets.contextdir}}"/
           ln -sf /usr/bin/setup_cgroups "${{targets.contextdir}}"/setup_cgroups
 
+  - name: gitaly-compat-${{vars.major-minor-version}}
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    dependencies:
+      provides:
+        - gitaly-compat=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/local/bin
+          ln -sf /usr/bin/gitaly "${{targets.contextdir}}"/usr/local/bin/gitaly
+
+  - name: gitaly-git-compat-${{vars.major-minor-version}}
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    dependencies:
+      provides:
+        - gitaly-git-compat=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/local/bin
+          ln -sf /usr/bin/gitaly-git-* "${{targets.contextdir}}"/usr/local/bin/
+
 update:
   enabled: true
   release-monitor:

--- a/gitaly-17.2.yaml
+++ b/gitaly-17.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitaly-17.2
   version: 17.2.0
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: MIT

--- a/gitaly-17.2.yaml
+++ b/gitaly-17.2.yaml
@@ -48,7 +48,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-# Leave at top so that links are created for all binaries in package
+  # Leave at top so that links are created for all binaries in package
   - name: gitaly-compat-${{vars.major-minor-version}}
     description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
     dependencies:
@@ -95,6 +95,16 @@ subpackages:
           packages: .
           modroot: ./tools/gitaly-init-cgroups/
           output: setup_cgroups
+
+  - name: gitaly-init-cgroups-compat-${{vars.major-minor-version}}
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    dependencies:
+      provides:
+        - gitaly-init-cgroups-compat=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/
+          ln -sf /usr/bin/setup_cgroups "${{targets.contextdir}}"/setup_cgroups
 
 update:
   enabled: true

--- a/gitaly-17.2.yaml
+++ b/gitaly-17.2.yaml
@@ -48,7 +48,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  # Leave at top so that links are created for all binaries in package
+  # Leave at the top so that links are created for all binaries in package
   - name: gitaly-compat-${{vars.major-minor-version}}
     description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
     dependencies:
@@ -61,7 +61,6 @@ subpackages:
           for binary in *; do
             ln -sf /usr/bin/$binary ${{targets.contextdir}}/usr/local/bin/$binary
           done
-          ln -sf /usr/bin/setup_cgroups "${{targets.contextdir}}"/setup_cgroups
 
   - name: gitaly-git-${{vars.major-minor-version}}
     description: Bundled Git for Gitaly

--- a/gitaly-17.2.yaml
+++ b/gitaly-17.2.yaml
@@ -48,6 +48,21 @@ pipeline:
   - uses: strip
 
 subpackages:
+# Leave at top so that links are created for all binaries in package
+  - name: gitaly-compat-${{vars.major-minor-version}}
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    dependencies:
+      provides:
+        - gitaly-compat=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/local/bin
+          cd ${{targets.destdir}}/usr/bin
+          for binary in *; do
+            ln -sf /usr/bin/$binary ${{targets.contextdir}}/usr/local/bin/$binary
+          done
+          ln -sf /usr/bin/setup_cgroups "${{targets.contextdir}}"/setup_cgroups
+
   - name: gitaly-git-${{vars.major-minor-version}}
     description: Bundled Git for Gitaly
     dependencies:
@@ -80,36 +95,6 @@ subpackages:
           packages: .
           modroot: ./tools/gitaly-init-cgroups/
           output: setup_cgroups
-
-  - name: gitaly-init-cgroups-compat-${{vars.major-minor-version}}
-    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
-    dependencies:
-      provides:
-        - gitaly-init-cgroups-compat=${{package.full-version}}
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.contextdir}}"/
-          ln -sf /usr/bin/setup_cgroups "${{targets.contextdir}}"/setup_cgroups
-
-  - name: gitaly-compat-${{vars.major-minor-version}}
-    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
-    dependencies:
-      provides:
-        - gitaly-compat=${{package.full-version}}
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.contextdir}}"/usr/local/bin
-          ln -sf /usr/bin/gitaly "${{targets.contextdir}}"/usr/local/bin/gitaly
-
-  - name: gitaly-git-compat-${{vars.major-minor-version}}
-    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
-    dependencies:
-      provides:
-        - gitaly-git-compat=${{package.full-version}}
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.contextdir}}"/usr/local/bin
-          ln -sf /usr/bin/gitaly-git-* "${{targets.contextdir}}"/usr/local/bin/
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
