### PR TITLE
haproxy-ingress: attempt to unpin again

### DIFF
--- a/haproxy-ingress.yaml
+++ b/haproxy-ingress.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-ingress
   version: 0.14.7
-  epoch: 1
+  epoch: 2
   description: HAProxy Ingress
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - go-1.21
+      - go
       - wolfi-baselayout
 
 pipeline:


### PR DESCRIPTION
Note:
- https://github.com/wolfi-dev/os/pull/17653
- https://github.com/wolfi-dev/os/pull/17649
- https://github.com/jcmoraisjr/haproxy-ingress/releases/tag/v0.14.7
- https://github.com/jcmoraisjr/haproxy-ingress/blob/master/CHANGELOG/CHANGELOG-v0.14.md#v0147
- https://github.com/jcmoraisjr/haproxy-ingress/compare/v0.14.6...v0.14.7

Since previous pin, upstream did bump many dependencies but not the
k8s apis.

go-1.21 is now EOL and thus there is need to rebuild with supported go
version to mediate CVEs in the standard library.

Note upstream published containers are built with EOL go1.19.13.

Used the elastic build published repository `TF_VAR_extra_repositories=["https://apk.cgr.dev/wolfi-presubmit/04322d52041192fdbd66523c814f6659b2dfeeae"]` and both public and private image builds and releases successfully. Previously image release failure has caused the above golang pin pull request, it seems.