### PR TITLE
py3-nltk - fix import, add a test.

### DIFF
--- a/py3-nltk.yaml
+++ b/py3-nltk.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-nltk
   version: 3.9.1
-  epoch: 0
+  epoch: 1
   description: Natural Language Toolkit
   copyright:
     - license: BSD-3-Clause
@@ -19,7 +19,6 @@ package:
       - py3-scipy
       - py3-tqdm
       - py3-twython
-      - python3
 
 environment:
   contents:
@@ -41,6 +40,8 @@ pipeline:
       repository: https://github.com/nltk/nltk
       expected-commit: aca78cb2add4084f76b9eac921d8a73927d7a086
       tag: ${{package.version}}
+      cherry-picks: |
+        develop/7d1cbc71441f607daea0894333912268e2911cab: required to "import nltk"
 
   - name: Python Build
     uses: python/build
@@ -49,6 +50,13 @@ pipeline:
     uses: python/install
 
   - uses: strip
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import nltk
 
 update:
   enabled: true


### PR DESCRIPTION
The 3.9.1 tag is really just DOA.  The pypi distribution of 3.9.1 has this patch applied.
