### PR TITLE
py3-semantic-version: fix update block

### DIFF
--- a/py3-semantic-version.yaml
+++ b/py3-semantic-version.yaml
@@ -62,3 +62,4 @@ update:
   enabled: true
   github:
     identifier: rbarrois/python-semanticversion
+    use-tag: true


### PR DESCRIPTION
Update check will fail as there is a newer version available.  Once this PR merges we will get an automated update PR