### PR TITLE
 bash - fix test.

### DIFF
--- a/bash.yaml
+++ b/bash.yaml
@@ -1,7 +1,7 @@
 package:
   name: bash
   version: 5.2.32
-  epoch: 1
+  epoch: 2
   description: "GNU bourne again shell"
   copyright:
     - license: GPL-3.0-or-later
@@ -87,6 +87,8 @@ update:
 test:
   pipeline:
     - runs: |
-        /bin/bash --version || grep ${{package.version}}
+        out=$(/bin/bash --version)
+        echo "$out" | grep "${{package.version}}"
     - runs: |
-        /bin/bash -c "echo 'hello world'" || exit 1
+        out=$(/bin/bash -c "echo hello world")
+        [ "$out" = "hello world" ]


### PR DESCRIPTION
The test that was here had incorrect OR ('||')
when what was intended was PIPE ('|'):

    bash --version || grep "${{package.version}}"

Will run bash --version and only execute grep if it failed.

Changed to:

    out=$(/bin/bash --version)
    echo "$out" | grep "${{package.version}}"

This way , due to `set -e` checks that 'bash --version' exits success and that its stdout has package.version inside.

Also improve the second test to validate the output rather than only checking that bash exited zero.
