### PR TITLE
Ruby-3.3 GHSA-5866-49gr-22v4 remediation

### DIFF
--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.3
   version: 3.3.4
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.3/rexml.patch
+++ b/ruby-3.3/rexml.patch
@@ -7,7 +7,7 @@ index aa96ab841c..3538b5248e 100644
  rake            13.1.0  https://github.com/ruby/rake
  test-unit       3.6.1   https://github.com/test-unit/test-unit
 -rexml           3.2.8   https://github.com/ruby/rexml
-+rexml           3.3.2   https://github.com/ruby/rexml
++rexml           3.3.5   https://github.com/ruby/rexml
  rss             0.3.0   https://github.com/ruby/rss
  net-ftp         0.3.4   https://github.com/ruby/net-ftp
  net-imap        0.4.9.1   https://github.com/ruby/net-imap


### PR DESCRIPTION
To resolve GHSA-5866-49gr-22v4, the rexml patch file for ruby-3.3 has been updated so rexml is using 3.3.5 instead of 3.3.2

