### PR TITLE
squid - add test of squid proxy

### DIFF
--- a/squid.yaml
+++ b/squid.yaml
@@ -2,7 +2,7 @@
 package:
   name: squid
   version: "6.10"
-  epoch: 1
+  epoch: 2
   description: Full-featured Web proxy cache server
   copyright:
     - license: GPL-2.0-or-later
@@ -37,6 +37,14 @@ pipeline:
       expected-commit: e071b58dfccdf8805fd32b7e4cce239ee12182d9
       repository: https://github.com/squid-cache/squid.git
       tag: SQUID_${{vars.mangled-package-version}}
+
+  - runs: |
+      set -x
+      # see https://github.com/chainguard-dev/melange/issues/1422
+      git fetch --no-tags origin master:master
+      # Fix bootstrap build with automake 1.17
+      git show 82e18891262580e1d6ea23e97283ab0dccaa8c1e -- bootstrap.sh > partial-cherry-pick.patch
+      git apply partial-cherry-pick.patch
 
   - runs: ./bootstrap.sh
 

--- a/squid.yaml
+++ b/squid.yaml
@@ -87,6 +87,7 @@ update:
   github:
     identifier: squid-cache/squid
     strip-prefix: SQUID_
+    use-tag: true
 
 test:
   environment:

--- a/squid.yaml
+++ b/squid.yaml
@@ -89,6 +89,51 @@ update:
     strip-prefix: SQUID_
 
 test:
+  environment:
+    accounts:
+      groups:
+        - groupname: squid
+          gid: 65532
+      users:
+        - username: squid
+          gid: 65532
+          uid: 65532
+    contents:
+      packages:
+        - curl
   pipeline:
     - runs: |
         squid -v
+    - name: Squid Server sniff
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          cfg=/etc/squid.conf
+          [ -f "$cfg" ] || { echo "no $cfg file found"; exit 1; }
+          # default is 30 seconds idle before exit on SIGTERM
+          echo "shutdown_lifetime 1 seconds" >> "$cfg"
+          # not sure why, but chown 65532:65532 /var/log/squid fails with Invalid argument
+          # so just chmod
+          chmod ugo+w /var/log/squid/
+        start: squid -N -d1
+        expected_output: |
+          Accepting HTTP Socket connections
+          listening port: 3128
+        post: |
+          host="cgr.dev"
+          url="https://$host/"
+          expected="chainguard"
+          proxy=127.0.0.1:3128
+
+          echo "checking $url for \"$expected\" via proxy $proxy"
+          out=$(HTTPS_PROXY=$proxy curl --silent --location --fail-with-body "$url")
+          echo "$out" | grep -qi "$expected" || {
+            echo "FAIL: output of url $url did not contain \"$expected\""
+            echo "$out"
+            exit 1
+          }
+          echo "PASS: $url contained \"$expected\""
+          log=/var/log/squid/access.log
+          grep -q "$host" "$log" &&
+             echo "PASS: $log contained $host" ||
+             { echo "FAIL: $log did not contain \"$host\""; exit 1; }


### PR DESCRIPTION
Add squid test via test/daemon-check-output.
Test depends on:
1. cgr.dev being up
2. content at https://cgr.dev/ having string 'chainguard'.
