### PR TITLE
Multi-versionize py3-mdurl

### DIFF
--- a/py3-mdurl.yaml
+++ b/py3-mdurl.yaml
@@ -6,19 +6,27 @@ package:
   copyright:
     - license: MIT
   dependencies:
+    provider-priority: 0
     runtime:
       - python3
+
+vars:
+  pypi-package: mdurl
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 environment:
   contents:
     packages:
       - busybox
       - ca-certificates-bundle
-      - py3-flit-core
-      - py3-gpep517
-      - py3-setuptools
-      - py3-wheel
-      - python3
+      - py3-supported-flit-core
+      - py3-supported-pip
       - wolfi-base
 
 pipeline:
@@ -28,17 +36,23 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 596bf1c8752de45fa576a52c315d6d8cc5bb1a4e
 
-  - runs: |
-      python3 -m gpep517 build-wheel \
-        --wheel-dir dist \
-        --output-fd 3 3>&1 >&2
-      python3 -m installer \
-        -d "${{targets.destdir}}" \
-        dist/mdurl-${{package.version}}-*.whl
-      install -Dm644 LICENSE \
-        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
-
-  - uses: strip
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: mdurl
 
 update:
   enabled: true


### PR DESCRIPTION
Build py3-mdurl for multiple python3 versions

Fixes:

Related:
