### PR TITLE
Add py3-pip-wheel and py3-setuptools-wheel as for ensurepip

### DIFF
--- a/py3-pip-wheel.yaml
+++ b/py3-pip-wheel.yaml
@@ -1,0 +1,34 @@
+# This package provides a binary wheel for python-3.XX packages
+# in lieu of ensurepip's bundled wheels.  It allows us to proctively
+# update those wheels by tracking the upstream package release.
+# python is compiled with --with-wheel-pkg-dir=/usr/share/python-wheels
+package:
+  name: py3-pip-wheel
+  version: "24.2"
+  epoch: 0
+  description: "python3 pip wheel from pypi"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://files.pythonhosted.org/packages/py3/p/pip/pip-${{package.version}}-py3-none-any.whl
+      expected-sha256: 2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2
+      extract: false
+
+  - name: Install wheel
+    runs: |
+      wdir="${{targets.contextdir}}/usr/share/python-wheels"
+      mkdir -p "$wdir"
+      cp -v *.whl "$wdir"
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 6529

--- a/py3-setuptools-wheel.yaml
+++ b/py3-setuptools-wheel.yaml
@@ -1,0 +1,34 @@
+# This package provides a binary wheel for python-3.XX packages
+# in lieu of ensurepip's bundled wheels.  It allows us to proctively
+# update those wheels by tracking the upstream package release.
+# python is compiled with --with-wheel-pkg-dir=/usr/share/python-wheels
+package:
+  name: py3-setuptools-wheel
+  version: "72.1.0"
+  epoch: 0
+  description: "python3 setuptools wheel from pypi"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://files.pythonhosted.org/packages/py3/s/setuptools/setuptools-${{package.version}}-py3-none-any.whl
+      expected-sha256: 5a03e1860cf56bb6ef48ce186b0e557fdba433237481a9a625176c2831be15d1
+      extract: false
+
+  - name: Install wheel
+    runs: |
+      wdir="${{targets.contextdir}}/usr/share/python-wheels"
+      mkdir -p "$wdir"
+      cp -v *.whl "$wdir"
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 4021


### PR DESCRIPTION
_This is the first half of https://github.com/wolfi-dev/os/pull/25818.  That PR is failing to test because it tries to test python packages before building the newly added py3-setuptools-wheel and py3-pip-wheel upon which they runtime depend._

cpython's stdlib package 'ensurepip' bundles a pip wheel inside the python distribution.  That is used to 'ensure' that there is a pip inside a `python3 -m venv mydir`.  In python 3.8 to python 3.11 there is also a bundled setuptools wheel.

That wheel is updated occasionally.

In order to make sure we're shipping the most recent versions of setuptools and pip, we are removing the wheels from the python packages and adding a dependency on these "wheel" packages.
