### PR TITLE
ssl_client

### DIFF
--- a/ssl_client.yaml
+++ b/ssl_client.yaml
@@ -34,6 +34,7 @@ update:
   github:
     identifier: alpinelinux/aports
     use-tag: true
+    tag-filter: v3
 
 test:
   pipeline:

--- a/ssl_client.yaml
+++ b/ssl_client.yaml
@@ -2,7 +2,7 @@ package:
   name: ssl_client
   version: 3.20.2
   epoch: 0
-  description: ssl_client from alpine busybox 
+  description: ssl_client from alpine busybox
   copyright:
     - license: GPL-2.0-only
 
@@ -34,7 +34,7 @@ update:
   github:
     identifier: alpinelinux/aports
     use-tag: true
-    
+
 test:
   pipeline:
     - runs: |

--- a/ssl_client.yaml
+++ b/ssl_client.yaml
@@ -11,7 +11,6 @@ environment:
     packages:
       - build-base
       - busybox
-      - gcc
       - openssl-dev
 
 pipeline:

--- a/ssl_client.yaml
+++ b/ssl_client.yaml
@@ -1,0 +1,42 @@
+package:
+  name: ssl_client
+  version: 3.20.2
+  epoch: 0
+  description: ssl_client from alpine busybox 
+  copyright:
+    - license: GPL-2.0-only
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - gcc
+      - openssl-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 766c515e175cac9a2531f94a5b092fef67cbbdcd
+      repository: https://github.com/alpinelinux/aports
+      tag: v${{package.version}}
+
+  - runs: |
+      cd main/busybox
+      gcc -o ssl_client ssl_client.c -lssl -lcrypto
+      mkdir -p ${{targets.destdir}}/usr/bin
+      install -Dm755 ssl_client ${{targets.destdir}}/usr/bin/
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: alpinelinux/aports
+    use-tag: true
+    
+test:
+  pipeline:
+    - runs: |
+        # basic help test only, not sure how to use it
+        ssl_client -h |grep usage

--- a/ssl_client.yaml
+++ b/ssl_client.yaml
@@ -35,6 +35,7 @@ update:
     identifier: alpinelinux/aports
     use-tag: true
     tag-filter: v3
+    strip-prefix: v
 
 test:
   pipeline:


### PR DESCRIPTION
Adds ssl_client, which is used like netcat with file descriptors and sockets for tls connections.

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [X] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license


