### PR TITLE
Simplify xz test by using cmp instead of grep

### DIFF
--- a/xz.yaml
+++ b/xz.yaml
@@ -56,10 +56,11 @@ test:
     - name: Basic xz compression and decompression test
       runs: |
         echo "Hello, Wolfi!" > data.txt
+        cp data.txt data.bak
         xz -z data.txt
         xz -t data.txt.xz
         xz -d data.txt.xz
-        cat data.txt | grep "Wolfi"
+        cmp data.txt data.bak
 
 update:
   enabled: true


### PR DESCRIPTION
Using grep for the test of xz seemed a bit heavy handed and additionally error prone given that only "Wolfi" was being searched for in data.txt. This seemed a bit simpler to me and a useful way for me to test processes.

Here is the output of the test:

2024/09/18 14:21:49 INFO running step "Basic xz compression and decompression test"
2024/09/18 14:21:49 WARN + '[' -d /home/build ]
2024/09/18 14:21:49 WARN + cd /home/build
2024/09/18 14:21:49 WARN + echo 'Hello, Wolfi!'
2024/09/18 14:21:49 WARN + cp data.txt data.txt.bak
2024/09/18 14:21:49 WARN + xz -z data.txt
2024/09/18 14:21:49 WARN + xz -t data.txt.xz
2024/09/18 14:21:49 WARN + xz -d data.txt.xz
2024/09/18 14:21:49 WARN + cmp data.txt data.txt.bak
2024/09/18 14:21:49 WARN + exit 0