### PR TITLE
add percona-xtrabackup-8.4

### DIFF
--- a/percona-xtrabackup-8.4.yaml
+++ b/percona-xtrabackup-8.4.yaml
@@ -1,0 +1,103 @@
+package:
+  name: percona-xtrabackup-8.4
+  version: 8.4.0
+  epoch: 0
+  description: Open source hot backup tool for InnoDB and XtraDB databases
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - bison
+      - bpftool
+      - build-base
+      - busybox
+      - c-ares-dev
+      - ca-certificates
+      - clang-18
+      - clang-18-dev
+      - clang-18-extras
+      - cmake
+      - curl
+      - curl-dev
+      - elfutils-dev
+      - vim
+      - eudev-dev
+      - gcc-12-default
+      - git
+      - grpc-dev
+      - hardening-check
+      - isl-dev
+      - libaio-dev
+      - libbpf
+      - libbpf-dev
+      - libcurl-openssl4
+      - libelf-static
+      - libev-dev
+      - libgcrypt-dev
+      - liblz4-1
+      - libtool
+      - lsb-release-minimal
+      - lz4
+      - lz4-dev
+      - mpc-dev
+      - ncurses-dev
+      # - libdbd-mysql-perl
+      - numactl-dev
+      - openssl-dev
+      - pkgconf
+      - procps-dev
+      - protobuf-dev
+      - py3-docutils
+      # - qpress
+      - py3-sphinx
+      - rsync
+      - socat
+      - rtmpdump-dev
+      - librtmp
+      - yaml-cpp-dev
+      - zlib-dev
+      - zstd
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/percona/percona-xtrabackup
+      tag: percona-xtrabackup-${{package.version}}
+      expected-commit: da6e1abde099d91b9b725f44b944f95db156cf7f
+      recurse-submodules: true
+
+  - runs: |
+      mkdir build && cd build
+      cmake \
+        -DWITH_BOOST=PATH-TO-BOOST-LIBRARY \
+        -DDOWNLOAD_BOOST=ON \
+        -DBUILD_CONFIG=xtrabackup_release \
+        -DWITH_MAN_PAGES=OFF \
+        ..
+      make -j$(nproc)
+
+  - working-directory: build
+    uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/local/xtrabackup/bin/
+          ln -sf /usr/bin/xtrabackup ${{targets.contextdir}}/usr/local/xtrabackup/bin/xtrabackup
+
+update:
+  enabled: true
+  github:
+    identifier: percona/percona-xtrabackup
+    strip-prefix: percona-xtrabackup-
+    use-tag: true
+    tag-filter: percona-xtrabackup-8.4

--- a/percona-xtrabackup-8.4.yaml
+++ b/percona-xtrabackup-8.4.yaml
@@ -1,10 +1,22 @@
 package:
   name: percona-xtrabackup-8.4
-  version: 8.4.0
+  version: 8.4.0.1
   epoch: 0
   description: Open source hot backup tool for InnoDB and XtraDB databases
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - percona-xtrabackup=${{package.full-version}}
+    runtime:
+      - perl
+
+# Replace the last `.` with `-` to fetch the correct tag.
+var-transforms:
+  - from: ${{package.version}}
+    match: '\.(\d+)$'
+    replace: "-$1"
+    to: mangled-package-version
 
 environment:
   contents:
@@ -25,7 +37,6 @@ environment:
       - curl
       - curl-dev
       - elfutils-dev
-      - vim
       - eudev-dev
       - gcc-12-default
       - git
@@ -40,25 +51,26 @@ environment:
       - libev-dev
       - libgcrypt-dev
       - liblz4-1
+      - librtmp
       - libtool
       - lsb-release-minimal
       - lz4
       - lz4-dev
       - mpc-dev
       - ncurses-dev
-      # - libdbd-mysql-perl
       - numactl-dev
+      - openldap-dev
       - openssl-dev
       - pkgconf
       - procps-dev
       - protobuf-dev
       - py3-docutils
-      # - qpress
       - py3-sphinx
+      - qpress
       - rsync
-      - socat
       - rtmpdump-dev
-      - librtmp
+      - socat
+      - vim
       - yaml-cpp-dev
       - zlib-dev
       - zstd
@@ -67,13 +79,16 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/percona/percona-xtrabackup
-      tag: percona-xtrabackup-${{package.version}}
+      tag: percona-xtrabackup-${{vars.mangled-package-version}}
       expected-commit: da6e1abde099d91b9b725f44b944f95db156cf7f
       recurse-submodules: true
 
   - runs: |
       mkdir build && cd build
       cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DCMAKE_BUILD_TYPE=MinSizeRel \
         -DWITH_BOOST=PATH-TO-BOOST-LIBRARY \
         -DDOWNLOAD_BOOST=ON \
         -DBUILD_CONFIG=xtrabackup_release \
@@ -92,7 +107,27 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/usr/local/xtrabackup/bin/
-          ln -sf /usr/bin/xtrabackup ${{targets.contextdir}}/usr/local/xtrabackup/bin/xtrabackup
+          for bin in $(find "${{targets.destdir}}"/usr/bin -type f -executable); do
+            ln -sf /usr/bin/$(basename $bin) ${{targets.contextdir}}/usr/local/xtrabackup/bin/$(basename $bin)
+          done
+
+  - name: ${{package.name}}-doc
+    pipeline:
+      - uses: split/manpages
+      - uses: split/infodir
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/share/man/man1
+          mv "${{targets.destdir}}"/usr/man/man1/* "${{targets.contextdir}}"/usr/share/man/man1/
+          rm -rf "${{targets.destdir}}"/usr/man
+    description: ${{package.name}} manpages
+
+  - name: "${{package.name}}-test"
+    description: "Provides xtrabackup-test"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr
+          mv "${{targets.destdir}}"/usr/xtrabackup-test ${{targets.contextdir}}/usr/xtrabackup-test
+          rm -rf "${{targets.destdir}}"/usr/xtrabackup-test
 
 update:
   enabled: true
@@ -101,3 +136,18 @@ update:
     strip-prefix: percona-xtrabackup-
     use-tag: true
     tag-filter: percona-xtrabackup-8.4
+  version-transform:
+    - match: ^(.+)\-(\d+)$
+      replace: $1.$2
+
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-compat
+  pipeline:
+    - name: Check binaries
+      runs: |
+        for bin in /usr/local/xtrabackup/bin/*; do
+          $bin --version
+        done

--- a/percona-xtrabackup-8.4.yaml
+++ b/percona-xtrabackup-8.4.yaml
@@ -151,3 +151,16 @@ test:
         for bin in /usr/local/xtrabackup/bin/*; do
           $bin --version
         done
+    - name: Test xbcrypt
+      runs: |
+        echo "This is a test" | xbcrypt -a aes256 -k testkey123456789 > /tmp/encrypted.xb
+        xbcrypt -d -a aes256 -k testkey123456789 -i /tmp/encrypted.xb
+    - name: Test xbstream
+      runs: |
+        echo "Test data" > file1.txt
+        echo "More test data" > file2.txt
+        xbstream -c file1.txt file2.txt > stream_output.xbstream
+        mkdir extract_dir
+        cat stream_output.xbstream | xbstream -x -C extract_dir
+        test -f extract_dir/file1.txt
+        test -f extract_dir/file2.txt


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
