### PR TITLE
py3-gcsfs: fix update block

### DIFF
--- a/py3-gcsfs.yaml
+++ b/py3-gcsfs.yaml
@@ -41,9 +41,9 @@ pipeline:
 
 update:
   enabled: true
-  manual: false
   github:
     identifier: fsspec/gcsfs
+    use-tag: true
 
 test:
   pipeline:


### PR DESCRIPTION
Update check is expected to fail as there is a new version available upstream.  Once this PR merged we will get an automated update PR.