### PR TITLE
fix(chromium): Implement fixes and improvements, update to 128.0.6613.84

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -295,11 +295,11 @@ subpackages:
   - name: ${{package.name}}-lang
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/usr/lib/${{package.name}}
-          mv ${{targets.destdir}}/usr/lib/${{package.name}}/locales ${{targets.subpkgdir}}/usr/lib/${{package.name}}
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/${{package.name}}/locales
+          mv ${{targets.destdir}}/usr/lib/${{package.name}}/locales/* ${{targets.subpkgdir}}/usr/lib/${{package.name}}/locales/
 
           # Ensure we provide one locale in the base package
-          mv ${{targets.subpkgdir}}/usr/lib/${{package.name}}/locales/en-US.pak ${{targets.destdir}}/usr/lib/${{package.name}}/locales
+          mv ${{targets.subpkgdir}}/usr/lib/${{package.name}}/locales/en-US.pak ${{targets.destdir}}/usr/lib/${{package.name}}/locales/en-US.pak
 
   # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/NodeChrome/Dockerfile
   - name: chromium-docker-selenium-compat

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -171,12 +171,12 @@ pipeline:
         -i services/device/public/cpp/usb/BUILD.gn
 
       # System libraries
+      # Chromium doesn't like our ffmpeg so remove for now
       system_libs="
         brotli
         crc32c
         dav1d
         double-conversion
-        ffmpeg
         flac
         fontconfig
         freetype
@@ -229,8 +229,8 @@ pipeline:
         clang_use_chrome_plugins=false
         chrome_pgo_phase=0
         enable_nocompile_tests_new=false
+        ffmpeg_branding="Chrome"
         icu_use_data_file=false
-        is_component_ffmpeg=true
         is_debug=false
         is_official_build=true
         link_pulseaudio=true

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -21,6 +21,7 @@ package:
       - font-opensans
       - fontconfig
       - icu-data-full
+      - libnss
       - mesa
       - systemd
       - xdg-utils
@@ -102,6 +103,7 @@ environment:
       - libxtst
       - libxtst-dev
       - linux-headers
+      - mesa
       - mesa-dev
       - mesa-gbm
       - minizip
@@ -123,7 +125,7 @@ environment:
       - samurai
       - speex-dev
       - sqlite-dev
-      - systemd
+      - systemd-dev
       - wget
       - xcb-proto
       - xz
@@ -133,7 +135,7 @@ environment:
     # Disable compiler warnings encountered when using system provided libraries
     CFLAGS: "$(echo ${CFLAGS}) -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-shift-count-overflow -Wno-ignored-attributes"
     CXXFLAGS: "$(echo ${CXXFLAGS}) -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-invalid-constexpr"
-    CPPFLAGS: "$(echo ${CPPFLAGS}) -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__="
+    CPPFLAGS: "$(echo ${CPPFLAGS/-Wp,-D_GLIBCXX_ASSERTIONS/}) -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__="
 
 pipeline:
   - uses: git-checkout
@@ -234,13 +236,13 @@ pipeline:
         enable_widevine=true
         ffmpeg_branding=\"Chrome\"
         icu_use_data_file=false
-        is_debug=false
-        is_official_build=true
+        is_debug=true
+        is_official_build=false
         link_pulseaudio=true
         moc_qt6_path=\"/usr/lib/qt6/libexec\"
         proprietary_codecs=true
         safe_browsing_use_unrar=false
-        symbol_level=0
+        symbol_level=2
         treat_warnings_as_errors=false
         use_lld=true
         use_pulseaudio=true

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -325,13 +325,14 @@ test:
       packages:
         - grep
         - posix-libc-utils
-        #- py3-pip
-        #- python3
+        - py3-pip
+        - python3
   pipeline:
     - runs: |
         # Make sure Chrome and ChromeDriver are at the correct path
-        test -f /usr/lib/chromium/chrome
-        test -f /usr/lib/chromium/chromedriver
+        test -x /usr/lib/chromium/chrome
+        test -x /usr/lib/chromium/chromedriver
+        test -f /usr/lib/chromium/locales/en-US.pak
 
         # Ensure all libraries are linked
         ldd /usr/lib/chromium/chrome
@@ -343,5 +344,5 @@ test:
         CHROMIUM_USER_FLAGS="--no-sandbox --headless --disable-gpu --dump-dom" chromium-browser https://www.chromestatus.com
 
         # Test ChromeDriver functionality
-        #pip3 install selenium
-        #python3 ./test-chromedriver.py
+        pip3 install selenium
+        python3 ./test-chromedriver.py

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -38,6 +38,7 @@ environment:
       - bzip2-dev
       - ca-certificates-bundle
       - cairo-dev
+      - clang-18
       - crc32c-dev
       - cups-dev
       - curl
@@ -102,6 +103,9 @@ environment:
       - libxtst
       - libxtst-dev
       - linux-headers
+      - llvm-18-dev
+      - llvm-lld-18-dev
+      - llvm-lld-18-static
       - mesa-dev
       - mesa-gbm
       - minizip
@@ -130,10 +134,19 @@ environment:
       - zlib-dev
       - zstd-dev
   environment:
+    # Use system clang
+    CC: clang
+    CXX: clang++
+    AR: ar
+    NM: nm
     # Disable compiler warnings encountered when using system provided libraries
     CFLAGS: "$(echo ${CFLAGS}) -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-shift-count-overflow -Wno-ignored-attributes"
     CXXFLAGS: "$(echo ${CXXFLAGS}) -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-invalid-constexpr"
-    CPPFLAGS: "$(echo ${CPPFLAGS}) -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__="
+    # https://crbug.com/957519#c122
+    CPPFLAGS: "$(echo ${CPPFLAGS/-Wp,-D_GLIBCXX_ASSERTIONS}) -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__="
+    # Allow the use of nightly features with stable Rust compiler
+    # https://github.com/ungoogled-software/ungoogled-chromium/pull/2696#issuecomment-1918173198
+    RUSTC_BOOTSTRAP: 1
 
 pipeline:
   - uses: git-checkout
@@ -226,22 +239,33 @@ pipeline:
       chmod +x third_party/node/linux/node-linux-x64/bin/node
       # === INFO === Generate config: takes about 30 minutes /
       cd /home/src
+      clang_version=$(clang --version | grep -m1 version | sed 's/.* \([0-9]\+\).*/\1/')
+      rustc_version=$(rustc --version)
       time gn gen /home/src/out/Default --args="
