### PR TITLE
Adds mattermost v10.0, which is the latest version

### DIFF
--- a/mattermost-10.0.yaml
+++ b/mattermost-10.0.yaml
@@ -1,13 +1,15 @@
 package:
-  name: mattermost-9
-  version: 9.11.1
-  epoch: 1
+  name: mattermost-10.0
+  version: 10.0.0
+  epoch: 0
   description: "Mattermost is an open source platform for secure collaboration across the entire software development lifecycle."
   copyright:
     - license: MIT
     - license: Apache-2.0
     - license: AGPL-3.0-only
   dependencies:
+    provides:
+      - mattermost=${{package.full-version}}
     runtime:
       - bash
       - tzdata
@@ -40,7 +42,7 @@ pipeline:
     with:
       repository: https://github.com/mattermost/mattermost
       tag: v${{package.version}}
-      expected-commit: 81c8b64b61d93520e731b86189000280082950f6
+      expected-commit: 2d83d21388f3111bffe4b1f63521b21d77ec2cef
 
   - runs: |
       mkdir -p ${{targets.contextdir}}/usr/bin
@@ -50,11 +52,6 @@ pipeline:
 
   - working-directory: server
     pipeline:
-      - uses: go/bump
-        with:
-          deps: google.golang.org/protobuf@v1.33.0 golang.org/x/image@v0.18.0 github.com/gorilla/schema@v1.4.1 github.com/rs/cors@v1.11.0
-          modroot: .
-          tidy: false # https://github.com/mattermost/mattermost/issues/26221
       - runs: make modules-tidy
       - runs: |
           # Our global LDFLAGS conflict with a Makefile parameter: `flag provided but not defined: -Wl,--as-needed,-O1,--sort-common`
@@ -97,7 +94,7 @@ update:
   github:
     identifier: mattermost/mattermost
     strip-prefix: v
-    tag-filter: v9.
+    tag-filter: v10.0
 
 test:
   environment:


### PR DESCRIPTION
This PR adds mattermost v10.0, which is the latest release which landed recently. It also removes the (now non-latest) version of mattermost v9. 