### PR TITLE
Apache2 improvements alternative

### DIFF
--- a/apache2.yaml
+++ b/apache2.yaml
@@ -155,7 +155,7 @@ subpackages:
         - dash-binsh
     pipeline:
       - runs: |
-          install -Dm755 entrypoint.sh "${{targets.destdir}}"/usr/libexec/entrypoint.sh
+          install -Dm755 entrypoint.sh "${{targets.destdir}}"/usr/bin/entrypoint.sh
 
 test:
   environment:

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -83,6 +83,11 @@ pipeline:
 
   - uses: autoconf/make-install
 
+  - runs: |
+      # Remove default configs, as we have a -config package
+      rm -rf "${{targets.destdir}}"/etc/extra;
+      rm -rf "${{targets.destdir}}"/etc/httpd.conf;
+
   - uses: strip
 
 subpackages:
@@ -128,6 +133,14 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/apache2/icons "${{targets.subpkgdir}}"/usr/share/apache2/
           mv "${{targets.destdir}}"/usr/share/apache2/error "${{targets.subpkgdir}}"/usr/share/apache2/
 
+  - name: ${{package.name}}-config
+    description: "Apache HTTP Server (config files)"
+    pipeline:
+      - runs: |
+          # Copy original files to they are usable
+          cp "${{targets.destdir}}"/etc/original/httpd.conf "${{targets.subpkgdir}}"/etc/httpd.conf
+          cp -r "${{targets.destdir}}"/etc/original/extra "${{targets.subpkgdir}}"/etc/extra
+
   - name: ${{package.name}}-oci-entrypoint
     description: "OCI entrypoint for apache2"
     dependencies:
@@ -136,6 +149,7 @@ subpackages:
     pipeline:
       - runs: |
           install -Dm755 entrypoint.sh "${{targets.subpkgdir}}"/usr/bin/entrypoint.sh
+          # install custom config files
           install -Dm644 httpd.conf "${{targets.subpkgdir}}"/etc/httpd.conf
           install -Dm644 httpd-ssl.conf "${{targets.subpkgdir}}"/etc/extra/httpd-ssl.conf
 
@@ -144,10 +158,9 @@ test:
     contents:
       packages:
         - curl
+        - ${{package.name}}-config
   pipeline:
     - runs: |
-        adduser -D -H www-data
-
         httpd -M
 
         mkdir -p /usr/local/apache2/conf

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -21,7 +21,6 @@ environment:
       - openssl-dev
       - pcre2-dev
       - readline-dev
-      - sed
       - wolfi-base
       - zlib-dev
 
@@ -84,25 +83,6 @@ pipeline:
 
   - uses: autoconf/make-install
 
-  - runs: |
-      set -x
-      # Modify User/Group and test to ensure changes are applied.
-      sed -ri \
-        -e 's!^(\s*User)\s+daemon\s*$!\1 www-data!g' \
-        -e 's!^(\s*Group)\s+daemon\s*$!\1 www-data!g' \
-        "${{targets.destdir}}"/etc/httpd.conf
-
-      grep -E '^\s*User www-data$' "${{targets.destdir}}"/etc/httpd.conf;
-      grep -E '^\s*Group www-data$' "${{targets.destdir}}"/etc/httpd.conf;
-
-      # Modify CustomLog/ErrorLog/TransferLog (it's ok it fails, no need to test).
-      sed -ri \
-        -e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
-        -e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
-        -e 's!^(\s*TransferLog)\s+\S+!\1 /proc/self/fd/1!g' \
-        "${{targets.destdir}}"/etc/httpd.conf \
-        "${{targets.destdir}}"/etc/extra/httpd-ssl.conf;
-
   - uses: strip
 
 subpackages:
@@ -155,7 +135,9 @@ subpackages:
         - dash-binsh
     pipeline:
       - runs: |
-          install -Dm755 entrypoint.sh "${{targets.destdir}}"/usr/bin/entrypoint.sh
+          install -Dm755 entrypoint.sh "${{targets.subpkgdir}}"/usr/bin/entrypoint.sh
+          install -Dm644 httpd.conf "${{targets.subpkgdir}}"/etc/httpd.conf
+          install -Dm644 httpd-ssl.conf "${{targets.subpkgdir}}"/etc/extra/httpd-ssl.conf
 
 test:
   environment:

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache2
   version: 2.4.62
