### PR TITLE
enforce k3s multicall

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.30.3.1
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: Apache-2.0
@@ -10,10 +10,14 @@ package:
       - busybox
       - conntrack-tools
       - containerd-shim-runc-v2
-      - ctr
       - ip6tables # this pulls in iptables as well
       - libseccomp
       - runc
+      # Do not include runtime dependencies already included in the multicall k3s
+      # - ctr
+      # - crictl
+      # - containerd
+      # - kubectl
 
 environment:
   contents:
@@ -209,3 +213,9 @@ test:
     - name: Basic version smoketest
       runs: |
         k3s --version
+    - name: Ensure the various tools are appropriately symlinked
+      runs: |
+        # Ensure the various tools are appropriately symlinked
+        [ "$(readlink /bin/kubectl)" = "/bin/_k3s-inner" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }
+        [ "$(readlink /bin/ctr)" = "/bin/_k3s-inner" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }
+        [ "$(readlink /bin/crictl)" = "/bin/_k3s-inner" ] || { echo "Error: the multicall symlinks are not set up appropriately" >&2; exit 1; }


### PR DESCRIPTION
rollback https://github.com/wolfi-dev/os/pull/26073 and enforce an appropriate multicall setup.

I checked the import with this image and things seem to work fine, so my guess is the error linked in #26073 was prior to https://github.com/wolfi-dev/os/commit/ced4d4ef318ec75c9180e4e69963fa52a9869346