### PR TITLE
add perl-dbi and perl-devel-checklib

### DIFF
--- a/perl-dbi.yaml
+++ b/perl-dbi.yaml
@@ -1,0 +1,55 @@
+package:
+  name: perl-dbi
+  version: "1.645"
+  epoch: 0
+  description: Database independent interface for Perl
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - perl
+      - perl-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/perl5-dbi/dbi
+      expected-commit: 87e6c731b464dc862afd1ba95c8b362fcfbee0db
+      tag: ${{package.version}}
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL \
+        INSTALLDIRS=vendor \
+        NO_PACKLIST=1 \
+        NO_PERLLOCAL=1
+      make
+
+  - runs: make DESTDIR="${{targets.destdir}}" install
+
+  - uses: strip
+
+subpackages:
+  - name: perl-dbi-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-dbi manpages
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - _
+  github:
+    identifier: perl5-dbi/dbi
+    use-tag: true
+
+test:
+  pipeline:
+    - name: Smoke test for DBI module
+      runs: |
+        perl -e "use DBI; print 'DBI loaded'"

--- a/perl-devel-checklib.yaml
+++ b/perl-devel-checklib.yaml
@@ -1,0 +1,64 @@
+package:
+  name: perl-devel-checklib
+  version: "1.16"
+  epoch: 0
+  description: check that a library is available
+  copyright:
+    - license: GPL-1.0-or-later OR Artistic-1.0-Perl
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - perl
+      - perl-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 869d38c258e646dcef676609f0dd7ca90f085f56cf6fd7001b019a5d5b831fca
+      uri: https://cpan.metacpan.org/authors/id/M/MA/MATTN/Devel-CheckLib-${{package.version}}.tar.gz
+
+  - runs: |
+      export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
+      PERL_MM_USE_DEFAULT=1 perl -I. Makefile.PL INSTALLDIRS=vendor
+      make
+
+  - runs: |
+      make DESTDIR="${{targets.destdir}}" install
+      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+
+  - uses: strip
+
+subpackages:
+  - name: perl-devel-checklib-doc
+    pipeline:
+      - uses: split/manpages
+    description: perl-devel-checklib manpages
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 5894
+
+test:
+  environment:
+    contents:
+      packages:
+        - build-base # Required to compile basic C code
+        - gcc # Required to compile basic C code
+  pipeline:
+    - name: Smoke test for Perl module
+      runs: |
+        perl -e "use Devel::CheckLib; print 'CheckLib loaded'"
+    - name: Check for existing library (libc)
+      runs: |
+        perl -MDevel::CheckLib -e 'Devel::CheckLib::check_lib_or_exit(lib => "c")'
+    - name: Compile and link with existing library (libc)
+      runs: |
+        perl -MDevel::CheckLib -e 'Devel::CheckLib::assert_lib(lib => "c")'
+    - name: Compile and link with multiple libraries
+      runs: |
+        perl -MDevel::CheckLib -e 'Devel::CheckLib::assert_lib(lib => ["c", "m"])'


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
