### PR TITLE
Add renovate test.

### DIFF
--- a/renovate.yaml
+++ b/renovate.yaml
@@ -1,6 +1,6 @@
 package:
   name: renovate
-  version: 38.10.0
+  version: 38.11.1
   epoch: 0
   description: "Automated dependency updates. Multi-platform and multi-language."
   copyright:

--- a/renovate.yaml
+++ b/renovate.yaml
@@ -1,7 +1,7 @@
 package:
   name: renovate
   version: 38.10.0
-  epoch: 0
+  epoch: 1
   description: "Automated dependency updates. Multi-platform and multi-language."
   copyright:
     - license: AGPL-3.0-only
@@ -32,10 +32,23 @@ pipeline:
       sed -i 's/monorepo-symlink-test/false-positive/g' ${{targets.contextdir}}/usr/local/lib/node_modules/renovate/node_modules/resolve/test/resolver/multirepo/package.json
 
 test:
+  environment:
+    environment:
+      # can be dropped after https://github.com/chainguard-dev/melange/pull/1408
+      HOME: /root
   pipeline:
     - name: Verify renovate version
       runs: |
         renovate --version
+    - name: Run with patgithub123
+      runs: |
+        # work around github push protection GH013
+        # renovate_token is github read-only token.
+        set +x
+        t1=_OrLizP6TZHJuTpnEPE9
+        export RENOVATE_TOKEN="ghp${t1}tlc69MrsuS84fUS9Y"
+        set -x
+        renovate --dry-run patgithub123/gomod1
 
 update:
   enabled: true


### PR DESCRIPTION
renovate execution will fail if nodejs version differs from its expected/supported version.
The added test would fail if nodejs were set to 'nodejs'.

The supported node version value comes (I think) from package.json https://github.com/renovatebot/renovate/blob/8b88d9790888c60c4029249e1f554f45f6d44bb2/package.json#L136

It ends up failing with an error like:

    Unsupported node environment detected. Please update your node version.
