### PR TITLE
py3-glpk - fix FTBFS

### DIFF
--- a/py3-glpk.yaml
+++ b/py3-glpk.yaml
@@ -1,13 +1,10 @@
 package:
   name: py3-glpk
   version: 0.4.7
-  epoch: 2
+  epoch: 3
   description: PyGLPK, a Python module encapsulating GLPK.
   copyright:
     - license: GPL-3.0-or-later
-  dependencies:
-    runtime:
-      - python3
 
 environment:
   contents:
@@ -15,7 +12,9 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc~13
       - glpk
+      - openssf-compiler-options
       - py3-setuptools
       - py3-setuptools-scm
       - python3


### PR DESCRIPTION
As seen https://github.com/wolfi-dev/os/issues/26522, this was FTBFS. It broke with gcc-14.
