### PR TITLE
Add python import tests to a subset of packages

### DIFF
--- a/py3-bcrypt.yaml
+++ b/py3-bcrypt.yaml
@@ -39,3 +39,9 @@ update:
   github:
     identifier: pyca/bcrypt
     use-tag: true
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: bcrypt

--- a/py3-boto3.yaml
+++ b/py3-boto3.yaml
@@ -37,3 +37,9 @@ update:
   enabled: true
   release-monitor:
     identifier: 29737
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: boto3

--- a/py3-cython.yaml
+++ b/py3-cython.yaml
@@ -55,3 +55,9 @@ update:
   enabled: true
   github:
     identifier: cython/cython
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: cython

--- a/py3-fastavro.yaml
+++ b/py3-fastavro.yaml
@@ -38,3 +38,9 @@ update:
   manual: false
   github:
     identifier: fastavro/fastavro
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: fastavro

--- a/py3-forestci.yaml
+++ b/py3-forestci.yaml
@@ -40,3 +40,9 @@ update:
   enabled: true
   github:
     identifier: scikit-learn-contrib/forest-confidence-interval
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: forestci

--- a/py3-hatch.yaml
+++ b/py3-hatch.yaml
@@ -58,3 +58,9 @@ update:
     identifier: pypa/hatch
     strip-prefix: hatch-v
     tag-filter: hatch-v
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: hatch

--- a/py3-ipykernel.yaml
+++ b/py3-ipykernel.yaml
@@ -51,3 +51,9 @@ update:
   enabled: true
   release-monitor:
     identifier: 10514
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: ipykernel

--- a/py3-ipywidgets.yaml
+++ b/py3-ipywidgets.yaml
@@ -40,3 +40,9 @@ update:
   enabled: true
   release-monitor:
     identifier: 10516
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: ipywidgets

--- a/py3-itables.yaml
+++ b/py3-itables.yaml
@@ -46,3 +46,9 @@ update:
   github:
     identifier: mwouts/itables
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: itables

--- a/py3-jsonschema.yaml
+++ b/py3-jsonschema.yaml
@@ -51,3 +51,9 @@ update:
     identifier: python-jsonschema/jsonschema
     tag-filter: v
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: jsonschema

--- a/py3-jupyterhub.yaml
+++ b/py3-jupyterhub.yaml
@@ -62,3 +62,9 @@ update:
   github:
     identifier: jupyterhub/jupyterhub
     use-tag: true
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: jupyterhub

--- a/py3-kubernetes.yaml
+++ b/py3-kubernetes.yaml
@@ -50,3 +50,9 @@ update:
   github:
     identifier: kubernetes-client/python
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: kubernetes

--- a/py3-libcst.yaml
+++ b/py3-libcst.yaml
@@ -44,3 +44,9 @@ update:
   github:
     identifier: Instagram/LibCST
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: libcst

--- a/py3-orjson.yaml
+++ b/py3-orjson.yaml
@@ -38,3 +38,9 @@ update:
   manual: false
   github:
     identifier: ijl/orjson
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: orjson

--- a/py3-peewee.yaml
+++ b/py3-peewee.yaml
@@ -43,3 +43,9 @@ update:
   enabled: true
   github:
     identifier: coleifer/peewee
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: peewee

--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -78,3 +78,9 @@ update:
   github:
     identifier: pypa/pip
     use-tag: true
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: pip

--- a/py3-pkginfo.yaml
+++ b/py3-pkginfo.yaml
@@ -35,3 +35,9 @@ update:
   enabled: true
   release-monitor:
     identifier: 11017
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: pkginfo

--- a/py3-portalocker.yaml
+++ b/py3-portalocker.yaml
@@ -36,3 +36,9 @@ update:
   github:
     identifier: wolph/portalocker
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: portalocker

--- a/py3-pybind11.yaml
+++ b/py3-pybind11.yaml
@@ -71,3 +71,9 @@ update:
   github:
     identifier: pybind/pybind11
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: pybind11

--- a/py3-pydot.yaml
+++ b/py3-pydot.yaml
@@ -43,3 +43,9 @@ update:
     use-tag: true
     tag-filter: v
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: pydot

--- a/py3-rapidfuzz.yaml
+++ b/py3-rapidfuzz.yaml
@@ -38,3 +38,9 @@ update:
     identifier: maxbachmann/RapidFuzz
     use-tag: true
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: rapidfuzz

--- a/py3-s3transfer.yaml
+++ b/py3-s3transfer.yaml
@@ -40,3 +40,9 @@ update:
   github:
     identifier: boto/s3transfer
     use-tag: true
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: s3transfer

--- a/py3-sphinx.yaml
+++ b/py3-sphinx.yaml
@@ -43,3 +43,9 @@ update:
   github:
     identifier: sphinx-doc/sphinx
     strip-prefix: v
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: sphinx

--- a/py3-typing.yaml
+++ b/py3-typing.yaml
@@ -39,3 +39,9 @@ update:
   shared: true
   release-monitor:
     identifier: 10922
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: typing

--- a/py3-virtualenv.yaml
+++ b/py3-virtualenv.yaml
@@ -48,3 +48,9 @@ update:
   github:
     identifier: pypa/virtualenv
     use-tag: true
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: virtualenv

--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -67,3 +67,9 @@ update:
   github:
     identifier: pypa/wheel
     use-tag: true
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: wheel

--- a/py3-zstandard.yaml
+++ b/py3-zstandard.yaml
@@ -42,3 +42,9 @@ update:
   github:
     identifier: indygreg/python-zstandard
     use-tag: true
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: zstandard


### PR DESCRIPTION
Add import tests to a subset of python packages. This should help unblock auto-bumping versions for these packages for the Sustaining Squad.