### PR TITLE
add percona-toolkit and deps (perl-devel-checklib, perl-dbi, perl-dbd-mysql)

### DIFF
--- a/percona-toolkit.yaml
+++ b/percona-toolkit.yaml
@@ -1,0 +1,48 @@
+package:
+  name: percona-toolkit
+  version: 3.6.0
+  epoch: 0
+  description: Toolkit for MySQL/MariaDB
+  copyright:
+    - license: GPL-2.0-only OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - perl
+      - perl-dbd-mysql
+      - perl-time-hires
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/percona/percona-toolkit
+      expected-commit: 655a5fa9db8039ae24c37a08cac58a4bc82b0d7f
+      tag: v${{package.version}}
+
+  - runs: |
+      PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+      make
+
+  - uses: autoconf/make-install
+
+  - runs: find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: percona-toolkit-doc
+    pipeline:
+      - uses: split/manpages
+    description: percona-toolkit manpages
+
+update:
+  enabled: true
+  github:
+    identifier: percona/percona-toolkit
+    strip-prefix: v
+    use-tag: true

--- a/perl-dbd-mysql.yaml
+++ b/perl-dbd-mysql.yaml
@@ -1,0 +1,48 @@
+package:
+  name: perl-dbd-mysql
+  version: "5.009"
+  epoch: 0
+  description: Perl CPAN DBD::Mysql module
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - mariadb-connector-c-dev
+      - perl
+      - perl-dbi
+      - perl-dev
+      - perl-devel-checklib
+      - zlib-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: a83f57af7817787de0ef56fb15fdfaf4f1c952c8f32ff907153b66d2da78ff5b
+      uri: https://cpan.metacpan.org/authors/id/D/DV/DVEEDEN/DBD-mysql-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+      make
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      make DESTDIR="${{targets.destdir}}" install
+
+  - uses: strip
+
+subpackages:
+  - name: perl-dbd-mysql-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-dbd-mysql manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2807

--- a/perl-dbd-mysql.yaml
+++ b/perl-dbd-mysql.yaml
@@ -22,7 +22,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: a83f57af7817787de0ef56fb15fdfaf4f1c952c8f32ff907153b66d2da78ff5b
+      expected-sha256: 8552d90dfddee9ef36e7a696da126ee1b42a1a00fbf2c6f3ce43ca2c63a5b952
       uri: https://cpan.metacpan.org/authors/id/D/DV/DVEEDEN/DBD-mysql-${{package.version}}.tar.gz
 
   - runs: |

--- a/perl-dbi.yaml
+++ b/perl-dbi.yaml
@@ -1,0 +1,45 @@
+package:
+  name: perl-dbi
+  version: "1.645"
+  epoch: 0
+  description: Database independent interface for Perl
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - perl
+      - perl-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: e38b7a5efee129decda12383cf894963da971ffac303f54cc1b93e40e3cf9921
+      uri: https://cpan.metacpan.org/authors/id/H/HM/HMBRAND/DBI-${{package.version}}.tgz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL \
+        INSTALLDIRS=vendor \
+        NO_PACKLIST=1 \
+        NO_PERLLOCAL=1
+      make
+
+  - runs: make DESTDIR="${{targets.destdir}}" install
+
+  - uses: strip
+
+subpackages:
+  - name: perl-dbi-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-dbi manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 2811

--- a/perl-devel-checklib.yaml
+++ b/perl-devel-checklib.yaml
@@ -1,0 +1,44 @@
+package:
+  name: perl-devel-checklib
+  version: "1.16"
+  epoch: 0
+  description: check that a library is available
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - perl
+      - perl-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 869d38c258e646dcef676609f0dd7ca90f085f56cf6fd7001b019a5d5b831fca
+      uri: https://cpan.metacpan.org/authors/id/M/MA/MATTN/Devel-CheckLib-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+      make
+
+  - runs: |
+      make DESTDIR="${{targets.destdir}}" install
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-devel-checklib-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-devel-checklib manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5894


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [X] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [X] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
