### PR TITLE
protobuf-c: Fix riemann-c-client build (wolfi-dev/#23359)

### DIFF
--- a/protobuf-c.yaml
+++ b/protobuf-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf-c
   version: 1.5.0
-  epoch: 7
+  epoch: 8
   description: Protocol Buffers implementation in C
   copyright:
     - license: BSD-2-Clause

--- a/protobuf-c/deprecated-FileDescriptorLegacy.patch
+++ b/protobuf-c/deprecated-FileDescriptorLegacy.patch
@@ -1,23 +1,5 @@
-From e3acc96ca2a00ef715fa2caa659f677cad8a9fa0 Mon Sep 17 00:00:00 2001
-From: Robert Edmonds <edmonds@users.noreply.github.com>
-Date: Wed, 20 Mar 2024 21:48:10 -0400
-Subject: [PATCH 1/3] FileGenerator::GenerateHeader(): Set `min_header_version`
- unconditionally
-
-Previously, we were conditionally trying to set `min_header_version` to
-the lowest possible value, and relying on a "legacy" Google interface to
-determine the file descriptor's syntax version as part of that
-determination.
-
-Instead, simply bump the minimum version to 1003000 (1.3.0). This
-release was almost 7 years ago. In practice protobuf-c users should not
-be shipping pre-compiled .pb-c.c/.pb-c.h files, anyway.
----
- protoc-c/c_file.cc | 9 +--------
- 1 file changed, 1 insertion(+), 8 deletions(-)
-
 diff --git a/protoc-c/c_file.cc b/protoc-c/c_file.cc
-index ca0ad34e..c6d8a240 100644
+index ca0ad34..c6d8a24 100644
 --- a/protoc-c/c_file.cc
 +++ b/protoc-c/c_file.cc
 @@ -117,14 +117,7 @@ FileGenerator::~FileGenerator() {}
@@ -36,44 +18,8 @@ index ca0ad34e..c6d8a240 100644
  
    // Generate top of header.
    printer->Print(
-
-From 1b4b205d87b1bc6f575db1fd1cbbb334a694abe8 Mon Sep 17 00:00:00 2001
-From: Robert Edmonds <edmonds@users.noreply.github.com>
-Date: Wed, 20 Mar 2024 22:25:54 -0400
-Subject: [PATCH 2/3] Reimplement FieldSyntax() to maximize compatibility
- across protobuf versions
-
-Recent versions of Google protobuf have broken the interfaces for
-determining the syntax version of a .proto file. The current protobuf-c
-1.5.0 release does not compile with Google protobuf 26.0 due to the most
-recentage breakage. There is a possible workaround involving the Google
-protobuf `FileDescriptorLegacy` class, which is documented as:
-
-// TODO Remove this deprecated API entirely.
-
-So we probably shouldn't rely on it.
-
-Instead, this commit obtains the `FileDescriptorProto` corresponding
-to the passed in `FieldDescriptor` and interrogates the `syntax` field
-directly. This is a single implementation with no version-specific
-workarounds. Hopefully this won't break in the next Google protobuf
-release.
-
-I tested the `FieldSyntax()` implementation in this commit across a
-number of different Google protobuf releases and found that it worked
-(`make && make check`) on all of them:
-
-- Google protobuf 3.6.1.3 (Ubuntu 20.04)
-- Google protobuf 3.12.4 (Ubuntu 22.04)
-- Google protobuf 3.21.12 (Debian 12 + Debian unstable)
-- Google protobuf 3.25.2 (Debian experimental)
-- Google protobuf 26.1-dev
----
- protoc-c/c_helpers.h | 24 ++++++++++++++----------
- 1 file changed, 14 insertions(+), 10 deletions(-)
-
 diff --git a/protoc-c/c_helpers.h b/protoc-c/c_helpers.h
-index 062d330b..be28b601 100644
+index 062d330..be28b60 100644
 --- a/protoc-c/c_helpers.h
 +++ b/protoc-c/c_helpers.h
 @@ -70,10 +70,6 @@
@@ -115,55 +61,3 @@ index 062d330b..be28b601 100644
  }
  
  // Work around changes in protobuf >= 22.x without breaking compilation against
-
-From d95aced22df60a2f0049fc03af48c8b02ce4d474 Mon Sep 17 00:00:00 2001
-From: Robert Edmonds <edmonds@users.noreply.github.com>
-Date: Wed, 20 Mar 2024 22:43:30 -0400
-Subject: [PATCH 3/3] CGenerator: Protect against being invoked against
- "edition" syntax .proto files
-
-The Google protobuf project is currently experimenting with a new syntax
-for .proto files called "editions". Since protobuf-c is a proto2/proto3
-compiler, after the previous commit reimplementing `FieldSyntax()`, the
-protobuf compiler will abort like this if presented with an "editions"
-syntax .proto file due to the safety check in `FieldSyntax()`:
-
-    $ protoc --experimental_editions --c_out=. test.proto
-    protoc-gen-c: ./protoc-c/c_helpers.h:178: int google::protobuf::compiler::c::FieldSyntax(const google::protobuf::FieldDescriptor*): Assertion `syntax == "proto2" || syntax == "proto3"' failed.
-    --c_out: protoc-gen-c: Plugin killed by signal 6.
-
-On protobuf 26, our `CodeGenerator` can implement certain methods to
-declare that we "support" editions, and then reject any other edition
-except proto2 and proto3, which have apparently been retroactively
-declared to be "editions". Of course this needs to be wrapped in a
-version guard.
-
-With this protection in place, the protobuf compiler cleanly exits with
-a nice error message like this:
-
-    $ protoc --experimental_editions --c_out=. test.proto
-    WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
-    E0000 00:00:1710988958.296200   20022 descriptor.cc:4620] Invalid proto descriptor for file "test.proto":
-    E0000 00:00:1710988958.296239   20022 descriptor.cc:4623]   test.proto: Edition 2023 is later than the maximum supported edition PROTO3
-    --c_out: protoc-gen-c: Plugin failed with status code 1.
----
- protoc-c/c_generator.h | 6 ++++++
- 1 file changed, 6 insertions(+)
-
-diff --git a/protoc-c/c_generator.h b/protoc-c/c_generator.h
-index b8b44aaa..4aeb5790 100644
---- a/protoc-c/c_generator.h
-+++ b/protoc-c/c_generator.h
-@@ -93,6 +93,12 @@ class PROTOC_C_EXPORT CGenerator : public CodeGenerator {
-                 const std::string& parameter,
-                 OutputDirectory* output_directory,
-                 std::string* error) const;
-+
-+#if GOOGLE_PROTOBUF_VERSION >= 5026000
-+  uint64_t GetSupportedFeatures() const { return CodeGenerator::FEATURE_SUPPORTS_EDITIONS; }
-+  Edition GetMinimumEdition() const { return Edition::EDITION_PROTO2; }
-+  Edition GetMaximumEdition() const { return Edition::EDITION_PROTO3; }
-+#endif
- };
- 
- }  // namespace c


### PR DESCRIPTION
It looks like we pulled in an unmerged patches [1] from which is now causing build issues with riemann-c-client. Once the patch causing issues is removed riemann-c-client builds cleanly again.

https://github.com/protobuf-c/protobuf-c/pull/711

Fixes:
https://github.com/wolfi-dev/os/issues/23359


PR:

I just downloaded the patch from the GitHub PR request instead of applying it and using format patch so some of the top matter is gone now. I can restore it if that's an issue.

Notes:

We should validate this doesn't break existing builds before merging.