### PR TITLE
Fix python packages with version 0.0.0 in distinfo

### DIFF
--- a/py3-anyio.yaml
+++ b/py3-anyio.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-anyio
   version: 4.4.0
-  epoch: 1
+  epoch: 2
   description: High level compatibility layer for multiple asynchronous event loop implementations
   copyright:
     - license: MIT
@@ -30,6 +30,7 @@ environment:
       - py3-supported-pip
       - py3-supported-python
       - py3-supported-setuptools
+      - py3-supported-setuptools-scm
       - wolfi-base
 
 pipeline:

--- a/py3-pluggy.yaml
+++ b/py3-pluggy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pluggy
   version: 1.5.0
-  epoch: 2
+  epoch: 3
   description: "Plugin management and hook calling for Python"
   copyright:
     - license: MIT
@@ -23,6 +23,7 @@ environment:
       - busybox
       - py3-supported-pip
       - py3-supported-python
+      - py3-supported-setuptools-scm
       - py3-supported-wheel
 
 pipeline:

--- a/py3-python-dateutil.yaml
+++ b/py3-python-dateutil.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-python-dateutil
   version: 2.9.0
-  epoch: 2
+  epoch: 3
   description: Extensions to the standard Python datetime module
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,7 @@ environment:
       - py3-supported-pip
       - py3-supported-python
       - py3-supported-setuptools
+      - py3-supported-setuptools-scm
       - py3-supported-wheel
       - wolfi-base
 

--- a/py3-tabulate.yaml
+++ b/py3-tabulate.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-tabulate
   version: 0.9.0
-  epoch: 2
+  epoch: 3
   description: Pretty-print tabular data
   copyright:
     - license: MIT
@@ -18,6 +18,7 @@ environment:
       - ca-certificates-bundle
       - py3-gpep517
       - py3-setuptools
+      - py3-setuptools-scm
       - py3-wheel
       - python3
       - wolfi-base

--- a/py3-tqdm.yaml
+++ b/py3-tqdm.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tqdm
   version: 4.66.5
-  epoch: 0
+  epoch: 1
   description: Fast, Extensible Progress Meter
   copyright:
     - license: MPL-2.0 AND MIT
@@ -26,6 +26,7 @@ environment:
       - py3-supported-build
       - py3-supported-pip
       - py3-supported-python
+      - py3-supported-setuptools-scm
       - py3-supported-wheel
 
 pipeline:

--- a/py3-trove-classifiers.yaml
+++ b/py3-trove-classifiers.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-trove-classifiers
   version: 2024.7.2
-  epoch: 4
+  epoch: 5
   description: Canonical source for classifiers on PyPI (pypi.org).
   copyright:
     - license: Apache-2.0
@@ -26,6 +26,7 @@ environment:
       - busybox
       - py3-supported-pip
       - py3-supported-python
+      - py3-supported-setuptools-scm
       - py3-supported-wheel
 
 pipeline:


### PR DESCRIPTION
These packages were getting built with their version being 0.0.0. The problem was lack of package setuptools-scm in the build environment. The result was:
 1. the dist-info directory path was like usr/lib/python3.12/site-packages/anyio-0.0.0.dist-info/
 2. pip check would complain about 0.0.0 packages not meeting deps.
 3. pip list would show 0.0.0