-  epoch: 0
+  epoch: 1
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0
@@ -83,6 +83,11 @@ pipeline:
 
   - uses: autoconf/make-install
 
+  - runs: |
+      set -x
+      mkdir -p "${{targets.destdir}}"/etc/apache2
+      mv "${{targets.destdir}}"/etc/original "${{targets.destdir}}"/etc/apache2/
+
   - uses: strip
 
 subpackages:
@@ -128,6 +133,17 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/share/apache2
           mv "${{targets.destdir}}"/usr/share/apache2/icons "${{targets.subpkgdir}}"/usr/share/apache2/
           mv "${{targets.destdir}}"/usr/share/apache2/error "${{targets.subpkgdir}}"/usr/share/apache2/
+
+  - name: ${{package.name}}-oci-entrypoint
+    description: "OCI entrypoint for apache2"
+    dependencies:
+      runtime:
+        - dash-binsh
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          mv entrypoint.sh ${{targets.subpkgdir}}/usr/bin/entrypoint.sh
+          chmod 0755 ${{targets.subpkgdir}}/usr/bin/entrypoint.sh
 
 test:
   environment:

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -84,18 +84,6 @@ pipeline:
 
   - uses: autoconf/make-install
 
-  - runs: |
-      set -x
-      mkdir -p "${{targets.destdir}}"/etc/apache2
-      sed -ri \
-        -e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
-        -e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
-        -e 's!^(\s*TransferLog)\s+\S+!\1 /proc/self/fd/1!g' \
-        -e 's!^(\s*User)\s+daemon\s*$!\1 www-data!g' \
-        -e 's!^(\s*Group)\s+daemon\s*$!\1 www-data!g' \
-        "${{targets.destdir}}"/etc/httpd.conf \
-        "${{targets.destdir}}"/etc/extra/httpd-ssl.conf;
-
   - uses: strip
 
 subpackages:
@@ -145,12 +133,24 @@ subpackages:
     description: "OCI entrypoint for apache2"
     dependencies:
       runtime:
+        - ${{package.name}}
         - dash-binsh
     pipeline:
       - runs: |
+          set -x
+          # Add the entrypoint
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           mv entrypoint.sh ${{targets.subpkgdir}}/usr/bin/entrypoint.sh
           chmod 0755 ${{targets.subpkgdir}}/usr/bin/entrypoint.sh
+          # Modify the default config
+          sed -ri \
+            -e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
+            -e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
+            -e 's!^(\s*TransferLog)\s+\S+!\1 /proc/self/fd/1!g' \
+            -e 's!^(\s*User)\s+daemon\s*$!\1 www-data!g' \
+            -e 's!^(\s*Group)\s+daemon\s*$!\1 www-data!g' \
+            "${{targets.destdir}}"/etc/httpd.conf \
+            "${{targets.destdir}}"/etc/extra/httpd-ssl.conf;
 
 test:
   environment:

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -21,6 +21,7 @@ environment:
       - openssl-dev
       - pcre2-dev
       - readline-dev
+      - sed
       - wolfi-base
       - zlib-dev
 
@@ -86,7 +87,14 @@ pipeline:
   - runs: |
       set -x
       mkdir -p "${{targets.destdir}}"/etc/apache2
-      mv "${{targets.destdir}}"/etc/original "${{targets.destdir}}"/etc/apache2/
+      sed -ri \
+        -e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
+        -e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
+        -e 's!^(\s*TransferLog)\s+\S+!\1 /proc/self/fd/1!g' \
+        -e 's!^(\s*User)\s+daemon\s*$!\1 www-data!g' \
+        -e 's!^(\s*Group)\s+daemon\s*$!\1 www-data!g' \
+        "${{targets.destdir}}"/etc/httpd.conf \
+        "${{targets.destdir}}"/etc/extra/httpd-ssl.conf;
 
   - uses: strip
 
