### PR TITLE
Multi-versionize py3-cloudpickle

### DIFF
--- a/py3-cloudpickle.yaml
+++ b/py3-cloudpickle.yaml
@@ -8,6 +8,17 @@ package:
   dependencies:
     runtime:
       - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: cloudpickle
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 environment:
   contents:
@@ -15,9 +26,10 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-flit-core
-      - py3-gpep517
-      - python3
+      - py3-supported-build
+      - py3-supported-flit-core
+      - py3-supported-installer
+      - py3-supported-pip
       - wolfi-base
 
 pipeline:
@@ -27,10 +39,24 @@ pipeline:
       expected-commit: 227f24668b97b15e627e9a3e1e3bec526b101f5c
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
-
-  - uses: strip
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    dependencies:
+      runtime:
+        - python-${{range.key}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: cloudpickle
 
 update:
   ignore-regex-patterns:
@@ -41,18 +67,3 @@ update:
     strip-prefix: v
     use-tag: true
     tag-filter: v
-
-test:
-  pipeline:
-    - runs: |
-        LIBRARY="cloudpickle"
-        IMPORT_STATEMENT="import cloudpickle"
-
-        if ! python -c "$IMPORT_STATEMENT"; then
-            echo "Failed to import library '$LIBRARY'."
-            python -c "$IMPORT_STATEMENT" 2>&1
-            exit 1
-        else
-            echo "Library '$LIBRARY' is installed and can be imported successfully."
-            exit 0
-        fi


### PR DESCRIPTION
Split py3-cloudpickle so it can build for multiple python3 versions


Fixes:

Related:

### Pre-review Checklist

