### PR TITLE
ingress-nginx-controller 1.11.2, fix modsecurity/lua-nginx/openresty issues

### DIFF
--- a/ingress-nginx-controller-1.11.yaml
+++ b/ingress-nginx-controller-1.11.yaml
@@ -1,8 +1,8 @@
 #nolint:valid-pipeline-fetch-digest
 package:
   name: ingress-nginx-controller-1.11
-  version: 1.11.1
-  epoch: 2
+  version: 1.11.2
+  epoch: 0
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -132,7 +132,7 @@ vars:
   MORE_HEADERS_VERSION: "0.37"
   NGINX_DIGEST_AUTH: "1.0.0"
   NGINX_SUBSTITUTIONS: "e12e965ac1837ca709709f9a26f572a54d83430e"
-  MODSECURITY_NGINX_VERSION: "1.0.3"
+  MODSECURITY_NGINX_VERSION: "ef64996aedd4bb5fa1831631361244813d48b82f"
   OWASP_MODSECURITY_CRS_VERSION: "v4.4.0"
   LUA_NGX_VERSION: "0.10.26"
   LUA_STREAM_NGX_VERSION: "bea8a0c0de94cede71554f53818ac0267d675d63"
@@ -145,7 +145,16 @@ pipeline:
     with:
       repository: https://github.com/kubernetes/ingress-nginx
       tag: controller-v${{package.version}}
-      expected-commit: 7b37df8f38c6f39c172b7a212c18d35bf10709a2
+      expected-commit: d3bb2b4f8757816f1d7c6268e02e433887373a3b
+
+  # TODO: ModSecurity-nginx needs a release beyond v1.0.3 to work properly
+  # see https://github.com/owasp-modsecurity/ModSecurity-nginx/issues/324
+  - uses: git-checkout
+    with:
+      repository: https://github.com/owasp-modsecurity/ModSecurity-nginx
+      branch: master
+      expected-commit: ${{vars.MODSECURITY_NGINX_VERSION}}
+      destination: ModSecurity-nginx-${{vars.MODSECURITY_NGINX_VERSION}}
 
   - name: Build ingress-nginx controller from source
     runs: |
@@ -235,12 +244,6 @@ pipeline:
     with:
       uri: https://github.com/atomx/nginx-http-auth-digest/archive/v${{vars.NGINX_DIGEST_AUTH}}.tar.gz
       expected-sha256: f09851e6309560a8ff3e901548405066c83f1f6ff88aa7171e0763bd9514762b
-      strip-components: 0
-
-  - uses: fetch
-    with:
-      uri: https://github.com/SpiderLabs/ModSecurity-nginx/archive/v${{vars.MODSECURITY_NGINX_VERSION}}.tar.gz
-      expected-sha256: 32a42256616cc674dca24c8654397390adff15b888b77eb74e0687f023c8751b
       strip-components: 0
 
   - uses: fetch

--- a/ingress-nginx-controller-1.11.yaml
+++ b/ingress-nginx-controller-1.11.yaml
@@ -135,7 +135,7 @@ vars:
   MODSECURITY_NGINX_VERSION: "ef64996aedd4bb5fa1831631361244813d48b82f"
   OWASP_MODSECURITY_CRS_VERSION: "v4.4.0"
   LUA_NGX_VERSION: "0.10.27"
-  LUA_STREAM_NGX_VERSION: "v0.0.15"
+  LUA_STREAM_NGX_VERSION: "0.0.15"
   LUA_UPSTREAM_VERSION: "542be0893543a4e42d89f6dd85372972f5ff2a36"
   GEOIP2_VERSION: "a607a41a8115fecfc05b5c283c81532a3d605425"
   NGX_BROTLI_SHA: 63ca02abdcf79c9e788d2eedcc388d2335902e52
@@ -230,7 +230,7 @@ pipeline:
 
   - uses: fetch
     with:
-      uri: https://github.com/openresty/stream-lua-nginx-module/archive/${{vars.LUA_STREAM_NGX_VERSION}}.tar.gz
+      uri: https://github.com/openresty/stream-lua-nginx-module/archive/v${{vars.LUA_STREAM_NGX_VERSION}}.tar.gz
       expected-sha256: ecf5c2afd345149cef19bf2e3e196bf1c514ca85e778f853f80a379284b70de1
       strip-components: 0
 

--- a/ingress-nginx-controller-1.11.yaml
+++ b/ingress-nginx-controller-1.11.yaml
@@ -135,7 +135,7 @@ vars:
   MODSECURITY_NGINX_VERSION: "ef64996aedd4bb5fa1831631361244813d48b82f"
   OWASP_MODSECURITY_CRS_VERSION: "v4.4.0"
   LUA_NGX_VERSION: "0.10.27"
-  LUA_STREAM_NGX_VERSION: "bea8a0c0de94cede71554f53818ac0267d675d63"
+  LUA_STREAM_NGX_VERSION: "v0.0.15"
   LUA_UPSTREAM_VERSION: "542be0893543a4e42d89f6dd85372972f5ff2a36"
   GEOIP2_VERSION: "a607a41a8115fecfc05b5c283c81532a3d605425"
   NGX_BROTLI_SHA: 63ca02abdcf79c9e788d2eedcc388d2335902e52
@@ -231,7 +231,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/openresty/stream-lua-nginx-module/archive/${{vars.LUA_STREAM_NGX_VERSION}}.tar.gz
-      expected-sha256: 0f5b5356d3dfe19ccd945ec6a2fcf2c27e1a517aefccb798f934132f09bb78fa
+      expected-sha256: ecf5c2afd345149cef19bf2e3e196bf1c514ca85e778f853f80a379284b70de1
       strip-components: 0
 
   - uses: fetch

--- a/ingress-nginx-controller-1.11.yaml
+++ b/ingress-nginx-controller-1.11.yaml
@@ -1,4 +1,4 @@
-#nolint:valid-pipeline-fetch-digest
+#nolint:valid-pipeline-fetch-digest,valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: ingress-nginx-controller-1.11
   version: 1.11.2

--- a/ingress-nginx-controller-1.11.yaml
+++ b/ingress-nginx-controller-1.11.yaml
@@ -134,7 +134,7 @@ vars:
   NGINX_SUBSTITUTIONS: "e12e965ac1837ca709709f9a26f572a54d83430e"
   MODSECURITY_NGINX_VERSION: "ef64996aedd4bb5fa1831631361244813d48b82f"
   OWASP_MODSECURITY_CRS_VERSION: "v4.4.0"
-  LUA_NGX_VERSION: "0.10.26"
+  LUA_NGX_VERSION: "0.10.27"
   LUA_STREAM_NGX_VERSION: "bea8a0c0de94cede71554f53818ac0267d675d63"
   LUA_UPSTREAM_VERSION: "542be0893543a4e42d89f6dd85372972f5ff2a36"
   GEOIP2_VERSION: "a607a41a8115fecfc05b5c283c81532a3d605425"
@@ -225,7 +225,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/openresty/lua-nginx-module/archive/v${{vars.LUA_NGX_VERSION}}.tar.gz
-      expected-sha256: a75983287a2bdc5e964ace56a51b215dc2ec996639d4916cd393d6ebba94b565
+      expected-sha256: a0a5e616c4a0a32e48899d12242fed5a371f69a85f11ff274a87a2f02f419876
       strip-components: 0
 
   - uses: fetch


### PR DESCRIPTION
instead of https://github.com/wolfi-dev/os/pull/26459
which is failing due to
```
2024/08/19 18:52:45 INFO adding module in /home/build/ModSecurity-nginx-1.0.3
2024/08/19 18:52:45 INFO checking for ModSecurity library ... not found
2024/08/19 18:52:45 INFO checking for ModSecurity library in /usr/local/modsecurity ... not found
2024/08/19 18:52:45 INFO  ./configure: error: ngx_http_modsecurity_module requires the ModSecurity library.
```