### PR TITLE
fix(CVE): Remove pinning of `rexml` in Gemfile as this was introducing CVEs not present in the version of rexml included by default now

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -40,9 +40,9 @@ environment:
       - wget
       - zlib-dev
 
-# https://github.com/javiercri/fluent-plugin-google-cloud/commit/619c813c265d51f4dd0b1cada3a07e615b47cdde
+# https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/commit/53d481a6f417e9d039cae717eab4773ab754738e
 vars:
-  FLUENT_PLUGIN_GOOGLE_CLOUD_COMMIT: "619c813c265d51f4dd0b1cada3a07e615b47cdde"
+  FLUENT_PLUGIN_GOOGLE_CLOUD_COMMIT: "53d481a6f417e9d039cae717eab4773ab754738e"
 
 pipeline:
   - uses: git-checkout
@@ -81,15 +81,13 @@ pipeline:
       mkdir -p ${{targets.destdir}}/etc/fluent/plugin
       mv ./plugins/* ${{targets.destdir}}/etc/fluent/plugin
 
-      # a forked version of fluent-plugin-google-cloud is used to align the fluentd version
-      # cloning here as CI checks fail when using the git-checkout pipeline
       cd ..
-      git clone https://github.com/javiercri/fluent-plugin-google-cloud.git
+      git clone https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud.git
       cd fluent-plugin-google-cloud
       git checkout ${{vars.FLUENT_PLUGIN_GOOGLE_CLOUD_COMMIT}}
 
       # to fix some CVEs in the grpc
-      sed -e "s/'grpc', '1.52.0'/'grpc', '1.53.2'/g" -i fluent-plugin-google-cloud.gemspec
+      sed -e "s/'grpc', '1.53.0'/'grpc', '1.53.2'/g" -i fluent-plugin-google-cloud.gemspec
 
       bundle config set --local path ${GEM_DIR}
       bundle config set --local without 'development test'

--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 14
+  epoch: 15
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -74,8 +74,6 @@ pipeline:
       echo "gem 'activemodel', '7.0.7.2'" >> Gemfile
       # Bump json-jwt to mitigate GHSA-c8v6-786g-vjx6
       echo "gem 'json-jwt', '1.15.3.1'" >> Gemfile
-      # Bump json-jwt to mitigate GHSA-4xqq-m2hx-25v8
-      echo "gem 'rexml', '3.3.3'" >> Gemfile
       # Bump rack to mitigate GHSA-xj5v-6v4g-jfw6
       bundle update rack
       bundle install

--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -86,8 +86,10 @@ pipeline:
       cd fluent-plugin-google-cloud
       git checkout ${{vars.FLUENT_PLUGIN_GOOGLE_CLOUD_COMMIT}}
 
-      # to fix some CVEs in the grpc
-      sed -e "s/'grpc', '1.53.0'/'grpc', '1.53.2'/g" -i fluent-plugin-google-cloud.gemspec
+      # Remediate GHSA-p25m-jpj4-qcrr CVE in the grpc. GHSA-p25m-jpj4-qcrr is fixed in grpc >=1.53.2 but 1.58.3 is
+      # the first version that has precompiled binaries for both x86_64 and aarch64. Compilation issues on aarch64
+      # prompted this change. It will result in faster builds too.
+      sed -e "s/'grpc', '1.53.0'/'grpc', '1.58.3'/g" -i fluent-plugin-google-cloud.gemspec
 
       bundle config set --local path ${GEM_DIR}
       bundle config set --local without 'development test'

--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -91,6 +91,11 @@ pipeline:
       # prompted this change. It will result in faster builds too.
       sed -e "s/'grpc', '1.53.0'/'grpc', '1.58.3'/g" -i fluent-plugin-google-cloud.gemspec
 
+      # Moving to grpc 1.58.3 causes a dependency resolution issue as grpc >= 1.55.0, < 1.59.0 requires
+      # google-protobuf ~> 3.23 but fluent-plugin-google-cloud had pinned google-protobuf to version 3.22.1.
+      # Bumping google-protobuf to 3.23 solves this.
+      sed -e "s/'google-protobuf', '3.22.1'/'google-protobuf', '3.23'/g" -i fluent-plugin-google-cloud.gemspec
+
       bundle config set --local path ${GEM_DIR}
       bundle config set --local without 'development test'
       bundle install


### PR DESCRIPTION
Previous remediation of GHSA-4xqq-m2hx-25v8 introduced a pin of rexml @ 3.3.3. This has since moved on upstream to a newer version which
is no longer vulnerable to GHSA-4xqq-m2hx-25v8.

This pinning removal remediates new CVE GHSA-vmwr-mc7x-5vc3 [1] present in rexml @ 3.3.3

[1] https://github.com/advisories/GHSA-vmwr-mc7x-5vc3

Signed-off-by: philroche <phil.roche@chainguard.dev>
