### PR TITLE
FTBFS xtail

### DIFF
--- a/xtail.yaml
+++ b/xtail.yaml
@@ -5,7 +5,7 @@ package:
   # This is really 2.1-9 upstream, so if we manually update this, we should fix
   # the fetch URL below.
   version: 2.1.9
-  epoch: 1
+  epoch: 2
   description: Like "tail -f", but works on truncated files, directories, more
   copyright:
     - license: BSD-3-Clause
@@ -32,6 +32,8 @@ pipeline:
       while IFS= read -r _file; do
         patch --directory=. --forward --strip=1 --input="$_patchdir/$_file"
       done <"$_patchdir/series"
+
+  - runs: autoreconf -fi
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
Obsolete configure fails to detect working gcc.
Force autoreconf to fix it.
