### PR TITLE
tzdata: fix update block

### DIFF
--- a/tzdata.yaml
+++ b/tzdata.yaml
@@ -39,3 +39,4 @@ update:
   enabled: true
   github:
     identifier: eggert/tz
+    use-tag: true


### PR DESCRIPTION
Update check will fail as there is a newer version available.  Once this PR merges we will get an automated update PR