### PR TITLE
neon: try to fix broken main build

### DIFF
--- a/neon.yaml
+++ b/neon.yaml
@@ -1,7 +1,7 @@
 package:
   name: neon
   version: "6142"
-  epoch: 0
+  epoch: 1
   description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,7 @@ environment:
       - icu-dev
       - libcurl-openssl4
       - libpq-16
+      - libpthread-stubs
       - libseccomp-dev
       - libtool
       - openssl-dev


### PR DESCRIPTION
```
linking with cc failed: exit status: 1
undefined reference to '__pthread_cond_timedwait64'
```
