### PR TITLE
ftbfs: meilisearch

### DIFF
--- a/meilisearch.yaml
+++ b/meilisearch.yaml
@@ -1,7 +1,7 @@
 package:
   name: meilisearch
   version: 1.9.0
-  epoch: 0
+  epoch: 1
   description: "A lightning-fast search engine that fits effortlessly into your apps, websites, and workflow."
   copyright:
     - license: MIT
@@ -25,6 +25,7 @@ pipeline:
 
   - name: Configure and build
     runs: |
+      cargo update --precise 0.3.36 --package time
       cargo build --release --locked -vv
       mkdir -p ${{targets.destdir}}/usr/bin/
       mv target/release/meilisearch ${{targets.destdir}}/usr/bin/


### PR DESCRIPTION
time crate fails to compile with latest stable version of rust. this commit updates the crate to the latest version.

<details><summary> scan results </summary>
<p>

```bash
[sdk] ❯ wolfictl scan ./packages/aarch64/meilisearch-1.9.0-r0.apk
🔎 Scanning "./packages/aarch64/meilisearch-1.9.0-r0.apk"
✅ No vulnerabilities found
```

</p>
</details> 

Related: https://github.com/wolfi-dev/os/issues/26401