### PR TITLE
create base foundation for victoriametrics packages

### DIFF
--- a/victoriametrics.yaml
+++ b/victoriametrics.yaml
@@ -6,6 +6,13 @@ package:
   copyright:
     - license: Apache-2.0
 
+data:
+  - name: victoria-packages
+    items:
+      victoria-metrics:
+      vmagent:
+      vmalert:
+
 pipeline:
   - uses: git-checkout
     with:
@@ -14,23 +21,31 @@ pipeline:
       tag: v${{package.version}}
 
 subpackages:
-  - name: ${{package.name}}-vmagent
-    description: vmagent is a tiny agent which helps you collect metrics from various sources, relabel and filter the collected metrics and store them in VictoriaMetrics or any other storage systems via Prometheus remote_write protocol or via VictoriaMetrics remote_write protocol.
+  - range: victoria-packages
+    name: "${{package.name}}-${{range.key}}"
+    description: >
+      ${{range.key}} is a tool for VictoriaMetrics.
+
     pipeline:
       - uses: go/build
         with:
           tags: nethttpomithttp2
-          packages: ./app/vmagent
-          output: vmagent
+          packages: ./app/${{range.key}}
+          output: ${{range.key}}
+          ldflags: -X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=${{range.key}}-$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%Y-%m-%dT%H:%M:%SZ")-$(git rev-parse HEAD)
     test:
-      environment:
-        contents:
-          packages:
-            - busybox
       pipeline:
-        - name: Test the vmagent binary
+        - name: Test the ${{range.key}} binary
           runs: |
-            vmagent -help
+            ${{range.key}} -version
+
+  - range: victoria-packages
+    name: "${{package.name}}-${{range.key}}-compat"
+    description: Compatibility package to place binaries in the location expected by upstream Dockerfile
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          ln -sf /usr/bin/${{range.key}} ${{targets.contextdir}}/${{range.key}}
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

I used data ranges victoria-metrics packages, so, this is not done yet for sure but if that makes sense to you we could continue adding more sub-packages to this PR @dakaneye. 

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
