### PR TITLE
Ruby 3.1 rexml CVE fixes

### DIFF
--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.6
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -48,6 +48,10 @@ pipeline:
       repository: https://github.com/ruby/ruby
       tag: v${{vars.underscore-package-version}}
       expected-commit: a777087be612b7675fe012560bf0d8fddff20f55
+
+  - uses: patch
+    with:
+      patches: rexml.patch
 
   - name: Generate and Configure
     runs: |

--- a/ruby-3.1/rexml.patch
+++ b/ruby-3.1/rexml.patch
@@ -1,0 +1,13 @@
+diff --git a/gems/bundled_gems b/gems/bundled_gems
+index 99059c9cf9..744852074a 100644
+--- a/gems/bundled_gems
++++ b/gems/bundled_gems
+@@ -3,7 +3,7 @@ minitest 5.15.0 https://github.com/seattlerb/minitest
+ power_assert 2.0.1 https://github.com/ruby/power_assert
+ rake 13.0.6 https://github.com/ruby/rake
+ test-unit 3.5.3 https://github.com/test-unit/test-unit
+-rexml 3.2.5 https://github.com/ruby/rexml
++rexml 3.3.4 https://github.com/ruby/rexml
+ rss 0.2.9 https://github.com/ruby/rss
+ net-ftp 0.1.4 https://github.com/ruby/net-ftp
+ net-imap 0.2.4 https://github.com/ruby/net-imap


### PR DESCRIPTION
GHSA-5866-49gr-22v4, GHSA-vg3r-rm7w-2xgh, GHSA-r55c-59qm-vjw6 and GHSA-4xqq-m2hx-25v8 are all remedied by updating the rexml version to the highest version that is being used upstream in the Ruby 3.1 branch. Build succeeds and ruby --version returns valid data in local-wolfi. 