### PR TITLE
fix(k3s): Transition from legacy go dependecy version bumps to gobump for k3s otelgrpc dependency

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -62,15 +62,9 @@ pipeline:
       sed -e '/curl --compressed/d' -i scripts/download
       mkdir -p build/static bin/aux etc
       ./scripts/download
-
-      # CVE-2023-47108
-      go mod edit -dropreplace=go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
-      go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.54.0
-
-      go mod tidy
   - uses: go/bump
     with:
-      deps: google.golang.org/grpc@v1.65.0
+      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.54.0 google.golang.org/grpc@v1.65.0
   - runs: |
       sed -i '/VERSION_RUNC=$(get-module-version github.com\/opencontainers\/runc)/a VERSION_RUNC="v1.1.14"' ./scripts/version.sh
 


### PR DESCRIPTION
To clean up legacy go bump dependencies this commit migrates otelgrpc CVE remediation to use gobump.

This continues to remediate CVE-2023-47108 but using gobump.

