### PR TITLE
py3-xmlsec - fix FTBFS, add openssf-compiler-flags

### DIFF
--- a/py3-xmlsec.yaml
+++ b/py3-xmlsec.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-xmlsec
   version: 1.3.14
-  epoch: 0
+  epoch: 1
   description: About Python bindings for the XML Security Library
   copyright:
     - license: MIT
@@ -10,7 +10,6 @@ package:
       - openssl
       - openssl-dev
       - py3-lxml
-      - python3
       - xmlsec
       - xmlsec-openssl
 
@@ -28,6 +27,7 @@ environment:
       - libxml2
       - libxml2-dev
       - libxslt-dev
+      - openssf-compiler-options
       - openssl-dev
       - pkgconf
       - pkgconf-dev
@@ -43,6 +43,9 @@ environment:
       - xmlsec
       - xmlsec-dev
       - xmlsec-openssl
+  environment:
+    # https://github.com/xmlsec/python-xmlsec/issues/323
+    CFLAGS: "-Wno-error=incompatible-pointer-types"
 
 pipeline:
   - uses: git-checkout
@@ -51,10 +54,7 @@ pipeline:
       repository: https://github.com/xmlsec/python-xmlsec
       tag: ${{package.version}}
 
-  - name: Python Install
-    runs: |
-      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 1
-      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
+  - uses: py/pip-build-install
 
   - uses: strip
 


### PR DESCRIPTION
The FTBFS is actually fixed simply with the CFLAGS.
