### PR TITLE
ensure kwok apiserver important endpoints are ready before continuing

### DIFF
--- a/pipelines/test/kwok/cluster.yaml
+++ b/pipelines/test/kwok/cluster.yaml
@@ -20,4 +20,28 @@ pipeline:
         --etcd-binary="/usr/bin/etcd"
       # Create a node
       kwokctl scale node --replicas 1
+
+      wait_for_ready() {
+          endpoint=$1
+          i=1
+          while [ $i -le 5 ]; do
+              if kubectl get --raw "$endpoint" >/dev/null 2>&1; then
+                  echo "$endpoint is ready"
+                  return 0
+              fi
+              echo "Attempt $i: $endpoint not ready, retrying..."
+              sleep 1
+              i=$((i + 1))
+          done
+          echo "$endpoint did not become ready in time"
+          return 1
+      }
+
+      for endpoint in "/healthz" "/readyz" "/openapi/v2"; do
+          if ! wait_for_ready "$endpoint"; then
+              exit 1
+          fi
+      done
+
       kubectl wait --for=condition=Ready nodes --all
+      kubectl cluster-info


### PR DESCRIPTION
prevent a race condition where users attempt to immediately access various endpoints