### PR TITLE
Revert to last successful wolfi post submit build

### DIFF
--- a/aws-c-event-stream.yaml
+++ b/aws-c-event-stream.yaml
@@ -1,6 +1,6 @@
 package:
   name: aws-c-event-stream
-  version: 0.4.3
+  version: 0.4.2
   epoch: 0
   description: "AWS C99 implementation of the vnd.amazon.eventstream content-type"
   copyright:
@@ -26,7 +26,7 @@ pipeline:
     with:
       repository: https://github.com/awslabs/aws-c-event-stream
       tag: v${{package.version}}
-      expected-commit: 1b3825fc9cae2e9c7ed7479ee5d354d52ebdf7a0
+      expected-commit: 1a70c50f78a6e706f1f91a4ed138478271b6d9d3
 
   - runs: |
       if [ "$CBUILD" != "$CHOST" ]; then

--- a/aws-c-http.yaml
+++ b/aws-c-http.yaml
@@ -1,6 +1,6 @@
 package:
   name: aws-c-http
-  version: 0.8.8
+  version: 0.8.7
   epoch: 0
   description: AWS C99 implementation of the HTTP/1.1 and HTTP/2 specifications
   copyright:
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 4e74ab1e3702763e0b87bd1752f5a37c2f0400ac
+      expected-commit: 7db2452238caece2d3a91e6cbed75324edccea7d
       repository: https://github.com/awslabs/aws-c-http
       tag: v${{package.version}}
 

--- a/c-ares-bootstrap.yaml
+++ b/c-ares-bootstrap.yaml
@@ -1,0 +1,53 @@
+package:
+  name: c-ares-bootstrap
+  version: 1.33.0
+  epoch: 1
+  description: "an asynchronous DNS resolution library"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - libev
+    provider-priority: 0
+    provides:
+      - c-ares=${{package.full-version}}
+      - c-ares-dev=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libtool
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/c-ares/c-ares
+      tag: v${{package.version}}
+      expected-commit: caffa5ffb3826cf0926405793361bbad11db3268
+
+  - runs: |
+      autoreconf -vfi
+
+  - uses: autoconf/configure
+    with:
+      # Enabling tests requires a gmock dependency. We have that packaged, but it introduces a dependency cycle.
+      opts: --enable-shared --enable-tests=no
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: c-ares/c-ares
+    tag-filter-prefix: v
+    strip-prefix: v

--- a/cargo-audit.yaml
+++ b/cargo-audit.yaml
@@ -1,6 +1,6 @@
 package:
   name: cargo-audit
-  version: 0.20.1
+  version: 0.20.0
   epoch: 0
   description: Audit your dependencies for crates with security vulnerabilities reported to the RustSec Advisory Database.
   copyright:
@@ -19,7 +19,7 @@ pipeline:
     with:
       repository: https://github.com/rustsec/rustsec
       tag: cargo-audit/v${{package.version}}
-      expected-commit: 318ad37b03d9987cd817cdee7bf1d2801bf4d8bc
+      expected-commit: 6f4ca8786ea5aa3fd7ef1115634c002d52073748
 
   - runs: |
       cd cargo-audit

--- a/cmake.yaml
+++ b/cmake.yaml
@@ -1,10 +1,8 @@
 package:
   name: cmake
   version: 3.29.0
-  epoch: 1
+  epoch: 0
   description: "CMake is an open-source, cross-platform family of tools designed to build, test and package software"
-  dependencies:
-    provider-priority: 10
   copyright:
     - license: BSD-3-Clause
 
@@ -15,9 +13,7 @@ environment:
       - busybox
       - bzip2-dev
       - ca-certificates-bundle
-      - curl-dev
       - expat-dev
-      - jsoncpp-dev
       - libarchive-dev
       - libuv-dev
       - ncurses-dev
@@ -35,9 +31,8 @@ pipeline:
       uri: https://www.cmake.org/files/v3.29/cmake-${{package.version}}.tar.gz
       expected-sha256: a0669630aae7baa4a8228048bf30b622f9e9fd8ee8cedb941754e9e38686c778
 
