### PR TITLE
go-1.23.1: bump all go packages

### DIFF
--- a/actions-runner-controller.yaml
+++ b/actions-runner-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: actions-runner-controller
   version: 0.9.3
-  epoch: 1
+  epoch: 2
   description: Kubernetes controller for GitHub Actions self-hosted runners
   copyright:
     - license: Apache-2.0

--- a/addon-resizer.yaml
+++ b/addon-resizer.yaml
@@ -1,7 +1,7 @@
 package:
   name: addon-resizer
   version: 1.8.22
-  epoch: 1
+  epoch: 2
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-workflows
   version: 3.5.10
-  epoch: 2
+  epoch: 3
   description: Workflow engine for Kubernetes.
   copyright:
     - license: Apache-2.0

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,7 +1,7 @@
 package:
   name: atlantis
   version: 0.29.0
-  epoch: 0
+  epoch: 1
   description: Terraform Pull Request Automation
   copyright:
     - license: Apache-2.0

--- a/aws-ebs-csi-driver.yaml
+++ b/aws-ebs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-ebs-csi-driver
   version: 1.34.0
-  epoch: 0
+  epoch: 1
   description: CSI driver for Amazon EBS.
   copyright:
     - license: Apache-2.0

--- a/aws-efs-csi-driver.yaml
+++ b/aws-efs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-efs-csi-driver
   version: 2.0.7
-  epoch: 0
+  epoch: 1
   description: CSI driver for Amazon EFS.
   copyright:
     - license: Apache-2.0

--- a/aws-flb-cloudwatch.yaml
+++ b/aws-flb-cloudwatch.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-cloudwatch
   version: 1.9.4
-  epoch: 12
+  epoch: 13
   description: A Fluent Bit output plugin for CloudWatch Logs
   copyright:
     - license: Apache-2.0

--- a/aws-flb-firehose.yaml
+++ b/aws-flb-firehose.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-firehose
   version: 1.7.2
-  epoch: 12
+  epoch: 13
   description: A Fluent Bit output plugin for Amazon Kinesis Data Firehose
   copyright:
     - license: Apache-2.0

--- a/aws-flb-kinesis.yaml
+++ b/aws-flb-kinesis.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-flb-kinesis
   version: 1.10.2
-  epoch: 13
+  epoch: 14
   description: A Fluent Bit output plugin for Kinesis Streams.
   copyright:
     - license: Apache-2.0

--- a/aws-load-balancer-controller.yaml
+++ b/aws-load-balancer-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-load-balancer-controller
   version: 2.8.2
-  epoch: 0
+  epoch: 1
   description: A Kubernetes controller for Elastic Load Balancers
   copyright:
     - license: Apache-2.0

--- a/bank-vaults.yaml
+++ b/bank-vaults.yaml
@@ -1,7 +1,7 @@
 package:
   name: bank-vaults
   version: 1.20.4
-  epoch: 17
+  epoch: 18
   description: A Vault swiss-army knife. A CLI tool to init, unseal and configure Vault (auth methods, secret engines).
   copyright:
     - license: Apache-2.0

--- a/bincapz.yaml
+++ b/bincapz.yaml
@@ -1,7 +1,7 @@
 package:
   name: bincapz
   version: 0.19.0
-  epoch: 0
+  epoch: 1
   description: enumerate binary capabilities, including malicious behaviors
   copyright:
     - license: Apache-2.0

--- a/boring-registry.yaml
+++ b/boring-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: boring-registry
   version: 0.15.2
-  epoch: 0
+  epoch: 1
   description: Terraform Provider and Module Registry
   copyright:
     - license: MIT

--- a/caddy.yaml
+++ b/caddy.yaml
@@ -1,7 +1,7 @@
 package:
   name: caddy
   version: 2.8.4
-  epoch: 2
+  epoch: 3
   description: Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS
   copyright:
     - license: Apache-2.0

--- a/cadvisor.yaml
+++ b/cadvisor.yaml
@@ -1,7 +1,7 @@
 package:
   name: cadvisor
   version: 0.50.0
-  epoch: 2
+  epoch: 3
   description: Analyzes resource usage and performance characteristics of running containers.
   copyright:
     - license: Apache-2.0

--- a/calico-3.28.yaml
+++ b/calico-3.28.yaml
@@ -1,7 +1,7 @@
 package:
   name: calico-3.28
   version: 3.28.1
-  epoch: 0
+  epoch: 1
   description: "Cloud native networking and network security"
   copyright:
     - license: Apache-2.0

--- a/cert-exporter.yaml
+++ b/cert-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: cert-exporter
   version: 2.13.0
-  epoch: 0
+  epoch: 1
   description: A Prometheus exporter that publishes cert expirations on disk and in Kubernetes secrets
   copyright:
     - license: Apache-2.0

--- a/cert-manager-1.15.yaml
+++ b/cert-manager-1.15.yaml
@@ -2,7 +2,7 @@ package:
   name: cert-manager-1.15
   # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
   version: 1.15.3
-  epoch: 0
+  epoch: 1
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0

--- a/cert-manager-webhook-pdns.yaml
+++ b/cert-manager-webhook-pdns.yaml
@@ -1,7 +1,7 @@
 package:
   name: cert-manager-webhook-pdns
   version: 2.5.1
-  epoch: 5
+  epoch: 6
   description: A PowerDNS webhook for cert-manager
   copyright:
     - license: Apache-2.0

--- a/certificate-transparency.yaml
+++ b/certificate-transparency.yaml
@@ -1,7 +1,7 @@
 package:
   name: certificate-transparency
   version: 1.2.1
-  epoch: 3
+  epoch: 4
   description: Auditing for TLS certificates
   copyright:
     - license: Apache-2.0

--- a/cfssl.yaml
+++ b/cfssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: cfssl
   version: 1.6.5
-  epoch: 8
+  epoch: 9
   description: Cloudflare's PKI and TLS toolkit
   copyright:
     - license: BSD-2-Clause

--- a/chartmuseum.yaml
+++ b/chartmuseum.yaml
@@ -1,7 +1,7 @@
 package:
   name: chartmuseum
   version: 0.16.2
-  epoch: 5
+  epoch: 6
   description: helm chart repository server
   copyright:
     - license: Apache-2.0

--- a/cilium-1.16.yaml
+++ b/cilium-1.16.yaml
@@ -2,7 +2,7 @@
 package:
   name: cilium-1.16
   version: 1.16.1
-  epoch: 1
+  epoch: 2
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0

--- a/cloud-sql-proxy.yaml
+++ b/cloud-sql-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloud-sql-proxy
   version: 2.13.0
-  epoch: 0
+  epoch: 1
   description: The Cloud SQL Auth Proxy is a utility for ensuring secure connections to your Cloud SQL instances
   copyright:
     - license: Apache-2.0

--- a/cloudnative-pg.yaml
+++ b/cloudnative-pg.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudnative-pg
   version: 1.24.0
-  epoch: 0
+  epoch: 1
   description: CloudNativePG is a comprehensive platform designed to seamlessly manage PostgreSQL databases
   copyright:
     - license: Apache-2.0

--- a/cluster-autoscaler-1.30.yaml
+++ b/cluster-autoscaler-1.30.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-autoscaler-1.30
   version: 1.30.2
-  epoch: 1
+  epoch: 2
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/cluster-proportional-autoscaler.yaml
+++ b/cluster-proportional-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: cluster-proportional-autoscaler
   version: 1.8.11
-  epoch: 8
+  epoch: 9
   description: Kubernetes Cluster Proportional Autoscaler Container
   copyright:
     - license: Apache-2.0

--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -1,7 +1,7 @@
 package:
   name: cni-plugins
   version: 1.5.1
-  epoch: 1
+  epoch: 2
   description: Some reference and example networking plugins, maintained by the CNI team.
   copyright:
     - license: Apache-2.0

--- a/configmap-reload.yaml
+++ b/configmap-reload.yaml
@@ -1,7 +1,7 @@
 package:
   name: configmap-reload
   version: 0.13.1
-  epoch: 1
+  epoch: 2
   description: Simple binary to trigger a reload when a Kubernetes ConfigMap is updated
   copyright:
     - license: Apache-2.0

--- a/confluent-common-docker.yaml
+++ b/confluent-common-docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: confluent-common-docker
   version: 7.6.0
