### PR TITLE
Revert beego bump in harbor-2.11

### DIFF
--- a/harbor-2.11.yaml
+++ b/harbor-2.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-2.11
   version: 2.11.0
-  epoch: 6
+  epoch: 7
   description: An open source trusted cloud native registry project that stores, signs, and scans content
   copyright:
     - license: Apache-2.0
@@ -177,7 +177,6 @@ test:
 
 update:
   enabled: true
-  manual: true # see #26370 for details
   ignore-regex-patterns:
     - '-rc'
     - '-beta'

--- a/harbor-2.11.yaml
+++ b/harbor-2.11.yaml
@@ -46,7 +46,7 @@ pipeline:
   - uses: go/bump
     with:
       modroot: ./src
-      deps: github.com/cloudevents/sdk-go/v2@v2.15.2 github.com/jackc/pgproto3/v2@v2.3.3 google.golang.org/protobuf@v1.33.0 github.com/docker/docker@v26.1.5 github.com/beego/beego/v2@v2.2.1
+      deps: github.com/cloudevents/sdk-go/v2@v2.15.2 github.com/jackc/pgproto3/v2@v2.3.3 google.golang.org/protobuf@v1.33.0 github.com/docker/docker@v26.1.5
 
   - uses: go/build
     with:

--- a/harbor-2.11.yaml
+++ b/harbor-2.11.yaml
@@ -177,6 +177,7 @@ test:
 
 update:
   enabled: true
+  manual: true # see #26370 for details
   ignore-regex-patterns:
     - '-rc'
     - '-beta'


### PR DESCRIPTION
@EyeCantCU reverted this in https://github.com/wolfi-dev/os/pull/26137 but then our automation added it back in (https://github.com/wolfi-dev/os/pull/26157). I think it's breaking the harbor helm test which is causing https://github.com/chainguard-dev/image-release-stats/issues/280 (cc @smoser)

I added `manual: true` for now but please let me know if there's a better way to stop automation from adding this back in