### PR TITLE
kyverno-policy-reporter: Update update.github tag filter.

### DIFF
--- a/kyverno-policy-reporter.yaml
+++ b/kyverno-policy-reporter.yaml
@@ -1,6 +1,6 @@
 package:
   name: kyverno-policy-reporter
-  version: 2.20.1
+  version: 2.24.1
   epoch: 0
   description: Monitoring and Observability Tool for the PolicyReport CRD with an optional UI.
   copyright:
@@ -18,7 +18,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/kyverno/policy-reporter
-      tag: v${{package.version}}
+      tag: policy-reporter-${{package.version}}
       expected-commit: 03626fd1986c0d3b0fa62a0942b66a41855d70b3
 
   - uses: go/build
@@ -46,10 +46,12 @@ subpackages:
 update:
   enabled: true
   ignore-regex-patterns:
-    - '-RC*'
-    - 'dev'
+    - "-RC*"
+    - "dev"
+    - "-chart-" # Avoid Helm chart tags
+    - "preview"
   github:
     identifier: kyverno/policy-reporter
     use-tag: true
-    strip-prefix: v
-    tag-filter: v # Avoid Helm chart tags
+    strip-prefix: policy-reporter-
+    tag-filter: policy-reporter


### PR DESCRIPTION
kyverno/policy-reporter is weird in that it has 2 different tagging schemes that use different semver:

```sh
$ git ls-remote https://github.com/kyverno/policy-reporter | grep 03626fd1986c0d3b0fa62a0942b66a41855d70b3
03626fd1986c0d3b0fa62a0942b66a41855d70b3        refs/tags/policy-reporter-2.24.1
03626fd1986c0d3b0fa62a0942b66a41855d70b3        refs/tags/v2.20.1
```

However, the new preview tags seem to be standardizing on the `policy-reporter-.*` convention? This version naming also lines up with the GitHub releases.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/chainguard-dev/image-requests/issues/1838
