### PR TITLE
fix: resolve dependency issues with build and remdediate grpc CVE GHSA-xr7q-jx4m-x55m

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -68,6 +68,9 @@ pipeline:
       go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.54.0
 
       go mod tidy
+  - uses: go/bump
+    with:
+      deps: google.golang.org/grpc@v1.65.0
   - runs: |
       # Override the go version check at runtime to always match the go version at build time
       # Ref: https://github.com/k3s-io/k3s/pull/9054

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -64,31 +64,8 @@ pipeline:
       ./scripts/download
 
       # CVE-2023-47108
-      go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/otlpmetric
-      go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc
-      go mod edit -dropreplace=go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
-      go mod edit -dropreplace=go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful
       go mod edit -dropreplace=go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
-      go mod edit -dropreplace=go.opentelemetry.io/otel
-      go mod edit -dropreplace=go.opentelemetry.io/otel/sdk
-      go mod edit -dropreplace=go.opentelemetry.io/otel/trace
-      go mod edit -dropreplace=go.opentelemetry.io/proto/otlp
-      go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
-      go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/otlptrace
-      go mod edit -dropreplace=go.opentelemetry.io/otel/metric
-      go mod edit -dropreplace=go.opentelemetry.io/otel/exporters/otlp/internal/retry
-
-      go get go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful@v0.46.1
-      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.1
-      go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.46.1
-      go get go.opentelemetry.io/otel@v1.21.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@v0.44.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.21.0
-      go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.21.0
-      go get go.opentelemetry.io/otel/metric@v1.21.0
-      go get go.opentelemetry.io/otel/sdk@v1.21.0
-      go get go.opentelemetry.io/otel/trace@v1.21.0
-      go get go.opentelemetry.io/proto/otlp@v1.0.0
+      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.54.0
 
       go mod tidy
   - runs: |


### PR DESCRIPTION
- **fix(CVE): K3S - Continue to remediate CVE GHSA-8pgv-569h-w5rw/CVE-2023-47108 but with reduced dependency changes**
- **fix(CVE): K3S - Remediate grpc CVE GHSA-xr7q-jx4m-x55m using gobump**
