### PR TITLE
php-fpm_exporter - fix ftbfs after upgrade to go 1.23

### DIFF
--- a/php-fpm_exporter.yaml
+++ b/php-fpm_exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-fpm_exporter
   version: 2.2.0
-  epoch: 6
+  epoch: 7
   description: A prometheus exporter for PHP-FPM.
   copyright:
     - license: Apache-2.0
@@ -22,11 +22,6 @@ pipeline:
       repository: https://github.com/hipages/php-fpm_exporter
       tag: v${{package.version}}
       expected-commit: c75d2df4037741c1cb146216d7156273d13ff91f
-
-  - runs: |
-      rm go.mod
-      go mod init github.com/hipages/php-fpm_exporter # init in recent version
-      go mod tidy
 
   - uses: go/bump
     with:


### PR DESCRIPTION
When go moved to 1.23 the result of 'go mod tidy' is different than it was with 1.22, and the result was an error in go bump like:

> running step "Bump go deps to a certain version"
> Running go mod tidy with go version '1.23.0' ...
> Error: Failed to running update.
> Error: package google.golang.org/protobuf with
>       version 'v1.33.0' is already at version v1.34.2

The 'go mod tidy' updates google.golang.org/protobuf to sufficient version.
