### PR TITLE
feat(melange): add microvm-init subpackage for qemu runners

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -41,7 +41,6 @@ subpackages:
         - openssh-server
         - util-linux-misc
         - e2fsprogs
-
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/

--- a/melange.yaml
+++ b/melange.yaml
@@ -30,6 +30,20 @@ pipeline:
 
   - uses: strip
 
+subpackages:
+  - name: melange-microvm-init
+    description: Minimal busybox init for microvm workloads
+    dependencies:
+      runtime:
+        - kmod
+        - mount
+        - net-tools
+        - openssh-server
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/
+          cp init ${{targets.subpkgdir}}/
+
 update:
   enabled: true
   github:

--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: 0.11.2
-  epoch: 0
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0
@@ -39,6 +39,9 @@ subpackages:
         - mount
         - net-tools
         - openssh-server
+        - util-linux-misc
+        - e2fsprogs
+
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/

--- a/melange.yaml
+++ b/melange.yaml
@@ -43,9 +43,8 @@ subpackages:
         - e2fsprogs
     pipeline:
       - runs: |
+          mkdir -p ${{targets.subpkgdir}}/
           cp init ${{targets.subpkgdir}}/
-          mkdir -p ${{targets.subpkgdir}}/
-          mkdir -p ${{targets.subpkgdir}}/
           mkdir -p -m 0755 \
               ${{targets.subpkgdir}}/etc \
               ${{targets.subpkgdir}}/dev \

--- a/melange.yaml
+++ b/melange.yaml
@@ -37,7 +37,7 @@ subpackages:
       runtime:
         - kmod
         - mount
-        - net-tools
+        - iproute2
         - openssh-server
         - util-linux-misc
         - e2fsprogs

--- a/melange.yaml
+++ b/melange.yaml
@@ -43,8 +43,27 @@ subpackages:
         - e2fsprogs
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/
           cp init ${{targets.subpkgdir}}/
+          mkdir -p ${{targets.subpkgdir}}/
+          mkdir -p ${{targets.subpkgdir}}/
+          mkdir -p -m 0755 \
+              ${{targets.subpkgdir}}/etc \
+              ${{targets.subpkgdir}}/dev \
+              ${{targets.subpkgdir}}/home \
+              ${{targets.subpkgdir}}/home/build/ \
+              ${{targets.subpkgdir}}/mnt \
+              ${{targets.subpkgdir}}/proc \
+              ${{targets.subpkgdir}}/root \
+              ${{targets.subpkgdir}}/run \
+              ${{targets.subpkgdir}}/sys \
+              ${{targets.subpkgdir}}/var \
+              ${{targets.subpkgdir}}/var/empty
+          mkdir -p -m 0777 \
+             ${{targets.subpkgdir}}/opt \
+             ${{targets.subpkgdir}}/tmp \
+             ${{targets.subpkgdir}}/var/cache \
+             ${{targets.subpkgdir}}/var/run
+          ln -sf /usr/share/zoneinfo/UTC  ${{targets.subpkgdir}}/etc/localtime
 
 update:
   enabled: true

--- a/melange/init
+++ b/melange/init
@@ -57,9 +57,9 @@ fi
 # If we have an external disk, we want to perform builds in that
 if [ -e /dev/vda ]; then
 	/usr/sbin/modprobe ext4
-	/sbin/mkfs.ext4 /dev/vda
+	/sbin/mkfs.ext4 -O ^has_journal -E nodiscard /dev/vda
 	/bin/mkdir -p /mount
-	/bin/mount -t ext4 /dev/vda /home/build
+	/bin/mount -o nobarrier,noatime,nodiratime,nobh -t ext4 /dev/vda /home/build
 fi
 
 # Setup SSH keys for external access

--- a/melange/init
+++ b/melange/init
@@ -17,6 +17,16 @@ if [ -x /sbin/ldconfig ]; then
 	/sbin/ldconfig /lib /usr/lib /usr/lib64 || :
 fi
 
+# Fetch settings from cmdline
+DNS="$(tr ' ' '\n' < /proc/cmdline | /bin/grep "dns=" | /usr/bin/cut -d'=' -f2-)"
+HOSTNAME="$(tr ' ' '\n' < /proc/cmdline | /bin/grep "hostname=" | /usr/bin/cut -d'=' -f2-)"
+SSHKEY="$(tr ' ' '\n' < /proc/cmdline | /bin/grep "sshkey=" | /usr/bin/cut -d'=' -f2- | /bin/base64 -d)"
+
+if [ -z "${SSHKEY}" ]; then
+	/bin/echo "Missing default mount for ssh keys"
+	exit 1
+fi
+
 # We can ignore this fail, if we use a kernel with kvm_guest.config, we won't need this
 # and network will work anyway
 # If this fails and we won't have network, the ifconfig command will fail anyway.
@@ -28,27 +38,8 @@ fi
 # modprobe 9p if absent
 /bin/grep -q 9p /proc/filesystems || /usr/sbin/modprobe 9p
 
-/bin/ifconfig lo up
-/bin/ifconfig eth0 10.0.2.15 netmask 255.255.255.0
-/bin/route add default gw 10.0.2.2 eth0
-
-# Setup hostname
-/bin/hostname wolfi-qemu
-/bin/sed  -i 's| localhost | localhost wolfi-qemu |g' /etc/hosts
-
-# Setup DNS
-/bin/echo "nameserver 1.1.1.1" >> /etc/resolv.conf
-
-# Setup UTC timezone
-/bin/ln -sf /usr/share/zoneinfo/UTC /etc/localtime
-
 # Setup default mountpoint for 9p shared dir
 /bin/mount -t 9p -o trans=virtio defaultshare /mnt/ -oversion=9p2000.L
-
-if [ ! -e /mnt/ssh/authorized_keys ]; then
-	/bin/echo "Missing default mount for ssh keys"
-	exit 1
-fi
 
 # If we have an external disk, we want to perform builds in that
 if [ -e /dev/vda ]; then
@@ -58,17 +49,28 @@ if [ -e /dev/vda ]; then
 	/bin/mount -o nobarrier,noatime,nodiratime,nobh -t ext4 /dev/vda /home/build
 fi
 
-# Setup SSH keys for external access
-/bin/mkdir -p -m 0700 /root/.ssh/ /home/build/.ssh/
-/bin/cp /mnt/ssh/authorized_keys /root/.ssh/
-/bin/cp /mnt/ssh/authorized_keys /home/build/.ssh/
-/bin/chmod 0400 /root/.ssh/authorized_keys /home/build/.ssh/authorized_keys
-
 # Fix home permissions from cpio command
 /bin/chown -R build:build /home/build
 
+# Setup default network
+/bin/ifconfig lo up
+/bin/ifconfig eth0 10.0.2.15 netmask 255.255.255.0
+/bin/route add default gw 10.0.2.2 eth0
+
+/bin/hostname "${HOSTNAME:-"wolfi-vm"}"
+echo "127.0.0.1 ${HOSTNAME:-"wolfi-vm"}" >> /etc/hosts
+/bin/echo "nameserver ${DNS:-"1.1.1.1"}" > /etc/resolv.conf
+
+##############
+# Entrypoint #
+##############
+# Setup SSH keys for external access
+/bin/mkdir -p -m 0700 /root/.ssh/ /home/build/.ssh/
+/bin/echo "${SSHKEY}" > /root/.ssh/authorized_keys
+/bin/echo "${SSHKEY}" > /home/build/.ssh/authorized_keys
+/bin/chmod 0400 /root/.ssh/authorized_keys /home/build/.ssh/authorized_keys
+/bin/chown -R build:build /home/build/.ssh/
 # Setting up AcceptEnv
 /bin/echo "AcceptEnv *" >> /etc/ssh/sshd_config
-
 /usr/bin/ssh-keygen -A
 exec /usr/sbin/sshd -D

--- a/melange/init
+++ b/melange/init
@@ -41,7 +41,7 @@ sort -u \
 grep -q 9p /proc/filesystems || modprobe 9p
 
 # Setup default mountpoint for 9p shared dir
