### PR TITLE
Multi-versionize py3-yarl

### DIFF
--- a/py3-cython.yaml
+++ b/py3-cython.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cython
   version: 3.0.11
-  epoch: 0
+  epoch: 1
   description: Cython is an optimising static compiler for both the Python & the extended Cython programming languages.
   copyright:
     - license: Apache-2.0
@@ -39,13 +39,47 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       provides:
-        - ${{package.name}}
-        - cython
+        - py3-cython # This does not provide the binary
     pipeline:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+      - runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
       - uses: strip
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+      provides:
+        - cython
+      provider-priority: ${{range.value}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      pipeline:
+        - runs: |
+            cython --version
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.pypi-package}}
 
   - name: py3-wheels-${{vars.pypi-package}}
     pipeline:

--- a/py3-yarl.yaml
+++ b/py3-yarl.yaml
@@ -1,17 +1,22 @@
-# Generated from https://pypi.org/project/yarl/
 package:
   name: py3-yarl
   version: 1.9.4
-  epoch: 0
+  epoch: 1
   description: Yet another URL library
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - py3-multidict
-      - py3-idna
-      - py3-typing-extensions
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: yarl
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 environment:
   contents:
@@ -19,22 +24,51 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-setuptools
-      - python3-dev
+      - py3-supported-cython
+      - py3-supported-expandvars
+      - py3-supported-pip
+      - py3-supported-python-dev
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 566db86717cf8080b99b58b083b773a908ae40f06681e87e589a976faf8246bf
-      uri: https://files.pythonhosted.org/packages/source/y/yarl/yarl-${{package.version}}.tar.gz
+      expected-commit: 6362ff155ba02964a5e773927412f7cf4ca23cd1
+      repository: https://github.com/aio-libs/yarl
+      tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-idna
+        - py${{range.key}}-multidict
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
 
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: ${{vars.pypi-package}}
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 12895
+  github:
+    identifier: aio-libs/yarl
+    tag-filter: v
+    use-tag: true

--- a/py3-yarl.yaml
+++ b/py3-yarl.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-yarl
-  version: 1.9.4
+  version: 1.9.8
   epoch: 1
   description: Yet another URL library
   copyright:
@@ -33,7 +33,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 6362ff155ba02964a5e773927412f7cf4ca23cd1
+      expected-commit: 8eea485bffe6d2591d4c80e9abc3f4cafd63d99f
       repository: https://github.com/aio-libs/yarl
       tag: v${{package.version}}
 
@@ -70,5 +70,6 @@ update:
   enabled: true
   github:
     identifier: aio-libs/yarl
+    strip-prefix: v
     tag-filter: v
     use-tag: true


### PR DESCRIPTION
Build py3-yarld and deps against multi versions of python3

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [X] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
