### PR TITLE
WIP: convert 'if:'s to new 'if-arch:'s

### DIFF
--- a/calico-3.28.yaml
+++ b/calico-3.28.yaml
@@ -158,8 +158,7 @@ subpackages:
           required-steps: 2
         pipeline:
           # Equivalent to target: "$(NODE_CONTAINER_BINARY)"
-          - if: ${{build.arch}} == 'x86_64' || ${{build.arch}} == 'aarch64' # Essentially a guard to make sure we never try to build beyond x86_64 and aarch64
-            runs: |
+          - runs: |
               _arch=${{build.goarch}}
 
               LIBBPF_CONTAINER_PATH=/home/build/felix/bpf-gpl/include/libbpf/src

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -86,7 +86,7 @@ pipeline:
       replaces: go.opentelemetry.io/collector=go.opentelemetry.io/collector@v0.102.1 github.com/mholt/archiver/v3=github.com/anchore/archiver/v3@v3.5.2
       show-diff: true
 
-  - if: ${{build.arch}} == 'aarch64'
+  - if-arch: aarch64
     runs: |
       mkdir -p /usr/src
       wget -O arch.deb http://deb.debian.org/debian-security/pool/updates/main/l/linux-5.10/linux-headers-${LINUX_HEADERS_VERSION}-arm64_${LINUX_KERNEL_VERSION}_arm64.deb
@@ -98,7 +98,7 @@ pipeline:
       wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/clang+llvm-12.0.1-aarch64-linux-gnu.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
       echo "3d4ad804b7c85007686548cbc917ab067bf17eaedeab43d9eb83d3a683d8e9d4  /tmp/clang.tar.xz" | sha256sum --check
 
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       mkdir -p /usr/src
       wget -O arch.deb http://deb.debian.org/debian-security/pool/updates/main/l/linux-5.10/linux-headers-${LINUX_HEADERS_VERSION}-amd64_${LINUX_KERNEL_VERSION}_amd64.deb

--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -65,7 +65,7 @@ pipeline:
       - assertions:
           required-steps: 1
         pipeline:
-          - if: ${{build.arch}} == 'aarch64'
+          - if-arch: aarch64
             runs: |
               ./build.sh --online --clean-while-building \
                 -- \
@@ -75,7 +75,7 @@ pipeline:
                 /p:PrebuiltPackagesPath=/home/build/src/packages \
                 /p:SkipPortableRuntimeBuild=true \
                 /p:TargetRid=linux-arm64
-          - if: ${{build.arch}} == 'x86_64'
+          - if-arch: x86_64
             runs: |
               ./build.sh --online --clean-while-building \
                 -- \
@@ -91,10 +91,10 @@ pipeline:
       - assertions:
           required-steps: 1
         pipeline:
-          - if: ${{build.arch}} == 'aarch64'
+          - if-arch: aarch64
             runs: |
               tar zxf artifacts/arm64/Release/dotnet-sdk-*.tar.gz -C "${{targets.destdir}}"/usr/share/dotnet
-          - if: ${{build.arch}} == 'x86_64'
+          - if-arch: x86_64
             runs: |
               tar zxf artifacts/x64/Release/dotnet-sdk-*.tar.gz -C "${{targets.destdir}}"/usr/share/dotnet
       - runs: |

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -77,10 +77,10 @@ pipeline:
       - assertions:
           required-steps: 1
         pipeline:
-          - if: ${{build.arch}} == 'aarch64'
+          - if-arch: aarch64
             runs: |
               tar zxf artifacts/arm64/Release/dotnet-sdk-*.tar.gz -C "${{targets.destdir}}"/usr/share/dotnet
-          - if: ${{build.arch}} == 'x86_64'
+          - if-arch: x86_64
             runs: |
               tar zxf artifacts/x64/Release/dotnet-sdk-*.tar.gz -C "${{targets.destdir}}"/usr/share/dotnet
       - runs: |

--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -67,10 +67,10 @@ pipeline:
       - assertions:
           required-steps: 1
         pipeline:
-          - if: ${{build.arch}} == 'aarch64'
+          - if-arch: aarch64
             runs: |
               tar zxf artifacts/arm64/Release/dotnet-sdk-*.tar.gz -C "${{targets.destdir}}"/usr/share/dotnet
-          - if: ${{build.arch}} == 'x86_64'
+          - if-arch: x86_64
             runs: |
               tar zxf artifacts/x64/Release/dotnet-sdk-*.tar.gz -C "${{targets.destdir}}"/usr/share/dotnet
       - runs: |

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -141,7 +141,7 @@ subpackages:
   - name: "libquadmath"
     description: "128-bit math library provided by GCC"
     pipeline:
