### PR TITLE
Enable auto-updates for haproxy, bump to v3.0.4

### DIFF
--- a/haproxy-3.0.yaml
+++ b/haproxy-3.0.yaml
@@ -1,6 +1,6 @@
 package:
   name: haproxy-3.0
-  version: 3.0.2
+  version: 3.0.4
   epoch: 0
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
@@ -10,6 +10,12 @@ package:
       - libgcc
     provides:
       - haproxy=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
 
 environment:
   contents:
@@ -23,14 +29,13 @@ environment:
       - openssl-dev
       - pcre2-dev
 
+# We have to use fetch, as there are issues cloning from: 'https://git.haproxy.org/git/haproxy-3.0.git'.
+# Namely: 'failed to validate pipeline git-checkout: failed to list refs for https://git.haproxy.org/git/haproxy-3.0.git/: pkt-line 1: invalid hash text: encoding/hex: invalid byte'
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://git.haproxy.org/git/haproxy-3.0.git/
-      tag: v${{package.version}}
-      expected-commit: a45a8e6235853e787e59b13f07355f4729ae3c8e
-      depth: "-1"
-
+      uri: https://www.haproxy.org/download/${{vars.major-minor-version}}/src/haproxy-${{package.version}}.tar.gz
+      expected-sha256: aabfd98ada721bbfb68f7805586ced0373fb4c8d73e18faa94055a16c2096936
   - uses: autoconf/make
     with:
       opts: |
@@ -45,13 +50,10 @@ pipeline:
         LUA_LIB=/usr/lib/lua5.3 \
         LUA_INC=/usr/include/lua5.3 \
         USE_GETADDRINFO=1
-
   - runs: |
       make install DESTDIR="${{targets.destdir}}" PREFIX=/usr DOCDIR=/usr/share/doc/haproxy
       install -d "${{targets.destdir}}"/var/lib/haproxy
-
   - uses: strip
-
   # This MUST run after strip, which strips capabilities too!
   - runs: setcap cap_net_bind_service=+eip "${{targets.destdir}}/usr/sbin/haproxy"
 
@@ -79,6 +81,11 @@ subpackages:
           chmod +x ${{targets.subpkgdir}}/usr/local/bin/docker-entrypoint.sh
 
 update:
-  enabled: false
+  enabled: true
   release-monitor:
     identifier: 1298
+
+test:
+  pipeline:
+    - runs: |
+        haproxy -v


### PR DESCRIPTION
Switch to using fetch and grab the source tarball, as git clone does not work with the upstream git repo reliably (https://git.haproxy.org/git/haproxy-3.0.git). Namely:

> failed to validate pipeline git-checkout: failed to list refs for https://git.haproxy.org/git/haproxy-3.0.git/: pkt-line 1: invalid hash text: encoding/hex: invalid byte

Re-enables automatic updates