### PR TITLE
New python package: durationpy

### DIFF
--- a/py3-durationpy.yaml
+++ b/py3-durationpy.yaml
@@ -1,0 +1,63 @@
+package:
+  name: py3-durationpy
+  version: 0.7
+  epoch: 0
+  description: Module for converting between datetime.timedelta and Go's time.Duration strings.
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: "durationpy"
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-supported-pip
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/icholy/durationpy.git
+      tag: ${{package.version}}
+      expected-commit: e4d076ed93dd6e1ded3fe45d415fc796cbb75df3
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-frozenlist
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+
+update:
+  enabled: true
+  github:
+    use-tag: true
+    identifier: icholy/durationpy


### PR DESCRIPTION
Adds new python package: `durationpy`. This is required in order to build the latest version of py3-kubernetes. For example, the following package update PR requires this package:

 - https://github.com/wolfi-dev/os/pull/28978