### PR TITLE
fix(CVE): K3S - Remediate runc CVE GHSA-jfvp-7x6p-h2pv in sub package k3s-static by using wolfi runc

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.31.0.1
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -144,6 +144,7 @@ subpackages:
         - conntrack-tools
         - ip6tables
         - mount
+        - runc
         - umount
         - kmod
     pipeline:
@@ -156,7 +157,15 @@ subpackages:
           # Clean up the build directory
           rm -rf bin etc
 
+          # Override the go version check at runtime to always match the go version at build time
+          # Ref: https://github.com/k3s-io/k3s/pull/9054
+          GOVERSION=$(go env GOVERSION)
+          sed -i "s/\${VERSION_GOLANG}/$GOVERSION/g" scripts/build
+
           STATIC_BUILD=true ./scripts/build
+
+          # Remove non-embedded components and replace with Wolfi variants at runtime
+          rm -rf bin/runc
 
           for cni in bandwidth bridge firewall flannel host-local loopback portmap; do ln -s cni bin/$cni; done
 


### PR DESCRIPTION
This follows the same changes made in parent k3s package

Confirmed using runc 1.14 as expected and CVE is no longer detected with CVE scan.

Signed-off-by: philroche <phil.roche@chainguard.dev>