-  epoch: 7
+  epoch: 8
   description: Confluent Commons with support for building and testing Docker images.
   copyright:
     - license: Apache-2.0

--- a/conftest.yaml
+++ b/conftest.yaml
@@ -1,7 +1,7 @@
 package:
   name: conftest
   version: 0.55.0
-  epoch: 0
+  epoch: 1
   description: Write tests against structured configuration data using the Open Policy Agent Rego query language
   copyright:
     - license: Apache-2.0

--- a/contour-1.30.yaml
+++ b/contour-1.30.yaml
@@ -1,7 +1,7 @@
 package:
   name: contour-1.30
   version: 1.30.0
-  epoch: 2
+  epoch: 3
   description: Contour is a Kubernetes ingress controller using Envoy proxy.
   copyright:
     - license: Apache-2.0

--- a/coredns.yaml
+++ b/coredns.yaml
@@ -1,7 +1,7 @@
 package:
   name: coredns
   version: 1.11.3
-  epoch: 6
+  epoch: 7
   description: CoreDNS is a DNS server that chains plugins
   copyright:
     - license: Apache-2.0

--- a/cortex.yaml
+++ b/cortex.yaml
@@ -1,7 +1,7 @@
 package:
   name: cortex
   version: 1.18.0
-  epoch: 0
+  epoch: 1
   description: A horizontally scalable, highly available, multi-tenant, long term Prometheus.
   copyright:
     - license: Apache-2.0

--- a/cosign.yaml
+++ b/cosign.yaml
@@ -1,7 +1,7 @@
 package:
   name: cosign
   version: 2.4.0
-  epoch: 2
+  epoch: 3
   description: Container Signing
   copyright:
     - license: Apache-2.0

--- a/crane.yaml
+++ b/crane.yaml
@@ -1,7 +1,7 @@
 package:
   name: crane
   version: 0.20.2
-  epoch: 0
+  epoch: 1
   description: Tool for interacting with remote images and registries.
   copyright:
     - license: Apache-2.0

--- a/crossplane-provider-aws.yaml
+++ b/crossplane-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-aws
   version: 1.13.0
-  epoch: 0
+  epoch: 1
   description: Official AWS Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0

--- a/crossplane-provider-azure.yaml
+++ b/crossplane-provider-azure.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane-provider-azure
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: Official Azure Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -1,7 +1,7 @@
 package:
   name: crossplane
   version: 1.16.0
-  epoch: 4
+  epoch: 5
   description: Cloud Native Control Planes
   copyright:
     - license: Apache-2.0

--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-gateway
   version: 2024.1.0
-  epoch: 9
+  epoch: 10
   description: "A multi-tenant server for securely deploying and managing Dask clusters."
   copyright:
     - license: BSD-3-Clause

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent
   version: 7.56.2
-  epoch: 0
+  epoch: 1
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0

--- a/dex.yaml
+++ b/dex.yaml
@@ -2,7 +2,7 @@ package:
   name: dex
   # When bumping the version check if the GHSA mitigations below can be removed.
   version: 2.41.1
-  epoch: 0
+  epoch: 1
   description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors
   copyright:
     - license: Apache-2.0

--- a/distribution.yaml
+++ b/distribution.yaml
@@ -1,7 +1,7 @@
 package:
   name: distribution
   version: 3.0.0
-  epoch: 1
+  epoch: 2
   description: The toolkit to pack, ship, store, and deliver container content
   copyright:
     - license: Apache-2.0

--- a/dive.yaml
+++ b/dive.yaml
@@ -1,7 +1,7 @@
 package:
   name: dive
   version: 0.12.0
-  epoch: 11
+  epoch: 12
   description: A tool for exploring each layer in a docker image
   copyright:
     - license: MIT

--- a/dockerize.yaml
+++ b/dockerize.yaml
@@ -1,7 +1,7 @@
 package:
   name: dockerize
   version: 0.8.0
-  epoch: 0
+  epoch: 1
   description: Utility to simplify running applications in docker containers
   copyright:
     - license: MIT

--- a/doppler-kubernetes-operator.yaml
+++ b/doppler-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: doppler-kubernetes-operator
   version: 1.5.1
-  epoch: 3
+  epoch: 4
   description: Automatically sync secrets from Doppler to Kubernetes and auto-reload deployments when secrets change.
   copyright:
     - license: Apache-2.0

--- a/dynamic-localpv-provisioner.yaml
+++ b/dynamic-localpv-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: dynamic-localpv-provisioner
   version: 4.1.0
-  epoch: 0
+  epoch: 1
   description: Dynamic Local Volumes for Kubernetes Stateful workloads.
   copyright:
     - license: Apache-2.0

--- a/esbuild.yaml
+++ b/esbuild.yaml
@@ -1,7 +1,7 @@
 package:
   name: esbuild
   version: 0.23.1
-  epoch: 0
+  epoch: 1
   description: An extremely fast bundler for the web
   copyright:
     - license: MIT

--- a/falcosidekick.yaml
+++ b/falcosidekick.yaml
@@ -1,7 +1,7 @@
 package:
   name: falcosidekick
   version: 2.29.0
-  epoch: 2
+  epoch: 3
   description: Connect Falco to your ecosystem
   copyright:
     - license: MIT

--- a/filebeat.yaml
+++ b/filebeat.yaml
@@ -1,7 +1,7 @@
 package:
   name: filebeat
   version: 8.15.1
-  epoch: 0
+  epoch: 1
   description: Filebeat is an open source file harvester, mostly used to fetch logs files and feed them into logstash
   copyright:
     - license: Apache-2.0

--- a/flannel-cni-plugin.yaml
+++ b/flannel-cni-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: flannel-cni-plugin
   version: 1.5.1
-  epoch: 1
+  epoch: 2
   description: flannel cni plugin
   copyright:
     - license: Apache-2.0

--- a/fluent-bit-plugin-loki.yaml
+++ b/fluent-bit-plugin-loki.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-bit-plugin-loki
   version: 3.1.1
-  epoch: 0
+  epoch: 1
   description: The Fluent Bit loki plugin allows you to send your log or events to a Loki service.
   copyright:
     - license: AGPL-3.0-or-later

--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-operator
   version: 3.1.0
-  epoch: 0
+  epoch: 1
   description: Operate Fluent Bit and Fluentd in the Kubernetes way - Previously known as FluentBit Operator
   copyright:
     - license: Apache-2.0

--- a/flux-helm-controller.yaml
+++ b/flux-helm-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-helm-controller
   version: 1.0.1
-  epoch: 6
+  epoch: 7
   description: The GitOps Toolkit Helm reconciler, for declarative Helming
   copyright:
     - license: Apache-2.0

--- a/flux-image-automation-controller.yaml
+++ b/flux-image-automation-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-image-automation-controller
   version: 0.38.0
-  epoch: 5
+  epoch: 6
   description: GitOps Toolkit controller that patches container image tags in Git
   copyright:
     - license: Apache-2.0

--- a/flux-image-reflector-controller.yaml
+++ b/flux-image-reflector-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-image-reflector-controller
   version: 0.32.0
-  epoch: 7
+  epoch: 8
   description: GitOps Toolkit controller that scans container registries
   copyright:
     - license: Apache-2.0

--- a/flux-kustomize-controller.yaml
+++ b/flux-kustomize-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-kustomize-controller
   version: 1.3.0
-  epoch: 6
+  epoch: 7
   description: The GitOps Toolkit Kustomize reconciler
   copyright:
     - license: Apache-2.0

--- a/flux-notification-controller.yaml
+++ b/flux-notification-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-notification-controller
   version: 1.3.0
-  epoch: 5
+  epoch: 6
   description: The GitOps Toolkit event forwarded and notification dispatcher
   copyright:
     - license: Apache-2.0

--- a/flux-source-controller.yaml
+++ b/flux-source-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux-source-controller
   version: 1.3.0
-  epoch: 7
+  epoch: 8
   description: The GitOps Toolkit source management component
   copyright:
     - license: Apache-2.0

--- a/flux.yaml
+++ b/flux.yaml
@@ -1,7 +1,7 @@
 package:
   name: flux
   version: 2.3.0
-  epoch: 6
+  epoch: 7
   description: Open and extensible continuous delivery solution for Kubernetes. Powered by GitOps Toolkit.
   copyright:
     - license: Apache-2.0

