### PR TITLE
qdrant: update quinn-proto to mitigate CVE-2024-45311

### DIFF
--- a/qdrant.yaml
+++ b/qdrant.yaml
@@ -1,7 +1,7 @@
 package:
   name: qdrant
   version: 1.11.3
-  epoch: 0
+  epoch: 1
   description: "High-performance, massive-scale Vector Database for the next generation of AI"
   copyright:
     - license: Apache-2.0
@@ -41,6 +41,8 @@ pipeline:
 
   - name: build-qdrant-binary
     runs: |
+      # CVE-2024-45311
+      cargo update --precise 0.11.8 --package quinn-proto
       cargo auditable build --release --bin qdrant
 
   - runs: |


### PR DESCRIPTION
cargo auditable is hoisting the `quinn-proto` as the vulnerable where grape just classifies its CVE , the upstream has upgraded the dependency in their dev branch and its not in the used in the released builds 