### PR TITLE
include uvx with uv package

### DIFF
--- a/uv.yaml
+++ b/uv.yaml
@@ -1,7 +1,7 @@
 package:
   name: uv
   version: 0.3.4
-  epoch: 0
+  epoch: 1
   description: An extremely fast Python package installer and resolver, written in Rust.
   copyright:
     - license: MIT
@@ -28,6 +28,7 @@ pipeline:
   - runs: |
       cargo auditable build --locked --release
       install -Dm755 target/release/uv "${{targets.destdir}}"/usr/bin/uv
+      install -Dm755 target/release/uvx "${{targets.destdir}}"/usr/bin/uvx
 
   - uses: strip
 
@@ -40,3 +41,4 @@ test:
   pipeline:
     - runs: |
         uv --version | grep ${{package.version}}
+        uvx --version | grep ${{package.version}}


### PR DESCRIPTION
uvx is a handy alias to `uv tool run` and this gets shipped out of the box with official installer.

ref: https://docs.astral.sh/uv/concepts/tools/#the-uv-tool-interface

```bash
# upstream release asset archive
$ tar -tvf uv-x86_64-unknown-linux-gnu.tar.gz
drwxr-xr-x runner/docker     0 2024-08-26 21:00 uv-x86_64-unknown-linux-gnu/
-rwxr-xr-x runner/docker 26799352 2024-08-26 21:00 uv-x86_64-unknown-linux-gnu/uv
-rwxr-xr-x runner/docker   350584 2024-08-26 21:00 uv-x86_64-unknown-linux-gnu/uvx
```