-mount -t 9p -o trans=virtio defaultshare /mnt/ -oversion=9p2000.L
+mount -t 9p -otrans=virtio -oversion=9p2000.L  defaultshare /mnt/
 
 # If we have an external disk, we want to perform builds in that
 if [ -e /dev/vda ]; then

--- a/melange/init
+++ b/melange/init
@@ -2,16 +2,12 @@
 set -e
 set -x
 
-# creating base directories
-/bin/mkdir -p -m 0755 /dev /home /home/build/ /mnt /proc /root /run /sys /var /var/empty
-# creating base world writable/readable directories
-/bin/mkdir -p -m 0777 /opt /tmp /var/cache /var/run
-
 /bin/mount -t proc proc -o nodev,nosuid,hidepid=2 /proc
 /bin/mount -t devtmpfs -o nosuid,noexec devtmpfs /dev
 /bin/mount -t sysfs sys -o nodev,nosuid,noexec /sys
 /bin/mount -t tmpfs -o nodev,nosuid,noexec tmpfs /tmp
 
+# Setup tty/pty
 /bin/mkdir /dev/pts
 /bin/mount -t devpts devpts -o noexec,nosuid,newinstance,ptmxmode=0666,mode=0620,gid=tty /dev/pts/
 /bin/mount --bind /dev/pts/ptmx /dev/ptmx

--- a/melange/init
+++ b/melange/init
@@ -46,7 +46,7 @@ mount -t 9p -o trans=virtio defaultshare /mnt/ -oversion=9p2000.L
 # If we have an external disk, we want to perform builds in that
 if [ -e /dev/vda ]; then
 	modprobe ext4
-	mkfs.ext4 -O ^has_journal -E lazy_itable_init=0,lazy_journal_init=0 /dev/vda
+	mkfs.ext4 -O ^has_journal /dev/vda
 	mkdir -p /mount
 	mount -o nobarrier,noatime,nodiratime,nobh -t ext4 /dev/vda /home/build
 fi
@@ -55,9 +55,11 @@ fi
 chown -R build:build /home/build
 
 # Setup default network
-ifconfig lo up
-ifconfig eth0 10.0.2.15 netmask 255.255.255.0
-route add default gw 10.0.2.2 eth0
+interface_name="$(ip -o link show | grep -v 'lo:' | cut -d':' -f2 | tr -d ' ')"
+ip link set lo up
+ip link set "${interface_name:-"eth0"}" up
+ip addr add 10.0.2.15/24 dev "${interface_name:-"eth0"}"
+ip route add default via 10.0.2.2 dev "${interface_name:-"eth0"}"
 
 hostname "${HOSTNAME:-"wolfi-vm"}"
 echo "127.0.0.1 ${HOSTNAME:-"wolfi-vm"}" >> /etc/hosts

--- a/melange/init
+++ b/melange/init
@@ -2,28 +2,30 @@
 set -e
 set -x
 
-/bin/mount -t proc proc -o nodev,nosuid,hidepid=2 /proc
-/bin/mount -t devtmpfs -o nosuid,noexec devtmpfs /dev
-/bin/mount -t sysfs sys -o nodev,nosuid,noexec /sys
-/bin/mount -t tmpfs -o nodev,nosuid,noexec tmpfs /tmp
+PATH=/usr/bin:/usr/sbin:/sbin:/bin
+
+mount -t proc proc -o nodev,nosuid,hidepid=2 /proc
+mount -t devtmpfs -o nosuid,noexec devtmpfs /dev
+mount -t sysfs sys -o nodev,nosuid,noexec /sys
+mount -t tmpfs -o nodev,nosuid,noexec tmpfs /tmp
 
 # Setup tty/pty