+        blink_enable_generated_code_formatting=false
+        clang_base_path=\"/usr\"
         clang_use_chrome_plugins=false
+        clang_version=\"$clang_version\"
         chrome_pgo_phase=0
+        custom_toolchain=\"//build/toolchain/linux/unbundle:default\"
+        disable_fieldtrial_testing_config=true
         enable_nacl=false
-        enable_nocompile_tests_new=false
         enable_widevine=true
         ffmpeg_branding=\"Chrome\"
+        host_toolchain=\"//build/toolchain/linux/unbundle:default\"
         icu_use_data_file=false
         is_debug=false
         is_official_build=true
         link_pulseaudio=true
         moc_qt6_path=\"/usr/lib/qt6/libexec\"
         proprietary_codecs=true
+        rust_sysroot_absolute=\"/usr\"
+        rust_bindgen_root=\"/usr\"
+        rustc_version=\"$rustc_version\"
         safe_browsing_use_unrar=false
         symbol_level=0
         treat_warnings_as_errors=false
+        use_custom_libcxx=true
         use_lld=true
         use_pulseaudio=true
         use_qt6=true

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -327,6 +327,8 @@ test:
         - posix-libc-utils
         - py3-pip
         - python3
+        - shadow
+        - sudo-rs
   pipeline:
     - runs: |
         # Make sure Chrome and ChromeDriver are at the correct path
@@ -337,8 +339,13 @@ test:
         # Ensure all libraries are linked
         ldd /usr/lib/chromium/chrome
 
-        # Check status
-        chromium --no-sandbox --headless --disable-gpu --dump-dom https://www.chromestatus.com
+        # Create Chrome user (needed to resolve permissions running with new headless mode)
+        useradd chrome
+        mkdir -p /home/chrome
+        chown -R chrome /home/chrome
+
+        # Check status with new headless mode
+        sudo -u chrome chromium --no-sandbox --headless=new --disable-gpu --dump-dom https://www.chromestatus.com
 
         # Test wrapper
         CHROMIUM_USER_FLAGS="--no-sandbox --headless --disable-gpu --dump-dom" chromium-browser https://www.chromestatus.com

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -108,6 +108,7 @@ environment:
       - mesa-gbm
       - minizip
       - nghttp2-dev
+      - openh264-dev
       - opus-dev
       - pango
       - pango-dev
@@ -119,6 +120,7 @@ environment:
       - py3-setuptools
       - python3
       - qt5-qtbase-dev
+      - qt6-qtbase-dev
       - rust
       - samurai
       - speex-dev
@@ -231,17 +233,19 @@ pipeline:
         enable_nacl=false
         enable_nocompile_tests_new=false
         enable_widevine=true
