### PR TITLE
adds py3.11 google-cloud-sdk and updates the older version

### DIFF
--- a/py3.11-crcmod.yaml
+++ b/py3.11-crcmod.yaml
@@ -1,0 +1,55 @@
+package:
+  name: py3.11-crcmod
+  version: "1.7"
+  epoch: 0
+  description: Cyclic Redundancy Check (CRC) implementation in Python
+  copyright:
+    - license: 'MIT'
+  dependencies:
+    runtime:
+      - python-3.11
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3.11-setuptools
+      - python-3.11
+      - python-3.11-dev
+      - wolfi-base
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://files.pythonhosted.org/packages/source/c/crcmod/crcmod-${{package.version}}.tar.gz
+      expected-sha256: dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e
+
+  - runs: |
+      python setup.py build
+
+  - runs: |
+      python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 12017
+
+test:
+  pipeline:
+    - runs: |
+        LIBRARY="crcmod"
+        IMPORT_STATEMENT="import crcmod"
+
+        if ! python -c "$IMPORT_STATEMENT"; then
+            echo "Failed to import library '$LIBRARY'."
+            python -c "$IMPORT_STATEMENT" 2>&1
+            exit 1
+        else
+            echo "Library '$LIBRARY' is installed and can be imported successfully."
+            exit 0
+        fi

--- a/py3.11-google-cloud-sdk.yaml
+++ b/py3.11-google-cloud-sdk.yaml
@@ -1,5 +1,5 @@
 package:
-  name: py3.10-google-cloud-sdk
+  name: py3.11-google-cloud-sdk
   version: 486.0.0
   epoch: 0
   description: "Google Cloud Command Line Interface"
@@ -8,8 +8,8 @@ package:
   dependencies:
     runtime:
       # Required for cyclic redunancy check (gsutil help crcmod)
-      - py3.10-crcmod
-      - python-3.10
+      - py3.11-crcmod
+      - python-3.11
 
 environment:
   contents:
@@ -18,9 +18,9 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3.10-setuptools
-      - python-3.10
-      - python-3.10-dev
+      - py3.11-setuptools
+      - python-3.11
+      - python-3.11-dev
       - wolfi-base
 
 pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