-/bin/mkdir /dev/pts
-/bin/mount -t devpts devpts -o noexec,nosuid,newinstance,ptmxmode=0666,mode=0620,gid=tty /dev/pts/
-/bin/mount --bind /dev/pts/ptmx /dev/ptmx
+mkdir /dev/pts
+mount -t devpts devpts -o noexec,nosuid,newinstance,ptmxmode=0666,mode=0620,gid=tty /dev/pts/
+mount --bind /dev/pts/ptmx /dev/ptmx
 
 # ldconfig is run to prime ld.so.cache for glibc packages which require it.
 if [ -x /sbin/ldconfig ]; then
-	/sbin/ldconfig /lib /usr/lib /usr/lib64 || :
+	ldconfig /lib /usr/lib /usr/lib64
 fi
 
 # Fetch settings from cmdline
-DNS="$(tr ' ' '\n' < /proc/cmdline | /bin/grep "dns=" | /usr/bin/cut -d'=' -f2-)"
-HOSTNAME="$(tr ' ' '\n' < /proc/cmdline | /bin/grep "hostname=" | /usr/bin/cut -d'=' -f2-)"
-SSHKEY="$(tr ' ' '\n' < /proc/cmdline | /bin/grep "sshkey=" | /usr/bin/cut -d'=' -f2- | /bin/base64 -d)"
+DNS="$(tr ' ' '\n' < /proc/cmdline | grep "dns=" | cut -d'=' -f2-)"
+HOSTNAME="$(tr ' ' '\n' < /proc/cmdline | grep "hostname=" | cut -d'=' -f2-)"
+SSHKEY="$(tr ' ' '\n' < /proc/cmdline | grep "sshkey=" | cut -d'=' -f2- | base64 -d)"
 
 if [ -z "${SSHKEY}" ]; then
-	/bin/echo "Missing default mount for ssh keys"
+	echo "Missing default mount for ssh keys"
 	exit 1
 fi
 
@@ -31,46 +33,46 @@ fi
 # and network will work anyway
 # If this fails and we won't have network, the ifconfig command will fail anyway.
 # Also we load cpu accelleration drivers in case those are needed.
-/usr/sbin/depmod -a || :
-/usr/bin/sort -u \
+depmod -a || :
+sort -u \
 	/sys/devices/system/cpu/modalias  \
-	/sys/devices/pci*/*/virtio*/modalias | /usr/bin/xargs -n1 /usr/sbin/modprobe 2>/dev/null || :
+	/sys/devices/pci*/*/virtio*/modalias | xargs -n1 modprobe 2>/dev/null || :
 # modprobe 9p if absent
-/bin/grep -q 9p /proc/filesystems || /usr/sbin/modprobe 9p
+grep -q 9p /proc/filesystems || modprobe 9p
 
 # Setup default mountpoint for 9p shared dir
-/bin/mount -t 9p -o trans=virtio defaultshare /mnt/ -oversion=9p2000.L
+mount -t 9p -o trans=virtio defaultshare /mnt/ -oversion=9p2000.L
 
 # If we have an external disk, we want to perform builds in that
 if [ -e /dev/vda ]; then
-	/usr/sbin/modprobe ext4
-	/sbin/mkfs.ext4 -O ^has_journal -E lazy_itable_init=0,lazy_journal_init=0 /dev/vda
-	/bin/mkdir -p /mount
-	/bin/mount -o nobarrier,noatime,nodiratime,nobh -t ext4 /dev/vda /home/build
+	modprobe ext4
+	mkfs.ext4 -O ^has_journal -E lazy_itable_init=0,lazy_journal_init=0 /dev/vda
+	mkdir -p /mount
+	mount -o nobarrier,noatime,nodiratime,nobh -t ext4 /dev/vda /home/build
 fi
 
 # Fix home permissions from cpio command
-/bin/chown -R build:build /home/build
+chown -R build:build /home/build
 
 # Setup default network
-/bin/ifconfig lo up
-/bin/ifconfig eth0 10.0.2.15 netmask 255.255.255.0
-/bin/route add default gw 10.0.2.2 eth0
+ifconfig lo up
+ifconfig eth0 10.0.2.15 netmask 255.255.255.0
+route add default gw 10.0.2.2 eth0
 
