### PR TITLE
kyverno-policy-reporter-ui: switch to git update monitor as upstream …

### DIFF
--- a/kyverno-policy-reporter-ui.yaml
+++ b/kyverno-policy-reporter-ui.yaml
@@ -68,7 +68,6 @@ update:
   ignore-regex-patterns:
     - 'alpha'
     - 'policy-reporter-ui-chart-'
-  github:
-    identifier: kyverno/policy-reporter-ui
-    use-tag: true
+  git:
     strip-prefix: v
+    tag-filter-prefix: v


### PR DESCRIPTION
…has many tags pushed to the same repo which impacts the github monitor
