### PR TITLE
fix(coredns): Actually use plugins set in plugin config

### DIFF
--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: 1.11.3
-  epoch: 4
+  epoch: 5
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0
@@ -20,8 +20,8 @@ pipeline:
       tag: v${{package.version}}
 
   - runs: |
-      # Ensures plugins get included
-      make check
+      # Generate code and fetch plugins
+      make gen
 
   - uses: go/build
     with:
@@ -39,8 +39,8 @@ subpackages:
           # Build with plugins used by Kuma
           # Plugin list: https://github.com/kumahq/coredns-builds/blob/main/plugin.cfg
           mv kuma-plugin.cfg plugin.cfg
-          # Ensures plugins get included
-          make check
+          # Generate code and fetch plugins
+          make gen
       - uses: go/build
         with:
           ldflags: -X github.com/coredns/coredns/coremain.GitCommit=v${{package.version}}


### PR DESCRIPTION
Generate missing code and actually fetch CoreDNS plugins

Somehow works for me locally without this step, but was exposed in CI/workstations leading to Kuma CoreDNS using the standard set of CoreDNS plugins