-/bin/hostname "${HOSTNAME:-"wolfi-vm"}"
+hostname "${HOSTNAME:-"wolfi-vm"}"
 echo "127.0.0.1 ${HOSTNAME:-"wolfi-vm"}" >> /etc/hosts
-/bin/echo "nameserver ${DNS:-"1.1.1.1"}" > /etc/resolv.conf
+echo "nameserver ${DNS:-"1.1.1.1"}" > /etc/resolv.conf
 
 ##############
 # Entrypoint #
 ##############
 # Setup SSH keys for external access
-/bin/mkdir -p -m 0700 /root/.ssh/ /home/build/.ssh/
-/bin/echo "${SSHKEY}" > /root/.ssh/authorized_keys
-/bin/echo "${SSHKEY}" > /home/build/.ssh/authorized_keys
-/bin/chmod 0400 /root/.ssh/authorized_keys /home/build/.ssh/authorized_keys
-/bin/chown -R build:build /home/build/.ssh/
+mkdir -p -m 0700 /root/.ssh/ /home/build/.ssh/
+echo "${SSHKEY}" > /root/.ssh/authorized_keys
+echo "${SSHKEY}" > /home/build/.ssh/authorized_keys
+chmod 0400 /root/.ssh/authorized_keys /home/build/.ssh/authorized_keys
+chown -R build:build /home/build/.ssh/
 # Setting up AcceptEnv
-/bin/echo "AcceptEnv *" >> /etc/ssh/sshd_config
-/usr/bin/ssh-keygen -A
-exec /usr/sbin/sshd -D
+echo "AcceptEnv *" >> /etc/ssh/sshd_config
+ssh-keygen -A
+exec sshd -D

--- a/melange/init
+++ b/melange/init
@@ -75,4 +75,4 @@ chown -R build:build /home/build/.ssh/
 # Setting up AcceptEnv
 echo "AcceptEnv *" >> /etc/ssh/sshd_config
 ssh-keygen -A
-exec sshd -D
+exec /usr/sbin/sshd -D

--- a/melange/init
+++ b/melange/init
@@ -54,6 +54,14 @@ if [ ! -e /mnt/ssh/authorized_keys ]; then
 	exit 1
 fi
 
+# If we have an external disk, we want to perform builds in that
+if [ -e /dev/vda ]; then
+	/usr/sbin/modprobe ext4
+	/sbin/mkfs.ext4 /dev/vda
+	/bin/mkdir -p /mount
+	/bin/mount -t ext4 /dev/vda /home/build
+fi
+
 # Setup SSH keys for external access
 /bin/mkdir -p -m 0700 /root/.ssh/ /home/build/.ssh/
 /bin/cp /mnt/ssh/authorized_keys /root/.ssh/

--- a/melange/init
+++ b/melange/init
@@ -57,7 +57,7 @@ fi
 # If we have an external disk, we want to perform builds in that
 if [ -e /dev/vda ]; then
 	/usr/sbin/modprobe ext4
-	/sbin/mkfs.ext4 -O ^has_journal -E nodiscard /dev/vda
+	/sbin/mkfs.ext4 -O ^has_journal -E lazy_itable_init=0,lazy_journal_init=0 /dev/vda
 	/bin/mkdir -p /mount
 	/bin/mount -o nobarrier,noatime,nodiratime,nobh -t ext4 /dev/vda /home/build
 fi

--- a/melange/init
+++ b/melange/init
@@ -45,7 +45,7 @@ mount -t 9p -otrans=virtio -oversion=9p2000.L  defaultshare /mnt/
 
 # If we have an external disk, we want to perform builds in that
 if [ -e /dev/vda ]; then
-	modprobe ext4
+	grep -q ext4 /proc/filesystems || modprobe ext4
 	mkfs.ext4 -O ^has_journal /dev/vda
 	mkdir -p /mount
 	mount -o nobarrier,noatime,nodiratime,nobh -t ext4 /dev/vda /home/build
@@ -55,7 +55,7 @@ fi
 chown -R build:build /home/build
 
 # Setup default network
