### PR TITLE
py3-pygments - make py3.XX-package provide py3-package

### DIFF
--- a/py3-pluggy.yaml
+++ b/py3-pluggy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pluggy
   version: 1.5.0
-  epoch: 3
+  epoch: 4
   description: "Plugin management and hook calling for Python"
   copyright:
     - license: MIT
@@ -44,7 +44,6 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
-      - uses: strip
     test:
       pipeline:
         - uses: python/import

--- a/py3-pygments.yaml
+++ b/py3-pygments.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pygments
   version: 2.18.0
-  epoch: 0
+  epoch: 1
   description: Syntax highlighting package written in Python
   copyright:
     - license: BSD-2-Clause
@@ -43,6 +43,8 @@ subpackages:
     description: ${{vars.pypi-package}} installed for python${{range.key}}
     dependencies:
       provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
     pipeline:
       - uses: py/pip-build-install
         with:


### PR DESCRIPTION
These were missing boilerplate from the multi-version python packaging.

The result is that if you 'apk add py3-pygments' you only get the empty parent package.

