### PR TITLE
tcpdump: fix update block

### DIFF
--- a/tcpdump.yaml
+++ b/tcpdump.yaml
@@ -45,3 +45,5 @@ update:
   github:
     identifier: the-tcpdump-group/tcpdump
     strip-prefix: tcpdump-
+    tag-filter-prefix: tcpdump-
+    use-tag: true


### PR DESCRIPTION
Update check will fail as there is a newer version available.  Once this PR merges we will get an automated update PR