### PR TITLE
gcc: Fix /usr/lib64 usage

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 14.2.0
-  epoch: 1
+  epoch: 2
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -102,12 +102,20 @@ pipeline:
   - runs: |
       make -C build -j$(nproc) install DESTDIR="${{targets.destdir}}"
 
+  # Despite disable-multilib, gcc installs things into lib64
+  # This breaks apk audit, as we symlink lib64 to lib.
+  # https://stackoverflow.com/questions/28696199/build-gcc-from-scratch-without-lib64-directory
+  - name: Fix /usr/lib64 usage
+    runs: |
+      mv ${{targets.destdir}}/usr/lib64/* ${{targets.destdir}}/usr/lib/
+      rmdir ${{targets.destdir}}/usr/lib64
+
   # We don't want to keep the .la files.
   - runs: |
       find ${{targets.destdir}} -name '*.la' -print -exec rm \{} \;
 
   - runs: |
-      chmod 755 ${{targets.destdir}}/usr/lib64/libgcc_s.*
+      chmod 755 ${{targets.destdir}}/usr/lib/libgcc_s.*
 
   - name: 'Clean up documentation'
     runs: |
@@ -123,17 +131,17 @@ subpackages:
   - name: 'libstdc++'
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          mv "${{targets.destdir}}"/usr/lib64/*++.so.* "${{targets.subpkgdir}}"/usr/lib64/
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/*++.so.* "${{targets.subpkgdir}}"/usr/lib/
 
   - name: 'libstdc++-dev'
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mkdir -p "${{targets.subpkgdir}}"/usr/include
           mkdir -p "${{targets.subpkgdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx
-          mv "${{targets.destdir}}"/usr/lib64/*++.a "${{targets.subpkgdir}}"/usr/lib64/
-          mv "${{targets.destdir}}"/usr/lib64/libstdc++.so "${{targets.subpkgdir}}"/usr/lib64/
+          mv "${{targets.destdir}}"/usr/lib/*++.a "${{targets.subpkgdir}}"/usr/lib/
+          mv "${{targets.destdir}}"/usr/lib/libstdc++.so "${{targets.subpkgdir}}"/usr/lib/
           mv "${{targets.destdir}}"/usr/include/*++* "${{targets.subpkgdir}}"/usr/include/
           mv "${{targets.destdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/* \
             "${{targets.subpkgdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/
@@ -143,15 +151,15 @@ subpackages:
     pipeline:
       - if: ${{build.arch}} == 'x86_64'
         runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          mv "${{targets.destdir}}"/usr/lib64/libquadmath.so.* "${{targets.subpkgdir}}"/usr/lib64/
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libquadmath.so.* "${{targets.subpkgdir}}"/usr/lib/
 
   - name: "libgfortran"
     description: "Fortran runtime library provided by GCC"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          mv "${{targets.destdir}}"/usr/lib64/libgfortran.so.* "${{targets.subpkgdir}}"/usr/lib64/
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libgfortran.so.* "${{targets.subpkgdir}}"/usr/lib/
 
   - name: "gfortran"
     description: "GNU Fortran Compiler"
@@ -160,13 +168,13 @@ subpackages:
           _libexecdir=/usr/libexec/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
           _libdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
 
-          for i in "$_libexecdir" "$_libdir" usr/lib64 usr/bin; do
+          for i in "$_libexecdir" "$_libdir" usr/lib usr/bin; do
             mkdir -p "${{targets.subpkgdir}}"/$i
           done
 
           mv "${{targets.destdir}}"/usr/bin/*fortran "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/lib64/libgfortran* "${{targets.subpkgdir}}"/usr/lib64
-          [ -f "${{targets.destdir}}"/usr/lib64/libquadmath* ] && mv "${{targets.destdir}}"/usr/lib64/libquadmath* "${{targets.subpkgdir}}"/usr/lib64
+          mv "${{targets.destdir}}"/usr/lib/libgfortran* "${{targets.subpkgdir}}"/usr/lib
+          [ -f "${{targets.destdir}}"/usr/lib/libquadmath* ] && mv "${{targets.destdir}}"/usr/lib/libquadmath* "${{targets.subpkgdir}}"/usr/lib
 
           mv "${{targets.destdir}}"/$_libdir/finclude "${{targets.subpkgdir}}"/$_libdir
           mv "${{targets.destdir}}"/$_libexecdir/f951 "${{targets.subpkgdir}}"/$_libexecdir
@@ -196,36 +204,36 @@ subpackages:
     description: "GCC stack protection library"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          mv "${{targets.destdir}}"/usr/lib64/libssp* "${{targets.subpkgdir}}"/usr/lib64
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libssp* "${{targets.subpkgdir}}"/usr/lib
 
   - name: "libgomp"
     description: "GNU parallel programming library"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          mv "${{targets.destdir}}"/usr/lib64/libgomp.so.* "${{targets.subpkgdir}}"/usr/lib64/
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libgomp.so.* "${{targets.subpkgdir}}"/usr/lib/
 
   - name: "libgcc"
     description: "GCC runtime library"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          mv "${{targets.destdir}}"/usr/lib64/libgcc_s.so.* "${{targets.subpkgdir}}"/usr/lib64/
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libgcc_s.so.* "${{targets.subpkgdir}}"/usr/lib/
 
   - name: "libatomic"
     description: "GCC atomic library"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          mv "${{targets.destdir}}"/usr/lib64/libatomic.so.* "${{targets.subpkgdir}}"/usr/lib64/
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libatomic.so.* "${{targets.subpkgdir}}"/usr/lib/
 
   - name: "libgo"
     description: "GCC go runtime library"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib64
-          mv "${{targets.destdir}}"/usr/lib64/libgo.so.* "${{targets.subpkgdir}}"/usr/lib64/
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libgo.so.* "${{targets.subpkgdir}}"/usr/lib/
 
   - name: "gcc-go"
     description: "GCC go compiler"
@@ -236,7 +244,7 @@ subpackages:
       - runs: |
           _libexecdir=/usr/libexec/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
 
-          for i in "$_libexecdir" usr/lib64 usr/bin; do
+          for i in "$_libexecdir" usr/lib usr/bin; do
             mkdir -p "${{targets.subpkgdir}}"/$i
           done
 
@@ -245,11 +253,11 @@ subpackages:
             mv "${{targets.destdir}}"/usr/bin/$i "${{targets.subpkgdir}}"/usr/bin/
           done
 
-          mv "${{targets.destdir}}"/usr/lib64/go "${{targets.subpkgdir}}"/usr/lib64/
-          mv "${{targets.destdir}}"/usr/lib64/libgo.a "${{targets.subpkgdir}}"/usr/lib64/
-          mv "${{targets.destdir}}"/usr/lib64/libgobegin.a "${{targets.subpkgdir}}"/usr/lib64/
-          mv "${{targets.destdir}}"/usr/lib64/libgolibbegin.a "${{targets.subpkgdir}}"/usr/lib64/
-          mv "${{targets.destdir}}"/usr/lib64/libgo.so "${{targets.subpkgdir}}"/usr/lib64/
+          mv "${{targets.destdir}}"/usr/lib/go "${{targets.subpkgdir}}"/usr/lib/
+          mv "${{targets.destdir}}"/usr/lib/libgo.a "${{targets.subpkgdir}}"/usr/lib/
+          mv "${{targets.destdir}}"/usr/lib/libgobegin.a "${{targets.subpkgdir}}"/usr/lib/
+          mv "${{targets.destdir}}"/usr/lib/libgolibbegin.a "${{targets.subpkgdir}}"/usr/lib/
+          mv "${{targets.destdir}}"/usr/lib/libgo.so "${{targets.subpkgdir}}"/usr/lib/
 
           for i in cgo go1; do
             mv "${{targets.destdir}}"/"$_libexecdir"/$i "${{targets.subpkgdir}}"/"$_libexecdir"/


### PR DESCRIPTION
By default gcc installs runtime libraries in /usr/lib64 which breaks `apk audit` command. This is because we symlink `/usr/lib64` to `/usr/lib` and thus true file locations are elsewhere.

With this packaging change `apk audit` output should no longer have `A /usr/lib/*.so*` entries for all the gcc provided libraries.

```console
$ docker run -ti --entrypoint sh cgr.dev/chainguard-private/gcc-glibc:latest-dev -c 'apk audit --full' | grep 'A usr/lib/lib' | head -n10
A usr/lib/libitm.so.1
A usr/lib/libtsan.so.2
A usr/lib/libgomp.spec
A usr/lib/libgo.so.23.0.0
A usr/lib/libhwasan.so
A usr/lib/liblsan.a
A usr/lib/libstdc++fs.a
A usr/lib/libatomic.so.1.2.0
A usr/lib/libquadmath.so.0.0.0
A usr/lib/libtsan.so.2.0.0
```