--- a/fulcio.yaml
+++ b/fulcio.yaml
@@ -1,7 +1,7 @@
 package:
   name: fulcio
   version: 1.6.4
-  epoch: 0
+  epoch: 1
   description: Sigstore OIDC PKI
   copyright:
     - license: Apache-2.0

--- a/fuse-overlayfs-snapshotter.yaml
+++ b/fuse-overlayfs-snapshotter.yaml
@@ -1,7 +1,7 @@
 package:
   name: fuse-overlayfs-snapshotter
   version: 1.0.8
-  epoch: 11
+  epoch: 12
   description: fuse-overlayfs plugin for rootless containerd
   copyright:
     - license: Apache-2.0

--- a/gatekeeper-3.16.yaml
+++ b/gatekeeper-3.16.yaml
@@ -1,7 +1,7 @@
 package:
   name: gatekeeper-3.16
   version: 3.16.3
-  epoch: 4
+  epoch: 5
   description: Gatekeeper - Policy Controller for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/git-lfs.yaml
+++ b/git-lfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-lfs
   version: 3.5.1
-  epoch: 7
+  epoch: 8
   description: "large file support for git"
   copyright:
     - license: MIT

--- a/gitlab-runner-17.3.yaml
+++ b/gitlab-runner-17.3.yaml
@@ -19,7 +19,7 @@ var-transforms:
 package:
   name: gitlab-runner-17.3
   version: 17.3.1
-  epoch: 0
+  epoch: 1
   description: GitLab Runner is the open source project that is used to run your CI/CD jobs and send the results back to GitLab
   copyright:
     - license: MIT

--- a/gitness.yaml
+++ b/gitness.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitness
   version: 3.0.0_beta6
-  epoch: 5
+  epoch: 6
   description: Gitness is an Open Source developer platform with Source Control management, Continuous Integration and Continuous Delivery.
   copyright:
     - license: Apache-2.0

--- a/gomplate.yaml
+++ b/gomplate.yaml
@@ -1,7 +1,7 @@
 package:
   name: gomplate
   version: 4.1.0
-  epoch: 1
+  epoch: 2
   description: A go templating utility.
   copyright:
     - license: MIT

--- a/gops.yaml
+++ b/gops.yaml
@@ -1,7 +1,7 @@
 package:
   name: gops
   version: 0.3.28
-  epoch: 12
+  epoch: 13
   description: gops is a command to list and diagnose Go processes currently running on your system.
   copyright:
     - license: BSD-3-Clause

--- a/gosu.yaml
+++ b/gosu.yaml
@@ -1,7 +1,7 @@
 package:
   name: gosu
   version: "1.17"
-  epoch: 7
+  epoch: 8
   description: Simple Go-based setuid+setgid+setgroups+exec
   copyright:
     - license: Apache-2.0

--- a/gptscript.yaml
+++ b/gptscript.yaml
@@ -1,7 +1,7 @@
 package:
   name: gptscript
   version: 0.9.4
-  epoch: 0
+  epoch: 1
   description: Develop LLM Apps in Natural Language
   copyright:
     - license: Apache-2.0

--- a/gpu-feature-discovery.yaml
+++ b/gpu-feature-discovery.yaml
@@ -1,7 +1,7 @@
 package:
   name: gpu-feature-discovery
   version: 0.8.2
-  epoch: 5
+  epoch: 6
   description: GPU plugin to the node feature discovery for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/grafana-11.2.yaml
+++ b/grafana-11.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-11.2
   version: 11.2.0
-  epoch: 1
+  epoch: 2
   description: The open and composable observability and data visualization platform.
   copyright:
     - license: AGPL-3.0-or-later

--- a/grafana-agent-operator.yaml
+++ b/grafana-agent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-agent-operator
   version: 0.42.0
-  epoch: 1
+  epoch: 2
   description: Grafana Agent Operator is a Kubernetes operator for the static mode of Grafana Agent. It makes it easier to deploy and configure static mode to collect telemetry data from Kubernetes resources.
   copyright:
     - license: Apache-2.0

--- a/grafana-alloy.yaml
+++ b/grafana-alloy.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-alloy
   version: 1.3.1
-  epoch: 1
+  epoch: 2
   description: OpenTelemetry Collector distribution with programmable pipelines
   copyright:
     - license: Apache-2.0

--- a/grafana-mimir.yaml
+++ b/grafana-mimir.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-mimir
   version: 2.13.0
-  epoch: 2
+  epoch: 3
   description: Grafana Mimir provides horizontally scalable, highly available, multi-tenant, long-term storage for Prometheus.
   copyright:
     - license: AGPL-3.0-or-later

--- a/grafana-rollout-operator-0.14.yaml
+++ b/grafana-rollout-operator-0.14.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-rollout-operator-0.14
   version: 0.14.0
-  epoch: 3
+  epoch: 4
   description: Kubernetes Rollout Operator
   copyright:
     - license: Apache-2.0

--- a/grpc-health-probe.yaml
+++ b/grpc-health-probe.yaml
@@ -2,7 +2,7 @@ package:
   name: grpc-health-probe
   version: 0.4.32
   # bump to epoch 1 when 0.4.29 is released
-  epoch: 0
+  epoch: 1
   description: A command-line tool to perform health-checks for gRPC applications in Kubernetes and elsewhere
   copyright:
     - license: Apache-2.0

--- a/grpcurl.yaml
+++ b/grpcurl.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpcurl
   version: 1.9.1
-  epoch: 5
+  epoch: 6
   description: CLI tool to interact with gRPC servers
   copyright:
     - license: MIT

--- a/haproxy-ingress.yaml
+++ b/haproxy-ingress.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-ingress
   version: 0.14.7
-  epoch: 2
+  epoch: 3
   description: HAProxy Ingress
   copyright:
     - license: Apache-2.0

--- a/harbor-2.11.yaml
+++ b/harbor-2.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-2.11
   version: 2.11.1
-  epoch: 0
+  epoch: 1
   description: An open source trusted cloud native registry project that stores, signs, and scans content
   copyright:
     - license: Apache-2.0

--- a/harbor-registry.yaml
+++ b/harbor-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-registry
   version: 3.0.0_alpha1
-  epoch: 6
+  epoch: 7
   description: An open source trusted cloud native registry project that stores, signs, and scans content (registry)
   copyright:
     - license: Apache-2.0

--- a/harbor-scanner-trivy.yaml
+++ b/harbor-scanner-trivy.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-scanner-trivy
   version: 0.31.4
-  epoch: 0
+  epoch: 1
   description: Use Trivy as a plug-in vulnerability scanner in the Harbor registry
   copyright:
     - license: Apache-2.0

--- a/helm-operator.yaml
+++ b/helm-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: helm-operator
   version: 1.36.1
-  epoch: 1
+  epoch: 2
   description: open source toolkit to manage Kubernetes native applications.
   copyright:
     - license: Apache-2.0

--- a/hey.yaml
+++ b/hey.yaml
@@ -1,7 +1,7 @@
 package:
   name: hey
   version: 0.1.4
-  epoch: 15
+  epoch: 16
   description: HTTP load generator, ApacheBench (ab) replacement
   copyright:
     - license: Apache-2.0

--- a/http-echo.yaml
+++ b/http-echo.yaml
@@ -1,7 +1,7 @@
 package:
   name: http-echo
   version: 1.0.0
-  epoch: 8
+  epoch: 9
   description: A tiny go web server that echos what you start it with!
   copyright:
     - license: MPL-2.0

--- a/hubble-ui.yaml
+++ b/hubble-ui.yaml
@@ -1,7 +1,7 @@
 package:
   name: hubble-ui
   version: 0.13.1
-  epoch: 5
+  epoch: 6
   description: "Observability & troubleshooting for Kubernetes services"
   copyright:
     - license: "Apache-2.0"

--- a/influx.yaml
+++ b/influx.yaml
@@ -1,7 +1,7 @@
 package:
   name: influx
   version: 2.7.5
-  epoch: 3
+  epoch: 4
   description: CLI for managing resources in InfluxDB v2
   copyright:
     - license: MIT

--- a/influxd.yaml
+++ b/influxd.yaml
@@ -1,7 +1,7 @@
 package:
   name: influxd
   version: 2.7.10
