### PR TITLE
Add explicit depends on perl-test-simple to ensure lcov builds after perl-test-simple is built

### DIFF
--- a/lcov.yaml
+++ b/lcov.yaml
@@ -1,4 +1,3 @@
-# Generated from https://git.alpinelinux.org/aports/plain/testing/lcov/APKBUILD
 package:
   name: lcov
   version: "2.1"
@@ -12,8 +11,8 @@ package:
       - perl
       - perl-capture-tiny
       - perl-datetime
-      - perl-digest-md5
       - perl-devel-cover
+      - perl-digest-md5
       - perl-json-xs
       - perl-memory-process
       - perl-time-hires
@@ -34,6 +33,7 @@ environment:
       - perl-digest-md5
       - perl-json-xs
       - perl-memory-process
+      - perl-test-simple
       - perl-time-hires
 
 pipeline:

--- a/perl-test-simple.yaml
+++ b/perl-test-simple.yaml
@@ -1,4 +1,3 @@
-# Generated from https://git.alpinelinux.org/aports/plain/main/perl-test-simple/APKBUILD
 package:
   name: perl-test-simple
   version: "1.302200"

--- a/perl-test2-plugin-nowarnings.yaml
+++ b/perl-test2-plugin-nowarnings.yaml
@@ -1,4 +1,3 @@
-# Generated from https://git.alpinelinux.org/aports/plain/main/perl-test2-plugin-nowarnings/APKBUILD
 package:
   name: perl-test2-plugin-nowarnings
   version: "0.10"


### PR DESCRIPTION
Add explicit depends on perl-test-simple to ensure lcov builds after perl-test-simple is built

This should unbork post-submit builds.