### PR TITLE
zlib openssf

### DIFF
--- a/zlib.yaml
+++ b/zlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: zlib
   version: 1.3.1
-  epoch: 3
+  epoch: 4
   description: "a library implementing the zlib compression algorithms"
   copyright:
     - license: MPL-2.0 AND MIT
@@ -15,7 +15,14 @@ environment:
       - busybox
       - ca-certificates-bundle
       - libtool
+      - openssf-compiler-options
       - wolfi-baselayout
+  environment:
+    # Using openssf-compiler-options instead
+    CFLAGS: ""
+    CPPFLAGS: ""
+    CXXFLAGS: ""
+    LDFLAGS: ""
 
 pipeline:
   - uses: git-checkout
@@ -25,7 +32,7 @@ pipeline:
       tag: v${{package.version}}
 
   - runs: |
-      CHOST="${{host.triplet.gnu}}" ./configure \
+      ./configure \
         --prefix=/usr \
         --libdir=/lib \
         --shared
@@ -92,6 +99,16 @@ subpackages:
             --enable-static=no
           make
           make install DESTDIR="${{targets.contextdir}}"
+
+test:
+  environment:
+    contents:
+      packages:
+        - minizip
+  pipeline:
+    - uses: test/hardening-check
+      with:
+        package-match: "zlib\\|minizip"
 
 update:
   enabled: true


### PR DESCRIPTION
- **OpenSSF hardening of zlib**
  Add test case to check hardening, add openssf-compiler-options as a
  build dependency. Fix configure script, to use native gcc for build.
  
  This enables Control Flow integrity for zlib.
  