### PR TITLE
mariadb: provide mysql-client and add tests

### DIFF
--- a/mariadb-11.5.yaml
+++ b/mariadb-11.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-11.5
   version: 11.5.2
-  epoch: 1
+  epoch: 2
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -187,6 +187,7 @@ subpackages:
     dependencies:
       provides:
         - mariadb-client=${{package.full-version}}
+        - mysql-client=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/bin
@@ -232,3 +233,13 @@ update:
     strip-prefix: mariadb-
     use-tag: true
     tag-filter: mariadb-11.5.
+
+test:
+  environment:
+    contents:
+      packages:
+        - mysql-client
+  pipeline:
+    - name: Check mysql client version
+      runs: |
+        mysql --version

--- a/mariadb-11.5.yaml
+++ b/mariadb-11.5.yaml
@@ -187,6 +187,7 @@ subpackages:
     dependencies:
       provides:
         - mariadb-client=${{package.full-version}}
+        # mysql-client is the legacy name of the mariadb-client package, both are exactly the same
         - mysql-client=${{package.full-version}}
     pipeline:
       - runs: |
@@ -238,8 +239,37 @@ test:
   environment:
     contents:
       packages:
+        - mariadb-dev
+        - mariadb
         - mysql-client
+        - shadow
+        - sudo-rs
+    environment:
+      DBDATA: /var/lib/mysql
+      DBUSER: mysql
   pipeline:
-    - name: Check mysql client version
+    - name: Check versions
       runs: |
         mysql --version
+        mariadb --version
+        mariadbd --version
+        mysqladmin --version
+        mariadb-admin --version
+    - name: Test mariadbd start and stop
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          useradd $DBUSER
+          chown $DBUSER:$DBUSER $DBDATA
+          sudo -u $DBUSER mkdir -p $DBDATA
+          mkdir -p /var/tmp
+          mkdir -p /run/mysqld
+          chown $DBUSER:$DBUSER /var/tmp
+          chown $DBUSER:$DBUSER /run/mysqld
+          sudo -u $DBUSER mysql_install_db --user=$DBUSER --datadir=$DBDATA --basedir=/usr
+        start: sudo -u $DBUSER mysqld_safe --user=$DBUSER
+        post: |
+          sudo -u $DBUSER mysqladmin ping --silent --wait=5
+        timeout: 60
+        expected_output: |
+          Starting mariadbd daemon


### PR DESCRIPTION
Provide `mysql-client` on `mariadb-client` package as it's the same package.