### PR TITLE
supercronic: remove redundant dependency

### DIFF
--- a/supercronic.yaml
+++ b/supercronic.yaml
@@ -1,7 +1,7 @@
 package:
   name: supercronic
   version: 0.2.30
-  epoch: 1
+  epoch: 2
   description: Cron for containers
   copyright:
     - license: MIT

--- a/supercronic.yaml
+++ b/supercronic.yaml
@@ -5,9 +5,6 @@ package:
   description: Cron for containers
   copyright:
     - license: MIT
-  dependencies:
-    runtime:
-      - go
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
The `supercronic` application doesn't need the `go` runtime (it only needs `go` at build time). Removing this unnecessary dependency saves roughly 700 MB of dependency packages from getting installed together with `supercronic`.