-  # Depending on system libraries for everything we have, as if any of
-  # them use cmake they are built with cmake-bootstrap instead. Apart
-  # from cppdap, as we don't package it standalone.
+  # Depending on system cppdap, jsoncpp, and curl would create a circular
+  # dependency; thus, we use bundled ones.
   - runs: |
       ./bootstrap \
         --prefix=/usr \
@@ -46,6 +41,8 @@ pipeline:
         --docdir=/share/doc/cmake \
         --system-libs \
         --no-system-cppdap \
+        --no-system-jsoncpp \
+        --no-system-curl \
         --generator=Ninja \
         --parallel=$(nproc)
 

--- a/cryptsetup.yaml
+++ b/cryptsetup.yaml
@@ -1,17 +1,11 @@
 # Generated from https://git.alpinelinux.org/aports/plain/main/cryptsetup/APKBUILD
 package:
   name: cryptsetup
-  version: 2.7.4
+  version: 2.6.1
   epoch: 0
   description: Userspace setup tool for transparent encryption of block devices using the Linux 2.6 cryptoapi
   copyright:
     - license: GPL-2.0-or-later WITH cryptsetup-OpenSSL-exception
-
-var-transforms:
-  - from: ${{package.version}}
-    match: ^(\d+\.\d+)\.\d+$
-    replace: "$1"
-    to: major-minor-version
 
 environment:
   contents:
@@ -36,8 +30,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 2cee74381c537ab5b40afad807fe196efde112522dc9a6acae81b3082a744da7
-      uri: https://www.kernel.org/pub/linux/utils/cryptsetup/v${{vars.major-minor-version}}/cryptsetup-${{package.version}}.tar.gz
+      expected-sha256: da1769da8fa1682f03773e50e75d9d1c4f7464cb660200c00bf5e4586be83308
+      uri: https://www.kernel.org/pub/linux/utils/cryptsetup/v2.6/cryptsetup-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:

--- a/grpc.yaml
+++ b/grpc.yaml
@@ -1,6 +1,6 @@
 package:
   name: grpc
-  version: 1.65.5
+  version: 1.65.4
   epoch: 0
   description: The C based gRPC
   copyright:
@@ -48,7 +48,7 @@ pipeline:
     with:
       repository: https://github.com/grpc/grpc
       tag: v${{package.version}}
-      expected-commit: c93b7788310705514a84d0f6f8921b9aef87f5d9
+      expected-commit: c3407b728428b84f4c0b8c1b653094903fe2f462
 
   - runs: |
       cd third_party

--- a/gtk-doc.yaml
+++ b/gtk-doc.yaml
@@ -1,6 +1,6 @@
 package:
   name: gtk-doc
-  version: 1.34.0
+  version: 1.33.2
   epoch: 0
   description: Documentation tool for public library API
   copyright:
@@ -10,12 +10,6 @@ package:
       - docbook-xml
       - py3-pygments
       - python3
-
-var-transforms:
-  - from: ${{package.version}}
-    match: ^(\d+\.\d+)\.\d+$
-    replace: "$1"
-    to: major-minor-version
 
 environment:
   contents:
@@ -38,8 +32,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: b20b72b32a80bc18c7f975c9d4c16460c2276566a0b50f87d6852dff3aa7861c
-      uri: https://download.gnome.org/sources/gtk-doc/${{vars.major-minor-version}}/gtk-doc-${{package.version}}.tar.xz
+      expected-sha256: cc1b709a20eb030a278a1f9842a362e00402b7f834ae1df4c1998a723152bf43
+      uri: https://download.gnome.org/sources/gtk-doc/1.33/gtk-doc-${{package.version}}.tar.xz
 
   - runs: |
       autoreconf -vif

--- a/guac.yaml
+++ b/guac.yaml
@@ -1,7 +1,7 @@
 package:
   name: guac
-  version: 0.8.1
-  epoch: 0
+  version: 0.8.0
+  epoch: 3
   description: GUAC aggregates software security metadata into a high fidelity graph database.
   copyright:
     - license: Apache-2.0
@@ -19,11 +19,11 @@ pipeline:
     with:
       repository: https://github.com/guacsec/guac
       tag: v${{package.version}}
-      expected-commit: a3a752567af133b9e69c1435660bda068ea62c06
+      expected-commit: 0c6dc86ff3ab98e9572d5c936160c75e84d7c4df
 
   - uses: go/bump
     with:
-      deps: github.com/docker/docker@v26.1.5
+      deps: github.com/regclient/regclient@v0.7.1 github.com/docker/docker@v26.1.5
 
   - uses: go/build
     with:

--- a/istio-cni-1.23.yaml
+++ b/istio-cni-1.23.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-cni-1.23
   version: 1.23.0
-  epoch: 1
+  epoch: 0
   description: Istio Container Network Interface
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
     with:
       repository: https://github.com/istio/istio
       tag: ${{package.version}}
-      expected-commit: d0ca037e58f90f58b38b33c5769fec25b6bfa9f3
+      expected-commit: 2ed399ccdbf4bc6394d7350cd384e6b0424f70f2
 
   - uses: go/build
     with:

--- a/istio-operator-1.23.yaml
+++ b/istio-operator-1.23.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-operator-1.23
   version: 1.23.0
-  epoch: 1
+  epoch: 0
   description: Istio operator provides user friendly options to operate the Istio service mesh
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
     with:
       repository: https://github.com/istio/istio
       tag: ${{package.version}}
-      expected-commit: d0ca037e58f90f58b38b33c5769fec25b6bfa9f3
+      expected-commit: 2ed399ccdbf4bc6394d7350cd384e6b0424f70f2
 
   - uses: go/bump
     with:

--- a/istio-pilot-agent-1.23.yaml
+++ b/istio-pilot-agent-1.23.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-pilot-agent-1.23
   version: 1.23.0
-  epoch: 1
+  epoch: 0
   description: Nanny binary for Istio Envoy
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
     with:
       repository: https://github.com/istio/istio
       tag: ${{package.version}}
-      expected-commit: d0ca037e58f90f58b38b33c5769fec25b6bfa9f3
+      expected-commit: 2ed399ccdbf4bc6394d7350cd384e6b0424f70f2
 
   - uses: go/bump
     with:

--- a/istio-pilot-discovery-1.23.yaml
+++ b/istio-pilot-discovery-1.23.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-pilot-discovery-1.23
   version: 1.23.0
-  epoch: 1
+  epoch: 0
   description: Istio controller
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ pipeline:
     with:
       repository: https://github.com/istio/istio
       tag: ${{package.version}}
-      expected-commit: d0ca037e58f90f58b38b33c5769fec25b6bfa9f3
+      expected-commit: 2ed399ccdbf4bc6394d7350cd384e6b0424f70f2
 
   - uses: go/bump
     with:

--- a/kargo.yaml
+++ b/kargo.yaml
@@ -1,7 +1,7 @@
 package:
   name: kargo
-  version: 0.8.5
-  epoch: 0
+  version: 0.8.4
+  epoch: 1
   description: Application lifecycle orchestration
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,7 @@ pipeline:
     with:
       repository: https://github.com/akuity/kargo
       tag: v${{package.version}}
-      expected-commit: 5b6cfa0e7da3d446a6dbca5253a167b63b74d304
+      expected-commit: 68ca409b23e1a6d4b9819fe7604b3f6c94a5a72d
 
   - uses: go/bump
     with:

--- a/kubebuilder.yaml
+++ b/kubebuilder.yaml
@@ -1,6 +1,6 @@
 package:
   name: kubebuilder
-  version: 4.2.0
+  version: 4.1.1
   epoch: 0
   description: SDK for building Kubernetes APIs using CRDs
   copyright:
@@ -22,7 +22,7 @@ pipeline:
     with:
       repository: https://github.com/kubernetes-sigs/kubebuilder
       tag: v${{package.version}}
-      expected-commit: c7cde5172dc8271267dbf2899e65ef6f9d30f91e
+      expected-commit: e65415f10a6f5708604deca089eee6b165174e5e
 
   - uses: go/build
     with:

--- a/less.yaml
+++ b/less.yaml
@@ -1,7 +1,7 @@
 # Generated from https://git.alpinelinux.org/aports/plain/main/less/APKBUILD
 package:
   name: less
-  version: "663"
+  version: "662"
   epoch: 0
   description: File pager
   copyright:
