### PR TITLE
build static jq binaries

### DIFF
--- a/jq.yaml
+++ b/jq.yaml
@@ -1,7 +1,7 @@
 package:
   name: jq
   version: 1.7.1
-  epoch: 2
+  epoch: 3
   description: "a lightweight and flexible JSON processor"
   copyright:
     - license: MIT
@@ -28,6 +28,10 @@ pipeline:
       autoreconf -vfi
 
   - uses: autoconf/configure
+    with:
+      opts: |
+        --enable-static \
+        --enable-all-static
 
   - uses: autoconf/make-install
 


### PR DESCRIPTION
upstream ref: https://github.com/jqlang/jq/blob/c1d885b0249f3978de3a21ea2bfb7ced06ed2aff/.github/workflows/ci.yml#L85-L94

this commit builds `jq` as per upstream releases and links statically without relying on any system deps.

the current `jq` executable dynamically links to some system dependencies.
```bash
/ # apk add cmd:jq cmd:ldd
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/6) Installing oniguruma (6.9.9-r3)
(2/6) Installing jq (1.7.1-r2)
(3/6) Installing ncurses-terminfo-base (6.5_p20240629-r0)
(4/6) Installing ncurses (6.5_p20240629-r0)
(5/6) Installing bash (5.2.21-r5)
(6/6) Installing posix-libc-utils (2.39-r7)
OK: 19 MiB in 20 packages
/ # ldd $(command -v jq)
	linux-vdso.so.1 (0x0000e63c4f41b000)
	libm.so.6 => /lib/libm.so.6 (0x0000e63c4f2b0000)
	libonig.so.5 => /usr/lib/libonig.so.5 (0x0000e63c4f200000)
	libc.so.6 => /lib/libc.so.6 (0x0000e63c4f040000)
	/lib/ld-linux-aarch64.so.1 (0x0000e63c4f3de000)

# test for this patch:
[sdk] ❯ apk add --allow-untrusted ./packages/aarch64/jq-1.7.1-r2.apk
(1/1) Replacing jq (1.7.1-r2 -> 1.7.1-r2)
OK: 1089 MiB in 67 packages
[sdk] ❯ ldd $(command -v jq)
	not a dynamic executable
[sdk] ❯
```
