### PR TITLE
Make maturin package provide maturin and depend on a py3-maturin

### DIFF
--- a/py3-maturin.yaml
+++ b/py3-maturin.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-maturin
   version: 1.7.1
-  epoch: 1
+  epoch: 2
   description: Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages
   copyright:
     - license: MIT OR Apache-2.0
@@ -62,23 +62,59 @@ subpackages:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
 
-  - range: py-versions
-    name: py${{range.key}}-${{vars.pypi-package}}-bin
-    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+  - name: maturin
+    description: maturin executable
     dependencies:
       runtime:
-        - py${{range.key}}-${{vars.pypi-package}}
-      provides:
-        - py3-${{vars.pypi-package}}-bin
-      provider-priority: ${{range.value}}
+        - py3-maturin
+        - rust
     pipeline:
       - runs: |
-          mkdir -p ${{targets.contextdir}}/usr
-          mv ${{targets.contextdir}}/../py${{range.key}}-${{vars.pypi-package}}/usr/bin ${{targets.contextdir}}/usr
+          # steal a /usr/bin/maturin from one of the py3.XX-maturin packages above.
+          # ensure that all of the /usr/bin/maturin bins were the same, so we can
+          # be sure that any one we pick was the right one.
+          mkdir -p ${{targets.contextdir}}
+          set --
+          for f in ${{targets.contextdir}}/../py*-${{vars.pypi-package}}/usr/bin/maturin; do
+            [ -f "$f" ] || continue
+            set -- "$@" "$f"
+            [ -f "$f" -a -x "$f" ] && found="$f"
+          done
+
+          if [ $# -eq 0 ]; then
+              echo "did not find any /usr/bin/maturin executables"
+              exit 1
+          fi
+          sha256sum "$@" >/tmp/all
+          found=$1
+          shift
+          read mysum path <"/tmp/all"
+          while read sum path ; do
+            [ "$mysum" = "$sum" ] || {
+              echo "FAIL: selected maturin exe '$found' ($mysum) differed from $path $(sum)"
+              exit 1
+            }
+          done </tmp/all
+
+          sha256sum "$found" "$@"
+          echo "using $found for /usr/bin/maturin"
+
+          mkdir -p ${{targets.contextdir}}/usr/bin
+          mv "$found" ${{targets.contextdir}}/usr/bin/
+          rm "$@"
     test:
       pipeline:
         - runs: |
             maturin --help
+        - runs: |
+            # maturin list-python writes (to stderr) something like:
+            # 2 python interpreter found:
+            #   - CPython 3.12 at /usr/bin/python3.12
+            #   - CPython 3.11 at /usr/bin/python3.11
+            tmpf=$(mktemp)
+            trap "rm -f '$tmpf'" EXIT
+            maturin list-python >"$tmpf" 2>&1
+            grep 'CPython .* at /usr/bin/python3' "$tmpf"
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.

--- a/py3-pendulum.yaml
+++ b/py3-pendulum.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pendulum
   version: 3.0.0
-  epoch: 1
+  epoch: 2
   description: Python datetimes made easy
   copyright:
     - license: MIT
@@ -18,10 +18,11 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - maturin
       - poetry
       - py3-gpep517
       - py3-installer
-      - py3-maturin-bin
+      - py3-maturin
       - py3-pip
       - py3-setuptools
       - py3-wheel

--- a/py3-pydantic-core.yaml
+++ b/py3-pydantic-core.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pydantic-core
   version: 2.23.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:
@@ -14,8 +14,10 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - maturin
       - py3-supported-build
       - py3-supported-installer
+      - py3-supported-maturin
       - py3-supported-pip
       - py3-supported-python
       - py3-supported-setuptools
@@ -53,7 +55,6 @@ subpackages:
         - py3-${{vars.pypi-package}}
       provider-priority: ${{range.value}}
     pipeline:
-      - runs: pip${{range.key}} install maturin
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}


### PR DESCRIPTION
maturin is a single executable that depends on a specific installed python3 maturin libs and on rust.  the single maturin will work for all py3.XX-maturin packages.

