### PR TITLE
lmdb: cherry-pick Debian patch to provide a soname

### DIFF
--- a/ingress-nginx-controller-1.11.yaml
+++ b/ingress-nginx-controller-1.11.yaml
@@ -2,7 +2,7 @@
 package:
   name: ingress-nginx-controller-1.11
   version: 1.11.2
-  epoch: 2
+  epoch: 3
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0

--- a/ldb.yaml
+++ b/ldb.yaml
@@ -1,7 +1,7 @@
 package:
   name: ldb
   version: 2.9.1
-  epoch: 0
+  epoch: 1
   description: schema-less, ldap like, API and database
   copyright:
     - license: LGPL-3.0-or-later

--- a/lmdb.yaml
+++ b/lmdb.yaml
@@ -29,18 +29,18 @@ pipeline:
   - runs: |
       cd libraries/liblmdb
 
-      cat > lmdb.pc << EOF
+      cat > lmdb.pc << 'EOF'
       prefix=/usr
-      exec_prefix=\${prefix}
-      libdir=\${exec_prefix}/lib
-      includedir=\${prefix}/include
+      exec_prefix=${prefix}
+      libdir=${exec_prefix}/lib
+      includedir=${prefix}/include
 
       Name: liblmdb
       Description: Lightning Memory-mapped key-value database
       URL: http://symas.com/mdb/
       Version: @@VERSION@@
-      Libs: -L\${libdir} -llmdb
-      Cflags: -I\${includedir}
+      Libs: -L${libdir} -llmdb
+      Cflags: -I${includedir}
       EOF
 
       sed -i "s|@@VERSION@@|${{package.version}}|" -i *.pc

--- a/lmdb.yaml
+++ b/lmdb.yaml
@@ -1,8 +1,7 @@
-# Generated from https://git.alpinelinux.org/aports/plain/main/lmdb/APKBUILD
 package:
   name: lmdb
   version: 0.9.31
-  epoch: 0
+  epoch: 1
   description: Lightning Memory-Mapped Database
   copyright:
     - license: OLDAP-2.8
@@ -23,21 +22,25 @@ pipeline:
       tag: LMDB_${{package.version}}
       expected-commit: ce201088de95d26fc0da36ba805bf2ddc2ba74ff
 
+  - uses: patch
+    with:
+      patches: 0001-Debian-quirks-to-make-shared-library-versioned.patch
+
   - runs: |
       cd libraries/liblmdb
 
       cat > lmdb.pc << EOF
       prefix=/usr
-      exec_prefix=${prefix}
-      libdir=${exec_prefix}/lib
-      includedir=${prefix}/include
+      exec_prefix=\${prefix}
+      libdir=\${exec_prefix}/lib
+      includedir=\${prefix}/include
 
       Name: liblmdb
       Description: Lightning Memory-mapped key-value database
       URL: http://symas.com/mdb/
       Version: @@VERSION@@
-      Libs: -L${libdir} -llmdb
-      Cflags: -I${includedir}
+      Libs: -L\${libdir} -llmdb
+      Cflags: -I\${includedir}
       EOF
 
       sed -i "s|@@VERSION@@|${{package.version}}|" -i *.pc

