### PR TITLE
fix(gitlab-exporter-17.2): Bundle expected gems

### DIFF
--- a/gitlab-cng-17.2.yaml
+++ b/gitlab-cng-17.2.yaml
@@ -33,7 +33,7 @@ var-transforms:
 package:
   name: gitlab-cng-17.2
   version: 17.2.1
-  epoch: 0
+  epoch: 1
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -309,63 +309,32 @@ subpackages:
         - ruby-3.2
         - libpq-16
         - busybox
-        - ruby3.2-webrick
-        - ruby3.2-faraday
-        - ruby3.2-faraday-excon
-        - ruby3.2-mustermann
         - ruby3.2-bundler
-        - ruby3.2-deep_merge
-        - ruby3.2-redis
-        - ruby3.2-redis-namespace
-        - ruby3.2-sinatra
-        - ruby3.2-puma
-        - ruby3.2-pg
-        - ruby3.2-sidekiq
-        - ruby3.2-quantile
-        - ruby3.2-connection_pool
-        - ruby3.2-tilt
-        - ruby3.2-nio4r
-        - ruby3.2-rack-2.2
-        - ruby3.2-rack-protection
     pipeline:
-      # GitLab-Exporter
       - uses: git-checkout
         with:
           repository: https://gitlab.com/gitlab-org/gitlab-exporter
           tag: ${{vars.exporter-tag}}
           expected-commit: ${{vars.exporter-commit}}
           destination: ./exporter
-      # GitLab-Exporter Runtime Dependencies
-      - uses: ruby/unlock-spec
-      - working-directory: ./exporter
-        runs: |
-          cat gitlab-exporter.gemspec
-
-          # CVE-2023-40175 puma
-          sed -e 's/5.6.7/>= 5.6.7/' -i gitlab-exporter.gemspec
-
-          # CVE-2023-26141 sidekiq conflicting with the redis version as well
-          sed -e 's/6.4.0/>= 6.5.10/' -i gitlab-exporter.gemspec
-          sed -e 's/4.4.0/>= 4.5.0/' -i gitlab-exporter.gemspec
-
-          # Unlock strict version requirements of connection_pool, pg, redis-namespace and quantile
-          sed -e 's/2.2.5/>= 2.4.1/' -i gitlab-exporter.gemspec
-          sed -e 's/1.5.3/>= 1.5.3/' -i gitlab-exporter.gemspec
-          sed -e 's/1.9.0/>= 1.9.0/' -i gitlab-exporter.gemspec
-          sed -e 's/0.2.1/>= 0.2.1/' -i gitlab-exporter.gemspec
-
-          # Unlock Faraday
-          sed -e 's/faraday", \[">= 1.8.0", "<= 2.8.1"\]/faraday", ">= 1.8.0"/' -i gitlab-exporter.gemspec
-          sed -e "s:(=:(>=:g" -i Gemfile.lock
       - uses: ruby/build
         with:
           gem: gitlab-exporter
           dir: ./exporter
-      - uses: ruby/install
-        with:
-          gem: gitlab-exporter
-          version: ${{vars.exporter-tag}}
-          dir: ./exporter
+      - working-directory: ./exporter
+        runs: |
+          TARGET_DIR_BIN="${{targets.contextdir}}/usr/bin"
+          TARGET_DIR_INSTALL="${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/"
+
+          mkdir -p "${TARGET_DIR_BIN}"
+          mkdir -p "${TARGET_DIR_INSTALL}"
+
+          gem install gitlab-exporter-${{vars.exporter-tag}}.gem \
+            --install-dir ${TARGET_DIR_INSTALL}  \
+            --bindir ${TARGET_DIR_BIN} \
+            --version ${{vars.exporter-tag}} \
+            --no-document \
+            --verbose
       - uses: ruby/clean
     test:
       pipeline:


### PR DESCRIPTION
To remediate CVEs, we drop in the latest versions of gems we build in Wolfi

These CVE remediations have unfortunately left the exporter in a broken state. There are several deps that are interdependent and break when incremented

Drop remediations (that no longer appear to be needed anyway) and ship the explicit versions of the gems requested to avoid breaking the exporter in the future