### PR TITLE
Fix dangling symlinks

### DIFF
--- a/ccache.yaml
+++ b/ccache.yaml
@@ -1,7 +1,7 @@
 package:
   name: ccache
   version: 4.10.2
-  epoch: 0
+  epoch: 1
   description: Fast C/C++ compiler cache
   copyright:
     - license: GPL-3.0-or-later
@@ -39,7 +39,7 @@ pipeline:
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/lib/ccache/bin
       for link in cc gcc g++ cpp c++ clang clang++ c89 c99; do
-          ln -sf ${{targets.destdir}}/bin/ccache ${{targets.destdir}}/usr/lib/ccache/bin/${link}
+          ln -sf /bin/ccache ${{targets.destdir}}/usr/lib/ccache/bin/${link}
       done
 
 update:

--- a/iputils.yaml
+++ b/iputils.yaml
@@ -1,7 +1,7 @@
 package:
   name: iputils
   version: "20240117"
-  epoch: 2
+  epoch: 3
   description: IP Configuration Utilities
   copyright:
     - license: BSD-3-Clause AND GPL-2.0-or-later
@@ -44,8 +44,8 @@ pipeline:
       for name in arping clockdiff tracepath; do
          install -Dm755 output/$name "${{targets.destdir}}"/usr/sbin/$name
       done
-      ln -s "${{targets.destdir}}"/usr/sbin/tracepath "${{targets.destdir}}"/usr/sbin/tracepath6
-      ln -s "${{targets.destdir}}"/bin/ping "${{targets.destdir}}"/bin/ping6
+      ln -s /usr/sbin/tracepath "${{targets.destdir}}"/usr/sbin/tracepath6
+      ln -s /bin/ping "${{targets.destdir}}"/bin/ping6
 
   - uses: strip
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #26225 

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