-  epoch: 0
+  epoch: 1
   description: Scalable datastore for metrics, events, and real-time analytics
   copyright:
     - license: MIT

--- a/ingress-nginx-controller-1.11.yaml
+++ b/ingress-nginx-controller-1.11.yaml
@@ -2,7 +2,7 @@
 package:
   name: ingress-nginx-controller-1.11
   version: 1.11.2
-  epoch: 1
+  epoch: 2
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0

--- a/ip-masq-agent.yaml
+++ b/ip-masq-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: ip-masq-agent
   version: 2.9.3
-  epoch: 14
+  epoch: 15
   description: Manage IP masquerade on nodes
   copyright:
     - license: Apache-2.0

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.30.4.1
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0

--- a/k8sgpt-operator.yaml
+++ b/k8sgpt-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8sgpt-operator
   version: 0.1.7
-  epoch: 0
+  epoch: 1
   description: Automatic SRE Superpowers within your Kubernetes cluster
   copyright:
     - license: Apache-2.0

--- a/k8sgpt.yaml
+++ b/k8sgpt.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8sgpt
   version: 0.3.40
-  epoch: 0
+  epoch: 1
   description: Giving Kubernetes Superpowers to everyone
   copyright:
     - license: Apache-2.0

--- a/k8ssandra-client.yaml
+++ b/k8ssandra-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8ssandra-client
   version: 0.5.0
-  epoch: 1
+  epoch: 2
   description: A kubectl plugin to simplify usage of k8ssandra.
   copyright:
     - license: Apache-2.0

--- a/k8ssandra-operator.yaml
+++ b/k8ssandra-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8ssandra-operator
   version: 1.19.0
-  epoch: 1
+  epoch: 2
   description: The Kubernetes operator for K8ssandra
   copyright:
     - license: Apache-2.0

--- a/kaf.yaml
+++ b/kaf.yaml
@@ -1,7 +1,7 @@
 package:
   name: kaf
   version: 0.2.8
-  epoch: 5
+  epoch: 6
   description: Modern CLI for Apache Kafka, written in Go
   copyright:
     - license: Apache-2.0

--- a/keda-2.15.yaml
+++ b/keda-2.15.yaml
@@ -1,7 +1,7 @@
 package:
   name: keda-2.15
   version: 2.15.1
-  epoch: 0
+  epoch: 1
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.16.0
-  epoch: 2
+  epoch: 3
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0

--- a/kor.yaml
+++ b/kor.yaml
@@ -1,7 +1,7 @@
 package:
   name: kor
   version: 0.5.5
-  epoch: 0
+  epoch: 1
   description: A Golang Tool to discover unused Kubernetes Resources
   copyright:
     - license: MIT

--- a/kpt.yaml
+++ b/kpt.yaml
@@ -1,7 +1,7 @@
 package:
   name: kpt
   version: 1.0.0_beta49
-  epoch: 10
+  epoch: 11
   description: Automate Kubernetes Configuration Editing
   copyright:
     - license: Apache-2.0

--- a/kube-bench.yaml
+++ b/kube-bench.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-bench
   version: 0.8.0
-  epoch: 1
+  epoch: 2
   description: Checks whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark
   copyright:
     - license: Apache-2.0

--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 15
+  epoch: 16
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT

--- a/kube-logging-operator.yaml
+++ b/kube-logging-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-logging-operator
   version: 4.9.1
-  epoch: 0
+  epoch: 1
   description: Logging operator for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/kube-metrics-adapter.yaml
+++ b/kube-metrics-adapter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-metrics-adapter
   version: 0.2.3
-  epoch: 0
+  epoch: 1
   description: General purpose metrics adapter for Kubernetes HPA metrics
   copyright:
     - license: MIT

--- a/kube-rbac-proxy.yaml
+++ b/kube-rbac-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-rbac-proxy
   version: 0.18.1
-  epoch: 0
+  epoch: 1
   description: Kubernetes RBAC authorizing HTTP proxy for a single upstream.
   copyright:
     - license: Apache-2.0

--- a/kube-state-metrics.yaml
+++ b/kube-state-metrics.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-state-metrics
   version: 2.13.0
-  epoch: 0
+  epoch: 1
   description: Add-on agent to generate and expose cluster-level metrics.
   copyright:
     - license: Apache-2.0

--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-centraldashboard
   version: 1.9.0
-  epoch: 1
+  epoch: 2
   description: Landing page and central dashboard for Kubeflow deployments
   copyright:
     - license: MIT

--- a/kubeflow-katib.yaml
+++ b/kubeflow-katib.yaml
@@ -1,6 +1,6 @@
 package:
   name: kubeflow-katib
-  epoch: 3
+  epoch: 4
   version: 0.17.0
   description: Kubeflow Katib services
   copyright:

--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: 2.2.0
-  epoch: 11
+  epoch: 12
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:

--- a/kubernetes-1.31.yaml
+++ b/kubernetes-1.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.31
   version: 1.31.0
-  epoch: 2
+  epoch: 3
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-external-attacher-4.4.yaml
+++ b/kubernetes-csi-external-attacher-4.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-attacher-4.4
   version: 4.4.4
-  epoch: 5
+  epoch: 6
   description: Sidecar container that watches Kubernetes VolumeAttachment objects and triggers ControllerPublish/Unpublish against a CSI endpoint
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-external-provisioner.yaml
+++ b/kubernetes-csi-external-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-provisioner
   version: 5.1.0
-  epoch: 0
+  epoch: 1
   description: A dynamic provisioner for Kubernetes CSI plugins.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-external-resizer-1.10.yaml
+++ b/kubernetes-csi-external-resizer-1.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-resizer-1.10
   version: 1.10.1
-  epoch: 6
+  epoch: 7
   description: Sidecar container that watches Kubernetes PersistentVolumeClaims objects and triggers controller side expansion operation against a CSI endpoint
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-external-snapshotter-8.0.yaml
+++ b/kubernetes-csi-external-snapshotter-8.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-external-snapshotter-8.0
   version: 8.0.1
-  epoch: 2
+  epoch: 3
   description: Sidecar container that watches Kubernetes Snapshot CRD objects and triggers CreateSnapshot/DeleteSnapshot against a CSI endpoint
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-livenessprobe.yaml
+++ b/kubernetes-csi-livenessprobe.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-livenessprobe
   version: 2.14.0
-  epoch: 0
+  epoch: 1
   description: A sidecar container that can be included in a CSI plugin pod to enable integration with Kubernetes Liveness Probe.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-csi-node-driver-registrar-2.12.yaml
+++ b/kubernetes-csi-node-driver-registrar-2.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-node-driver-registrar-2.12
   version: 2.12.0
-  epoch: 0
+  epoch: 1
   description: Sidecar container that registers a CSI driver with the kubelet using the kubelet plugin registration mechanism.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-dashboard-metrics-scraper.yaml
+++ b/kubernetes-dashboard-metrics-scraper.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard-metrics-scraper
   version: 1.0.9
-  epoch: 18
+  epoch: 19
   description: Container to scrape, store, and retrieve a window of time from the Metrics Server.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-dashboard.yaml
+++ b/kubernetes-dashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dashboard
   version: 7.5.0
-  epoch: 0
+  epoch: 1
   description: General-purpose web UI for Kubernetes clusters
   copyright:
     - license: Apache-2.0

--- a/kubernetes-dns-node-cache.yaml
+++ b/kubernetes-dns-node-cache.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-dns-node-cache
   version: 1.23.1
-  epoch: 3
+  epoch: 4
   description: NodeLocal DNSCache improves Cluster DNS performance by running a DNS caching agent on cluster nodes as a DaemonSet.
   copyright:
     - license: Apache-2.0

--- a/kubernetes-event-exporter.yaml
+++ b/kubernetes-event-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-event-exporter
   version: "1.7"
-  epoch: 10
+  epoch: 11
   description: Export Kubernetes events to multiple destinations with routing and filtering
   copyright:
     - license: Apache-2.0

--- a/kubevela.yaml
+++ b/kubevela.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubevela
   version: 1.9.11
-  epoch: 6
+  epoch: 7
   description: KubeVela is a modern application delivery platform that makes deploying and operating applications across today's hybrid, multi-cloud environments easier, faster and more reliable
   copyright:
     - license: Apache-2.0

