### PR TITLE
heimdal - fix FTBFS with gcc~13, add openssf-compiler-options.

### DIFF
--- a/heimdal.yaml
+++ b/heimdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: heimdal
   version: 7.8.0
-  epoch: 4
+  epoch: 5
   description: "Implementation of Kerberos 5"
   copyright:
     - license: BSD-3-Clause
@@ -16,6 +16,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - gawk
+      - gcc~13
       - gdbm-dev
       - libtool
       - ncurses-dev
@@ -36,10 +37,9 @@ pipeline:
     with:
       patches: CVE-2022-45142.patch
 
-  - runs: |
-      ./configure \
-        --build=$CBUILD \
-        --host=$CHOST \
+  - uses: autoconf/configure
+    with:
+      opts: |
         --prefix=/usr \
         --enable-shared=yes \
         --without-x \


### PR DESCRIPTION
package does not build with gcc-14.
So build with gcc~13.
Then, while we're there
 * convert configure to 'uses: autoconf/configure' and drop the use of the unset env variable CBUILD and CHOST.
 * add openssf-compiler-options