### PR TITLE
argo-workflows: ship embedded webapp in a subpackage for SBOM

### DIFF
--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-workflows
   version: 3.5.8
-  epoch: 1
+  epoch: 2
   description: Workflow engine for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -100,6 +100,13 @@ subpackages:
     dependencies:
       runtime:
         - argo-workflows
+
+  - name: "argo-workflows-ui"
+    description: "Argo workflows embedded UI"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/argo-workflows-ui
+          cp -ar ui/ ${{targets.subpkgdir}}/usr/lib/argo-workflows-ui
 
 update:
   enabled: true


### PR DESCRIPTION
The webapp is packed as static files and embedded inside the go
binary. Ship it additionally in a subpackage, such that syft can pick
it up.

This makes wolfictl scan pick up 7 CVEs in the embedded webapp.
