### PR TITLE
statsd - Add modules that statsd depends on

### DIFF
--- a/statsd.yaml
+++ b/statsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: statsd
   version: 0.10.2
-  epoch: 0
+  epoch: 1
   description: Daemon for easy but powerful stats aggregation
   copyright:
     - license: MIT
@@ -10,6 +10,8 @@ environment:
   contents:
     packages:
       - busybox
+      - nodejs
+      - npm
 
 pipeline:
   - uses: git-checkout
@@ -27,9 +29,47 @@ pipeline:
       done
 
   - runs: |
+      cd ${{targets.contextdir}}/usr/src/app
+      # optional includes hashring, a dep for proxy.js
+      npm install --omit=dev
+
+  - runs: |
       # Set graphite hostname to "graphite"
       sed -i 's/graphite.example.com/graphite/' exampleConfig.js
       mv exampleConfig.js ${{targets.destdir}}/usr/src/app/config.js
+
+test:
+  environment:
+    contents:
+      packages:
+        - nodejs
+        - curl
+  pipeline:
+    - name: verify proxy scaling
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          #!/bin/sh -ex
+          # exampleProxyConfig.js is taken from statsd
+          cat >/tmp/exampleProxyConfig.js <<"EOF"
+          {
+          nodes: [
+          {host: '127.0.0.1', port: 8127, adminport: 8128},
+          {host: '127.0.0.1', port: 8129, adminport: 8130},
+          ],
+          server: './servers/udp',
+          host:  '0.0.0.0',
+          port: 8125,
+          udp_version:'udp4',
+          mgmt_port: 8126,
+          forkCount: 0,
+          checkInterval: 1000,
+          cacheSize: 10000
+          }
+          EOF
+        start: sh -xc 'cd /usr/src/app && exec node proxy.js exampleProxyConfig.js'
+        expected_output: |
+          server is up
 
 update:
   enabled: true


### PR DESCRIPTION
The request that triggered this was for proxy.js function which would throw an error :

    Error: Cannot find module 'hashring'
    code: 'MODULE_NOT_FOUND',

We were not installing any of its dependencies, so this adds both the production dependencies (only "generic-pool") and the optional (modern-syslog, hashring, winser).