--- a/kubewatch.yaml
+++ b/kubewatch.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubewatch
   version: 2.8.0
-  epoch: 0
+  epoch: 1
   description: Watch k8s events and trigger Handlers
   copyright:
     - license: Apache-2.0

--- a/kustomize.yaml
+++ b/kustomize.yaml
@@ -1,7 +1,7 @@
 package:
   name: kustomize
   version: 5.4.3
-  epoch: 0
+  epoch: 1
   description: Customization of kubernetes YAML configurations
   copyright:
     - license: Apache-2.0

--- a/kyverno-1.12.yaml
+++ b/kyverno-1.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-1.12
   version: 1.12.5
-  epoch: 2
+  epoch: 3
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0

--- a/kyverno-policy-reporter-kyverno-plugin.yaml
+++ b/kyverno-policy-reporter-kyverno-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-policy-reporter-kyverno-plugin
   version: 1.6.4
-  epoch: 0
+  epoch: 1
   description: Policy Reporter Kyverno Plugin
   copyright:
     - license: Apache-2.0

--- a/kyverno-policy-reporter-ui.yaml
+++ b/kyverno-policy-reporter-ui.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-policy-reporter-ui
   version: 1.9.2
-  epoch: 8
+  epoch: 9
   description: Policy Reporter UI
   copyright:
     - license: Apache-2.0

--- a/kyverno-policy-reporter.yaml
+++ b/kyverno-policy-reporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-policy-reporter
   version: 2.24.1
-  epoch: 0
+  epoch: 1
   description: Monitoring and Observability Tool for the PolicyReport CRD with an optional UI.
   copyright:
     - license: Apache-2.0

--- a/libnvidia-container.yaml
+++ b/libnvidia-container.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnvidia-container
   version: 1.16.1
-  epoch: 0
+  epoch: 1
   description: NVIDIA container runtime library
   copyright:
     - license: Apache-2.0

--- a/litestream.yaml
+++ b/litestream.yaml
@@ -1,7 +1,7 @@
 package:
   name: litestream
   version: 0.3.13
-  epoch: 4
+  epoch: 5
   description: Streaming replication for SQLite.
   copyright:
     - license: Apache-2.0

--- a/local-path-provisioner.yaml
+++ b/local-path-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: local-path-provisioner
   version: 0.0.29
-  epoch: 0
+  epoch: 1
   description: Dynamically provisioning persistent local storage with Kubernetes
   copyright:
     - license: Apache-2.0

--- a/local-static-provisioner.yaml
+++ b/local-static-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: local-static-provisioner
   version: 2.7.0
-  epoch: 6
+  epoch: 7
   description: Static provisioner of local volumes
   copyright:
     - license: Apache-2.0

--- a/logstash-exporter.yaml
+++ b/logstash-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: logstash-exporter
   version: 1.7.0
-  epoch: 0
+  epoch: 1
   description: Prometheus exporter for Logstash written in Go
   copyright:
     - license: Apache-2.0

--- a/mattermost-9.yaml
+++ b/mattermost-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: mattermost-9
   version: 9.11.1
-  epoch: 0
+  epoch: 1
   description: "Mattermost is an open source platform for secure collaboration across the entire software development lifecycle."
   copyright:
     - license: MIT

--- a/mc.yaml
+++ b/mc.yaml
@@ -3,7 +3,7 @@ package:
   # minio uses strange versioning, the upstream version is RELEASE.2023-12-02T02-03-28Z
   # when bumping this, also bump the tag in git-checkout below
   version: 0.20231220.071422
-  epoch: 11
+  epoch: 12
   description: Multi-Cloud Object Storage
   copyright:
     - license: AGPL-3.0-or-later

--- a/memcached-exporter.yaml
+++ b/memcached-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached-exporter
   version: 0.14.4
-  epoch: 1
+  epoch: 2
   description: Exports metrics from memcached servers for consumption by Prometheus.
   copyright:
     - license: Apache-2.0

--- a/metacontroller.yaml
+++ b/metacontroller.yaml
@@ -1,7 +1,7 @@
 package:
   name: metacontroller
   version: 4.11.17
-  epoch: 1
+  epoch: 2
   description: Writing kubernetes controllers can be simple
   copyright:
     - license: Apache-2.0

--- a/metallb.yaml
+++ b/metallb.yaml
@@ -1,7 +1,7 @@
 package:
   name: metallb
   version: 0.14.8
-  epoch: 0
+  epoch: 1
   description: "A network load-balancer implementation for Kubernetes using standard routing protocols"
   copyright:
     - license: Apache-2.0

--- a/metrics-server.yaml
+++ b/metrics-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: metrics-server
   version: 0.7.2
-  epoch: 0
+  epoch: 1
   description: Scalable and efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.
   copyright:
     - license: Apache-2.0

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: minio-operator
   version: 6.0.3
-  epoch: 0
+  epoch: 1
   description: Minio Operator creates/configures/manages Minio on Kubernetes
   copyright:
     - license: AGPL-3.0-only

--- a/mongo-tools.yaml
+++ b/mongo-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: mongo-tools
   version: 100.10.0
-  epoch: 1
+  epoch: 2
   description: Tools for MongoDB
   copyright:
     - license: Apache-2.0

--- a/multus-cni.yaml
+++ b/multus-cni.yaml
@@ -1,7 +1,7 @@
 package:
   name: multus-cni
   version: 4.1.0
-  epoch: 0
+  epoch: 1
   description: A CNI meta-plugin for multi-homed pods in Kubernetes
   copyright:
     - license: Apache-2.0

--- a/nats-server.yaml
+++ b/nats-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: nats-server
   version: 2.10.20
-  epoch: 0
+  epoch: 1
   description: High-Performance server for NATS.io, the cloud and edge native messaging system.
   copyright:
     - license: Apache-2.0

--- a/newrelic-fluent-bit-output.yaml
+++ b/newrelic-fluent-bit-output.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-fluent-bit-output
   version: 2.0.1
-  epoch: 0
+  epoch: 1
   description: A Fluent Bit output plugin that sends logs to New Relic
   copyright:
     - license: Apache-2.0

--- a/newrelic-infrastructure-agent.yaml
+++ b/newrelic-infrastructure-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-infrastructure-agent
   version: 1.57.0
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Agent
   copyright:
     - license: Apache-2.0

--- a/newrelic-nri-statsd.yaml
+++ b/newrelic-nri-statsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-nri-statsd
   version: 2.9.2
-  epoch: 0
+  epoch: 1
   description: An implementation of Etsy's statsd in Go with tags support
   copyright:
     - license: MIT

--- a/newrelic-prometheus-configurator.yaml
+++ b/newrelic-prometheus-configurator.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-prometheus-configurator
   version: 1.17.3
-  epoch: 0
+  epoch: 1
   description: New Relic Prometheus Configurator
   copyright:
     - license: Apache-2.0

--- a/nfs-subdir-external-provisioner.yaml
+++ b/nfs-subdir-external-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: nfs-subdir-external-provisioner
   version: 4.0.18
-  epoch: 9
+  epoch: 10
   description: Dynamic sub-dir volume provisioner on a remote NFS server.
   copyright:
     - license: Apache-2.0

--- a/node-feature-discovery-0.16.yaml
+++ b/node-feature-discovery-0.16.yaml
@@ -1,7 +1,7 @@
 package:
   name: node-feature-discovery-0.16
   version: 0.16.4
-  epoch: 1
+  epoch: 2
   description: Node feature discovery for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/node-problem-detector-0.8.yaml
+++ b/node-problem-detector-0.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: node-problem-detector-0.8
   version: 0.8.19
-  epoch: 3
+  epoch: 4
   description: node-problem-detector aims to make various node problems visible to the upstream layers in the cluster management stack.
   copyright:
     - license: Apache-2.0

--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-16
   version: 16.20.2
-  epoch: 6
+  epoch: 7
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-21
   version: 21.7.3
-  epoch: 2
+  epoch: 3
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodetaint.yaml
+++ b/nodetaint.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodetaint
   version: 0.0.4
-  epoch: 21
+  epoch: 22
   description: Controller to manage taints for nodes in a k8s cluster.
   copyright:
     - license: Apache-2.0

