### PR TITLE
bump patch release

### DIFF
--- a/py3-setuptools.yaml
+++ b/py3-setuptools.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-setuptools
-  version: 73.0.0
+  version: 73.0.1
   epoch: 0
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
@@ -31,7 +31,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 4147b093d0aea4f57757c699a0b25bbc3aab2580
+      expected-commit: ebddeb36f72c9d758b5cc0e9f81f8a66aa837d96
       repository: https://github.com/pypa/setuptools.git
       tag: v${{package.version}}
 


### PR DESCRIPTION
Bump py3-setuptools package to pick-up fix for: https://github.com/scipy/scipy/issues/21416

This was a bug introduced upstream which is causing a number of our packages to fail to build. This patch release resolves it: https://github.com/pypa/setuptools/commit/ebddeb36f72c9d758b5cc0e9f81f8a66aa837d96

The tag was cut 4 days ago but they haven't cut a release yet - we're monitoring releases not tags. But given this is causing package failures, bumping ahead.