### PR TITLE
Removing dotnet 7 references from file

### DIFF
--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -114,7 +114,7 @@ subpackages:
         - aspnet-runtime=8
 
   - name: dotnet-8-targeting-pack
-    description: "The .NET Core targeting pack, version 7"
+    description: "The .NET Core targeting pack, version 8"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/dotnet/packs
@@ -122,7 +122,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/dotnet/packs/Microsoft.NETCore.App.* "${{targets.subpkgdir}}"/usr/share/dotnet/packs/
 
   - name: aspnet-8-targeting-pack
-    description: "The ASP.NET targeting pack, version 7"
+    description: "The ASP.NET targeting pack, version 8"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/dotnet/packs
@@ -132,7 +132,7 @@ subpackages:
         - dotnet-8-targeting-pack
 
   - name: dotnet-8-sdk
-    description: "The .NET Core SDK, version 7"
+    description: "The .NET Core SDK, version 8"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/dotnet


### PR DESCRIPTION

* Removing description with version 7 references in  dotnet-8.yaml "

Fixes:
From:
dotnet-6.yaml:    description: "The .NET Core targeting pack, version 6"
dotnet-6.yaml:    description: "The ASP.NET targeting pack, version 6"
dotnet-7.yaml:    description: "The .NET Core targeting pack, version 7"
dotnet-7.yaml:    description: "The ASP.NET targeting pack, version 7"
dotnet-8.yaml:    description: "The .NET Core targeting pack, version 7"
dotnet-8.yaml:    description: "The ASP.NET targeting pack, version 7"
To:
dotnet-6.yaml:    description: "The .NET Core targeting pack, version 6"
dotnet-6.yaml:    description: "The ASP.NET targeting pack, version 6"
dotnet-7.yaml:    description: "The .NET Core targeting pack, version 7"
dotnet-7.yaml:    description: "The ASP.NET targeting pack, version 7"
dotnet-8.yaml:    description: "The .NET Core targeting pack, version 8"
dotnet-8.yaml:    description: "The ASP.NET targeting pack, version 8"