### PR TITLE
libevent: ensure static library is compiled with PIC

### DIFF
--- a/libevent.yaml
+++ b/libevent.yaml
@@ -1,7 +1,7 @@
 package:
   name: libevent
   version: 2.1.12
-  epoch: 5
+  epoch: 6
   description: An event notification library
   copyright:
     - license: BSD-3-Clause
@@ -15,6 +15,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - libtool
+      - openssf-compiler-options
       - openssl-dev
       - python3-dev
 
@@ -34,6 +35,8 @@ pipeline:
       sed -i -e "s/@VERSION@/${{package.version}}-r${{package.epoch}}/" *.pc.in
 
   - uses: autoconf/configure
+    with:
+      opts: --with-pic
 
   - uses: autoconf/make
 


### PR DESCRIPTION
- **libevent: ensure static library is compiled with PIC**
  Currently libevent-static is not usable to link into shared libraries,
  as objects included in the static library were compiled without PIC.
  
  This resolve compatibility with other distributions, and open source
  software that sometimes expects to have ability to link static
  libevent library into a shared library, as seen by some NVIDIA
  releases software.
  