### PR TITLE
py3-breezy: new package

### DIFF
--- a/py3-breezy.yaml
+++ b/py3-breezy.yaml
@@ -1,0 +1,63 @@
+# Generated from https://pypi.org/project/breezy/
+package:
+  name: py3-breezy
+  version: 3.3.8
+  epoch: 0
+  description: Friendly distributed version control system
+  copyright:
+    - license: GPL-2.0-or-later
+  dependencies:
+    runtime:
+      - python-3
+      - py3-configobj
+      - py3-dulwich
+      - py3-fastbencode
+      - py3-merge3
+      - py3-patiencediff
+      - py3-tzlocal
+      - py3-urllib3
+      - py3-pyyaml
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - python3-dev
+      - rust
+      - wolfi-base
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 14d59bbdf86b66c17327eb79a5883b4c70cc7794ed34f3e8a0adfce64edc58bf
+      uri: https://files.pythonhosted.org/packages/source/b/breezy/breezy-${{package.version}}.tar.gz
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+test:
+  pipeline:
+    - runs: |
+        mkdir test
+        cd test
+        brz init-repo .
+        brz init
+        cat > hello.txt <<'EOF'
+        Hello
+        EOF
+        brz add hello.txt
+        brz whoami 'Test test@chainguard.dev'
+        brz commit -m 'Test commit'
+        brz log
+
+update:
+  enabled: true
+  github:
+    identifier: breezy-team/breezy
+    strip-prefix: brz-
+    tag-filter: brz-
+    use-tag: true


### PR DESCRIPTION
* "py3-breezy: new package"


```
Run wolfictl scan \
🔎 Scanning "/tmp/artifacts-1/packages/x86_64/py3-breezy-3.3.8-r0.apk"
└── 📄 /.PKGINFO
        📦 py3-breezy 3.3.8-r0 (apk)
            Medium CVE-2012-5811
```
points to https://nvd.nist.gov/vuln/detail/CVE-2012-5811 but that's for an Android printing app with the same name, not this distributed version control.