### PR TITLE
libpcap: fix update block

### DIFF
--- a/libpcap.yaml
+++ b/libpcap.yaml
@@ -61,3 +61,4 @@ update:
   github:
     identifier: the-tcpdump-group/libpcap
     strip-prefix: libpcap-
+    use-tag: true


### PR DESCRIPTION
Update check will fail as there is a newer version available.  Once this PR merges we will get an automated update PR