### PR TITLE
buildkitd: provide runc and use test/daemon-check-output

### DIFF
--- a/buildkitd.yaml
+++ b/buildkitd.yaml
@@ -2,9 +2,15 @@ package:
   name: buildkitd
   version: 0.16.0
   description: "concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - buildctl
+      - runc
+    provides:
+      - buildkit=${{package.full-version}}
 
 environment:
   contents:
@@ -63,18 +69,11 @@ update:
     tag-filter: v
 
 test:
-  environment:
-    contents:
-      packages:
-        - runc
   pipeline:
-    - runs: |
-        /usr/bin/buildkitd > /tmp/logs.txt 2>&1 &
-        PID=$!
-
-        sleep 5 # ensure that enough time is given for the logs to get written
-        if ! cat /tmp/logs.txt | grep -i 'running server'; then
-          cat /tmp/logs.txt
-          exit 1
-        fi
-        kill $PID
+    - name: "start daemon"
+      uses: test/daemon-check-output
+      with:
+        start: "/usr/bin/buildkitd"
+        timeout: 60
+        expected_output: |
+          running server


### PR DESCRIPTION
Provide the required deps in the runtime, migrate to `test/daemon-check-output`.