### PR TITLE
Add kserve-modelmesh-serving-compat

### DIFF
--- a/kserve-modelmesh-serving.yaml
+++ b/kserve-modelmesh-serving.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve-modelmesh-serving
   version: 0.12.0
-  epoch: 0
+  epoch: 1
   description: ModelMesh Serving is the Controller for managing ModelMesh, a general-purpose model serving management/routing layer.
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,16 @@ pipeline:
     runs: |
       mkdir -p ${{targets.destdir}}/etc/model-serving/config/default
       cp ./config/default/config-defaults.yaml ${{targets.destdir}}/etc/model-serving/config/default/config-defaults.yaml
+
+subpackages:
+  - name: kserve-modelmesh-serving-compat
+    description: compatibility symlinks package for modelmesh-controller Deployment
+    pipeline:
+      - runs: |
+          # Symlink the binary from /usr/bin to /
+          # See https://github.com/kserve/modelmesh-serving/blob/f8cc7aa73f6a9360d7635ca5e5c3461d0c60b392/config/manager/manager.yaml#L44
+          mkdir -p ${{targets.subpkgdir}}
+          ln -sf /usr/bin/manager ${{targets.subpkgdir}}/manager
 
 test:
   environment:


### PR DESCRIPTION
Adds symlink for manager binary in root directory.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->


Related: https://github.com/chainguard-dev/image-requests/issues/3818