--- a/nri-apache.yaml
+++ b/nri-apache.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-apache
   version: 1.12.6
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Apache Integration
   copyright:
     - license: Apache-2.0

--- a/nri-cassandra.yaml
+++ b/nri-cassandra.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-cassandra
   version: 2.13.9
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Cassandra Integration
   copyright:
     - license: Apache-2.0

--- a/nri-consul.yaml
+++ b/nri-consul.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-consul
   version: 2.7.13
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Consul Integration
   copyright:
     - license: MIT

--- a/nri-couchbase.yaml
+++ b/nri-couchbase.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-couchbase
   version: 2.6.7
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Couchbase Integration
   copyright:
     - license: Apache-2.0

--- a/nri-discovery-kubernetes.yaml
+++ b/nri-discovery-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-discovery-kubernetes
   version: 1.9.2
-  epoch: 0
+  epoch: 1
   description: New Relic Kubernetes Auto-Discovery
   copyright:
     - license: Apache-2.0

--- a/nri-elasticsearch.yaml
+++ b/nri-elasticsearch.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-elasticsearch
   version: 5.2.6
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Elasticsearch Integration
   copyright:
     - license: MIT

--- a/nri-f5.yaml
+++ b/nri-f5.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-f5
   version: 2.7.6
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure F5 Integration
   copyright:
     - license: Apache-2.0

--- a/nri-haproxy.yaml
+++ b/nri-haproxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-haproxy
   version: 3.0.2
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure HAproxy Integration
   copyright:
     - license: MIT

--- a/nri-jmx.yaml
+++ b/nri-jmx.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-jmx
   version: 3.7.0
-  epoch: 2
+  epoch: 3
   description: New Relic Infrastructure JMX Integration
   copyright:
     - license: Apache-2.0

--- a/nri-kafka.yaml
+++ b/nri-kafka.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-kafka
   version: 3.7.4
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Kafka Integration
   copyright:
     - license: MIT

--- a/nri-kubernetes.yaml
+++ b/nri-kubernetes.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-kubernetes
   version: 3.29.4
-  epoch: 0
+  epoch: 1
   description: New Relic integration for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/nri-memcached.yaml
+++ b/nri-memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-memcached
   version: 2.5.7
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure memcached Integration
   copyright:
     - license: MIT

--- a/nri-mongodb.yaml
+++ b/nri-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-mongodb
   version: 2.8.6
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure MongoDB Integration
   copyright:
     - license: MIT

--- a/nri-mssql.yaml
+++ b/nri-mssql.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-mssql
   version: 2.12.6
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Mssql Integration
   copyright:
     - license: Apache-2.0

--- a/nri-mysql.yaml
+++ b/nri-mysql.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-mysql
   version: 1.10.10
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure MySQL Integration
   copyright:
     - license: Apache-2.0

--- a/nri-nagios.yaml
+++ b/nri-nagios.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-nagios
   version: 2.9.6
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Nagios Integration
   copyright:
     - license: MIT

--- a/nri-nginx.yaml
+++ b/nri-nginx.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-nginx
   version: 3.4.8
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Nginx Integration
   copyright:
     - license: Apache-2.0

--- a/nri-postgresql.yaml
+++ b/nri-postgresql.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-postgresql
   version: 2.13.7
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Postgresql Integration
   copyright:
     - license: MIT

--- a/nri-rabbitmq.yaml
+++ b/nri-rabbitmq.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-rabbitmq
   version: 2.13.8
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure RabbitMQ Integration
   copyright:
     - license: MIT

--- a/nri-redis.yaml
+++ b/nri-redis.yaml
@@ -1,7 +1,7 @@
 package:
   name: nri-redis
   version: 1.11.8
-  epoch: 0
+  epoch: 1
   description: New Relic Infrastructure Redis Integration
   copyright:
     - license: Apache-2.0

--- a/nvidia-container-toolkit.yaml
+++ b/nvidia-container-toolkit.yaml
@@ -1,7 +1,7 @@
 package:
   name: nvidia-container-toolkit
   version: 1.16.1
-  epoch: 0
+  epoch: 1
   description: Build and run containers leveraging NVIDIA GPUs
   copyright:
     - license: Apache-2.0

--- a/nvidia-device-plugin.yaml
+++ b/nvidia-device-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: nvidia-device-plugin
   version: 0.16.2
-  epoch: 0
+  epoch: 1
   description: NVIDIA device plugin for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/octo-sts.yaml
+++ b/octo-sts.yaml
@@ -1,7 +1,7 @@
 package:
   name: octo-sts
   version: 0.4.2
-  epoch: 0
+  epoch: 1
   description: A GitHub App that acts like a Security Token Service (STS) for the Github API.
   copyright:
     - license: Apache-2.0

--- a/oras.yaml
+++ b/oras.yaml
@@ -1,7 +1,7 @@
 package:
   name: oras
   version: 1.2.0
-  epoch: 2
+  epoch: 3
   description: OCI registry client - managing content like artifacts, images, packages.
   copyright:
     - license: Apache-2.0

--- a/paranoia.yaml
+++ b/paranoia.yaml
@@ -1,7 +1,7 @@
 package:
   name: paranoia
   version: 0.2.1
-  epoch: 18
+  epoch: 19
   description: Inspect certificate authorities in container images
   copyright:
     - license: Apache-2.0

--- a/php-fpm_exporter.yaml
+++ b/php-fpm_exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-fpm_exporter
   version: 2.2.0
-  epoch: 8
+  epoch: 9
   description: A prometheus exporter for PHP-FPM.
   copyright:
     - license: Apache-2.0

--- a/policy-controller.yaml
+++ b/policy-controller.yaml
@@ -1,7 +1,7 @@
 package:
   name: policy-controller
   version: 0.9.0
-  epoch: 8
+  epoch: 9
   description: The policy admission controller used to enforce policy on a cluster on verifiable supply-chain metadata from cosign.
   copyright:
     - license: Apache-2.0

--- a/postgres-operator.yaml
+++ b/postgres-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgres-operator
   version: 1.13.0
-  epoch: 0
+  epoch: 1
   description: Postgres operator creates and manages PostgreSQL clusters running in Kubernetes
   copyright:
     - license: MIT

--- a/prometheus-2.54.yaml
+++ b/prometheus-2.54.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-2.54
   version: 2.54.1
-  epoch: 0
+  epoch: 1
   description: The Prometheus monitoring system and time series database.
   copyright:
     - license: Apache-2.0

--- a/prometheus-adapter.yaml
+++ b/prometheus-adapter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-adapter
   version: 0.12.0
-  epoch: 2
+  epoch: 3
   description: Prometheus Adapter for Kubernetes Metrics APIs
   copyright:
     - license: Apache-2.0

--- a/prometheus-alertmanager.yaml
+++ b/prometheus-alertmanager.yaml
@@ -2,7 +2,7 @@ package:
   name: prometheus-alertmanager
   # When bumping this version you can remove the `go get` line in the build script
   version: 0.27.0
-  epoch: 9
+  epoch: 10
   description: Prometheus Alertmanager
   copyright:
     - license: Apache-2.0

--- a/prometheus-blackbox-exporter.yaml
+++ b/prometheus-blackbox-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-blackbox-exporter
   version: 0.25.0
-  epoch: 6
+  epoch: 7
   description: Blackbox prober exporter
   copyright:
     - license: Apache-2.0

--- a/prometheus-elasticsearch-exporter.yaml
+++ b/prometheus-elasticsearch-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-elasticsearch-exporter
   version: 1.7.0
-  epoch: 9
+  epoch: 10
   description: Elasticsearch stats exporter for Prometheus
   copyright:
     - license: Apache-2.0

--- a/prometheus-mongodb-exporter.yaml
+++ b/prometheus-mongodb-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-mongodb-exporter
   version: 0.40.0
-  epoch: 11
+  epoch: 12
   description: A Prometheus exporter for MongoDB including sharding, replication and storage engines
   copyright:
     - license: MIT

--- a/prometheus-mysqld-exporter.yaml
+++ b/prometheus-mysqld-exporter.yaml
@@ -2,7 +2,7 @@ package:
   name: prometheus-mysqld-exporter
   # When bumping this version you can remove the `go get` line in the build script
   version: 0.15.1
-  epoch: 9
+  epoch: 10
   description: Prometheus Exporter for MySQL server metrics
   copyright:
     - license: Apache-2.0

