### PR TITLE
add packer-plugin-googlecompute package

### DIFF
--- a/packer-plugin-google.yaml
+++ b/packer-plugin-google.yaml
@@ -1,0 +1,29 @@
+package:
+  name: packer-plugin-googlecompute
+  version: 1.1.6
+  epoch: 0
+  copyright:
+    - license: MPL-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hashicorp/packer-plugin-googlecompute
+      tag: v${{package.version}}
+      expected-commit: 901527ae067872d869ea41d2e3aab1db10092626
+
+  - uses: go/bump
+    with:
+      deps: github.com/hashicorp/go-retryablehttp@v0.7.7
+
+  - uses: go/build
+    with:
+      packages: .
+      output: packer-plugin-google
+      ldflags: -X github.com/hashicorp/packer-plugin-googlecompute/version.Version=${{package.version}}
+
+update:
+  enabled: true
+  github:
+    identifier: hashicorp/packer-plugin-google
+    strip-prefix: v


### PR DESCRIPTION
tests are missing because we don't have packer. 