### PR TITLE
Fix ngrep FTBFS after update to gcc-14, add openssf flags.

### DIFF
--- a/ngrep.yaml
+++ b/ngrep.yaml
@@ -1,7 +1,7 @@
 package:
   name: ngrep
   version: 1.47
-  epoch: 1
+  epoch: 2
   description: A grep-like utility that allows you to search for network packets on an interface
   copyright:
     - license: BSD-3-Clause
@@ -15,6 +15,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - libpcap-dev
+      - openssf-compiler-options
       - pcre-dev
 
 # transform melange version 1.47 => 1_47
@@ -31,7 +32,9 @@ pipeline:
       tag: V${{vars.mangled-package-version}}
       expected-commit: 351ac491358f89a7860bbbe9963cb4bc7d60000f
 
-  - runs: autoreconf -vif
+  - runs: |
+      autoreconf -vif
+      ( cd regex-0.12 && autoreconf -vif )
 
   - uses: autoconf/configure
     with:
@@ -46,6 +49,18 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+test:
+  pipeline:
+    - name: "check 'ngrep -V' for expected version"
+      runs: |
+        set +x
+        out=$(ngrep -V) || { echo "FAIL: ngrep -V exited $?"; exit 1; }
+        echo "$out" | grep -q "${{package.version}}" || {
+          echo "FAIL: ngrep -V did not contain ${{package.version}}"
+          exit 1
+        }
+        echo "PASS: ngrep -V contained expected version (${{package.version}})"
 
 update:
   version-separator: _


### PR DESCRIPTION
gcc-13 will build ngrep fine.  gcc-14 fails because config.h doesn't get created in the vendored regex-0.12 directory.

This fixes build with gcc-14 and adds openssf flags.

Fixes: https://github.com/wolfi-dev/os/issues/27333
