### PR TITLE
gcc: enable zstd compression support for LTO metadata

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 14.2.0
-  epoch: 2
+  epoch: 3
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -21,6 +21,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - file
       - flex-dev
       - gawk
       - gmp-dev
@@ -32,6 +33,7 @@ environment:
       - texinfo
       - wolfi-baselayout
       - zlib-dev
+      - zstd-dev
 
 var-transforms:
   - from: ${{package.version}}


### PR DESCRIPTION
Currently gcc build only supports zlib, with this change zstd is also
supported as typically produced by toolchains from other vendors.

This enables feature parity, and ability to reuse foreign libraries
with LTO information.

    $ gcc --version --verbose 2>&1 | grep 'Supported LTO'
    Supported LTO compression algorithms: zlib zstd
