### PR TITLE
fix(keycloak-bitnami-compat): cp instead of symlinking keycloak files

### DIFF
--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak
   version: 25.0.2
-  epoch: 3
+  epoch: 4
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0
@@ -104,21 +104,10 @@ subpackages:
 
           chmod g+rwX ${{targets.contextdir}}/opt/bitnami
 
-          # Symlink the directories under /usr/share/java/keycloak/* to /opt/bitnami/keycloak/*.
-          for dir in ${{targets.destdir}}/usr/share/java/keycloak/*; do
-            if [ -d "$dir" ]; then
-              base_dir=$(basename "$dir")
-              mkdir -p ${{targets.contextdir}}/opt/bitnami/keycloak/$base_dir
-              for file in "$dir"/*; do
-                if [ -e "$file" ]; then
-                  target="${{targets.contextdir}}/opt/bitnami/keycloak/$base_dir/$(basename "$file")"
-                  source="/usr/share/java/keycloak/$base_dir/$(basename "$file")"
-                  ln -sf "$source" "$target" || true
-                  echo "Created symlink: $target -> $source"
-                fi
-              done
-            fi
-          done
+          # Copy keycloak files to /opt/bitnami/keycloak for compatibility with
+          # their Helm Chart, which copies the directories into an emptyDir in
+          # an initContainer
+          cp -r ${{targets.destdir}}/usr/share/java/keycloak/* ${{targets.contextdir}}/opt/bitnami/keycloak
 
           # Replace the incorrect Java paths in the Bitnami scripts
           sed -i 's/JAVA_HOME="\/opt\/bitnami\/java"/JAVA_HOME="\/usr\/lib\/jvm\/java-17-openjdk"/g' ${{targets.contextdir}}/opt/bitnami/scripts/keycloak-env.sh


### PR DESCRIPTION
resolves https://github.com/chainguard-dev/image-release-stats/issues/287