### PR TITLE
Show stderr in wolfictl scan action nif it does not look right.

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -335,10 +335,21 @@ jobs:
 
       - name: Scan for CVEs
         run: |
+          stderrf="/tmp/scan.stderr"
           wolfictl scan \
             --build-log \
             --advisories-repo-dir 'data/wolfi-advisories' \
             --advisory-filter 'resolved' \
             --require-zero \
             /tmp/artifacts-1 \
-            2> /dev/null # The error message renders strangely on GitHub Actions, and the important information is already being sent to stdout.
+            2> "$stderrf" && rc=0 || rc=$?
+
+          # The error message renders strangely on GitHub Actions so it is
+          # captured and shown only if it does not match expected "vulnerabilities found"
+          if [ $rc -ne 0 ] &&
+             ! grep -qi "vulnerabilities found" "$stderrf"; then
+             echo "Unexpected error content" 1>&2
+             sed 's,^,| ,' "$stderrf" 1>&2
+          fi
+          rm -f "$stderrf"
+          exit $rc


### PR DESCRIPTION
A previous comment says that stderr output is confusing to viewing the github action so it was sent to /dev/null.

That makes debugging harder. So if it doens't look like a "there were vulnerabilities found" error, then show it.
