### PR TITLE
fix(kuma-coredns): Don't allow access to privileged ports

### DIFF
--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: 1.11.3
-  epoch: 5
+  epoch: 6
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0
@@ -46,7 +46,6 @@ subpackages:
           ldflags: -X github.com/coredns/coredns/coremain.GitCommit=v${{package.version}}
           output: coredns
           packages: .
-      - runs: setcap cap_net_bind_service=+ep "${{targets.contextdir}}/usr/bin/coredns"
     test:
       pipeline:
         - runs: |


### PR DESCRIPTION
Hitting this at random otherwise:

```
Error: failed to execute coreDNS at path /usr/bin/coredns: fork/exec /usr/bin/coredns: operation not permitted
```

Running with escalated privileges does not help here.

Looking at Kuma's CoreDNS build repo, they aren't granting access to privileged ports, unlike upstream:

https://github.com/kumahq/coredns-builds/blob/987ec5457098249e8ffe280c8679bd70bcd7f7a5/Makefile#L28

Validated that this is a non-issue with our existing CoreDNS image