### PR TITLE
fix(gitlab-runner-17.2): Add Docker Machine

### DIFF
--- a/gitlab-runner-17.2.yaml
+++ b/gitlab-runner-17.2.yaml
@@ -102,6 +102,11 @@ subpackages:
           tag: v${{vars.machine-tag}}
           expected-commit: ${{vars.machine-commit}}
           destination: ./machine
+      - uses: go/bump
+        with:
+          deps: github.com/golang-jwt/jwt/v4@v4.4.2
+          replaces: github.com/dgrijalva/jwt-go=github.com/golang-jwt/jwt/v4@v4.4.2
+          modroot: ./machine
       - uses: go/build
         with:
           packages: ./cmd/docker-machine

--- a/gitlab-runner-17.2.yaml
+++ b/gitlab-runner-17.2.yaml
@@ -1,19 +1,31 @@
+# This tracks and the expected commit and tag used by Docker Machine.
+# This varies for each version of GitLab's runner and requires manual
+# intervention between updates.
+#
+# Pleas ensure the expected commit and tag match the version of Docker
+# Machine defined here:
+#
+# https://gitlab.com/gitlab-org/gitlab-runner/-/blob/v${{package.version}}/.gitlab/ci/_common.gitlab-ci.yml?ref_type=heads#L17
+vars:
+  machine-commit: 3bd4e68e7958cc0d1b1d61bc2ce69443c7f5c825
+  machine-tag: 0.16.2-gitlab.27
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+
 package:
   name: gitlab-runner-17.2
   version: 17.2.1
-  epoch: 1
+  epoch: 2
   description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
   copyright:
     - license: MIT
   dependencies:
     provides:
       - gitlab-runner=${{package.full-version}}
-
-var-transforms:
-  - from: ${{package.version}}
-    match: ^(\d+\.\d+)\.\d+$
-    replace: "$1"
-    to: short-package-version
 
 pipeline:
   - uses: git-checkout
@@ -33,7 +45,7 @@ pipeline:
       ldflags: -w -X gitlab.com/gitlab-org/gitlab-runner/common.NAME=${{package.name}} -X gitlab.com/gitlab-org/gitlab-runner/common.VERSION=v${{package.version}}
 
 subpackages:
-  - name: gitlab-runner-helper-${{vars.short-package-version}}
+  - name: gitlab-runner-helper-${{vars.major-minor-version}}
     description: GitLab Runner Helper
     dependencies:
       provides:
@@ -45,7 +57,7 @@ subpackages:
           output: gitlab-runner-helper
           ldflags: -w -X gitlab.com/gitlab-org/gitlab-runner/common.NAME=${{package.name}} -X gitlab.com/gitlab-org/gitlab-runner/common.VERSION=v${{package.version}}
 
-  - name: "gitlab-runner-oci-entrypoint-${{vars.short-package-version}}"
+  - name: "gitlab-runner-oci-entrypoint-${{vars.major-minor-version}}"
     description: "Gitlab-runner oci entrypoint"
     dependencies:
       provides:
@@ -56,7 +68,7 @@ subpackages:
           cp dockerfiles/runner/alpine/entrypoint "${{targets.subpkgdir}}"/entrypoint
           chmod 755 "${{targets.subpkgdir}}"/entrypoint
 
-  - name: "gitlab-runner-helper-oci-entrypoint-${{vars.short-package-version}}"
+  - name: "gitlab-runner-helper-oci-entrypoint-${{vars.major-minor-version}}"
     description: "Gitlab-runner-helper oci entrypoint"
     dependencies:
       provides:
@@ -67,7 +79,7 @@ subpackages:
           cp dockerfiles/runner-helper/scripts/gitlab-runner-build "${{targets.subpkgdir}}"/usr/bin/gitlab-runner-build
           cp dockerfiles/runner-helper/helpers/entrypoint "${{targets.subpkgdir}}"/entrypoint
 
-  - name: "gitlab-runner-helper-compat-${{vars.short-package-version}}"
+  - name: "gitlab-runner-helper-compat-${{vars.major-minor-version}}"
     description: "Gitlab-runner-helper compat"
     dependencies:
       provides:
@@ -77,6 +89,30 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           ln -sf /usr/bin/gitlab-runner "${{targets.subpkgdir}}"/usr/bin/gitlab-ci-multi-runner
           ln -sf /usr/bin/miniperl "${{targets.subpkgdir}}"/usr/bin/perl
+
+  - name: gitlab-docker-machine-${{vars.major-minor-version}}
+    description: "Creates Docker hosts used by GitLab runner."
+    dependencies:
+      provides:
+        - gitlab-docker-machine=${{package.full-version}}
+    pipeline:
+      - uses: git-checkout
+        with:
+          repository: https://gitlab.com/gitlab-org/ci-cd/docker-machine
+          tag: v${{vars.machine-tag}}
+          expected-commit: ${{vars.machine-commit}}
+          destination: ./machine
+      - uses: go/build
+        with:
+          packages: ./cmd/docker-machine
+          output: docker-machine
+          ldflags: -w -X github.com/docker/machine/version.GitCommit=$(git rev-parse --short HEAD 2>/dev/null)
+          modroot: ./machine
+    test:
+      pipeline:
+        - runs: |
+            docker-machine -v | grep ${{vars.machine-tag}}
+            docker-machine -h
 
 update:
   enabled: true
@@ -90,7 +126,7 @@ test:
   environment:
     contents:
       packages:
-        - gitlab-runner-helper-compat-${{vars.short-package-version}}
+        - gitlab-runner-helper-compat-${{vars.major-minor-version}}
         - gitlab-runner-helper=${{package.full-version}}
   pipeline:
     - runs: |


### PR DESCRIPTION
Creates a subpackage for Docker Machine, used to create Docker hosts on GitLab's runner
