### PR TITLE
Rebuild gcc against new glibc

### DIFF
--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.4.0
-  epoch: 4
+  epoch: 5
   description: "the GNU compiler collection - version 12"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-13
   version: 13.3.0
-  epoch: 3
+  epoch: 4
   description: "the GNU compiler collection - version 13"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/gcc-6.yaml
+++ b/gcc-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-6
   version: 6.5.0
-  epoch: 2
+  epoch: 3
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
pthread mutex appears to use private symbols, and thus needs rebuild against new glibc.

Ideally need test for this, but nothing small is identified yet.

Typical symptoms are:

```
2024/08/21 00:42:33 WARN /usr/lib/gcc/x86_64-pc-linux-gnu/12/../../../../x86_64-pc-linux-gnu/bin/ld: somefile:(.text+0x5aa6): more undefined references to `__pthread_mutex_timedlock64' follow
```