-        ffmpeg_branding="Chrome"
+        ffmpeg_branding=\"Chrome\"
         icu_use_data_file=false
         is_debug=false
         is_official_build=true
         link_pulseaudio=true
+        moc_qt6_path=\"/usr/lib/qt6/libexec\"
         proprietary_codecs=true
         safe_browsing_use_unrar=false
         symbol_level=0
         treat_warnings_as_errors=false
         use_lld=true
         use_pulseaudio=true
+        use_qt6=true
         use_sysroot=false
         use_system_freetype=true
         use_system_harfbuzz=true

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -6,8 +6,8 @@
 # And remove the use of the strip pipeline below
 package:
   name: chromium
-  version: 127.0.6533.119
-  epoch: 1
+  version: 128.0.6613.84
+  epoch: 0
   description: "Open souce version of Google's chrome web browser"
   copyright:
     - license: BSD-3-Clause
@@ -22,6 +22,7 @@ package:
       - coreutils
       - font-opensans
       - fontconfig
+      - icu-data-full
       - libnss
       - mesa
 
@@ -38,19 +39,23 @@ environment:
       - bzip2-dev
       - ca-certificates-bundle
       - cairo-dev
+      - crc32c-dev
       - cups-dev
       - curl
       - curl-dev
       - dav1d-dev
       - dbus-dev
       - dbus-glib-dev
+      - double-conversion-dev
       - elfutils
       - elfutils-dev
+      - eudev-dev
       - expat-dev
       - ffmpeg-dev
       - findutils
       - flac-dev
       - flex
+      - fontconfig-dev
       - freetype-dev
       - fribidi-dev
       - git
@@ -63,6 +68,8 @@ environment:
       - harfbuzz-dev
       - harfbuzz-static
       - hwdata-dev
+      - hwdata-usb
+      - icu-dev
       - krb5-dev
       - lcms2-dev
       - libbsd-dev
@@ -74,6 +81,7 @@ environment:
       - libjpeg-turbo-dev
       - libnspr-dev
       - libnss-dev
+      - libogg-dev
       - libpsl-dev
       - libpsl-static
       - libsecret-dev
@@ -98,6 +106,7 @@ environment:
       - linux-headers
       - mesa-dev
       - mesa-gbm
+      - minizip
       - nghttp2-dev
       - opus-dev
       - pango
@@ -114,12 +123,16 @@ environment:
       - samurai
       - speex-dev
       - sqlite-dev
-      - systemd-dev
       - wget
       - xcb-proto
       - xz
       - zlib-dev
       - zstd-dev
+  environment:
+    # Disable compiler warnings encountered when using system provided libraries
+    CFLAGS: "$(echo ${CFLAGS}) -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-shift-count-overflow -Wno-ignored-attributes"
+    CXXFLAGS: "$(echo ${CXXFLAGS}) -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-invalid-constexpr"
+    CPPFLAGS: "$(echo ${CPPFLAGS}) -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__="
 
 pipeline:
   - uses: git-checkout
@@ -128,7 +141,7 @@ pipeline:
       repository: https://chromium.googlesource.com/chromium/src.git
       tag: ${{package.version}}
       depth: 1
-      expected-commit: bdef6783a05f0b3f885591e7d2c7b2aec1a89dea
+      expected-commit: 606aa55c7d687518d34b55accc5a71ea0bd28727
       destination: /home/src
 
   - runs: |
@@ -152,6 +165,61 @@ pipeline:
       # go back into our chromium src directory
       cd /home/src
       time gclient sync --no-history
