### PR TITLE
ruby: create -base ruby subpackages similar to python

### DIFF
--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.0
   version: 3.0.7
-  epoch: 2
+  epoch: 3
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -9,6 +9,8 @@ package:
   dependencies:
     provides:
       - ruby=${{package.full-version}}
+    runtime:
+      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -34,6 +36,12 @@ environment:
 vars:
   prefix: /usr
 
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d).(\d+).(\d+)
+    replace: '$1.$2'
+    to: rubyversion
+
 pipeline:
   - uses: fetch
     with:
@@ -51,6 +59,8 @@ pipeline:
          --build=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
          --prefix=${{vars.prefix}} \
+         --program-suffix=${{vars.rubyversion}} \
+         --with-soname=ruby-${{vars.rubyversion}} \
          --enable-ipv6 \
          --enable-loadable-sqlite-extensions \
          --enable-optimizations \
@@ -70,6 +80,9 @@ pipeline:
   - uses: strip
 
   - runs: |-
+      # Remove lock files
+      find ${{targets.destdir}}/usr/bin -type f -name '*.lock' -exec rm -rf '{}' +
+
       # Ignore the patch version of ruby since ruby will install under the
       # version of the latest standard library. Should produce the string 3.0.*
       RUBYWILD="$(echo ${{package.version}} | cut -d. -f-2).*"
@@ -82,11 +95,44 @@ pipeline:
       rm -rf ${GEMDIR}/gems/bundler-*
       rm ${GEMDIR}/specifications/default/bundler-*.gemspec
 
-      rm ${{targets.destdir}}/usr/bin/bundle \
-         ${{targets.destdir}}/usr/bin/bundler
+      rm ${{targets.destdir}}/usr/bin/bundle${{vars.rubyversion}} \
+         ${{targets.destdir}}/usr/bin/bundler${{vars.rubyversion}}
+
+      # Create symlinks for default install
+      for bin in erb gem irb rdoc ri ruby; do
+          ln -s "${bin}${{vars.rubyversion}}" "${{targets.destdir}}/usr/bin/${bin}"
+          ln -s "${bin}${{vars.rubyversion}}.1" "${{targets.destdir}}/usr/share/man/man1/${bin}.1"
+      done
 
 subpackages:
