### PR TITLE
exclude reason added for fluent-bit-tag-normaliser

### DIFF
--- a/fluent-plugin-tag-normaliser.yaml
+++ b/fluent-plugin-tag-normaliser.yaml
@@ -1,8 +1,8 @@
-#nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
+#nolint:valid-pipeline-git-checkout-tag
 package:
   name: fluent-plugin-tag-normaliser
-  version: 0.1.2_git20230928
-  epoch: 3
+  version: 0_git20240917
+  epoch: 0
   description: Tag-normaliser is a `fluentd` plugin to help re-tag logs with Kubernetes metadata. It uses special placeholders to change tag.
   copyright:
     - license: Apache-2.0
@@ -21,20 +21,19 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  - runs: |
-      git clone https://github.com/kube-logging/fluent-plugin-tag-normaliser
-      cd fluent-plugin-tag-normaliser
-      git checkout 977a7a0de97db777d83f0db660a3789dcd83a5d4
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kube-logging/fluent-plugin-tag-normaliser
+      branch: master
+      expected-commit: 6f882532c1e40239a5aa6b143040ce186b9de0d9
 
   - uses: ruby/build
     with:
       gem: ${{vars.gem}}
-      dir: fluent-plugin-tag-normaliser
 
   - uses: ruby/install
     with:
       gem: ${{vars.gem}}
-      dir: fluent-plugin-tag-normaliser
       version: 0.1.2 # hard coded as no tags or releases
 
   - uses: ruby/clean
@@ -43,4 +42,8 @@ vars:
   gem: fluent-plugin-tag-normaliser
 
 update:
-  enabled: false
+  enabled: true
+  schedule:
+    period: daily
+    reason: Upstream does not maintain tags or releases
+  git: {}


### PR DESCRIPTION
I used the latest commit date as a version which is 6months~ ago: https://github.com/kube-logging/fluent-plugin-tag-normaliser/commit/6f882532c1e40239a5aa6b143040ce186b9de0d9

then I enabled the updates using daily schedule.

