### PR TITLE
add tests for argo-rollouts

### DIFF
--- a/argo-rollouts.yaml
+++ b/argo-rollouts.yaml
@@ -64,3 +64,14 @@ update:
   github:
     identifier: argoproj/argo-rollouts
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - kubectl-argo-rollouts
+  pipeline:
+    - name: Version Check
+      runs: |
+        rollouts-controller --version
+        kubectl-argo-rollouts version


### PR DESCRIPTION
    add tests for argo-rollouts
    
    this commit adds tests which is basically a version check for both
    rollouts-controller and kubectl-argo-rollouts
    
    Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>