### PR TITLE
enable bunch of flags according to eclipse-mosquitto

### DIFF
--- a/libwebsockets.yaml
+++ b/libwebsockets.yaml
@@ -1,7 +1,7 @@
 package:
   name: libwebsockets
   version: 4.3.3
-  epoch: 1
+  epoch: 2
   description: C library for lightweight websocket clients and servers
   copyright:
     - license: MIT
@@ -35,7 +35,17 @@ pipeline:
         -DLWS_WITH_LIBUV=ON \
         -DLWS_WITH_STATIC=OFF \
         -DLWS_LINK_TESTAPPS_DYNAMIC=ON \
-        -DLWS_WITH_SDEVENT=OFF
+        -DLWS_WITH_SDEVENT=OFF \
+        -DCMAKE_BUILD_TYPE=MinSizeRel \
+        -DDISABLE_WERROR=ON \
+        -DLWS_IPV6=ON \
+        -DLWS_WITHOUT_BUILTIN_GETIFADDRS=ON \
+        -DLWS_WITHOUT_CLIENT=ON \
+        -DLWS_WITHOUT_EXTENSIONS=ON \
+        -DLWS_WITH_EXTERNAL_POLL=ON \
+        -DLWS_WITH_HTTP2=OFF \
+        -DLWS_WITH_ZIP_FOPS=OFF \
+        -DLWS_WITH_ZLIB=OFF
 
   - uses: cmake/build
 

--- a/mosquitto.yaml
+++ b/mosquitto.yaml
@@ -1,7 +1,7 @@
 package:
   name: mosquitto
   version: 2.0.18
-  epoch: 2
+  epoch: 3
   description: open source MQTT broker
   copyright:
     - license: EPL-1.0
@@ -29,11 +29,16 @@ pipeline:
 
   - runs: |
       make \
+        CFLAGS="$CFLAGS -Wall -O2 -I/build/lws/include -I/build" \
+        LDFLAGS="$LDFLAGS -L/build/lws/lib" \
         WITH_MEMORY_TRACKING=no \
         WITH_WEBSOCKETS=yes \
         WITH_CJSON=yes \
         WITH_SRV=yes \
         WITH_ADNS=no \
+        WITH_DOCS=no \
+        WITH_SHARED_LIBRARIES=yes \
+        WITH_TLS_PSK=no \
         prefix=/usr
 
   - runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

eclipse-mosquitto needs bunch of additional options for both mosquitto and libwebsockets packages:

- https://github.com/eclipse/mosquitto/blob/15292b20b0894ec7c5c3d47e4b22ee9d89f91132/docker/2.0/Dockerfile#L63-L74
- https://github.com/eclipse/mosquitto/blob/15292b20b0894ec7c5c3d47e4b22ee9d89f91132/docker/2.0/Dockerfile#L27-L40

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
