### PR TITLE
py3-setproctitle: fix update block

### DIFF
--- a/py3-setproctitle.yaml
+++ b/py3-setproctitle.yaml
@@ -41,3 +41,5 @@ update:
   github:
     identifier: dvarrazzo/py-setproctitle
     use-tag: true
+    tag-filter-prefix: version-
+    strip-prefix: version-


### PR DESCRIPTION
Update check will fail as there is a newer version available.  Once this PR merges we will get an automated update PR