### PR TITLE
ruby3.2-concurrent-ruby: fix update block

### DIFF
--- a/ruby3.2-concurrent-ruby.yaml
+++ b/ruby3.2-concurrent-ruby.yaml
@@ -115,3 +115,4 @@ update:
   github:
     identifier: ruby-concurrency/concurrent-ruby
     strip-prefix: v
+    tag-filter-prefix: v


### PR DESCRIPTION
Update check will fail as there is a newer version available.  Once this PR merges we will get an automated update PR