-      - if: ${{build.arch}} == 'x86_64'
+      - if-arch: x86_64
         runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib64
           mv "${{targets.destdir}}"/usr/lib64/libquadmath.so.* "${{targets.subpkgdir}}"/usr/lib64/

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -339,12 +339,12 @@ subpackages:
       - assertions:
           required-steps: 1
         pipeline:
-          - if: ${{build.arch}} == 'aarch64'
+          - if-arch: aarch64
             runs: |
               mkdir -p "${{targets.subpkgdir}}"/lib
               mv "${{targets.destdir}}"/lib/ld-linux-aarch64.so.1 "${{targets.subpkgdir}}"/lib/
           # Regrettably, the LSB *requires* the GLIBC ELF loader to be installed in `/lib64`.
-          - if: ${{build.arch}} == 'x86_64'
+          - if-arch: x86_64
             runs: |
               mkdir -p "${{targets.subpkgdir}}"/lib64
               mv "${{targets.destdir}}"/lib/ld-linux-x86-64.so.2 "${{targets.subpkgdir}}"/lib64/

--- a/google-cloud-sdk.yaml
+++ b/google-cloud-sdk.yaml
@@ -32,14 +32,14 @@ pipeline:
       echo "SHA256 of google-cloud-sdk-${{package.version}}-linux-arm.tar.gz"
       curl -sL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-arm.tar.gz | sha256sum -
 
-  - if: ${{build.arch}} == "x86_64"
+  - if-arch: x86_64
     uses: fetch
     with:
       uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-x86_64.tar.gz
       expected-sha256: a9129eb385d74b93e8548ffd5e5697e426b174a20bd399aa1ba850bf4f3f3c58
       strip-components: 0
 
-  - if: ${{build.arch}} == "aarch64"
+  - if-arch: arm64
     uses: fetch
     with:
       uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-arm.tar.gz

--- a/guile.yaml
+++ b/guile.yaml
@@ -47,7 +47,7 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
-    if: ${{build.arch}} != 'x86_64' && ${{build.arch}} != 'x86' && ${{build.arch}} != 'mips64'
+    if-arch: aarch64
 
 subpackages:
   - name: guile-dev

--- a/py3.10-google-cloud-sdk.yaml
+++ b/py3.10-google-cloud-sdk.yaml
@@ -32,14 +32,14 @@ pipeline:
       echo "SHA256 of google-cloud-sdk-${{package.version}}-linux-arm.tar.gz"
       curl -sL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-arm.tar.gz | sha256sum -
 
-  - if: ${{build.arch}} == "x86_64"
+  - if-arch: x86_64
     uses: fetch
     with:
       uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-x86_64.tar.gz
       expected-sha256: da4197eded5b292942d75ec164ffaa811ab79379edbc2371dc68da27787c10a7
       strip-components: 0
 
-  - if: ${{build.arch}} == "aarch64"
+  - if-arch: aarch64
     uses: fetch
     with:
       uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-arm.tar.gz

--- a/py3.11-google-cloud-sdk.yaml
+++ b/py3.11-google-cloud-sdk.yaml
@@ -32,14 +32,14 @@ pipeline:
       echo "SHA256 of google-cloud-sdk-${{package.version}}-linux-arm.tar.gz"
       curl -sL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-arm.tar.gz | sha256sum -
 
-  - if: ${{build.arch}} == "x86_64"
+  - if-arch: x86_64
     uses: fetch
     with:
       uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-x86_64.tar.gz
       expected-sha256: da4197eded5b292942d75ec164ffaa811ab79379edbc2371dc68da27787c10a7
       strip-components: 0
 
-  - if: ${{build.arch}} == "aarch64"
+  - if-arch: aarch64
     uses: fetch
     with:
       uri: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${{package.version}}-linux-arm.tar.gz

