### PR TITLE
install the libgcrypt-config binary in libgcrypt-dev and add some tests

### DIFF
--- a/libgcrypt.yaml
+++ b/libgcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgcrypt
   version: 1.11.0
-  epoch: 0
+  epoch: 1
   description: General purpose crypto library based on the code used in GnuPG
   copyright:
     - license: LGPL-2.1-or-later
@@ -43,6 +43,9 @@ subpackages:
   - name: libgcrypt-dev
     pipeline:
       - uses: split/dev
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin/
+          cp -f ./src/libgcrypt-config "${{targets.subpkgdir}}"/usr/bin/
     dependencies:
       runtime:
         - libgcrypt
@@ -58,3 +61,15 @@ update:
   enabled: true
   release-monitor:
     identifier: 1623
+
+test:
+  environment:
+    contents:
+      packages:
+        - pkgconf
+        - libgcrypt
+        - libgcrypt-dev
+  pipeline:
+    - runs: |
+        pkg-config --libs libgcrypt | grep /usr/lib
+        libgcrypt-config --version


### PR DESCRIPTION
The rsyslog build depends on the libgcrypt-config binary which we build, but don't actually install in /usr/bin/.  Let's fix this.  Also, let's add some tests while we're at it.