### PR TITLE
Rebuild njs against new nginx

### DIFF
--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -1,5 +1,6 @@
 package:
   name: nginx-mainline
+  # Must also bump njs at the same time
   version: 1.27.1
   epoch: 0
   description: HTTP and reverse proxy server (mainline version)

--- a/njs.yaml
+++ b/njs.yaml
@@ -1,7 +1,7 @@
 package:
   name: njs
   version: 0.8.5
-  epoch: 0
+  epoch: 1
   description: njs scripting language CLI utility
   copyright:
     - license: BSD-2-Clause
@@ -18,7 +18,8 @@ environment:
       - libedit-dev
       - libxml2-dev
       - libxslt-dev
-      - nginx-mainline-src
+      # Must bump this when nginx-mainline is upgraded
+      - nginx-mainline-src~1.27.1
       - openssl-dev
       - pcre-dev
 
@@ -47,7 +48,7 @@ pipeline:
 
       cd $builddir/build
 
-      /usr/src/nginx/configure \
+      /usr/src/nginx/auto/configure \
         --with-compat \
         --with-stream \
         --with-http_ssl_module \


### PR DESCRIPTION
Currently installing nginx & njs together fails to start, as the
module was not rebuild against new nginx, upon version upgrade.

```
nginx: [emerg] module "/usr/lib/nginx/modules/ngx_http_js_module.so" version 1027000 instead of 1027001 in /etc/nginx/nginx.conf:3
```

Add major version dependency, such that upon nginx-mainline lifecycle
upgrades, wolfictl text fails resolve dependencies forcing us to bump
njs at the same time. Leave comments w.r.t. this coupling, to avoid
this in the future.

Currently njs package has been broken for over a month.

Fixes: https://github.com/chainguard-dev/image-release-stats/issues/308

Discovered by running the docker run command without detach and reading the error message.
