### PR TITLE
Py3 markdown it py

### DIFF
--- a/py3-markdown-it-py.yaml
+++ b/py3-markdown-it-py.yaml
@@ -1,25 +1,30 @@
 package:
   name: py3-markdown-it-py
   version: 3.0.0
-  epoch: 2
+  epoch: 3
   description: "Python port of markdown-it. Markdown parsing, done right!"
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - py3-mdurl
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: markdown-it-py
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 environment:
   contents:
     packages:
       - busybox
       - ca-certificates-bundle
-      - py3-flit-core
-      - py3-gpep517
-      - py3-setuptools
-      - py3-wheel
-      - python3
+      - py3-supported-flit-core
+      - py3-supported-pip
       - wolfi-base
 
 pipeline:
@@ -29,19 +34,33 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: bee6d1953be75717a3f2f6a917da6f464bed421d
 
-  - runs: |
-      python3 -m gpep517 build-wheel \
-        --wheel-dir dist \
-        --output-fd 3 3>&1 >&2
-      python3 -m installer \
-        -d "${{targets.destdir}}" \
-        dist/markdown_it_py-${{package.version}}-*.whl
-      install -Dm644 LICENSE \
-        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
-      install -Dm644 LICENSE.markdown-it \
-        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE.markdown-it
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-mdurl
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: markdown_it
 
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: markdown_it
 
 update:
   enabled: true


### PR DESCRIPTION
Build py3-markdown-it-py for multiple py3 versions

Also bump py3-mdurl because I didn't in a previous commit.