### PR TITLE
Fix(logstash): CVE GHSA-vmwr-mc7x-5vc3 remidiation

### DIFF
--- a/logstash.yaml
+++ b/logstash.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash
   version: 8.15.0
-  epoch: 1
+  epoch: 2
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -68,6 +68,7 @@ pipeline:
   - name: Patch sources
     runs: |
       echo "gem 'fugit', '1.11.1'" >> Gemfile.template
+      echo "gem 'rexml', '3.3.6'" >> Gemfile.template
       # Disable the logstash-integration-jdbc plugin download as we build and
       # package it separately
       jq 'del(.["logstash-integration-jdbc"])' rakelib/plugins-metadata.json > /tmp/plugins-metadata.json


### PR DESCRIPTION
CVE GHSA-vmwr-mc7x-5vc3 fix rexml updated to the patched version