### PR TITLE
spark: omit openjdk from runtime deps

### DIFF
--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -1,18 +1,20 @@
 package:
   name: spark-3.5
   version: 3.5.1
-  epoch: 7
+  epoch: 8
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
       - spark=${{package.full-version}}
+    # Both `python` and `openjdk-{11,17}-default-jvm` are required for running Spark,
+    # but will be added in the image, since upstream supports different Python versions
+    # and Java versions. So we don't need to specify them here to avoid conflicts.
     runtime:
+      - R
       - bash
       - busybox
-      - openjdk-17
-      - openjdk-17-default-jvm
       - procps
 
 environment:
@@ -128,8 +130,8 @@ test:
   environment:
     contents:
       packages:
-        - R
         - python3
+        - openjdk-17-default-jvm
     environment:
       LANG: en_US.UTF-8
       JAVA_HOME: /usr/lib/jvm/java-17-openjdk


### PR DESCRIPTION
This PR omits `openjdk-17` dependency on the runtime, to allow to use with both 11 and 17 versions.

Upstream image built with JDK8.

And since they [support](https://github.com/apache/spark/blob/6bf6088e7719eccf050910d6ae495b369afb25be/python/docs/source/getting_started/install.rst#python-versions-supported) Python versions starting from > 3.9, the related Python version will be added in the image.