### PR TITLE
cdparanoia: Fix build

### DIFF
--- a/cdparanoia.yaml
+++ b/cdparanoia.yaml
@@ -1,7 +1,7 @@
 package:
   name: cdparanoia
   version: 10.2
-  epoch: 4
+  epoch: 5
   description: An audio CD extraction application
   copyright:
     - license: GPL-2.0-or-later
@@ -51,6 +51,9 @@ pipeline:
         CXXFLAGS="$CFLAGS"
 
   - uses: autoconf/make
+    with:
+      opts: |
+        MAKEFLAGS=-j1
 
   - runs: |
       make -j1 prefix="${{targets.destdir}}"/usr LIBDIR=${{targets.destdir}}/usr/lib MANDIR="${{targets.destdir}}"/usr/share/man install


### PR DESCRIPTION
cdparanoia doesn't successfully build in parallel.  The autoconf/make pipeline defaults to maximum parallel. We set -j1 in the ENV variable so make picks it up.  The -j in the below line only applies to the install run its doing not the pipline make step.
Fixes:

https://github.com/wolfi-dev/os/issues/23354

