### PR TITLE
Add python versioned httpcore and hatch-fancy-pypi-readme

### DIFF
--- a/py3-hatch-fancy-pypi-readme.yaml
+++ b/py3-hatch-fancy-pypi-readme.yaml
@@ -12,6 +12,7 @@ package:
 vars:
   pypi-package: hatch-fancy-pypi-readme
   module-name: hatch_fancy_pypi_readme
+
 data:
   - name: py-versions
     items:
@@ -25,11 +26,11 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - py3-supported-hatchling
       - py3-supported-pip
       - py3-supported-python
       - py3-supported-setuptools
       - py3-supported-wheel
-      - py3-supported-hatchling
       - wolfi-base
   environment:
     # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
@@ -47,7 +48,7 @@ subpackages:
     name: py${{range.key}}-${{vars.pypi-package}}
     description: ${{vars.pypi-package}} installed for python${{range.key}}
     dependencies:
-      runtime: 
+      runtime:
         - py${{range.key}}-hatchling
         - py${{range.key}}-pathspec
         - py${{range.key}}-pluggy

--- a/py3-hatch-fancy-pypi-readme.yaml
+++ b/py3-hatch-fancy-pypi-readme.yaml
@@ -1,0 +1,98 @@
+# Generated from https://pypi.org/project/httpcore/
+package:
+  name: py3-hatch-fancy-pypi-readme
+  version: 24.1.0
+  epoch: 0
+  description: Fancy PyPI READMEs with Hatch
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: hatch-fancy-pypi-readme
+  module-name: hatch_fancy_pypi_readme
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-wheel
+      - py3-supported-hatchling
+      - wolfi-base
+  environment:
+    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
+    SOURCE_DATE_EPOCH: 315532800
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: c340dcb0019cae8444fd390929f88ee647ac840d
+      repository: https://github.com/hynek/hatch-fancy-pypi-readme
+      tag: ${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime: 
+        - py${{range.key}}-hatchling
+        - py${{range.key}}-pathspec
+        - py${{range.key}}-pluggy
+        - py${{range.key}}-trove-classifiers
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - runs: |
+          find ${{targets.destdir}} -name "*.pyc" -exec rm -rf '{}' +
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.module-name}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr
+          mv ${{targets.contextdir}}/../py${{range.key}}-${{vars.pypi-package}}/usr/bin ${{targets.contextdir}}/usr
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+
+update:
+  enabled: true
+  github:
+    identifier: hynek/hatch-fancy-pypi-readme
+    use-tag: true

--- a/py3-hatch-fancy-pypi-readme.yaml
+++ b/py3-hatch-fancy-pypi-readme.yaml
@@ -94,6 +94,8 @@ subpackages:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - dev
   github:
     identifier: hynek/hatch-fancy-pypi-readme
     use-tag: true

--- a/py3-httpcore.yaml
+++ b/py3-httpcore.yaml
@@ -25,14 +25,14 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - py3-supported-build
+      - py3-supported-hatch-fancy-pypi-readme
+      - py3-supported-hatchling
+      - py3-supported-installer
       - py3-supported-pip
       - py3-supported-python
       - py3-supported-setuptools
       - py3-supported-wheel
-      - py3-supported-installer
-      - py3-supported-hatchling
-      - py3-supported-hatch-fancy-pypi-readme
-      - py3-supported-build
       - wolfi-base
   environment:
     # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
@@ -50,7 +50,7 @@ subpackages:
     name: py${{range.key}}-${{vars.pypi-package}}
     description: ${{vars.pypi-package}} installed for python${{range.key}}
     dependencies:
-      runtime: 
+      runtime:
         - py${{range.key}}-h11
         - py${{range.key}}-sniffio
         - py${{range.key}}-anyio

--- a/py3-httpcore.yaml
+++ b/py3-httpcore.yaml
@@ -2,17 +2,22 @@
 package:
   name: py3-httpcore
   version: 1.0.5
-  epoch: 0
+  epoch: 1
   description: A minimal low-level HTTP client.
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-h11
-      - py3-sniffio
-      - py3-anyio
-      - py3-certifi
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: httpcore
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 environment:
   contents:
@@ -20,10 +25,14 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-setuptools
-      - python-3
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-wheel
+      - py3-supported-installer
+      - py3-supported-hatchling
+      - py3-supported-hatch-fancy-pypi-readme
+      - py3-supported-build
       - wolfi-base
   environment:
     # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
@@ -36,13 +45,32 @@ pipeline:
       repository: https://github.com/encode/httpcore
       tag: ${{package.version}}
 
-  - name: Python Build
-    runs: |
-      python -m build
-      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
-      find ${{targets.destdir}} -name "*.pyc" -exec rm -rf '{}' +
-
-  - uses: strip
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime: 
+        - py${{range.key}}-h11
+        - py${{range.key}}-sniffio
+        - py${{range.key}}-anyio
+        - py${{range.key}}-certifi
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - runs: |
+          find ${{targets.destdir}} -name "*.pyc" -exec rm -rf '{}' +
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
 
 update:
   enabled: true


### PR DESCRIPTION
Adds hatch-fancy-pypi-readme with -supported and -bin subpackages needed as build time tools for httpcore