### PR TITLE
add descheduler-compat subpackage

### DIFF
--- a/descheduler.yaml
+++ b/descheduler.yaml
@@ -1,7 +1,7 @@
 package:
   name: descheduler
   version: 0.30.1
-  epoch: 0
+  epoch: 1
   description: Descheduler for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,14 @@ pipeline:
         -X sigs.k8s.io/descheduler/pkg/version.buildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
         -X sigs.k8s.io/descheduler/pkg/version.gitbranch=$(git rev-parse --abbrev-ref HEAD)
       output: descheduler
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/bin/
+          ln -sf /usr/bin/descheduler ${{targets.contextdir}}/bin/descheduler
 
 update:
   enabled: true


### PR DESCRIPTION
upstream helm chart expect binary at /bin/descheduler

ref: 
- https://github.com/kubernetes-sigs/descheduler/blob/0f1890e5cd2782c580951b20b04f40a5ed0f6642/charts/descheduler/values.yaml#L78-L79
- https://github.com/kubernetes-sigs/descheduler/blob/0f1890e5cd2782c580951b20b04f40a5ed0f6642/Dockerfile#L32