### PR TITLE
add libcld2

### DIFF
--- a/libcld2.yaml
+++ b/libcld2.yaml
@@ -1,0 +1,111 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: libcld2
+  description: Compact Language Detector 2
+  url: https://github.com/CLD2Owners/cld2
+  version: 0_git20240911
+  epoch: 0
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - glibc-dev
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - libtool
+      - wolfi-baselayout
+  environment:
+    CXXFLAGS: "-fPIC"
+    LDFLAGS: "-Wl,-soname,libcld2.so.0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: b56fa78a2fe44ac2851bae5bf4f4693a0644da7b
+      repository: https://github.com/CLD2Owners/cld2
+      branch: master
+
+  # https://salsa.debian.org/debian/cld2/-/tree/master/debian/patches
+  - uses: patch
+    with:
+      series: series
+
+  - working-directory: internal
+    pipeline:
+      - runs: |
+          ./compile_libs.sh
+          install -Dm755 libcld2.so "${{targets.destdir}}"/usr/local/lib/libcld2.so
+          install -Dm755 libcld2_full.so "${{targets.destdir}}"/usr/local/lib/libcld2_full.so
+          mkdir -p "${{targets.destdir}}"/usr/local/include/cld2/internal
+          install -Dm644 *.h "${{targets.destdir}}"/usr/local/include/cld2/internal
+
+  - working-directory: public
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.destdir}}"/usr/local/include/cld2/public
+          install -Dm644 *.h "${{targets.destdir}}"/usr/local/include/cld2/public
+
+  - uses: strip
+
+subpackages:
+  - name: "libcld2-static"
+    description: "libcld2 static libraries"
+    pipeline:
+      - uses: split/static
+
+  - name: "libcld2-dev"
+    description: "libcld2 development headers"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - libcld2
+
+update:
+  enabled: false
+  exclude-reason: No releases or tags
+  schedule:
+    period: daily
+    reason: Upstream does not maintain tags or releases
+  git: {}
+
+test:
+  environment:
+    contents:
+      packages:
+        - gcc
+        - libcld2-dev
+  pipeline:
+    - name: Smoke test for libcld2
+      runs: |
+        # Verify libcld2 shared library is available
+        ldconfig -p | grep -q libcld2
+    - name: Verify header file installation
+      runs: |
+        find /usr -name compact_lang_det.h
+    - name: Test library linkage with explicit include path and missing header fix
+      runs: |
+        INCLUDE_DIR=$(find /usr -name compact_lang_det.h | xargs dirname)
+        echo '#include <cstdio>' > test.cpp
+        echo '#include <compact_lang_det.h>' >> test.cpp
+        echo 'int main() { CLD2::CLDHints hints; return 0; }' >> test.cpp
+        g++ -I$INCLUDE_DIR test.cpp -o test_binary -lcld2
+        ./test_binary
+    - name: Test basic language detection functionality with simplified arguments
+      runs: |
+        INCLUDE_DIR=$(find /usr -name compact_lang_det.h | xargs dirname)
+        echo '#include <iostream>' > detect_test.cpp
+        echo '#include <cstdio>' >> detect_test.cpp
+        echo '#include <cstring>' >> detect_test.cpp
+        echo '#include <compact_lang_det.h>' >> detect_test.cpp
+        echo 'int main() { const char* text = "Hello, this is a language detection test."; bool is_plain_text = true; bool is_reliable = false; CLD2::Language lang = CLD2::DetectLanguage(text, strlen(text), is_plain_text, &is_reliable); std::cout << "Detected language: " << CLD2::LanguageCode(lang) << std::endl; return 0; }' >> detect_test.cpp
+        g++ -I$INCLUDE_DIR detect_test.cpp -o detect_binary -lcld2
+        ./detect_binary | grep -q "en"

