### PR TITLE
python deps cleanups

### DIFF
--- a/py3-cryptography.yaml
+++ b/py3-cryptography.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cryptography
   version: 43.0.1
-  epoch: 1
+  epoch: 2
   description: cryptography is a package which provides cryptographic recipes and primitives to Python developers.
   copyright:
     - license: Apache-2.0 OR BSD-3-Clause
@@ -50,17 +50,25 @@ subpackages:
       provider-priority: ${{range.value}}
       provides:
         - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-cffi
     pipeline:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
       - uses: strip
     test:
+      environment:
+        contents:
+          packages:
+            - openssl-provider-legacy
       pipeline:
         - uses: python/import
           with:
             python: python${{range.key}}
-            import: ${{vars.pypi-package}}
+            imports: |
+              import ${{vars.pypi-package}}
+              import cryptography.hazmat.primitives.ciphers
 
 update:
   enabled: true

--- a/py3-pbr.yaml
+++ b/py3-pbr.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pbr
   version: 6.1.0
-  epoch: 0
+  epoch: 1
   description: Python Build Reasonableness
   copyright:
     - license: "Apache-2.0"
@@ -10,7 +10,7 @@ package:
     provider-priority: 0
 
 vars:
-  pypi-packagename: pbr
+  pypi-package: pbr
 
 data:
   - name: py-versions
@@ -36,10 +36,12 @@ pipeline:
 
 subpackages:
   - range: py-versions
-    name: py${{range.key}}-${{vars.pypi-packagename}}
-    description: python${{range.key} version of ${{vars.pypi-packagename}}
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key} version of ${{vars.pypi-package}}
     dependencies:
       provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
       runtime:
         - python-${{range.key}}
     pipeline:
@@ -52,7 +54,7 @@ subpackages:
         - uses: python/import
           with:
             python: python${{range.key}}
-            import: ${{vars.pypi-packagename}}
+            import: ${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-python-dateutil.yaml
+++ b/py3-python-dateutil.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-python-dateutil
   version: 2.9.0
-  epoch: 3
+  epoch: 4
   description: Extensions to the standard Python datetime module
   copyright:
     - license: Apache-2.0
@@ -49,6 +49,7 @@ subpackages:
       runtime:
         - py${{range.key}}-six
       provides:
+        - py3-python-dateutil
         - py3-${{vars.pypi-package}}
         - py${{range.key}}-${{vars.pypi-package}}
       provider-priority: ${{range.value}}


### PR DESCRIPTION
 *  py3-python-dateutil - provide py3-python-dateutil
    
    This package is poorly named. I'm not sure why it originally
    got the redundant py3-python-dateutil name, but some other packages
    (py3-jupyter-client) have a dependency on that name.
    
    Because the versioned packages did not provide py3-python-dateutil
    (the did provide py3-dateutil and py3.XX-dateutil) installing
    py3-jupyter-client would just leave you with the skeleton un-versioned
    python package.

 *  py3-pbr - make py3.XX-package provide py3-package
    
    These were missing boilerplate from the multi-version python
    packaging.
    
    The result is that if you 'apk add py3-pbr' you only
    get the empty parent package. Also update variable name for 
    consistency.

 *  py3-cryptography - add runtime depends on cffi
    
    This was discovered by py3-paramiko failing.
    Improve this package's test to also fail.
