### PR TITLE
fix(chromium): Continue using release monitor

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -316,7 +316,8 @@ subpackages:
 
 update:
   enabled: true
-  git: {}
+  release-monitor:
+    identifier: 13344
 
 test:
   environment:


### PR DESCRIPTION
As we switched to the git poller, we began picking up updates for the dev releases of Chromium instead of only the stable releases. Updates jumped from 129 to 131 (the current dev channel) which we should not track

Revert to using release monitor for now. Ideally, we'd want to somehow track the current major release - 2 with the poller in the future

The current stable release of Chromium can be found here:

https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/stable/versions/all/releases