### PR TITLE
cni-plugins: add compat for aws-k8s-cni

### DIFF
--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -55,44 +55,38 @@ data:
       tap: Creates a tap device inside the container namespace.
       vrf: Creates a VRF in the network namespace and assigns it the interface passed in the arguments.
 
+vars:
+  all-plugins: bridge bandwidth dhcp dummy firewall host-device host-local ipvlan loopback macvlan ptp portmap sbr static tap tuning vrf vlan
+  main-plugins: bridge dummy host-device ipvlan loopback macvlan ptp tap vlan
+  ipam-plugins: dhcp host-local static
+  meta-plugins: bandwidth firewall portmap sbr tuning vrf
+
 # CNI Plugins, separated into groups
 subpackages:
   - name: "cni-plugins-main"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          for f in bridge \
-                    ipvlan \
-                    loopback \
-                    macvlan \
-                    ptp \
-                    vlan \
-                    host-device \
-                    tap \
-                    dummy; do
-            cp bin/$f "${{targets.subpkgdir}}"/usr/bin/
+          for binary in ${{vars.main-plugins}}; do
+            cp bin/$binary "${{targets.subpkgdir}}"/usr/bin/
           done
+
   - name: "cni-plugins-ipam"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          for f in dhcp \
-                    host-local \
-                    static; do
-            cp bin/$f "${{targets.subpkgdir}}"/usr/bin/
+          for binary in ${{vars.ipam-plugins}}; do
+            cp bin/$binary "${{targets.subpkgdir}}"/usr/bin/
           done
+
   - name: "cni-plugins-meta"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          for f in tuning \
-                    portmap \
-                    bandwidth \
-                    sbr \
-                    vrf \
-                    firewall; do
-            cp bin/$f "${{targets.subpkgdir}}"/usr/bin/
+          for binary in ${{vars.meta-plugins}}; do
+            cp bin/$binary "${{targets.subpkgdir}}"/usr/bin/
           done
+
   - range: plugins
     name: "cni-plugins-${{range.key}}"
     description: ${{range.value}}
@@ -104,6 +98,7 @@ subpackages:
       pipeline:
         - runs: |
             ${{range.key}} --version
+
   - range: plugins
     name: cni-plugins-${{range.key}}-compat
     dependencies:
@@ -113,30 +108,14 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/opt/cni/bin
           ln -s /usr/bin/${{range.key}} "${{targets.subpkgdir}}"/opt/cni/bin/${{range.key}}
+
   - name: "cni-plugins-aws-k8s-compat"
     description: "Compatibility package for aws-k8s-cni"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/init
-          for f in bandwidth \
-                    bridge \
-                    dhcp \
-                    dummy \
-                    firewall \
-                    host-device \
-                    host-local \
-                    ipvlan \
-                    loopback \
-                    macvlan \
-                    portmap \
-                    ptp \
-                    sbr \
-                    static \
-                    tap \
-                    tuning \
-                    vlan \
-                    vrf; do
-            cp bin/$f "${{targets.subpkgdir}}"/init/
+          for binary in ${{vars.all-plugins}}; do
+            cp bin/${binary} "${{targets.subpkgdir}}"/init/
           done
 
 update:

--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -100,6 +100,10 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
           cp bin/${{range.key}} "${{targets.subpkgdir}}"/usr/bin
+    test:
+      pipeline:
+        - runs: |
+            ${{range.key}} --version
   - range: plugins
     name: cni-plugins-${{range.key}}-compat
     dependencies:

--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -56,10 +56,10 @@ data:
       vrf: Creates a VRF in the network namespace and assigns it the interface passed in the arguments.
 
 vars:
-  all-plugins: bridge bandwidth dhcp dummy firewall host-device host-local ipvlan loopback macvlan ptp portmap sbr static tap tuning vrf vlan
-  main-plugins: bridge dummy host-device ipvlan loopback macvlan ptp tap vlan
-  ipam-plugins: dhcp host-local static
-  meta-plugins: bandwidth firewall portmap sbr tuning vrf
+  plugins-all: bridge bandwidth dhcp dummy firewall host-device host-local ipvlan loopback macvlan ptp portmap sbr static tap tuning vrf vlan
+  plugins-main: bridge dummy host-device ipvlan loopback macvlan ptp tap vlan
+  plugins-ipam: dhcp host-local static
+  plugins-meta: bandwidth firewall portmap sbr tuning vrf
 
 # CNI Plugins, separated into groups
 subpackages:
@@ -67,26 +67,23 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          for binary in ${{vars.main-plugins}}; do
-            cp bin/$binary "${{targets.subpkgdir}}"/usr/bin/
+          for f in ${{vars.plugins-main}}; do
+            cp bin/$f "${{targets.subpkgdir}}"/usr/bin/
           done
-
   - name: "cni-plugins-ipam"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          for binary in ${{vars.ipam-plugins}}; do
