### PR TITLE
feat: Bump "axios" package version to "^1.7.4" to remediate GHSA-8hc4-vh64-cxmj

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: 2.8.0
-  epoch: 0
+  epoch: 1
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT

--- a/jitsucom-jitsu/upgrade-deps.patch
+++ b/jitsucom-jitsu/upgrade-deps.patch
@@ -1,18 +1,8 @@
-From d47108bf013f01f516e264cf58b78aa08c38c525 Mon Sep 17 00:00:00 2001
-From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
-Date: Thu, 13 Jun 2024 23:48:47 +0300
-Subject: [PATCH] upgrade deps
-
-Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
----
- package.json | 14 +++++++++++++-
- 1 file changed, 13 insertions(+), 1 deletion(-)
-
 diff --git a/package.json b/package.json
-index 514fc5cc..60e2b3ba 100644
+index 40a2078..fd5df42 100644
 --- a/package.json
 +++ b/package.json
-@@ -54,5 +54,17 @@
+@@ -54,5 +54,18 @@
      "services/*",
      "cli/*",
      "libs/*"
@@ -27,11 +17,9 @@ index 514fc5cc..60e2b3ba 100644
 +      "jose": "^4.15.5",
 +      "@sentry/nextjs": "^7.77.0",
 +      "esbuild": "^0.20.2",
-+      "@grpc/grpc-js": "^1.9.15"
++      "@grpc/grpc-js": "^1.9.15",
++      "axios": "^1.7.4"
 +    }
 +  }
  }
 \ No newline at end of file
--- 
-2.39.3 (Apple Git-146)
-


### PR DESCRIPTION
axios is vulnerable to GHSA-8hc4-vh64-cxmj/ CVE-2024-39338 [1] for versions <= 1.7.3

This commit amends the existing patch we are applying to also include bump to "axios" package version "^1.7.4".

[1] https://github.com/advisories/GHSA-8hc4-vh64-cxmj

Signed-off-by: philroche <phil.roche@chainguard.dev>

Fixes: GHSA-8hc4-vh64-cxmj/ CVE-2024-39338

