### PR TITLE
Use the version of sleep provided by the package not the built-in

### DIFF
--- a/uutils.yaml
+++ b/uutils.yaml
@@ -150,7 +150,7 @@ test:
         seq --version
         shred --version
         shuf --version
-        sleep --version
+        /usr/bin/sleep --version
         sort --version
         split --version
         stat --version


### PR DESCRIPTION
Use the version of sleep provided by the package not the built-in one so that the test passes.

Test log snippet:
```
2024/09/19 14:20:36 WARN + /usr/bin/sleep --version
2024/09/19 14:20:36 INFO /usr/bin/sleep 0.0.27
```
