### PR TITLE
Fix hardcoded versions in subpackage names

### DIFF
--- a/istio-cni-1.23.yaml
+++ b/istio-cni-1.23.yaml
@@ -1,13 +1,19 @@
 package:
   name: istio-cni-1.23
   version: 1.23.0
-  epoch: 1
+  epoch: 2
   description: Istio Container Network Interface
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
       - istio-cni=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
 
 environment:
   contents:
@@ -43,7 +49,7 @@ subpackages:
       provides:
         - istio-cni-compat=${{package.full-version}}
 
-  - name: istio-install-cni-1.22
+  - name: istio-install-cni-${{vars.major-minor-version}}
     pipeline:
       - uses: go/build
         with:
@@ -54,7 +60,7 @@ subpackages:
       provides:
         - istio-install-cni=${{package.full-version}}
 
-  - name: istio-install-cni-1.22-compat
+  - name: istio-install-cni-${{vars.major-minor-version}}-compat
     pipeline:
       - runs: |
           # See https://github.com/istio/istio/blob/1.20.0/cni/deployments/kubernetes/Dockerfile.install-cni


### PR DESCRIPTION
Some of the subpackages had hardcoded versions in them. As a result when our automation re-creates new packages for later versions, these were not getting updated.

We also had an image failure which was failing, as it was unable to find a v1.23 version of this subpackage