### PR TITLE
kserve - add kserve-storage-controller, run strip

### DIFF
--- a/kserve.yaml
+++ b/kserve.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve
   version: 0.13.1
-  epoch: 1
+  epoch: 2
   description: "Standardized Serverless ML Inference Platform on Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -10,6 +10,8 @@ environment:
   contents:
     packages:
       - go
+      - py3.11-pip
+      - python-3.11-dev
 
 pipeline:
   - uses: git-checkout
@@ -55,6 +57,59 @@ subpackages:
         - name: "check paths"
           runs: |
             [ -x /ko-app/${{range.key}} -a -f /ko-app/${{range.key}} ]
+
+  - name: kserve-storage-controller
+    options:
+      no-commands: true
+    pipeline:
+      - working-directory: ./python
+        runs: |
+          python=$(which python3.11)
+
+          (
+            set -x
+            cd kserve
+
+            # get poetry - until poetry is multi-versioned, just install from pip
+            workd=$(mktemp -d)
+            $python -m venv "$workd"
+            $workd/bin/pip install poetry
+
+            $workd/bin/poetry build
+
+            wheel=$(echo dist/*.whl)
+            [ -f "$wheel" ] || { echo "not exactly one wheel: $wheel"; exit 1; }
+
+            # just let pip handle deps for now.
+            $python -m pip install --verbose --prefix=/usr "--root=${{targets.contextdir}}" \
+               "$wheel[storage]"
+
+            rm -Rf "$workd"
+          )
+
+          (
+            d=${{targets.contextdir}}/storage-initializer/scripts/
+            mkdir -p "$d"
+            cp storage-initializer/scripts/initializer-entrypoint "$d"
+            cd "$d"
+            chmod 755 initializer-entrypoint
+
+            # update shbang to point to the python used rather than '/usr/bin/env python'
+            sed -i.dist "1s,#!/usr/bin/env python[^ ]*,#!$python," initializer-entrypoint
+            # exit fail if it did not change anything
+            diff -u initializer-entrypoint.dist initializer-entrypoint && exit 1
+            rm initializer-entrypoint.dist
+          )
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - busybox
+      pipeline:
+        - name: "test entrypoint usage"
+          runs: |
+            /storage-initializer/scripts/initializer-entrypoint --help
 
 update:
   enabled: true


### PR DESCRIPTION
based on
  https://github.com/kserve/kserve/blob/master/python/storage-initializer.Dockerfile

Some notes:
1. storage-initializer says it is <3.12, so we're using 3.11 here.

2. we do not have python3.11 poetry, so a. let 'python3.11 -m pip' install poetry b. let that poetry to build a wheel c. install that wheel with 'python3.11 -m pip'

3. This _does_ use pip to install into the system path.  There are lots of deps we already have that we could use, but for now let pip do it.
