### PR TITLE
Add minio-operator package

### DIFF
--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: Minio Operator creates/configures/manages Minio on Kubernetes
   copyright:
-    - license: AGPL-3.0
+    - license: AGPL-3.0-only
 
 environment:
   contents:
@@ -21,13 +21,16 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 15c388bd4ce0a03084f1b3762f16a65679b83423
 
-  - runs: |
-      make regen-crd
+  - uses: go/bump
+    with:
+      deps: github.com/docker/docker@v27.1.1
+      modroot: .
 
   - uses: go/build
     with:
       modroot: ./cmd/operator
       packages: .
+      output: minio-operator
       ldflags: -s -w -X github.com/minio/operator/pkg.ReleaseTag=${{package.full-version}} -X github.com/minio/operator/pkg.Version=${{package.full-version}} -X github.com/minio/operator/pkg.ShortCommitID=$(git rev-parse HEAD)
 
   - uses: strip
@@ -35,6 +38,14 @@ pipeline:
   - runs: |
       mkdir ${{targets.destdir}}/licenses
       cp CREDITS LICENSE ${{targets.destdir}}/licenses/
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: compatibility symlinks package for minio-operator Dockerfile
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          ln -sf /usr/bin/minio-operator ${{targets.contextdir}}/minio-operator
 
 update:
   enabled: true

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -1,0 +1,48 @@
+package:
+  name: minio-operator
+  version: 6.0.2
+  epoch: 0
+  description: Minio Operator creates/configures/manages Minio on Kubernetes
+  copyright:
+    - license: AGPL-3.0
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/minio/operator
+      tag: v${{package.version}}
+      expected-commit: 15c388bd4ce0a03084f1b3762f16a65679b83423
+
+  - runs: |
+      make regen-crd
+
+  - uses: go/build
+    with:
+      modroot: ./cmd/operator
+      packages: .
+      ldflags: -s -w -X github.com/minio/operator/pkg.ReleaseTag=${{package.full-version}} -X github.com/minio/operator/pkg.Version=${{package.full-version}} -X github.com/minio/operator/pkg.ShortCommitID=$(git rev-parse HEAD)
+
+  - uses: strip
+
+  - runs: |
+      mkdir ${{targets.destdir}}/licenses
+      cp CREDITS LICENSE ${{targets.destdir}}/licenses/
+
+update:
+  enabled: true
+  github:
+    identifier: minio/operator
+    strip-prefix: v
+
+# comprehensive test with kwok and minio's kustomize want ephemeral storage, so just check version here
+test:
+  pipeline:
+    - runs: minio-operator --version


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
