### PR TITLE
apk-tools: double check that RSA256 signed repos are usable

### DIFF
--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -62,6 +62,19 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr
           mv "${{targets.destdir}}"/usr/lib "${{targets.subpkgdir}}"/usr/lib
 
+test:
+  environment:
+    contents:
+      packages:
+        - wget
+  pipeline:
+    - name: Verify apk-tools can work with RSA256 signed repositories
+      runs: |
+        wget https://raw.githubusercontent.com/chainguard-dev/apko/71f1961fde53a10c5bd40b80dd4c00a9250dd9f7/pkg/apk/apk/testdata/rsa256-signed/test-rsa256.rsa.pub -O /etc/apk/keys/test-rsa256.rsa.pub
+        mkdir -p packages/aarch64/
+        wget https://raw.githubusercontent.com/chainguard-dev/apko/71f1961fde53a10c5bd40b80dd4c00a9250dd9f7/pkg/apk/apk/testdata/rsa256-signed/APKINDEX.tar.gz -O packages/aarch64/APKINDEX.tar.gz
+        apk --arch aarch64 --repository ./packages/ info --all alpine-baselayout
+
 update:
   enabled: false
   exclude-reason: setting the update to false until the latest apk tools fails for previously built packages


### PR DESCRIPTION
Whilst supported for many years, not actually in use in the
wild. Re-verify that RSA256 signed repos work with apk.

No epoch bump, as it is a test case only.