### PR TITLE
fuse2

### DIFF
--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: 8.9.1
-  epoch: 1
+  epoch: 2
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT
@@ -54,6 +54,12 @@ subpackages:
     description: "headers for libcurl"
     pipeline:
       - uses: split/dev
+    dependencies:
+      runtime:
+        - brotli-dev
+        - libpsl-dev
+        - nghttp2-dev
+        - openssl-dev
 
   - name: "curl-doc"
     description: "documentation for curl"

--- a/fuse2.yaml
+++ b/fuse2.yaml
@@ -1,0 +1,81 @@
+package:
+  name: fuse2
+  version: 2.9.9
+  epoch: 0
+  description: A library that makes it possible to implement a filesystem in a userspace program.
+  copyright:
+    - license: GPL-2.0-only AND LGPL-2.1-only
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - fuse-common
+      - gettext-dev
+      - libtool
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/libfuse/libfuse.git
+      tag: fuse-${{package.version}}
+      expected-commit: d04687923194d906fe5ad82dcd546c9807bf15b6
+
+  - uses: patch
+    with:
+      patches: fuse-namespace-conflict-fix.patch
+
+  - uses: patch
+    with:
+      patches: fuse-closefrom.patch
+
+  - runs: |
+      ./makeconf.sh
+
+  - runs: |
+      UDEV_RULES_PATH=/lib/udev/rules.d ./configure \
+        --prefix=/usr \
+        --enable-static \
+        --enable-shared \
+        --disable-example \
+        --enable-lib \
+        --enable-util \
+        --bindir=/bin
+
+  - runs: make -j$(nproc)
+
+  - uses: autoconf/make-install
+
+  - runs: rm -r "${{targets.contextdir}}"/dev "${{targets.contextdir}}"/etc/init.d
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-static
+    pipeline:
+      - uses: split/static
+    description: fuse static
+
+  - name: ${{package.name}}-dev
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - fuse-common
+    description: fuse dev
+
+  - name: ${{package.name}}-doc
+    pipeline:
+      - uses: split/manpages
+    description: fuse manpages
+
+update:
+  enabled: true
+  github:
+    identifier: libfuse/libfuse
+    strip-prefix: fuse-
+    tag-filter: v2.9.

--- a/fuse2/fuse-closefrom.patch
+++ b/fuse2/fuse-closefrom.patch
@@ -1,0 +1,20 @@
+--- fuse-2.9.2/util/ulockmgr_server.c.closefromfix	2019-01-04 05:33:33.000000000 -0800
++++ fuse-2.9.2/util/ulockmgr_server.c	2022-07-12 12:29:56.445402244 -0700
+@@ -124,7 +124,7 @@
+ 	return res;
+ }
+ 
+-static int closefrom(int minfd)
++static int _closefrom(int minfd)
+ {
+ 	DIR *dir = opendir("/proc/self/fd");
+ 	if (dir) {
+@@ -384,7 +384,7 @@
+ 		dup2(nullfd, 1);
+ 	}
+ 	close(3);
+-	closefrom(5);
++	_closefrom(5);
+ 	while (1) {
+ 		char c;
+ 		int sock;

--- a/fuse2/fuse-namespace-conflict-fix.patch
+++ b/fuse2/fuse-namespace-conflict-fix.patch
@@ -1,0 +1,21 @@
+diff -up fuse-2.9.2/include/fuse_kernel.h.conflictfix fuse-2.9.2/include/fuse_kernel.h
+--- fuse-2.9.2/include/fuse_kernel.h.conflictfix	2013-06-26 09:31:57.862198038 -0400
++++ fuse-2.9.2/include/fuse_kernel.h	2013-06-26 09:32:19.679198365 -0400
+@@ -88,12 +88,16 @@
+ #ifndef _LINUX_FUSE_H
+ #define _LINUX_FUSE_H
+ 
+-#include <sys/types.h>
++#ifdef __linux__
++#include <linux/types.h>
++#else
++#include <stdint.h>
+ #define __u64 uint64_t
+ #define __s64 int64_t
+ #define __u32 uint32_t
+ #define __s32 int32_t
+ #define __u16 uint16_t
++#endif
+ 
+ /*
+  * Version negotiation:

--- a/s3fs-fuse.yaml
+++ b/s3fs-fuse.yaml
@@ -1,0 +1,50 @@
+package:
+  name: s3fs-fuse
+  version: "1.94"
+  epoch: 0
+  description: FUSE-based file system backed by Amazon S3
+  copyright:
+    - license: GPL-2.0-only
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - curl-dev
+      - fuse2
+      - fuse2-dev
+      - libxml2-dev
+      - pkgconf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/s3fs-fuse/s3fs-fuse
+      tag: v${{package.version}}
+      expected-commit: 70a30d6e26a5dfd07a00cf79ce1196079e5ab11a
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --with-openssl
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: s3fs-fuse-doc
+    pipeline:
+      - uses: split/manpages
+    description: s3fs-fuse manpages
+
+update:
+  enabled: true
+  github:
+    identifier: s3fs-fuse/s3fs-fuse
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
