### PR TITLE
Fix xh test.

### DIFF
--- a/xh.yaml
+++ b/xh.yaml
@@ -1,7 +1,7 @@
 package:
   name: xh
   version: 0.22.2
-  epoch: 1
+  epoch: 2
   description: Friendly and fast tool for sending HTTP requests.
   copyright:
     - license: MIT
@@ -39,4 +39,4 @@ test:
     - runs: |
         xh --version | grep ${{package.version}}
     - runs: |
-        xh https://example.com
+        xh GET https://example.com


### PR DESCRIPTION
This started failing with 405 bad http method code for some reason, I think something changed on the example.com side.

https://github.com/wolfi-dev/os/actions/runs/10855772987/job/30129159092