### PR TITLE
gh/2.55.0 package update

### DIFF
--- a/gh.yaml
+++ b/gh.yaml
@@ -1,7 +1,7 @@
 package:
   name: gh
-  version: 2.54.0
-  epoch: 1
+  version: 2.55.0
+  epoch: 0
   description: GitHub's official command line tool
   copyright:
     - license: MIT
@@ -18,13 +18,9 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 89cbcfe7eb186ff4edbe10792d17bdc55b04f297
+      expected-commit: 95a2f95f75f4b143699d87294788210ffb558248
       repository: https://github.com/cli/cli
       tag: v${{package.version}}
-
-  - uses: go/bump
-    with:
-      deps: github.com/docker/docker@v26.1.5
 
   - runs: make install prefix=${{targets.destdir}}/usr
 


### PR DESCRIPTION
bumps gh to 2.55.0

Fixes https://github.com/wolfi-dev/os/pull/26756

<details><summary> scan results </summary>
<p>

```bash
[sdk] ❯ wolfictl scan ./packages/aarch64/gh-2.55.0-r0.apk
🔎 Scanning "./packages/aarch64/gh-2.55.0-r0.apk"
✅ No vulnerabilities found
```

</p>
</details> 