### PR TITLE
rancher-agent: fix CVE GHSA-jfvp-7x6p-h2pv

### DIFF
--- a/rancher-2.9.yaml
+++ b/rancher-2.9.yaml
@@ -12,7 +12,7 @@ var-transforms:
 package:
   name: rancher-2.9
   version: 2.9.0
-  epoch: 3
+  epoch: 4
   description: Complete container management platform
   copyright:
     - license: Apache-2.0
@@ -76,7 +76,7 @@ subpackages:
     pipeline:
       - uses: go/bump
         with:
-          deps: github.com/go-jose/go-jose/v3@v3.0.3 k8s.io/kubernetes@v1.30.3 k8s.io/apiserver@v0.30.3
+          deps: github.com/go-jose/go-jose/v3@v3.0.3 k8s.io/kubernetes@v1.30.3 k8s.io/apiserver@v0.30.3 github.com/opencontainers/runc@v1.1.14
       - uses: go/build
         with:
           packages: ./cmd/agent
@@ -103,7 +103,7 @@ subpackages:
         with:
           repository: https://github.com/rancher/kontainer-driver-metadata/
           branch: release-v${{vars.major-minor-version}}
-          expected-commit: 013113ed0a841b5ca591175e103b6994b9fcebe2
+          expected-commit: 8a6018c790c232c931e2900021afed519c01d38f
           destination: kontainer-driver-metadata
       - working-directory: ./kontainer-driver-metadata
         runs: |
@@ -146,7 +146,7 @@ subpackages:
           repository: https://github.com/rancher/partner-charts
           branch: main
           destination: partner-charts
-          expected-commit: 55971306935bddfaf98e642898d985ab93741a45
+          expected-commit: 511aaf57e51a2c0f8a519c619991bdf31240920e
       - working-directory: ./partner-charts
         runs: |
           shasum256=$(echo -n "https://git.rancher.io/partner-charts" |shasum -a 256 | awk '{ print $1 }')
@@ -173,7 +173,7 @@ subpackages:
           repository: https://github.com/rancher/charts
           branch: release-v${{vars.major-minor-version}}
           destination: charts
-          expected-commit: 47e69f03a552ca966b3688050b2d9517c233a877
+          expected-commit: f1158fc0ef7e27acd2cfd2bd40ae8afb626293ba
           depth: -1
       - working-directory: ./charts
         runs: |
@@ -208,7 +208,7 @@ subpackages:
           repository: https://github.com/rancher/rke2-charts
           branch: main
           destination: rke2-charts
-          expected-commit: ced0ac0f44b7b33c75fdf708cb214de1a5182cfd
+          expected-commit: 3289e7de5c60113616d3a248c70164619f2d8fa9
       - working-directory: ./rke2-charts
         runs: |
           shasum256=$(echo -n "https://git.rancher.io/rke2-charts" |shasum -a 256 | awk '{ print $1 }')


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
