### PR TITLE
gitaly-17.2: withdraw incorrect version 17.3

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,14 +1,7 @@
-redis-7.4-7.4.0-r0.apk
-redis-7.2-bitnami-compat-7.4.0-r0.apk
-redis-cli-7.2-7.4.0-r0.apk
-redis-benchmark-7.2-7.4.0-r0.apk
-redis-sentinel-7.2-bitnami-compat-7.4.0-r0.apk
-redis-cluster-7.2-bitnami-compat-7.4.0-r0.apk
-rancher-kontainer-driver-metadata-2.9-r0.apk
-rancher-loglevel-0.1.6-r0.apk
 abseillib-20230802.0-r0.apk
 abseillib-20230802.0-r1.apk
 abseillib-20230802.1-r0.apk
 abseillib-20240116.0-r0.apk
 abseillib-20240116.1-r0.apk
 abseillib-20240116.2-r0.apk
+gitaly-17.2-17.3.0-r0.apk


### PR DESCRIPTION
I have another PR https://github.com/wolfi-dev/os/pull/26468#issuecomment-2293279759 which reverts the version from the package yaml and fixes the update.  This is failing, I think because the bad 17.3 version is in the index and getting installed in the test env which fails that presubmit check.


FWIW when I looked in the apk repo I could see the abseillib apks that the withdrawn-packages.txt should have removed.  That's why I've left those in this change but removed the others, as they have been withdrawn.