### PR TITLE
k3s: add ctr to runtime deps

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.30.3.1
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -10,6 +10,7 @@ package:
       - busybox
       - conntrack-tools
       - containerd-shim-runc-v2
+      - ctr
       - ip6tables # this pulls in iptables as well
       - libseccomp
       - runc


### PR DESCRIPTION
Pass missing `ctr` binary to `k3s` image.

https://github.com/k3d-io/k3d/blob/ef937a0aeff176a4f6b12ba7baecf11454e85097/pkg/client/tools.go#L142

It will fix the following `import` issue:
```
ERRO[0008] failed to import images in node 'k3d-k3s-default-server-0': Exec process in node 'k3d-k3s-default-server-0' failed with exit code '126': Logs from failed access process:
 CI runtime exec failed: exec failed: unable to start container process: exec: "ctr": executable file not found in $PATH: unknown
```