### PR TITLE
py3-dateutil: versioned python

### DIFF
--- a/py3-python-dateutil.yaml
+++ b/py3-python-dateutil.yaml
@@ -2,16 +2,12 @@
 package:
   name: py3-python-dateutil
   version: 2.9.0
-  epoch: 1
+  epoch: 2
   description: Extensions to the standard Python datetime module
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - py3-six
-      - python3
-    provides:
-      - py3-dateutil=${{package.full-version}}
+    provider-priority: 0
 
 environment:
   contents:
@@ -19,11 +15,23 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-setuptools
-      - python3
+      - py3-supported-build
+      - py3-supported-installer
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-wheel
       - wolfi-base
+
+vars:
+  pypi-package: dateutil
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 pipeline:
   - uses: git-checkout
@@ -32,10 +40,28 @@ pipeline:
       repository: https://github.com/dateutil/dateutil
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
-
-  - uses: strip
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-python-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-six
+      provides:
+        - py3-${{vars.pypi-package}}
+        - py${{range.key}}-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-python-dateutil.yaml
+++ b/py3-python-dateutil.yaml
@@ -78,4 +78,3 @@ update:
     - post
   github:
     identifier: dateutil/dateutil
-

--- a/py3-python-dateutil.yaml
+++ b/py3-python-dateutil.yaml
@@ -63,6 +63,14 @@ subpackages:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
 
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+
 update:
   enabled: true
   manual: false

--- a/py3-python-dateutil.yaml
+++ b/py3-python-dateutil.yaml
@@ -66,5 +66,8 @@ subpackages:
 update:
   enabled: true
   manual: false
+  ignore-regex-patterns:
+    - post
   github:
     identifier: dateutil/dateutil
+


### PR DESCRIPTION
Adds python-dateutil for 3.10, 3.11 and 3.12
