### PR TITLE
fix(cve): GHSA-857q-xmph-p2v5 in efs-utils

### DIFF
--- a/efs-utils.yaml
+++ b/efs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: efs-utils
   version: 2.0.4
-  epoch: 0
+  epoch: 1
   description: Utilities for Amazon Elastic File System (EFS)
   copyright:
     - license: MIT
@@ -36,7 +36,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: GHSA-52xf-5p2m-9wrv.patch
+      patches: GHSA-857q-xmph-p2v5.patch
 
   # This looks a little funny, but it aims to be easier to maintain, so we just
   # copy from the upstream `build-deb.sh` script the bits we need.

--- a/efs-utils/GHSA-857q-xmph-p2v5.patch
+++ b/efs-utils/GHSA-857q-xmph-p2v5.patch
@@ -1,3 +1,4 @@
+Fix CVE: GHSA-857q-xmph-p2v5, GHSA-52xf-5p2m-9wrv
 diff --git a/src/proxy/Cargo.toml b/src/proxy/Cargo.toml
 index 0a6d0ad..1d92f38 100644
 --- a/src/proxy/Cargo.toml
@@ -9,9 +10,9 @@ index 0a6d0ad..1d92f38 100644
 -s2n-tls = "0.0"
 -s2n-tls-tokio = "0.0"
 -s2n-tls-sys = "0.0"
-+s2n-tls = "0.2.7"
-+s2n-tls-tokio = "0.2.7"
-+s2n-tls-sys = "0.2.7"
++s2n-tls = "0.3.0"
++s2n-tls-tokio = "0.3.0"
++s2n-tls-sys = "0.3.0"
  serde = {version="1.0.175",features=["derive"]}
  serde_ini = "0.2.0"
  thiserror = "1.0.44"


### PR DESCRIPTION
Fixes:
https://github.com/chainguard-dev/CVE-Dashboard/issues/10706

