### PR TITLE
CargoBump ::: feat: add cargobump pipeline for rust

### DIFF
--- a/cargobump.yaml
+++ b/cargobump.yaml
@@ -1,0 +1,33 @@
+package:
+  name: cargobump
+  version: 0.0.1
+  epoch: 0
+  description: Rust tool to declaratively bump dependencies using cargo
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/chainguard-dev/cargobump.git
+      tag: v${{package.version}}
+      expected-commit: d51d6682138403b68f6a8464ffb1b5fa83e90544
+
+  - uses: go/build
+    with:
+      packages: .
+      output: cargobump
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: chainguard-dev/cargobump
+    strip-prefix: v
+    use-tag: true
+
+test:
+  pipeline:
+    - runs: |
+        cargobump version

--- a/pipelines/rust/cargobump.yaml
+++ b/pipelines/rust/cargobump.yaml
@@ -1,0 +1,35 @@
+name: Bump rust deps to a certain version
+
+# Leave go off here, some packages pin to an older version. Let's just assume this gets injected elsewhere.
+needs:
+  packages:
+    - git
+    - cargobump
+
+inputs:
+  cargoroot:
+    description: The root of the cargo lock file
+    default: .
+  bump-file:
+    description: |
+      Patches file to use for updating the Cargo lock file
+    default: ./cargobump-deps.yaml
+  packages:
+    description: |
+      Packages to be used for updating the Cargo lock file via command line flag    
+
+pipeline:
+  - runs: |
+      set -x
+      cd "${{inputs.cargoroot}}"
+      
+      BUMP_FILE_FLAG=""
+      PACKAGES_FLAG=""
+
+      if [ -n "${{inputs.packages}}" ]; then
+        PACKAGES_FLAG="--packages ${{inputs.packages}}"
+      elif [ -f "${{inputs.bump-file}}" ]; then
+        BUMP_FILE_FLAG="--bump-file ${{inputs.bump-file}}"
+      fi
+
+      cargobump $PACKAGES_FLAG $BUMP_FILE_FLAG

--- a/pulumi-watch.yaml
+++ b/pulumi-watch.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-watch
   version: 0.1.5
-  epoch: 5
+  epoch: 6
   description: Supports the functionality of the pulumi watch command
   copyright:
     - license: Apache-2.0
@@ -25,14 +25,12 @@ pipeline:
       expected-commit: bae2913e89662fbd0bf3264cb2985ea6b6c73c59
 
   - working-directory: ${{package.name}}
+    uses: rust/cargobump
+
+  - working-directory: ${{package.name}}
     pipeline:
       - runs: |
           set -x
-          cargo update mio --precise 0.8.11
-          # mitigate GHSA-7rrj-xr53-82p7
-          cargo update tokio --precise 1.20.4
-          # mitigate GHSA-wcg3-cvx6-7396
-          cargo update chrono --precise 0.4.38
           cargo auditable build --release -vv
           mkdir -p "${{targets.destdir}}/usr/bin/"
           mv target/release/pulumi-watch "${{targets.destdir}}/usr/bin/"

--- a/pulumi-watch/pulumi-watch/cargobump-deps.yaml
+++ b/pulumi-watch/pulumi-watch/cargobump-deps.yaml
@@ -1,0 +1,7 @@
+packages:
+  - name: mio
+    version: 0.8.11
+  - name: tokio
+    version: 1.20.4
+  - name: chrono
+    version: 0.4.38


### PR DESCRIPTION
This tools uses https://github.com/hectorj2f/cargobump to handle and bump dependencies in Cargo.lock files for Rust packages.