### PR TITLE
adds apache beam python3.11 sdk

### DIFF
--- a/apache-beam-python-3.11-sdk.yaml
+++ b/apache-beam-python-3.11-sdk.yaml
@@ -1,0 +1,69 @@
+package:
+  name: apache-beam-python-3.11-sdk
+  version: 2.57.0
+  epoch: 0
+  description: Apache Beam Python SDK
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - geos-dev
+      - google-cloud-sdk
+      - openjdk-17-default-jvm
+      - python-3.11-base
+      - snappy-dev
+      - yaml-dev
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gcc-12-default
+      - go
+      - openjdk-17
+      - openjdk-17-default-jvm
+      - py3.11-pip
+      - python-3.11-base
+      - python-3.11-base-dev
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/beam
+      expected-commit: e3314d4c942d6fb7c9669e7eb98c5e526b83e1aa
+      tag: v${{package.version}}
+
+  # Since we can't install multiple versions of Python at the same time, and their build system
+  # uses the Python 3.8 while issuing `setupVirtualenv`, this is a hacky-fix to make it work.
+  - runs: ln -sf /usr/bin/python /usr/bin/python3.8
+
+  - runs: |
+      ./gradlew :sdks:python:container:py39:generatePythonRequirements
+      ./gradlew :sdks:python:container:goBuild
+
+  - runs: |
+      pip install --no-deps -v sdks/python/build/apache-beam.tar.gz
+
+      _arch=$(uname -m); case $_arch in aarch64) _arch="arm64" ;; x86_64) _arch="amd64" ;; esac
+      install -D -m 755 sdks/python/container/build/target/launcher/linux_$_arch/boot /usr/bin/boot
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/opt/apache/beam
+          ln -sf /usr/bin/boot ${{targets.contextdir}}/opt/apache/beam/boot
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - sdks/
+  github:
+    identifier: apache/beam
+    strip-prefix: v
+    use-tag: true

--- a/apache-beam-python-3.11-sdk.yaml
+++ b/apache-beam-python-3.11-sdk.yaml
@@ -10,7 +10,7 @@ package:
       - geos-dev
       - google-cloud-sdk
       - openjdk-17-default-jvm
-      - python-3.11-base
+      - python-3.11
       - snappy-dev
       - yaml-dev
 
@@ -25,8 +25,8 @@ environment:
       - openjdk-17
       - openjdk-17-default-jvm
       - py3.11-pip
-      - python-3.11-base
-      - python-3.11-base-dev
+      - python-3.11
+      - python-3.11-dev
   environment:
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
@@ -42,7 +42,7 @@ pipeline:
   - runs: ln -sf /usr/bin/python /usr/bin/python3.8
 
   - runs: |
-      ./gradlew :sdks:python:container:py39:generatePythonRequirements
+      ./gradlew :sdks:python:container:py311:generatePythonRequirements
       ./gradlew :sdks:python:container:goBuild
 
   - runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
