### PR TITLE
DNM: Debug Chromium

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -6,7 +6,7 @@
 # And remove the use of the strip pipeline below
 package:
   name: chromium
-  version: 128.0.6613.84
+  version: 128.0.6613.113
   epoch: 0
   description: "Open souce version of Google's chrome web browser"
   copyright:

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -237,13 +237,13 @@ pipeline:
         enable_widevine=true
         ffmpeg_branding=\"Chrome\"
         icu_use_data_file=false
-        is_debug=false
-        is_official_build=true
+        is_debug=true
+        is_official_build=false
         link_pulseaudio=true
         moc_qt6_path=\"/usr/lib/qt6/libexec\"
         proprietary_codecs=true
         safe_browsing_use_unrar=false
-        symbol_level=0
+        symbol_level=2
         treat_warnings_as_errors=false
         use_lld=true
         use_pulseaudio=true
@@ -283,9 +283,9 @@ pipeline:
       ln -sf /usr/lib/${{package.name}}/chromedriver ${{targets.destdir}}/usr/bin/chromedriver
       mkdir -p ${{targets.destdir}}/etc/chromium
 
-  - uses: strip
-    with:
-      opts: -s
+  #- uses: strip
+    #with:
+      #opts: -s
 
   # Do not strip ChromeDriver
   - working-directory: /home/src/out/Default

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -145,7 +145,7 @@ pipeline:
       repository: https://chromium.googlesource.com/chromium/src.git
       tag: ${{package.version}}
       depth: 1
-      expected-commit: 606aa55c7d687518d34b55accc5a71ea0bd28727
+      expected-commit: 9597ae93a15d4d03089b4e9997b1072228baa9ad
       destination: /home/src
 
   - runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