--- a/lmdb/0001-Debian-quirks-to-make-shared-library-versioned.patch
+++ b/lmdb/0001-Debian-quirks-to-make-shared-library-versioned.patch
@@ -1,0 +1,55 @@
+From: Debian Berkeley DB Group <pkg-db-devel@lists.alioth.debian.org>
+Date: Tue, 22 Dec 2015 09:36:38 +0100
+Subject: Debian quirks to make shared library versioned
+
+---
+ libraries/liblmdb/Makefile | 28 +++++++++++++++++-----------
+ 1 file changed, 17 insertions(+), 11 deletions(-)
+
+diff --git a/libraries/liblmdb/Makefile b/libraries/liblmdb/Makefile
+index f254511..8f21cc1 100644
+--- a/libraries/liblmdb/Makefile
++++ b/libraries/liblmdb/Makefile
+@@ -27,5 +27,6 @@ CFLAGS	= $(THREADS) $(OPT) $(W) $(XCFLAGS)
+ LDLIBS	=
+ SOLIBS	=
+ SOEXT	= .so
+-prefix	= /usr/local
++SOVER   = 0
++prefix	= /usr
+ exec_prefix = $(prefix)
+@@ -38,7 +39,7 @@ mandir = $(datarootdir)/man
+ ########################################################################
+ 
+ IHDRS	= lmdb.h
+-ILIBS	= liblmdb.a liblmdb$(SOEXT)
++ILIBS	= liblmdb.a liblmdb$(SOEXT) liblmdb$(SOEXT).$(SOVER) liblmdb$(SOEXT).$(SOVER).0.0
+ IPROGS	= mdb_stat mdb_copy mdb_dump mdb_load
+ IDOCS	= mdb_stat.1 mdb_copy.1 mdb_dump.1 mdb_load.1
+ PROGS	= $(IPROGS) mtest mtest2 mtest3 mtest4 mtest5
+@@ -56,6 +57,6 @@
+ 
+ clean:
+-	rm -rf $(PROGS) *.[ao] *.[ls]o *~ testdb
++	rm -rf $(PROGS) *.[ao] *.[ls]o *.[ls]o.* *~ testdb
+ 
+ test:	all
+ 	rm -rf testdb && mkdir testdb
+@@ -64,9 +65,14 @@ test:	all
+ liblmdb.a:	mdb.o midl.o
+ 	$(AR) rs $@ mdb.o midl.o
+ 
+-liblmdb$(SOEXT):	mdb.lo midl.lo
+-#	$(CC) $(LDFLAGS) -pthread -shared -Wl,-Bsymbolic -o $@ mdb.o midl.o $(SOLIBS)
+-	$(CC) $(LDFLAGS) -pthread -shared -o $@ mdb.lo midl.lo $(SOLIBS)
++liblmdb$(SOEXT).$(SOVER).0.0:	mdb.lo midl.lo
++	$(CC) $(LDFLAGS) -fPIC -Wl,-soname,liblmdb$(SOEXT).$(SOVER) -pthread -Wl,-Bsymbolic -shared -o $@ mdb.lo midl.lo $(SOLIBS)
++
++liblmdb$(SOEXT).$(SOVER):	liblmdb$(SOEXT).$(SOVER).0.0
++	ln -sf liblmdb$(SOEXT).$(SOVER).0.0 liblmdb$(SOEXT).$(SOVER)
++
++liblmdb$(SOEXT):	liblmdb$(SOEXT).$(SOVER)
++	ln -sf liblmdb$(SOEXT).$(SOVER) liblmdb$(SOEXT)
+ 
+ mdb_stat: mdb_stat.o liblmdb.a
+ mdb_copy: mdb_copy.o liblmdb.a

--- a/postfix.yaml
+++ b/postfix.yaml
@@ -1,7 +1,7 @@
 package:
   name: postfix
   version: 3.9.0
-  epoch: 0
+  epoch: 1
   description: Secure and fast drop-in replacement for Sendmail (MTA)
   copyright:
     - license: IPL-1.0 OR EPL-2.0


### PR DESCRIPTION
Without a soname, package splits; linking; SCA dependencies do not work.

Add "0" soname to lmdb by cherry-picking patch from debian.

Also fix the pc file, as lots of variables got interpreted prior to writing them out. Possibly it would have been a better idea to simply commit .pc file in the overlayd dir.

Once all that is in place, rebuild reverse dependencies to get correct linking with liblmdb.so.0 and runtime dependencies.

This makes postmap be executable without undefined symbols:

before:
```
postmap lmdb:/etc/postfix/aliases
postmap: fatal: load_library_symbols: dlopen failure loading /usr/lib/postfix/postfix-lmdb.so: /usr/lib/postfix/postfix-lmdb.so: undefined symbol: mdb_drop
```

after
```
 ldd /usr/lib/postfix/postfix-lmdb.so 
	linux-vdso.so.1 (0x00007ffd80c9a000)
	liblmdb.so.0 => /usr/lib/liblmdb.so.0 (0x00007c60f87b2000)
	libc.so.6 => /lib/libc.so.6 (0x00007c60f85bd000)
	/lib64/ld-linux-x86-64.so.2 (0x00007c60f87d4000)
```