### PR TITLE
Fix runit FTBFS with gcc-14

### DIFF
--- a/runit.yaml
+++ b/runit.yaml
@@ -1,7 +1,7 @@
 package:
   name: runit
   version: 2.1.2
-  epoch: 3
+  epoch: 4
   description: UNIX init scheme with service supervision
   copyright:
     - license: BSD-3-Clause
@@ -28,6 +28,17 @@ pipeline:
   - uses: patch
     with:
       patches: svlogd-udp.patch
+
+  - runs: |
+      # patch in some flags, or it will not build with gcc-14
+      cp conf-cc conf-cc.dist
+      for flag in \
+          implicit-function-declaration \
+          incompatible-pointer-types \
+          ; do
+          sed -i -e "1s/$/ -Wno-error=$flag/" conf-cc
+      done
+      diff conf-cc.dist conf-cc && exit 1
 
   - uses: autoconf/make
 


### PR DESCRIPTION
Fix runit FTBFS with gcc-14

The build system does not respect CFLAGS, or any other sane
way to get flags to the environment, so .... sedit!
