### PR TITLE
gobject-introspection - depend on py3-setuptools-73

### DIFF
--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobject-introspection
   version: 1.80.1
-  epoch: 0
+  epoch: 1
   description: Introspection system for GObject-based libraries
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT
@@ -49,6 +49,10 @@ pipeline:
     with:
       expected-sha256: a1df7c424e15bda1ab639c00e9051b9adf5cea1a9e512f8a603b53cd199bc6d8
       uri: https://download.gnome.org/sources/gobject-introspection/${{vars.mangled-package-version}}/gobject-introspection-${{package.version}}.tar.xz
+
+  - uses: patch
+    with:
+      patches: fix-giscanner-with-setuptools-74.patch
 
   - uses: meson/configure
     with:

--- a/gobject-introspection/fix-giscanner-with-setuptools-74.patch
+++ b/gobject-introspection/fix-giscanner-with-setuptools-74.patch
@@ -1,0 +1,103 @@
+https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/490
+
+From fcf79ca8d068d2e30a6aefdc42dcc6aeab4655e2 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Wed, 28 Aug 2024 21:26:02 +0200
+Subject: [PATCH] giscanner: remove dependency on distutils.msvccompiler
+
+It was removed with setuptools 74.0.0. Since we still depend on the
+MSVCCompiler class use new_compiler() to get it some other way.
+
+Remove any reference to MSVC9Compiler, which was for Visual Studio 2008
+which we no longer support anyway.
+
+Fixes #515
+---
+ giscanner/ccompiler.py    |  7 +++----
+ giscanner/msvccompiler.py | 14 +++++++-------
+ 2 files changed, 10 insertions(+), 11 deletions(-)
+
+diff --git a/giscanner/ccompiler.py b/giscanner/ccompiler.py
+index d0ed70a3c..9a732cd5e 100644
+--- a/giscanner/ccompiler.py
++++ b/giscanner/ccompiler.py
+@@ -26,7 +26,6 @@ import tempfile
+ import sys
+ import distutils
+ 
+-from distutils.msvccompiler import MSVCCompiler
+ from distutils.unixccompiler import UnixCCompiler
+ from distutils.cygwinccompiler import Mingw32CCompiler
+ from distutils.sysconfig import get_config_vars
+@@ -167,7 +166,7 @@ class CCompiler(object):
+         # Now, create the distutils ccompiler instance based on the info we have.
+         if compiler_name == 'msvc':
+             # For MSVC, we need to create a instance of a subclass of distutil's
+-            # MSVC9Compiler class, as it does not provide a preprocess()
++            # MSVCCompiler class, as it does not provide a preprocess()
+             # implementation
+             from . import msvccompiler
+             self.compiler = msvccompiler.get_msvc_compiler()
+@@ -460,7 +459,7 @@ class CCompiler(object):
+             return self.compiler.linker_exe
+ 
+     def check_is_msvc(self):
+-        return isinstance(self.compiler, MSVCCompiler)
++        return self.compiler.compiler_type == "msvc"
+ 
+     # Private APIs
+     def _set_cpp_options(self, options):
+@@ -486,7 +485,7 @@ class CCompiler(object):
+                     # macros for compiling using distutils
+                     # get dropped for MSVC builds, so
+                     # escape the escape character.
+-                    if isinstance(self.compiler, MSVCCompiler):
++                    if self.check_is_msvc():
+                         macro_value = macro_value.replace('\"', '\\\"')
+                 macros.append((macro_name, macro_value))
+             elif option.startswith('-U'):
+diff --git a/giscanner/msvccompiler.py b/giscanner/msvccompiler.py
+index 0a5439820..e333a80f5 100644
+--- a/giscanner/msvccompiler.py
++++ b/giscanner/msvccompiler.py
+@@ -19,30 +19,30 @@
+ #
+ 
+ import os
+-import distutils
++from typing import Type
+ 
+ from distutils.errors import DistutilsExecError, CompileError
+-from distutils.ccompiler import CCompiler, gen_preprocess_options
++from distutils.ccompiler import CCompiler, gen_preprocess_options, new_compiler
+ from distutils.dep_util import newer
+ 
+ # Distutil's MSVCCompiler does not provide a preprocess()
+ # Implementation, so do our own here.
+ 
+ 
++DistutilsMSVCCompiler: Type = type(new_compiler(compiler="msvc"))
++
++
+ def get_msvc_compiler():
+     return MSVCCompiler()
+ 
+ 
+-class MSVCCompiler(distutils.msvccompiler.MSVCCompiler):
++class MSVCCompiler(DistutilsMSVCCompiler):
+ 
+     def __init__(self, verbose=0, dry_run=0, force=0):
+-        super(distutils.msvccompiler.MSVCCompiler, self).__init__()
++        super(DistutilsMSVCCompiler, self).__init__()
+         CCompiler.__init__(self, verbose, dry_run, force)
+         self.__paths = []
+         self.__arch = None  # deprecated name
+-        if os.name == 'nt':
+-            if isinstance(self, distutils.msvc9compiler.MSVCCompiler):
+-                self.__version = distutils.msvc9compiler.VERSION
+         self.initialized = False
+         self.preprocess_options = None
+         if self.check_is_clang_cl():
+-- 
+GitLab
+


### PR DESCRIPTION
gdk-pixbuf was found to be FTBFS, failing with a stacktrace like:

> ```
> Traceback (most recent call last):
>   File "/usr/bin/g-ir-scanner", line 103, in <module>
>     from giscanner.scannermain import scanner_main
>   File "/usr/lib/gobject-introspection/giscanner/scannermain.py", line 35, in <module>
>     from giscanner.ast import Include, Namespace
>   File "/usr/lib/gobject-introspection/giscanner/ast.py", line 27, in <module>
>     from .sourcescanner import CTYPE_TYPEDEF, CSYMBOL_TYPE_TYPEDEF
>   File "/usr/lib/gobject-introspection/giscanner/sourcescanner.py", line 25, in <module>
>     from .ccompiler import CCompiler
>   File "/usr/lib/gobject-introspection/giscanner/ccompiler.py", line 29, in <module>
>     from distutils.msvccompiler import MSVCCompiler
> ModuleNotFoundError: No module named 'distutils.msvccompiler'
> ```

Upstream issue to follow gobject-introspection removeing use of distutils is
 https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/515
or https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/395
