### PR TITLE
py3-supported-python: Add exclude-reason

### DIFF
--- a/py3-supported-python.yaml
+++ b/py3-supported-python.yaml
@@ -28,3 +28,4 @@ subpackages:
 
 update:
   enabled: false
+  exclude-reason: No source to watch for the new versions


### PR DESCRIPTION
This package has no relevant upstream.

