### PR TITLE
add a pipeline for testing executables

### DIFF
--- a/7zip.yaml
+++ b/7zip.yaml
@@ -49,3 +49,9 @@ update:
   enabled: true
   release-monitor:
     identifier: 265148
+
+test:
+  pipeline:
+    - uses: test/execs
+      with:
+        package: 7zip

--- a/pipelines/test/execs.yaml
+++ b/pipelines/test/execs.yaml
@@ -1,0 +1,41 @@
+name: Test package binaries execution
+
+inputs:
+  package:
+    description: The package to test
+    required: true
+  test-params:
+    description: Space-separated list of parameters to test
+    default: "--version --help -v -h -V -H version help"
+  timeout:
+    description: Timeout for each command execution (in seconds)
+    default: "10"
+
+pipeline:
+  - runs: |
+      set -eu
+
+      pkg="${{inputs.package}}"
+      try="${{inputs.test-params}}"
+
+      path_regex=$(echo "$PATH" | sed -e 's/:/|/g' -e 's/^/^/' -e 's/$/\//')
+
+      apk info -L "$pkg" | grep -E "$path_regex" | while read -r bin; do
+        [ -x "/$bin" ] || continue
+        echo "PACKAGE [$pkg] with BINARY [$bin]"
+        ls -halF "/$bin"
+        cmd=$(basename "/$bin")
+        success=false
+        for param in $try; do
+          if timeout ${{inputs.timeout}}s "$cmd" $param; then
+            success=true
+            break
+          fi
+        done
+        if ! $success; then
+          echo "ERROR: All attempts failed for $cmd"
+          exit 1
+        fi
+      done
+
+      echo "Testing complete for package [$pkg]"


### PR DESCRIPTION
pipeline form of https://github.com/wolfi-dev/os/pull/28463.

I don't love that we need to specify `uses` for each call, so maybe this is something we can just bake into `melange`. I recall there being ideas for doing this a while back and we pushed back, but I can't remember why