### PR TITLE
fix the compat and kubewebhook-cert-gen subpackages names

### DIFF
--- a/ingress-nginx-controller-1.11.yaml
+++ b/ingress-nginx-controller-1.11.yaml
@@ -2,7 +2,7 @@
 package:
   name: ingress-nginx-controller-1.11
   version: 1.11.1
-  epoch: 1
+  epoch: 2
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -43,6 +43,12 @@ package:
       - modsecurity
       - mimalloc
       - pcre
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: nginx-ingress-major-minor
 
 environment:
   contents:
@@ -469,7 +475,7 @@ pipeline:
         && setcap -v cap_net_bind_service=+ep ${{targets.destdir}}/usr/bin/dumb-init
 
 subpackages:
-  - name: ${{package.name}}-compat
+  - name: ingress-nginx-controller-compat-${{vars.nginx-ingress-major-minor}}
     description: Compatibility package for ingress-nginx-controller
     dependencies:
       provides:
@@ -505,7 +511,7 @@ subpackages:
   # subpackage of ingress-nginx-controller since the one use
   # (kube-prometheus-stack charts) points to a hybrid tag of the
   # $ingress-nginx-$kube-webhook-certgen version.    # $ingress-nginx-$kube-webhook-certgen version.
-  - name: ${{package.name}}-kube-webhook-certgen
+  - name: kube-webhook-certgen-${{vars.nginx-ingress-major-minor}}
     description: Tools to help with self signed cert generation for Kubernetes test environment
     dependencies:
       provides:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
