### PR TITLE
add kubernetes-sigs/descheduler package

### DIFF
--- a/descheduler.yaml
+++ b/descheduler.yaml
@@ -1,0 +1,42 @@
+package:
+  name: descheduler
+  version: 0.30.1
+  epoch: 0
+  description: Descheduler for Kubernetes
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-sigs/descheduler
+      tag: v${{package.version}}
+      expected-commit: 9f7e7fd5bb64989f5188eb42152370602c1c9eda
+
+  - uses: go/build
+    with:
+      packages: ./cmd/descheduler
+      ldflags: |
+        -s -w
+        -X sigs.k8s.io/descheduler/pkg/version.version=${{package.version}}
+        -X sigs.k8s.io/descheduler/pkg/version.gitsha1=$(git rev-parse HEAD)
+        -X sigs.k8s.io/descheduler/pkg/version.buildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        -X sigs.k8s.io/descheduler/pkg/version.gitbranch=$(git rev-parse --abbrev-ref HEAD)
+      output: descheduler
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/descheduler
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        descheduler version

--- a/descheduler.yaml
+++ b/descheduler.yaml
@@ -6,10 +6,6 @@ package:
   copyright:
     - license: Apache-2.0
 
-environment:
-  environment:
-    CGO_ENABLED: "0"
-
 pipeline:
   - uses: git-checkout
     with:
@@ -21,14 +17,11 @@ pipeline:
     with:
       packages: ./cmd/descheduler
       ldflags: |
-        -s -w
         -X sigs.k8s.io/descheduler/pkg/version.version=${{package.version}}
         -X sigs.k8s.io/descheduler/pkg/version.gitsha1=$(git rev-parse HEAD)
         -X sigs.k8s.io/descheduler/pkg/version.buildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
         -X sigs.k8s.io/descheduler/pkg/version.gitbranch=$(git rev-parse --abbrev-ref HEAD)
       output: descheduler
-
-  - uses: strip
 
 update:
   enabled: true


### PR DESCRIPTION
this commit adds kubernetes-sigs/descheduler package

```bash
[sdk] ❯ make test/descheduler
# truncated output
2024/09/05 11:33:31 WARN + '[' -d /home/build ]
2024/09/05 11:33:31 WARN + cd /home/build
2024/09/05 11:33:31 WARN + descheduler version
2024/09/05 11:33:31 INFO Descheduler version {Major: Minor: GitVersion:0.30.1 GitBranch:HEAD GitSha1:9f7e7fd5bb64989f5188eb42152370602c1c9eda BuildDate:2024-09-05T11:32:28Z GoVersion:go1.23.0 Compiler:gc Platform:linux/arm64}
2024/09/05 11:33:31 WARN + exit 0
[sdk] ❯ wolfictl scan ./packages/aarch64/descheduler-0.30.1-r0.apk
🔎 Scanning "./packages/aarch64/descheduler-0.30.1-r0.apk"
✅ No vulnerabilities found
```

Fixes:

Related:

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
