### PR TITLE
kubernetes-release

### DIFF
--- a/kubernetes-release.yaml
+++ b/kubernetes-release.yaml
@@ -1,0 +1,51 @@
+package:
+  name: kubernetes-release
+  version: 0.17.3
+  epoch: 0
+  description: Release infrastructure for Kubernetes and related components
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes/release
+      tag: v${{package.version}}
+      expected-commit: 2b2218a101a09c7ac1c179c8f9b5f3f64f7272f5
+
+subpackages:
+  - name: ${{package.name}}-go-runner
+    description: "A go based binary that can run commands and wrap stdout/stderr"
+    pipeline:
+      - working-directory: /home/build/images/build/go-runner
+        uses: go/build
+        with:
+          packages: .
+          output: go-runner
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/
+          ln -sf /usr/bin/go-runner ${{targets.subpkgdir}}/go-runner
+
+test:
+  environment:
+    contents:
+      packages:
+        - go
+        - ${{package.name}}-go-runner
+  pipeline:
+    - name: Verify go-runner installation
+      runs: |
+        go-runner go version
+        /go-runner go version
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes/release
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
