### PR TITLE
Update pyhosted urls to update-friendly version

### DIFF
--- a/pip-zipapp.yaml
+++ b/pip-zipapp.yaml
@@ -1,7 +1,7 @@
 package:
   name: pip-zipapp
   version: "24.2"
-  epoch: 0
+  epoch: 1
   description: "Pip as a python zipapp"
   copyright:
     - license: MIT
@@ -28,27 +28,27 @@ pipeline:
       extract: false
   - uses: fetch
     with:
-      uri: "https://files.pythonhosted.org/packages/e5/ca/1172b6638d52f2d6caa2dd262ec4c811ba59eee96d54a7701930726bce18/installer-0.7.0-py3-none-any.whl"
+      uri: "https://files.pythonhosted.org/packages/py3/i/installer/installer-0.7.0-py3-none-any.whl"
       expected-sha256: "05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53"
       extract: false
   - uses: fetch
     with:
-      uri: "https://files.pythonhosted.org/packages/de/88/70c5767a0e43eb4451c2200f07d042a4bcd7639276003a9c54a68cfcc1f8/setuptools-70.0.0-py3-none-any.whl"
-      expected-sha256: "54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4"
+      uri: "https://files.pythonhosted.org/packages/py3/s/setuptools/setuptools-72.1.0-py3-none-any.whl"
+      expected-sha256: "5a03e1860cf56bb6ef48ce186b0e557fdba433237481a9a625176c2831be15d1"
       extract: false
   - uses: fetch
     with:
-      uri: "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl"
+      uri: "https://files.pythonhosted.org/packages/py3/t/tomli/tomli-2.0.1-py3-none-any.whl"
       expected-sha256: "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"
       extract: false
   - uses: fetch
     with:
-      uri: "https://files.pythonhosted.org/packages/7d/cd/d7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce/wheel-0.43.0-py3-none-any.whl"
-      expected-sha256: "55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81"
+      uri: "https://files.pythonhosted.org/packages/py3/w/wheel/wheel-0.44.0-py3-none-any.whl"
+      expected-sha256: "2376a90c98cc337d18623527a97c31797bd02bad0033d41547043a1cbfbe448f"
       extract: false
   - uses: fetch
     with:
-      uri: "https://files.pythonhosted.org/packages/38/45/618e84e49a6c51e5dd15565ec2fcd82ab273434f236b8f108f065ded517a/flit_core-3.9.0-py3-none-any.whl"
+      uri: "https://files.pythonhosted.org/packages/py3/f/flit_core/flit_core-3.9.0-py3-none-any.whl"
       expected-sha256: "7aada352fb0c7f5538c4fafeddf314d3a6a92ee8e2b1de70482329e42de70301"
       extract: false
   - runs: |

--- a/py3-certipy.yaml
+++ b/py3-certipy.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-certipy
   version: 0.1.3
-  epoch: 1
+  epoch: 2
   description: Utility to create and sign CAs and certificates
   copyright:
     - license: BSD-3-Clause
@@ -25,7 +25,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 695704b7716b033375c9a1324d0d30f27110a28895c40151a90ec07ff1032859
-      uri: https://files.pythonhosted.org/packages/3a/b3/f9228354c1eac06cd3577a981571b9188392d73d583fcaa7a8f3fb374a56/certipy-${{package.version}}.tar.gz
+      uri: https://files.pythonhosted.org/packages/source/c/certipy/certipy-${{package.version}}.tar.gz
 
   - name: Python Build
     uses: python/build-wheel

--- a/py3-jupyter-telemetry.yaml
+++ b/py3-jupyter-telemetry.yaml
@@ -28,7 +28,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 445c613ae3df70d255fe3de202f936bba8b77b4055c43207edf22468ac875314
-      uri: https://files.pythonhosted.org/packages/c4/59/edd04590235d9afe2b2b49ec449c6146dc71b717110f4a1034d52eb54303/jupyter_telemetry-${{package.version}}.tar.gz
+      uri: https://files.pythonhosted.org/packages/source/j/jupyter_telemetry/jupyter_telemetry-${{package.version}}.tar.gz
 
   - name: Python Build
     uses: python/build-wheel

--- a/py3-jupyterhub-hmacauthenticator.yaml
+++ b/py3-jupyterhub-hmacauthenticator.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-jupyterhub-hmacauthenticator
   version: 1.0
-  epoch: 0
+  epoch: 1
   description: Dummy Authenticator for JupyterHub
   copyright:
     - license: BSD-3-Clause
@@ -24,7 +24,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: b2b220a5d3762dd43beb6e29ed1bd0e414b3de8ef8b2d1835b9986260a19c374
-      uri: https://files.pythonhosted.org/packages/cf/40/2b3c5785628d3d707fcf6ff6ce1f22652cf0dff02040b411d96389ea659c/jupyterhub-hmacauthenticator-${{package.version}}.tar.gz
+      uri: https://files.pythonhosted.org/packages/source/j/jupyterhub-hmacauthenticator/jupyterhub-hmacauthenticator-${{package.version}}.tar.gz
 
   - name: Python Build
     uses: python/build-wheel

