### PR TITLE
FTBFS zsh

### DIFF
--- a/zsh.yaml
+++ b/zsh.yaml
@@ -2,7 +2,7 @@
 package:
   name: zsh
   version: "5.9"
-  epoch: 2
+  epoch: 3
   description: Very advanced and programmable command interpreter (shell)
   copyright:
     - license: MIT-Modern-Variant AND ISC AND GPL-2.0-only
@@ -26,6 +26,14 @@ pipeline:
       expected-commit: 73d317384c9225e46d66444f93b46f0fbe7084ef
       repository: https://git.code.sf.net/p/zsh/code
       tag: zsh-${{package.version}}
+
+  - runs: |
+      set -x
+      # see https://github.com/chainguard-dev/melange/issues/1422
+      git fetch --no-tags origin master:master
+      # Fix configure.ac to use valid C in tests with gcc-14
+      git show 4c89849c98172c951a9def3690e8647dae76308f -- configure.ac > partial-cherry-pick.patch
+      git apply partial-cherry-pick.patch
 
   # https://www.zsh.org/mla/workers/2022/msg00964.html
   - uses: patch


### PR DESCRIPTION
Cherry-pick upstream changes to configure.ac to use valid C and thus
correctly detect terminfo libraries with gcc-14.
