### PR TITLE
new pkg: pbzip2

### DIFF
--- a/pbzip2.yaml
+++ b/pbzip2.yaml
@@ -39,3 +39,53 @@ test:
     - name: version test
       runs: |
         pbzip2 --version
+    - name: basic compress/decompress test
+      runs: |
+        echo "Hello from pbzip2!" > test.txt
+        # Compress with pbzip2
+        pbzip2 test.txt
+        # Decompress
+        pbzip2 -d test.txt.bz2
+        # Verify the result
+        if ! grep -q "Hello from pbzip2!" test.txt; then
+          echo "ERROR: Decompressed file does not contain the expected text."
+          exit 1
+        fi
+    - name: parallel compression example
+      runs: |
+        # Create a sample file of some size
+        dd if=/dev/urandom of=random.dat bs=1K count=50
+
+        # Compress using 4 threads
+        pbzip2 -p4 random.dat
+
+        # We should now have random.dat.bz2
+        if [ ! -f random.dat.bz2 ]; then
+          echo "ERROR: Parallel compression failed; random.dat.bz2 not found."
+          exit 1
+        fi
+
+        # Decompress
+        pbzip2 -d random.dat.bz2
+
+        # Make sure the file came back
+        if [ ! -f random.dat ]; then
+          echo "ERROR: Decompression failed; random.dat not restored."
+          exit 1
+        fi
+        echo "Parallel compression test passed."
+    - name: cross-compatibility test with bzip2
+      runs: |
+        echo "Cross-compatibility test" > cross.txt
+
+        # Compress with pbzip2
+        pbzip2 cross.txt
+        # Decompress with standard bzip2
+        bzip2 -d cross.txt.bz2
+
+        # Check the content
+        if ! grep -q "Cross-compatibility test" cross.txt; then
+          echo "ERROR: Cross-compatibility test failed."
+          exit 1
+        fi
+        echo "Cross-compatibility test passed."

--- a/pbzip2.yaml
+++ b/pbzip2.yaml
@@ -1,0 +1,41 @@
+package:
+  name: pbzip2
+  version: 1.1.13
+  epoch: 0
+  description: Parallel implementation of the bzip2 block-sorting file compressor
+  copyright:
+    - license: BSD
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - bzip2-dev
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 8fd13eaaa266f7ee91f85c1ea97c86d9c9cc985969db9059cdebcb1e1b7bdbe6
+      uri: https://launchpad.net/pbzip2/1.1/${{package.version}}/+download/pbzip2-${{package.version}}.tar.gz
+
+  - runs: |
+      # Delete {CXX,LD}FLAGS from Makefile. Use one from Wolfi build env
+      sed -i '/^\(CXX\|LD\)FLAGS =/d' Makefile
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: false
+  exclude-reason: Need support for git.launchpad.net
+
+test:
+  pipeline:
+    - name: pbzip2
+      runs: |
+        pbzip2 --help || exit 1

--- a/pbzip2.yaml
+++ b/pbzip2.yaml
@@ -36,6 +36,6 @@ update:
 
 test:
   pipeline:
-    - name: pbzip2
+    - name: version test
       runs: |
-        pbzip2 --help || exit 1
+        pbzip2 --version


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/27820

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
