### PR TITLE
feat(coredns): Add subpackage built with plugins used by Kuma

### DIFF
--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,26 +1,16 @@
 package:
   name: coredns
   version: 1.11.3
-  epoch: 3
+  epoch: 4
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - ca-certificates-bundle
 
 environment:
   contents:
     packages:
-      - bash
-      - build-base
-      - busybox
-      - ca-certificates-bundle
       - libcap-utils
       - make
-      - wolfi-baselayout
-  environment:
-    CGO_ENABLED: 0
 
 pipeline:
   - uses: git-checkout
@@ -35,13 +25,33 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w -X github.com/coredns/coredns/coremain.GitCommit=v${{package.version}}
+      ldflags: -X github.com/coredns/coredns/coremain.GitCommit=v${{package.version}}
       output: coredns
       packages: .
 
-  - uses: strip
+  - runs: setcap cap_net_bind_service=+ep "${{targets.contextdir}}/usr/bin/coredns"
 
-  - runs: setcap cap_net_bind_service=+ep "${{targets.destdir}}/usr/bin/coredns"
+subpackages:
+  - name: kuma-coredns
+    description: CoreDNS with plugins used by Kuma
+    pipeline:
+      - runs: |
+          # Build with plugins used by Kuma
+          # Plugin list: https://github.com/kumahq/coredns-builds/blob/main/plugin.cfg
+          mv kuma-plugin.cfg plugin.cfg
+          # Ensures plugins get included
+          make check
+      - uses: go/build
+        with:
+          ldflags: -X github.com/coredns/coredns/coremain.GitCommit=v${{package.version}}
+          output: coredns
+          packages: .
+      - runs: setcap cap_net_bind_service=+ep "${{targets.contextdir}}/usr/bin/coredns"
+    test:
+      pipeline:
+        - runs: |
+            coredns -version
+            coredns -plugins
 
 update:
   enabled: true

--- a/coredns/kuma-plugin.cfg
+++ b/coredns/kuma-plugin.cfg
@@ -1,0 +1,6 @@
+prometheus:metrics
+errors:errors
+log:log
+template:template
+alternate:github.com/coredns/alternate
+forward:forward


### PR DESCRIPTION
Adds a CoreDNS subpackage with plugin support tailored for Kuma

Additionally make a couple small misc adjustments:
- Enable symbol table (leveraged by govulncheck)
- Remove unused buildtime dependencies, remove implicit runtime dep
- Remove redundant use of strip pipeline and `CGO_ENABLED: 0`