### PR TITLE
loki-3 - fix ftbfs with go-1.23

### DIFF
--- a/loki-3.yaml
+++ b/loki-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: loki-3
   version: 3.1.1
-  epoch: 1
+  epoch: 2
   description: Like Prometheus, but for logs.
   copyright:
     - license: AGPL-3.0-or-later
@@ -29,6 +29,12 @@ pipeline:
       deps: github.com/docker/docker@v26.1.5
       replaces: go.etcd.io/bbolt=go.etcd.io/bbolt@v1.3.6
       show-diff: true
+
+  # fix compilation with go-1.23
+  # https://github.com/grafana/pyroscope-go/releases/tag/godeltaprof%2Fv0.1.8
+  - uses: go/bump
+    with:
+      deps: github.com/grafana/pyroscope-go/godeltaprof@v0.1.8
 
   - uses: autoconf/make
 


### PR DESCRIPTION
I'm interested in what @xnox feels about this. Move forward to go-1.23  with go-bump  of a [dep](https://github.com/grafana/pyroscope-go/releases/tag/godeltaprof%2Fv0.1.8 ) versus just changing 'go' go 'go-1.22'.