### PR TITLE
libpsl: Drop build-time dep on gtk-doc

### DIFF
--- a/libpsl.yaml
+++ b/libpsl.yaml
@@ -2,7 +2,7 @@
 package:
   name: libpsl
   version: 0.21.5
-  epoch: 3
+  epoch: 4
   description: C library for the Publix Suffix List
   copyright:
     - license: MIT
@@ -16,7 +16,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - gettext-dev
-      - gtk-doc
       - libidn2-dev
       - libtool
       - libunistring-dev


### PR DESCRIPTION
This is causing cycles in the build graph.