### PR TITLE
add missing packages

### DIFF
--- a/rancher-2.9.yaml
+++ b/rancher-2.9.yaml
@@ -12,7 +12,7 @@ var-transforms:
 package:
   name: rancher-2.9
   version: 2.9.0
-  epoch: 1
+  epoch: 2
   description: Complete container management platform
   copyright:
     - license: Apache-2.0
@@ -69,6 +69,10 @@ subpackages:
         - iproute2
         - net-tools
         - openssh-client
+        - busybox
+        - posix-libc-utils
+        - curl
+        - openssl
     pipeline:
       - uses: go/bump
         with:
@@ -142,7 +146,7 @@ subpackages:
           repository: https://github.com/rancher/partner-charts
           branch: main
           destination: partner-charts
-          expected-commit: 55929c0a097d933d60cba63eb94c85fa9a661d38
+          expected-commit: e95ababa2c9a41b8a974752157646a5013ea0f4d
       - working-directory: ./partner-charts
         runs: |
           shasum256=$(echo -n "https://git.rancher.io/partner-charts" |shasum -a 256 | awk '{ print $1 }')
@@ -204,7 +208,7 @@ subpackages:
           repository: https://github.com/rancher/rke2-charts
           branch: main
           destination: rke2-charts
-          expected-commit: 68f4b59d416f9e2f182c35dfe2ed68a6238b59ef
+          expected-commit: 0f967664cd95614fc06646eb1fb49b9346b1dbcb
       - working-directory: ./rke2-charts
         runs: |
           shasum256=$(echo -n "https://git.rancher.io/rke2-charts" |shasum -a 256 | awk '{ print $1 }')


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
