### PR TITLE
chore(gitaly-17.2): bump to 17.2.2

### DIFF
--- a/gitaly-17.2.yaml
+++ b/gitaly-17.2.yaml
@@ -1,6 +1,6 @@
 package:
   name: gitaly-17.2
-  version: 17.2.1
+  version: 17.2.2
   epoch: 0
   description:
   copyright:
@@ -36,7 +36,7 @@ pipeline:
     with:
       repository: https://gitlab.com/gitlab-org/gitaly.git
       tag: v${{package.version}}
-      expected-commit: d91c5dafd5ffa6a60032219cd8ff7f24650c4e05
+      expected-commit: f361b25764d8001ad58f2b64c2fe8bbc898870df
 
   - uses: go/bump
     with:


### PR DESCRIPTION


#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0


