### PR TITLE
cryptsetup: manual update to minor

### DIFF
--- a/cryptsetup.yaml
+++ b/cryptsetup.yaml
@@ -7,6 +7,12 @@ package:
   copyright:
     - license: GPL-2.0-or-later WITH cryptsetup-OpenSSL-exception
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+
 environment:
   contents:
     packages:
@@ -31,7 +37,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: 2cee74381c537ab5b40afad807fe196efde112522dc9a6acae81b3082a744da7
-      uri: https://www.kernel.org/pub/linux/utils/cryptsetup/v2.7/cryptsetup-${{package.version}}.tar.gz
+      uri: https://www.kernel.org/pub/linux/utils/cryptsetup/v${{vars.major-minor-version}}/cryptsetup-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:

--- a/cryptsetup.yaml
+++ b/cryptsetup.yaml
@@ -1,7 +1,7 @@
 # Generated from https://git.alpinelinux.org/aports/plain/main/cryptsetup/APKBUILD
 package:
   name: cryptsetup
-  version: 2.6.1
+  version: 2.7.4
   epoch: 0
   description: Userspace setup tool for transparent encryption of block devices using the Linux 2.6 cryptoapi
   copyright:
@@ -30,8 +30,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: da1769da8fa1682f03773e50e75d9d1c4f7464cb660200c00bf5e4586be83308
-      uri: https://www.kernel.org/pub/linux/utils/cryptsetup/v2.6/cryptsetup-${{package.version}}.tar.gz
+      expected-sha256: 2cee74381c537ab5b40afad807fe196efde112522dc9a6acae81b3082a744da7
+      uri: https://www.kernel.org/pub/linux/utils/cryptsetup/v2.7/cryptsetup-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
The uri is broken whenever we try to update to a new minor release. We must investigate if there is a better way to pull the latest version.