--- a/libcld2/1.patch
+++ b/libcld2/1.patch
@@ -1,0 +1,338 @@
+# Ref: https://salsa.debian.org/debian/cld2/-/raw/master/debian/patches/1.patch?ref_type=heads
+Origin: https://github.com/jmhodges/cld2/pull/1
+From d885e355ae66ede72d2bb07ded8e5412b20bd282 Mon Sep 17 00:00:00 2001
+From: Jeff Hodges <jeff@somethingsimilar.com>
+Date: Sat, 22 Oct 2016 22:33:16 -0700
+Subject: [PATCH] hack up generated files to compile as c++0x
+
+Use a bunch of static_cast<uint8> to get around the c++11-narrowing
+errors when building as C++0x.
+
+This hack is necessary because the source files and generation code has
+not been released.
+
+See https://github.com/CLD2Owners/cld2/issues/33 on the source file
+check-in.
+
+See https://github.com/CLD2Owners/cld2/issues/47
+https://github.com/CLD2Owners/cld2/issues/51
+https://github.com/CLD2Owners/cld2/issues/26 and I'm sure there are
+others for the C++0x problem.
+---
+ internal/cld_generated_cjk_uni_prop_80.cc | 110 +++++++++++-----------
+ internal/scoreonescriptspan.cc            |   4 +-
+ 2 files changed, 57 insertions(+), 57 deletions(-)
+
+diff --git a/internal/cld_generated_cjk_uni_prop_80.cc b/internal/cld_generated_cjk_uni_prop_80.cc
+index 06ad806..af6f9ed 100644
+--- a/internal/cld_generated_cjk_uni_prop_80.cc
++++ b/internal/cld_generated_cjk_uni_prop_80.cc
+@@ -165,8 +165,8 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ // state[16 + 2] 0x000000 Byte 2 of 3 (relative offsets)
+ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+--14,-14,-14,-14,-14,-14,-14,-14, -14,-14,-14,-14,-14,-14,-14,-14,
+--14,-14,-14,-14,-14,-14,-14,-14, -14,-14,-14,-14,-14,-14,-14,-14,
++static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14), static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),
++static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14), static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),static_cast<uint8>(-14),
+ 
+ // state[17 + 2] 0x0031c0 Byte 3 of 3 (property)
+   0,  0,  0,  0,  0,  0,  0,  0,   0,  0,  0,  0,  0,  0,  0,  0,
+@@ -259,10 +259,10 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 229,229,229,  3,208,  0,229,  5, 233,  0,229,229,229,208,229,229,
+ 
+ // state[32 + 2] 0x002000 Byte 2 of 3 (relative offsets)
+--30,-30,-30,-30,-30,-30,-30,-30, -30,-30,-30,-30,-30,-30,-30,-30,
+--30,-30,-30,-30,-30,-30,-30,-30, -30,-30,-30,-30,-30,-30,-30,-30,
+--30,-30,-30,-30,-30,-30,-30,-30, -30,-30,-30,-30,-30,-30,-30,-30,
+--30,-30,-30,-30,-30,-30,-30,-30, -30,-30,-30,-30,-30,-30,-30,-30,
++static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30), static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),
++static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30), static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),
++static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30), static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),
++static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30), static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),static_cast<uint8>(-30),
+ 
+ // state[33 + 2] 0x003780 Byte 3 of 3 (property)
+ 229,208,229,229,208,229,229,229, 208,208,208,208,208,  4,  6,208,
+@@ -355,10 +355,10 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 228,229,229,229,229,233,233,  6, 208,229,  3,229,233,  6,  6,  0,
+ 
+ // state[48 + 2] 0x001000 Byte 2 of 3 (relative offsets)
+--46,-46,-46,-46,-42,-41,-40,-39, -46,-46,-46,-46,-46,-46,-46,-46,
+--46,-46,-46,-46,-46,-46,-46,-46, -46,-46,-46,-46,-46,-46,-46,-46,
+--46,-46,-46,-46,-46,-46,-46,-46, -46,-46,-46,-46,-46,-46,-46,-46,
+--46,-46,-46,-46,-46,-46,-46,-46, -46,-46,-46,-46,-46,-46,-46,-46,
++static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-42),static_cast<uint8>(-41),static_cast<uint8>(-40),static_cast<uint8>(-39), static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),
++static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46), static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),
++static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46), static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),
++static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46), static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),static_cast<uint8>(-46),
+ 
+ // state[49 + 2] 0x003b40 Byte 3 of 3 (property)
+   6,227,208,233,208,  3,  3,208, 208,229,  0,229,233,219,  0,  6,
+@@ -451,10 +451,10 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 229,208,208,208,217,208,229,229, 229,229,208,217,208,229,229,229,
+ 
+ // state[64 + 2] 0x003000 Byte 2 of 3 (relative offsets)
+--54,-53,-52,-51,-50,-58,-49,-47, -62,-62,-62,-62,-62,-62,-62,-62,
+--46,-45,-44,-43,-42,-41,-40,-39, -38,-37,-36,-35,-34,-33,-31,-30,
+--29,-28,-27,-26,-25,-24,-23,-22, -21,-20,-19,-18,-17,-15,-14,-13,
+--12,-11,-10, -9, -8, -7, -6, -5,  -4, -3, -2, -1,  1,  2,  3,  4,
++static_cast<uint8>(-54),static_cast<uint8>(-53),static_cast<uint8>(-52),static_cast<uint8>(-51),static_cast<uint8>(-50),static_cast<uint8>(-58),static_cast<uint8>(-49),static_cast<uint8>(-47), static_cast<uint8>(-62),static_cast<uint8>(-62),static_cast<uint8>(-62),static_cast<uint8>(-62),static_cast<uint8>(-62),static_cast<uint8>(-62),static_cast<uint8>(-62),static_cast<uint8>(-62),
++static_cast<uint8>(-46),static_cast<uint8>(-45),static_cast<uint8>(-44),static_cast<uint8>(-43),static_cast<uint8>(-42),static_cast<uint8>(-41),static_cast<uint8>(-40),static_cast<uint8>(-39), static_cast<uint8>(-38),static_cast<uint8>(-37),static_cast<uint8>(-36),static_cast<uint8>(-35),static_cast<uint8>(-34),static_cast<uint8>(-33),static_cast<uint8>(-31),static_cast<uint8>(-30),
++static_cast<uint8>(-29),static_cast<uint8>(-28),static_cast<uint8>(-27),static_cast<uint8>(-26),static_cast<uint8>(-25),static_cast<uint8>(-24),static_cast<uint8>(-23),static_cast<uint8>(-22), static_cast<uint8>(-21),static_cast<uint8>(-20),static_cast<uint8>(-19),static_cast<uint8>(-18),static_cast<uint8>(-17),static_cast<uint8>(-15),static_cast<uint8>(-14),static_cast<uint8>(-13),
++static_cast<uint8>(-12),static_cast<uint8>(-11),static_cast<uint8>(-10), static_cast<uint8>(-9), static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5),  static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),  1,  2,  3,  4,
+ 
+ // state[65 + 2] 0x003f00 Byte 3 of 3 (property)
+ 217,217,208,  3,208,217,208,208,   6,229,208,228,229,229,208,229,
+@@ -547,10 +547,10 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 229,208,229,229,208,229,233,  0, 208,208,229,208,227,229,229,229,
+ 
+ // state[80 + 2] 0x004000 Byte 2 of 3 (relative offsets)
+--11,-10, -9, -8, -7, -6, -5, -4,  -3, -2, -1,  1,  2,  3,  4,  5,
++static_cast<uint8>(-11),static_cast<uint8>(-10), static_cast<uint8>(-9), static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4),  static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),  1,  2,  3,  4,  5,
+   6,  7,  8,  9, 10, 11, 12, 13,  14, 15, 16, 17, 18, 19, 20, 21,
+  22, 23, 24, 25, 26, 27, 28, 29,  30, 31, 32, 33, 34, 35, 36, 37,
+- 38, 39, 40, 41, 42, 43, 44,-78,  45, 46, 47, 48, 49, 50, 51, 52,
++ 38, 39, 40, 41, 42, 43, 44,static_cast<uint8>(-78),  45, 46, 47, 48, 49, 50, 51, 52,
+ 
+ // state[81 + 2] 0x0042c0 Byte 3 of 3 (property)
+ 229,  0,229,229,229,  3,  4,  4, 229,229,229,229,208,229,  0,208,
+@@ -931,7 +931,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+   0,142, 98, 28,117,206,212,212, 220, 15,  0,231,199,231,111, 28,
+ 
+ // state[144 + 2] 0x005000 Byte 2 of 3 (relative offsets)
+--11,-10, -9, -8, -7, -6, -5, -4,  -3, -2, -1,  1,  2,  3,  4,  5,
++static_cast<uint8>(-11),static_cast<uint8>(-10), static_cast<uint8>(-9), static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4),  static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),  1,  2,  3,  4,  5,
+   6,  7,  8,  9, 10, 11, 12, 13,  14, 15, 16, 17, 18, 19, 20, 21,
+  22, 23, 24, 25, 26, 27, 28, 29,  30, 31, 32, 33, 34, 35, 36, 37,
+  38, 39, 40, 41, 42, 43, 44, 45,  46, 47, 48, 49, 50, 51, 52, 53,
+@@ -1315,7 +1315,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+  16, 15,211,118,  0,231, 68,231,   0, 99,161,  0,115,221,144,140,
+ 
+ // state[208 + 2] 0x006000 Byte 2 of 3 (relative offsets)
+--10, -9, -8, -7, -6, -5, -4, -3,  -2, -1,  1,  2,  3,  4,  5,  6,
++static_cast<uint8>(-10), static_cast<uint8>(-9), static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3),  static_cast<uint8>(-2), static_cast<uint8>(-1),  1,  2,  3,  4,  5,  6,
+   7,  8,  9, 10, 11, 12, 13, 14,  15, 16, 17, 18, 19, 20, 21, 22,
+  23, 24, 25, 26, 27, 28, 29, 30,  31, 32, 33, 34, 35, 36, 37, 38,
+  39, 40, 41, 42, 43, 44, 45, 46,  47, 48, 49, 50, 51, 52, 53, 54,
+@@ -1699,7 +1699,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 119, 16, 51,  0,  0, 68,136, 72, 144,118, 87,201,191,136, 78,233,
+ 
+ // state[272 + 2] 0x007000 Byte 2 of 3 (relative offsets)
+- -9, -8, -7, -6, -5, -4, -3, -2,  -1,  1,  2,  3,  4,  5,  6,  7,
++ static_cast<uint8>(-9), static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2),  static_cast<uint8>(-1),  1,  2,  3,  4,  5,  6,  7,
+   8,  9, 10, 11, 12, 13, 14, 15,  16, 17, 18, 19, 20, 21, 22, 23,
+  24, 25, 26, 27, 28, 29, 30, 31,  32, 33, 34, 35, 36, 37, 38, 39,
+  40, 41, 42, 43, 44, 45, 46, 47,  48, 49, 50, 51, 52, 53, 54, 55,
+@@ -2083,7 +2083,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 212,212,  0,126,140,220,220,  0,   0,  0,127,118,106,  0,199,  0,
+ 
+ // state[336 + 2] 0x008000 Byte 2 of 3 (relative offsets)
+- -8, -7, -6, -5, -4, -3, -2, -1,   1,  2,  3,  4,  5,  6,  7,  8,
++ static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),   1,  2,  3,  4,  5,  6,  7,  8,
+   9, 10, 11, 12, 13, 14, 15, 16,  17, 18, 19, 20, 21, 22, 23, 24,
+  25, 26, 27, 28, 29, 30, 31, 32,  33, 34, 35, 36, 37, 38, 39, 40,
+  41, 42, 43, 44, 45, 46, 47, 48,  49, 50, 51, 52, 53, 54, 55, 56,
+@@ -2467,7 +2467,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+   0,122,  0,231,100,232,  0,  0, 117,  0,206,231,  0,  0,231,  0,
+ 
+ // state[400 + 2] 0x009000 Byte 2 of 3 (relative offsets)
+- -7, -6, -5, -4, -3, -2, -1,  1,   2,  3,  4,  5,  6,  7,  8,  9,
++ static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),  1,   2,  3,  4,  5,  6,  7,  8,  9,
+  10, 11, 12, 13, 14, 15, 16, 17,  18, 19, 20, 21, 22, 23, 24, 25,
+  26, 27, 28, 29, 30, 31, 32, 33,  34, 35, 36, 37, 38, 39, 40, 41,
+  42, 43, 44, 45, 46, 47, 48, 49,  50, 51, 52, 53, 54, 55, 56, 57,
+@@ -2851,10 +2851,10 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+   0,  0,  0,  0,  0,  0,  0,  0,   0,  0,  0,  0,  0,  0,  0,  0,
+ 
+ // state[464 + 2] 0x00a000 Byte 2 of 3 (relative offsets)
+- -6, -6, -6, -6, -6, -6, -6, -6,  -6, -6, -6, -6, -6, -6, -6, -6,
+- -6, -6, -6, -6, -6, -6, -6, -6,  -6, -6, -6, -6, -6, -6, -6, -6,
+- -6, -6, -6, -6, -6, -6, -6, -6,  -6, -6, -6, -6, -6, -6, -6, -6,
+- -5, -5, -5, -5, -5, -5, -5, -5,  -5, -5, -5, -5, -5, -5, -5, -5,
++ static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6),  static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6),
++ static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6),  static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6),
++ static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6),  static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6), static_cast<uint8>(-6),
++ static_cast<uint8>(-5), static_cast<uint8>(-5), static_cast<uint8>(-5), static_cast<uint8>(-5), static_cast<uint8>(-5), static_cast<uint8>(-5), static_cast<uint8>(-5), static_cast<uint8>(-5),  static_cast<uint8>(-5), static_cast<uint8>(-5), static_cast<uint8>(-5), static_cast<uint8>(-5), static_cast<uint8>(-5), static_cast<uint8>(-5), static_cast<uint8>(-5), static_cast<uint8>(-5),
+ 
+ // state[465 + 2] 0x000080 Byte 2 of 2 (property)
+   0,  0,  0,  0,  0,  0,  0,  0,   0,  0,  0,  0,  0,  0,  0,  0,
+@@ -2947,10 +2947,10 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 208,208,208,208,  5,  6,208,  2,   0,  6,  6,  5,208,208,208,  6,
+ 
+ // state[480 + 2] 0x00b000 Byte 2 of 3 (relative offsets)
+--20,-20,-20,-20,-20,-20,-20,-20, -20,-20,-20,-20,-20,-20,-20,-20,
+--20,-20,-20,-20,-20,-20,-20,-20, -20,-20,-20,-20,-20,-20,-20,-20,
+--20,-20,-20,-20,-20,-20,-20,-20, -20,-20,-20,-20,-20,-20,-20,-20,
+--20,-20,-20,-20,-20,-20,-20,-20, -20,-20,-20,-20,-20,-20,-20,-20,
++static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20), static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),
++static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20), static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),
++static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20), static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),
++static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20), static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),static_cast<uint8>(-20),
+ 
+ // state[481 + 2] 0x020100 Byte 4 of 4 (property)
+   2,  6,  5,  6,  5,229,  5,208, 208,208,208,208,208,208,208,229,
+@@ -3043,10 +3043,10 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 208,208,  5,  5,  5,208,208,  2, 229,  5,  5,  5,  5,  5,  6,208,
+ 
+ // state[496 + 2] 0x00d000 Byte 2 of 3 (relative offsets)
+--35,-35,-35,-35,-35,-35,-35,-35, -35,-35,-35,-35,-35,-35,-35,-35,
+--35,-35,-35,-35,-35,-35,-35,-35, -35,-35,-35,-35,-35,-35,-34,-33,
+--33,-33,-33,-33,-33,-33,-33,-33, -33,-33,-33,-33,-33,-33,-33,-33,
+--33,-33,-33,-33,-33,-33,-33,-33, -33,-33,-33,-33,-33,-33,-33,-33,
++static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35), static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),
++static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35), static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-35),static_cast<uint8>(-34),static_cast<uint8>(-33),
++static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33), static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),
++static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33), static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),static_cast<uint8>(-33),
+ 
+ // state[497 + 2] 0x0204c0 Byte 4 of 4 (property)
+   2,  2,  5,  5,  5,  2,208,  2,   5,  5,  6,208,208,  5,  5,  5,
+@@ -3139,10 +3139,10 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 208,208,  5,  5,  5,  5,  6,  6, 208,208,  2,208,208,208,208,208,
+ 
+ // state[512 + 2] 0x00f000 Byte 2 of 3 (relative offsets)
+--47,-47,-47,-47,-47,-47,-47,-47, -47,-47,-47,-47,-47,-47,-47,-47,
+--47,-47,-47,-47,-47,-47,-47,-47, -47,-47,-47,-47,-47,-47,-47,-47,
+--47,-47,-47,-47,-46,-45,-44,-43, -42,-41,-44,-40,-47,-47,-47,-47,
+--47,-47,-47,-47,-47,-47,-47,-47, -47,-47,-47,-47,-47,-39,-38,-37,
++static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47), static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),
++static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47), static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),
++static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-46),static_cast<uint8>(-45),static_cast<uint8>(-44),static_cast<uint8>(-43), static_cast<uint8>(-42),static_cast<uint8>(-41),static_cast<uint8>(-44),static_cast<uint8>(-40),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),
++static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47), static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-47),static_cast<uint8>(-39),static_cast<uint8>(-38),static_cast<uint8>(-37),
+ 
+ // state[513 + 2] 0x020880 Byte 4 of 4 (property)
+   5,  5,  5,  6,208,208,208,208, 208,208,  5,  5,  6,  6,208,208,
+@@ -3235,10 +3235,10 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+   5,  6,208,218,208,208,208,218, 208,  6,227,229,  6,  6,  6,208,
+ 
+ // state[528 + 2] 0x020000 Byte 3 of 4 (relative offsets)
+--52,-51,-50,-49,-47,-46,-45,-44, -43,-42,-41,-40,-39,-38,-37,-36,
+--35,-34,-33,-31,-30,-29,-28,-27, -26,-25,-24,-23,-22,-21,-20,-19,
+--18,-17,-15,-14,-13,-12,-11,-10,  -9, -8, -7, -6, -5, -4, -3, -2,
+- -1,  1,  2,  3,  4,  5,  6,  7,   8,  9, 10, 11, 12, 13, 14, 15,
++static_cast<uint8>(-52),static_cast<uint8>(-51),static_cast<uint8>(-50),static_cast<uint8>(-49),static_cast<uint8>(-47),static_cast<uint8>(-46),static_cast<uint8>(-45),static_cast<uint8>(-44), static_cast<uint8>(-43),static_cast<uint8>(-42),static_cast<uint8>(-41),static_cast<uint8>(-40),static_cast<uint8>(-39),static_cast<uint8>(-38),static_cast<uint8>(-37),static_cast<uint8>(-36),
++static_cast<uint8>(-35),static_cast<uint8>(-34),static_cast<uint8>(-33),static_cast<uint8>(-31),static_cast<uint8>(-30),static_cast<uint8>(-29),static_cast<uint8>(-28),static_cast<uint8>(-27), static_cast<uint8>(-26),static_cast<uint8>(-25),static_cast<uint8>(-24),static_cast<uint8>(-23),static_cast<uint8>(-22),static_cast<uint8>(-21),static_cast<uint8>(-20),static_cast<uint8>(-19),
++static_cast<uint8>(-18),static_cast<uint8>(-17),static_cast<uint8>(-15),static_cast<uint8>(-14),static_cast<uint8>(-13),static_cast<uint8>(-12),static_cast<uint8>(-11),static_cast<uint8>(-10),  static_cast<uint8>(-9), static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2),
++ static_cast<uint8>(-1),  1,  2,  3,  4,  5,  6,  7,   8,  9, 10, 11, 12, 13, 14, 15,
+ 
+ // state[529 + 2] 0x020c40 Byte 4 of 4 (property)
+ 227,  5,  5,  5,  2,  2,  2,  2, 213,  2,  2,  2,  2,  2,208,  6,
+@@ -3427,7 +3427,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 208,208,208,208,208,208,208,208, 208,  6,  6,  6,  6,  2,  5,  5,
+ 
+ // state[560 + 2] 0x021000 Byte 3 of 4 (relative offsets)
+--16,-15,-14,-13,-12,-11,-10, -9,  -8, -7, -6, -5, -4, -3, -2, -1,
++static_cast<uint8>(-16),static_cast<uint8>(-15),static_cast<uint8>(-14),static_cast<uint8>(-13),static_cast<uint8>(-12),static_cast<uint8>(-11),static_cast<uint8>(-10), static_cast<uint8>(-9),  static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),
+   1,  2,  3,  4,  5,  6,  7,  8,   9, 10, 11, 12, 13, 14, 15, 16,
+  17, 18, 19, 20, 21, 22, 23, 24,  25, 26, 27, 28, 29, 30, 31, 32,
+  33, 34, 35, 36, 37, 38, 39, 40,  41, 42, 43, 44, 45, 46, 47, 48,
+@@ -3811,7 +3811,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+   5,  5,  5,  6,  6,  6,  5,208, 208,229,208,208,  5,  5,  5,  5,
+ 
+ // state[624 + 2] 0x022000 Byte 3 of 4 (relative offsets)
+--15,-14,-13,-12,-11,-10, -9, -8,  -7, -6, -5, -4, -3, -2, -1,  1,
++static_cast<uint8>(-15),static_cast<uint8>(-14),static_cast<uint8>(-13),static_cast<uint8>(-12),static_cast<uint8>(-11),static_cast<uint8>(-10), static_cast<uint8>(-9), static_cast<uint8>(-8),  static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),  1,
+   2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
+  18, 19, 20, 21, 22, 23, 24, 25,  26, 27, 28, 29, 30, 31, 32, 33,
+  34, 35, 36, 37, 38, 39, 40, 41,  42, 43, 44, 45, 46, 47, 48, 49,
+@@ -4195,7 +4195,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+   6,  6,  4,  5,208,208,208,208, 208,208,229,  6,  5,  6,  6,  6,
+ 
+ // state[688 + 2] 0x023000 Byte 3 of 4 (relative offsets)
+--14,-13,-12,-11,-10, -9, -8, -7,  -6, -5, -4, -3, -2, -1,  1,  2,
++static_cast<uint8>(-14),static_cast<uint8>(-13),static_cast<uint8>(-12),static_cast<uint8>(-11),static_cast<uint8>(-10), static_cast<uint8>(-9), static_cast<uint8>(-8), static_cast<uint8>(-7),  static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),  1,  2,
+   3,  4,  5,  6,  7,  8,  9, 10,  11, 12, 13, 14, 15, 16, 17, 18,
+  19, 20, 21, 22, 23, 24, 25, 26,  27, 28, 29, 30, 31, 32, 33, 34,
+  35, 36, 37, 38, 39, 40, 41, 42,  43, 44, 45, 46, 47, 48, 49, 50,
+@@ -4579,7 +4579,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+   5,  5,  5,  5,  5,  5,  5,  6, 208,208,208,208,208,208,  6,  6,
+ 
+ // state[752 + 2] 0x024000 Byte 3 of 4 (relative offsets)
+--13,-12,-11,-10, -9, -8, -7, -6,  -5, -4, -3, -2, -1,  1,  2,  3,
++static_cast<uint8>(-13),static_cast<uint8>(-12),static_cast<uint8>(-11),static_cast<uint8>(-10), static_cast<uint8>(-9), static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6),  static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),  1,  2,  3,
+   4,  5,  6,  7,  8,  9, 10, 11,  12, 13, 14, 15, 16, 17, 18, 19,
+  20, 21, 22, 23, 24, 25, 26, 27,  28, 29, 30, 31, 32, 33, 34, 35,
+  36, 37, 38, 39, 40, 41, 42, 43,  44, 45, 46, 47, 48, 49, 50, 51,
+@@ -4963,7 +4963,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 229,  6,  2,  2,  2,  2,  2,  2,   2,  2,  2,  5,  2,  2,  6,229,
+ 
+ // state[816 + 2] 0x025000 Byte 3 of 4 (relative offsets)
+--12,-11,-10, -9, -8, -7, -6, -5,  -4, -3, -2, -1,  1,  2,  3,  4,
++static_cast<uint8>(-12),static_cast<uint8>(-11),static_cast<uint8>(-10), static_cast<uint8>(-9), static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5),  static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),  1,  2,  3,  4,
+   5,  6,  7,  8,  9, 10, 11, 12,  13, 14, 15, 16, 17, 18, 19, 20,
+  21, 22, 23, 24, 25, 26, 27, 28,  29, 30, 31, 32, 33, 34, 35, 36,
+  37, 38, 39, 40, 41, 42, 43, 44,  45, 46, 47, 48, 49, 50, 51, 52,
+@@ -5347,7 +5347,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+   6,  6,  6,  5,  5,  5,  5,  6,   6,  6,  3,  6,229,208,208,229,
+ 
+ // state[880 + 2] 0x026000 Byte 3 of 4 (relative offsets)
+--11,-10, -9, -8, -7, -6, -5, -4,  -3, -2, -1,  1,  2,  3,  4,  5,
++static_cast<uint8>(-11),static_cast<uint8>(-10), static_cast<uint8>(-9), static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4),  static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),  1,  2,  3,  4,  5,
+   6,  7,  8,  9, 10, 11, 12, 13,  14, 15, 16, 17, 18, 19, 20, 21,
+  22, 23, 24, 25, 26, 27, 28, 29,  30, 31, 32, 33, 34, 35, 36, 37,
+  38, 39, 40, 41, 42, 43, 44, 45,  46, 47, 48, 49, 50, 51, 52, 53,
+@@ -5731,7 +5731,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 208,  6,  6,208,208,208,208,208,   6,  6,  6,216,  5,  5,  5,  5,
+ 
+ // state[944 + 2] 0x027000 Byte 3 of 4 (relative offsets)
+--10, -9, -8, -7, -6, -5, -4, -3,  -2, -1,  1,  2,  3,  4,  5,  6,
++static_cast<uint8>(-10), static_cast<uint8>(-9), static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3),  static_cast<uint8>(-2), static_cast<uint8>(-1),  1,  2,  3,  4,  5,  6,
+   7,  8,  9, 10, 11, 12, 13, 14,  15, 16, 17, 18, 19, 20, 21, 22,
+  23, 24, 25, 26, 27, 28, 29, 30,  31, 32, 33, 34, 35, 36, 37, 38,
+  39, 40, 41, 42, 43, 44, 45, 46,  47, 48, 49, 50, 51, 52, 53, 54,
+@@ -6115,7 +6115,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+   5,  5,  5,  6,208,208,  6,  6, 208,229,208,208,208,  5,  5,  5,
+ 
+ // state[1008 + 2] 0x028000 Byte 3 of 4 (relative offsets)
+- -9, -8, -7, -6, -5, -4, -3, -2,  -1,  1,  2,  3,  4,  5,  6,  7,
++ static_cast<uint8>(-9), static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2),  static_cast<uint8>(-1),  1,  2,  3,  4,  5,  6,  7,
+   8,  9, 10, 11, 12, 13, 14, 15,  16, 17, 18, 19, 20, 21, 22, 23,
+  24, 25, 26, 27, 28, 29, 30, 31,  32, 33, 34, 35, 36, 37, 38, 39,
+  40, 41, 42, 43, 44, 45, 46, 47,  48, 49, 50, 51, 52, 53, 54, 55,
+@@ -6499,7 +6499,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 208,208,  5,  5,  6,208,208,  5, 208,208,208,  6,208,  6,208,208,
+ 
+ // state[1072 + 2] 0x029000 Byte 3 of 4 (relative offsets)
+- -8, -7, -6, -5, -4, -3, -2, -1,   1,  2,  3,  4,  5,  6,  7,  8,
++ static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),   1,  2,  3,  4,  5,  6,  7,  8,
+   9, 10, 11, 12, 13, 14, 15, 16,  17, 18, 19, 20, 21, 22, 23, 24,
+  25, 26, 27, 28, 29, 30, 31, 32,  33, 34, 35, 36, 37, 38, 39, 40,
+  41, 42, 43, 44, 45, 46, 47, 48,  49, 50, 51, 52, 53, 54, 55, 56,
+@@ -6883,7 +6883,7 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+ 229,229,229,229,208,208,208,229, 208,208,208,229,  0,229,208,208,
+ 
+ // state[1136 + 2] 0x02a000 Byte 3 of 4 (relative offsets)
+- -7, -6, -5, -4, -3, -2, -1,  1,   2,  3,  4,  5,  6,  7,  8,  9,
++ static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),  1,   2,  3,  4,  5,  6,  7,  8,  9,
+  10, 11, 12, 13, 14, 15, 16, 17,  18, 19, 20, 21, 22, 22, 22, 22,
+  22, 22, 22, 22, 22, 22, 22, 22,  22, 22, 22, 22, 22, 22, 22, 22,
+  22, 22, 22, 22, 22, 22, 22, 22,  22, 22, 22, 22, 22, 22, 22, 22,
+@@ -7075,10 +7075,10 @@ X__,X__,X__,X__,X__,X__,X__,X__, X__,X__,X__,X__,X__,X__,X__,X__,
+   5,  5,  5,  5,  5,  5,  5,  5,   5,  5,  5,  5,  5,  5,  5,  5,
+ 
+ // state[1168 + 2] 0x02f000 Byte 3 of 4 (relative offsets)
+- -9, -9, -9, -9, -9, -9, -9, -9,  -9, -9, -9, -9, -9, -9, -9, -9,
+- -9, -9, -9, -9, -9, -9, -9, -9,  -9, -9, -9, -9, -9, -9, -9, -9,
+- -8, -7, -6, -5, -4, -3, -2, -1,   1, -9, -9, -9, -9, -9, -9, -9,
+- -9, -9, -9, -9, -9, -9, -9, -9,  -9, -9, -9, -9, -9, -9, -9, -9,
++ static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9),  static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9),
++ static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9),  static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9),
++ static_cast<uint8>(-8), static_cast<uint8>(-7), static_cast<uint8>(-6), static_cast<uint8>(-5), static_cast<uint8>(-4), static_cast<uint8>(-3), static_cast<uint8>(-2), static_cast<uint8>(-1),   1, static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9),
++  static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9),  static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9), static_cast<uint8>(-9),
+ 
+ // state[1169 + 2] 0x02fa00 Byte 4 of 4 (property)
+ 217,  5,  5,  5,  5,  5,  5,  5,   5,  5,  5,  5,  5,217,  5,  5,
+diff --git a/internal/scoreonescriptspan.cc b/internal/scoreonescriptspan.cc
+index 11ccaea..8313ecc 100644
+--- a/internal/scoreonescriptspan.cc
++++ b/internal/scoreonescriptspan.cc
+@@ -1144,8 +1144,8 @@ void ScoreEntireScriptSpan(const LangSpan& scriptspan,
+   if (scoringcontext->flags_cld2_html) {
+     ChunkSummary chunksummary = {
+       1, 0,
+-      one_one_lang, UNKNOWN_LANGUAGE, score, 1,
+-      bytes, 0, scriptspan.ulscript, reliability, reliability
++      static_cast<uint8>(one_one_lang), UNKNOWN_LANGUAGE, static_cast<uint8>(score), 1,
++      static_cast<uint8>(bytes), 0, static_cast<uint8>(scriptspan.ulscript), static_cast<uint8>(reliability), static_cast<uint8>(reliability)
+     };
+     CLD2_Debug(scriptspan.text, 1, scriptspan.text_bytes,
+                false, false, NULL,

--- a/libcld2/add-cmake-file.patch
+++ b/libcld2/add-cmake-file.patch
@@ -1,0 +1,166 @@
+# Ref: https://salsa.debian.org/debian/cld2/-/raw/master/debian/patches/add-cmake-file.patch?ref_type=heads
+Description: Add a cmake file to properly handle the source files
+
+Author: Gianfranco Costamagna <costamagnagianfranco@yahoo.it>
+Forwarded: https://github.com/CLD2Owners/cld2/issues/29
+
+Index: cld2-0.0.0~svn194/CMakeLists.txt
+===================================================================
+--- /dev/null	1970-01-01 00:00:00.000000000 +0000
++++ cld2-0.0.0~svn194/CMakeLists.txt	2015-03-30 16:29:14.318639846 +0200
+@@ -0,0 +1,155 @@
++cmake_minimum_required(VERSION 2.8)
++project (cld2)
++enable_language(CXX)
++
++set (VERSION "0.0.197")
++set (common_SOURCE_FILES
++    internal/cldutil.cc
++    internal/cldutil_shared.cc
++    internal/compact_lang_det.cc
++    internal/compact_lang_det_hint_code.cc
++    internal/compact_lang_det_impl.cc
++    internal/debug.cc
++    internal/fixunicodevalue.cc 
++    internal/generated_entities.cc
++    internal/generated_language.cc
++    internal/generated_ulscript.cc
++    internal/getonescriptspan.cc
++    internal/lang_script.cc
++    internal/offsetmap.cc
++    internal/scoreonescriptspan.cc
++    internal/tote.cc
++    internal/utf8statetable.cc
++    )
++
++set (cld2_SOURCE_FILES
++    internal/generated_distinct_bi_0.cc
++    internal/cld_generated_cjk_uni_prop_80.cc
++    internal/cld2_generated_cjk_compatible.cc
++    internal/cld_generated_cjk_delta_bi_4.cc
++    internal/cld2_generated_quadchrome_2.cc
++    internal/cld2_generated_deltaoctachrome.cc
++    internal/cld2_generated_distinctoctachrome.cc
++    internal/cld_generated_score_quad_octa_2.cc
++    )
++
++set (cld2_full_SOURCE_FILES
++    internal/generated_distinct_bi_0.cc
++    internal/cld_generated_cjk_uni_prop_80.cc
++    internal/cld2_generated_cjk_compatible.cc
++    internal/cld_generated_cjk_delta_bi_32.cc
++    internal/cld2_generated_quad0122.cc
++    internal/cld2_generated_deltaocta0122.cc
++    internal/cld2_generated_distinctocta0122.cc
++    internal/cld_generated_score_quad_octa_0122.cc
++    )
++
++set (cld2_dynamic_SOURCE_FILES
++    internal/cld2_dynamic_data.cc
++    internal/cld2_dynamic_data_loader.cc
++    )
++
++add_library(cld2 SHARED ${common_SOURCE_FILES} ${cld2_SOURCE_FILES})
++set_target_properties(cld2 PROPERTIES
++  ENABLE_EXPORTS On
++  OUTPUT_NAME cld2
++  VERSION ${VERSION}
++  SOVERSION 0
++  )
++add_library(cld2_full SHARED ${cld2_full_SOURCE_FILES})
++set_target_properties(cld2_full PROPERTIES
++  ENABLE_EXPORTS On
++  OUTPUT_NAME cld2_full
++  VERSION ${VERSION}
++  SOVERSION 0
++  )
++
++add_library(cld2_dynamic SHARED ${cld2_dynamic_SOURCE_FILES})
++set_target_properties(cld2_dynamic PROPERTIES
++  ENABLE_EXPORTS On
++  OUTPUT_NAME cld2_dynamic
++  VERSION ${VERSION}
++  SOVERSION 0
++  COMPILE_FLAGS "-DCLD2_DYNAMIC_MODE"
++  )
++install(TARGETS cld2 DESTINATION lib/${CMAKE_LIBRARY_ARCHITECTURE})
++install(TARGETS cld2_full DESTINATION lib/${CMAKE_LIBRARY_ARCHITECTURE})
++install(TARGETS cld2_dynamic DESTINATION lib/${CMAKE_LIBRARY_ARCHITECTURE})
++
++set (cld2_internal_HEADERS
++    internal/cld2_dynamic_compat.h
++    internal/cld2_dynamic_data_extractor.h
++    internal/cld2_dynamic_data.h
++    internal/cld2_dynamic_data_loader.h
++    internal/cld2tablesummary.h
++    internal/cldutil.h
++    internal/cldutil_offline.h
++    internal/cldutil_shared.h
++    internal/compact_lang_det_hint_code.h
++    internal/compact_lang_det_impl.h
++    internal/debug.h
++    internal/fixunicodevalue.h
++    internal/generated_language.h
++    internal/generated_ulscript.h
++    internal/getonescriptspan.h
++    internal/integral_types.h
++    internal/lang_script.h
++    internal/langspan.h
++    internal/offsetmap.h
++    internal/port.h
++    internal/scoreonescriptspan.h
++    internal/stringpiece.h
++    internal/tote.h
++    internal/unittest_data.h
++    internal/utf8acceptinterchange.h
++    internal/utf8prop_lettermarkscriptnum.h
++    internal/utf8repl_lettermarklower.h
++    internal/utf8scannot_lettermarkspecial.h
++    internal/utf8statetable.h
++    )
++
++install(FILES ${cld2_internal_HEADERS} DESTINATION include/cld2/internal)
++set (cld2_public_HEADERS
++    public/compact_lang_det.h
++    public/encodings.h
++    )
++install(FILES ${cld2_public_HEADERS} DESTINATION include/cld2/public)
++
++set (full_SOURCE_FILES
++    internal/cld_generated_cjk_uni_prop_80.cc
++    internal/cld2_generated_cjk_compatible.cc
++    internal/cld_generated_cjk_delta_bi_32.cc
++    internal/generated_distinct_bi_0.cc
++    internal/cld2_generated_quad0122.cc
++    internal/cld2_generated_deltaocta0122.cc
++    internal/cld2_generated_distinctocta0122.cc
++    internal/cld_generated_score_quad_octa_0122.cc
++    )
++
++add_executable(compact_lang_det_test_full ${full_SOURCE_FILES} internal/compact_lang_det_test.cc)
++add_executable(cld2_unittest_full         ${full_SOURCE_FILES} internal/cld2_unittest_full.cc)
++add_executable(cld2_unittest_full_avoid   ${full_SOURCE_FILES} internal/cld2_unittest_full.cc)
++set_target_properties(cld2_unittest_full_avoid PROPERTIES COMPILE_FLAGS "-Davoid_utf8_string_constants")
++
++add_executable(cld2_dynamic_data_tool               internal/cld2_dynamic_data_extractor.cc internal/cld2_dynamic_data_tool.cc)
++add_executable(compact_lang_det_dynamic_test_chrome ${common_SOURCE_FILES} internal/cld2_dynamic_data_extractor.cc internal/compact_lang_det_test.cc)
++add_executable(cld2_dynamic_unittest                ${common_SOURCE_FILES} internal/cld2_unittest.cc)
++set_target_properties(compact_lang_det_dynamic_test_chrome PROPERTIES COMPILE_FLAGS "-DCLD2_DYNAMIC_MODE")
++set_target_properties(cld2_dynamic_unittest PROPERTIES COMPILE_FLAGS "-DCLD2_DYNAMIC_MODE")
++
++add_executable(compact_lang_det_test_chrome_2  internal/compact_lang_det_test.cc)
++add_executable(compact_lang_det_test_chrome_16 internal/compact_lang_det_test.cc)
++add_executable(cld2_unittest_chrome_2          internal/cld2_unittest.cc)
++add_executable(cld2_unittest_avoid_chrome_2    internal/cld2_unittest.cc)
++set_target_properties(cld2_unittest_avoid_chrome_2 PROPERTIES COMPILE_FLAGS "-Davoid_utf8_string_constants")
++
++target_link_libraries(compact_lang_det_test_full cld2)
++target_link_libraries(cld2_unittest_full cld2)
++target_link_libraries(cld2_unittest_full_avoid cld2)
++target_link_libraries(cld2_dynamic_data_tool cld2 cld2_dynamic)
++target_link_libraries(compact_lang_det_dynamic_test_chrome cld2_dynamic)
++target_link_libraries(cld2_dynamic_unittest cld2_dynamic)
++target_link_libraries(compact_lang_det_test_chrome_2 cld2)
++target_link_libraries(compact_lang_det_test_chrome_16 cld2)
++target_link_libraries(cld2_unittest_chrome_2 cld2)
++target_link_libraries(cld2_unittest_avoid_chrome_2 cld2)

--- a/libcld2/series
+++ b/libcld2/series
@@ -1,0 +1,2 @@
+add-cmake-file.patch
+1.patch


### PR DESCRIPTION
Adds `libcld2` and `libcld2-dev` from https://salsa.debian.org/debian/cld2/-/tree/master?ref_type=heads