### PR TITLE
fix(argo-cd-2.12): rebuild with go1.23.1

### DIFF
--- a/argo-cd-2.12.yaml
+++ b/argo-cd-2.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.12
   version: 2.12.3
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
To mitigate some CVEs:


```
wolfictl scan argo-cd-2.12-2.12.3-r0.apk
🔎 Scanning "argo-cd-2.12-2.12.3-r0.apk"
└── 📄 /usr/bin/argocd
        📦 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.1.0 (go-module)
            Medium CVE-2024-35255 GHSA-m5vv-6r4h-3vj9 fixed in 1.6.0
        📦 k8s.io/kubernetes v1.29.6 (go-module)
            Medium CVE-2024-5321 GHSA-82m2-cv7p-4m75 fixed in 1.29.7
        📦 stdlib go1.23.0 (go-module)
            Unknown CVE-2024-34155
            High CVE-2024-34156
            High CVE-2024-34158
```