### PR TITLE
py3-cassandra-driver: fix update block

### DIFF
--- a/py3-cassandra-driver.yaml
+++ b/py3-cassandra-driver.yaml
@@ -42,3 +42,4 @@ update:
   enabled: true
   github:
     identifier: datastax/python-driver
+    use-tag: true


### PR DESCRIPTION
Update check will fail as there is a newer version available.  Once this PR merges we will get an automated update PR