-  - name: "ruby-3.0-doc"
+  - name: "${{package.name}}-base"
+    description: "${{package.name}} without default symlinks"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin ${{targets.subpkgdir}}/usr/lib
+
+          # move versioned executables
+          mv -v ${{targets.destdir}}/usr/bin/*${{vars.rubyversion}} \
+              ${{targets.subpkgdir}}/usr/bin
+
+          # libs are already versioned
+          mv -v ${{targets.destdir}}/usr/lib/libruby-${{vars.rubyversion}}.so.* \
+             ${{targets.destdir}}/usr/lib/ruby \
+             ${{targets.subpkgdir}}/usr/lib
+
+  - name: "${{package.name}}-doc"
+    description: "ruby documentation"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base-doc=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share/man/man1
+          for bin in erb gem irb rdoc ri ruby; do
+              mv "${{targets.destdir}}/usr/share/man/man1/$bin.1" ${{targets.subpkgdir}}/usr/share/man/man1
+          done
+
+  - name: "${{package.name}}-base-doc"
     description: "ruby documentation"
     pipeline:
       - uses: split/manpages
@@ -95,8 +141,11 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
           mv "${{targets.destdir}}"/usr/share/ri "${{targets.subpkgdir}}"/usr/share/
 
-  - name: "ruby-3.0-dev"
+  - name: "${{package.name}}-dev"
     description: "ruby development headers"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
     pipeline:
       - uses: split/dev
 

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.6
-  epoch: 3
+  epoch: 4
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -9,6 +9,8 @@ package:
   dependencies:
     provides:
       - ruby=${{package.full-version}}
+    runtime:
+      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -41,6 +43,10 @@ var-transforms:
     match: \.
     replace: _
     to: underscore-package-version
+  - from: ${{package.version}}
+    match: (\d).(\d+).(\d+)
+    replace: '$1.$2'
+    to: rubyversion
 
 pipeline:
   - uses: git-checkout
@@ -61,6 +67,8 @@ pipeline:
          --build=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
          --prefix=${{vars.prefix}} \
+         --program-suffix=${{vars.rubyversion}} \
+         --with-soname=ruby-${{vars.rubyversion}} \
          --enable-ipv6 \
          --enable-loadable-sqlite-extensions \
          --enable-optimizations \
@@ -80,6 +88,9 @@ pipeline:
   - uses: strip
 
   - runs: |-
+      # Remove lock files
+      find ${{targets.destdir}}/usr/bin -type f -name '*.lock' -exec rm -rf '{}' +
+
       # Ignore the patch version of ruby since ruby will install under the
       # version of the latest standard library. Should produce the string 3.1.*
       RUBYWILD="$(echo ${{package.version}} | cut -d. -f-2).*"
@@ -92,11 +103,44 @@ pipeline:
       rm -rf ${GEMDIR}/gems/bundler-*
       rm ${GEMDIR}/specifications/default/bundler-*.gemspec
 
-      rm ${{targets.destdir}}/usr/bin/bundle \
-         ${{targets.destdir}}/usr/bin/bundler
+      rm ${{targets.destdir}}/usr/bin/bundle${{vars.rubyversion}} \
+         ${{targets.destdir}}/usr/bin/bundler${{vars.rubyversion}}
+
+      # Create symlinks for default install
+      for bin in erb gem irb rdoc ri ruby; do
+          ln -s "${bin}${{vars.rubyversion}}" "${{targets.destdir}}/usr/bin/${bin}"
+          ln -s "${bin}${{vars.rubyversion}}.1" "${{targets.destdir}}/usr/share/man/man1/${bin}.1"
+      done
 
 subpackages:
-  - name: "ruby-3.1-doc"
+  - name: "${{package.name}}-base"
+    description: "${{package.name}} without default symlinks"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin ${{targets.subpkgdir}}/usr/lib
+
+          # move versioned executables
+          mv -v ${{targets.destdir}}/usr/bin/*${{vars.rubyversion}} \
+              ${{targets.subpkgdir}}/usr/bin
+
+          # libs are already versioned
+          mv -v ${{targets.destdir}}/usr/lib/libruby-${{vars.rubyversion}}.so.* \
+             ${{targets.destdir}}/usr/lib/ruby \
+             ${{targets.subpkgdir}}/usr/lib
+
+  - name: "${{package.name}}-doc"
+    description: "ruby documentation"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base-doc=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share/man/man1
+          for bin in erb gem irb rdoc ri ruby; do
+              mv "${{targets.destdir}}/usr/share/man/man1/$bin.1" ${{targets.subpkgdir}}/usr/share/man/man1
+          done
+
+  - name: "${{package.name}}-base-doc"
     description: "ruby documentation"
     pipeline:
       - uses: split/manpages
@@ -105,8 +149,11 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
           mv "${{targets.destdir}}"/usr/share/ri "${{targets.subpkgdir}}"/usr/share/
 
-  - name: "ruby-3.1-dev"
+  - name: "${{package.name}}-dev"
     description: "ruby development headers"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
     pipeline:
       - uses: split/dev
 

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: 3.2.5
-  epoch: 2
+  epoch: 3
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -9,6 +9,8 @@ package:
   dependencies:
     provides:
       - ruby=${{package.full-version}}
+    runtime:
+      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -43,6 +45,10 @@ var-transforms:
     match: \.
     replace: _
     to: underscore-package-version
+  - from: ${{package.version}}
+    match: (\d).(\d+).(\d+)
+    replace: '$1.$2'
+    to: rubyversion
 
 pipeline:
   - uses: git-checkout
@@ -63,6 +69,8 @@ pipeline:
          --build=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
          --prefix=${{vars.prefix}} \
+         --program-suffix=${{vars.rubyversion}} \
+         --with-soname=ruby-${{vars.rubyversion}} \
          --enable-ipv6 \
          --enable-loadable-sqlite-extensions \
          --enable-optimizations \
@@ -83,6 +91,9 @@ pipeline:
   - uses: strip
 
   - runs: |-
+      # Remove lock files
+      find ${{targets.destdir}}/usr/bin -type f -name '*.lock' -exec rm -rf '{}' +
+
       # Ignore the patch version of ruby since ruby will install under the
       # version of the latest standard library. Should produce the string 3.2.*
       RUBYWILD="$(echo ${{package.version}} | cut -d. -f-2).*"
@@ -95,11 +106,44 @@ pipeline:
       rm -rf ${GEMDIR}/gems/bundler-*
       rm ${GEMDIR}/specifications/default/bundler-*.gemspec
 
-      rm ${{targets.destdir}}/usr/bin/bundle \
-         ${{targets.destdir}}/usr/bin/bundler
+      rm ${{targets.destdir}}/usr/bin/bundle${{vars.rubyversion}} \
+         ${{targets.destdir}}/usr/bin/bundler${{vars.rubyversion}}
+
+      # Create symlinks for default install
+      for bin in erb gem irb rdoc ri ruby; do
+          ln -s "${bin}${{vars.rubyversion}}" "${{targets.destdir}}/usr/bin/${bin}"
+          ln -s "${bin}${{vars.rubyversion}}.1" "${{targets.destdir}}/usr/share/man/man1/${bin}.1"
+      done
 
 subpackages:
-  - name: "ruby-3.2-doc"
+  - name: "${{package.name}}-base"
+    description: "${{package.name}} without default symlinks"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin ${{targets.subpkgdir}}/usr/lib
+
+          # move versioned executables
+          mv -v ${{targets.destdir}}/usr/bin/*${{vars.rubyversion}} \
+              ${{targets.subpkgdir}}/usr/bin
+
+          # libs are already versioned
+          mv -v ${{targets.destdir}}/usr/lib/libruby-${{vars.rubyversion}}.so.* \
+             ${{targets.destdir}}/usr/lib/ruby \
+             ${{targets.subpkgdir}}/usr/lib
+
+  - name: "${{package.name}}-doc"
+    description: "ruby documentation"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base-doc=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share/man/man1
+          for bin in erb gem irb rdoc ri ruby; do
+              mv "${{targets.destdir}}/usr/share/man/man1/$bin.1" ${{targets.subpkgdir}}/usr/share/man/man1
+          done
+
+  - name: "${{package.name}}-base-doc"
     description: "ruby documentation"
     pipeline:
       - uses: split/manpages
@@ -108,8 +152,11 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
           mv "${{targets.destdir}}"/usr/share/ri "${{targets.subpkgdir}}"/usr/share/
 
-  - name: "ruby-3.2-dev"
+  - name: "${{package.name}}-dev"
     description: "ruby development headers"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
     pipeline:
       - uses: split/dev
 

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.3
   version: 3.3.5
-  epoch: 1
+  epoch: 2
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -9,6 +9,8 @@ package:
   dependencies:
     provides:
       - ruby=${{package.full-version}}
+    runtime:
+      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -43,6 +45,10 @@ var-transforms:
     match: \.
     replace: _
     to: underscore-package-version
+  - from: ${{package.version}}
+    match: (\d).(\d+).(\d+)
+    replace: '$1.$2'
+    to: rubyversion
 
 pipeline:
   - uses: git-checkout
@@ -59,6 +65,8 @@ pipeline:
          --build=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
          --prefix=${{vars.prefix}} \
+         --program-suffix=${{vars.rubyversion}} \
+         --with-soname=ruby-${{vars.rubyversion}} \
          --enable-ipv6 \
          --enable-loadable-sqlite-extensions \
          --enable-optimizations \
@@ -79,6 +87,9 @@ pipeline:
   - uses: strip
 
   - runs: |-
+      # Remove lock files
+      find ${{targets.destdir}}/usr/bin -type f -name '*.lock' -exec rm -rf '{}' +
+
       # Ignore the patch version of ruby since ruby will install under the
       # version of the latest standard library. Should produce the string 3.3.*
       RUBYWILD="$(echo ${{package.version}} | cut -d. -f-2).*"
@@ -91,11 +102,44 @@ pipeline:
       rm -rf ${GEMDIR}/gems/bundler-*
       rm ${GEMDIR}/specifications/default/bundler-*.gemspec
 
-      rm ${{targets.destdir}}/usr/bin/bundle \
-         ${{targets.destdir}}/usr/bin/bundler
+      rm ${{targets.destdir}}/usr/bin/bundle${{vars.rubyversion}} \
+         ${{targets.destdir}}/usr/bin/bundler${{vars.rubyversion}}
+
+      # Create symlinks for default install
+      for bin in erb gem irb rdoc ri ruby; do
+          ln -s "${bin}${{vars.rubyversion}}" "${{targets.destdir}}/usr/bin/${bin}"
+          ln -s "${bin}${{vars.rubyversion}}.1" "${{targets.destdir}}/usr/share/man/man1/${bin}.1"
+      done
 
 subpackages:
-  - name: "ruby-3.3-doc"
+  - name: "${{package.name}}-base"
+    description: "${{package.name}} without default symlinks"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin ${{targets.subpkgdir}}/usr/lib
+
+          # move versioned executables
+          mv -v ${{targets.destdir}}/usr/bin/*${{vars.rubyversion}} \
+              ${{targets.subpkgdir}}/usr/bin
+
+          # libs are already versioned
+          mv -v ${{targets.destdir}}/usr/lib/libruby-${{vars.rubyversion}}.so.* \
+             ${{targets.destdir}}/usr/lib/ruby \
+             ${{targets.subpkgdir}}/usr/lib
+
+  - name: "${{package.name}}-doc"
+    description: "ruby documentation"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base-doc=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/share/man/man1
+          for bin in erb gem irb rdoc ri ruby; do
+              mv "${{targets.destdir}}/usr/share/man/man1/$bin.1" ${{targets.subpkgdir}}/usr/share/man/man1
+          done
+
+  - name: "${{package.name}}-base-doc"
     description: "ruby documentation"
     pipeline:
       - uses: split/manpages
@@ -104,8 +148,11 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
           mv "${{targets.destdir}}"/usr/share/ri "${{targets.subpkgdir}}"/usr/share/
 
-  - name: "ruby-3.3-dev"
+  - name: "${{package.name}}-dev"
     description: "ruby development headers"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
     pipeline:
       - uses: split/dev
 


### PR DESCRIPTION
This will enable multiple installations of Ruby. This is non-breaking as the non -base ruby packages depends on the -base packages. The gem packages are still dependent on the non -base packages due to melange.

melange [automatically adds the ruby dependency](https://github.com/chainguard-dev/melange/blob/2b86234a03fa55f4e253f49ab11435d64d549342/pkg/sca/sca.go#L581) from SCA. melange should be updated to use the -base package instead.

This also makes the generated -base packages depend on the non-base package which will still prevent multiple installations. After the melange change, the ruby packages should be rebuilt to enable multiple versions.

The ruby gem packages can be rebuilt as needed, as they will still depend on the non-base ruby packages until rebuilt.

Fixes:
* multiple ruby installation version conflicts