### PR TITLE
neuvector - be explicit about phython version

### DIFF
--- a/neuvector-manager.yaml
+++ b/neuvector-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: neuvector-manager
   version: 5.4.0
-  epoch: 0
+  epoch: 1
   description: NeuVector Security Center Admin Console.
   copyright:
     - license: Apache-2.0
@@ -14,6 +14,9 @@ package:
       - openjdk-11-default-jvm
       - procps
 
+vars:
+  py-version: 3.12
+
 environment:
   environment:
     JAVA_OPTS: "-Xms2g -Xmx3g"
@@ -25,8 +28,12 @@ environment:
       - npm
       - openjdk-11
       - openjdk-11-default-jvm
-      - py3-pip
-      - python3
+      - py${{vars.py-version}}-build-base
+      - py${{vars.py-version}}-click
+      - py${{vars.py-version}}-requests
+      - py${{vars.py-version}}-six
+      - py${{vars.py-version}}-wcwidth
+      - python-${{vars.py-version}}
       - sbt
       - wget
       - zip
@@ -65,44 +72,40 @@ subpackages:
     description: NeuVector Manager CLI
     dependencies:
       runtime:
-        - py3-click
-        - py3-requests
-        - py3-six
-        - py3-urllib3
-        - python3
-        - supervisor
+        - py${{vars.py-version}}-click
+        - py${{vars.py-version}}-requests
+        - py${{vars.py-version}}-six
+        - py${{vars.py-version}}-wcwidth
     pipeline:
       - runs: |
           # Setup virtual environment
-          python3 -m venv .venv --system-site-packages
-          .venv/bin/pip install -I cmd2 prettytable --no-compile
+          python${{vars.py-version}} -m venv .venv --system-site-packages
+
+          # README.md lists dependencies deps here are those not
+          # packaged in wolfi.  Packaged libs versions must be listed in both
+          # * build environment - so that --system-site-packages sees them
+          #   and does not add them to the venv
+          # * as runtime deps so they can be used at runtime.
+          .venv/bin/pip install --no-compile cmd2 prettytable
 
           # Remove pip from venv
           .venv/bin/pip uninstall --yes pip
 
           # Upstream places this at /. Let's put it in /usr/share/...
-          mkdir -p ${{targets.contextdir}}/usr/share/neuvector-manager-cli
-          mv .venv ${{targets.contextdir}}/usr/share/neuvector-manager-cli/
+          runpath="usr/share/neuvector-manager-cli"
+          bindir="$runpath/.venv/bin"
+          mkdir -p "${{targets.contextdir}}/$runpath"
+          mv .venv "${{targets.contextdir}}/$runpath"
 
           # Install CLI
           mkdir -p ${{targets.contextdir}}/usr/local/bin
-          install -Dm755 cli/cli.py ${{targets.contextdir}}/usr/share/neuvector-manager-cli/.venv/bin/cli
-          ln -sf /usr/share/neuvector-manager-cli/.venv/bin/cli ${{targets.contextdir}}/usr/local/bin/cli
-          mv cli/prog ${{targets.contextdir}}/usr/share/neuvector-manager-cli/.venv/bin/
+          install -Dm755 cli/cli.py "${{targets.contextdir}}/$bindir/cli"
+          ln -sf "/$bindir/cli" ${{targets.contextdir}}/usr/local/bin/cli
+          cp -r cli/prog "${{targets.contextdir}}/$bindir/"
 
-          # Use Python provided by venv
-          sed -i "s|bin/python3|share/neuvector-manager-cli/.venv/bin/python3|g" ${{targets.contextdir}}/usr/share/neuvector-manager-cli/.venv/bin/cli
+          # Update shbang to use venv
+          sed -i "s|^#!.*python3[^ ]*|#!/$bindir/python3|g" ${{targets.contextdir}}/$bindir/cli
     test:
-      # Without these environment packages explicitly included, we have no python to run the cli (which is just a python script)
-      environment:
-        contents:
-          packages:
-            - py3-click
-            - py3-requests
-            - py3-six
-            - py3-urllib3
-            - python3
-            - supervisor
       pipeline:
         - runs: |
             cli -h


### PR DESCRIPTION
Explicitly set the python version being used here.
Otherwise, the build-time installs things into one version (3.12)
and then later runtime resolution may install 3.13 for dependencies.

Note, the npm install section actually needs python3 executable and
setuptools. Also here is dropping the 'supervisor' dep of the 
neuvector-manager-cli package.  I could not find why that was there,
and it mean tthat we would get 2 python stacks installed.