### PR TITLE
unzip: fix build by building with linux_noasm

### DIFF
--- a/unzip.yaml
+++ b/unzip.yaml
@@ -1,7 +1,7 @@
 package:
   name: unzip
   version: 6.0
-  epoch: 0
+  epoch: 1
   description: Extract PKZIP-compatible .zip files
   copyright:
     - license: Info-ZIP
@@ -12,6 +12,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - openssf-compiler-options
 
 pipeline:
   - uses: fetch
@@ -19,7 +20,7 @@ pipeline:
       expected-sha256: 036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37
       uri: https://sourceforge.net/projects/infozip/files/UnZip%206.x%20%28latest%29/UnZip%20${{package.version}}/unzip60.tar.gz/download
 
-  - runs: make -f unix/Makefile LOCAL_UNZIP="$CFLAGS $CPPFLAGS -DNO_LCHMOD" prefix=/usr generic
+  - runs: make -f unix/Makefile LOCAL_UNZIP="$CFLAGS $CPPFLAGS -DNO_LCHMOD" prefix=/usr linux_noasm
 
   - runs: make -f unix/Makefile prefix=${{targets.destdir}}/usr MANDIR=${{targets.destdir}}/usr/share/man install
 


### PR DESCRIPTION
The generic targets adds -DNO_DIR and we do in fact have the headers for DIR. Building just for linux pulls in some i386 asm code and the instructions say for non intel platforms use no_asm.  In the future we should look into using a custom set of flags and importing other distros fixes.

Fixes: https://github.com/wolfi-dev/os/issues/26522

