### PR TITLE
Adds jiter-python needed for openai-python

### DIFF
--- a/py3-jiter.yaml
+++ b/py3-jiter.yaml
@@ -53,7 +53,8 @@ subpackages:
       provider-priority: ${{range.value}}
     pipeline:
       - uses: py/pip-build-install
-        with:
+        working directory:/home/build/crates/jiter-python
+	with:
           python: python${{range.key}}
       - uses: strip
     test:

--- a/py3-jiter.yaml
+++ b/py3-jiter.yaml
@@ -30,10 +30,7 @@ environment:
       - py3-supported-pip
       - py3-supported-ujson
       - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
-
+      
 pipeline:
   - uses: git-checkout
     with:

--- a/py3-jiter.yaml
+++ b/py3-jiter.yaml
@@ -30,7 +30,7 @@ environment:
       - py3-supported-pip
       - py3-supported-ujson
       - wolfi-base
-      
+
 pipeline:
   - uses: git-checkout
     with:

--- a/py3-jiter.yaml
+++ b/py3-jiter.yaml
@@ -28,10 +28,7 @@ environment:
       - py3-supported-maturin
       - py3-supported-orjson
       - py3-supported-pip
-      - py3-supported-python
-      - py3-supported-setuptools
       - py3-supported-ujson
-      - py3-supported-wheel
       - wolfi-base
   environment:
     # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"

--- a/py3-jiter.yaml
+++ b/py3-jiter.yaml
@@ -1,0 +1,71 @@
+package:
+  name: py3-jiter
+  version: 0.5.0
+  epoch: 0
+  description: Fast iterable JSON parser
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: jiter
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-wheel
+      - wolfi-base
+      - maturin
+      - py3-supported-ujson
+      - py3-supported-orjson
+  environment:
+    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
+    SOURCE_DATE_EPOCH: 315532800
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/pydantic/jiter.git
+      tag: v${{package.version}}
+      expected-commit: 7cb88e65eaa084b9b9138ac43a2cabb1ec4bd5f6
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+
+update:
+  enabled: true
+  github:
+    identifier: pydantic/jiter
+    tag-filter: v
+    strip-prefix: v

--- a/py3-jiter.yaml
+++ b/py3-jiter.yaml
@@ -24,14 +24,15 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - maturin
+      - py3-supported-orjson
+      - py3-supported-maturin
       - py3-supported-pip
       - py3-supported-python
       - py3-supported-setuptools
+      - py3-supported-ujson
       - py3-supported-wheel
       - wolfi-base
-      - maturin
-      - py3-supported-ujson
-      - py3-supported-orjson
   environment:
     # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
     SOURCE_DATE_EPOCH: 315532800
@@ -53,8 +54,8 @@ subpackages:
       provider-priority: ${{range.value}}
     pipeline:
       - uses: py/pip-build-install
-        working directory:/home/build/crates/jiter-python
-	with:
+        working-directory: /home/build/crates/jiter-python
+        with:
           python: python${{range.key}}
       - uses: strip
     test:

--- a/py3-jiter.yaml
+++ b/py3-jiter.yaml
@@ -25,8 +25,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - maturin
-      - py3-supported-orjson
       - py3-supported-maturin
+      - py3-supported-orjson
       - py3-supported-pip
       - py3-supported-python
       - py3-supported-setuptools

--- a/py3-openai.yaml
+++ b/py3-openai.yaml
@@ -1,22 +1,23 @@
 # Generated from https://pypi.org/project/openai/
 package:
   name: py3-openai
-  version: 1.39.0
-  epoch: 0
+  version: 1.42.0
+  epoch: 1
   description: Python client library for the OpenAI API
   copyright:
     - license: MIT
   dependencies:
-    provides:
-      - openai
-    runtime:
-      - py3-anyio
-      - py3-distro
-      - py3-httpx
-      - py3-pydantic
-      - py3-tqdm
-      - py3-typing-extensions
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: openai
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
 
 environment:
   contents:
@@ -24,8 +25,12 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-setuptools
-      - python3
+      - py3-supported-hatch-fancy-pypi-readme
+      - py3-supported-hatchling
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-wheel
       - wolfi-base
   environment:
     # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
@@ -36,18 +41,35 @@ pipeline:
     with:
       repository: https://github.com/openai/openai-python.git
       tag: v${{package.version}}
-      expected-commit: a5f5c8ed9a0f2658214525011507e3091c186bdf
+      expected-commit: 05fa732c024b55ddda1f5f8b107ce78233acd3ce
 
-  - name: Python Build
-    uses: python/build-wheel
-
-  - uses: strip
-
-test:
-  pipeline:
-    - uses: python/import
-      with:
-        import: openai
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-anyio
+        - py${{range.key}}-distro
+        - py${{range.key}}-httpx
+        - py${{range.key}}-pydantic
+        - py${{range.key}}-tqdm
+        - py${{range.key}}-typing-extensions
+        - py${{range.key}}-jiter
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-openai.yaml
+++ b/py3-openai.yaml
@@ -28,9 +28,6 @@ environment:
       - py3-supported-hatch-fancy-pypi-readme
       - py3-supported-hatchling
       - py3-supported-pip
-      - py3-supported-python
-      - py3-supported-setuptools
-      - py3-supported-wheel
       - wolfi-base
   environment:
     # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"

--- a/py3-openai.yaml
+++ b/py3-openai.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-openai
   version: 1.42.0
-  epoch: 1
+  epoch: 0
   description: Python client library for the OpenAI API
   copyright:
     - license: MIT


### PR DESCRIPTION
py3-openai version bump builds have been failing, it looks like it was missing  'jiter' module

References within openapi-python: https://github.com/openai/openai-python/blob/05fa732c024b55ddda1f5f8b107ce78233acd3ce/pyproject.toml#L19
Upstream repository for jiter: https://github.com/pydantic/jiter/tree/main


#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
