### PR TITLE
Add full bash-completion package

### DIFF
--- a/bash-completion.yaml
+++ b/bash-completion.yaml
@@ -48,7 +48,7 @@ pipeline:
 
 update:
   enabled: true
-  github: 
+  github:
     identifier: scop/bash-completion
     use-tag: true
     tag-filter: v

--- a/bash-completion.yaml
+++ b/bash-completion.yaml
@@ -51,7 +51,7 @@ update:
   github:
     identifier: scop/bash-completion
     use-tag: true
-    tag-filter: v
+    tag-filter: 2.
 
 # this is hard to test since it expects an interactive shell and dynamic input
 test:

--- a/bash-completion.yaml
+++ b/bash-completion.yaml
@@ -1,0 +1,61 @@
+package:
+  name: bash-completion
+  version: 2.14.0
+  epoch: 0
+  description: "Programmable completion functions for bash"
+  copyright:
+    - license: GPL-2.0
+  dependencies:
+    runtime:
+      - bash
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/scop/bash-completion
+      expected-commit: 0543d1a28ce3d36741675c7ef6da7c2286288f3e
+      tag: ${{package.version}}
+
+  - runs: autoreconf -fiv
+
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --host=${{host.triplet.gnu}} \
+        --target=${{host.triplet.gnu}} \
+        --prefix=/usr \
+        --bindir=/bin \
+        --sysconfdir=/etc \
+        --without-libidn \
+        --with-ssl=openssl \
+        --disable-nls \
+        --enable-readline \
+        --without-bash-malloc \
+        --with-curses
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+update:
+  enabled: true
+  github: 
+    identifier: scop/bash-completion
+    use-tag: true
+    tag-filter: v
+
+# this is hard to test since it expects an interactive shell and dynamic input
+test:
+  pipeline:
+    - runs: |
+        #!/bin/bash
+        . /etc/profile.d/bash_completion.sh


### PR DESCRIPTION
There are lots of per-package completion subpackages, but wolfi is missing `bash-completion` itself.

Try it out - run `bash`, source `/etc/profile.d/bash-completion.sh`, then apk add `xz` as an example and run `xz -<tab>`.

### Pre-review Checklist

#### For new package PRs only
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates