### PR TITLE
fix(neuvector-manager): Disable version mismatch notification

### DIFF
--- a/neuvector-manager.yaml
+++ b/neuvector-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: neuvector-manager
   version: 5.3.4
-  epoch: 0
+  epoch: 1
   description: NeuVector Security Center Admin Console.
   copyright:
     - license: Apache-2.0
@@ -37,6 +37,12 @@ pipeline:
       expected-commit: 81cefc87be99625beafe47489f25256af0733ae5
       repository: https://github.com/neuvector/manager
       tag: v${{package.version}}
+
+  # The version mismatch notification is misleading when the NV version isn't set via a label
+  # We do not set image labels so disable the notification altogether to avoid confusion
+  - uses: patch
+    with:
+      patches: disable_version_mismatch_notif.patch
 
   - runs: |
       # Build UI

--- a/neuvector-manager/disable_version_mismatch_notif.patch
+++ b/neuvector-manager/disable_version_mismatch_notif.patch
@@ -1,0 +1,21 @@
+diff --git a/admin/webapp/websrc/app/routes/components/global-notifications/global-notifications.component.ts b/admin/webapp/websrc/app/routes/components/global-notifications/global-notifications.component.ts
+index 0ff2bc82..79beeca0 100644
+--- a/admin/webapp/websrc/app/routes/components/global-notifications/global-notifications.component.ts
++++ b/admin/webapp/websrc/app/routes/components/global-notifications/global-notifications.component.ts
+@@ -36,6 +36,7 @@ export class GlobalNotificationsComponent implements OnInit {
+   telemetryStatus!: TelemetryStatus | null;
+   unUpdateDays!: number;
+   get isVersionMismatch() {
++    /*
+     return GlobalVariable.summary.component_versions
+       ? (GlobalVariable.summary.component_versions.length > 1 &&
+           GlobalVariable.summary.component_versions[0] !==
+@@ -45,6 +46,8 @@ export class GlobalNotificationsComponent implements OnInit {
+               ? GlobalVariable.summary.component_versions[0].substring(1)
+               : GlobalVariable.summary.component_versions[0])
+       : false;
++    */
++    return false
+   }
+   get passwordExpiration() {
+     return GlobalVariable.user.token.password_days_until_expire;


### PR DESCRIPTION
NeuVector appears to chcek a few places to verify the version of the component thats running. One of those places being image labels. As we do not set image labels, disable the version mismatch notification as it is misleading when labels are not set