### PR TITLE
Add opa-envoy

### DIFF
--- a/opa-envoy.yaml
+++ b/opa-envoy.yaml
@@ -1,0 +1,69 @@
+package:
+  name: opa-envoy
+  version: 0.68.0_rc4
+  epoch: 0
+  description: A plugin to enforce OPA policies with Envoy.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - opa=${{vars.base-semver}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - wolfi-baselayout
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(.+)_rc(\d*)$
+    replace: $1-envoy-$2
+    to: mangled-package-version
+  # Trim trailing suffix - this can happen if the original tag didn't have a number at the end of its `-envoy` suffix.
+  - from: ${{vars.mangled-package-version}}
+    match: "-$"
+    replace: ""
+    to: trimmed-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+\.\d+).*$
+    replace: $1
+    to: base-semver
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/open-policy-agent/opa-envoy-plugin
+      tag: v${{vars.trimmed-version}}
+      expected-commit: b6580ba697ce8edda334c1d013c2e9888bfa6aec
+
+  - uses: go/build
+    with:
+      ldflags: "-X github.com/open-policy-agent/opa/version.Version=${{package.version}}"
+      modroot: .
+      packages: ./cmd/opa-envoy-plugin
+      output: opa
+
+update:
+  enabled: true
+  github:
+    identifier: open-policy-agent/opa-envoy-plugin
+    strip-prefix: v
+    use-tag: true
+  version-transform:
+    - match: ^v(.+)\-envoy-?(\d+)?$
+      # we use _rc here since it's an allowable suffix with or without a number
+      # see https://github.com/wolfi-dev/wolfictl/blob/b168a068d4ea555968116a7577964310adf8ec33/pkg/versions/validate.go#L12 for spec.
+      # Examples:
+      # v0.68.0-envoy -> 0.68.0_rc
+      # v0.68.0-envoy-2 -> 0.68.0_rc2
+      replace: $1_rc$2
+
+test:
+  pipeline:
+    - runs: |
+        opa version
+        opa test . -v


### PR DESCRIPTION
This binary is a variant of opa with envoy plugin installed.

Versioning is a little weird due to [upstream tagging conventions](https://github.com/open-policy-agent/opa-envoy-plugin/tags): we use _rc here since it's an allowable suffix with or without a number
see https://github.com/wolfi-dev/wolfictl/blob/b168a068d4ea555968116a7577964310adf8ec33/pkg/versions/validate.go#L12 for spec.

Examples:
- v0.68.0-envoy -> 0.68.0_rc
- v0.68.0-envoy-2 -> 0.68.0_rc2

Related: https://github.com/chainguard-dev/image-requests/issues/4085

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

