### PR TITLE
gcc 13 openssf integration

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 13.3.0
-  epoch: 1
+  epoch: 2
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -85,6 +85,7 @@ pipeline:
         --enable-gnu-unique-object \
         --enable-cet=auto \
         --enable-link-mutex \
+        --with-gcc-major-version-only \
         --with-linker-hash-style=gnu
 
   - runs: |

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -33,6 +33,12 @@ environment:
       - wolfi-baselayout
       - zlib-dev
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
 pipeline:
   - uses: fetch
     with:
@@ -123,12 +129,12 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib64
           mkdir -p "${{targets.subpkgdir}}"/usr/include
-          mkdir -p "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx
           mv "${{targets.destdir}}"/usr/lib64/*++.a "${{targets.subpkgdir}}"/usr/lib64/
           mv "${{targets.destdir}}"/usr/lib64/libstdc++.so "${{targets.subpkgdir}}"/usr/lib64/
           mv "${{targets.destdir}}"/usr/include/*++* "${{targets.subpkgdir}}"/usr/include/
-          mv "${{targets.destdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/* \
-            "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/
+          mv "${{targets.destdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/* \
+            "${{targets.subpkgdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/
 
   - name: "libquadmath"
     description: "128-bit math library provided by GCC"
@@ -149,8 +155,8 @@ subpackages:
     description: "GNU Fortran Compiler"
     pipeline:
       - runs: |
-          _libexecdir=/usr/libexec/gcc/${{host.triplet.gnu}}/${{package.version}}
-          _libdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+          _libexecdir=/usr/libexec/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
+          _libdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
 
           for i in "$_libexecdir" "$_libdir" usr/lib64 usr/bin; do
             mkdir -p "${{targets.subpkgdir}}"/$i
@@ -226,7 +232,7 @@ subpackages:
         - go-bootstrap=1.18
     pipeline:
       - runs: |
-          _libexecdir=/usr/libexec/gcc/${{host.triplet.gnu}}/${{package.version}}
+          _libexecdir=/usr/libexec/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
 
           for i in "$_libexecdir" usr/lib64 usr/bin; do
             mkdir -p "${{targets.subpkgdir}}"/$i


### PR DESCRIPTION
- **gcc: use major version only in filesystem paths**
  Only major versions are co-installable, and this make specs file
  location predictable
  

- **gcc: fixup major-version only libdir**
  Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
  

- **Bump gcc**

This changes paths like these:

    usr/libexec/gcc/x86_64-pc-linux-gnu/13.3.0/cc1

to

    usr/libexec/gcc/x86_64-pc-linux-gnu/13/cc1
  
Like it is in all other distributions, this makes location of specs files predictable within a given gcc release series.