### PR TITLE
add k6 package 

### DIFF
--- a/k6.yaml
+++ b/k6.yaml
@@ -1,0 +1,41 @@
+package:
+  name: k6
+  version: 0.52.0
+  epoch: 0
+  description: A modern load testing tool, using Go and JavaScript
+  copyright:
+    - license: AGPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/grafana/k6
+      tag: v${{package.version}}
+      expected-commit: 20f8febb5becbdc571f46adc8cdcfc0df1113a5f
+
+  - uses: go/build
+    with:
+      packages: .
+      output: k6
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: grafana/k6
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        k6 version


### PR DESCRIPTION
k6: new package 

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license _(not sure)_
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)