### PR TITLE
git-doc: subpackage

### DIFF
--- a/git.yaml
+++ b/git.yaml
@@ -1,7 +1,7 @@
 package:
   name: git
   version: 2.46.0
-  epoch: 0
+  epoch: 1
   description: "distributed version control system"
   copyright:
     - license: GPL-2.0-or-later
@@ -26,6 +26,12 @@ pipeline:
     with:
       uri: https://www.kernel.org/pub/software/scm/git/git-${{package.version}}.tar.xz
       expected-sha256: 7f123462a28b7ca3ebe2607485f7168554c2b10dfc155c7ec46300666ac27f95
+
+  - uses: fetch
+    working-directory: /home/build/git-manpages
+    with:
+      uri: https://www.kernel.org/pub/software/scm/git/git-manpages-${{package.version}}.tar.xz
+      expected-sha256: dc118b1d4036e58d5cc4f4e804d903e1e137dac3e9826a246a7e517afd877bd3
 
   - runs: |
       cat >> config.mak <<-EOF
@@ -105,6 +111,14 @@ subpackages:
             - wolfi-base
       pipeline:
         - runs: ls /usr/local/etc/profile.d/*.bash
+
+  - name: "git-doc"
+    description: "git manpages"
+    pipeline:
+      - working-directory: /home/build/git-manpages
+        runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/share/man
+          mv man1 man5 man7 "${{targets.contextdir}}"/usr/share/man
 
 update:
   enabled: true


### PR DESCRIPTION
use git-manpages releases to add optional manpages

Signed-off-by: Pris Nasrat <pris.nasrat@chainguard.dev>
