### PR TITLE
c-ares: switch from autotools to cmake

### DIFF
--- a/c-ares-bootstrap.yaml
+++ b/c-ares-bootstrap.yaml
@@ -1,0 +1,53 @@
+package:
+  name: c-ares-bootstrap
+  version: 1.33.0
+  epoch: 1
+  description: "an asynchronous DNS resolution library"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - libev
+    provider-priority: 0
+    provides:
+      - c-ares=${{package.full-version}}
+      - c-ares-dev=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libtool
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/c-ares/c-ares
+      tag: v${{package.version}}
+      expected-commit: caffa5ffb3826cf0926405793361bbad11db3268
+
+  - runs: |
+      autoreconf -vfi
+
+  - uses: autoconf/configure
+    with:
+      # Enabling tests requires a gmock dependency. We have that packaged, but it introduces a dependency cycle.
+      opts: --enable-shared --enable-tests=no
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: c-ares/c-ares
+    tag-filter-prefix: v
+    strip-prefix: v

--- a/c-ares.yaml
+++ b/c-ares.yaml
@@ -1,7 +1,7 @@
 package:
   name: c-ares
   version: 1.33.0
-  epoch: 0
+  epoch: 1
   description: "an asynchronous DNS resolution library"
   copyright:
     - license: MIT
@@ -14,27 +14,29 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cmake
       - libtool
       - wolfi-base
 
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/c-ares/c-ares.git
+      repository: https://github.com/c-ares/c-ares
       tag: v${{package.version}}
       expected-commit: caffa5ffb3826cf0926405793361bbad11db3268
 
-  - runs: |
-      autoreconf -vfi
-
-  - uses: autoconf/configure
+  - uses: cmake/configure
     with:
-      # Enabling tests requires a gmock dependency. We have that packaged, but it introduces a dependency cycle.
-      opts: --enable-shared --enable-tests=no
+      opts: |
+        -DCARES_BUILD_TOOLS=OFF \
+        -DCARES_SHARED=ON \
+        -DCARES_STATIC=ON \
+        -DCARES_SYMBOL_HIDING=ON \
+        -DCARES_BUILD_TESTS=OFF
 
-  - uses: autoconf/make
+  - uses: cmake/build
 
-  - uses: autoconf/make-install
+  - uses: cmake/install
 
   - uses: strip
 


### PR DESCRIPTION
Build c-ares with cmake instead of autotools. This installs additional
.cmake files in the -dev package, as needed to build other cmake-based
projects that depend on c-ares (e.g. bun).
