### PR TITLE
cilium-cli/0.16.16 package update

### DIFF
--- a/cilium-cli.yaml
+++ b/cilium-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: cilium-cli
-  version: 0.16.15
-  epoch: 2
+  version: 0.16.16
+  epoch: 0
   description: CLI to install, manage & troubleshoot Kubernetes clusters running Cilium
   copyright:
     - license: Apache-2.0
@@ -19,13 +19,8 @@ pipeline:
     with:
       repository: https://github.com/cilium/cilium-cli
       tag: v${{package.version}}
-      expected-commit: 99ff3d9edd4050d7b5c9d1f51dcf6ebeeb613d15
+      expected-commit: 62bd4511031211b50a4623870955a5ad27b43e3b
       destination: cilium-cli
-
-  - uses: go/bump
-    with:
-      deps: github.com/docker/docker@v26.1.5 github.com/cilium/cilium@v1.16.1
-      modroot: cilium-cli
 
   - runs: |
       cd cilium-cli


### PR DESCRIPTION
bumps cilium-cli to 0.16.16

Fixes: https://github.com/wolfi-dev/os/pull/26699

<details><summary> scan results </summary>
<p>

```bash
[sdk] ❯ wolfictl scan ./packages/aarch64/cilium-cli-0.16.16-r0.apk
🔎 Scanning "./packages/aarch64/cilium-cli-0.16.16-r0.apk"
✅ No vulnerabilities found
[sdk] ❯
```

</p>
</details> 