+      # === INFO === Use system dependencies
+      # Use USB IDs already provided by hwdata-usb
+      sed 's|//third_party/usb_ids/usb.ids|/usr/share/hwdata/usb.ids|g' \
+        -i services/device/public/cpp/usb/BUILD.gn
+
+      # System libraries
+      system_libs="
+        brotli
+        crc32c
+        dav1d
+        double-conversion
+        ffmpeg
+        flac
+        fontconfig
+        freetype
+        harfbuzz-ng
+        icu
+        libdrm
+        libevent
+        libjpeg
+        libsecret
+        libusb
+        libwebp
+        libxml
+        libxslt
+        openh264
+        opus
+        zlib
+        zstd
+      "
+
+      # Remove system provided library buildscripts
+      for _lib in $system_libs libjpeg_turbo unrar; do
+        echo "Removing buildscripts for system provided $_lib"
+        _lib="${_lib/swiftshader-/swiftshader/third_party/}"
+          find . -type f -path "*third_party/$_lib/*" \
+          \! -path "*third_party/$_lib/chromium/*" \
+          \! -path "*third_party/$_lib/google/*" \
+          \! -path './base/third_party/icu/*' \
+          \! -path './third_party/libxml/*' \
+          \! -path './third_party/pdfium/third_party/freetype/include/pstables.h' \
+          \! -path './third_party/harfbuzz-ng/utils/hb_scoped.h' \
+          \! -path './third_party/crashpad/crashpad/third_party/zlib/zlib_crashpad.h' \
+          \! -regex '.*\.\(gn\|gni\|isolate\|py\)' \
+          -delete
+      done
+
+      # Update gn configuration to use system libraries
+      python3 build/linux/unbundle/replace_gn_files.py --system-libraries $system_libs
+      python3 third_party/libaddressinput/chromium/tools/update-strings.py
+
+      # Allow system dependencies in "official builds"
+      sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' \
+        tools/generate_shim_headers/generate_shim_headers.py
+
       # === INFO === Make node executable: works around permission denial
       cd /home/src
       chmod +x third_party/node/linux/node-linux-x64/bin/node
@@ -161,10 +229,16 @@ pipeline:
         clang_use_chrome_plugins=false
         chrome_pgo_phase=0
         enable_nocompile_tests_new=false
+        icu_use_data_file=false
+        is_component_ffmpeg=true
         is_debug=false
         is_official_build=true
+        link_pulseaudio=true
+        safe_browsing_use_unrar=false
         symbol_level=0
+        treat_warnings_as_errors=false
         use_lld=true
+        use_pulseaudio=true
         use_sysroot=false
         use_system_freetype=true
         use_system_harfbuzz=true

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -327,8 +327,8 @@ test:
         - posix-libc-utils
         - py3-pip
         - python3
-        - shadow
-        - sudo-rs
+    environment:
+      HOME: /home/chrome
   pipeline:
     - runs: |
         # Make sure Chrome and ChromeDriver are at the correct path
@@ -339,13 +339,11 @@ test:
         # Ensure all libraries are linked
         ldd /usr/lib/chromium/chrome
 
-        # Create Chrome user (needed to resolve permissions running with new headless mode)
-        useradd chrome
-        mkdir -p /home/chrome
-        chown -R chrome /home/chrome
+        # Create homedir, configuration is written here
+        mkdir -p "${HOME}"
 
         # Check status with new headless mode
-        sudo -u chrome chromium --no-sandbox --headless=new --disable-gpu --dump-dom https://www.chromestatus.com
+        chromium --no-sandbox --headless=new --disable-gpu --dump-dom https://www.chromestatus.com
 
         # Test wrapper
         CHROMIUM_USER_FLAGS="--no-sandbox --headless --disable-gpu --dump-dom" chromium-browser https://www.chromestatus.com

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -18,13 +18,12 @@ package:
     - x86_64
   dependencies:
     runtime:
-      - busybox
-      - coreutils
       - font-opensans
       - fontconfig
       - icu-data-full
-      - libnss
       - mesa
+      - systemd
+      - xdg-utils
 
 environment:
   contents:
@@ -49,7 +48,6 @@ environment:
       - double-conversion-dev
       - elfutils
       - elfutils-dev
-      - eudev-dev
       - expat-dev
       - ffmpeg-dev
       - findutils
@@ -125,6 +123,7 @@ environment:
       - samurai
       - speex-dev
       - sqlite-dev
+      - systemd
       - wget
       - xcb-proto
       - xz

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -228,6 +228,7 @@ pipeline:
       time gn gen /home/src/out/Default --args="
         clang_use_chrome_plugins=false
         chrome_pgo_phase=0
+        enable_nacl=false
         enable_nocompile_tests_new=false
         enable_widevine=true
         ffmpeg_branding="Chrome"

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -38,7 +38,6 @@ environment:
       - bzip2-dev
       - ca-certificates-bundle
       - cairo-dev
-      - clang-18
       - crc32c-dev
       - cups-dev
       - curl
@@ -103,9 +102,6 @@ environment:
       - libxtst
       - libxtst-dev
       - linux-headers
-      - llvm-18-dev
-      - llvm-lld-18-dev
-      - llvm-lld-18-static
       - mesa-dev
       - mesa-gbm
       - minizip
@@ -134,19 +130,10 @@ environment:
       - zlib-dev
       - zstd-dev
   environment:
-    # Use system clang
-    CC: clang
-    CXX: clang++
-    AR: ar
-    NM: nm
     # Disable compiler warnings encountered when using system provided libraries
     CFLAGS: "$(echo ${CFLAGS}) -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-shift-count-overflow -Wno-ignored-attributes"
     CXXFLAGS: "$(echo ${CXXFLAGS}) -Wno-unknown-warning-option -Wno-builtin-macro-redefined -Wno-deprecated-declarations -Wno-invalid-constexpr"
-    # https://crbug.com/957519#c122
-    CPPFLAGS: "$(echo ${CPPFLAGS/-Wp,-D_GLIBCXX_ASSERTIONS}) -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__="
-    # Allow the use of nightly features with stable Rust compiler
-    # https://github.com/ungoogled-software/ungoogled-chromium/pull/2696#issuecomment-1918173198
-    RUSTC_BOOTSTRAP: 1
+    CPPFLAGS: "$(echo ${CPPFLAGS}) -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__="
 
 pipeline:
   - uses: git-checkout
@@ -239,33 +226,22 @@ pipeline:
       chmod +x third_party/node/linux/node-linux-x64/bin/node
       # === INFO === Generate config: takes about 30 minutes /
       cd /home/src
-      clang_version=$(clang --version | grep -m1 version | sed 's/.* \([0-9]\+\).*/\1/')
-      rustc_version=$(rustc --version)
       time gn gen /home/src/out/Default --args="
-        blink_enable_generated_code_formatting=false
-        clang_base_path=\"/usr\"
         clang_use_chrome_plugins=false
-        clang_version=\"$clang_version\"
         chrome_pgo_phase=0
-        custom_toolchain=\"//build/toolchain/linux/unbundle:default\"
-        disable_fieldtrial_testing_config=true
         enable_nacl=false
+        enable_nocompile_tests_new=false
         enable_widevine=true
         ffmpeg_branding=\"Chrome\"
-        host_toolchain=\"//build/toolchain/linux/unbundle:default\"
         icu_use_data_file=false
         is_debug=false
         is_official_build=true
         link_pulseaudio=true
         moc_qt6_path=\"/usr/lib/qt6/libexec\"
         proprietary_codecs=true
-        rust_sysroot_absolute=\"/usr\"
-        rust_bindgen_root=\"/usr\"
-        rustc_version=\"$rustc_version\"
         safe_browsing_use_unrar=false
         symbol_level=0
         treat_warnings_as_errors=false
-        use_custom_libcxx=true
         use_lld=true
         use_pulseaudio=true
         use_qt6=true

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -267,7 +267,6 @@ pipeline:
       # resources
       mv snapshot_blob.bin ${{targets.destdir}}/usr/lib/${{package.name}}
       mv v8_context_snapshot.bin ${{targets.destdir}}/usr/lib/${{package.name}}
-      mv icudtl.dat ${{targets.destdir}}/usr/lib/${{package.name}}
       mv xdg-mime ${{targets.destdir}}/usr/lib/${{package.name}}
       mv xdg-settings ${{targets.destdir}}/usr/lib/${{package.name}}
       mv vk_swiftshader_icd.json ${{targets.destdir}}/usr/lib/${{package.name}}

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -229,11 +229,13 @@ pipeline:
         clang_use_chrome_plugins=false
         chrome_pgo_phase=0
         enable_nocompile_tests_new=false
+        enable_widevine=true
         ffmpeg_branding="Chrome"
         icu_use_data_file=false
         is_debug=false
         is_official_build=true
         link_pulseaudio=true
+        proprietary_codecs=true
         safe_browsing_use_unrar=false
         symbol_level=0
         treat_warnings_as_errors=false

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -20,6 +20,7 @@ package:
     runtime:
       - font-opensans
       - fontconfig
+      - gtk
       - icu-data-full
       - libnss
       - mesa
@@ -236,13 +237,13 @@ pipeline:
         enable_widevine=true
         ffmpeg_branding=\"Chrome\"
         icu_use_data_file=false
-        is_debug=true
-        is_official_build=false
+        is_debug=false
+        is_official_build=true
         link_pulseaudio=true
         moc_qt6_path=\"/usr/lib/qt6/libexec\"
         proprietary_codecs=true
         safe_browsing_use_unrar=false
-        symbol_level=2
+        symbol_level=0
         treat_warnings_as_errors=false
         use_lld=true
         use_pulseaudio=true


### PR DESCRIPTION
- Update to 128.0.6613.84
- Use more system dependencies
- Build with qt6 support
- Enable proprietary codec and widevine support
- Disable deprecated native client
- Enable pulseaudio
- Properly copy over language packs
- Restore ChromeDriver test
- Test new headless mode