### PR TITLE
cve rancher 2.9 36b671989ad13000c1c8c11d7d8ad0f0

### DIFF
--- a/rancher-2.9.yaml
+++ b/rancher-2.9.yaml
@@ -103,7 +103,7 @@ subpackages:
         with:
           repository: https://github.com/rancher/kontainer-driver-metadata/
           branch: release-v${{vars.major-minor-version}}
-          expected-commit: 8bdffff5b7271f8e5cb9d148ae25c1c3192b62b6
+          expected-commit: 013113ed0a841b5ca591175e103b6994b9fcebe2
           destination: kontainer-driver-metadata
       - working-directory: ./kontainer-driver-metadata
         runs: |
@@ -146,7 +146,7 @@ subpackages:
           repository: https://github.com/rancher/partner-charts
           branch: main
           destination: partner-charts
-          expected-commit: e95ababa2c9a41b8a974752157646a5013ea0f4d
+          expected-commit: 55971306935bddfaf98e642898d985ab93741a45
       - working-directory: ./partner-charts
         runs: |
           shasum256=$(echo -n "https://git.rancher.io/partner-charts" |shasum -a 256 | awk '{ print $1 }')
@@ -173,7 +173,7 @@ subpackages:
           repository: https://github.com/rancher/charts
           branch: release-v${{vars.major-minor-version}}
           destination: charts
-          expected-commit: bfa3b06d877703e24c94f62187cdfce3cdbb2c67
+          expected-commit: 47e69f03a552ca966b3688050b2d9517c233a877
           depth: -1
       - working-directory: ./charts
         runs: |
@@ -208,7 +208,7 @@ subpackages:
           repository: https://github.com/rancher/rke2-charts
           branch: main
           destination: rke2-charts
-          expected-commit: 0f967664cd95614fc06646eb1fb49b9346b1dbcb
+          expected-commit: ced0ac0f44b7b33c75fdf708cb214de1a5182cfd
       - working-directory: ./rke2-charts
         runs: |
           shasum256=$(echo -n "https://git.rancher.io/rke2-charts" |shasum -a 256 | awk '{ print $1 }')

--- a/rancher-2.9.yaml
+++ b/rancher-2.9.yaml
@@ -39,10 +39,6 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 9e0cc54e7e3a924cf0ed5c5d4db0a6e53805c75e
 
-  - uses: go/bump
-    with:
-      deps: github.com/docker/docker@v23.0.15
-
 subpackages:
   - name: rancher-agent-${{vars.major-minor-version}}
     dependencies:


### PR DESCRIPTION
- **rancher-2.9/2.9.0-r2: fix GHSA-v23v-6jw2-98fq**
- **fix(CVE): remove go/bump as these docker deps are too old and need upgraded by upstream**
- **fix(CVE): Bump rancher-2.9 sub package checksums**
