### PR TITLE
daemon-check-output: add new case for GemSpecError

### DIFF
--- a/pipelines/test/daemon-check-output.yaml
+++ b/pipelines/test/daemon-check-output.yaml
@@ -40,6 +40,7 @@ inputs:
       Exception in thread
       java.lang.NullPointerException
       java.lang.RuntimeException
+      Gem::MissingSpecError
 
 pipeline:
   - name: "start daemon on localhost"


### PR DESCRIPTION
Add `Gem::MissingSpecError` check to `daemon-check-output`.