@@ -21,7 +21,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: b1548ca1188aca424026103da8284d1db25150f6
+      expected-commit: 83cc7d3a334ca62820e7c51b16e5d009087a6f10
       repository: https://github.com/gwsw/less
       tag: v${{package.version}}
 

--- a/libmamba.yaml
+++ b/libmamba.yaml
@@ -35,6 +35,7 @@ environment:
       - spdlog-dev
       - tl-expected
       - yaml-cpp-dev
+      - zstd-cmake
       - zstd-dev
       - zstd-static
 

--- a/lz4.yaml
+++ b/lz4.yaml
@@ -21,14 +21,11 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: ebb370ca83af193212df4dcbadcc5d87bc0de2f0
 
-  - uses: cmake/configure
-    with:
-      opts: |
-        -S build/cmake
+  - runs: |
+      make -j$(nproc) CC=${{host.triplet.gnu}}-gcc
 
-  - uses: cmake/build
-
-  - uses: cmake/install
+  - runs: |
+      make install PREFIX="/usr" DESTDIR="${{targets.destdir}}"
 
   - uses: strip
 

--- a/mariadb-11.4.yaml
+++ b/mariadb-11.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-11.4
   version: 11.4.3
-  epoch: 1
+  epoch: 0
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -182,15 +182,6 @@ subpackages:
             "${{targets.destdir}}"/usr/bin/mariadb-backup \
             "${{targets.destdir}}"/usr/bin/mbstream \
             "${{targets.subpkgdir}}"/usr/bin/
-
-  - name: "${{package.name}}-client"
-    dependencies:
-      provides:
-        - mariadb-client=${{package.full-version}}
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/mariadb "${{targets.subpkgdir}}"/usr/bin/
 
   - name: "${{package.name}}-oci-entrypoint"
     description: Entrypoint for using HAProxy in OCI containers

--- a/minio.yaml
+++ b/minio.yaml
@@ -1,7 +1,7 @@
 package:
   name: minio
-  version: 0.20240817.012454
-  epoch: 0
+  version: 0.20240803.043323
+  epoch: 1
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0-or-later
@@ -26,7 +26,7 @@ pipeline:
     with:
       repository: https://github.com/minio/minio
       tag: ${{vars.mangled-package-version}}
-      expected-commit: 72cff79c8a7cc59bccb591995e3c3ed6aa2f4cd5
+      expected-commit: 6efb56851c40da88d1ca15112e2d686a4ecec6b3
 
   - runs: |
       make build

--- a/mockery.yaml
+++ b/mockery.yaml
@@ -1,6 +1,6 @@
 package:
   name: mockery
-  version: 2.44.2
+  version: 2.44.1
   epoch: 0
   description: A mock code autogenerator for Go
   copyright:
@@ -16,7 +16,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/vektra/mockery
-      expected-commit: 910874a957d28e153ac8e3d6cd367f6eaeabada5
+      expected-commit: c6d2a9e73a48b9ad88a37ef31406c22f6a9ef523
       tag: v${{package.version}}
 
   - runs: |

--- a/nri-nginx.yaml
+++ b/nri-nginx.yaml
@@ -1,6 +1,6 @@
 package:
   name: nri-nginx
-  version: 3.4.8
+  version: 3.4.7
   epoch: 0
   description: New Relic Infrastructure Nginx Integration
   copyright:
@@ -10,7 +10,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/newrelic/nri-nginx
-      expected-commit: 546df406ef9f1ebb9fc7be3f0342e1675da12756
+      expected-commit: 57aa1b42bb5a46ad9fe004f10dd0e7b150c5a5bf
       tag: v${{package.version}}
 
   - uses: go/build

--- a/nri-postgresql.yaml
+++ b/nri-postgresql.yaml
@@ -1,6 +1,6 @@
 package:
   name: nri-postgresql
-  version: 2.13.7
+  version: 2.13.6
   epoch: 0
   description: New Relic Infrastructure Postgresql Integration
   copyright:
@@ -10,7 +10,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/newrelic/nri-postgresql
-      expected-commit: 6b2051dd11b76df78bc057755ff5f3f06ef79db1
+      expected-commit: 5dbd0f5097995553fb000acb87c16fb0aeaf672d
       tag: v${{package.version}}
 
   - uses: go/build

