### PR TITLE
add tests for grafana

### DIFF
--- a/grafana-11.1.yaml
+++ b/grafana-11.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-11.1
   version: 11.1.5
-  epoch: 0
+  epoch: 1
   description: The open and composable observability and data visualization platform.
   copyright:
     - license: AGPL-3.0-or-later
@@ -35,33 +35,29 @@ pipeline:
     with:
       deps: github.com/rs/cors@v1.11.0 google.golang.org/grpc@v1.64.1
 
-  - runs: |
+  - name: Build
+    runs: |
       yarn install
-      yarn run build
-      yarn run plugins:build-bundled
 
-      # Bump the version of wire used, the old version panics with new Go
-      # https://github.com/google/wire/issues/400
-      # sed -i "s/v0.5.0/v0.6.0/g" .bingo/wire.mod
-
+      # Builds frontend and backend (build-go build-js)
       make build
-
-      mkdir -p ${{targets.destdir}}/usr/bin
-      mv ./bin/linux-*/* ${{targets.destdir}}/usr/bin/
 
   - name: package
     runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/usr/share/grafana
+      mkdir -p ${{targets.destdir}}/etc/grafana
+
+      cp bin/linux-*/* ${{targets.destdir}}/usr/bin/
+      cp -r conf public ${{targets.destdir}}/usr/share/grafana/
+      cp -r plugins-bundled ${{targets.destdir}}/usr/share/grafana/
+
       mkdir -p ${{targets.destdir}}/usr/share/grafana/plugins-bundled
       mkdir -p ${{targets.destdir}}/usr/share/grafana/scripts
       mkdir -p ${{targets.destdir}}/usr/share/grafana/bin
 
-      mv ./conf ${{targets.destdir}}/usr/share/grafana/
-      # mv ./plugins-bundled/internal ${{targets.destdir}}/usr/share/grafana/plugins-bundled/
-      mv ./public ${{targets.destdir}}/usr/share/grafana/
-      mv ./scripts/*.sh ${{targets.destdir}}/usr/share/grafana/scripts/
-
-      mkdir -p ${{targets.destdir}}/etc/grafana/
-      cp ${{targets.destdir}}/usr/share/grafana/conf/sample.ini ${{targets.destdir}}/etc/grafana/grafana.ini
+      cp conf/sample.ini ${{targets.destdir}}/etc/grafana/grafana.ini
+      cp conf/sample.ini ${{targets.destdir}}/etc/grafana/grafana.ini.example
 
 subpackages:
   - name: grafana-oci-compat
@@ -76,3 +72,48 @@ update:
     identifier: grafana/grafana
     strip-prefix: v
     tag-filter-prefix: v11.1.
+
+test:
+  environment:
+    contents:
+      packages:
+        - bash
+        - curl
+        - jq
+        - procps
+        - shadow
+  pipeline:
+    - name: "Check Grafana version"
+      runs: |
+        grafana -v
+    - name: "Check Grafana CLI version"
+      runs: |
+        grafana-cli -v
+    - name: "Check Grafana server version"
+      runs: |
+        grafana-server -v
+    - name: "Test Grafana server startup"
+      uses: test/daemon-check-output
+      with:
+        start: |
+          grafana-server \
+            --config /etc/grafana/grafana.ini \
+            --homepath /usr/share/grafana \
+            --packaging=wolfi
+        timeout: 60
+        expected_output: |
+          Starting Grafana
+          HTTP Server Listen
+        setup: |
+          mkdir -p /var/lib/grafana
+          chown -R root:root /var/lib/grafana
+        post: |
+          curl -s http://localhost:3000/api/health
+          curl -s http://localhost:3000/api/org
+          curl -s http://localhost:3000/api/dashboards/home
+    - name: "Check configuration file"
+      runs: |
+        grep -q "app_mode = production" /etc/grafana/grafana.ini
+    - name: "Test Grafana CLI commands"
+      runs: |
+        grafana-cli plugins list-remote

--- a/grafana-11.2.yaml
+++ b/grafana-11.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-11.2
   version: 11.2.0
-  epoch: 0
+  epoch: 1
   description: The open and composable observability and data visualization platform.
   copyright:
     - license: AGPL-3.0-or-later
@@ -23,6 +23,7 @@ environment:
       - py3-setuptools
       - python3
       - yarn
+      - zlib-dev
 
 pipeline:
   - uses: git-checkout
@@ -35,33 +36,29 @@ pipeline:
     with:
       deps: github.com/rs/cors@v1.11.0
 
-  - runs: |
+  - name: Build
+    runs: |
       yarn install
-      yarn run build
-      yarn run plugins:build-bundled
 
-      # Bump the version of wire used, the old version panics with new Go
-      # https://github.com/google/wire/issues/400
-      # sed -i "s/v0.5.0/v0.6.0/g" .bingo/wire.mod
-
+      # Builds frontend and backend (build-go build-js)
       make build
-
-      mkdir -p ${{targets.destdir}}/usr/bin
-      mv ./bin/linux-*/* ${{targets.destdir}}/usr/bin/
 
   - name: package
     runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mkdir -p ${{targets.destdir}}/usr/share/grafana
