### PR TITLE
fix(kuma-2.8): Remove Envoy version requirement

### DIFF
--- a/kuma-2.8.yaml
+++ b/kuma-2.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: kuma-2.8
   version: 2.8.2
-  epoch: 2
+  epoch: 3
   description: A multi-zone service mesh for containers, Kubernetes and VMs.
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,10 @@ pipeline:
       repository: https://github.com/kumahq/kuma
       tag: ${{package.version}}
       expected-commit: ffb0a135b8320cd474c503b785b43627d77a1338
+
+  - uses: patch
+    with:
+      patches: remove_envoy_version_check.patch
 
   - uses: go/bump
     with:

--- a/kuma-2.8/remove_envoy_version_check.patch
+++ b/kuma-2.8/remove_envoy_version_check.patch
@@ -1,0 +1,33 @@
+diff --git a/app/kuma-dp/pkg/dataplane/envoy/compatibility.go b/app/kuma-dp/pkg/dataplane/envoy/compatibility.go
+index 4a7b03dcb..e30d4f10b 100644
+--- a/app/kuma-dp/pkg/dataplane/envoy/compatibility.go
++++ b/app/kuma-dp/pkg/dataplane/envoy/compatibility.go
+@@ -1,13 +1,16 @@
+ package envoy
+ 
++/*
+ import (
+ 	"github.com/Masterminds/semver/v3"
+ 	"github.com/pkg/errors"
+ )
++*/
+ 
+ // VersionCompatible returns true if the given version of
+ // envoy is compatible with this DP, false otherwise, expectedVersion is in Masterminds/semver/v3 format.
+ func VersionCompatible(expectedVersion string, envoyVersion string) (bool, error) {
++	/*
+ 	ver, err := semver.NewVersion(envoyVersion)
+ 	if err != nil {
+ 		return false, errors.Wrapf(err, "unable to parse envoy version %s", envoyVersion)
+@@ -15,9 +18,10 @@ func VersionCompatible(expectedVersion string, envoyVersion string) (bool, error
+ 
+ 	constraint, err := semver.NewConstraint(expectedVersion)
+ 	if err != nil {
+-		// Programmer error
+ 		panic(errors.Wrapf(err, "Invalid envoy compatibility constraint %s", expectedVersion))
+ 	}
+ 
+ 	return constraint.Check(ver), nil
++	*/
++	return true, nil
+ }


### PR DESCRIPTION
This check validates down to the patch level that the version of Envoy provided at buildtime is inline with the version at runtime. This would mean rebuilding Kuma every time Envoy updates. Given there really isn't a reason to rebuild Kuma otherwise, just patch out the check for now. An issue has been filed upstream suggesting to only validate the major and minor version of Envoy.

https://github.com/kumahq/kuma/issues/11086