--- a/perl-clone.yaml
+++ b/perl-clone.yaml
@@ -1,7 +1,7 @@
 package:
   name: perl-clone
-  version: "0.47"
-  epoch: 0
+  version: "0.46"
+  epoch: 3
   description: Clone perl module
   copyright:
     - license: GPL-1.0-or-later OR Artistic-1.0-Perl
@@ -22,7 +22,7 @@ pipeline:
     with:
       repository: https://github.com/garu/Clone.git
       tag: ${{package.version}}
-      expected-commit: d21e36bef003dbcd87fc7195bc56ac890ca8f21a
+      expected-commit: 7f73e27bc6371e26e3d0a58d9abac31ea61edd54
 
   - uses: perl/make
 

--- a/playwright.yaml
+++ b/playwright.yaml
@@ -1,6 +1,6 @@
 package:
   name: playwright
-  version: 1.46.1
+  version: 1.46.0
   epoch: 0
   description: "Framework for Web Testing and Automation. It allows testing Chromium, Firefox and WebKit with a single API"
   copyright:

--- a/py3-cachetools.yaml
+++ b/py3-cachetools.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-cachetools
-  version: 5.5.0
+  version: 5.4.0
   epoch: 0
   description: Extensible memoizing collections and decorators
   copyright:
@@ -24,7 +24,7 @@ pipeline:
     with:
       repository: https://github.com/tkem/cachetools/
       tag: v${{package.version}}
-      expected-commit: 6c78a8ff67b21834c3873cc918d87b2c5cb22e5c
+      expected-commit: 990665be51af3ae879136709e8846e61d7c0e12e
 
   - name: Python Build
     runs: python setup.py build

--- a/py3-grpcio-tools.yaml
+++ b/py3-grpcio-tools.yaml
@@ -1,7 +1,7 @@
 # Generated from https://pypi.org/project/grpcio-tools/
 package:
   name: py3-grpcio-tools
-  version: 1.65.5
+  version: 1.65.4
   epoch: 0
   description: Protobuf code generator for gRPC
   copyright:
@@ -32,7 +32,7 @@ pipeline:
     with:
       repository: https://github.com/grpc/grpc
       tag: v${{package.version}}
-      expected-commit: c93b7788310705514a84d0f6f8921b9aef87f5d9
+      expected-commit: c3407b728428b84f4c0b8c1b653094903fe2f462
 
   - runs: |
       git submodule update --init

--- a/py3-importlib-resources.yaml
+++ b/py3-importlib-resources.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-importlib-resources
-  version: 6.4.3
+  version: 6.4.2
   epoch: 0
   description: Read resources from Python packages
   copyright:
@@ -33,7 +33,7 @@ pipeline:
     with:
       repository: https://github.com/python/importlib_resources
       tag: v${{package.version}}
-      expected-commit: d02141768b62468e46064614276036ea5c746056
+      expected-commit: 509cabd46b54f5f6e372d923039c2bff8fff7d94
 
 subpackages:
   - range: py-versions

--- a/py3-markdown.yaml
+++ b/py3-markdown.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-markdown
-  version: "3.7"
+  version: "3.6"
   epoch: 0
   description: Python implementation of John Gruber's Markdown.
   copyright:
@@ -25,7 +25,7 @@ pipeline:
     with:
       repository: https://github.com/Python-Markdown/markdown
       tag: ${{package.version}}
-      expected-commit: da03cd646d00a77786ae1e0bc79b01a5539852bc
+      expected-commit: e524b8fe938738cb4492411a34cce89051cb9695
 
   - name: Python Build
     uses: python/build-wheel

--- a/py3-nltk.yaml
+++ b/py3-nltk.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-nltk
-  version: 3.9.1
+  version: 3.8.2
   epoch: 0
   description: Natural Language Toolkit
   copyright:
@@ -39,7 +39,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/nltk/nltk
-      expected-commit: aca78cb2add4084f76b9eac921d8a73927d7a086
+      expected-commit: 0753ee5bb0096b4a4b3dd587e784ce07e7f34dab
       tag: ${{package.version}}
 
   - name: Python Build

--- a/py3-sqlglot.yaml
+++ b/py3-sqlglot.yaml
@@ -1,7 +1,7 @@
 # Generated from https://pypi.org/project/sqlglot/
 package:
   name: py3-sqlglot
