### PR TITLE
fix(gitlab-runner-17.3): Use correct tag filter

### DIFF
--- a/gitlab-runner-17.3.yaml
+++ b/gitlab-runner-17.3.yaml
@@ -123,7 +123,7 @@ update:
   enabled: true
   git:
     strip-prefix: v
-    tag-filter-prefix: v17.2
+    tag-filter-prefix: v17.3
 
 test:
   environment:


### PR DESCRIPTION
Updates tag filter for v17.3 from v17.2