### PR TITLE
perl: build with openssf-compiler-options enabled

### DIFF
--- a/perl.yaml
+++ b/perl.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl
   version: 5.40.0 # when bumping this version also bump Perl packages epochs to trigger a rebuild
-  epoch: 2
+  epoch: 3
   description: "Larry Wall's Practical Extraction and Report Language"
   copyright:
     - license: Artistic-1.0-Perl OR GPL-1.0-or-later
@@ -14,6 +14,7 @@ environment:
       - busybox
       - bzip2-dev
       - ca-certificates-bundle
+      - openssf-compiler-options
       - wolfi-baselayout
       - zlib-dev
 
@@ -42,7 +43,6 @@ pipeline:
       ./Configure -des \
          -Dcc=gcc \
          -Dcccdlflags='-fPIC' \
-         -Dcccdlflags='-fPIC' \
          -Dccdlflags='-rdynamic' \
          -Dprefix=/usr \
          -Dprivlib=/usr/share/perl5/core_perl \
@@ -67,6 +67,7 @@ pipeline:
          -Dcf_by='Wolfi GNU/Linux' \
          -Ud_csh
 
+      make depend
       make -j$(nproc) libperl.so
       make -j$(nproc)
 
@@ -74,6 +75,7 @@ pipeline:
 
   - runs: |
       find "${{targets.destdir}}" -name '.*' -delete
+      chmod -R +w "${{targets.destdir}}"
 
   - uses: strip
 
@@ -151,6 +153,9 @@ update:
 
 test:
   pipeline:
+    - uses: test/hardening-check
+      with:
+        args: --nofortify --nostackprotector
     - runs: |
         perl --version
     - runs: |

--- a/pipelines/test/hardening-check.yaml
+++ b/pipelines/test/hardening-check.yaml
@@ -77,6 +77,10 @@ pipeline:
                       debug "$f: not an ELF file"
                       continue
                   fi
+                  if grep -qi "readelf: Error: .*: Failed to read file's magic number" "$errf"; then
+                      debug "$f: not an ELF file"
+                      continue
+                  fi
                   checkfile "$f" || errors=$((errors+1))
                   files=$((files+1))
               done < "$flist"


### PR DESCRIPTION
Perl builds currently is missing multiple hardening features, with
openssf-compiler-options many of them get enabled, specifically
bind-now, control flow protection. And for most, but not all, binaries
also stack protector and fortify source.

Whilst not ideal in terms of enforcement, this is improvement over
status quo.

Further investigation of perl configuration flags (or patches) is
required, as perl builds in other distributions appears to have stack
protected for more binaries. But it could be a false negative.

Other fixes:
- Remove duplicate configure flag.
- Ensure dependent source code is generated first, to prevent parallel make failures.
- Ensure code is writable, for strip to process binaries.
- Add hardening-check pipeline.
- Fixup hardening-check pipeline for tiny files, smaller than ELF magic.
