### PR TITLE
FTBFS libevdev

### DIFF
--- a/libevdev.yaml
+++ b/libevdev.yaml
@@ -1,7 +1,7 @@
 package:
   name: libevdev
   version: 1.13.2
-  epoch: 0
+  epoch: 1
   description: Kernel Evdev Device Wrapper Library
   copyright:
     - license: MIT
@@ -22,7 +22,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 3eca86a6ce55b81d5bce910637fc451c8bbe373b1f9698f375c7f1ad0de3ac48
-      uri: https://freedesktop.org/software/libevdev/libevdev-${{package.version}}.tar.xz
+      uri: https://www.freedesktop.org/software/libevdev/libevdev-${{package.version}}.tar.xz
 
   - uses: meson/configure
     with:


### PR DESCRIPTION
Fix certificate error, by using canonical url form with www.

Fixes failure to build from source like this

    2024/08/15 17:53:22 INFO running step "Fetch and extract external object into workspace"
    2024/08/15 17:53:22 WARN --2024-08-15 16:53:22--  https://freedesktop.org/software/libevdev/libevdev-1.13.2.tar.xz
    2024/08/15 17:53:22 WARN Resolving freedesktop.org... 131.252.210.176
    2024/08/15 17:53:23 WARN Connecting to freedesktop.org|131.252.210.176|:443... connected.
    2024/08/15 17:53:23 WARN ERROR: no certificate subject alternative name matches
    2024/08/15 17:53:23 WARN     requested host name 'freedesktop.org'.
    2024/08/15 17:53:23 WARN To connect to freedesktop.org insecurely, use `--no-check-certificate'.
