### PR TITLE
Add missing Dir to Redis Cluster Compat

### DIFF
--- a/redis-7.2.yaml
+++ b/redis-7.2.yaml
@@ -147,6 +147,7 @@ subpackages:
       - runs: |
           # Bitnami startup scripts _require_ the redis-default.conf to exist
           mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/redis/etc.default
           cp redis.conf ${{targets.subpkgdir}}/opt/bitnami/redis/etc/redis-default.conf
 
 update:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
Add `/opt/bitnami/redis/etc.default` dir to redis cluster bitnami issue to resolve issue when deploying `bitnami-redis-cluster` chart.

Currently chart fails to deploy and displays the following errors
```k logs -l app.kubernetes.io/name=redis-cluster
redis-cluster 13:21:50.19 INFO  ==>
redis-cluster 13:21:50.19 INFO  ==> Welcome to the Bitnami myapp container
redis-cluster 13:21:50.19 INFO  ==> Subscribe to project updates by watching https://github.com/bitnami/containers
redis-cluster 13:21:50.19 INFO  ==> Submit issues and feature requests at https://github.com/bitnami/containers/issues
redis-cluster 13:21:50.19 INFO  ==> Upgrade to Tanzu Application Catalog for production environments to access custom-configured and pre-packaged software components. Gain enhanced features, including Software Bill of Materials (SBOM), CVE scan result reports, and VEX documents. To learn more, visit https://bitnami.com/enterprise
redis-cluster 13:21:50.19 INFO  ==>
cp: cannot stat '/opt/bitnami/redis/etc.default/.': No such file or directory
```

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only

#### For package updates (renames) in the base images
