### PR TITLE
superset/GHSA-fw5r-6m3x-rh7p fix

### DIFF
--- a/superset.yaml
+++ b/superset.yaml
@@ -1,7 +1,7 @@
 package:
   name: superset
   version: 4.0.2
-  epoch: 3
+  epoch: 4
   description: Data Visualization and Data Exploration Platform
   copyright:
     - license: Apache-2.0
@@ -57,11 +57,11 @@ pipeline:
       pip install -r requirements/base.txt
 
       # To fix vulnerabilities
-      pip install --upgrade dnspython==2.6.1 gunicorn==22.0.0 idna==3.7 setuptools==70.0.0 sqlparse==0.5.0 Jinja2==3.1.4 Werkzeug==3.0.3 requests==2.32.0 urllib3==1.26.19 certifi==2024.07.04 zipp==3.19.2
+      pip install --upgrade dnspython==2.6.1 gunicorn==22.0.0 idna==3.7 setuptools==70.0.0 sqlparse==0.5.0 Jinja2==3.1.4 Werkzeug==3.0.3 requests==2.32.0 urllib3==1.26.19 certifi==2024.07.04 zipp==3.19.2 Flask-Appbuilder==4.5.1
       # Dependencies required during runtime
       pip install pillow pyarrow
       # For running translations
-      pip install flask flask-appbuilder
+      pip install flask 
 
       # Build Apache Superset
       pip install .

--- a/superset.yaml
+++ b/superset.yaml
@@ -61,7 +61,7 @@ pipeline:
       # Dependencies required during runtime
       pip install pillow pyarrow
       # For running translations
-      pip install flask 
+      pip install flask
 
       # Build Apache Superset
       pip install .


### PR DESCRIPTION
Dependency version bump for https://github.com/advisories/GHSA-fw5r-6m3x-rh7p, dependency [version change to 4.5.1 from 4.4.1](https://pypi.org/project/Flask-AppBuilder/4.5.1/#history)
