### PR TITLE
Multi-versionize py3-psutil

### DIFF
--- a/py3-psutil.yaml
+++ b/py3-psutil.yaml
@@ -1,15 +1,26 @@
 package:
   name: py3-psutil
   version: 5.9.5
-  epoch: 2
+  epoch: 3
   description: Cross-platform lib for process and system monitoring in Python.
   copyright:
     - license: BSD-3-Clause
   dependencies:
+    provider-priority: 0
     runtime:
       - linux-headers
       - python3
       - python3-dev
+
+vars:
+  pypi-package: psutil
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 environment:
   contents:
@@ -18,8 +29,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - py3-setuptools
-      - python3
-      - python3-dev
+      - py3-supported-pip
+      - py3-supported-python-dev
       - wolfi-base
 
 pipeline:
@@ -29,13 +40,30 @@ pipeline:
       expected-commit: 0d4900b073f8697ab21c47d823621bea61f39a3b
       tag: release-${{package.version}}
 
-  - name: Python Build
-    runs: python setup.py build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - runs: python${{range.key}} -c "import psutil"
 
-  - name: Python Install
-    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
-
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
 
 update:
   enabled: true
@@ -49,5 +77,6 @@ test:
       packages:
         - python3
   pipeline:
-    - runs: |
-        python -c "import psutil; print(psutil.__version__)"
+    - uses: python/import
+      with:
+        import: psutil


### PR DESCRIPTION

Fixes:

Related:

### Pre-review Checklist

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

