### PR TITLE
fix(CVE): Bump az epoch to remediate GHSA-h4gh-qq45-vh27

### DIFF
--- a/az.yaml
+++ b/az.yaml
@@ -1,7 +1,7 @@
 package:
   name: az
   version: 2.64.0
-  epoch: 0
+  epoch: 1
   description: Azure CLI
   copyright:
     - license: MIT


### PR DESCRIPTION
GHSA-h4gh-qq45-vh27 has been remediated in updates to the cryptography component
via py3-cryptography package update to version 43.0.1-r1 which was published @
2024-09-12 16:34:07 +0000 UTC

Bumping the epoch will cause a rebuild which will pull in new py3-cryptography.

Local rebuild shows that CVE GHSA-h4gh-qq45-vh27 is no longer detected.

Signed-off-by: philroche <phil.roche@chainguard.dev>
