### PR TITLE
kserve-modelmesh-serving: Fix internal config.

### DIFF
--- a/kserve-modelmesh-serving.yaml
+++ b/kserve-modelmesh-serving.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve-modelmesh-serving
   version: 0.12.0
-  epoch: 1
+  epoch: 2
   description: ModelMesh Serving is the Controller for managing ModelMesh, a general-purpose model serving management/routing layer.
   copyright:
     - license: Apache-2.0
@@ -18,10 +18,13 @@ pipeline:
       packages: .
       output: manager
 
-  - name: Copy default config
+  - name: Copy configs
+    # Binary assumes path is populated relative to the workdir. In the upstream image this is /.
+    # See https://github.com/kserve/modelmesh-serving/blob/f8cc7aa73f6a9360d7635ca5e5c3461d0c60b392/controllers/modelmesh/modelmesh.go#L95
+    #     https://github.com/kserve/modelmesh-serving/blob/f8cc7aa73f6a9360d7635ca5e5c3461d0c60b392/Dockerfile#L71
     runs: |
-      mkdir -p ${{targets.destdir}}/etc/model-serving/config/default
-      cp ./config/default/config-defaults.yaml ${{targets.destdir}}/etc/model-serving/config/default/config-defaults.yaml
+      mkdir -p ${{targets.destdir}}/config
+      cp -a ./config/internal ${{targets.destdir}}/config/internal
 
 subpackages:
   - name: kserve-modelmesh-serving-compat
@@ -73,6 +76,12 @@ test:
           name: model-serving-config
           namespace: modelmesh-serving
         EOF
+    # Binary assumes default config is mounted locally at runtime.
+    # See https://github.com/kserve/modelmesh-serving/blob/f8cc7aa73f6a9360d7635ca5e5c3461d0c60b392/config/manager/manager.yaml#L76
+    - name: Populate default config
+      runs: |
+        mkdir -p /etc/model-serving/config/default
+        cp ./config/default/config-defaults.yaml /etc/model-serving/config/default/config-defaults.yaml
     # Binary assumes mTLS certs are mounted locally.
     - name: Download mTLS certs
       runs: |


### PR DESCRIPTION
config/internal needs to be present with the binary, but the default config gets mounted in the deployment yaml so doesn't need to be a part of the package.

Q: Should the config be a separate subpackage/folder? Technically it can be in a different location, but it always needs to be relative to the workdir where the binary is being run from.


Related: https://github.com/chainguard-dev/image-requests/issues/3818