### PR TITLE
test/hardening-check: enforce cfprotection on x86_64 by default

### DIFF
--- a/busybox.yaml
+++ b/busybox.yaml
@@ -125,6 +125,8 @@ subpackages:
 test:
   pipeline:
     - uses: test/hardening-check
+      with:
+        args: --nocfprotection
     - runs: |
         busybox --help
         busybox --list-full >full.txt

--- a/pipelines/test/hardening-check.yaml
+++ b/pipelines/test/hardening-check.yaml
@@ -15,9 +15,7 @@ inputs:
   args:
     description: |
       arguments to pass to hardening-check
-    required: true
-    # Current toolchains do not have cf-protection turned on
-    default: '--nocfprotection'
+    default: ''
 
 pipeline:
   - name: "check files for hardening flags"


### PR DESCRIPTION
Instead, explicitely opt out of CF protection check in the busybox
package, as it appears to be an exception, rather than the rule.

There are no other users of this check as of right now.
