### PR TITLE
Fix jack build problems (wolfi-dev#23358)

### DIFF
--- a/jack.yaml
+++ b/jack.yaml
@@ -2,7 +2,7 @@
 package:
   name: jack
   version: 1.9.22
-  epoch: 0
+  epoch: 1
   description: The Jack Audio Connection Kit
   copyright:
     - license: GPL-2.0-or-later
@@ -23,7 +23,7 @@ environment:
       - libsndfile-dev
       - linux-headers
       - ncurses-dev
-      - python3
+      - python-3.11 # The next upstream release should support 3.12
       - readline-dev
 
 pipeline:


### PR DESCRIPTION
The `imp` module was deprecated in 3.11 and removed in 3.12. Fix jack at python 3.11 until the upstream jack releases with 3.12 support.

Fixes:
wolfi-dev#23358

Related:

### Pre-review Checklist

