### PR TITLE
pgaudit-16: provide pgaudit

### DIFF
--- a/pgaudit-16.yaml
+++ b/pgaudit-16.yaml
@@ -3,10 +3,13 @@
 package:
   name: pgaudit-16
   version: 16.0
-  epoch: 2
+  epoch: 3
   description: PostgreSQL Audit Extension
   copyright:
     - license: BSD-3-Clause
+  dependencies:
+    provides:
+      - pgaudit=${{package.full-version}}
 
 environment:
   contents:


### PR DESCRIPTION
This enables the public image build, which depends on the version-less `pgaudit` package, which nothing currently provides.