### PR TITLE
abseillib: withdraw old naming broken by single name in range loop

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -6,3 +6,9 @@ redis-sentinel-7.2-bitnami-compat-7.4.0-r0.apk
 redis-cluster-7.2-bitnami-compat-7.4.0-r0.apk
 rancher-kontainer-driver-metadata-2.9-r0.apk
 rancher-loglevel-0.1.6-r0.apk
+abseillib-20230802.0-r0.apk
+abseillib-20230802.0-r1.apk
+abseillib-20230802.1-r0.apk
+abseillib-20240116.0-r0.apk
+abseillib-20240116.1-r0.apk
+abseillib-20240116.2-r0.apk


### PR DESCRIPTION
See https://github.com/wolfi-dev/os/blob/dcdbbbe5b40e832af12dce53dbc7143241d4be4c/abseil-cpp.yaml#L150

See: https://github.com/wolfi-dev/os/pull/20351 which fixed this
Signed-off-by: Pris Nasrat <pris.nasrat@chainguard.dev>
