### PR TITLE
Adding dependencies to thingsboard required during runtime

### DIFF
--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -5,6 +5,9 @@ package:
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - openjdk-17-default-jvm
 
 environment:
   contents:
@@ -13,12 +16,15 @@ environment:
       - busybox
       - ca-certificates-bundle
       - dpkg
+      - fontconfig
       - gnutar
       - jq
+      - lcms2
       - maven
       - nodejs-16
       - openjdk-17
       - openjdk-17-default-jvm
+      - ttf-dejavu
       - xz
       - yarn
 
@@ -80,7 +86,6 @@ subpackages:
     description: Handles MQTT-based device communication and API requests for ThingsBoard.
     dependencies:
       runtime:
-        - openjdk-17
         - openjdk-17-default-jvm
     pipeline:
       - name: Extract tb-mqtt-transport to target directories
@@ -105,9 +110,9 @@ subpackages:
     description: "Core service responsible for handling REST API, WebSocket subscriptions, and processing messages via the rule engine."
     dependencies:
       runtime:
+        - eudev
         - fontconfig
         - lcms2
-        - openjdk-17
         - openjdk-17-default-jvm
         - ttf-dejavu
     pipeline:
@@ -119,6 +124,11 @@ subpackages:
           cp start-tb-node.sh ${{targets.subpkgdir}}/usr/bin
           mkdir -p ${{targets.subpkgdir}}/config
           cp -r ${{targets.subpkgdir}}/usr/share/thingsboard/conf/* ${{targets.subpkgdir}}/config
+
+          # mkdir -p /usr/share/fonts/
+          # fc-cache -fv
+          # mkdir -p ${{targets.subpkgdir}}/usr/share/fonts/
+          # cp -r /usr/share/fonts/ ${{targets.subpkgdir}}/usr/share/
     test:
       pipeline:
         - name: Test server logs
@@ -177,4 +187,3 @@ update:
     identifier: thingsboard/thingsboard
     tag-filter: v
     strip-prefix: v
-

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -105,7 +105,6 @@ subpackages:
     description: "Core service responsible for handling REST API, WebSocket subscriptions, and processing messages via the rule engine."
     dependencies:
       runtime:
-        - eudev
         - fontconfig
         - lcms2
         - openjdk-17
@@ -120,11 +119,6 @@ subpackages:
           cp start-tb-node.sh ${{targets.subpkgdir}}/usr/bin
           mkdir -p ${{targets.subpkgdir}}/config
           cp -r ${{targets.subpkgdir}}/usr/share/thingsboard/conf/* ${{targets.subpkgdir}}/config
-
-          # mkdir -p /usr/share/fonts/
-          # fc-cache -fv
-          # mkdir -p ${{targets.subpkgdir}}/usr/share/fonts/
-          # cp -r /usr/share/fonts/ ${{targets.subpkgdir}}/usr/share/
     test:
       pipeline:
         - name: Test server logs

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -5,9 +5,6 @@ package:
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - openjdk-17-default-jvm
 
 environment:
   contents:

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -121,11 +121,6 @@ subpackages:
           cp start-tb-node.sh ${{targets.subpkgdir}}/usr/bin
           mkdir -p ${{targets.subpkgdir}}/config
           cp -r ${{targets.subpkgdir}}/usr/share/thingsboard/conf/* ${{targets.subpkgdir}}/config
-
-          # mkdir -p /usr/share/fonts/
-          # fc-cache -fv
-          # mkdir -p ${{targets.subpkgdir}}/usr/share/fonts/
-          # cp -r /usr/share/fonts/ ${{targets.subpkgdir}}/usr/share/
     test:
       pipeline:
         - name: Test server logs

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -13,15 +13,12 @@ environment:
       - busybox
       - ca-certificates-bundle
       - dpkg
-      - fontconfig
       - gnutar
       - jq
-      - lcms2
       - maven
       - nodejs-16
       - openjdk-17
       - openjdk-17-default-jvm
-      - ttf-dejavu
       - xz
       - yarn
 

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: thingsboard
   version: 3.7
-  epoch: 0
+  epoch: 1
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0
@@ -12,13 +12,16 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - dpkg # dpkg requires gnutar and xz
+      - dpkg
+      - fontconfig
       - gnutar
       - jq
+      - lcms2
       - maven
       - nodejs-16
       - openjdk-17
       - openjdk-17-default-jvm
+      - ttf-dejavu
       - xz
       - yarn
 
@@ -105,8 +108,12 @@ subpackages:
     description: "Core service responsible for handling REST API, WebSocket subscriptions, and processing messages via the rule engine."
     dependencies:
       runtime:
+        - eudev
+        - fontconfig
+        - lcms2
         - openjdk-17
         - openjdk-17-default-jvm
+        - ttf-dejavu
     pipeline:
       - name: Extract tb-node to target directories
         runs: |
@@ -116,6 +123,11 @@ subpackages:
           cp start-tb-node.sh ${{targets.subpkgdir}}/usr/bin
           mkdir -p ${{targets.subpkgdir}}/config
           cp -r ${{targets.subpkgdir}}/usr/share/thingsboard/conf/* ${{targets.subpkgdir}}/config
+
+          # mkdir -p /usr/share/fonts/
+          # fc-cache -fv
+          # mkdir -p ${{targets.subpkgdir}}/usr/share/fonts/
+          # cp -r /usr/share/fonts/ ${{targets.subpkgdir}}/usr/share/
     test:
       pipeline:
         - name: Test server logs
@@ -174,3 +186,4 @@ update:
     identifier: thingsboard/thingsboard
     tag-filter: v
     strip-prefix: v
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
