### PR TITLE
Include version in the provides like subpackages.

### DIFF
--- a/kubernetes-csi-external-snapshotter-8.0.yaml
+++ b/kubernetes-csi-external-snapshotter-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-snapshotter-8.0
   version: 8.0.1
-  epoch: 1
+  epoch: 2
   description: Sidecar container that watches Kubernetes Snapshot CRD objects and triggers CreateSnapshot/DeleteSnapshot against a CSI endpoint
   copyright:
     - license: Apache-2.0
@@ -9,6 +9,7 @@ package:
     provides:
       - kubernetes-csi-external-snapshotter=${{package.full-version}}
       - kubernetes-csi-external-csi-snapshotter=${{package.full-version}}
+      - kubernetes-csi-external-csi-snapshotter-${{vars.major-minor-version}}=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.version}}


### PR DESCRIPTION
The subpackages contain major-minor in the package name, the main package does not make it. Make things consistent by providing a provides with that information in it:
https://github.com/wolfi-dev/os/blob/main/kubernetes-csi-external-snapshotter-8.0.yaml#L39
