### PR TITLE
kserve - Bump python dependencies to address CVE.

### DIFF
--- a/kserve.yaml
+++ b/kserve.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve
   version: 0.13.1
-  epoch: 2
+  epoch: 3
   description: "Standardized Serverless ML Inference Platform on Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -75,6 +75,22 @@ subpackages:
             $python -m venv "$workd"
             $workd/bin/pip install poetry
 
+            # PATCH_RAY: patch ray to address its embedded thirdparty_files
+            #  aiohttp CVE-2024-30251, CVE-2024-27306, CVE-2024-42367
+            #  idna CVE-2024-3651
+            #
+            # error if new version does not have 2.10.0, so we do not pin
+            # current version is 2.35
+            $workd/bin/poetry show ray >/tmp/out
+            ver=$(awk '$1 == "version" { print $3 }' /tmp/out)
+            case "$ver" in
+              2.10.*) :;;
+              *) echo "FAIL: Found ray at version '$ver', expected 2.10.*,"
+                 echo "FAIL: update or drop PATCH_RAY section"
+                 exit 1;;
+            esac
+            $workd/bin/poetry add ray~2.35 --extras=serve --lock
+
             $workd/bin/poetry build
 
             wheel=$(echo dist/*.whl)
@@ -85,6 +101,15 @@ subpackages:
                "$wheel[storage]"
 
             rm -Rf "$workd"
+          )
+
+          # CVE-2024-6345 - see duplicate code in py3-virtualenv.yaml
+          ( cd "${{targets.contextdir}}" &&
+            cd usr/lib/python*/site-packages/virtualenv/seed/wheels/embed &&
+            rm -v \
+               setuptools-68.0.0-py3-none-any.whl \
+               pip-24.0-py3-none-any.whl \
+               wheel-0.42.0-py3-none-any.whl
           )
 
           (


### PR DESCRIPTION
This is really ugly, but we do not have any pretty mechanism for it.

2 things.

1. bump the requirement on ray from 2.10.0 to 2.35 (latest) ray's git log lists the last breaking change at 2.0.9, so ... maybe this is safe.

   Be careful not to keep doing this when upstream bumps.

2. Remove embedded wheels from virtualenv dependency.
