### PR TITLE
Add provides for csi-snapshotter for consistency.

### DIFF
--- a/kubernetes-csi-external-snapshotter-8.0.yaml
+++ b/kubernetes-csi-external-snapshotter-8.0.yaml
@@ -8,6 +8,7 @@ package:
   dependencies:
     provides:
       - kubernetes-csi-external-snapshotter=${{package.full-version}}
+      - kubernetes-csi-external-csi-snapshotter=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.version}}


### PR DESCRIPTION
The external images are named like so: https://github.com/kubernetes-csi/external-snapshotter/releases

```
docker pull registry.k8s.io/sig-storage/snapshot-controller:v8.0.1
docker pull registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1
docker pull registry.k8s.io/sig-storage/snapshot-validation-webhook:v8.0.1
```

And our packages are named like so:

```
kubernetes-csi-external-snapshot-controller-8.0-8.0.1-r0
kubernetes-csi-external-snapshot-validation-webhook-8.0-8.0.1-r0
kubernetes-csi-external-snapshotter-8.0-8.0.1-r0
```

So for consistency, add a provides for the snapshotter so if you strip the prefix kubernetes-csi-external, the remainder is consistent with upstream image names.