### PR TITLE
kube-fluentd-operator: fix GHSA-5866-49gr-22v4

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 13
+  epoch: 14
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -75,7 +75,7 @@ pipeline:
       # Bump json-jwt to mitigate GHSA-c8v6-786g-vjx6
       echo "gem 'json-jwt', '1.15.3.1'" >> Gemfile
       # Bump json-jwt to mitigate GHSA-4xqq-m2hx-25v8
-      echo "gem 'rexml', '3.3.2'" >> Gemfile
+      echo "gem 'rexml', '3.3.3'" >> Gemfile
       # Bump rack to mitigate GHSA-xj5v-6v4g-jfw6
       bundle update rack
       bundle install


### PR DESCRIPTION
related to https://github.com/chainguard-dev/CVE-Dashboard/issues/9918