### PR TITLE
amazon-k8s-cni

### DIFF
--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -17,15 +17,6 @@ environment:
     CGO_ENABLED: "0"
     GO111MODULE: "on"
 
-data:
-  - name: binaries
-    items:
-      aws-cni: routed-eni-cni-plugin
-      aws-k8s-agent: aws-k8s-agent
-      aws-vpc-cni: aws-vpc-cni
-      egress-cni: egress-cni-plugin
-      grpc-health-probe: grpc-health-probe:
-
 pipeline:
   - uses: git-checkout
     with:

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -1,5 +1,5 @@
 package:
-  name: amazon-vpc-cni
+  name: aws-k8s-cni
   version: 1.18.3
   epoch: 0
   description: Networking plugin repository for pod networking in Kubernetes using Elastic Network Interfaces on AWS

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -35,20 +35,23 @@ data:
 
 subpackages:
   - range: binaries
-    name: ${{range.key}}
-    description: Abseil Common C++ library
+    name: "${{range.key}}"
     pipeline:
-      uses: go/build
-      with:
-        packages: ./cmd/${{range.value}}
-        output: ${{range.key}}
-        ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+      - uses: go/build
+        with:
+          packages: ./cmd/${{range.value}}
+          output: ${{range.key}}
+          ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
 
   - name: "${{package.name}}-compat"
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"
     dependencies:
       runtime:
-        - "${{range.key}}"
+        - aws-cni
+        - aws-k8s-agent
+        - aws-vpc-cni
+        - egress-cni
+        - grpc-health-probe
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/app

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -12,7 +12,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
-      - iptables
   environment:
     CGO_ENABLED: "0"
     GO111MODULE: "on"
@@ -67,4 +66,4 @@ test:
   pipeline:
     - name: Basic search test
       runs: |
-        aws-vpc-cni | grep -q 'foo bar'
+        aws-vpc-cni | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -61,7 +61,4 @@ pipeline:
 
   - name: Copy required files
   - runs: |