@@ -108,7 +116,6 @@ subpackages:
           set -x
           mkdir -p "${{targets.subpkgdir}}"/usr/share/doc/apache2
           mv "${{targets.destdir}}"/usr/share/apache2/default-site/htdocs/manual "${{targets.subpkgdir}}"/usr/share/doc/apache2/
-          rm -rf /usr/share/apache2/default-site/htdocs
 
   - name: ${{package.name}}-utils
     description: "Apache HTTP Server (utilities)"

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -84,6 +84,25 @@ pipeline:
 
   - uses: autoconf/make-install
 
+  - runs: |
+      set -x
+      # Modify User/Group and test to ensure changes are applied.
+      sed -ri \
+        -e 's!^(\s*User)\s+daemon\s*$!\1 www-data!g' \
+        -e 's!^(\s*Group)\s+daemon\s*$!\1 www-data!g' \
+        "${{targets.destdir}}"/etc/httpd.conf
+
+      grep -E '^\s*User www-data$' "${{targets.destdir}}"/etc/httpd.conf;
+      grep -E '^\s*Group www-data$' "${{targets.destdir}}"/etc/httpd.conf;
+
+      # Modify CustomLog/ErrorLog/TransferLog (it's ok it fails, no need to test).
+      sed -ri \
+        -e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
+        -e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
+        -e 's!^(\s*TransferLog)\s+\S+!\1 /proc/self/fd/1!g' \
+        "${{targets.destdir}}"/etc/httpd.conf \
+        "${{targets.destdir}}"/etc/extra/httpd-ssl.conf;
+
   - uses: strip
 
 subpackages:
@@ -133,24 +152,10 @@ subpackages:
     description: "OCI entrypoint for apache2"
     dependencies:
       runtime:
-        - ${{package.name}}
         - dash-binsh
     pipeline:
       - runs: |
-          set -x
-          # Add the entrypoint
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          mv entrypoint.sh ${{targets.subpkgdir}}/usr/bin/entrypoint.sh
-          chmod 0755 ${{targets.subpkgdir}}/usr/bin/entrypoint.sh
-          # Modify the default config
-          sed -ri \
-            -e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
-            -e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
-            -e 's!^(\s*TransferLog)\s+\S+!\1 /proc/self/fd/1!g' \
-            -e 's!^(\s*User)\s+daemon\s*$!\1 www-data!g' \
-            -e 's!^(\s*Group)\s+daemon\s*$!\1 www-data!g' \
-            "${{targets.destdir}}"/etc/httpd.conf \
-            "${{targets.destdir}}"/etc/extra/httpd-ssl.conf;
+          install -Dm755 entrypoint.sh "${{targets.destdir}}"/usr/libexec/entrypoint.sh
 
 test:
   environment:
@@ -159,6 +164,8 @@ test:
         - curl
   pipeline:
     - runs: |
+        adduser -D -H www-data
+
         httpd -M
 
         mkdir -p /usr/local/apache2/conf

--- a/apache2/entrypoint.sh
+++ b/apache2/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+exec httpd -DFOREGROUND "$@"

--- a/apache2/entrypoint.sh
+++ b/apache2/entrypoint.sh
@@ -1,4 +1,2 @@
 #!/bin/sh
-set -e
-
 exec httpd -DFOREGROUND "$@"

--- a/apache2/httpd-ssl.conf
+++ b/apache2/httpd-ssl.conf
@@ -1,0 +1,40 @@
+Listen 443
+
+SSLCipherSuite HIGH:MEDIUM:!MD5:!RC4:!3DES
+SSLProxyCipherSuite HIGH:MEDIUM:!MD5:!RC4:!3DES
+SSLHonorCipherOrder on
+SSLProtocol all -SSLv3
+SSLProxyProtocol all -SSLv3
+SSLPassPhraseDialog  builtin
+SSLSessionCache        "shmcb://var/run/apache2/ssl_scache(512000)"
+SSLSessionCacheTimeout  300
+
+<VirtualHost _default_:443>
+
+DocumentRoot "//usr/share/apache2/default-site/htdocs"
+ServerName www.example.com:443
+ServerAdmin you@example.com
+
+ErrorLog /proc/self/fd/2
+TransferLog /proc/self/fd/1
+
+SSLEngine on
+SSLCertificateFile "/etc/server.crt"
+SSLCertificateKeyFile "/etc/server.key"
+
+<FilesMatch "\.(cgi|shtml|phtml|php)$">
+    SSLOptions +StdEnvVars
+</FilesMatch>
+
+<Directory "//usr/lib/cgi-bin">
+    SSLOptions +StdEnvVars
+</Directory>
+
+BrowserMatch "MSIE [2-5]" \
+         nokeepalive ssl-unclean-shutdown \
+         downgrade-1.0 force-response-1.0
+
+CustomLog /proc/self/fd/1 \
+          "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+
+</VirtualHost>

