### PR TITLE
py3-influxdb - fix FTBFS by moving to py/pip-build-install

### DIFF
--- a/py3-influxdb-client.yaml
+++ b/py3-influxdb-client.yaml
@@ -1,13 +1,10 @@
 package:
   name: py3-influxdb-client
   version: 1.45.0
-  epoch: 0
+  epoch: 1
   description: "InfluxDB 2.0 python client"
   copyright:
     - license: MIT
-  dependencies:
-    runtime:
-      - python3
 
 environment:
   contents:
@@ -29,11 +26,7 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: db1630d52ecd29f2f1008ca25c742fa26ee3777c
 
-  - name: Python Build
-    runs: python setup.py build
-
-  - name: Python Install
-    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+  - uses: py/pip-build-install
 
   - uses: strip
 


### PR DESCRIPTION
The FTBFS was really a problem with using 'python' when nothing in the build environment was going to guarantee that executable.
