### PR TITLE
fix(logstash CVE): GHSA-2m96-52r3-2f3g

### DIFF
--- a/logstash.yaml
+++ b/logstash.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash
   version: 8.15.0
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -67,6 +67,7 @@ pipeline:
 
   - name: Patch sources
     runs: |
+      echo "gem 'fugit', '1.11.1'" >> Gemfile.template
       # Disable the logstash-integration-jdbc plugin download as we build and
       # package it separately
       jq 'del(.["logstash-integration-jdbc"])' rakelib/plugins-metadata.json > /tmp/plugins-metadata.json


### PR DESCRIPTION
update the Gemfile template to force using the fix version of fugit gem
