### PR TITLE
py3-virtualenv - Remove embedded wheels supporting python3.7

### DIFF
--- a/py3-virtualenv.yaml
+++ b/py3-virtualenv.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-virtualenv
   version: 20.26.3
-  epoch: 1
+  epoch: 2
   description: Virtual Python Environment builder
   copyright:
     - license: "MIT"
@@ -50,6 +50,14 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+      - name: Remove embedded setuptools wheel for python3.7 (CVE-2024-6345)
+        runs: |
+          # https://github.com/pypa/virtualenv/issues/2758
+          cd ${{targets.contextdir}}/usr/lib/python${{range.key}}/site-packages/virtualenv/seed/wheels/embed/
+          rm -v \
+            pip-24.0-py3-none-any.whl \
+            setuptools-68.0.0-py3-none-any.whl \
+            wheel-0.42.0-py3-none-any.whl
       - uses: strip
     test:
       pipeline:


### PR DESCRIPTION
These wheels are from python 3.7.

This will stop scanner from reporting CVE-2024-634
and save 3MB of space.

See also https://github.com/pypa/virtualenv/issues/2758
