### PR TITLE
openssl hardening

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -108,9 +108,6 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libcrypto.so.3 "${{targets.subpkgdir}}"/usr/lib
 
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/engines-3
-          mv "${{targets.destdir}}"/usr/lib/engines-3/loader_attic.so "${{targets.subpkgdir}}"/usr/lib/engines-3/
-
   - name: "libssl3"
     description: "OpenSSL libssl library"
     pipeline:
@@ -130,6 +127,13 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib/engines-3
           mv "${{targets.destdir}}"/usr/lib/engines-3/${{range.key}}.so "${{targets.subpkgdir}}"/usr/lib/engines-3/
+
+  - name: "openssl-engine-loader-attic"
+    description: "OpenSSL Loader Attic internal test engine"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/engines-3
+          mv "${{targets.destdir}}"/usr/lib/engines-3/loader_attic.so "${{targets.subpkgdir}}"/usr/lib/engines-3/
 
   - name: "openssl-provider-legacy"
     description: "OpenSSL legacy provider"

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.3.1
-  epoch: 4
+  epoch: 5
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -21,7 +21,14 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - openssf-compiler-options
       - perl
+  environment:
+    # Using openssf-compiler-options instead
+    CFLAGS: ""
+    CPPFLAGS: ""
+    CXXFLAGS: ""
+    LDFLAGS: ""
 
 pipeline:
   - uses: git-checkout
@@ -150,6 +157,9 @@ test:
         - git
         - wget
   pipeline:
+    - uses: test/hardening-check
+      with:
+        package-match: "^openssl$\\|libssl3\\|libcrypto3"
     - name: Verify curl still works
       runs: |
         curl -I https://github.com/openssl/openssl


### PR DESCRIPTION
- **Split deprecated internal testing engine into seperate sub-package**
  No engines should be installed or used by default. And loader_attic is
  a unit-tests only engine.
  
  Split into separate package like all other engines.
  

- **Switch to using openssf-compiler-options**
  This stops using environmental variables, and relies on config files to
  produce hardened binaries.
  
  Add hardening-check to verify hardening.
  
  Net improvement is addition of Stack Clash protection and Control flow
  integrity to our build of OpenSSL.
  