### PR TITLE
bump delta to v0.18.0

### DIFF
--- a/delta.yaml
+++ b/delta.yaml
@@ -1,6 +1,6 @@
 package:
   name: delta
-  version: 0.17.0
+  version: 0.18.0
   epoch: 0
   description: Syntax-highlighting pager for git and diff output
   copyright:
@@ -19,7 +19,7 @@ pipeline:
     with:
       repository: https://github.com/dandavison/delta
       tag: ${{package.version}}
-      expected-commit: 13c8219799be3291ed592a9bd00e707577fbf6f6
+      expected-commit: b9ca4eb3f0638d4857ad1ddc6f6a12c3f656cfb7
 
   - runs: |
       cargo build --release


### PR DESCRIPTION
the previous version was failing to build from source due to some complains from the time crate but there's a new release meanwhile and this one is building fine. 
This commit bumps delta to the new version.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/wolfi-dev/os/issues/26401 (for delta package) 

### Pre-review Checklist


#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
