### PR TITLE
allow manual bundle builds to specify ref

### DIFF
--- a/.github/workflows/postsubmit-bundle-build.yaml
+++ b/.github/workflows/postsubmit-bundle-build.yaml
@@ -11,6 +11,11 @@ on:
         type: string
         default: ""
         description: "comma separated list of package names to build. If empty, build all packages."
+      checkout_ref:
+        required: false
+        type: string
+        default: ""
+        description: "Ref to checkout before building"
 
 # Only run one build at a time to prevent out of sync signatures.
 concurrency: 'bundle-runner-a'
@@ -40,6 +45,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.checkout_ref }}
 
       - name: 'Trust the github workspace'
         run: |


### PR DESCRIPTION
This allows us to run world builds on PRs and uncommitted refs, for testing.