### PR TITLE
fix: add nanohttp suppport

### DIFF
--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxml2
   version: 2.13.3
-  epoch: 0
+  epoch: 1
   description: XML parsing library, version 2
   copyright:
     - license: MIT
@@ -42,7 +42,8 @@ pipeline:
       opts: |
         PYTHON=/usr/bin/python3 \
         --with-lzma \
-        --with-zlib
+        --with-zlib \
+        --with-http
 
   - uses: autoconf/make
 


### PR DESCRIPTION
libxml2 make http support disable by default, but some other libs not make this change yet.
For example, `libgsf` need `xmlNanoHTTPOpen` symbol on `libxml2.so`
```
symbol lookup error: /usr/lib/libgsf-1.so.114: undefined symbol: xmlNanoHTTPOpen, version LIBXML2_2.4.30
```
With this flag we generate this simbols
```
# old compilation
[sdk] ❯ nm -gDC usr/lib/libxml2.so.2.13.3 | grep xmlNanoHTTPOpenen
[sdk] ❯
# new compilation
[sdk] ❯ nm -gDC usr/lib/libxml2.so.2.13.3-1 | grep xmlNanoHTTPOpen
0000000000095260 T xmlNanoHTTPOpen@@LIBXML2_2.4.30
0000000000095200 T xmlNanoHTTPOpenRedir@@LIBXML2_2.4.30
[sdk] ❯
```

Ref: https://github.com/GNOME/libxml2/commit/3018842c07e9b88d6bb0257f5644e7695cdeb2e2

cc @lpcalisi @icasarino