### PR TITLE
libtool: switch to git updates as release monitoring is listing pre-release versions as latest

### DIFF
--- a/libtool.yaml
+++ b/libtool.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtool
   version: 2.4.7
-  epoch: 3
+  epoch: 4
   description: "GNU libtool"
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later
@@ -19,10 +19,11 @@ environment:
       - m4
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://ftp.gnu.org/gnu/libtool/libtool-${{package.version}}.tar.xz
-      expected-sha256: 4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d
+      repository: https://git.savannah.gnu.org/git/libtool.git
+      expected-commit: 6d7ce133ce54898cf28abd89d167cccfbc3c9b2b
+      tag: v${{package.version}}
 
   - uses: patch
     with:
@@ -53,8 +54,11 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 1741
+  ignore-regex-patterns:
+    - ^\d+\.[13579]\.\d+$ # Ignore odd-numbered minor versions as these are pre-release
+  git:
+    tag-filter-prefix: v
+    strip-prefix: v
 
 test:
   environment:

--- a/libtool.yaml
+++ b/libtool.yaml
@@ -12,11 +12,19 @@ package:
 environment:
   contents:
     packages:
+      - apk-tools
+      - autoconf
+      - automake
       - build-base
       - busybox
       - ca-certificates-bundle
+      - coreutils
       - help2man
       - m4
+      - texinfo
+      - xz
+  environment:
+    M4: /usr/bin/m4
 
 pipeline:
   - uses: git-checkout
@@ -29,9 +37,9 @@ pipeline:
     with:
       patches: libtool-fix-cross-compile.patch
 
-  - runs: |
-      M4=/usr/bin/m4 ./configure \
-        --prefix=/usr
+  - runs: ./bootstrap
+
+  - uses: autoconf/configure
 
   - uses: autoconf/make
 
@@ -65,6 +73,7 @@ test:
     contents:
       packages:
         - build-base
+        - busybox
   pipeline:
     - name: Compile and Execute Test
       runs: |


### PR DESCRIPTION
Instead we can use git and an ignore regex to skip odd minor versions which indicates pre-releases
