### PR TITLE
Bump version to 5.1.0 and remove grpc manual bump.

### DIFF
--- a/kubernetes-csi-external-provisioner.yaml
+++ b/kubernetes-csi-external-provisioner.yaml
@@ -1,6 +1,6 @@
 package:
   name: kubernetes-csi-external-provisioner
-  version: 5.0.2
+  version: 5.1.0
   epoch: 0
   description: A dynamic provisioner for Kubernetes CSI plugins.
   copyright:
@@ -18,21 +18,21 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/kubernetes-csi/external-provisioner
-      expected-commit: dd31ba49bbdb81d35877cb8ed079a9c761c285b7
+      expected-commit: 656955bc2294f10a5ec505acfac6091048e30a08
       tag: v${{package.version}}
-
-  - uses: go/bump
-    with:
-      deps: google.golang.org/grpc@v1.64.1
 
   - uses: go/build
     with:
       packages: ./cmd/csi-provisioner
       output: csi-provisioner
-      ldflags: -s -w -X main.version=${{package.version}}
+      ldflags: -s -w -X main.version=$(git describe --long --tags --match='v*' --dirty)
       vendor: "true"
 
   - uses: strip
+
+test:
+  pipeline:
+    - runs: csi-provisioner --version | grep ${{package.version}}
 
 update:
   enabled: true


### PR DESCRIPTION
The manual bump was breaking the build as it is no longer necessary.

https://github.com/kubernetes-csi/external-provisioner/blob/master/go.mod#L18

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