--- a/py3-keras-preprocessing.yaml
+++ b/py3-keras-preprocessing.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-keras-preprocessing
   version: 1.1.2
-  epoch: 1
+  epoch: 2
   description: Easy data preprocessing and data augmentation for deep learning models
   copyright:
     - license: MIT
@@ -25,7 +25,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: add82567c50c8bc648c14195bf544a5ce7c1f76761536956c3d2978970179ef3
-      uri: https://files.pythonhosted.org/packages/5e/f1/b44337faca48874333769a29398fe4666686733c8880aa160b9fd5dfe600/Keras_Preprocessing-${{package.version}}.tar.gz
+      uri: https://files.pythonhosted.org/packages/source/k/keras_preprocessing/Keras_Preprocessing-${{package.version}}.tar.gz
 
   - name: Python Build
     uses: python/build

--- a/py3-mdit-plain.yaml
+++ b/py3-mdit-plain.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-mdit-plain
   version: 1.0.1
-  epoch: 0
+  epoch: 1
   description: A plain text renderer for markdown-it-py
   copyright:
     - license: "MIT"
@@ -24,7 +24,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: e0cd2c4c5371995e9df3c88eb503004f99eb240b7f6babe3fc49c98152cc25aa
-      uri: https://files.pythonhosted.org/packages/99/1e/abf67ad540527179ccd15053e2b2f346637280e0f04206bef6de5477d99c/mdit_plain-${{package.version}}.tar.gz
+      uri: https://files.pythonhosted.org/packages/source/m/mdit_plain/mdit_plain-${{package.version}}.tar.gz
 
   - name: Python Build
     uses: python/build-wheel

--- a/py3-pkgconfig.yaml
+++ b/py3-pkgconfig.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pkgconfig
   version: 1.5.5
-  epoch: 2
+  epoch: 3
   description: Interface Python with pkg-config
   copyright:
     - license: MIT
@@ -23,7 +23,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: deb4163ef11f75b520d822d9505c1f462761b4309b1bb713d08689759ea8b899
-      uri: https://files.pythonhosted.org/packages/c4/e0/e05fee8b5425db6f83237128742e7e5ef26219b687ab8f0d41ed0422125e/pkgconfig-${{package.version}}.tar.gz
+      uri: https://files.pythonhosted.org/packages/source/p/pkgconfig/pkgconfig-${{package.version}}.tar.gz
 
   - name: Python Build
     uses: python/build

--- a/py3-pyfarmhash.yaml
+++ b/py3-pyfarmhash.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pyfarmhash
   version: 0.3.2
-  epoch: 2
+  epoch: 3
   description: Google FarmHash Bindings for Python
   copyright:
     - license: MIT
@@ -25,7 +25,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 4146308a0ed0b37d69003199c90fa59b155666c9deb0249b40e594cee10551ea
-      uri: https://files.pythonhosted.org/packages/c3/7f/256f1954343fc44641d04292e1410470337db3720bd57b510782e449d6db/pyfarmhash-${{package.version}}.tar.gz
+      uri: https://files.pythonhosted.org/packages/source/p/pyfarmhash/pyfarmhash-${{package.version}}.tar.gz
 
   - name: Python Build
     uses: python/build-wheel

--- a/py3-pytz.yaml
+++ b/py3-pytz.yaml
@@ -1,8 +1,8 @@
 # Generated from https://pypi.org/project/pytz/
 package:
   name: py3-pytz
-  version: 2023.3_p1
-  epoch: 2
+  version: 2024.1
+  epoch: 0
   description: World timezone definitions, modern and historical
   copyright:
     - license: MIT
@@ -21,17 +21,11 @@ environment:
       - python3
       - wolfi-base
 
-var-transforms:
-  - from: ${{package.version}}
-    match: _p
-    replace: .post
-    to: mangled-package-version
-
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b
-      uri: https://files.pythonhosted.org/packages/69/4f/7bf883f12ad496ecc9514cd9e267b29a68b3e9629661a2bbc24f80eff168/pytz-${{vars.mangled-package-version}}.tar.gz
+      expected-sha256: 2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812
+      uri: https://files.pythonhosted.org/packages/source/p/pytz/pytz-${{package.version}}.tar.gz
 
   - name: Python Build
     uses: python/build-wheel

--- a/py3-rfc3986-validator.yaml
+++ b/py3-rfc3986-validator.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-rfc3986-validator
   version: 0.1.1
-  epoch: 2
+  epoch: 3
   description: Pure python rfc3986 validator
   copyright:
     - license: MIT
@@ -24,7 +24,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055
-      uri: https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-${{package.version}}.tar.gz
+      uri: https://files.pythonhosted.org/packages/source/r/rfc3986_validator/rfc3986_validator-${{package.version}}.tar.gz
 
   - name: Python Build
     uses: python/build-wheel


### PR DESCRIPTION
This updates all the occurrences of pyhosted urls that were using by-hash.

The benefit of this is that the updater can on these packages now.
