### PR TITLE
xorg-xserver: switch from gcrypt to openssl

### DIFF
--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: xorg-server
   version: 21.1.13
-  epoch: 0
+  epoch: 1
   description: "X Server"
   copyright:
     - license: SGI-B-2.0
@@ -29,7 +29,6 @@ environment:
       - libdrm-dev
       - libepoxy-dev
       - libfontenc-dev
-      - libgcrypt-dev
       - libpciaccess-dev
       - libx11-dev
       - libxcvt-dev
@@ -42,6 +41,7 @@ environment:
       - mesa-dev
       - mesa-gbm
       - mesa-gl
+      - openssl-dev
       - pixman-dev
       - zlib-dev
 


### PR DESCRIPTION
This will reduce number of cryptographic libraries in some images
which already have openssl, as most software uses openssl.
