### PR TITLE
Pin py3-gevent to gcc 13, add openssf.

### DIFF
--- a/py3-gevent.yaml
+++ b/py3-gevent.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-gevent
   version: 24.2.1
-  epoch: 0
+  epoch: 1
   description: Coroutine-based network library
   copyright:
     - license: MIT
@@ -20,6 +20,10 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - file
+      # https://github.com/gevent/gevent/issues/2028
+      - gcc~13
+      - openssf-compiler-options
       - python3-dev
       - wolfi-base
 


### PR DESCRIPTION
https://github.com/gevent/gevent/issues/2028

file is added just to avoid a configure warning on it missing.
