### PR TITLE
feat(cve): Remediate CVE GHSA-9cmq-m9j5-mvww in apache-nifi package by bumping spring-expression dependency to 5.3.39 using pombump

### DIFF
--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi
   version: 1.27.0
-  epoch: 0
+  epoch: 1
   description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
   copyright:
     - license: Apache-2.0
@@ -52,6 +52,8 @@ pipeline:
       repository: https://github.com/apache/nifi
       tag: rel/nifi-${{package.version}}
       expected-commit: e0c4461d90bd4f6e5f2b81765bcff5cd97ed3e18
+
+  - uses: maven/pombump
 
   - runs: |
       # Use single thread on x86_64

--- a/apache-nifi/pombump-deps.yaml
+++ b/apache-nifi/pombump-deps.yaml
@@ -1,0 +1,6 @@
+patches:
+  # Fixes GHSA-9cmq-m9j5-mvww/CVE-2024-38808
+  - groupId: org.springframework
+    artifactId: spring-framework-bom
+    version: 5.3.39
+    scope: import


### PR DESCRIPTION
spring-expression is a dependency of apache-nifi package. Current version in pom.xml is 5.3.37 but this
is vulnerable to GHSA-9cmq-m9j5-mvww/CVE-2024-38808.

This commit uses pombump to bump to the earliest version that is not vulnerable - 5.3.39.

[1] https://github.com/advisories/GHSA-9cmq-m9j5-mvww

Signed-off-by: philroche <phil.roche@chainguard.dev>


Fixes: CVE GHSA-9cmq-m9j5-mvww/CVE-2024-38808 

Related: https://github.com/advisories/GHSA-9cmq-m9j5-mvww
