### PR TITLE
Several dependency bumps to remedy CVEs in sqlpad

### DIFF
--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -1,7 +1,7 @@
 package:
   name: sqlpad
   version: 7.5.0 # when updating check the patch below as it contains dependency version updates which may downgrade if upstream upgrades them
-  epoch: 0
+  epoch: 1
   description: Web-based SQL editor. Legacy project in maintenance mode.
   copyright:
     - license: MIT
@@ -31,11 +31,11 @@ pipeline:
     runs: |
       # Create "resolutions" section of package.json
       jq '.resolutions |= (if . then . else {} end)' package.json > temp.json && mv temp.json package.json
-      for override in '"semver"="6.3.1"' '"@node-saml/node-saml"="4.0.5"' '"ip"="2.0.1"' '"jose"="4.15.5"' '"xlsx"="https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"' '"tar"="6.2.1"' '"@azure/identity"="4.2.1"' '"@azure/msal-node"="2.9.2"'; do
+      for override in '"semver"="6.3.1"' '"@node-saml/node-saml"="4.0.5"' '"ip"="2.0.1"' '"jose"="4.15.5"' '"xlsx"="https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"' '"tar"="6.2.1"' '"@azure/identity"="4.2.1"' '"@azure/msal-node"="2.9.2"' '"send"="0.19.0"'; do
         jq ".resolutions.${override}" package.json > temp.json && mv temp.json package.json
       done
 
-      for dep in '"express"="4.19.2"' '"mysql2"="3.9.8"'; do
+      for dep in '"express"="4.20.0"' '"body-parser"="1.20.3"' '"send"="0.19.0"' '"mysql2"="3.9.8"'; do
         jq ".dependencies.${dep}" package.json > temp.json && mv temp.json package.json
       done
 


### PR DESCRIPTION
The following dependency bumps remedy GHSA-cm22-4g7w-348p, GHSA-qw6h-vgh9-j6wx, GHSA-qwcr-r2fm-qrc7 and GHSA-9wv6-86v2-598j

express v4.19.2 > v4.20.0
send v0.18.0 > v0.19.0
body-parser v1.20.2 > v1.20.3