### PR TITLE
Split postgresql-16-bitnami-compat subpackage

### DIFF
--- a/postgresql-16-bitnami-compat.yaml
+++ b/postgresql-16-bitnami-compat.yaml
@@ -1,0 +1,53 @@
+package:
+  name: postgresql-16-bitnami-compat
+  version: "16.4"
+  epoch: 1
+  description: "compat package with postgresql image"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    provides:
+      - postgresql-bitnami-compat=${{package.full-version}}
+    runtime:
+      - bash
+      # Required by startup scripts
+      - busybox
+      - net-tools
+      - pgaudit-16
+      - postgresql-16
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - postgresql-16-base
+
+pipeline:
+  - uses: bitnami/compat
+    with:
+      image: postgresql
+      version-path: 16/debian-12
+
+  - runs: |
+      mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/conf
+      mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/bin
+      mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/share
+
+      # Copy sample configs used to generate Bitnami config
+      cp /usr/share/postgresql16/pg_hba.conf.sample ${{targets.contextdir}}/opt/bitnami/postgresql/share/pg_hba.conf.sample
+      cp /usr/share/postgresql16/postgresql.conf.sample ${{targets.contextdir}}/opt/bitnami/postgresql/share/postgresql.conf.sample
+
+      # Use package path while unpacking
+      find . -iname "*.sh" -exec sed 's#/opt/bitnami#${{targets.contextdir}}/opt/bitnami#g' -i {} \;
+        ${{targets.contextdir}}/opt/bitnami/scripts/postgresql/postunpack.sh || true
+      # Restore path
+      find ${{targets.contextdir}}/opt/bitnami -type f -exec sed 's#${{targets.contextdir}}##g' -i {} \;
+
+      # Remove sample configs
+      rm ${{targets.contextdir}}/opt/bitnami/postgresql/share/*.sample
+
+      # Link binaries used by Bitnami config
+      ln -sf /usr/libexec/postgresql16/initdb ${{targets.contextdir}}/opt/bitnami/postgresql/bin/initdb
+      ln -sf /usr/libexec/postgresql16/pg_ctl ${{targets.contextdir}}/opt/bitnami/postgresql/bin/pg_ctl
+      ln -sf /usr/libexec/postgresql16/pg_rewind ${{targets.contextdir}}/opt/bitnami/postgresql/bin/pg_rewind
+      ln -sf /usr/libexec/postgresql16/pg_isready /${{targets.contextdir}}/opt/bitnami/postgresql/bin/pg_isready

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.4"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause
@@ -189,47 +189,6 @@ subpackages:
           ln -s /usr/libexec/${{vars.mangled-package-name}}/docker-entrypoint.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/docker-entrypoint.sh
           ln -s /usr/libexec/${{vars.mangled-package-name}}/docker-ensure-initdb.sh ${{targets.subpkgdir}}/usr/bin/docker-ensure-initdb.sh
           ln -s /usr/libexec/${{vars.mangled-package-name}}/docker-ensure-initdb.sh ${{targets.subpkgdir}}/var/lib/postgres/initdb/docker-ensure-initdb.sh
-
-  - name: ${{package.name}}-bitnami-compat
-    description: "compat package with postgresql image"
-    dependencies:
-      provides:
-        - postgresql-bitnami-compat=${{package.full-version}}
-      runtime:
-        - ${{package.name}}
-        # Required by startup scripts
-        - busybox
-        - net-tools
-        - bash
-        - pgaudit-16
-    pipeline:
-      - uses: bitnami/compat
-        with:
-          image: postgresql
-          version-path: 16/debian-12
-      - runs: |
-          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/conf
-          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin
-          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/postgresql/share
-
-          # Copy sample configs used to generate Bitnami config
-          cp ${{targets.destdir}}/usr/share/${{vars.mangled-package-name}}/pg_hba.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/pg_hba.conf.sample
-          cp ${{targets.destdir}}/usr/share/${{vars.mangled-package-name}}/postgresql.conf.sample ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/postgresql.conf.sample
-
-          # Use package path while unpacking
-          find . -iname "*.sh" -exec sed 's#/opt/bitnami#${{targets.subpkgdir}}/opt/bitnami#g' -i {} \;
-            ${{targets.subpkgdir}}/opt/bitnami/scripts/postgresql/postunpack.sh || true
-          # Restore path
-          find ${{targets.subpkgdir}}/opt/bitnami -type f -exec sed 's#${{targets.subpkgdir}}##g' -i {} \;
-
-          # Remove sample configs
-          rm ${{targets.subpkgdir}}/opt/bitnami/postgresql/share/*.sample
-
-          # Link binaries used by Bitnami config
-          ln -sf /usr/libexec/${{vars.mangled-package-name}}/initdb ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/initdb
-          ln -sf /usr/libexec/${{vars.mangled-package-name}}/pg_ctl ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/pg_ctl
-          ln -sf /usr/libexec/${{vars.mangled-package-name}}/pg_rewind ${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/pg_rewind
-          ln -sf /usr/libexec/${{vars.mangled-package-name}}/pg_isready /${{targets.subpkgdir}}/opt/bitnami/postgresql/bin/pg_isready
 
   # This subpackage should always come last to avoid shipping resources included in other subpackages
   - name: "${{package.name}}-base"


### PR DESCRIPTION
This is causing a cycle preventing me from merging some [changes into wolfictl](https://github.com/wolfi-dev/wolfictl/pull/1150) because:

postgresql-16 contains subpackage
postgresql-16-bitnami-compat, which depends on
pgaudit-16, which depends on
postgresql-16-dev, which is a subpackage of
postgresql-16