### PR TITLE
Add patchutils package.

### DIFF
--- a/patchutils.yaml
+++ b/patchutils.yaml
@@ -1,0 +1,84 @@
+# Generated from https://git.alpinelinux.org/aports/plain/main/patchutils/APKBUILD
+package:
+  name: patchutils
+  version: 0.4.2
+  epoch: 0
+  description: A collection of programs for manipulating patch files
+  copyright:
+    - license: GPL-2.0-or-later
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - docbook-xml
+      - perl
+      - xmlto
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/twaugh/patchutils.git
+      expected-commit: 00619c9315af6b7dab30ac7474fad917a815f591
+      tag: ${{package.version}}
+
+  - runs: ./bootstrap
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: patchutils-extra
+    description: patchutils scripts
+    dependencies:
+      runtime:
+        - ${{package.name}}
+        - python3
+        - busybox
+    pipeline:
+      - runs: |
+          # interdiff, rediff, filterdiff are c programs
+          # other tools are either
+          # 1. symlinks to those
+          # 2. shell or python script with further depends (sed, vim, ...)
+          # throw all of the scripts into a this package.
+          echo name=${{package.name}}
+          mkdir -p ${{targets.contextdir}}/usr/bin
+          cd ${{targets.destdir}}/usr/bin
+          for f in *; do
+              if head -c 2 "$f" | grep -q '#!'; then
+                mv -v "$f" ${{targets.contextdir}}/usr/bin
+              fi
+          done
+
+  - name: patchutils-doc
+    pipeline:
+      - uses: split/manpages
+    description: patchutils manpages
+
+test:
+  pipeline:
+    - name: run --help
+      runs: |
+        set +x
+        fails=0
+        for p in filterdiff interdiff rediff ; do
+            echo "$ $p --help"
+            if ! "$p" --help; then
+                echo "FAIL: $p --help exited $?"
+                fails=$((fails+1))
+            fi
+        done
+        [ $fails -eq 0 ]
+
+update:
+  enabled: true
+  github:
+    identifier: twaugh/patchutils


### PR DESCRIPTION
My interest in patchutils is currently for 'filterdiff', which would be useful for cherry-picking patches that edit a file that many changes edit (ie, a NEWs file or changelog).

I'm suggesting the addition of patchutils for a need seen in https://github.com/wolfi-dev/os/pull/25652/files