### PR TITLE
add kserve-rest-proxy package

### DIFF
--- a/kserve-rest-proxy.yaml
+++ b/kserve-rest-proxy.yaml
@@ -6,10 +6,6 @@ package:
   copyright:
     - license: Apache-2.0
 
-environment:
-  contents:
-    packages:
-      - go
 
 pipeline:
   - uses: git-checkout

--- a/kserve-rest-proxy.yaml
+++ b/kserve-rest-proxy.yaml
@@ -6,7 +6,6 @@ package:
   copyright:
     - license: Apache-2.0
 
-
 pipeline:
   - uses: git-checkout
     with:

--- a/kserve-rest-proxy.yaml
+++ b/kserve-rest-proxy.yaml
@@ -21,9 +21,6 @@ pipeline:
 
 test:
   environment:
-    contents:
-      packages:
-        - curl
     environment:
       REST_PROXY_GRPC_PORT: 21700
   pipeline:

--- a/kserve-rest-proxy.yaml
+++ b/kserve-rest-proxy.yaml
@@ -1,0 +1,48 @@
+package:
+  name: kserve-rest-proxy
+  version: 0.12.0
+  epoch: 0
+  description: "REST API proxy for kserve, the standardized serverless ML inference platform on Kubernetes"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kserve/rest-proxy
+      tag: v${{package.version}}
+      expected-commit: c5a4f74b894506b058469eadcbf17ea456145ff9
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./proxy
+      output: rest-proxy
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+    environment:
+      REST_PROXY_GRPC_PORT: 21700
+  pipeline:
+    - uses: test/daemon-check-output
+      with:
+        start: |
+          rest-proxy
+        timeout: 60
+        expected_output: |
+          Not using TLS
+          Registering gRPC Inference Service Handler
+
+update:
+  enabled: true
+  github:
+    identifier: kserve/rest-proxy
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