-      mkdir -p ${{targets.destdir}}/app/
-      cp -r misc/10-aws.conflist ${{targets.destdir}}/app/
-      mv ${{targets.destdir}}/usr/bin/* ${{targets.destdir}}/app/
-      exit 1
+      cp -r misc/10-aws.conflist ${{targets.destdir}}

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -46,13 +46,6 @@ subpackages:
 
   - name: "${{package.name}}-compat"
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"
-    dependencies:
-      runtime:
-        - aws-k8s-cni-aws-cni
-        - aws-k8s-cni-aws-k8s-agent
-        - aws-k8s-cni-aws-vpc-cni
-        - aws-k8s-cni-egress-cni
-        - aws-k8s-cni-grpc-health-probe
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/app

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -12,9 +12,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
-  environment:
-    CGO_ENABLED: "0"
-    GO111MODULE: "on"
 
 pipeline:
   - uses: git-checkout

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -21,7 +21,7 @@ pipeline:
       expected-commit: 128a08e41001e81ed317410bd386954022b941af
 
   - name: Copy conflist
-  - runs: |
+    runs: |
       cp -r misc/10-aws.conflist ${{targets.destdir}}
 
 data:

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -27,11 +27,12 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cmd/aws-vpc-cni
-      output: app/aws-vpc-cni
+      output: aws-vpc-cni
       ldflags: -s -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
 
   - name: Copy required files
   - runs: |
       mkdir -p ${{targets.destdir}}/app/
-      cp -r aws-cni misc/10-aws.conflist aws-k8s-agent grpc-health-probe egress-cni aws-vpc-cni ${{targets.destdir}}/app/
+      cp -r aws-cni misc/10-aws.conflist ${{targets.destdir}}/app/
+      mv ${{targets.destdir}}/usr/bin aws-vpc-cni ${{targets.destdir}}/app/
       exit 1

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -28,35 +28,35 @@ pipeline:
     with:
       packages: ./cmd/routed-eni-cni-plugin
       output: aws-cni
-      ldflags: -s -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+      ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
 
   - name: Build aws-k8s-agent
     uses: go/build
     with:
       packages: ./cmd/aws-k8s-agent
       output: aws-k8s-agent
-      ldflags: -s -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+      ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
 
   - name: Build aws-vpc-cni
     uses: go/build
     with:
       packages: ./cmd/aws-vpc-cni
       output: aws-vpc-cni
-      ldflags: -s -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+      ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
 
   - name: Build egress-cni
     uses: go/build
     with:
       packages: ./cmd/egress-cni-plugin
       output: egress-cni
-      ldflags: -s -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+      ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
 
   - name: Build grpc-health-probe
     uses: go/build
     with:
       packages: ./cmd/grpc-health-probe
       output: grpc-health-probe
-      ldflags: -s -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+      ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
 
   - name: Copy required files
   - runs: |

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -76,4 +76,7 @@ test:
   pipeline:
     - name: Verify installation
       runs: |
+        /app/aws-cni 2>&1 | grep -q 'CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0, 1.1.0'
         /app/aws-vpc-cni 2>&1 | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'
+        /app/egress-cni 2>&1 | grep -q 'CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0, 1.1.0'
+        /app/aws-vpc-cni 2>&1 | grep -q 'grpc-health-probe'

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -62,6 +62,6 @@ pipeline:
   - name: Copy required files
   - runs: |
       mkdir -p ${{targets.destdir}}/app/
-      cp -r aws-cni misc/10-aws.conflist ${{targets.destdir}}/app/
+      cp -r misc/10-aws.conflist ${{targets.destdir}}/app/
       mv ${{targets.destdir}}/usr/bin/* ${{targets.destdir}}/app/
       exit 1

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -79,4 +79,4 @@ test:
         /app/aws-cni 2>&1 | grep -q 'CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0, 1.1.0'
         /app/aws-vpc-cni 2>&1 | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'
         /app/egress-cni 2>&1 | grep -q 'CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0, 1.1.0'
-        /app/aws-vpc-cni 2>&1 | grep -q 'grpc-health-probe'
+        /app/grpc-health-probe --addr test 2>&1 | grep -q '{"level":"info","ts":"2024-09-10T17:06:33.029Z","caller":"runtime/proc.go:272","msg":"timeout: failed to connect service \"test\" within 1s"}'

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -20,49 +20,35 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 128a08e41001e81ed317410bd386954022b941af
 
-  - name: Build aws-cni
-    uses: go/build
-    with:
-      packages: ./cmd/routed-eni-cni-plugin
-      output: aws-cni
-      ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
-
-  - name: Build aws-k8s-agent
-    uses: go/build
-    with:
-      packages: ./cmd/aws-k8s-agent
-      output: aws-k8s-agent
-      ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
-
-  - name: Build aws-vpc-cni
-    uses: go/build
-    with:
-      packages: ./cmd/aws-vpc-cni
-      output: aws-vpc-cni
-      ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
-
-  - name: Build egress-cni
-    uses: go/build
-    with:
-      packages: ./cmd/egress-cni-plugin
-      output: egress-cni
-      ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
-
-  - name: Build grpc-health-probe
-    uses: go/build
-    with:
-      packages: ./cmd/grpc-health-probe
-      output: grpc-health-probe
-      ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
-
-  - name: Copy required files
-
+  - name: Copy conflist
   - runs: |
       cp -r misc/10-aws.conflist ${{targets.destdir}}
 
+data:
+  - name: binaries
+    items:
+      aws-cni: routed-eni-cni-plugin
+      aws-k8s-agent: aws-k8s-agent
+      aws-vpc-cni: aws-vpc-cni
+      egress-cni: egress-cni-plugin
+      grpc-health-probe: grpc-health-probe
+
 subpackages:
+  - range: binaries
+    name: ${{range.key}}
+    description: Abseil Common C++ library
+    pipeline:
+      uses: go/build
+      with:
+        packages: ./cmd/${{range.value}}
+        output: ${{range.key}}
+        ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+
   - name: "${{package.name}}-compat"
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    dependencies:
+      runtime:
+        - "${{range.key}}"
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/app

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -1,0 +1,33 @@
+package:
+  name: aws-k8s-cni
+  version: 1.18.3
+  epoch: 0
+  description: Networking plugin repository for pod networking in Kubernetes using Elastic Network Interfaces on AWS
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - go
+  environment:
+    CGO_ENABLED: "0"
+    GO111MODULE: "on"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/aws/amazon-vpc-cni-k8s
+      tag: v${{package.version}}
+      expected-commit: 128a08e41001e81ed317410bd386954022b941af
+
+  - uses: go/build
+    with:
+      packages: ./cmd/aws-vpc-cni
+      output: aws-vpc-cni
+      ldflags: -s -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+
+  - runs: |
+      exit 1

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -17,6 +17,15 @@ environment:
     CGO_ENABLED: "0"
     GO111MODULE: "on"
 
+data:
+  - name: binaries
+    items:
+      aws-cni: routed-eni-cni-plugin
+      aws-k8s-agent: aws-k8s-agent
+      aws-vpc-cni: aws-vpc-cni
+      egress-cni: egress-cni-plugin
+      grpc-health-probe: grpc-health-probe:
+
 pipeline:
   - uses: git-checkout
     with:
@@ -24,15 +33,44 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 128a08e41001e81ed317410bd386954022b941af
 
-  - uses: go/build
+  - name: Build aws-cni
+    uses: go/build
+    with:
+      packages: ./cmd/routed-eni-cni-plugin
+      output: aws-cni
+      ldflags: -s -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+
+  - name: Build aws-k8s-agent
+    uses: go/build
+    with:
+      packages: ./cmd/aws-k8s-agent
+      output: aws-k8s-agent
+      ldflags: -s -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+
+  - name: Build aws-vpc-cni
+    uses: go/build
     with:
       packages: ./cmd/aws-vpc-cni
       output: aws-vpc-cni
+      ldflags: -s -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+
+  - name: Build egress-cni
+    uses: go/build
+    with:
+      packages: ./cmd/egress-cni-plugin
+      output: egress-cni
+      ldflags: -s -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+
+  - name: Build grpc-health-probe
+    uses: go/build
+    with:
+      packages: ./cmd/grpc-health-probe
+      output: grpc-health-probe
       ldflags: -s -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
 
   - name: Copy required files
   - runs: |
       mkdir -p ${{targets.destdir}}/app/
       cp -r aws-cni misc/10-aws.conflist ${{targets.destdir}}/app/
-      mv ${{targets.destdir}}/usr/bin aws-vpc-cni ${{targets.destdir}}/app/
+      mv ${{targets.destdir}}/usr/bin/* ${{targets.destdir}}/app/
       exit 1

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -56,6 +56,7 @@ pipeline:
       ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
 
   - name: Copy required files
+
   - runs: |
       cp -r misc/10-aws.conflist ${{targets.destdir}}
 

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -66,4 +66,4 @@ test:
   pipeline:
     - name: Basic search test
       runs: |
-        aws-vpc-cni | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'
+        aws-vpc-cni 2>&1 | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -1,5 +1,5 @@
 package:
-  name: aws-k8s-cni
+  name: amazon-vpc-cni
   version: 1.18.3
   epoch: 0
   description: Networking plugin repository for pod networking in Kubernetes using Elastic Network Interfaces on AWS
@@ -35,7 +35,7 @@ data:
 
 subpackages:
   - range: binaries
-    name: "aws-k8s-cni-${{range.key}}"
+    name: "${{package.name}}-${{range.key}}"
     description: "${{range.key}} binary for aws-cni"
     pipeline:
       - uses: go/build
@@ -67,6 +67,11 @@ test:
     contents:
       packages:
         - ${{package.name}}-compat
+        - ${{package.name}}-aws-cni
+        - ${{package.name}}-aws-k8s-agent
+        - ${{package.name}}-aws-vpc-cni
+        - ${{package.name}}-egress-cni
+        - ${{package.name}}-grpc-health-probe
   pipeline:
     - name: Verify installation
       runs: |

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -80,4 +80,4 @@ test:
         /app/aws-cni 2>&1 | grep -q 'CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0, 1.1.0'
         /app/aws-vpc-cni 2>&1 | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'
         /app/egress-cni 2>&1 | grep -q 'CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0, 1.1.0'
-        /app/grpc-health-probe --addr test 2>&1 | grep -q '"timeout: failed to connect service \"test\" within 1s"'
+        /app/grpc-health-probe --addr test 2>&1 | grep -q '"caller":"github.com/aws/amazon-vpc-cni-k8s/cmd/grpc-health-probe/main.go:59","msg":"error: --addr not specified"'

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -80,4 +80,4 @@ test:
         /app/aws-cni 2>&1 | grep -q 'CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0, 1.1.0'
         /app/aws-vpc-cni 2>&1 | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'
         /app/egress-cni 2>&1 | grep -q 'CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0, 1.1.0'
-        /app/grpc-health-probe --addr test 2>&1 | grep -q '{"level":"info","ts":"2024-09-10T17:06:33.029Z","caller":"runtime/proc.go:272","msg":"timeout: failed to connect service \"test\" within 1s"}'
+        /app/grpc-health-probe --addr test 2>&1 | grep -q '"timeout: failed to connect service \"test\" within 1s"'

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -35,7 +35,7 @@ data:
 
 subpackages:
   - range: binaries
-    name: "${{range.key}}"
+    name: "aws-k8s-cni-${{range.key}}"
     description: "${{range.key}} binary for aws-cni"
     pipeline:
       - uses: go/build
@@ -48,11 +48,11 @@ subpackages:
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"
     dependencies:
       runtime:
-        - aws-cni
-        - aws-k8s-agent
-        - aws-vpc-cni
-        - egress-cni
-        - grpc-health-probe
+        - aws-k8s-cni-aws-cni
+        - aws-k8s-cni-aws-k8s-agent
+        - aws-k8s-cni-aws-vpc-cni
+        - aws-k8s-cni-egress-cni
+        - aws-k8s-cni-grpc-health-probe
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/app

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -68,4 +68,4 @@ test:
   pipeline:
     - name:
       runs: |
-        ./app/aws-vpc-cni 2>&1 | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'
+        /app/aws-vpc-cni 2>&1 | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -66,6 +66,6 @@ pipeline:
 
 test:
   pipeline:
-    - name:
+    - name: Verify installation
       runs: |
         /app/aws-vpc-cni 2>&1 | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -64,8 +64,12 @@ subpackages:
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"
     pipeline:
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"
-          ln -sf /usr/bin/* ${{targets.subpkgdir}}/app
+        mkdir -p ${{targets.subpkgdir}}/app
+        ln -sf /usr/bin/aws-cni ${{targets.subpkgdir}}/app/aws-cni
+        ln -sf /usr/bin/aws-k8s-agent ${{targets.subpkgdir}}/app/aws-k8s-agent
+        ln -sf /usr/bin/aws-vpc-cni ${{targets.subpkgdir}}/app/aws-vpc-cni
+        ln -sf /usr/bin/egress-cni ${{targets.subpkgdir}}/app/egress-cni
+        ln -sf /usr/bin/grpc-health-probe ${{targets.subpkgdir}}/app/grpc-health-probe
 
 update:
   enabled: true

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -62,3 +62,9 @@ pipeline:
   - name: Copy required files
   - runs: |
       cp -r misc/10-aws.conflist ${{targets.destdir}}
+
+test:
+  pipeline:
+    - name: Basic search test
+      runs: |
+        aws-vpc-cni | grep -q 'foo bar'

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -64,12 +64,12 @@ subpackages:
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"
     pipeline:
       - runs: |
-        mkdir -p ${{targets.subpkgdir}}/app
-        ln -sf /usr/bin/aws-cni ${{targets.subpkgdir}}/app/aws-cni
-        ln -sf /usr/bin/aws-k8s-agent ${{targets.subpkgdir}}/app/aws-k8s-agent
-        ln -sf /usr/bin/aws-vpc-cni ${{targets.subpkgdir}}/app/aws-vpc-cni
-        ln -sf /usr/bin/egress-cni ${{targets.subpkgdir}}/app/egress-cni
-        ln -sf /usr/bin/grpc-health-probe ${{targets.subpkgdir}}/app/grpc-health-probe
+          mkdir -p ${{targets.subpkgdir}}/app
+          ln -sf /usr/bin/aws-cni ${{targets.subpkgdir}}/app/aws-cni
+          ln -sf /usr/bin/aws-k8s-agent ${{targets.subpkgdir}}/app/aws-k8s-agent
+          ln -sf /usr/bin/aws-vpc-cni ${{targets.subpkgdir}}/app/aws-vpc-cni
+          ln -sf /usr/bin/egress-cni ${{targets.subpkgdir}}/app/egress-cni
+          ln -sf /usr/bin/grpc-health-probe ${{targets.subpkgdir}}/app/grpc-health-probe
 
 update:
   enabled: true

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -64,6 +64,13 @@ pipeline:
       cp -r misc/10-aws.conflist ${{targets.destdir}}/app/
       cp -r ${{targets.destdir}}/usr/bin/* ${{targets.destdir}}/app/
 
+update:
+  enabled: true
+  github:
+    identifier: aws/amazon-vpc-cni-k8s
+    strip-prefix: v
+    use-tag: true
+
 test:
   pipeline:
     - name: Verify installation

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -57,9 +57,15 @@ pipeline:
 
   - name: Copy required files
   - runs: |
-      mkdir -p ${{targets.destdir}}/app
-      cp -r misc/10-aws.conflist ${{targets.destdir}}/app/
-      cp -r ${{targets.destdir}}/usr/bin/* ${{targets.destdir}}/app/
+      cp -r misc/10-aws.conflist ${{targets.destdir}}
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/* ${{targets.subpkgdir}}/app
 
 update:
   enabled: true
@@ -69,6 +75,10 @@ update:
     use-tag: true
 
 test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-compat
   pipeline:
     - name: Verify installation
       runs: |

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -60,10 +60,12 @@ pipeline:
 
   - name: Copy required files
   - runs: |
-      cp -r misc/10-aws.conflist ${{targets.destdir}}
+      mkdir -p ${{targets.destdir}}/app
+      cp -r misc/10-aws.conflist ${{targets.destdir}}/app/
+      cp -r ${{targets.destdir}}/usr/bin/* ${{targets.destdir}}/app/
 
 test:
   pipeline:
-    - name: Basic search test
+    - name:
       runs: |
-        aws-vpc-cni 2>&1 | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'
+        ./app/aws-vpc-cni 2>&1 | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -77,7 +77,7 @@ test:
   pipeline:
     - name: Verify installation
       runs: |
-        /app/aws-cni 2>&1 | grep -q 'CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0, 1.1.0'
-        /app/aws-vpc-cni 2>&1 | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'
-        /app/egress-cni 2>&1 | grep -q 'CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0, 1.1.0'
-        /app/grpc-health-probe --addr test 2>&1 | grep -q '"caller":"github.com/aws/amazon-vpc-cni-k8s/cmd/grpc-health-probe/main.go:59","msg":"error: --addr not specified"'
+        aws-cni 2>&1 | grep -q 'CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0, 1.1.0'
+        aws-vpc-cni 2>&1 | grep -q 'Failed to install CNI binaries" error="Failed to install /host/opt/cni/bin/aws-cni: failed to copy file: stat aws-cni: no such file or directory'
+        egress-cni 2>&1 | grep -q 'CNI protocol versions supported: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 1.0.0, 1.1.0'
+        grpc-health-probe 2>&1 | grep -q '"caller":"github.com/aws/amazon-vpc-cni-k8s/cmd/grpc-health-probe/main.go:59","msg":"error: --addr not specified"'

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -36,10 +36,11 @@ data:
 subpackages:
   - range: binaries
     name: "${{range.key}}"
+    description: "${{range.key}} binary for aws-cni"
     pipeline:
       - uses: go/build
         with:
-          ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+          ldflags: -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
           output: ${{range.key}}
           packages: ./cmd/${{range.value}}
 

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -39,9 +39,9 @@ subpackages:
     pipeline:
       - uses: go/build
         with:
-          packages: ./cmd/${{range.value}}
-          output: ${{range.key}}
           ldflags: -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
+          output: ${{range.key}}
+          packages: ./cmd/${{range.value}}
 
   - name: "${{package.name}}-compat"
     description: "Compatibility package to place binaries in the location expected by upstream helm charts"

--- a/aws-k8s-cni.yaml
+++ b/aws-k8s-cni.yaml
@@ -12,6 +12,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
+      - iptables
   environment:
     CGO_ENABLED: "0"
     GO111MODULE: "on"
@@ -26,8 +27,11 @@ pipeline:
   - uses: go/build
     with:
       packages: ./cmd/aws-vpc-cni
-      output: aws-vpc-cni
+      output: app/aws-vpc-cni
       ldflags: -s -w -X pkg/version/info.Version=${{package.version}} -X pkg/awsutils/awssession.version=${{package.version}}
 
+  - name: Copy required files
   - runs: |
+      mkdir -p ${{targets.destdir}}/app/
+      cp -r aws-cni misc/10-aws.conflist aws-k8s-agent grpc-health-probe egress-cni aws-vpc-cni ${{targets.destdir}}/app/
       exit 1


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
