### PR TITLE
fix(strimzi-kafka-operator): add tini-compat

### DIFF
--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: strimzi-kafka-operator
   version: 0.43.0
-  epoch: 1
+  epoch: 2
   description: Apache Kafka® running on Kubernetes
   copyright:
     - license: Apache-2.0
@@ -172,6 +172,7 @@ subpackages:
         - strimzi-kafka-operator-kafka-thirdparty-libs
         - strimzi-kafka-operator-kafka-thirdparty-libs-cc
         - tini
+        - tini-compat
       provides:
         - strimzi-kafka=${{package.full-version}}
     pipeline:


### PR DESCRIPTION
Adds the missing `tini-compat` package as `tini` was installing on `/sbin/tini` rather than `/usr/bin/tini`.