### PR TITLE
rancher 2.9

### DIFF
--- a/rancher-2.9.yaml
+++ b/rancher-2.9.yaml
@@ -1,12 +1,12 @@
-# NOTE: This is not a complete rancher-2.8 package with all the components.
+# NOTE: This is not a complete rancher-2.9 package with all the components.
 # This is just created for the purpose of building the rancher-agent package.
 vars:
-  CATTLE_SYSTEM_CHART_DEFAULT_BRANCH: release-v2.8
-  CATTLE_CHART_DEFAULT_BRANCH: release-v2.8
+  CATTLE_SYSTEM_CHART_DEFAULT_BRANCH: release-v2.9
+  CATTLE_CHART_DEFAULT_BRANCH: release-v2.9
   CATTLE_PARTNER_CHART_DEFAULT_BRANCH: main
   CATTLE_RKE2_CHART_DEFAULT_BRANCH: main
-  CATTLE_KDM_BRANCH: release-v2.8
-  LOGLEVEL_VERSION: 0.1.5
+  CATTLE_KDM_BRANCH: release-v2.9
+  LOGLEVEL_VERSION: 0.1.6
 
 var-transforms:
   - from: ${{package.version}}
@@ -15,8 +15,8 @@ var-transforms:
     to: major-minor-version
 
 package:
-  name: rancher-2.8
-  version: 2.8.5
+  name: rancher-2.9
+  version: 2.9.0
   epoch: 0
   description: Complete container management platform
   copyright:
@@ -42,7 +42,7 @@ pipeline:
     with:
       repository: https://github.com/rancher/rancher
       tag: v${{package.version}}
-      expected-commit: 7af1354e9b8900cec6e5360787e291acd376e6d3
+      expected-commit: 9e0cc54e7e3a924cf0ed5c5d4db0a6e53805c75e
 
 subpackages:
   - name: rancher-agent-${{vars.major-minor-version}}
@@ -59,11 +59,25 @@ subpackages:
         - rancher-loglevel-${{vars.major-minor-version}}
         - rancher-rke2-charts-${{vars.major-minor-version}}
         - rancher-helm3-charts-${{vars.major-minor-version}}
+        - util-linux-misc # unshare
+        - mount
+        - umount
+        - busybox # nsenter
+        - util-linux-dev
+        - jq
+        - gzip
+        - gawk
+        - bash
+        - sysstat
+        - acl-dev
+        - vim
+        - iproute2
+        - net-tools
+        - openssh-client
     pipeline:
       - uses: go/bump
         with:
-          deps: github.com/crewjam/saml@v0.4.14 github.com/go-jose/go-jose/v3@v3.0.3 github.com/hashicorp/go-retryablehttp@v0.7.7 google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0 k8s.io/kubernetes@v1.28.12 k8s.io/apiserver@v0.28.12 github.com/rancher/apiserver@v0.0.0-20240207153957-4fd7d821d952 github.com/rancher/norman@v0.0.0-20240207153100-3bb70b772b52
-          modroot: .
+          deps: github.com/go-jose/go-jose/v3@v3.0.3 k8s.io/kubernetes@v1.30.3 k8s.io/apiserver@v0.30.3
       - uses: go/build
         with:
           packages: ./cmd/agent
@@ -71,6 +85,11 @@ subpackages:
           ldflags: |
             -X main.VERSION=${{package.version}}
           tags: k8s
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/bin
+          install -Dm755 package/run.sh ${{targets.contextdir}}/usr/bin/
+          install -Dm755 package/kubectl-shell.sh ${{targets.contextdir}}/usr/bin/
+          install -Dm755 package/shell-setup.sh ${{targets.contextdir}}/usr/bin/
     test:
       pipeline:
         - runs: |
@@ -85,7 +104,7 @@ subpackages:
         with:
           repository: https://github.com/rancher/kontainer-driver-metadata/
           branch: ${{vars.CATTLE_KDM_BRANCH}}
-          expected-commit: c331ba8be30b10d6bf6fbd341d43da6c03214803
+          expected-commit: 6b07bc04422dd7cb6cb6bc8fd08f6e6806d48f6b
           destination: kontainer-driver-metadata
       - working-directory: ./kontainer-driver-metadata
         runs: |
@@ -107,7 +126,7 @@ subpackages:
           repository: https://github.com/rancher/system-charts
           branch: ${{vars.CATTLE_SYSTEM_CHART_DEFAULT_BRANCH}}
           destination: system-charts
-          expected-commit: 1eb0ac24e9e4d50bd0666f6530d05f45c9158994
+          expected-commit: 653a0337600f04df3a975106468a17bd64d6e1f9
       - working-directory: ./system-charts
         runs: |
           mkdir -p ${{targets.contextdir}}/var/lib/rancher-data/local-catalogs/system-library
@@ -128,7 +147,7 @@ subpackages:
           repository: https://github.com/rancher/partner-charts
           branch: ${{vars.CATTLE_PARTNER_CHART_DEFAULT_BRANCH}}
           destination: partner-charts
-          expected-commit: 00460454010ae9083847290b4426000e10618b52
+          expected-commit: 84b4f2fea5c87b5c5141dbed7580e07071907b75
       - working-directory: ./partner-charts
         runs: |
           shasum256=$(echo -n "https://git.rancher.io/partner-charts" |shasum -a 256 | awk '{ print $1 }')
@@ -155,7 +174,7 @@ subpackages:
           repository: https://github.com/rancher/charts
           branch: ${{vars.CATTLE_CHART_DEFAULT_BRANCH}}
           destination: charts
-          expected-commit: 0ccfd2651d7edc49c10a3e4204ecf742c1df6a02
+          expected-commit: bfa3b06d877703e24c94f62187cdfce3cdbb2c67
           depth: -1
       - working-directory: ./charts
         runs: |
@@ -235,7 +254,7 @@ subpackages:
     pipeline:
       - uses: git-checkout
         with:
-          expected-commit: 54744f948c5b400647b8b2b7d7bcd5285789eae7
+          expected-commit: 467a3f813c0a5f988fd1be76545ed28af15d9afc
           repository: https://github.com/rancher/loglevel
           tag: v${{vars.LOGLEVEL_VERSION}}
           destination: loglevel


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