-interface_name="$(ip -o link show | grep -v 'lo:' | cut -d':' -f2 | tr -d ' ')"
+interface_name="$(ip -o link show | grep 'BROADCAST,MULTICAST' | head -n 1 | cut -d':' -f2 | tr -d ' ')"
 ip link set lo up
 ip link set "${interface_name:-"eth0"}" up
 ip addr add 10.0.2.15/24 dev "${interface_name:-"eth0"}"

--- a/melange/init
+++ b/melange/init
@@ -1,0 +1,70 @@
+#!/bin/busybox sh
+set -e
+set -x
+
+# creating base directories
+/bin/mkdir -p -m 0755 /dev /home /home/build/ /mnt /proc /root /run /sys /var /var/empty
+# creating base world writable/readable directories
+/bin/mkdir -p -m 0777 /opt /tmp /var/cache /var/run
+
+/bin/mount -t proc proc -o nodev,nosuid,hidepid=2 /proc
+/bin/mount -t devtmpfs -o nosuid,noexec devtmpfs /dev
+/bin/mount -t sysfs sys -o nodev,nosuid,noexec /sys
+/bin/mount -t tmpfs -o nodev,nosuid,noexec tmpfs /tmp
+
+/bin/mkdir /dev/pts
+/bin/mount -t devpts devpts -o noexec,nosuid,newinstance,ptmxmode=0666,mode=0620,gid=tty /dev/pts/
+/bin/mount --bind /dev/pts/ptmx /dev/ptmx
+
+# ldconfig is run to prime ld.so.cache for glibc packages which require it.
+if [ -x /sbin/ldconfig ]; then
+	/sbin/ldconfig /lib /usr/lib /usr/lib64 || :
+fi
+
+# We can ignore this fail, if we use a kernel with kvm_guest.config, we won't need this
+# and network will work anyway
+# If this fails and we won't have network, the ifconfig command will fail anyway.
+# Also we load cpu accelleration drivers in case those are needed.
+/usr/sbin/depmod -a || :
+/usr/bin/sort -u \
+	/sys/devices/system/cpu/modalias  \
+	/sys/devices/pci*/*/virtio*/modalias | /usr/bin/xargs -n1 /usr/sbin/modprobe 2>/dev/null || :
+# modprobe 9p if absent
+/bin/grep -q 9p /proc/filesystems || /usr/sbin/modprobe 9p
+
+/bin/ifconfig lo up
+/bin/ifconfig eth0 10.0.2.15 netmask 255.255.255.0
+/bin/route add default gw 10.0.2.2 eth0
+
+# Setup hostname
+/bin/hostname wolfi-qemu
+/bin/sed  -i 's| localhost | localhost wolfi-qemu |g' /etc/hosts
+
+# Setup DNS
+/bin/echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+
+# Setup UTC timezone
+/bin/ln -sf /usr/share/zoneinfo/UTC /etc/localtime
+
+# Setup default mountpoint for 9p shared dir
+/bin/mount -t 9p -o trans=virtio defaultshare /mnt/ -oversion=9p2000.L
+
+if [ ! -e /mnt/ssh/authorized_keys ]; then
+	/bin/echo "Missing default mount for ssh keys"
+	exit 1
+fi
+
+# Setup SSH keys for external access
+/bin/mkdir -p -m 0700 /root/.ssh/ /home/build/.ssh/
+/bin/cp /mnt/ssh/authorized_keys /root/.ssh/
+/bin/cp /mnt/ssh/authorized_keys /home/build/.ssh/
+/bin/chmod 0400 /root/.ssh/authorized_keys /home/build/.ssh/authorized_keys
+
+# Fix home permissions from cpio command
+/bin/chown -R build:build /home/build
+
+# Setting up AcceptEnv
+/bin/echo "AcceptEnv *" >> /etc/ssh/sshd_config
+
+/usr/bin/ssh-keygen -A
+exec /usr/sbin/sshd -D


### PR DESCRIPTION
Add a melange subpackage to install a minimal busybox-based init for microvm/qemu runners.