--- a/prometheus-node-exporter.yaml
+++ b/prometheus-node-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-node-exporter
   version: 1.8.2
-  epoch: 1
+  epoch: 2
   description: Prometheus Exporter for machine metrics
   copyright:
     - license: Apache-2.0

--- a/prometheus-postgres-exporter.yaml
+++ b/prometheus-postgres-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-postgres-exporter
   version: 0.15.0
-  epoch: 11
+  epoch: 12
   description: Prometheus Exporter for Postgres server metrics
   copyright:
     - license: Apache-2.0

--- a/prometheus-pushgateway.yaml
+++ b/prometheus-pushgateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-pushgateway
   version: 1.9.0
-  epoch: 1
+  epoch: 2
   description: Push acceptor for ephemeral and batch jobs.
   copyright:
     - license: Apache-2.0

--- a/prometheus-statsd-exporter.yaml
+++ b/prometheus-statsd-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-statsd-exporter
   version: 0.27.1
-  epoch: 1
+  epoch: 2
   description: StatsD exporter for Prometheus
   copyright:
     - license: Apache-2.0

--- a/pulumi-kubernetes-operator.yaml
+++ b/pulumi-kubernetes-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-kubernetes-operator
   version: 1.16.0
-  epoch: 0
+  epoch: 1
   description: A Kubernetes Operator that automates the deployment of Pulumi Stacks
   copyright:
     - license: Apache-2.0

--- a/pulumi-language-yaml.yaml
+++ b/pulumi-language-yaml.yaml
@@ -1,7 +1,7 @@
 package:
   name: pulumi-language-yaml
   version: 1.10.0
-  epoch: 0
+  epoch: 1
   description: Pulumi Language SDK for YAML
   copyright:
     - license: Apache-2.0

--- a/rabbitmq-cluster-operator.yaml
+++ b/rabbitmq-cluster-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-cluster-operator
   version: 2.10.0
-  epoch: 0
+  epoch: 1
   description: Open source RabbitMQ cluster operator. Kubernetes operator to deploy and manage RabbitMQ clusters.
   copyright:
     - license: MPL-2.0

--- a/rabbitmq-default-user-credential-updater.yaml
+++ b/rabbitmq-default-user-credential-updater.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-default-user-credential-updater
   version: 1.0.4
-  epoch: 3
+  epoch: 4
   description: Updates RabbitMQ default user password
   copyright:
     - license: MPL-2.0

--- a/rabbitmq-messaging-topology-operator.yaml
+++ b/rabbitmq-messaging-topology-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-messaging-topology-operator
   version: 1.14.2
-  epoch: 2
+  epoch: 3
   description: Open source RabbitMQ cluster operator. Kubernetes operator to deploy and manage RabbitMQ clusters.
   copyright:
     - license: MPL-2.0

--- a/rancher-2.9.yaml
+++ b/rancher-2.9.yaml
@@ -12,7 +12,7 @@ var-transforms:
 package:
   name: rancher-2.9
   version: 2.9.0
-  epoch: 4
+  epoch: 5
   description: Complete container management platform
   copyright:
     - license: Apache-2.0

--- a/rancher-fleet.yaml
+++ b/rancher-fleet.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-fleet
   version: 0.10.1
-  epoch: 0
+  epoch: 1
   description: Deploy workloads from Git to large fleets of Kubernetes clusters
   copyright:
     - license: Apache-2.0

--- a/rancher-webhook-0.5.yaml
+++ b/rancher-webhook-0.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: rancher-webhook-0.5
   version: 0.5.0
-  epoch: 0
+  epoch: 1
   description: Rancher webhook for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/rekor.yaml
+++ b/rekor.yaml
@@ -1,7 +1,7 @@
 package:
   name: rekor
   version: 1.3.6
-  epoch: 8
+  epoch: 9
   description: Software Supply Chain Transparency Log
   copyright:
     - license: Apache-2.0

--- a/render-template.yaml
+++ b/render-template.yaml
@@ -1,7 +1,7 @@
 package:
   name: render-template
   version: 1.0.7
-  epoch: 1
+  epoch: 2
   description: CLI tool for rendering templates with custom data
   copyright:
     - license: Apache-2.0

--- a/restic.yaml
+++ b/restic.yaml
@@ -1,7 +1,7 @@
 package:
   name: restic
   version: 0.17.1
-  epoch: 0
+  epoch: 1
   description: restic is a backup program which allows saving multiple revisions of files and directories in an encrypted repository stored on different backends
   copyright:
     - license: BSD-2-Clause

--- a/runc.yaml
+++ b/runc.yaml
@@ -1,7 +1,7 @@
 package:
   name: runc
   version: 1.1.14
-  epoch: 0
+  epoch: 1
   description: CLI tool for spawning and running containers according to the OCI specification
   copyright:
     - license: Apache-2.0

--- a/secrets-store-csi-driver-provider-gcp.yaml
+++ b/secrets-store-csi-driver-provider-gcp.yaml
@@ -1,7 +1,7 @@
 package:
   name: secrets-store-csi-driver-provider-gcp
   version: 1.5.0
-  epoch: 7
+  epoch: 8
   description: Google Secret Manager provider for the Secret Store CSI Driver.
   copyright:
     - license: Apache-2.0

--- a/secrets-store-csi-driver.yaml
+++ b/secrets-store-csi-driver.yaml
@@ -2,7 +2,7 @@ package:
   name: secrets-store-csi-driver
   # When bumping the version check if the CVE mitigations below can be removed.
   version: 1.4.5
-  epoch: 0
+  epoch: 1
   description: Secrets Store CSI driver for Kubernetes secrets
   copyright:
     - license: Apache-2.0

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,7 +1,7 @@
 package:
   name: skaffold
   version: 2.13.2
-  epoch: 0
+  epoch: 1
   description: Easy and Repeatable Kubernetes Development
   copyright:
     - license: Apache-2.0

--- a/smarter-device-manager.yaml
+++ b/smarter-device-manager.yaml
@@ -5,7 +5,7 @@
 package:
   name: smarter-device-manager
   version: 1.20.11
-  epoch: 9
+  epoch: 10
   description: Device manager container that enables access to device drivers on containers for k8s
   copyright:
     - license: Apache-2.0

--- a/spark-operator.yaml
+++ b/spark-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-operator
   version: 1.4.6
-  epoch: 0
+  epoch: 1
   description: Kubernetes operator for managing the lifecycle of Apache Spark applications on Kubernetes.
   copyright:
     - license: Apache-2.0

--- a/spire-server.yaml
+++ b/spire-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: spire-server
   version: 1.10.3
-  epoch: 0
+  epoch: 1
   description: The SPIFFE Runtime Environment (SPIRE) server
   copyright:
     - license: Apache-2.0

--- a/stakater-reloader.yaml
+++ b/stakater-reloader.yaml
@@ -1,7 +1,7 @@
 package:
   name: stakater-reloader
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: A Kubernetes controller to watch changes in ConfigMap and Secrets and do rolling upgrades on Pods
   copyright:
     - license: Apache-2.0

--- a/step-ca.yaml
+++ b/step-ca.yaml
@@ -1,7 +1,7 @@
 package:
   name: step-ca
   version: 0.27.2
-  epoch: 0
+  epoch: 1
   description: A private certificate authority (X.509 & SSH) & ACME server for secure automated certificate management, so you can use TLS everywhere & SSO for SSH.
   copyright:
     - license: Apache-2.0

--- a/step-issuer.yaml
+++ b/step-issuer.yaml
@@ -1,7 +1,7 @@
 package:
   name: step-issuer
   version: 0.9.3
-  epoch: 0
+  epoch: 1
   description: A certificate issuer for cert-manager using step certificates CA
   copyright:
     - license: Apache-2.0

--- a/step.yaml
+++ b/step.yaml
@@ -1,7 +1,7 @@
 package:
   name: step
   version: 0.27.2
-  epoch: 0
+  epoch: 1
   description: A zero trust swiss army knife for working with X509, OAuth, JWT, OATH OTP, etc.
   copyright:
     - license: Apache-2.0

--- a/tctl.yaml
+++ b/tctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tctl
   version: 1.18.1
-  epoch: 2
+  epoch: 3
   description: Temporal CLI
   copyright:
     - license: MIT

