### PR TITLE
spark: include missing runtime deps and entrypoint

### DIFF
--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-3.5
   version: 3.5.1
-  epoch: 8
+  epoch: 9
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,14 @@ package:
       - bash
       - busybox
       - procps
+      - posix-libc-utils
+      - tini
+      - tini-compat
+      - net-tools
+      - logrotate
+      - linux-pam
+      - procps
+      - libnss
 
 environment:
   contents:
@@ -64,6 +72,7 @@ pipeline:
       patch dist/sbin/spark-daemon.sh spark-daemon.sh.diff
 
       mkdir -p ${{targets.destdir}}/usr/lib/spark
+      mkdir -p ${{targets.destdir}}/usr/lib/spark/work-dir
       mv dist/* ${{targets.destdir}}/usr/lib/spark/
 
 subpackages:
@@ -74,6 +83,8 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           mkdir -p "${{targets.subpkgdir}}"/opt/
           ln -s /usr/lib/spark/ ${{targets.subpkgdir}}/opt/spark
+          ln -sf /usr/lib/spark/kubernetes/dockerfiles/spark/entrypoint.sh ${{targets.subpkgdir}}/opt/entrypoint.sh
+          ln -sf /usr/lib/spark/kubernetes/dockerfiles/spark/decom.sh ${{targets.subpkgdir}}/opt/decom.sh
           ln -sf /usr/lib/spark/bin/spark-submit ${{targets.subpkgdir}}/usr/bin/spark-submit
           ln -sf /usr/lib/spark/bin/spark-shell ${{targets.subpkgdir}}/usr/bin/spark-shell
           ln -sf /usr/lib/spark/bin/pyspark ${{targets.subpkgdir}}/usr/bin/pyspark
@@ -140,6 +151,8 @@ test:
     - runs: /usr/lib/spark/bin/spark-submit --version
     - runs: /usr/lib/spark/bin/pyspark --version
     - runs: /usr/lib/spark/bin/spark-sql --version
+    - name: Test entrypoint
+      runs: timeout 10 /opt/entrypoint.sh /opt/spark/bin/spark-shell > spark_log.txt 2>&1 || [ $? -eq 143 ] && grep "Spark session available" spark_log.txt && exit_code=0 || exit_code=$? && echo $exit_code
     - name: Run a simple Scala test script
       runs: cat ./scala-test | /usr/lib/spark/bin/spark-shell
     - name: Run a simple Spark job in Scala


### PR DESCRIPTION
This PR includes some required [runtime](https://github.com/apache/spark/blob/01a6991a338cc3f0eac61e97470ef9dbdb170971/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile#L33) dependencies and creates a symlink to [entrypoint](https://github.com/apache/spark/blob/01a6991a338cc3f0eac61e97470ef9dbdb170971/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile#L51).