### PR TITLE
Refactor to provide versioned packages

### DIFF
--- a/py3-referencing.yaml
+++ b/py3-referencing.yaml
@@ -1,26 +1,34 @@
 package:
   name: py3-referencing
   version: 0.35.1
-  epoch: 1
+  epoch: 2
   description: "Cross-specification JSON referencing (JSON Schema, OpenAPI, and the one you just made up!)."
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - py3-attrs
-      - py3-rpds-py
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: referencing
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 environment:
   contents:
     packages:
       - busybox
       - ca-certificates-bundle
-      - py3-gpep517
-      - py3-pip
-      - py3-setuptools
-      - py3-wheel
-      - python3
+      - py3-supported-hatchling
+      - py3-supported-hatch-vcs
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-wheel
       - wolfi-base
 
 pipeline:
@@ -30,19 +38,28 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 1863d4a5c18af1edd0f3b49caeb9fedfdaff9845
 
-  - runs: |
-      # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-      export SOURCE_DATE_EPOCH=315532800
-      python3 -m pip install -U hatchling hatch-vcs
-      git submodule update --init
-      python3 -m gpep517 build-wheel \
-        --wheel-dir dist \
-        --output-fd 3 3>&1 >&2
-      python3 -m installer \
-        -d "${{targets.destdir}}" \
-        dist/referencing-${{package.version}}-*.whl
-
-  - uses: strip
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-attrs
+        - py${{range.key}}-rpds-py
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-referencing.yaml
+++ b/py3-referencing.yaml
@@ -23,8 +23,8 @@ environment:
     packages:
       - busybox
       - ca-certificates-bundle
-      - py3-supported-hatchling
       - py3-supported-hatch-vcs
+      - py3-supported-hatchling
       - py3-supported-pip
       - py3-supported-python
       - py3-supported-setuptools


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

Requires: https://github.com/wolfi-dev/os/pull/27060

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
