### PR TITLE
do not require 'python' setting in pip-build-install

### DIFF
--- a/pipelines/py/pip-build-install-bootstrap.yaml
+++ b/pipelines/py/pip-build-install-bootstrap.yaml
@@ -7,14 +7,14 @@ needs:
 inputs:
   python:
     description: which python to use
-    required: true
+    default: DEFAULT
   wheel:
     description: build a wheel?
     required: false
     default: true
   dest:
     description: the destination
-    default: ${{targets.subpkgdir}}
+    default: ${{targets.contextdir}}
 
 pipeline:
   - name: "pip-bootstrap build"
@@ -24,6 +24,27 @@ pipeline:
       pipzip=/usr/share/pip-zipapp/pip-zipapp.pyz
       [ -e "$pipzip" ] || { echo "missing pip-zip - $pipzip does not exist"; exit 1; }
       [ -f "$pipzip" ] || { echo "missing pip-zip - $pipzip is not a file"; exit 1; }
+      if [ "$py" = "DEFAULT" ]; then
+        if p=$(command -v python3); then
+          py=$p
+          if [ -L "$p" ]; then
+            py=$(readlink -f "$p") ||
+              { echo "ERROR: failed 'readlink -f $p'" 1>&2; exit 1; }
+          fi
+        else
+          glob="/usr/bin/python3.[0-9][0-9] /usr/bin/python3.[789]"
+          n=0
+          for p in $glob; do
+            [ -x "$p" ] && n=$((n+1)) && py=$p && found="$found $p"
+          done
+          if [ "$n" -ne 1 ]; then
+            echo "ERROR: must set inputs.python: " \
+                "found $n executables matching $glob" 1>&2
+            [ "$n" -eq 0 ] || echo "  found: $found" 1>&2
+            exit 1
+          fi
+        fi
+      fi
       pyver=$("$py" -c 'import sys; print("%s.%s" % (sys.version_info.major, sys.version_info.minor))')
       sitepkgd=$("$py" -c 'import site; print(site.getsitepackages()[0])')
       sitepkgd=${sitepkgd#/}

--- a/pipelines/py/pip-build-install.yaml
+++ b/pipelines/py/pip-build-install.yaml
@@ -3,16 +3,37 @@ name: Build and install python package with pip
 inputs:
   python:
     description: which python to use
-    required: true
+    default: DEFAULT
   dest:
     description: the destination
-    default: ${{targets.subpkgdir}}
+    default: ${{targets.contextdir}}
 
 pipeline:
-  - name: "pip build ${{inputs.python}}"
+  - name: "pip build"
     runs: |
       export SOURCE_DATE_EPOCH=315532800
       py=${{inputs.python}}
+      if [ "$py" = "DEFAULT" ]; then
+        if p=$(command -v python3); then
+          py=$p
+          if [ -L "$p" ]; then
+            py=$(readlink -f "$p") ||
+              { echo "ERROR: failed 'readlink -f $p'" 1>&2; exit 1; }
+          fi
+        else
+          glob="/usr/bin/python3.[0-9][0-9] /usr/bin/python3.[789]"
+          n=0
+          for p in $glob; do
+            [ -x "$p" ] && n=$((n+1)) && py=$p && found="$found $p"
+          done
+          if [ "$n" -ne 1 ]; then
+            echo "ERROR: must set inputs.python: " \
+                "found $n executables matching $glob" 1>&2
+            [ "$n" -eq 0 ] || echo "  found: $found" 1>&2
+            exit 1
+          fi
+        fi
+      fi
       pyver=$("$py" -c 'import sys; print("%s.%s" % (sys.version_info.major, sys.version_info.minor))')
       sitepkgd=$("$py" -c 'import site; print(site.getsitepackages()[0])')
       sitepkgd=${sitepkgd#/}

--- a/py3-antlr4-python3-runtime.yaml
+++ b/py3-antlr4-python3-runtime.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-antlr4-python3-runtime
   version: 4.13.2
-  epoch: 0
+  epoch: 1
   description: ANTLR runtime for Python 3
   copyright:
     - license: BSD-3-Clause
@@ -26,16 +26,8 @@ pipeline:
       repository: https://github.com/antlr/antlr4
       tag: ${{package.version}}
 
-  - runs: |
-      cd runtime/Python3
-      export SETUPTOOLS_SCM_PRETEND_VERSION=${{package.version}}
-      python3=$(readlink -f `which python3`)
-      $python3 -m pip install -U poetry
-      $python3 -m gpep517 build-wheel \
-        --wheel-dir dist \
-        --output-fd 3 3>&1 >&2
-      $python3 -m installer -d "${{targets.destdir}}" \
-        dist/*.whl
+  - uses: py/pip-build-install
+    working-directory: runtime/Python3
 
   - uses: strip
 


### PR DESCRIPTION
This allows non-"multi-versioned" py3 packages to use this pipeline without having to find which python is current themselves.

Update one such package py3-antlr4-python3-runtime.yaml to show the usage.

Default to using python3 in PATH.
If that is not present and there is only one /usr/bin/python3.XX then use it.
If you can't find a single obvious python3, then fail.