### PR TITLE
add carvel-dev/vendir package

### DIFF
--- a/vendir.yaml
+++ b/vendir.yaml
@@ -1,0 +1,34 @@
+package:
+  name: vendir
+  version: 0.42.0
+  epoch: 0
+  description: Easy way to vendor portions of git repos, github releases, helm charts, docker image contents, etc. declaratively
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 09ab9ab732b18cfaa735ab9b5b74be82a0f4d5ba
+      repository: https://github.com/carvel-dev/vendir
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      packages: ./cmd/vendir
+      output: vendir
+      ldflags: -X carvel.dev/vendir/pkg/vendir/version.Version=v${{package.version}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: carvel-dev/vendir
+    strip-prefix: v
+
+test:
+  pipeline:
+    - name: version check
+      runs: |
+        vendir version | grep ${{package.version}}

--- a/vendir.yaml
+++ b/vendir.yaml
@@ -19,8 +19,6 @@ pipeline:
       output: vendir
       ldflags: -X carvel.dev/vendir/pkg/vendir/version.Version=v${{package.version}}
 
-  - uses: strip
-
 update:
   enabled: true
   github:
@@ -32,3 +30,12 @@ test:
     - name: version check
       runs: |
         vendir version | grep ${{package.version}}
+    - uses: git-checkout
+      with:
+        expected-commit: 09ab9ab732b18cfaa735ab9b5b74be82a0f4d5ba
+        repository: https://github.com/carvel-dev/vendir
+        tag: v${{package.version}}
+    - name: run sync
+      runs: |
+        cd examples/inline
+        vendir sync


### PR DESCRIPTION
this is runtime dependency for kapp-controller image which is being added via https://github.com/wolfi-dev/os/pull/28410 

Ref: 
https://github.com/carvel-dev/kapp-controller/blob/68347a9701ea2bfa14e2ed4677c040c3fd38db77/Dockerfile#L11

Related: https://github.com/chainguard-dev/image-requests/issues/1635