### PR TITLE
gitaly-17.2: switch to git updates and revert to 17.2.2 as it was inc…

### DIFF
--- a/gitaly-17.2.yaml
+++ b/gitaly-17.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitaly-17.2
-  version: 17.3.0
-  epoch: 0
+  version: 17.2.2
+  epoch: 1
   description:
   copyright:
     - license: MIT
@@ -36,7 +36,7 @@ pipeline:
     with:
       repository: https://gitlab.com/gitlab-org/gitaly.git
       tag: v${{package.version}}
-      expected-commit: 6a0065b3fad38618a7afc98edb528f286bccb067
+      expected-commit: f361b25764d8001ad58f2b64c2fe8bbc898870df
 
   - runs: |
       make install DESTDIR="${{targets.destdir}}" PREFIX=/usr
@@ -103,8 +103,9 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 38196
+  git:
+    strip-prefix: v
+    tag-filter-prefix: v17.2
 
 test:
   pipeline:


### PR DESCRIPTION
…orrectly updated to 17.3 stream, withdraw bad apk

