### PR TITLE
disable the webdav module in nginx per hardening guidelines

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-mainline
   version: 1.27.0
-  epoch: 6
+  epoch: 7
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause
@@ -92,7 +92,6 @@ pipeline:
           --with-http_image_filter_module=dynamic \
           --with-http_geoip_module=dynamic \
           --with-http_sub_module \
-          --with-http_dav_module \
           --with-http_flv_module \
           --with-http_mp4_module \
           --with-http_gunzip_module \

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-stable
   version: 1.26.1
-  epoch: 6
+  epoch: 7
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause
@@ -92,7 +92,6 @@ pipeline:
           --with-http_image_filter_module=dynamic \
           --with-http_geoip_module=dynamic \
           --with-http_sub_module \
-          --with-http_dav_module \
           --with-http_flv_module \
           --with-http_mp4_module \
           --with-http_gunzip_module \


### PR DESCRIPTION
Per various hardening guides, building `nginx` without `webdav` is recommended: https://nginx.org/en/docs/http/ngx_http_dav_module.html

- https://github.com/kubernetes/ingress-nginx/blob/c6e86c86dc0a007e3bda34ee6eee9cabed34eb2c/docs/deploy/hardening-guide.md?plain=1#L39
- https://www.stigviewer.com/stig/web_server_security_requirements_guide/2023-09-13/finding/V-206383