### PR TITLE
Fix update polling for a number of packages

### DIFF
--- a/py3-appnope.yaml
+++ b/py3-appnope.yaml
@@ -37,6 +37,7 @@ update:
   manual: false
   github:
     identifier: minrk/appnope
+    use-tag: true
 
 test:
   environment:

--- a/py3-appnope.yaml
+++ b/py3-appnope.yaml
@@ -1,8 +1,8 @@
 # Generated from https://pypi.org/project/appnope/
 package:
   name: py3-appnope
-  version: 0.1.3
-  epoch: 2
+  version: 0.1.4
+  epoch: 0
   description: Disable App Nap on macOS >= 10.9
   copyright:
     - license: BSD-3-Clause
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 38e1e1252c263e4f110b427fd13cb81ac6fe56cb
+      expected-commit: 15d8c441ef444660655396b7159c92658982441e
       repository: https://github.com/minrk/appnope
       tag: ${{package.version}}
 

--- a/py3-astunparse.yaml
+++ b/py3-astunparse.yaml
@@ -41,6 +41,7 @@ update:
   github:
     identifier: simonpercivall/astunparse
     strip-prefix: v
+    use-tag: true
 
 test:
   pipeline:

--- a/py3-cachetools.yaml
+++ b/py3-cachetools.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-cachetools
-  version: 5.3.1
+  version: 5.4.0
   epoch: 3
   description: Extensible memoizing collections and decorators
   copyright:
@@ -24,7 +24,7 @@ pipeline:
     with:
       repository: https://github.com/tkem/cachetools/
       tag: v${{package.version}}
-      expected-commit: 8b56caa87f2dc624f3ec453127559ab893616efa
+      expected-commit: 990665be51af3ae879136709e8846e61d7c0e12e
 
   - name: Python Build
     runs: python setup.py build
@@ -38,6 +38,8 @@ update:
   enabled: true
   github:
     identifier: tkem/cachetools
+    strip-prefix: v
+    use-tag: true
 
 test:
   pipeline:

--- a/py3-cachetools.yaml
+++ b/py3-cachetools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cachetools
   version: 5.4.0
-  epoch: 3
+  epoch: 0
   description: Extensible memoizing collections and decorators
   copyright:
     - license: MIT

--- a/py3-cli-helpers.yaml
+++ b/py3-cli-helpers.yaml
@@ -1,7 +1,7 @@
 # Generated from https://pypi.org/project/cli-helpers/
 package:
   name: py3-cli-helpers
-  version: 2.3.0
+  version: 2.3.1
   epoch: 2
   description: Helpers for building command-line apps
   copyright:
@@ -27,7 +27,7 @@ pipeline:
     with:
       repository: https://github.com/dbcli/cli_helpers
       tag: v${{package.version}}
-      expected-commit: 58c7d280338748a6de6317a5e7d3104b6a27b8fb
+      expected-commit: 75e1b3af90c06f0138cd70bb2a4df39eed372d74
 
   - name: Python Build
     runs: python setup.py build
@@ -41,4 +41,5 @@ update:
   enabled: true
   github:
     identifier: dbcli/cli_helpers
+    use-tag: true
     strip-prefix: v

--- a/py3-cli-helpers.yaml
+++ b/py3-cli-helpers.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cli-helpers
   version: 2.3.1
-  epoch: 2
+  epoch: 0
   description: Helpers for building command-line apps
   copyright:
     - license: BSD-3-Clause

--- a/py3-face.yaml
+++ b/py3-face.yaml
@@ -43,3 +43,4 @@ update:
   github:
     identifier: mahmoud/face
     strip-prefix: v
+    use-tag: true

--- a/py3-mypy-extensions.yaml
+++ b/py3-mypy-extensions.yaml
@@ -37,3 +37,4 @@ update:
   manual: false
   github:
     identifier: python/mypy_extensions
+    use-tag: true

--- a/py3-pickleshare.yaml
+++ b/py3-pickleshare.yaml
@@ -38,3 +38,4 @@ update:
   manual: false
   github:
     identifier: pickleshare/pickleshare
+    use-tag: true

--- a/py3-sphinxcontrib-packages.yaml
+++ b/py3-sphinxcontrib-packages.yaml
@@ -45,3 +45,4 @@ update:
   github:
     identifier: sphinx-contrib/packages
     strip-prefix: v
+    use-tag: true

--- a/py3-testpath.yaml
+++ b/py3-testpath.yaml
@@ -37,3 +37,4 @@ update:
   manual: false
   github:
     identifier: jupyter/testpath
+    use-tag: true


### PR DESCRIPTION
These packages were defaulting to checking for 'releases'. However none of the projects publish releases, only tags.