### PR TITLE
net-snmp: fix update block

### DIFF
--- a/net-snmp.yaml
+++ b/net-snmp.yaml
@@ -136,6 +136,10 @@ subpackages:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - verfix
   github:
     identifier: net-snmp/net-snmp
     strip-prefix: v
+    tag-filter-prefix: v
+    use-tag: true


### PR DESCRIPTION
Update check will fail as there is a newer version available.  Once this PR merges we will get an automated update PR