### PR TITLE
fix(chromium): Install ChromeDriver at the correct path

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -7,7 +7,7 @@
 package:
   name: chromium
   version: 127.0.6533.119
-  epoch: 0
+  epoch: 1
   description: "Open souce version of Google's chrome web browser"
   copyright:
     - license: BSD-3-Clause
@@ -208,7 +208,7 @@ pipeline:
   # Do not strip ChromeDriver
   - working-directory: /home/src/out/Default
     runs: |
-      mv chromedriver.unstripped ${{targets.destdir}}/usr/lib/${{package.name}}
+      mv chromedriver.unstripped ${{targets.destdir}}/usr/lib/${{package.name}}/chromedriver
 
 subpackages:
   - name: ${{package.name}}-lang
@@ -247,6 +247,10 @@ test:
         #- python3
   pipeline:
     - runs: |
+        # Make sure Chrome and ChromeDriver are at the correct path
+        test -f /usr/lib/chromium/chrome
+        test -f /usr/lib/chromium/chromedriver
+
         # Ensure all libraries are linked
         ldd /usr/lib/chromium/chrome
 


### PR DESCRIPTION
When updating Chromium the other day, we migrated to an unstripped ChromeDriver. Provide this at the correct path