### PR TITLE
re-add accidently removed flag.Parse patch applied

### DIFF
--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-operator
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: Operate Fluent Bit and Fluentd in the Kubernetes way - Previously known as FluentBit Operator
   copyright:
     - license: Apache-2.0
@@ -17,6 +17,12 @@ pipeline:
       repository: https://github.com/fluent/fluent-operator
       expected-commit: 1d758ceab090b13a3a807292aeebd6b2fdef391e
       tag: v${{package.version}}
+
+  # until they cut a new release with that fix included
+  # https://github.com/fluent/fluent-operator/pull/1294
+  - uses: patch
+    with:
+      patches: 0001-re-add-accidently-removed-flag.Parse.patch
 
   - uses: go/build
     with:

--- a/fluent-operator/0001-re-add-accidently-removed-flag.Parse.patch
+++ b/fluent-operator/0001-re-add-accidently-removed-flag.Parse.patch
@@ -1,0 +1,26 @@
+From 7855cbb4dc030ac08bf403503edec6f2f80b86f0 Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Sun, 11 Aug 2024 20:42:16 +0300
+Subject: [PATCH] re-add accidently removed flag.Parse
+
+Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+---
+ cmd/fluent-watcher/fluentbit/main.go | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/cmd/fluent-watcher/fluentbit/main.go b/cmd/fluent-watcher/fluentbit/main.go
+index ff5215c..a6d90fa 100644
+--- a/cmd/fluent-watcher/fluentbit/main.go
++++ b/cmd/fluent-watcher/fluentbit/main.go
+@@ -72,6 +72,8 @@ func main() {
+ 		level.Warn(logger).Log("--flb-timeout is deprecated. Consider setting the terminationGracePeriod field on the `(Cluster)FluentBit` instance.")
+ 	}
+ 
++	flag.Parse()
++
+ 	// First, launch the fluent-bit process.
+ 	args := []string{"--enable-hot-reload", "-c", configPath}
+ 	if externalPluginPath != "" {
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
