### PR TITLE
python-3.11: cherry pick CVE-2024-8088 fixes

### DIFF
--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: 3.11.9
-  epoch: 7
+  epoch: 8
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -48,6 +48,8 @@ pipeline:
       expected-commit: de54cf5be371a6f5e2e9f208c38def5f81d3ef02
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
+      cherry-picks: |
+        3.11/795f2597a4be988e2bb19b69ff9958e981cb894e:  CVE-2024-8088 fixes
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
Based on the python advisories https://www.cve.org/CVERecord?id=CVE-2024-8088
https://github.com/python/cpython/commit/795f2597a4be988e2bb19b69ff9958e981cb894e
