### PR TITLE
mariadb: restore -client subpackage for image builds

### DIFF
--- a/mariadb-11.4.yaml
+++ b/mariadb-11.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-11.4
   version: 11.4.3
-  epoch: 0
+  epoch: 1
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -182,6 +182,15 @@ subpackages:
             "${{targets.destdir}}"/usr/bin/mariadb-backup \
             "${{targets.destdir}}"/usr/bin/mbstream \
             "${{targets.subpkgdir}}"/usr/bin/
+
+  - name: "${{package.name}}-client"
+    dependencies:
+      provides:
+        - mariadb-client=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mv "${{targets.destdir}}"/usr/bin/mariadb "${{targets.subpkgdir}}"/usr/bin/
 
   - name: "${{package.name}}-oci-entrypoint"
     description: Entrypoint for using HAProxy in OCI containers


### PR DESCRIPTION
client is a subpackage in most version streams, but missing from 11.4, this is breaking version streamed image builds.

Restore/add -client subpackage.