### PR TITLE
mariadb-connector-c: Fix build issues (wolfi-dev#23356)

### DIFF
--- a/mariadb-connector-c.yaml
+++ b/mariadb-connector-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-connector-c
   version: 3.3.8
-  epoch: 0
+  epoch: 1
   description: The MariaDB Native Client library (C driver)
   copyright:
     - license: LGPL-2.1-or-later
@@ -61,9 +61,6 @@ subpackages:
   - name: mariadb-connector-c-dev
     pipeline:
       - uses: split/dev
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/
-          mv "${{targets.destdir}}"/usr/bin "${{targets.subpkgdir}}"/usr/
     dependencies:
       replaces:
         - mariadb-dev


### PR DESCRIPTION
The run stage for mariadb-connector-c-dev tries to copy files that have already been copied via the split/dev pipline.

Fixes:

FTBFS: mariadb-connector-c
[#23356](https://github.com/wolfi-dev/os/issues/23356)


Output once built shows the bin contents in the dev package as expected.

```
tar tvf packages/aarch64/mariadb-connector-c-dev-3.3.8-r0.apk | grep bin
drwxr-xr-x  0 justin dialout     0 Aug  8 14:47 usr/bin
-rwxr-xr-x  0 justin dialout 71576 Aug  8 14:47 usr/bin/mariadb_config
lrwxr-xr-x  0 justin dialout     0 Aug  8 14:47 usr/bin/mysql_config -> mariadb_config
```