### PR TITLE
wasker: Fix wasker builds

### DIFF
--- a/wasker.yaml
+++ b/wasker.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasker
   version: 0.1.1
-  epoch: 0
+  epoch: 1
   description: "Wasm compiler for running Wasm on your favorite kernel"
   copyright:
     - license: MIT
@@ -17,7 +17,7 @@ environment:
       - llvm-tools
       - llvm15
       - llvm15-dev
-      - rust
+      - rust-1.72 # wasker requires llvm15 rust after this version has a dep on llvm
       - zlib-dev
 
 pipeline:


### PR DESCRIPTION
rust-1.73 was updated to require llvm17 which is bringing llvm into the build env. llvm17+ packages conflict with the llvm-15 packages. wasker the is specifying llvm15 as an explicit build dependency for inkwell. In theory we could update the inkwell feature to build for llvm18 instead but then we'll fail to build every time we update rust + llvm or pin it to a specific version anyway and we have to update the projects cargo deps so we'll just pin it to the llvm version upstream is using anyway.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

https://github.com/wolfi-dev/os/issues/23864