### PR TITLE
pipeline: py/numpy-migration-check

### DIFF
--- a/pipelines/py/numpy-migration-check.yaml
+++ b/pipelines/py/numpy-migration-check.yaml
@@ -1,0 +1,15 @@
+name: Runs ruff NPY201 checks
+
+needs:
+  packages:
+    - ruff
+
+inputs:
+  path:
+    description: the path to run the checks over
+    default: .
+
+pipeline:
+  - name: "ruff check ${{inputs.path}}"
+    runs: |
+      ruff check $path --select NPY201


### PR DESCRIPTION
Uses ruff check per numpy 2.0 migration guide

https://numpy.org/devdocs/numpy_2_0_migration_guide.html
Signed-off-by: Pris Nasrat <pris.nasrat@chainguard.dev>
