### PR TITLE
ftbfs: composer

### DIFF
--- a/composer.yaml
+++ b/composer.yaml
@@ -1,7 +1,7 @@
 package:
   name: composer
   version: 2.7.7
-  epoch: 0
+  epoch: 1
   description: "the PHP package manager"
   copyright:
     - license: MIT
@@ -20,7 +20,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://getcomposer.org/download/${{package.version}}/composer.phar
-      expected-sha256: 06e4c4bc6d32b8975174f4f4a0a93476d8907da92a1484c5a8ef138897a760e1
+      expected-sha256: aab940cd53d285a54c50465820a2080fcb7182a4ba1e5f795abfb10414a4b4be
       extract: "false"
       delete: "false"
 


### PR DESCRIPTION
it was a SHA mismatch.

ref: https://getcomposer.org/download/

related: https://github.com/wolfi-dev/os/issues/26401

```bash
[sdk] ❯ wolfictl scan ./packages/aarch64/composer-2.7.7-r1.apk
🔎 Scanning "./packages/aarch64/composer-2.7.7-r1.apk"
✅ No vulnerabilities found
```