-  version: 25.13.0
+  version: 25.12.0
   epoch: 0
   description: An easily customizable SQL parser and transpiler
   copyright:
@@ -26,7 +26,7 @@ pipeline:
     with:
       repository: https://github.com/tobymao/sqlglot
       tag: v${{package.version}}
-      expected-commit: 46496a6af80bd49d36ef8d265800679d2b07c4db
+      expected-commit: 9a66903975f16a09d84337a8405bf70945706412
 
   - name: Python Build
     runs: python setup.py build

--- a/tflint.yaml
+++ b/tflint.yaml
@@ -1,7 +1,7 @@
 package:
   name: tflint
-  version: 0.53.0
-  epoch: 0
+  version: 0.52.0
+  epoch: 1
   description: A Pluggable Terraform Linter
   copyright:
     - license: MPL-2.0
@@ -18,9 +18,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 51fe0738442a0cbcc6d55ec7326abe807bce763f
+      expected-commit: a7ebc9b6592b599b628bcb9d3b0cc82047cd5f2a
       repository: https://github.com/terraform-linters/tflint
       tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: google.golang.org/grpc@v1.64.1
 
   - runs: |
       make build

--- a/vulkan-loader.yaml
+++ b/vulkan-loader.yaml
@@ -1,6 +1,6 @@
 package:
   name: vulkan-loader
-  version: 1.3.293
+  version: 1.3.292
   epoch: 0
   description: Vulkan Installable Client Driver (ICD) Loader
   copyright:
@@ -25,7 +25,7 @@ pipeline:
     with:
       repository: https://github.com/KhronosGroup/Vulkan-Loader
       tag: v${{package.version}}
-      expected-commit: 2804c254bfd109806817330ddcd5829492368775
+      expected-commit: faeb5882c7faf3e683ebb1d9d7dbf9bc337b8fa6
 
   - runs: |
       cmake -B build -G Ninja \

--- a/wolfictl.yaml
+++ b/wolfictl.yaml
@@ -1,6 +1,6 @@
 package:
   name: wolfictl
-  version: 0.23.1
+  version: 0.23.0
   epoch: 0
   description: Helper CLI for managing Wolfi
   copyright:
@@ -11,7 +11,7 @@ pipeline:
     with:
       repository: https://github.com/wolfi-dev/wolfictl
       tag: v${{package.version}}
-      expected-commit: 619d575ec6f123f9bb2c1ef1698717ce962b0994
+      expected-commit: affbb6fe1dba8bc65f1eca8a74ffa434bd162b2a
 
   - uses: go/build
     with:

--- a/yam.yaml
+++ b/yam.yaml
@@ -1,6 +1,6 @@
 package:
   name: yam
-  version: 0.1.1
+  version: 0.1.0
   epoch: 0
   description: A sweet little formatter for YAML
   copyright:
@@ -11,7 +11,7 @@ pipeline:
     with:
       repository: https://github.com/chainguard-dev/yam
       tag: v${{package.version}}
-      expected-commit: 142514ff647f31612f46adf046c68c2a195ced94
+      expected-commit: 7fe30a1443b1f1bafe32f29fc1fcffb6bfbf161b
 
   - uses: go/build
     with:

--- a/zip.yaml
+++ b/zip.yaml
@@ -1,7 +1,7 @@
 package:
   name: zip
   version: 3.0
-  epoch: 5
+  epoch: 4
   description: Creates PKZIP-compatible .zip files
   copyright:
     - license: Info-ZIP
@@ -18,12 +18,6 @@ pipeline:
     with:
       expected-sha256: f0e8bb1f9b7eb0b01285495a2699df3a4b766784c1765a8f1aeedf63c0806369
       uri: https://sourceforge.net/projects/infozip/files/Zip%203.x%20%28latest%29/${{package.version}}/zip30.tar.gz
-
-  # Import patches from debian that improve hardening and fix FTBFS
-  # with gcc-14
-  - uses: patch
-    with:
-      patches: 06-stack-markings-to-avoid-executable-stack.patch 07-fclose-in-file-not-fclose-x.patch 08-hardening-build-fix-1.patch 09-hardening-build-fix-2.patch 10-remove-build-date.patch 12-fix-build-with-gcc-14.patch
 
   - runs: make -f unix/Makefile LOCAL_ZIP="${CFLAGS} ${CPPFLAGS}" prefix=/usr generic
 

