### PR TITLE
CVE fix: GHSA-h4gh-qq45-vh27 py3-cassandra-medusa

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -37,6 +37,10 @@ pipeline:
     runs: |
       pip install wheel
       pip install poetry
+      # fix GHSA-h4gh-qq45-vh27
+      poetry add "pyOpenSSL==24.2.1"
+      poetry add "cryptography==43.0.1"
+
       poetry add "aiohttp==3.9.4"
       poetry add "certifi==2024.7.4"
       poetry add "dnspython==2.6.1"
@@ -113,7 +117,6 @@ test:
       packages:
         - wolfi-base
         - python-3.11-dev
-        # - python-3.11-base
         - grpc-health-probe
   pipeline:
     - runs: medusa --version

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: 0.22.2
-  epoch: 0
+  epoch: 1
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
@@ -113,6 +113,7 @@ test:
       packages:
         - wolfi-base
         - python-3.11-dev
+        # - python-3.11-base
         - grpc-health-probe
   pipeline:
     - runs: medusa --version


### PR DESCRIPTION
The test is not passing even before these changes we have made here. look [CI check for b7dddcc](https://github.com/wolfi-dev/os/pull/28199/checks?check_run_id=30046967029)