### PR TITLE
create Jupyterhub k8s network tools package

### DIFF
--- a/jupyterhub-k8s-network-tools.yaml
+++ b/jupyterhub-k8s-network-tools.yaml
@@ -1,0 +1,33 @@
+package:
+  name: jupyterhub-k8s-network-tools
+  version: 3.3.8
+  epoch: 0
+  description: Network diagnostic tools for use within a JupyterHub Kubernetes cluster
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - iptables
+      - wolfi-base
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - name: Install
+    runs: |
+      mkdir -p "${{targets.destdir}}"
+
+test:
+  pipeline:
+    - name: Test iptables
+      runs: |
+        iptables --version
+
+update:
+  enabled: true
+  github:
+    identifier: jupyterhub/zero-to-jupyterhub-k8s
+    use-tag: true

--- a/jupyterhub-k8s-network-tools.yaml
+++ b/jupyterhub-k8s-network-tools.yaml
@@ -1,4 +1,7 @@
-package:
+Creates a package which represents the following upstream image:
+- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/images/network-tools/Dockerfile
+
+At the time of writing, the image only contains iptables. We also need the package to take it's versioning from the upstream repo. Essentially this is just a wolfi-base image with iptables, that takes it's versioning from the upstream image repo (Until such times that upstream add additional tool in future)
   name: jupyterhub-k8s-network-tools
   version: 3.3.8
   epoch: 0

--- a/jupyterhub-k8s-network-tools.yaml
+++ b/jupyterhub-k8s-network-tools.yaml
@@ -1,7 +1,5 @@
-Creates a package which represents the following upstream image:
-- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/images/network-tools/Dockerfile
-
-At the time of writing, the image only contains iptables. We also need the package to take it's versioning from the upstream repo. Essentially this is just a wolfi-base image with iptables, that takes it's versioning from the upstream image repo (Until such times that upstream add additional tool in future)
+# At the time of writing, the image only contains iptables. We also need the package to take it's versioning from the upstream repo. Essentially this is just a wolfi-base image with iptables, that takes it's versioning from the upstream image repo (Until such times that upstream add additional tool in future)
+package:
   name: jupyterhub-k8s-network-tools
   version: 3.3.8
   epoch: 0

--- a/jupyterhub-k8s-network-tools.yaml
+++ b/jupyterhub-k8s-network-tools.yaml
@@ -8,7 +8,6 @@ package:
   dependencies:
     runtime:
       - iptables
-      - wolfi-base
 
 environment:
   contents:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related: https://github.com/chainguard-dev/image-requests/issues/3789

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
