### PR TITLE
chore(mesa): Use git checkout

### DIFF
--- a/mesa.yaml
+++ b/mesa.yaml
@@ -1,7 +1,7 @@
 package:
   name: mesa
   version: 24.2.1
-  epoch: 0
+  epoch: 1
   description: Mesa DRI OpenGL library
   copyright:
     - license: MIT AND SGI-B-2.0 AND BSL-1.0
@@ -56,10 +56,11 @@ environment:
       - zstd-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: fc9a495f3a9af906838be89367564e10ef335e058f88965ad49ccc3e9a3b420b
-      uri: https://mesa.freedesktop.org/archive/mesa-${{package.version}}.tar.xz
+      repository: https://gitlab.freedesktop.org/mesa/mesa
+      tag: mesa-${{package.version}}
+      expected-commit: c222f7299c4cddbaa1958437fbfe27f09b28575d
 
   - runs: |
       export CFLAGS="$CFLAGS -O2 -g1"
@@ -132,11 +133,6 @@ subpackages:
       - uses: split/dev
     description: mesa dev
 
-update:
-  enabled: true
-  release-monitor:
-    identifier: 1970
-
 test:
   environment:
     contents:
@@ -159,3 +155,12 @@ test:
 
         # Compile the glxgears.c source file
         gcc glxgears.c -o glxgears -lGL -lX11 -lXext -lm
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - '_'
+    - '-'
+  git:
+    strip-prefix: mesa-
+    tag-filter-prefix: mesa-


### PR DESCRIPTION
Use git checkout instead of fetching the source tarball for mesa
