### PR TITLE
libgsf: fix FTBFS against new libxml2

### DIFF
--- a/libgsf.yaml
+++ b/libgsf.yaml
@@ -46,8 +46,9 @@ pipeline:
   - runs: |
       git fetch origin master:master
       # Fix failure to build from source against new libxml2, without
-      # nanohttp support. Ignore merge conflict in NEWS.
-      git cherry-pick -x 5d4bb55095d3d6ef793c1908a88504183e28644c || true
+      # nanohttp support.
+      git show 5d4bb55095d3d6ef793c1908a88504183e28644c -- configure.ac gsf/gsf-input-http.c > partial-cherry-pick.patch
+      git apply partial-cherry-pick.patch
 
   - runs: |
       sed -i -e 's/gsf-gnome//' -e 's/thumbnailer//' Makefile.*

--- a/libgsf.yaml
+++ b/libgsf.yaml
@@ -2,7 +2,7 @@
 package:
   name: libgsf
   version: 1.14.52
-  epoch: 1
+  epoch: 2
   description: Utility library for reading and writing structured file formats
   copyright:
     - license: LGPL-2.1-only
@@ -42,6 +42,12 @@ pipeline:
       repository: https://gitlab.gnome.org/GNOME/libgsf.git
       expected-commit: ea9d8cd1369661bf62d0476474700a9e0887c812
       tag: LIBGSF_${{vars.mangled-package-version}}
+
+  - runs: |
+      git fetch origin master:master
+      # Fix failure to build from source against new libxml2, without
+      # nanohttp support. Ignore merge conflict in NEWS.
+      git cherry-pick -x 5d4bb55095d3d6ef793c1908a88504183e28644c || true
 
   - runs: |
       sed -i -e 's/gsf-gnome//' -e 's/thumbnailer//' Makefile.*


### PR DESCRIPTION
Fix failure to build from source against new libxml2 without nanohttp support.

This is alternative to:
- #25640