### PR TITLE
Superset troubleshooting appbuilder 4.4.1 vs 4.5.1 build times

### DIFF
--- a/superset.yaml
+++ b/superset.yaml
@@ -57,14 +57,14 @@ pipeline:
       pip install -r requirements/base.txt
 
       # To fix vulnerabilities
-      pip install --upgrade dnspython==2.6.1 gunicorn==22.0.0 idna==3.7 setuptools==70.0.0 sqlparse==0.5.0 Jinja2==3.1.4 Werkzeug==3.0.3 requests==2.32.0 urllib3==1.26.19 certifi==2024.07.04 zipp==3.19.2 Flask-Appbuilder==4.5.1
+      pip install --upgrade dnspython==2.6.1 gunicorn==22.0.0 idna==3.7 setuptools==70.0.0 sqlparse==0.5.0 Jinja2==3.1.4 Werkzeug==3.0.3 requests==2.32.0 urllib3==1.26.19 certifi==2024.07.04 zipp==3.19.2 
       # Dependencies required during runtime
       pip install pillow pyarrow
       # For running translations
-      pip install flask
+      pip install flask flask-appbuilder
 
       # Build Apache Superset
-      pip install .
+      pip install . 
 
       # translations for the web application, Is a non-blocking call, so errors may be ignored
       flask fab babel-compile --target superset/translations

--- a/superset.yaml
+++ b/superset.yaml
@@ -1,7 +1,7 @@
 package:
   name: superset
   version: 4.0.2
-  epoch: 3
+  epoch: 4
   description: Data Visualization and Data Exploration Platform
   copyright:
     - license: Apache-2.0
@@ -57,11 +57,11 @@ pipeline:
       pip install -r requirements/base.txt
 
       # To fix vulnerabilities
-      pip install --upgrade dnspython==2.6.1 gunicorn==22.0.0 idna==3.7 setuptools==70.0.0 sqlparse==0.5.0 Jinja2==3.1.4 Werkzeug==3.0.3 requests==2.32.0 urllib3==1.26.19 certifi==2024.07.04 zipp==3.19.2
+      pip install --upgrade dnspython==2.6.1 gunicorn==22.0.0 idna==3.7 setuptools==70.0.0 sqlparse==0.5.0 Jinja2==3.1.4 Werkzeug==3.0.3 requests==2.32.0 urllib3==1.26.19 certifi==2024.07.04 zipp==3.19.2 Flask-Appbuilder==4.5.1
       # Dependencies required during runtime
       pip install pillow pyarrow
       # For running translations
-      pip install flask flask-appbuilder
+      pip install flask 
 
       # Build Apache Superset
       pip install .

--- a/superset.yaml
+++ b/superset.yaml
@@ -61,7 +61,7 @@ pipeline:
       # Dependencies required during runtime
       pip install pillow pyarrow
       # For running translations
-      pip install flask 
+      pip install flask
 
       # Build Apache Superset
       pip install .

--- a/superset.yaml
+++ b/superset.yaml
@@ -57,14 +57,14 @@ pipeline:
       pip install -r requirements/base.txt
 
       # To fix vulnerabilities
-      pip install --upgrade dnspython==2.6.1 gunicorn==22.0.0 idna==3.7 setuptools==70.0.0 sqlparse==0.5.0 Jinja2==3.1.4 Werkzeug==3.0.3 requests==2.32.0 urllib3==1.26.19 certifi==2024.07.04 zipp==3.19.2 
+      pip install --upgrade dnspython==2.6.1 gunicorn==22.0.0 idna==3.7 setuptools==70.0.0 sqlparse==0.5.0 Jinja2==3.1.4 Werkzeug==3.0.3 requests==2.32.0 urllib3==1.26.19 certifi==2024.07.04 zipp==3.19.2
       # Dependencies required during runtime
       pip install pillow pyarrow
       # For running translations
       pip install flask flask-appbuilder
 
       # Build Apache Superset
-      pip install . 
+      pip install .
 
       # translations for the web application, Is a non-blocking call, so errors may be ignored
       flask fab babel-compile --target superset/translations


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
