### PR TITLE
fluent-operator remove tag filter

### DIFF
--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-operator
-  version: 2.9.0
-  epoch: 2
+  version: 3.0.0
+  epoch: 0
   description: Operate Fluent Bit and Fluentd in the Kubernetes way - Previously known as FluentBit Operator
   copyright:
     - license: Apache-2.0
@@ -15,7 +15,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/fluent/fluent-operator
-      expected-commit: 65e422d8bc8d76c0903ab65f9018cf253274f06c
+      expected-commit: 1d758ceab090b13a3a807292aeebd6b2fdef391e
       tag: v${{package.version}}
 
   - uses: go/build
@@ -30,7 +30,6 @@ subpackages:
   - name: fluent-watcher
     pipeline:
       - runs: |
-          # https://github.com/fluent/fluent-operator/blob/v2.8.0/cmd/fluent-watcher/fluentbit/main.go#L24
           mkdir -p "${{targets.contextdir}}"/fluent-bit/config
       - uses: go/build
         with:
@@ -47,7 +46,6 @@ subpackages:
       pipeline:
         - runs: |
             echo "Testing fluent-watcher"
-            fluent-watcher -h
             # Run fluent-watcher in the background and redirect its output to a temporary file
             tempfile=$(mktemp)
             fluent-watcher > "$tempfile" 2>&1 &
@@ -56,8 +54,6 @@ subpackages:
             FLUENT_WATCHER_PID=$!
 
             sleep 5
-
-            cat "$tempfile"
 
             # Use grep to filter the output
             cat "$tempfile" | grep -i "fluent-bit started"
@@ -79,7 +75,6 @@ update:
   github:
     identifier: fluent/fluent-operator
     strip-prefix: v
-    tag-filter: v2
     use-tag: true
 
 test:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
