### PR TITLE
fix: poppler-glib support

### DIFF
--- a/poppler.yaml
+++ b/poppler.yaml
@@ -1,7 +1,7 @@
 package:
   name: poppler
   version: 24.08.0
-  epoch: 0
+  epoch: 1
   description: Poppler is a PDF rendering library based on the xpdf-3.0 code base.
   copyright:
     - license: GPL-2.0-or-later
@@ -14,8 +14,9 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cairo-dev
-      - cmake
       - expat-dev
+      - glib-dev
+      - glib-gir
       - gobject-introspection-dev
       - lcms2-dev
       - libfontconfig1
@@ -26,7 +27,6 @@ environment:
       - libxml2-dev
       - openjpeg-dev
       - openjpeg-tools
-      - samurai
       - tiff-dev
       - zlib-dev
 
@@ -44,7 +44,8 @@ pipeline:
         -DENABLE_LIBCURL=OFF \
         -DCMAKE_BUILD_TYPE=Release \
         -DENABLE_QT5=OFF \
-        -DENABLE_QT6=OFF
+        -DENABLE_QT6=OFF \
+        -DENABLE_GLIB=ON
 
   - uses: cmake/build
 
@@ -52,18 +53,6 @@ pipeline:
 
 subpackages:
   - name: poppler-dev
-    pipeline:
-      - uses: split/dev
-
-  - name: poppler-doc
-    pipeline:
-      - uses: split/dev
-
-  - name: poppler-glib
-    pipeline:
-      - uses: split/dev
-
-  - name: poppler-utils
     pipeline:
       - uses: split/dev
 


### PR DESCRIPTION
The package as currently defined does not provide support for poppler-glib, although a subpackage being created

Fixes:

Add support for glib in poppler package

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

