### PR TITLE
Add consul-k8s, go-discovery

### DIFF
--- a/consul-k8s.yaml
+++ b/consul-k8s.yaml
@@ -1,0 +1,57 @@
+package:
+  name: consul-k8s
+  version: 1.5.3
+  epoch: 0
+  description: The consul-k8s includes first-class integrations between Consul and Kubernetes.
+  copyright:
+    - license: MPL-2.0
+  dependencies:
+    runtime:
+      - go-discover
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hashicorp/consul-k8s
+      expected-commit: 2cb07690ef4f557e65cd0606af30deafd18c3f6a
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      modroot: ./control-plane/cni
+      output: consul-cni
+      packages: .
+
+  - uses: go/build
+    with:
+      modroot: ./control-plane
+      output: consul-k8s-control-plane
+      packages: .
+
+subpackages:
+  - name: ${{package.name}}-cli
+    description: "CLI for interacting with Consul on Kubernetes"
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: ./cli
+          output: consul-k8s
+          packages: .
+    test:
+      pipeline:
+        - name: Verify help
+          runs: |
+            consul-k8s --help
+
+update:
+  enabled: true
+  github:
+    identifier: hashicorp/consul-k8s
+    strip-prefix: v
+
+test:
+  pipeline:
+    - name: Verify help
+      runs: |
+        consul-cni --help
+        consul-k8s-control-plane --help

--- a/go-discover.yaml
+++ b/go-discover.yaml
@@ -1,0 +1,33 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: go-discover
+  version: 0_git20240923
+  epoch: 0
+  description: go-discover is a Go (golang) library and command line tool to discover ip addresses of nodes in cloud environments based on meta information like tags provided by the environment.
+  copyright:
+    - license: MPL-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hashicorp/go-discover
+      expected-commit: 275a71457aa412bf20df9f9b77c380667164a5e6
+      branch: master
+
+  - uses: go/build
+    with:
+      output: discover
+      packages: ./cmd/discover
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: daily
+    reason: Upstream does not maintain tags or releases
+
+test:
+  pipeline:
+    - name: Verify help
+      runs: |
+        discover --help


### PR DESCRIPTION
Testing looks like its better suited for a full k8s environment, so holding off on more detailed functional tests here.

Also includes go-discovery, [which is a runtime dependency of consul-k8s](https://github.com/hashicorp/consul-k8s/blob/0c3745134cbb81198758c442b8d80d61bb351bed/control-plane/Dockerfile#L58). go-discovery is unversioned upstream.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->


Related: https://github.com/chainguard-dev/image-requests/issues/4271

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

Not eol.date, but looks like multiple version streams supported: 1.1 - 1.5

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))
