### PR TITLE
ruby3.2-mustermann: fix update block

### DIFF
--- a/ruby3.2-mustermann.yaml
+++ b/ruby3.2-mustermann.yaml
@@ -49,3 +49,5 @@ update:
   github:
     identifier: sinatra/mustermann
     strip-prefix: v
+    tag-filter-prefix: v
+    use-tag: true


### PR DESCRIPTION
The update check is expected to fail as there is a newer upstream version available 3.0.3.  Once this merges we will get the automated update PR.