-            cp bin/$binary "${{targets.subpkgdir}}"/usr/bin/
+          for f in ${{vars.plugins-ipam}}; do
+            cp bin/$f "${{targets.subpkgdir}}"/usr/bin/
           done
-
   - name: "cni-plugins-meta"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          for binary in ${{vars.meta-plugins}}; do
-            cp bin/$binary "${{targets.subpkgdir}}"/usr/bin/
+          for f in ${{vars.plugins-meta}}; do
+            cp bin/$f "${{targets.subpkgdir}}"/usr/bin/
           done
-
   - range: plugins
     name: "cni-plugins-${{range.key}}"
     description: ${{range.value}}
@@ -98,7 +95,6 @@ subpackages:
       pipeline:
         - runs: |
             ${{range.key}} --version
-
   - range: plugins
     name: cni-plugins-${{range.key}}-compat
     dependencies:
@@ -108,13 +104,12 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/opt/cni/bin
           ln -s /usr/bin/${{range.key}} "${{targets.subpkgdir}}"/opt/cni/bin/${{range.key}}
-
   - name: "cni-plugins-aws-k8s-compat"
     description: "Compatibility package for aws-k8s-cni"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/init
-          for binary in ${{vars.all-plugins}}; do
+          for binary in ${{vars.plugins-all}}; do
             cp bin/${binary} "${{targets.subpkgdir}}"/init/
           done
 

--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -1,7 +1,7 @@
 package:
   name: cni-plugins
   version: 1.5.1
-  epoch: 2
+  epoch: 3
   description: Some reference and example networking plugins, maintained by the CNI team.
   copyright:
     - license: Apache-2.0
@@ -52,6 +52,8 @@ data:
       bandwidth: Allows bandwidth-limiting through use of traffic control tbf (ingress/egress).
       sbr: A plugin that configures source based routing for an interface (from which it is chained).
       firewall: A firewall plugin which uses iptables or firewalld to add rules to allow traffic to/from the container.
+      tap: Creates a tap device inside the container namespace.
+      vrf: Creates a VRF in the network namespace and assigns it the interface passed in the arguments.
 
 # CNI Plugins, separated into groups
 subpackages:
@@ -66,6 +68,7 @@ subpackages:
                     ptp \
                     vlan \
                     host-device \
+                    tap \
                     dummy; do
             cp bin/$f "${{targets.subpkgdir}}"/usr/bin/
           done
@@ -86,6 +89,7 @@ subpackages:
                     portmap \
                     bandwidth \
                     sbr \
+                    vrf \
                     firewall; do
             cp bin/$f "${{targets.subpkgdir}}"/usr/bin/
           done
@@ -105,6 +109,31 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/opt/cni/bin
           ln -s /usr/bin/${{range.key}} "${{targets.subpkgdir}}"/opt/cni/bin/${{range.key}}
+  - name: "cni-plugins-aws-k8s-compat"
+    description: "Compatibility package for aws-k8s-cni"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/init
+          for f in bandwidth \
+                    bridge \
+                    dhcp \
+                    dummy \
+                    firewall \
+                    host-device \
+                    host-local \
+                    ipvlan \
+                    loopback \
+                    macvlan \
+                    portmap \
+                    ptp \
+                    sbr \
+                    static \
+                    tap \
+                    tuning \
+                    vlan \
+                    vrf; do
+            cp bin/$f "${{targets.subpkgdir}}"/init/
+          done
 
 update:
   enabled: true

--- a/cni-plugins.yaml
+++ b/cni-plugins.yaml
@@ -67,22 +67,22 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          for f in ${{vars.plugins-main}}; do
-            cp bin/$f "${{targets.subpkgdir}}"/usr/bin/
+          for binary in ${{vars.plugins-main}}; do
+            cp bin/$binary "${{targets.subpkgdir}}"/usr/bin/
           done
   - name: "cni-plugins-ipam"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          for f in ${{vars.plugins-ipam}}; do
-            cp bin/$f "${{targets.subpkgdir}}"/usr/bin/
+          for binary in ${{vars.plugins-ipam}}; do
+            cp bin/$binary "${{targets.subpkgdir}}"/usr/bin/
           done
   - name: "cni-plugins-meta"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          for f in ${{vars.plugins-meta}}; do
-            cp bin/$f "${{targets.subpkgdir}}"/usr/bin/
+          for binary in ${{vars.plugins-meta}}; do
+            cp bin/$binary "${{targets.subpkgdir}}"/usr/bin/
           done
   - range: plugins
     name: "cni-plugins-${{range.key}}"


### PR DESCRIPTION
- Added missing [`tap`](https://www.cni.dev/plugins/current/main/tap/) and [`vrf`](https://www.cni.dev/plugins/current/meta/vrf/) to the plugin groups.
- Added a compat package for `aws-k8s-cni-init`. All the plugins need to be copied into the `/init` directory. The entrypoint script then copies them to the host, so we can't use `ln`. See: https://github.com/chainguard-dev/image-requests/issues/4138
- Added simple `--version` test
- Refactored the plugins list into `vars`