### PR TITLE
py3-attrs split out for versions add deps

### DIFF
--- a/py3-attrs.yaml
+++ b/py3-attrs.yaml
@@ -2,14 +2,22 @@
 package:
   name: py3-attrs
   version: 24.2.0
-  epoch: 0
+  epoch: 1
   description: Classes Without Boilerplate
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - py3-importlib-metadata
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: attrs
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 environment:
   contents:
@@ -17,17 +25,12 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-gpep517
-      - py3-hatchling
-      - py3-pip
-      - py3-setuptools
-      - py3-wheel
-      - python3
+      - py3-supported-build
+      - py3-supported-hatch-fancy-pypi-readme
+      - py3-supported-hatch-vcs
+      - py3-supported-hatchling
+      - py3-supported-pip
       - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    # The script
-    SOURCE_DATE_EPOCH: 315532800
 
 pipeline:
   - uses: git-checkout
@@ -40,10 +43,35 @@ pipeline:
     runs: |
       git fetch --unshallow
 
-  - name: Python Install
-    runs: export SOURCE_DATE_EPOCH=$(git log -1 --format=%ct || $SOURCE_DATE_EPOCH) && pip3 install . --root=${{targets.destdir}}
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+      runtime:
+        - py${{range.key}}-importlib-metadata
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: attrs
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
 
 update:
   enabled: true
@@ -51,9 +79,3 @@ update:
     - "^.*?post\\d"
   github:
     identifier: python-attrs/attrs
-
-test:
-  pipeline:
-    - uses: python/import
-      with:
-        import: attrs


### PR DESCRIPTION
This splits py3-attrs into multiple python3 versions and adds the hatch-fancy-pypi-readme package which is an attrs dep.

Fixes:

Related:

### Pre-review Checklist


#### For new package PRs only
<!-- remove if unrelated -->
- [X] This PR is marked as fixing a pre-existing package request bug
  - [X] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [X] The upstream project actually supports multiple concurrent versions.
- [X] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [X] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions
