### PR TITLE
py3-setuptools-scm - drop importlib dependency / break cyclic deps

### DIFF
--- a/py3-setuptools-scm.yaml
+++ b/py3-setuptools-scm.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-setuptools-scm
   version: 8.1.0
-  epoch: 1
+  epoch: 2
   description: the blessed package to manage your versions by scm tags
   copyright:
     - license: MIT
@@ -49,7 +49,6 @@ subpackages:
         - py${{range.key}}-setuptools
         - py${{range.key}}-typing-extensions
         - py${{range.key}}-tomli
-        - py${{range.key}}-importlib-metadata
       provider-priority: ${{range.value}}
       provides:
         - py3-${{vars.pypi-package}}


### PR DESCRIPTION
From https://github.com/wolfi-dev/wolfictl/pull/1150 we see:

```
  2024/08/27 23:00:40 ERRO unresolvable cycle:
        py3-zipp:3.20.1-r0@local -> py3-supported-setuptools-scm:8.1.0-r1@local,
        caused by: py3-supported-setuptools-scm:8.1.0-r1@local
           -> py3-setuptools-scm:8.1.0-r1@local
           -> py3.12-importlib-metadata:8.4.0-r0@local
           -> py3-importlib-metadata:8.4.0-r0@local
           -> py3.11-zipp:3.20.1-r0@local
           -> py3-zipp:3.20.1-r0@local
```

This drops py3-setuptools-scm dep on py3-importlib-metadata. Pypi's setuptools-scm  has no mention of importlib-metadata.