--- a/rust-1.29.yaml
+++ b/rust-1.29.yaml
@@ -242,7 +242,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.30.yaml
+++ b/rust-1.30.yaml
@@ -165,7 +165,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.31.yaml
+++ b/rust-1.31.yaml
@@ -165,7 +165,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.32.yaml
+++ b/rust-1.32.yaml
@@ -167,7 +167,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.33.yaml
+++ b/rust-1.33.yaml
@@ -167,7 +167,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.34.yaml
+++ b/rust-1.34.yaml
@@ -168,7 +168,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.35.yaml
+++ b/rust-1.35.yaml
@@ -168,7 +168,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.36.yaml
+++ b/rust-1.36.yaml
@@ -168,7 +168,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.37.yaml
+++ b/rust-1.37.yaml
@@ -168,7 +168,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.38.yaml
+++ b/rust-1.38.yaml
@@ -168,7 +168,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.39.yaml
+++ b/rust-1.39.yaml
@@ -168,7 +168,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.40.yaml
+++ b/rust-1.40.yaml
@@ -168,7 +168,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.41.yaml
+++ b/rust-1.41.yaml
@@ -168,7 +168,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.42.yaml
+++ b/rust-1.42.yaml
@@ -162,7 +162,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.43.yaml
+++ b/rust-1.43.yaml
@@ -162,7 +162,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.44.yaml
+++ b/rust-1.44.yaml
@@ -162,7 +162,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.45.yaml
+++ b/rust-1.45.yaml
@@ -172,7 +172,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.46.yaml
+++ b/rust-1.46.yaml
@@ -172,7 +172,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.47.yaml
+++ b/rust-1.47.yaml
@@ -169,7 +169,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.48.yaml
+++ b/rust-1.48.yaml
@@ -170,7 +170,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.49.yaml
+++ b/rust-1.49.yaml
@@ -170,7 +170,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.50.yaml
+++ b/rust-1.50.yaml
@@ -170,7 +170,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.51.yaml
+++ b/rust-1.51.yaml
@@ -170,7 +170,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.52.yaml
+++ b/rust-1.52.yaml
@@ -170,7 +170,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.53.yaml
+++ b/rust-1.53.yaml
@@ -170,7 +170,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.54.yaml
+++ b/rust-1.54.yaml
@@ -170,7 +170,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.55.yaml
+++ b/rust-1.55.yaml
@@ -121,7 +121,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.56.yaml
+++ b/rust-1.56.yaml
@@ -121,7 +121,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.57.yaml
+++ b/rust-1.57.yaml
@@ -121,7 +121,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.58.yaml
+++ b/rust-1.58.yaml
@@ -121,7 +121,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.59.yaml
+++ b/rust-1.59.yaml
@@ -121,7 +121,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.60.yaml
+++ b/rust-1.60.yaml
@@ -121,7 +121,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.61.yaml
+++ b/rust-1.61.yaml
@@ -121,7 +121,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.62.yaml
+++ b/rust-1.62.yaml
@@ -121,7 +121,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.63.yaml
+++ b/rust-1.63.yaml
@@ -121,7 +121,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.64.yaml
+++ b/rust-1.64.yaml
@@ -116,7 +116,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.65.yaml
+++ b/rust-1.65.yaml
@@ -116,7 +116,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.66.yaml
+++ b/rust-1.66.yaml
@@ -116,7 +116,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.67.yaml
+++ b/rust-1.67.yaml
@@ -116,7 +116,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.68.yaml
+++ b/rust-1.68.yaml
@@ -116,7 +116,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.69.yaml
+++ b/rust-1.69.yaml
@@ -112,7 +112,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.70.yaml
+++ b/rust-1.70.yaml
@@ -108,7 +108,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.71.yaml
+++ b/rust-1.71.yaml
@@ -108,7 +108,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.72.yaml
+++ b/rust-1.72.yaml
@@ -108,7 +108,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.73.yaml
+++ b/rust-1.73.yaml
@@ -118,7 +118,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-1.74.yaml
+++ b/rust-1.74.yaml
@@ -118,7 +118,7 @@ pipeline:
 
   # rustbuild always installs copies of the shared libraries to /usr/lib,
   # overwrite them with symlinks to the per-architecture versions
-  - if: ${{build.arch}} == 'x86_64'
+  - if-arch: x86_64
     runs: |
       cd ${{targets.destdir}}
       mkdir -p ${{targets.destdir}}/usr/lib32

--- a/rust-stage0.yaml
+++ b/rust-stage0.yaml
@@ -24,12 +24,12 @@ pipeline:
   - assertions:
       required-steps: 1
     pipeline:
-      - if: ${{build.arch}} == 'x86_64'
+      - if-arch: x86_64
         uses: fetch
         with:
           uri: https://static.rust-lang.org/dist/rust-${{package.version}}-x86_64-unknown-linux-gnu.tar.gz
           expected-sha256: df7c7466ef35556e855c0d35af7ff08e133040400452eb3427c53202b6731926
-      - if: ${{build.arch}} == 'aarch64'
+      - if-arch: aarch64
         uses: fetch
         with:
           uri: https://static.rust-lang.org/dist/rust-${{package.version}}-aarch64-unknown-linux-gnu.tar.gz


### PR DESCRIPTION
This converts packages to use `if-arch`, introduced in https://github.com/chainguard-dev/melange/pull/1450

After this change we can remove `if` and `assertions` from melange (https://github.com/chainguard-dev/melange/pull/1449)