### PR TITLE
git: switch to openssf-compiler-options

### DIFF
--- a/git.yaml
+++ b/git.yaml
@@ -1,7 +1,7 @@
 package:
   name: git
   version: 2.46.0
-  epoch: 1
+  epoch: 2
   description: "distributed version control system"
   copyright:
     - license: GPL-2.0-or-later
@@ -16,6 +16,7 @@ environment:
       - ca-certificates-bundle
       - curl-dev
       - expat-dev
+      - openssf-compiler-options
       - openssl-dev
       - pcre2-dev
       - wolfi-base
@@ -48,7 +49,6 @@ pipeline:
 
   - runs: |
       make prefix=/usr \
-        CFLAGS="-O2 -Wall" \
         DESTDIR="${{targets.destdir}}" \
         INSTALLDIRS=vendor \
         install -j$(nproc)
@@ -130,6 +130,7 @@ test:
     environment:
       HOME: /tmp
   pipeline:
+    - uses: test/hardening-check
     - name: Verify git installation
       runs: |
         git --version || exit 1

--- a/pipelines/test/hardening-check.yaml
+++ b/pipelines/test/hardening-check.yaml
@@ -77,7 +77,7 @@ pipeline:
                       debug "$f: not an ELF file"
                       continue
                   fi
-                  if grep -qi "readelf: Error: .*: Failed to read file's magic number" "$errf"; then
+                  if grep -qi "readelf: Error: .*: Failed to read file.*" "$errf"; then
                       debug "$f: not an ELF file"
                       continue
                   fi


### PR DESCRIPTION
Together with perl this should complete hardening of gcc-glibc image.
