### PR TITLE
fix: apache beam and grpcio_health_checking fetch URIs

### DIFF
--- a/py3-apache-beam.yaml
+++ b/py3-apache-beam.yaml
@@ -1,7 +1,7 @@
 # Generated from https://pypi.org/project/apache-beam/
 package:
   name: py3-apache-beam
-  version: 2.55.1
+  version: 2.58.1
   epoch: 0
   description: Apache Beam SDK for Python
   copyright:
@@ -48,8 +48,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: b47e2c9a10882557a83da07f1ba118cbdab869d09189057ef4a006354a3e110b
-      uri: https://files.pythonhosted.org/packages/source/a/apache-beam/apache-beam-${{package.version}}.tar.gz
+      expected-sha256: 921a1f13b56098d9d2f5201531387982312a762e5e3b4add59d083ee6a796041
+      uri: https://files.pythonhosted.org/packages/source/a/apache-beam/apache_beam-${{package.version}}.tar.gz
 
   - runs: |
       python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 3 3>&1 >&2

--- a/py3-grpcio-health-checking.yaml
+++ b/py3-grpcio-health-checking.yaml
@@ -1,7 +1,7 @@
 # Generated from https://pypi.org/project/grpcio-health-checking/
 package:
   name: py3-grpcio-health-checking
-  version: 1.62.2
+  version: 1.65.4
   epoch: 0
   description: Standard Health Checking Service for gRPC
   copyright:
@@ -23,8 +23,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: a44d1ea1e1510b5c62265dada04d86621bb1491d75de987713c9c0ea005c10a8
-      uri: https://files.pythonhosted.org/packages/source/g/grpcio-health-checking/grpcio-health-checking-${{package.version}}.tar.gz
+      expected-sha256: 1e841f6db05a0051a62cc48d40dd2dcc9e717584bb19049ad51fb673281b9c4a
+      uri: https://files.pythonhosted.org/packages/source/g/grpcio-health-checking/grpcio_health_checking-${{package.version}}.tar.gz
 
   - name: Python Build
     uses: python/build-wheel


### PR DESCRIPTION
The update bot is failing to upgrade these two packages due to changes in the format of the fetch URI.