### PR TITLE
adds Catch2-2.13

### DIFF
--- a/Catch2-2.13.yaml
+++ b/Catch2-2.13.yaml
@@ -1,0 +1,49 @@
+# Adding older version, needed only for build time in building of certain packages which haven't migrated to v3 yet
+# https://github.com/catchorg/Catch2/blob/v3.7.0/docs/migrate-v2-to-v3.md#top
+package:
+  name: Catch2-2.13
+  version: 2.13.9
+  epoch: 0
+  description: "A modern, C++-native, test framework"
+  copyright:
+    - license: 'BSL-1.0'
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - python3
+      - python3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/catchorg/Catch2
+      tag: v${{package.version}}
+      expected-commit: 62fd660583d3ae7a7886930b413c3c570e89786c
+
+  - uses: cmake/configure
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-static
+    description: "A modern, C++-native, test framework - static libraries"
+    pipeline:
+      - uses: split/static
+
+  - name: ${{package.name}}-dev
+    description: "A modern, C++-native, test framework - development headers"
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: catchorg/Catch2
+    strip-prefix: v


### PR DESCRIPTION
Adding older version, needed only for build time in building of certain packages which haven't migrated to v3 yet
https://github.com/catchorg/Catch2/blob/v3.7.0/docs/migrate-v2-to-v3.md#top