### PR TITLE
curl upgrade

### DIFF
--- a/curl.yaml
+++ b/curl.yaml
@@ -1,6 +1,6 @@
 package:
   name: curl
-  version: 8.10.0
+  version: 8.10.1
   epoch: 0
   description: "URL retrieval utility and library"
   copyright:
@@ -26,7 +26,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://curl.se/download/curl-${{package.version}}.tar.xz
-      expected-sha256: e6b142f0e85e954759d37e26a3627e2278137595be80e3a860c4353e4335e5a0
+      expected-sha256: 73a4b0e99596a09fa5924a4fb7e4b995a85fda0d18a2c02ab9cf134bebce04ee
 
   - uses: autoconf/configure
     with:

--- a/curl.yaml
+++ b/curl.yaml
@@ -90,8 +90,13 @@ update:
     strip-prefix: curl-
 
 test:
+  environment:
+    contents:
+      packages:
+        - git
   pipeline:
     - runs: |
         curl --version
         curl -v https://example.com
         curl -s --output /dev/null --compressed https://aur.archlinux.org
+        git clone https://github.com/lyoung-confluent/lots-of-refs.git


### PR DESCRIPTION
- **curl: add test cases excercising a large HTTP/2 based transfer**
  

- **Upgrade to 8.10.1, resolve http/2 failures**
  Fixes: https://github.com/chainguard-dev/customer-issues/issues/1726
  