### PR TITLE
gnupg glow up

### DIFF
--- a/gnupg.yaml
+++ b/gnupg.yaml
@@ -1,7 +1,7 @@
 package:
   name: gnupg
   version: 2.2.41
-  epoch: 3
+  epoch: 4
   description: GNU Privacy Guard 2 - meta package for full GnuPG suite
   copyright:
     - license: GPL-3.0-or-later
@@ -27,10 +27,13 @@ environment:
       - libusb-dev
       - npth-dev
       - openldap-dev
+      - openssf-compiler-options
       - readline-dev
       - sqlite-dev
       - texinfo
       - zlib-dev
+  environment:
+    CPPFLAGS: -Wp,-DLDAP_DEPRECATED=1
 
 pipeline:
   - uses: fetch
@@ -242,5 +245,6 @@ test:
       packages:
         - gpg
   pipeline:
+    - uses: test/hardening-check
     - runs: |
         gpg --version


### PR DESCRIPTION
Fix FTBFS against new openldap which deprecates functions used by
gnupg. Upstream commit
https://github.com/gpg/gnupg/commit/ddc6f7d194918791ac9dff0e5af4b80933189afd

Enable hardening flags

Enable hardening check
