### PR TITLE
llvm-18: improve package splits

### DIFF
--- a/llvm-18.yaml
+++ b/llvm-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: llvm-18
   version: 18.1.8
-  epoch: 0
+  epoch: 1
   description: "low-level virtual machine - core frameworks"
   copyright:
     - license: Apache-2.0
@@ -80,21 +80,6 @@ pipeline:
         ln -s ../lib/${{package.name}}/bin/$name "${{targets.contextdir}}"/usr/bin/$name
       done
 
-  - runs: |
-      cd "${{targets.contextdir}}"/usr/lib/${{package.name}}
-
-      mkdir -p "${{targets.contextdir}}"/usr/lib/
-      for path in "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/*.a; do
-        name=${path##*/}
-        ln -s ../lib/${{package.name}}/lib/$name "${{targets.contextdir}}"/usr/lib/$name
-      done
-
-      mkdir -p "${{targets.contextdir}}"/usr/lib/
-      for path in "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/*.so*; do
-        name=${path##*/}
-        ln -s ../lib/${{package.name}}/lib/$name "${{targets.contextdir}}"/usr/lib/$name
-      done
-
   - working-directory: ${{targets.contextdir}}/usr/lib/${{package.name}}
     runs: |
       mkdir -p "${{targets.contextdir}}"/usr/lib/cmake
@@ -108,25 +93,13 @@ subpackages:
     description: "LLVM 18 runtime library"
     pipeline:
       - runs: |
-          soname="libLLVM.so"
-          sonamefull="libLLVM-${{package.version}}.so"
-
+          soname="libLLVM.so.18.1"
+          sonamefull="libLLVM-18.so"
           mkdir -p "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/
           mv "${{targets.destdir}}"/usr/lib/${{package.name}}/lib/$soname "${{targets.contextdir}}"/usr/lib/
           ln -s $soname "${{targets.contextdir}}"/usr/lib/$sonamefull
-
-          ln -s ../../$soname "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/$soname
-          ln -s ../../$soname "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/$sonamefull
-
-
-
-          ls -al "${{targets.destdir}}"/usr/lib/${{package.name}}/lib
-          rm -f "${{targets.destdir}}"/usr/lib/${{package.name}}/lib/$soname
-          rm -f "${{targets.destdir}}"/usr/lib/${{package.name}}/lib/$sonamefull
-
-          ls -al "${{targets.destdir}}"/usr/lib
-          rm -f "${{targets.destdir}}"/usr/lib/$soname
-          rm -f "${{targets.destdir}}"/usr/lib/$sonamefull
+          ln -sf ../../$soname "${{targets.destdir}}"/usr/lib/${{package.name}}/lib/$soname
+          ln -sf ../../$soname "${{targets.destdir}}"/usr/lib/${{package.name}}/lib/$sonamefull
 
   - name: "${{package.name}}-dev"
     description: "headers for ${{package.name}}"
@@ -135,19 +108,9 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/lib/${{package.name}}/bin
           mv "${{targets.destdir}}"/usr/lib/${{package.name}}/bin/llvm-config "${{targets.contextdir}}"/usr/lib/${{package.name}}/bin/
-
-          soname="libLLVM.so"
-          sonamefull="libLLVM-${{package.version}}.so"
-
-          rm -f "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/$soname
-          rm -f "${{targets.contextdir}}"/usr/lib/${{package.name}}/lib/$sonamefull
-
-          rm -f "${{targets.contextdir}}"/usr/lib/libLLVM.so
-          rm -f "${{targets.contextdir}}"/usr/lib/$soname
-          rm -f "${{targets.contextdir}}"/usr/lib/$sonamefull
     dependencies:
       runtime:
-        - libLLVM-18
+        - llvm-18
 
 update:
   enabled: true


### PR DESCRIPTION
Due to a typpo, libllvm.so was being split out of main/-dev packages
into runtime library package. Instead of the runtime library
libllvm-18.so / libllvm.so.18.1. Also other versioned libLLVM are not
split correctly either.

Also upstream package version doesn't feature in the soname in
full. And other distributions do not expose libLTO nor
libRemarks. Thus stop exposing them.

Static libraries made public, simply results in install conflicts if
one wants to co-install multiple llvm versions, and due to header
locations the custom path to them will be used anyway during
linking. Thus public exposure of them is redundant.

This fixes current inability to coninstall compilers that use
different LLVM stacks - e.g. clang-16 with rustc (which uses
libllvm-18.so), as currently libllvm-18.so is shipped in the main
package which has conflicting tools with llvm-16 (needed by clang-16).

Also llvm-18 split from llvm-18-dev doesn't really make any
sense. Splitting tools (usr/bin/) would make sense though, but nothing
seems to really care. Adding depedency from llvm-18-dev to llvm-18
will enable to drop duplicate dependencies in all the
reverse-dependant packages.