+      mkdir -p ${{targets.destdir}}/etc/grafana
+
+      cp bin/linux-*/* ${{targets.destdir}}/usr/bin/
+      cp -r conf public ${{targets.destdir}}/usr/share/grafana/
+      cp -r plugins-bundled ${{targets.destdir}}/usr/share/grafana/
+
       mkdir -p ${{targets.destdir}}/usr/share/grafana/plugins-bundled
       mkdir -p ${{targets.destdir}}/usr/share/grafana/scripts
       mkdir -p ${{targets.destdir}}/usr/share/grafana/bin
 
-      mv ./conf ${{targets.destdir}}/usr/share/grafana/
-      # mv ./plugins-bundled/internal ${{targets.destdir}}/usr/share/grafana/plugins-bundled/
-      mv ./public ${{targets.destdir}}/usr/share/grafana/
-      mv ./scripts/*.sh ${{targets.destdir}}/usr/share/grafana/scripts/
-
-      mkdir -p ${{targets.destdir}}/etc/grafana/
-      cp ${{targets.destdir}}/usr/share/grafana/conf/sample.ini ${{targets.destdir}}/etc/grafana/grafana.ini
+      cp conf/sample.ini ${{targets.destdir}}/etc/grafana/grafana.ini
+      cp conf/sample.ini ${{targets.destdir}}/etc/grafana/grafana.ini.example
 
 subpackages:
   - name: grafana-oci-compat
@@ -76,3 +73,48 @@ update:
     identifier: grafana/grafana
     strip-prefix: v
     tag-filter-prefix: v11.2.
+
+test:
+  environment:
+    contents:
+      packages:
+        - bash
+        - curl
+        - jq
+        - procps
+        - shadow
+  pipeline:
+    - name: "Check Grafana version"
+      runs: |
+        grafana -v
+    - name: "Check Grafana CLI version"
+      runs: |
+        grafana-cli -v
+    - name: "Check Grafana server version"
+      runs: |
+        grafana-server -v
+    - name: "Test Grafana server startup"
+      uses: test/daemon-check-output
+      with:
+        start: |
+          grafana-server \
+            --config /etc/grafana/grafana.ini \
+            --homepath /usr/share/grafana \
+            --packaging=wolfi
+        timeout: 60
+        expected_output: |
+          Starting Grafana
+          HTTP Server Listen
+        setup: |
+          mkdir -p /var/lib/grafana
+          chown -R root:root /var/lib/grafana
+        post: |
+          curl -s http://localhost:3000/api/health
+          curl -s http://localhost:3000/api/org
+          curl -s http://localhost:3000/api/dashboards/home
+    - name: "Check configuration file"
+      runs: |
+        grep -q "app_mode = production" /etc/grafana/grafana.ini
+    - name: "Test Grafana CLI commands"
+      runs: |
+        grafana-cli plugins list-remote


### PR DESCRIPTION
adds tests for grafana

also moves around our packaging a bit to match other managers (`homebrew`: https://github.com/Homebrew/homebrew-core/blob/250e7f2925a7e60a58f18488be15043494ead877/Formula/g/grafana.rb)

#13623 