### PR TITLE
Build py3-pip-wheel as part of py3-pip

### DIFF
--- a/py3-pip-wheel-bootstrap.yaml
+++ b/py3-pip-wheel-bootstrap.yaml
@@ -3,12 +3,16 @@
 # update those wheels by tracking the upstream package release.
 # python is compiled with --with-wheel-pkg-dir=/usr/share/python-wheels
 package:
-  name: py3-pip-wheel
+  name: py3-pip-wheel-bootstrap
   version: "24.2"
-  epoch: 0
+  epoch: 1
   description: "python3 pip wheel from pypi"
   copyright:
     - license: MIT
+  dependencies:
+    provider-priority: 0
+    provides:
+      - py3-pip-wheel
 
 environment:
   contents:

--- a/py3-pip.yaml
+++ b/py3-pip.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pip
   version: "24.2"
-  epoch: 1
+  epoch: 2
   description: The PyPA recommended tool for installing Python packages.
   copyright:
     - license: MIT
@@ -73,6 +73,31 @@ subpackages:
         - py3.12-${{vars.pypi-package}}-base
         - py3.11-${{vars.pypi-package}}-base
         - py3.10-${{vars.pypi-package}}-base
+
+  - name: py3-pip-wheel
+    description: "wheel of pip"
+    # priority here is higher than the py3-pip-wheel-bootstrap priority.
+    dependencies:
+      provider-priority: 10
+    pipeline:
+      - runs: |
+          set -- ./.wheels/*/*.whl
+          [ -e "$1" ] || { echo "did not find wheels matching ./wheels/*/*.whl"; exit 1; }
+          echo "found $# wheels"
+          sha256sum "$@" >/tmp/all
+          found=$1
+          shift
+          read mysum path <"/tmp/all"
+          while read sum path ; do
+            [ "$mysum" = "$sum" ] || {
+              echo "FAIL: selected wheel '$found' ($mysum) differed from $path $(sum)"
+              exit 1
+            }
+          done </tmp/all
+
+          wdir="${{targets.contextdir}}/usr/share/python-wheels"
+          mkdir -p "$wdir"
+          cp -v "$1" "$wdir"
 
 update:
   ignore-regex-patterns:


### PR DESCRIPTION
 *  py3-pip - provide py3-pip-wheel
    
    When we took the embedded wheel out of python3 packages (#25860) and
    started depending on py3-pip-wheel, we could not use py3-pip package
    because the py3-pip package requires python to build.  So we made
    the py3-pip-wheel package which directly downloaded from pypa and
    thus had no build dependency on python.
    
    The fallout of that was that the py3-pip-wheel package was not being
    patched (as seen in (#26220).
    
    We could either
    1. accept that we would have to patch the downloaded wheel
    2. adjust things so we could use py3-pip origin.
    
    Now py3-pip will build py3-pip-wheel.  No one should get the
    py3-pip-wheel-bootsrap package version other than for bootstrapping.

 * rename py3-pip-wheel to py3-pip-wheel-bootstrap