--- a/zsh.yaml
+++ b/zsh.yaml
@@ -2,7 +2,7 @@
 package:
   name: zsh
   version: "5.9"
-  epoch: 3
+  epoch: 2
   description: Very advanced and programmable command interpreter (shell)
   copyright:
     - license: MIT-Modern-Variant AND ISC AND GPL-2.0-only
@@ -26,14 +26,6 @@ pipeline:
       expected-commit: 73d317384c9225e46d66444f93b46f0fbe7084ef
       repository: https://git.code.sf.net/p/zsh/code
       tag: zsh-${{package.version}}
-
-  - runs: |
-      set -x
-      # see https://github.com/chainguard-dev/melange/issues/1422
-      git fetch --no-tags origin master:master
-      # Fix configure.ac to use valid C in tests with gcc-14
-      git show 4c89849c98172c951a9def3690e8647dae76308f -- configure.ac > partial-cherry-pick.patch
-      git apply partial-cherry-pick.patch
 
   # https://www.zsh.org/mla/workers/2022/msg00964.html
   - uses: patch

--- a/zstd-cmake.yaml
+++ b/zstd-cmake.yaml
@@ -1,0 +1,49 @@
+package:
+  name: zstd-cmake
+  version: 1.5.6
+  epoch: 0
+  description: "cmake files for the Zstandard compression algorithm"
+  copyright:
+    - license: BSD-2-Clause AND GPL-2.0-only
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - grep
+      - samurai
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/facebook/zstd
+      expected-commit: 794ea1b0afca0f020f4e57b6732332231fb23c70
+      tag: v${{package.version}}
+
+  - uses: cmake/configure
+    with:
+      opts: |
+        -S build/cmake \
+        -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - runs: |
+      rm -rf ${{targets.destdir}}/usr/bin
+      rm -rf ${{targets.destdir}}/usr/share
+      rm -rf ${{targets.destdir}}/usr/lib/lib*
+      rm -rf ${{targets.destdir}}/usr/lib/pkgconfig
+      rm -rf ${{targets.destdir}}/usr/include
+
+update:
+  enabled: true
+  github:
+    identifier: facebook/zstd
+    strip-prefix: v
+    tag-filter: v

--- a/zstd.yaml
+++ b/zstd.yaml
@@ -1,7 +1,7 @@
 package:
   name: zstd
   version: 1.5.6
-  epoch: 4
+  epoch: 3
   description: "the Zstandard compression algorithm"
   copyright:
     - license: BSD-2-Clause AND GPL-2.0-only
@@ -12,26 +12,21 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - cmake-bootstrap
       - grep
-      - samurai
       - wolfi-base
 
 pipeline:
   - uses: git-checkout
     with:
       expected-commit: 794ea1b0afca0f020f4e57b6732332231fb23c70
-      repository: https://github.com/facebook/zstd
+      repository: https://github.com/facebook/zstd.git
       tag: v${{package.version}}
 
-  - uses: cmake/configure
-    with:
-      opts: |
-        -S build/cmake
+  - runs: |
+      make -j$(nproc) CC=${{host.triplet.gnu}}-gcc PREFIX="/usr"
 
-  - uses: cmake/build
-
-  - uses: cmake/install
+  - runs: |
+      make install PREFIX="/usr" DESTDIR="${{targets.destdir}}"
 
   - uses: strip
 
@@ -49,9 +44,6 @@ subpackages:
 
   - name: "zstd-dev"
     description: "zstd development headers"
-    dependencies:
-      provides:
-        - zstd-cmake=${{package.full-version}}
     pipeline:
       - uses: split/dev
 


### PR DESCRIPTION
Generated with

    git checkout 44d4db15c4483dc7175afa43a60649eb8d445b1e .
    git restore --staged -- gcc.yaml glibc/ glibc.yaml

To revert everyting to
https://github.com/wolfi-dev/os/actions/runs/10452480885 but
glibc+gcc, to let glibc+gcc publish together.
