### PR TITLE
link kubectl for startups

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
-  version: 1.30.2
-  epoch: 1
+  version: 1.30.2.2
+  epoch: 0
   description:
   copyright:
     - license: Apache-2.0
@@ -29,14 +29,10 @@ environment:
       - zstd
 
 var-transforms:
-  # TODO: This transforms the version into the real k3s version. It's needed
-  # because the wolfictl update bot doesn't yet support the k3s version format
-  # (+k3s#). This is a hack, and means if upstream ships a >k3s1 revision, we
-  # won't automatically pick it up. However, this is rare, and this solution
-  # buys us enough time to add support for the k3s version scheme.
+  # Transform melange version 1.30.2.2 => 1.30.2+k3s2
   - from: ${{package.version}}
-    match: ^(.+)$
-    replace: $1+k3s1 # NOTE: Update k3s# if upstream ships a >k3s# revision
+    match: \.(\d+)$
+    replace: +k3s$1
     to: full-package-version
 
 # Upstream uses `dapper` to initialize build environments, but since melange
@@ -47,7 +43,7 @@ pipeline:
     with:
       repository: https://github.com/k3s-io/k3s
       tag: v${{vars.full-package-version}}
-      expected-commit: aa4794b37223156c5f651d94e23670bd7e581607
+      expected-commit: faeaf1b01b2a708a46cae2a67c1b4d381ee1ba6b
   # Build things (almost) identical to upstream, with the k3s components
   # embedded in the "outer" multicall binary.
   - runs: |
@@ -86,7 +82,7 @@ pipeline:
       go mod tidy
   - uses: go/bump
     with:
-      deps: github.com/docker/docker@v25.0.5+incompatible golang.org/x/net@v0.24.0 github.com/hashicorp/go-retryablehttp@v0.7.7
+      deps: github.com/docker/docker@v25.0.5+incompatible github.com/hashicorp/go-retryablehttp@v0.7.7
   - runs: |
       # Override the go version check at runtime to always match the go version at build time
       # Ref: https://github.com/k3s-io/k3s/pull/9054
@@ -120,7 +116,7 @@ pipeline:
       # Remove the upload portion from the upstream package-cli script
       sed -e '/scripts\/build-upload/d' -i scripts/package-cli
 
-      # Upstream handles the ctr link at install time, since we don't have an "install" phase, we do it here
+      # Upstream handles a few links at install time, since we don't have an "install" phase, we do it here
       rm -rf bin/ctr && ln -s /bin/_k3s-inner bin/ctr
 
       ./scripts/package-cli
@@ -128,6 +124,11 @@ pipeline:
       # Check that the multicall symlinks were created
       [ "$(readlink ./bin/k3s-server)" = "/bin/_k3s-inner" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }
       [ "$(readlink ./bin/loopback)" = "cni" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }
+
+      # Include any additional symlinks valid before k3s runs
+      ln -s /bin/_k3s-inner ${{targets.destdir}}/bin/kubectl
+      ln -s /bin/_k3s-inner ${{targets.destdir}}/bin/ctr
+      ln -s /bin/_k3s-inner ${{targets.destdir}}/bin/crictl
 
       # Finally, install the "outer" k3s multicall binary. This should only
       # contain the go runtime plus the self extracting multicall logic, and
@@ -190,10 +191,12 @@ subpackages:
 
 update:
   enabled: true
+  version-transform:
+    - match: \.(\d+)$
+      replace: +k3s$1
   github:
     identifier: k3s-io/k3s
     strip-prefix: v
-    strip-suffix: "+k3s1" # NOTE: Update k3s# if upstream ships a >k3s1 revision
 
 test:
   environment:


### PR DESCRIPTION
this _technically_ already exists in `/var/lib/rancher/k3s/data/current/bin`, but that directoy only exists _post_ startup.

create a link in `/bin` that'll get picked up for the scenarios where `kubectl` needs to be accessed _before_ `k3s` is run