### PR TITLE
vulkan-headers: Update build to use Ninja generator

### DIFF
--- a/vulkan-headers.yaml
+++ b/vulkan-headers.yaml
@@ -1,7 +1,7 @@
 package:
   name: vulkan-headers
-  version: 1.3.292
-  epoch: 1
+  version: 1.3.295
+  epoch: 0
   description: Vulkan header files and API registry
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: https://github.com/KhronosGroup/Vulkan-Headers
       tag: v${{package.version}}
-      expected-commit: 595c8d4794410a4e64b98dc58d27c0310d7ea2fd
+      expected-commit: c6391a7b8cd57e79ce6b6c832c8e3043c4d9967b
 
   - runs: |
       cmake -G Ninja -B build \

--- a/vulkan-headers.yaml
+++ b/vulkan-headers.yaml
@@ -1,7 +1,7 @@
 package:
   name: vulkan-headers
   version: 1.3.292
-  epoch: 0
+  epoch: 1
   description: Vulkan header files and API registry
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
-      - samurai
+      - ninja-build # samurai doesn't provide a new enough version
 
 pipeline:
   - uses: git-checkout
@@ -23,14 +23,14 @@ pipeline:
       expected-commit: 595c8d4794410a4e64b98dc58d27c0310d7ea2fd
 
   - runs: |
-      cmake -B build \
+      cmake -G Ninja -B build \
+       -DCMAKE_MAKE_PROGRAM="/usr/lib/ninja-build/bin/ninja" \
         -DCMAKE_BUILD_TYPE=None \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INSTALL_LIBDIR=lib
-      make -C build
 
   - runs: |
-      DESTDIR="${{targets.destdir}}" cmake --install build
+      DESTDIR="${{targets.destdir}}" cmake  --install build
 
   - uses: strip
 


### PR DESCRIPTION
The Makefile generator can't handle C++20 modules. To use the Ninja generator with modules we need ninja 1.11 or later which samurai doesn't provide. So instead we swap to using the Ninja generator with the ninja-build packages.


Fixes: https://github.com/wolfi-dev/os/issues/26522

