### PR TITLE
docker/docker-cli - Resolve circular dep by dropping compat things.

### DIFF
--- a/docker-cli.yaml
+++ b/docker-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-cli
   version: 27.2.1
-  epoch: 0
+  epoch: 1
   description: The Docker CLI
   copyright:
     - license: Apache-2.0
@@ -53,13 +53,6 @@ subpackages:
     description: "docker-cli documentation"
     pipeline:
       - uses: split/manpages
-
-  # Ref: https://github.com/docker-library/docker/blob/master/Dockerfile-cli.template
-  - name: docker-cli-compat
-    dependencies:
-      runtime:
-        - docker-oci-entrypoint
-        - docker-modprobe-compat
 
 update:
   enabled: true

--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: 27.2.1
-  epoch: 0
+  epoch: 1
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -148,15 +148,6 @@ subpackages:
     pipeline:
       - runs: |
           install -Dm755 /home/build/hack/dind "${{targets.subpkgdir}}"/usr/bin/dind
-
-  # I can't believe this is a real thing
-  - name: docker-modprobe-compat
-    dependencies:
-      runtime:
-        - docker
-    pipeline:
-      - runs: |
-          install -Dm755 /home/docker-library/modprobe.sh "${{targets.subpkgdir}}"/usr/bin/modprobe
 
 update:
   enabled: true


### PR DESCRIPTION
This removes the packages:
1. docker-cli-compat
2. docker-modprobe-compat

This should be safe because:
 * nothing rdepends on docker-cli-compat and no images reference docker-modprobe-compat
 * docker-modprobe-compat was being installed in /usr/bin. If you actually tried to call it from /usr/bin, it provides a forkbomb.  It re-execs itself infinitely after trying to use 'ip' and 'lsmod' which aren't installed.

