### PR TITLE
prometheus: disable net/http/pprof

### DIFF
--- a/prometheus-2.54.yaml
+++ b/prometheus-2.54.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-2.54
   version: 2.54.0
-  epoch: 2
+  epoch: 3
   description: The Prometheus monitoring system and time series database.
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,10 @@ pipeline:
       expected-commit: 5354e87a70d3eb26b81b601b286d66ff983990f6
       repository: https://github.com/prometheus/prometheus
       tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      patches: disable-pprof.patch
 
   - uses: go/bump
     with:

--- a/prometheus-2.54/disable-pprof.patch
+++ b/prometheus-2.54/disable-pprof.patch
@@ -1,0 +1,71 @@
+diff --git a/cmd/prometheus/main.go b/cmd/prometheus/main.go
+index 1d844ddba..efcdacf1f 100644
+--- a/cmd/prometheus/main.go
++++ b/cmd/prometheus/main.go
+@@ -22,7 +22,6 @@ import (
+ 	"math/bits"
+ 	"net"
+ 	"net/http"
+-	_ "net/http/pprof" // Comment this line to disable pprof endpoint.
+ 	"net/url"
+ 	"os"
+ 	"os/signal"
+diff --git a/web/web.go b/web/web.go
+index 9426ed935..afedb193b 100644
+--- a/web/web.go
++++ b/web/web.go
+@@ -23,7 +23,6 @@ import (
+ 	"math"
+ 	"net"
+ 	"net/http"
+-	"net/http/pprof"
+ 	"net/url"
+ 	"os"
+ 	"path"
+@@ -476,9 +475,6 @@ func New(logger log.Logger, o *Options) *Handler {
+ 		w.Write([]byte("Only POST or PUT requests allowed"))
+ 	})
+ 
+-	router.Get("/debug/*subpath", serveDebug)
+-	router.Post("/debug/*subpath", serveDebug)
+-
+ 	router.Get("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
+ 		w.WriteHeader(http.StatusOK)
+ 		fmt.Fprintf(w, o.AppName+" is Healthy.\n")
+@@ -497,36 +493,6 @@ func New(logger log.Logger, o *Options) *Handler {
+ 	return h
+ }
+ 
+-func serveDebug(w http.ResponseWriter, req *http.Request) {
+-	ctx := req.Context()
+-	subpath := route.Param(ctx, "subpath")
+-
+-	if subpath == "/pprof" {
+-		http.Redirect(w, req, req.URL.Path+"/", http.StatusMovedPermanently)
+-		return
+-	}
+-
+-	if !strings.HasPrefix(subpath, "/pprof/") {
+-		http.NotFound(w, req)
+-		return
+-	}
+-	subpath = strings.TrimPrefix(subpath, "/pprof/")
+-
+-	switch subpath {
+-	case "cmdline":
+-		pprof.Cmdline(w, req)
+-	case "profile":
+-		pprof.Profile(w, req)
+-	case "symbol":
+-		pprof.Symbol(w, req)
+-	case "trace":
+-		pprof.Trace(w, req)
+-	default:
+-		req.URL.Path = "/debug/pprof/" + subpath
+-		pprof.Index(w, req)
+-	}
+-}
+-
+ // SetReady sets the ready status of our web Handler.
+ func (h *Handler) SetReady(v bool) {
+ 	if v {

--- a/prometheus-alertmanager.yaml
+++ b/prometheus-alertmanager.yaml
@@ -2,7 +2,7 @@ package:
   name: prometheus-alertmanager
   # When bumping this version you can remove the `go get` line in the build script
   version: 0.27.0
-  epoch: 8
+  epoch: 9
   description: Prometheus Alertmanager
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,10 @@ pipeline:
   - uses: go/bump
     with:
       deps: google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0 github.com/rs/cors@v1.11.0
+
+  - runs: |
+      sed -i '/_ "net\/http\/pprof"/d' ui/web.go
+      git diff
 
   - runs: |
       make build

--- a/prometheus-blackbox-exporter.yaml
+++ b/prometheus-blackbox-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-blackbox-exporter
   version: 0.25.0
-  epoch: 5
+  epoch: 6
   description: Blackbox prober exporter
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,10 @@ pipeline:
 
   - runs: |
       make common-build
+
+  - runs: |
+      sed -i '/_ "net\/http\/pprof"/d' main.go
+      git diff
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin

--- a/prometheus-node-exporter.yaml
+++ b/prometheus-node-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-node-exporter
   version: 1.8.2
-  epoch: 0
+  epoch: 1
   description: Prometheus Exporter for machine metrics
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,10 @@ pipeline:
       repository: https://github.com/prometheus/node_exporter
       tag: v${{package.version}}
       expected-commit: f1e0e8360aa60b6cb5e5cc1560bed348fc2c1895
+
+  - runs: |
+      sed -i '/_ "net\/http\/pprof"/d' node_exporter.go
+      git diff
 
   - runs: |
       make build

--- a/prometheus-statsd-exporter.yaml
+++ b/prometheus-statsd-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-statsd-exporter
   version: 0.27.1
-  epoch: 0
+  epoch: 1
   description: StatsD exporter for Prometheus
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,10 @@ pipeline:
 
   - runs: |
       make common-build
+
+  - runs: |
+      sed -i '/_ "net\/http\/pprof"/d' main.go
+      git diff
 
   - runs: |
       install -Dm755 statsd_exporter "${{targets.destdir}}"/usr/bin/statsd_exporter


### PR DESCRIPTION
Whilst https://pkg.go.dev/net/http/pprof is a useful diagnostics tool, it exposes a potentially unaaccounted for endpoint. It is unsuitable to have this enabled in production deployments.

Compile out this functionality. Ideally there would be a toolchain build tag to turn this functionality off https://github.com/golang/go/issues/69030 until then sed and patch it out by hand.
