### PR TITLE
versioning for python packages

### DIFF
--- a/py3-maturin.yaml
+++ b/py3-maturin.yaml
@@ -1,13 +1,12 @@
 package:
   name: py3-maturin
   version: 1.7.0
-  epoch: 1
+  epoch: 2
   description: Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages
   copyright:
     - license: MIT OR Apache-2.0
   dependencies:
-    runtime:
-      - py3-tomli
+    provider-priority: 0
 
 environment:
   contents:
@@ -15,9 +14,24 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - python3-dev
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-python-dev
+      - py3-supported-setuptools
+      - py3-supported-setuptools-rust
+      - py3-supported-wheel
       - rust
       - wolfi-base
+
+vars:
+  pypi-package: maturin
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 pipeline:
   - uses: git-checkout
@@ -26,17 +40,35 @@ pipeline:
       repository: https://github.com/pyo3/maturin
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-tomli
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
 
-  - uses: strip
-
-test:
-  pipeline:
-    - uses: python/import
-      with:
-        imports: |
-          import maturin
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-maturin.yaml
+++ b/py3-maturin.yaml
@@ -55,6 +55,20 @@ subpackages:
         with:
           python: python${{range.key}}
       - uses: strip
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr
+          mv ${{targets.contextdir}}/../py${{range.key}}-${{vars.pypi-package}}/usr/bin ${{targets.contextdir}}/usr
     test:
       pipeline:
         - uses: python/import

--- a/py3-pydantic-core.yaml
+++ b/py3-pydantic-core.yaml
@@ -65,14 +65,6 @@ subpackages:
             python: python${{range.key}}
             import: ${{vars.module-name}}
 
-  - name: py3-supported-${{vars.pypi-package}}
-    description: meta package providing ${{vars.pypi-package}} for supported python versions.
-    dependencies:
-      runtime:
-        - py3.10-${{vars.pypi-package}}
-        - py3.11-${{vars.pypi-package}}
-        - py3.12-${{vars.pypi-package}}
-
 update:
   enabled: true
   github:

--- a/py3-pydantic-core.yaml
+++ b/py3-pydantic-core.yaml
@@ -2,13 +2,11 @@
 package:
   name: py3-pydantic-core
   version: 2.22.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - py3-typing-extensions
-      - python3
+    provider-priority: 0
 
 environment:
   contents:
@@ -16,13 +14,26 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-setuptools
-      - py3-typing-extensions
-      - python3
+      - py3-supported-build
+      - py3-supported-installer
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-typing-extensions
+      - py3-supported-wheel
       - rust
       - wolfi-base
+
+vars:
+  pypi-package: pydantic-core
+  module-name: pydantic_core
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 pipeline:
   - uses: git-checkout
@@ -31,16 +42,36 @@ pipeline:
       repository: https://github.com/pydantic/pydantic-core
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-typing-extensions
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - runs: pip${{range.key}} install maturin
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.module-name}}
 
-  - uses: strip
-
-test:
-  pipeline:
-    - uses: python/import
-      with:
-        import: pydantic_core
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-setuptools-rust.yaml
+++ b/py3-setuptools-rust.yaml
@@ -2,16 +2,12 @@
 package:
   name: py3-setuptools-rust
   version: 1.10.1
-  epoch: 0
+  epoch: 1
   description: Setuptools Rust extension plugin
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - py3-setuptools
-      - py3-semantic-version
-      - py3-typing-extensions
-      - python3
+    provider-priority: 0
 
 environment:
   contents:
@@ -19,11 +15,24 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-setuptools
-      - python3
+      - py3-supported-build
+      - py3-supported-installer
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-wheel
       - wolfi-base
+
+vars:
+  pypi-package: setuptools-rust
+  module-name: setuptools_rust
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 pipeline:
   - uses: git-checkout
@@ -32,13 +41,37 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: df30297ac3d06b3a6536c3d304e780cdccc86da1
 
-  - name: Python Build
-    runs: python -m build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-setuptools
+        - py${{range.key}}-semantic-version
+        - py${{range.key}}-typing-extensions
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.module-name}}
 
-  - name: Python Install
-    runs: python3 -m installer -d "${{targets.destdir}}" dist/*.whl
-
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-typing-extensions.yaml
+++ b/py3-typing-extensions.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-typing-extensions
   version: 4.12.2
-  epoch: 3
+  epoch: 4
   description: Backported and Experimental Type Hints for Python 3.7+
   copyright:
     - license: PSF-2.0
@@ -56,6 +56,14 @@ subpackages:
     test:
       pipeline:
         - runs: python${{range.key}} -c "from ${{vars.module_name}} import TypeAlias, TypeGuard"
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
 
 update:
   enabled: true


### PR DESCRIPTION
maturin: Add supported- subpackage; needed for pydantic-core build
pydantic-core: versioned python
setuptools-rust: Add supported- subpackage; needed for maturin build
typing-extensions: Add supported- subpackage; needed for pydantic-core build