### PR TITLE
fix: update git settings are wrong

### DIFF
--- a/tiff.yaml
+++ b/tiff.yaml
@@ -66,6 +66,6 @@ subpackages:
 
 update:
   enabled: true
-  github:
+  git:
     strip-prefix: v
     tag-filter-prefix: v


### PR DESCRIPTION
We were getting errors when checking the github identifier for this package when it should be using `git`.