### PR TITLE
fix(harbor): Rollback CVE-2024-40465 remediation

### DIFF
--- a/harbor-2.11.yaml
+++ b/harbor-2.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-2.11
   version: 2.11.0
-  epoch: 4
+  epoch: 5
   description: An open source trusted cloud native registry project that stores, signs, and scans content
   copyright:
     - license: Apache-2.0
@@ -46,7 +46,7 @@ pipeline:
   - uses: go/bump
     with:
       modroot: ./src
-      deps: github.com/cloudevents/sdk-go/v2@v2.15.2 github.com/jackc/pgproto3/v2@v2.3.3 google.golang.org/protobuf@v1.33.0 github.com/beego/beego/v2@v2.2.1 github.com/docker/docker@v26.1.5
+      deps: github.com/cloudevents/sdk-go/v2@v2.15.2 github.com/jackc/pgproto3/v2@v2.3.3 google.golang.org/protobuf@v1.33.0 github.com/docker/docker@v26.1.5
 
   - uses: go/build
     with:


### PR DESCRIPTION
Bumping beego to v2.2.1 requires other changes be made that have not made their way down to prior versions of Harbor:

https://github.com/goharbor/harbor/pull/20555/files