### PR TITLE
victoriametrics-operator

### DIFF
--- a/victoriametrics-operator.yaml
+++ b/victoriametrics-operator.yaml
@@ -1,0 +1,79 @@
+package:
+  name: victoriametrics-operator
+  version: 0.47.0
+  epoch: 0
+  description: Kubernetes operator for Victoria Metrics
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 9f11b443a67fafb2df94fbd07fcb41d08b46bcf2
+      repository: https://github.com/VictoriaMetrics/operator
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      modroot: ./cmd
+      output: app
+      packages: .
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: compatibility symlinks package for victoriametrics-operator Dockerfile
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          ln -sf /usr/bin/app ${{targets.contextdir}}/app
+
+update:
+  enabled: true
+  github:
+    identifier: VictoriaMetrics/operator
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+        - git
+        - curl
+        - kustomize
+        - kubectl
+  pipeline:
+    - uses: test/kwok/cluster
+    - name: Fetch the testdata from the source repo
+      runs: |
+        git clone --depth=1 https://github.com/VictoriaMetrics/operator
+        cd operator
+        kustomize build config/crd/overlay | kubectl apply -f -
+
+        # Start the operator
+        app &
+        sleep 15
+        cat << EOF | kubectl apply -f -
+        apiVersion: operator.victoriametrics.com/v1beta1
+        kind: VMAgent
+        metadata:
+          name: example-vmagent
+        spec:
+          selectAllByDefault: true
+          replicaCount: 1
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "350Mi"
+            limits:
+              cpu: "500m"
+              memory: "850Mi"
+          extraArgs:
+            memory.allowedPercent: "40"
+          remoteWrite:
+          - url: "http://vmsingle-example-vmsingle-pvc.default.svc:8429/api/v1/write"
+        EOF
+
+        sleep 5
+        # wait for the pod to be created
+        kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance=example-vmagent --timeout=300s


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
