### PR TITLE
add jmxfetch.jar to the expected location by datadog

### DIFF
--- a/datadog-jmxfetch.yaml
+++ b/datadog-jmxfetch.yaml
@@ -1,0 +1,46 @@
+package:
+  name: datadog-jmxfetch
+  version: 0.49.4
+  epoch: 0
+  description: Export JMX metrics
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - maven
+      - openjdk-17
+      - openjdk-17-default-jvm
+  environment:
+    LANG: en_US.UTF-8
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/DataDog/jmxfetch
+      tag: ${{package.version}}
+      expected-commit: 76f0a049b18f2b9de52d3937a2759444586c40dc
+
+  - runs: |
+      ./mvnw -DskipTests clean package assembly:single;
+      mkdir -p ${{targets.contextdir}}/opt/datadog-agent/bin/agent/dist/jmx
+      mv target/jmxfetch-*-jar-with-dependencies.jar ${{targets.contextdir}}/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.jar
+
+update:
+  enabled: true
+  github:
+    identifier: https://github.com/DataDog/jmxfetch
+
+test:
+  pipeline:
+    - runs: |
+        # check if there is a file /opt/datadog-agent/bin/agent/dist/jmx
+        if [ ! -f /opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.jar ]; then
+          echo "jmxfetch.jar not found"
+          exit 1
+        fi


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
