### PR TITLE
add tini to runtime dependencies

### DIFF
--- a/gitlab-cng-17.2.yaml
+++ b/gitlab-cng-17.2.yaml
@@ -32,8 +32,8 @@ var-transforms:
 
 package:
   name: gitlab-cng-17.2
-  version: 17.2.0
-  epoch: 1
+  version: 17.2.1
+  epoch: 0
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -63,7 +63,7 @@ pipeline:
     with:
       repository: https://gitlab.com/gitlab-org/build/CNG.git
       tag: v${{package.version}}
-      expected-commit: aedef75c1f6e67aa8cd7c344a2dd49e6414560d0
+      expected-commit: 7b7006df209c05f72b0fb5968c0bfb619d049d56
 
 data:
   # Used to create all of the *-scripts subpackages from the CNG repo.
@@ -127,6 +127,8 @@ subpackages:
         - gomplate
         - procps
         - xtail
+        - tini
+        - tini-compat
 
   - name: gitlab-webservice-config-${{vars.major-minor-version}}
     pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

They released this commit https://gitlab.com/gitlab-org/build/CNG/-/commit/19faab2afd6fbb1f4393d5379e0d881d7724bf7e in version 17.2 that enables /usr/bin/tini to use as an entrypoint by default for gitlab-base, so, lots of images that use the gitlab-base is failing due to that.

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
