### PR TITLE
Ftbfs py3 ruamel yaml clib

### DIFF
--- a/py3-ruamel-yaml-clib.yaml
+++ b/py3-ruamel-yaml-clib.yaml
@@ -1,13 +1,10 @@
 package:
   name: py3-ruamel-yaml-clib
   version: 0.2.8
-  epoch: 1
+  epoch: 2
   description: "C version of reader, parser and emitter for ruamel.yaml derived from libyaml."
   copyright:
     - license: MIT
-  dependencies:
-    runtime:
-      - python3
 
 environment:
   contents:
@@ -15,7 +12,10 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc~13
+      - openssf-compiler-options
       - py3-gpep517
+      - py3-pip
       - py3-setuptools
       - py3-wheel
       - python3
@@ -28,13 +28,9 @@ pipeline:
       uri: https://files.pythonhosted.org/packages/source/r/ruamel.yaml.clib/ruamel.yaml.clib-${{package.version}}.tar.gz
       expected-sha256: beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512
 
+  - uses: py/pip-build-install
+
   - runs: |
-      python3 -m gpep517 build-wheel \
-        --wheel-dir dist \
-        --output-fd 3 3>&1 >&2
-      python3 -m installer \
-        -d "${{targets.destdir}}" \
-        dist/ruamel.yaml.clib-${{package.version}}-*.whl
       install -Dm644 LICENSE \
         "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
 


### PR DESCRIPTION
    fix FTBFS py3-ruamel-yaml-clib by pinning to gcc 13.

```    
    yaml.h:636:22: note: expected 'yaml_char_t *' {aka 'unsigned char *'} but argument is
                   of type 'char *'
      636 |         yaml_char_t *anchor, yaml_char_t *tag, int implicit,
          |         ~~~~~~~~~~~~~^~~~~~
    _ruamel_yaml.c:24755:90: warning: pointer targets in passing argument 3 of
            'yaml_mapping_start_event_initialize' differ in signedness [-Wpointer-sign]
    24755 |       __pyx_t_2 = (yaml_mapping_start_event_initialize((&__pyx_v_event),
          |          __pyx_v_anchor, __pyx_v_tag, __pyx_v_i mplicit, __pyx_v_mapping_style) == 0);
          |                          ^~~~~~~~~~~
          |  char * yaml.h:636:43: note: expected 'yaml_char_t *' {aka 'unsigned char *'}
          |  but argument is of type 'char *'
      636 |         yaml_char_t *anchor, yaml_char_t *tag, int implicit,
          |                              ~~~~~~~~~~~~~^~~
    error: command '/usr/bin/x86_64-pc-linux-gnu-gcc' failed with exit code 1
    error: subprocess-exited-with-error
```