### PR TITLE
py3-jupyterlab-pygments: fix update block

### DIFF
--- a/py3-jupyterlab-pygments.yaml
+++ b/py3-jupyterlab-pygments.yaml
@@ -49,6 +49,6 @@ pipeline:
 
 update:
   enabled: true
-  manual: false
   github:
     identifier: jupyterlab/jupyterlab_pygments
+    use-tag: true


### PR DESCRIPTION
Update check will fail as there is a newer version available.  Once this PR merges we will get an automated update PR