### PR TITLE
go-licenses: Add test reproing the failure.

### DIFF
--- a/go-licenses.yaml
+++ b/go-licenses.yaml
@@ -44,15 +44,17 @@ test:
         tag: v${{package.version}}
         expected-commit: 5348b744d0983d85713295ea08a20cca1654a45e
 
-    - runs: |
+    - name: Test go-licenses when installed with go install
+      runs: |
         mkdir /tmp/go
         export GOPATH=/tmp/go
-        go install github.com/google/go-licenses@v1.6.0
+        go install github.com/google/go-licenses@v${{package.version}}
         cd testdata/modules/hello01/
         /tmp/go/bin/go-licenses csv . > /tmp/licenses-installed.csv
         diff ./licenses.csv /tmp/licenses-installed.csv
 
-    - runs: |
+    - name: Test go-licenses when using apk
+      runs: |
         cd testdata/modules/hello01/
         go-licenses csv . > /tmp/licenses-new.csv
         diff ./licenses.csv /tmp/licenses-new.csv

--- a/go-licenses.yaml
+++ b/go-licenses.yaml
@@ -31,6 +31,32 @@ pipeline:
 
   - uses: strip
 
+test:
+  environment:
+    contents:
+      packages:
+        - git
+        - go
+  pipeline:
+    - uses: git-checkout
+      with:
+        repository: https://github.com/google/go-licenses
+        tag: v${{package.version}}
+        expected-commit: 5348b744d0983d85713295ea08a20cca1654a45e
+
+    - runs: |
+        mkdir /tmp/go
+        export GOPATH=/tmp/go
+        go install github.com/google/go-licenses@v1.6.0
+        cd testdata/modules/hello01/
+        /tmp/go/bin/go-licenses csv . > /tmp/licenses-installed.csv
+        diff ./licenses.csv /tmp/licenses-installed.csv
+
+    - runs: |
+        cd testdata/modules/hello01/
+        go-licenses csv . > /tmp/licenses-new.csv
+        diff ./licenses.csv /tmp/licenses-new.csv
+
 update:
   enabled: true
   github:


### PR DESCRIPTION
go-licenses apk package does not seem to work as expected, so add a test showing how it fails when using apk, and works with the `go install` one.

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