--- a/tekton-chains.yaml
+++ b/tekton-chains.yaml
@@ -1,7 +1,7 @@
 package:
   name: tekton-chains
   version: 0.22.0
-  epoch: 0
+  epoch: 1
   description: Supply Chain Security in Tekton Pipelines
   copyright:
     - license: Apache-2.0

--- a/tekton-pipelines.yaml
+++ b/tekton-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: tekton-pipelines
   version: 0.63.0
-  epoch: 0
+  epoch: 1
   description: A cloud-native Pipeline resource.
   copyright:
     - license: Apache-2.0

--- a/telegraf-1.31.yaml
+++ b/telegraf-1.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: telegraf-1.31
   version: 1.31.3
-  epoch: 0
+  epoch: 1
   description: Telegraf is an agent for collecting, processing, aggregating, and writing metric
   copyright:
     - license: MIT

--- a/temporal.yaml
+++ b/temporal.yaml
@@ -1,7 +1,7 @@
 package:
   name: temporal
   version: 1.0.0
-  epoch: 0
+  epoch: 1
   description: Command-line interface for running Temporal Server and interacting with Workflows, Activities, Namespaces, and other parts of Temporal
   copyright:
     - license: MIT

--- a/thanos-operator.yaml
+++ b/thanos-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos-operator
   version: 0.3.7
-  epoch: 19
+  epoch: 20
   description: Kubernetes operator for deploying Thanos
   copyright:
     - license: Apache-2.0

--- a/thanos.yaml
+++ b/thanos.yaml
@@ -1,7 +1,7 @@
 package:
   name: thanos
   version: 0.36.1
-  epoch: 0
+  epoch: 1
   description: Highly available Prometheus setup with long term storage capabilities.
   copyright:
     - license: Apache-2.0

--- a/tigera-operator-1.35.yaml
+++ b/tigera-operator-1.35.yaml
@@ -1,7 +1,7 @@
 package:
   name: tigera-operator-1.35
   version: 1.35.0
-  epoch: 0
+  epoch: 1
   description: Kubernetes operator for installing Calico and Calico Enterprise
   copyright:
     - license: Apache-2.0

--- a/timestamp-authority.yaml
+++ b/timestamp-authority.yaml
@@ -1,7 +1,7 @@
 package:
   name: timestamp-authority
   version: 1.2.2
-  epoch: 12
+  epoch: 13
   description: RFC3161 Timestamp Authority
   copyright:
     - license: Apache-2.0

--- a/timoni.yaml
+++ b/timoni.yaml
@@ -1,7 +1,7 @@
 package:
   name: timoni
   version: 0.22.0
-  epoch: 3
+  epoch: 4
   description: Timoni is a package manager for Kubernetes, powered by CUE and inspired by Helm.
   copyright:
     - license: Apache-2.0

--- a/trillian.yaml
+++ b/trillian.yaml
@@ -1,7 +1,7 @@
 package:
   name: trillian
   version: 1.6.1
-  epoch: 0
+  epoch: 1
   description: Merkle tree implementation used in Sigstore
   copyright:
     - license: Apache-2.0

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,7 +1,7 @@
 package:
   name: trivy
   version: 0.55.1
-  epoch: 0
+  epoch: 1
   description: Simple and comprehensive vulnerability scanner for containers
   copyright:
     - license: Apache-2.0

--- a/trust-manager.yaml
+++ b/trust-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: trust-manager
   version: 0.12.0
-  epoch: 0
+  epoch: 1
   description: trust-manager is an operator for distributing trust bundles across a Kubernetes cluster.
   copyright:
     - license: Apache-2.0

--- a/vault-k8s.yaml
+++ b/vault-k8s.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-k8s
   version: 1.4.2 # When updating, make sure to check that the license is still MPL!
-  epoch: 0
+  epoch: 1
   description: Tool for encryption as a service, secrets and privileged access management
   copyright:
     - license: MPL-2.0

--- a/velero-plugin-for-aws.yaml
+++ b/velero-plugin-for-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: velero-plugin-for-aws
   version: 1.10.1
-  epoch: 0
+  epoch: 1
   description: Plugins to support Velero on AWS
   copyright:
     - license: Apache-2.0

--- a/velero.yaml
+++ b/velero.yaml
@@ -1,7 +1,7 @@
 package:
   name: velero
   version: 1.14.1
-  epoch: 0
+  epoch: 1
   description: Backup and migrate Kubernetes applications and their persistent volumes
   copyright:
     - license: Apache-2.0

--- a/vertical-pod-autoscaler.yaml
+++ b/vertical-pod-autoscaler.yaml
@@ -1,7 +1,7 @@
 package:
   name: vertical-pod-autoscaler
   version: 1.2.1
-  epoch: 0
+  epoch: 1
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0

--- a/victoriametrics-cluster.yaml
+++ b/victoriametrics-cluster.yaml
@@ -1,7 +1,7 @@
 package:
   name: victoriametrics-cluster
   version: 1.103.0
-  epoch: 0
+  epoch: 1
   description: VictoriaMetrics is a fast, cost-effective, and scalable monitoring solution and time series database designed for high performance and reliability. It supports both single-server and clustered installations, providing flexibility for various deployment needs, and integrates well with tools like Grafana for data visualization.
   copyright:
     - license: Apache-2.0

--- a/victoriametrics-operator.yaml
+++ b/victoriametrics-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: victoriametrics-operator
   version: 0.47.3
-  epoch: 0
+  epoch: 1
   description: Kubernetes operator for Victoria Metrics
   copyright:
     - license: Apache-2.0

--- a/victoriametrics.yaml
+++ b/victoriametrics.yaml
@@ -1,7 +1,7 @@
 package:
   name: victoriametrics
   version: 1.103.0
-  epoch: 0
+  epoch: 1
   description: VictoriaMetrics is a fast, cost-effective, and scalable monitoring solution and time series database designed for high performance and reliability. It supports both single-server and clustered installations, providing flexibility for various deployment needs, and integrates well with tools like Grafana for data visualization.
   copyright:
     - license: Apache-2.0

--- a/vt-cli.yaml
+++ b/vt-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: vt-cli
   version: 1.0.1
-  epoch: 1
+  epoch: 2
   description: "VirusTotal Command Line Interface"
   copyright:
     - license: Apache-2.0

--- a/wait-for-port.yaml
+++ b/wait-for-port.yaml
@@ -1,7 +1,7 @@
 package:
   name: wait-for-port
   version: 1.0.8
-  epoch: 1
+  epoch: 2
   description: CLI tool for waiting until a TCP port reaches the desired state
   copyright:
     - license: Apache-2.0

--- a/wave.yaml
+++ b/wave.yaml
@@ -1,7 +1,7 @@
 package:
   name: wave
   version: 0.9.0
-  epoch: 1
+  epoch: 2
   description: Kubernetes configuration tracking controller
   copyright:
     - license: Apache-2.0

--- a/wazero.yaml
+++ b/wazero.yaml
@@ -1,7 +1,7 @@
 package:
   name: wazero
   version: 1.8.0
-  epoch: 0
+  epoch: 1
   description: The zero dependency WebAssembly runtime for Go developers
   copyright:
     - license: Apache-2.0

--- a/whereabouts.yaml
+++ b/whereabouts.yaml
@@ -1,7 +1,7 @@
 package:
   name: whereabouts
   version: 0.8.0
-  epoch: 0
+  epoch: 1
   description: A CNI IPAM plugin that assigns IP addresses cluster-wide
   dependencies:
     runtime:

--- a/yq.yaml
+++ b/yq.yaml
@@ -1,7 +1,7 @@
 package:
   name: yq
   version: 4.44.3
-  epoch: 0
+  epoch: 1
   description: "yq is a portable command-line YAML, JSON, XML, CSV and properties processor"
   copyright:
     - license: Apache-2.0

--- a/zot.yaml
+++ b/zot.yaml
@@ -1,7 +1,7 @@
 package:
   name: zot
   version: 2.1.1
-  epoch: 0
+  epoch: 1
   description: A production-ready vendor-neutral OCI-native container image registry (purely based on OCI Distribution Specification)
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
This bumps most of the go packages with the  CVE-2024-34155 , 
rebuilding with the latest go 1.23.1 would fix 
