### PR TITLE
Bump py3-psutil to 6.0.0, fix update section.

### DIFF
--- a/py3-psutil.yaml
+++ b/py3-psutil.yaml
@@ -1,16 +1,12 @@
 package:
   name: py3-psutil
-  version: 5.9.5
-  epoch: 3
+  version: 6.0.0
+  epoch: 0
   description: Cross-platform lib for process and system monitoring in Python.
   copyright:
     - license: BSD-3-Clause
   dependencies:
     provider-priority: 0
-    runtime:
-      - linux-headers
-      - python3
-      - python3-dev
 
 vars:
   pypi-package: psutil
@@ -37,7 +33,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/giampaolo/psutil
-      expected-commit: 0d4900b073f8697ab21c47d823621bea61f39a3b
+      expected-commit: 3d5522aafb6c9cbcbcf4edfa11348f755af97d96
       tag: release-${{package.version}}
 
 subpackages:
@@ -55,7 +51,10 @@ subpackages:
       - uses: strip
     test:
       pipeline:
-        - runs: python${{range.key}} -c "import psutil"
+        - uses: python/import
+          with:
+            imports: |
+              import ${{vars.pypi-package}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -70,13 +69,4 @@ update:
   github:
     identifier: giampaolo/psutil
     strip-prefix: release-
-
-test:
-  environment:
-    contents:
-      packages:
-        - python3
-  pipeline:
-    - uses: python/import
-      with:
-        import: psutil
+    use-tag: true


### PR DESCRIPTION
Update section didn't have 'use-tag' so we weren't getting updates. Fix that and bump to current version.
