### PR TITLE
py3-matplotlib-inline: fix update block

### DIFF
--- a/py3-matplotlib-inline.yaml
+++ b/py3-matplotlib-inline.yaml
@@ -35,6 +35,6 @@ pipeline:
 
 update:
   enabled: true
-  manual: false
   github:
     identifier: ipython/matplotlib-inline
+    use-tag: true


### PR DESCRIPTION
Update check will fail as there is a newer version available.  Once this PR merges we will get an automated update PR