### PR TITLE
ruby3.2-fluentd-1.17: add tests and required runtime deps

### DIFF
--- a/ruby3.2-fluentd-1.17.yaml
+++ b/ruby3.2-fluentd-1.17.yaml
@@ -2,16 +2,20 @@ package:
   # fluentd supported versions: https://github.com/fluent/fluentd/blob/master/SECURITY.md
   name: ruby3.2-fluentd-1.17
   version: 1.17.1
-  epoch: 0
+  epoch: 1
   description: Fluentd is an open source data collector designed to scale and simplify log management. It can collect, process and ship many kinds of data in near real-time.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - ruby-3.2
+      - ruby3.2-base64
       - ruby3.2-bundler
       - ruby3.2-cool.io
+      - ruby3.2-csv
+      - ruby3.2-drb
       - ruby3.2-http_parser.rb
+      - ruby3.2-logger
       - ruby3.2-msgpack
       - ruby3.2-serverengine
       - ruby3.2-sigdump
@@ -85,3 +89,14 @@ update:
     identifier: fluent/fluentd
     strip-prefix: v
     tag-filter: v1.17.
+
+test:
+  pipeline:
+    - name: Daemon test
+      uses: test/daemon-check-output
+      with:
+        start: /usr/bin/fluentd
+        setup: |
+          mkdir -p /etc/fluent/
+          touch /etc/fluent/fluent.conf
+        expected_output: "fluentd worker is now running"


### PR DESCRIPTION
Adds test for `ruby3.2-fluentd-1.17` and also some required runtime deps: https://github.com/fluent/fluentd/blob/78a7972bfe6b421f08472701f04f00515ed24bee/fluentd.gemspec#L38-L43