### PR TITLE
fix(neuvector): Append missing 'v' prefix to version

### DIFF
--- a/neuvector.yaml
+++ b/neuvector.yaml
@@ -39,7 +39,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/opencontainers/runc@v1.1.12 github.com/opencontainers/image-spec@v1.1.0 github.com/docker/distribution@v2.8.2-beta.1+incompatible golang.org/x/sys@v0.19.0 golang.org/x/net@v0.23.0 golang.org/x/text@v0.14.0 gopkg.in/yaml.v3@v3.0.1 github.com/containerd/containerd@v1.6.26 google.golang.org/grpc@v1.56.3 github.com/golang/protobuf@v1.5.4 golang.org/x/crypto@v0.22.0 github.com/docker/docker@v26.1.4
+      deps: github.com/opencontainers/runc@v1.1.12 github.com/opencontainers/image-spec@v1.1.0 github.com/docker/distribution@v2.8.2-beta.1+incompatible golang.org/x/sys@v0.19.0 golang.org/x/net@v0.23.0 golang.org/x/text@v0.14.0 gopkg.in/yaml.v3@v3.0.1 github.com/containerd/containerd@v1.6.26 google.golang.org/grpc@v1.56.3 github.com/golang/protobuf@v1.5.4 golang.org/x/crypto@v0.22.0 github.com/docker/docker@v26.1.5
       replaces: github.com/samalba/dockerclient=github.com/Dentrax/dockerclient@v0.1.0 github.com/vishvananda/netlink=github.com/vishvananda/netlink@v1.1.0 github.com/dgrijalva/jwt-go=github.com/golang-jwt/jwt/v4@v4.4.2 github.com/docker/docker=github.com/docker/docker@v26.1.4+incompatible
       show-diff: true
 

--- a/neuvector.yaml
+++ b/neuvector.yaml
@@ -1,7 +1,7 @@
 package:
   name: neuvector
   version: 5.3.4
-  epoch: 1
+  epoch: 2
   description: "NeuVector Full Lifecycle Container Security Platform"
   copyright:
     - license: Apache-2.0
@@ -100,7 +100,7 @@ subpackages:
         - yq
     pipeline:
       - runs: |
-          sed -i 's|interim/master.xxxx|${{package.version}}|g' agent/version.go
+          sed -i 's|interim/master.xxxx|v${{package.version}}|g' agent/version.go
       - uses: go/build
         with:
           modroot: agent
@@ -165,7 +165,7 @@ subpackages:
         - procps
     pipeline:
       - runs: |
-          sed -i 's|interim/master.xxxx|${{package.version}}|g' controller/version.go
+          sed -i 's|interim/master.xxxx|v${{package.version}}|g' controller/version.go
       - uses: go/build
         with:
           modroot: controller
@@ -197,6 +197,7 @@ update:
   ignore-regex-patterns:
     - '.*\-.*'
     - '.*fnb.*'
+    - '.*oc.*'
   github:
     identifier: neuvector/neuvector
     tag-filter: v


### PR DESCRIPTION
NeuVector expects vX.Y.Z when it performs version checks. If not inline with expected formatting, it reports a mismatch
