### PR TITLE
add undock

### DIFF
--- a/undock.yaml
+++ b/undock.yaml
@@ -1,0 +1,65 @@
+package:
+  name: undock
+  version: 0.8.0
+  epoch: 0
+  description: Extract contents of a container image in a local folder
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - btrfs-progs-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - gpgme-dev
+      - libassuan-dev
+      - libgpg-error-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/crazy-max/undock
+      tag: v${{package.version}}
+      expected-commit: adfc8cf74aa5ea70cd5e28c954022d791d1cf4fd
+
+  - uses: go/bump
+    with:
+      deps: github.com/docker/cli@v26.1.4 github.com/docker/docker@v26.1.5
+
+  - uses: go/build
+    with:
+      ldflags: -X main.version=v${{package.version}}
+      output: undock
+      packages: ./cmd/
+      vendor: true
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: crazy-max/undock
+    strip-prefix: v
+    use-tag: true
+
+test:
+  environment:
+    accounts:
+      groups:
+        - groupname: nginx
+          gid: 65532
+      users:
+        - username: nginx
+          gid: 65532
+          uid: 65532
+  pipeline:
+    - runs: undock --help
+    # https://crazymax.dev/undock/usage/examples/
+    # The `handling file: dev/console: cannot handle file mode: Dcrw--w----` error is expected
+    # since the `dev/console` file is a device and cannot be extracted.
+    - name: Simple
+      runs: undock --rm-dist cgr.dev/chainguard/busybox:latest /home/build/out 2>&1 | grep "Extracting"
+    - name: Extract a multi-platform image
+      runs: undock --rm-dist --all cgr.dev/chainguard/busybox:latest /home/build/out 2>&1 | grep "Extracting"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
