### PR TITLE
spark: build packages for supported JDK versions

### DIFF
--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -1,13 +1,11 @@
 package:
   name: spark-3.5
   version: 3.5.2
-  epoch: 1
+  epoch: 2
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0
   dependencies:
-    provides:
-      - spark=${{package.full-version}}
     # Both `python` and `openjdk-{11,17}-default-jvm` are required for running Spark,
     # but will be added in the image, since upstream supports different Python versions
     # and Java versions. So we don't need to specify them here to avoid conflicts.
@@ -37,8 +35,10 @@ environment:
       - glibc-locale-en
       - grep
       - maven
+      - openjdk-11
+      - openjdk-17
+      # Only 8 is used during the build process
       - openjdk-8
-      - openjdk-8-default-jvm
       - perl-utils
       - procps
       - py3.11-pip
@@ -48,7 +48,6 @@ environment:
       - yaml-dev
   environment:
     LANG: en_US.UTF-8
-    JAVA_HOME: /usr/lib/jvm/java-1.8-openjdk
 
 pipeline:
   - uses: git-checkout
@@ -63,18 +62,105 @@ pipeline:
 
   - uses: maven/pombump
 
-  - name: build
-    runs: |
-      ./dev/make-distribution.sh --name custom-spark --pip -Psparkr -Phive -Phive-thriftserver -Pmesos -Pyarn -Pkubernetes
-
-      patch dist/bin/load-spark-env.sh load-spark-env.sh.diff
-      patch dist/sbin/spark-daemon.sh spark-daemon.sh.diff
-
-      mkdir -p ${{targets.destdir}}/usr/lib/spark
-      mkdir -p ${{targets.destdir}}/usr/lib/spark/work-dir
-      mv dist/* ${{targets.destdir}}/usr/lib/spark/
+data:
+  - name: openjdk-versions
+    items:
+      8: "java-1.8-openjdk"
+      11: "java-11-openjdk"
+      17: "java-17-openjdk"
 
 subpackages:
+  - range: openjdk-versions
+    name: ${{package.name}}-openjdk-${{range.key}}
+    dependencies:
+      runtime:
+        - openjdk-${{range.key}}-default-jvm
+      provides:
+        - spark=${{package.full-version}}
+        - ${{package.name}}=${{package.full-version}}
+    pipeline:
+      - runs: |
+          export JAVA_HOME="/usr/lib/jvm/${{range.value}}"
+          export PATH=$PATH:$JAVA_HOME/bin
+
+          ./dev/make-distribution.sh --name custom-spark --pip -Psparkr -Phive -Phive-thriftserver -Pmesos -Pyarn -Pkubernetes
+
+          patch dist/bin/load-spark-env.sh load-spark-env.sh.diff
+          patch dist/sbin/spark-daemon.sh spark-daemon.sh.diff
+
+          mkdir -p ${{targets.contextdir}}/usr/lib/spark
+          mkdir -p ${{targets.contextdir}}/usr/lib/spark/work-dir
+          mv dist/* ${{targets.contextdir}}/usr/lib/spark/
+    test:
+      environment:
+        contents:
+          packages:
+            - python3
+            - ${{range.value}}-default-jvm
+            - R
+        environment:
+          LANG: en_US.UTF-8
+          JAVA_HOME: /usr/lib/jvm/${{range.value}}
+      pipeline:
+        - name: Test ${{package.name}} with OpenJDK ${{range.key}}
+          pipeline:
+            - runs: /usr/lib/spark/bin/spark-shell --version
+            - runs: /usr/lib/spark/bin/spark-submit --version
+            - runs: /usr/lib/spark/bin/pyspark --version
+            - runs: /usr/lib/spark/bin/spark-sql --version
+            - name: Test entrypoint
+              runs: timeout 10 /opt/entrypoint.sh /opt/spark/bin/spark-shell > spark_log.txt 2>&1 || [ $? -eq 143 ] && grep "Spark session available" spark_log.txt && exit_code=0 || exit_code=$? && echo $exit_code
+            - name: Run a simple Scala test script
+              runs: cat ./scala-test | /usr/lib/spark/bin/spark-shell
+            - name: Run a simple Spark job in Scala
+              runs: |
+                cat <<EOF > SimpleJob.scala
+                val data = Seq(1, 2, 3, 4, 5)
+                val rdd = spark.sparkContext.parallelize(data)
+                val sum = rdd.reduce(_ + _)
+                assert(sum == 15)
+                EOF
+                cat SimpleJob.scala | /usr/lib/spark/bin/spark-shell
+            - name: Run a simple Spark job in Python
+              runs: |
+                cat <<EOF > simple_job.py
+                from pyspark.sql import SparkSession
+                spark = SparkSession.builder.appName("SimpleJob").getOrCreate()
+                data = [1, 2, 3, 4, 5]
+                rdd = spark.sparkContext.parallelize(data)
+                sum = rdd.reduce(lambda x, y: x + y)
+                assert sum == 15
+                EOF
+                /usr/lib/spark/bin/spark-submit simple_job.py
+            - name: Perform SQL query on DataFrame in Scala
+              runs: |
+                cat <<EOF > SQLTest.scala
+                import org.apache.spark.sql.SparkSession
+                val spark = SparkSession.builder.appName("SQLTest").getOrCreate()
+                import spark.implicits._
+                val df = Seq((1, "Alice"), (2, "Bob")).toDF("id", "name")
+                df.createOrReplaceTempView("people")
+                val result = spark.sql("SELECT name FROM people WHERE id = 2")
+                assert(result.count() == 1 && result.first().getString(0) == "Bob")
+                EOF
+                cat SQLTest.scala | /usr/lib/spark/bin/spark-shell
+            - name: Run basic SQL query with spark-sql
+              runs: |
+                echo 'CREATE OR REPLACE TEMP VIEW test AS SELECT 1 AS id;' > test.sql
+                echo 'SELECT * FROM test;' >> test.sql
+                /usr/lib/spark/bin/spark-sql -f test.sql
+            - name: Run SparkR script
+              runs: |
+                cat <<EOF > sparkr_test.R
+                library(SparkR)
+                sparkR.session()
+                df <- as.DataFrame(data.frame(id = c(1, 2), name = c("Alice", "Bob")))
+                createOrReplaceTempView(df, "people")
+                df2 <- sql("SELECT * FROM people WHERE id > 1")
+                stopifnot(count(df2) == 1)
+                EOF
+                /usr/lib/spark/bin/spark-submit sparkr_test.R
+
   - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by upstream image"
     pipeline:
@@ -92,10 +178,19 @@ subpackages:
           ln -sf /usr/lib/spark/bin/sparkR ${{targets.subpkgdir}}/usr/bin/spark
       - uses: strip
 
-  - name: ${{package.name}}-minimal
-    description: Minimal version of Spark
+  - range: openjdk-versions
+    name: ${{package.name}}-minimal-openjdk-${{range.key}}
+    dependencies:
+      runtime:
+        - openjdk-${{range.key}}-default-jvm
+      provides:
+        - spark-minimal=${{package.full-version}}
+        - ${{package.name}}-minimal=${{package.full-version}}
     pipeline:
       - runs: |
+          export JAVA_HOME="/usr/lib/jvm/${{range.value}}"
+          export PATH=$PATH:$JAVA_HOME/bin
+
           ./dev/make-distribution.sh --name minimal-spark --pip -Psparkr -Phive
 
           mkdir -p ${{targets.contextdir}}/usr/lib/spark
@@ -135,71 +230,3 @@ update:
     use-tag: true
     strip-prefix: v
     tag-filter: v3.5
-
-test:
-  environment:
-    contents:
-      packages:
-        - python3
-        - openjdk-17-default-jvm
-        - R
-    environment:
-      LANG: en_US.UTF-8
-      JAVA_HOME: /usr/lib/jvm/java-17-openjdk
-  pipeline:
-    - runs: /usr/lib/spark/bin/spark-shell --version
-    - runs: /usr/lib/spark/bin/spark-submit --version
-    - runs: /usr/lib/spark/bin/pyspark --version
-    - runs: /usr/lib/spark/bin/spark-sql --version
-    - name: Test entrypoint
-      runs: timeout 10 /opt/entrypoint.sh /opt/spark/bin/spark-shell > spark_log.txt 2>&1 || [ $? -eq 143 ] && grep "Spark session available" spark_log.txt && exit_code=0 || exit_code=$? && echo $exit_code
-    - name: Run a simple Scala test script
-      runs: cat ./scala-test | /usr/lib/spark/bin/spark-shell
-    - name: Run a simple Spark job in Scala
-      runs: |
-        cat <<EOF > SimpleJob.scala
-        val data = Seq(1, 2, 3, 4, 5)
-        val rdd = spark.sparkContext.parallelize(data)
-        val sum = rdd.reduce(_ + _)
-        assert(sum == 15)
-        EOF
-        cat SimpleJob.scala | /usr/lib/spark/bin/spark-shell
-    - name: Run a simple Spark job in Python
-      runs: |
-        cat <<EOF > simple_job.py
-        from pyspark.sql import SparkSession
-        spark = SparkSession.builder.appName("SimpleJob").getOrCreate()
-        data = [1, 2, 3, 4, 5]
-        rdd = spark.sparkContext.parallelize(data)
-        sum = rdd.reduce(lambda x, y: x + y)
-        assert sum == 15
-        EOF
-        /usr/lib/spark/bin/spark-submit simple_job.py
-    - name: Perform SQL query on DataFrame in Scala
-      runs: |
-        cat <<EOF > SQLTest.scala
-        import org.apache.spark.sql.SparkSession
-        val spark = SparkSession.builder.appName("SQLTest").getOrCreate()
-        import spark.implicits._
-        val df = Seq((1, "Alice"), (2, "Bob")).toDF("id", "name")
-        df.createOrReplaceTempView("people")
-        val result = spark.sql("SELECT name FROM people WHERE id = 2")
-        assert(result.count() == 1 && result.first().getString(0) == "Bob")
-        EOF
-        cat SQLTest.scala | /usr/lib/spark/bin/spark-shell
-    - name: Run basic SQL query with spark-sql
-      runs: |
-        echo 'CREATE OR REPLACE TEMP VIEW test AS SELECT 1 AS id;' > test.sql
-        echo 'SELECT * FROM test;' >> test.sql
-        /usr/lib/spark/bin/spark-sql -f test.sql
-    - name: Run SparkR script
-      runs: |
-        cat <<EOF > sparkr_test.R
-        library(SparkR)
-        sparkR.session()
-        df <- as.DataFrame(data.frame(id = c(1, 2), name = c("Alice", "Bob")))
-        createOrReplaceTempView(df, "people")
-        df2 <- sql("SELECT * FROM people WHERE id > 1")
-        stopifnot(count(df2) == 1)
-        EOF
-        /usr/lib/spark/bin/spark-submit sparkr_test.R

--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -37,6 +37,7 @@ environment:
       - maven
       - openjdk-11
       - openjdk-17
+      - openjdk-21
       # Only 8 is used during the build process
       - openjdk-8
       - perl-utils
@@ -68,6 +69,7 @@ data:
       8: "java-1.8-openjdk"
       11: "java-11-openjdk"
       17: "java-17-openjdk"
+      21: "java-21-openjdk"
 
 subpackages:
   - range: openjdk-versions
@@ -210,8 +212,10 @@ subpackages:
 
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/spark/conf.default/
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/spark/conf/
-          ln -sf /usr/lib/spark/conf ${{targets.subpkgdir}}/opt/bitnami/spark/conf.default
-          ln -sf /usr/lib/spark/conf ${{targets.subpkgdir}}/opt/bitnami/spark/conf
+
+          cp -r /home/build/${{package.name}}-openjdk-21/usr/lib/spark/conf/* ${{targets.subpkgdir}}/opt/bitnami/spark/conf.default/
+          # We copy conf instead of symlinking to avoid issues with the bitnami volume mount.
+          cp -r /home/build/${{package.name}}-openjdk-21/usr/lib/spark/conf/* ${{targets.subpkgdir}}/opt/bitnami/spark/conf/
 
           ln -s /usr/lib/spark/jars ${{targets.subpkgdir}}/opt/bitnami/spark/jars
           ln -s /usr/lib/spark/bin ${{targets.subpkgdir}}/opt/bitnami/spark/bin

--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -210,9 +210,8 @@ subpackages:
 
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/spark/conf.default/
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/spark/conf/
-          cp -r ${{targets.destdir}}/usr/lib/spark/conf/* ${{targets.subpkgdir}}/opt/bitnami/spark/conf.default/
-          # We copy conf instead of symlinking to avoid issues with the bitnami volume mount.
-          cp -r ${{targets.destdir}}/usr/lib/spark/conf/* ${{targets.subpkgdir}}/opt/bitnami/spark/conf/
+          ln -sf /usr/lib/spark/conf ${{targets.subpkgdir}}/opt/bitnami/spark/conf.default
+          ln -sf /usr/lib/spark/conf ${{targets.subpkgdir}}/opt/bitnami/spark/conf
 
           ln -s /usr/lib/spark/jars ${{targets.subpkgdir}}/opt/bitnami/spark/jars
           ln -s /usr/lib/spark/bin ${{targets.subpkgdir}}/opt/bitnami/spark/bin

--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -5,22 +5,6 @@ package:
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0
-  dependencies:
-    # Both `python` and `openjdk-{11,17}-default-jvm` are required for running Spark,
-    # but will be added in the image, since upstream supports different Python versions
-    # and Java versions. So we don't need to specify them here to avoid conflicts.
-    runtime:
-      - bash
-      - busybox
-      - procps
-      - posix-libc-utils
-      - tini
-      - tini-compat
-      - net-tools
-      - logrotate
-      - linux-pam
-      - procps
-      - libnss
 
 environment:
   contents:
@@ -73,8 +57,22 @@ subpackages:
   - range: openjdk-versions
     name: ${{package.name}}-openjdk-${{range.key}}
     dependencies:
+      # Both `python` and `openjdk-{11,17}-default-jvm` are required for running Spark,
+      # but will be added in the image, since upstream supports different Python versions
+      # and Java versions. So we don't need to specify them here to avoid conflicts.
       runtime:
         - openjdk-${{range.key}}-default-jvm
+        - bash
+        - busybox
+        - procps
+        - posix-libc-utils
+        - tini
+        - tini-compat
+        - net-tools
+        - logrotate
+        - linux-pam
+        - procps
+        - libnss
       provides:
         - spark=${{package.full-version}}
         - ${{package.name}}=${{package.full-version}}

--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -37,7 +37,6 @@ environment:
       - maven
       - openjdk-11
       - openjdk-17
-      - openjdk-21
       # Only 8 is used during the build process
       - openjdk-8
       - perl-utils
@@ -69,7 +68,6 @@ data:
       8: "java-1.8-openjdk"
       11: "java-11-openjdk"
       17: "java-17-openjdk"
-      21: "java-21-openjdk"
 
 subpackages:
   - range: openjdk-versions
@@ -213,9 +211,9 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/spark/conf.default/
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/spark/conf/
 
-          cp -r /home/build/${{package.name}}-openjdk-21/usr/lib/spark/conf/* ${{targets.subpkgdir}}/opt/bitnami/spark/conf.default/
+          cp -r /home/build/melange-out/${{package.name}}-openjdk-17/usr/lib/spark/conf/* ${{targets.subpkgdir}}/opt/bitnami/spark/conf.default/
           # We copy conf instead of symlinking to avoid issues with the bitnami volume mount.
-          cp -r /home/build/${{package.name}}-openjdk-21/usr/lib/spark/conf/* ${{targets.subpkgdir}}/opt/bitnami/spark/conf/
+          cp -r /home/build/melange-out/${{package.name}}-openjdk-17/usr/lib/spark/conf/* ${{targets.subpkgdir}}/opt/bitnami/spark/conf/
 
           ln -s /usr/lib/spark/jars ${{targets.subpkgdir}}/opt/bitnami/spark/jars
           ln -s /usr/lib/spark/bin ${{targets.subpkgdir}}/opt/bitnami/spark/bin


### PR DESCRIPTION
Allows us to bundle the correct JDK version with the package and run tests for each supported JDK version at the package level for Spark.