### PR TITLE
FTBFS collectd

### DIFF
--- a/collectd.yaml
+++ b/collectd.yaml
@@ -6,7 +6,7 @@
 package:
   name: collectd
   version: 5.12.0
-  epoch: 1
+  epoch: 2
   description: "The system statistics collection daemon."
   copyright:
     - license: MIT
@@ -63,7 +63,7 @@ environment:
       - rabbitmq-c-dev
       - riemann-c-client-dev
       - rrdtool-dev
-      - varnish
+      - varnish-dev
       - yajl-dev
       - zlib-dev
 
@@ -78,6 +78,7 @@ pipeline:
       ./build.sh
 
       CFLAGS="$CFLAGS -fPIC" \
+      LDFLAGS="$LDFLAGS -lgcrypt" \
       CPPFLAGS="$CFLAGS" \
       CXXFLAGS="$CFLAGS"
       ./configure \


### PR DESCRIPTION
Fix failure to build from source of collectd. Update environment
dependencies on the dev package for varnish, and ask to link with
libgcrypt harder as configure.ac is not using pkg-config and thus does
not set GCRYPT_LIBS=-lgcrypt. Easier to do this as a variable, than
patching configure.ac.
