### PR TITLE
kontainer-driver-metadata for rancher

### DIFF
--- a/rancher-kontainer-driver-metadata.yaml
+++ b/rancher-kontainer-driver-metadata.yaml
@@ -1,0 +1,36 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: rancher-kontainer-driver-metadata
+  version: 2.9
+  epoch: 0
+  description: This repository is to keep information of k8s versions and their dependencies like k8s components flags and system addons images.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rancher/kontainer-driver-metadata/
+      branch: release-v${{package.version}}
+      expected-commit: 6b07bc04422dd7cb6cb6bc8fd08f6e6806d48f6b
+
+  - runs: |
+      mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/driver-metadata
+      install -Dm755 data/data.json  ${{targets.contextdir}}/var/lib/rancher-data/driver-metadata/data.json
+
+update:
+  enabled: false
+  exclude-reason: they use branches for releases instead of tags https://github.com/rancher/kontainer-driver-metadata/branches
+
+test:
+  pipeline:
+    - runs: |
+        # check data.json is available at the expected location at `/var/lib/rancher-data/driver-metadata/`
+        test -f /var/lib/rancher-data/driver-metadata/data.json


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
