### PR TITLE
eclipse-mosquitto

### DIFF
--- a/mosquitto.yaml
+++ b/mosquitto.yaml
@@ -1,7 +1,7 @@
 package:
   name: mosquitto
   version: 2.0.18
-  epoch: 3
+  epoch: 4
   description: open source MQTT broker
   copyright:
     - license: EPL-1.0
@@ -16,16 +16,24 @@ environment:
       - c-ares-dev
       - ca-certificates-bundle
       - cjson-dev
+      - docbook-xml
       - libwebsockets-dev
       - libxslt
       - openssl-dev
       - util-linux-dev
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: d665fe7d0032881b1371a47f34169ee4edab67903b2cd2b4c083822823f4448a
-      uri: https://mosquitto.org/files/source/mosquitto-${{package.version}}.tar.gz
+      expected-commit: 3923526c6b4c048bbecad2506c4c9963bc46cd36
+      repository: https://github.com/eclipse/mosquitto
+      tag: v${{package.version}}
 
   - runs: |
       make \
@@ -85,7 +93,82 @@ subpackages:
           mv ${{targets.destdir}}/usr/bin/mosquitto_[ps]ub ${{targets.subpkgdir}}/usr/bin/
     description: Mosquitto command line MQTT clients
 
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}
+          mkdir -p ${{targets.contextdir}}/mosquitto/config
+          mkdir -p ${{targets.contextdir}}/mosquitto/data
+          mkdir -p ${{targets.contextdir}}/mosquitto/log
+          install -Dm755 docker/${{vars.major-minor-version}}-openssl/docker-entrypoint.sh ${{targets.contextdir}}/docker-entrypoint.sh
+          install -Dm644 docker/${{vars.major-minor-version}}-openssl/mosquitto-no-auth.conf ${{targets.contextdir}}/mosquitto-no-auth.conf
+
 update:
   enabled: true
-  release-monitor:
-    identifier: 6078
+  github:
+    identifier: eclipse/mosquitto
+    strip-prefix: v
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - libwebsockets
+        - mosquitto-libs++
+        - mosquitto-libs
+        - mosquitto-clients
+        - mosquitto
+        - ${{package.name}}-compat
+  pipeline:
+    - runs: |
+        #!/bin/bash
+
+        # Define the topic and message
+        TOPIC="test/topic"
+        MESSAGE="Hello, Mosquitto!"
+
+        # Create the mosquitto group and user if they do not already exist
+        if ! getent group mosquitto > /dev/null; then
+            addgroup -S mosquitto
+        fi
+
+        if ! id -u mosquitto > /dev/null 2>&1; then
+            adduser -S -G mosquitto mosquitto
+        fi
+
+        # Create a minimal Mosquitto configuration
+        cat <<EOF > /etc/mosquitto/mosquitto.conf
+        allow_anonymous true
+        listener 1883
+        EOF
+
+        # Switch to the mosquitto user and start the Mosquitto broker
+        /docker-entrypoint.sh /usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf &
+
+        # Wait for a moment to ensure Mosquitto has started
+        sleep 2
+
+        # Subscribe to the topic in the background and save the output to a file
+        mosquitto_sub -h localhost -t $TOPIC -C 1 > output.txt &
+
+        # Wait for a moment to ensure the subscriber is ready
+        sleep 1
+
+        # Publish a message to the topic
+        mosquitto_pub -h localhost -t $TOPIC -m "$MESSAGE"
+
+        # Wait a moment to allow the subscriber to receive the message
+        sleep 1
+
+        # Check if the message was received
+        RECEIVED_MESSAGE=$(cat output.txt)
+
+        if [ "$RECEIVED_MESSAGE" == "$MESSAGE" ]; then
+            echo "Test Passed: Message received correctly."
+        else
+            echo "Test Failed: Message not received correctly."
+        fi
+
+        # Clean up
+        rm output.txt


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
