### PR TITLE
gtk-doc: fix package

### DIFF
--- a/gtk-doc.yaml
+++ b/gtk-doc.yaml
@@ -1,6 +1,6 @@
 package:
   name: gtk-doc
-  version: 1.33.2
+  version: 1.34.0
   epoch: 0
   description: Documentation tool for public library API
   copyright:
@@ -32,8 +32,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: cc1b709a20eb030a278a1f9842a362e00402b7f834ae1df4c1998a723152bf43
-      uri: https://download.gnome.org/sources/gtk-doc/1.33/gtk-doc-${{package.version}}.tar.xz
+      expected-sha256: b20b72b32a80bc18c7f975c9d4c16460c2276566a0b50f87d6852dff3aa7861c
+      uri: https://download.gnome.org/sources/gtk-doc/1.34/gtk-doc-${{package.version}}.tar.xz
 
   - runs: |
       autoreconf -vif

--- a/gtk-doc.yaml
+++ b/gtk-doc.yaml
@@ -11,6 +11,12 @@ package:
       - py3-pygments
       - python3
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+
 environment:
   contents:
     packages:
@@ -33,7 +39,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: b20b72b32a80bc18c7f975c9d4c16460c2276566a0b50f87d6852dff3aa7861c
-      uri: https://download.gnome.org/sources/gtk-doc/1.34/gtk-doc-${{package.version}}.tar.xz
+      uri: https://download.gnome.org/sources/gtk-doc/${{vars.major-minor-version}}/gtk-doc-${{package.version}}.tar.xz
 
   - runs: |
       autoreconf -vif


### PR DESCRIPTION
Update is broken due to hardcoded uri pointing to a lower minor version.