--- a/apache2/httpd.conf
+++ b/apache2/httpd.conf
@@ -1,0 +1,107 @@
+# Custom httpd.conf
+ServerRoot "/"
+Listen 80
+
+LoadModule mpm_prefork_module usr/lib/apache2/modules/mod_mpm_prefork.so
+LoadModule authn_file_module usr/lib/apache2/modules/mod_authn_file.so
+LoadModule authn_core_module usr/lib/apache2/modules/mod_authn_core.so
+LoadModule authz_host_module usr/lib/apache2/modules/mod_authz_host.so
+LoadModule authz_groupfile_module usr/lib/apache2/modules/mod_authz_groupfile.so
+LoadModule authz_user_module usr/lib/apache2/modules/mod_authz_user.so
+LoadModule authz_core_module usr/lib/apache2/modules/mod_authz_core.so
+LoadModule access_compat_module usr/lib/apache2/modules/mod_access_compat.so
+LoadModule auth_basic_module usr/lib/apache2/modules/mod_auth_basic.so
+LoadModule reqtimeout_module usr/lib/apache2/modules/mod_reqtimeout.so
+LoadModule filter_module usr/lib/apache2/modules/mod_filter.so
+LoadModule mime_module usr/lib/apache2/modules/mod_mime.so
+LoadModule log_config_module usr/lib/apache2/modules/mod_log_config.so
+LoadModule env_module usr/lib/apache2/modules/mod_env.so
+LoadModule headers_module usr/lib/apache2/modules/mod_headers.so
+LoadModule setenvif_module usr/lib/apache2/modules/mod_setenvif.so
+LoadModule version_module usr/lib/apache2/modules/mod_version.so
+LoadModule unixd_module usr/lib/apache2/modules/mod_unixd.so
+LoadModule status_module usr/lib/apache2/modules/mod_status.so
+LoadModule autoindex_module usr/lib/apache2/modules/mod_autoindex.so
+
+<IfModule !mpm_prefork_module>
+
+</IfModule>
+<IfModule mpm_prefork_module>
+
+</IfModule>
+
+LoadModule dir_module usr/lib/apache2/modules/mod_dir.so
+LoadModule alias_module usr/lib/apache2/modules/mod_alias.so
+
+<IfModule unixd_module>
+User www-data
+Group www-data
+</IfModule>
+
+ServerAdmin you@example.com
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+DocumentRoot "//usr/share/apache2/default-site/htdocs"
+<Directory "//usr/share/apache2/default-site/htdocs">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>
+
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+<Files ".ht*">
+    Require all denied
+</Files>
+
+ErrorLog /proc/self/fd/2
+
+LogLevel warn
+
+<IfModule log_config_module>
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+    <IfModule logio_module>
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+
+    CustomLog /proc/self/fd/1 common
+</IfModule>
+
+<IfModule alias_module>
+    ScriptAlias /cgi-bin/ "//usr/lib/cgi-bin/"
+</IfModule>
+
+<IfModule cgid_module>
+
+</IfModule>
+
+<Directory "//usr/lib/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule headers_module>
+    RequestHeader unset Proxy early
+</IfModule>
+
+<IfModule mime_module>
+    TypesConfig etc/mime.types
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+</IfModule>
+
+<IfModule proxy_html_module>
+Include etc/extra/proxy-html.conf
+</IfModule>
+
+<IfModule ssl_module>
+SSLRandomSeed startup builtin
+SSLRandomSeed connect builtin
+</IfModule>


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
