### PR TITLE
ci-build - faster determining packages to build

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -45,24 +45,44 @@ jobs:
       - name: Build package list
         id: package-list
         run: |
-          printf "packages=" >> $GITHUB_OUTPUT
-
+          set +f # disable pathname expansion
           wolfictl text -t name --pipeline-dir=./pipelines/ \
               -r https://packages.wolfi.dev/bootstrap/stage3 \
-              -k https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub > packages-list
-          while read pkg; do
-            for file in ${{ steps.changes.outputs.melange_all_changed_files }}; do
-              # Since the file is a path, we need to strip out only the file
-              # name from it.
-              base_file=$(basename $file)
-              base_file="${base_file%.melange.yaml}"
-              base_file="${base_file%.yaml}"
-              printf "base_file: $base_file"
-              [ "${base_file}" = "$pkg" ] && printf "%s " ${base_file} >> $GITHUB_OUTPUT
-            done
-          done < packages-list
+              -k https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub > all-packages-list
 
-          printf "\n" >> $GITHUB_OUTPUT
+          echo "all-packages-list has $(wc -l < all-packages-list)"
+          n=0
+          for f in ${{ steps.changes.outputs.melange_all_changed_files }}; do
+              # filter anything not .yaml
+              case "$f" in
+                  */pipelines/*) continue;;
+                  *.yaml) :;;
+                  *) continue;;
+              esac
+              pkg=${f##*/}
+              pkg=${pkg%.yaml}
+              pkg=${pkg%.melange.yaml}
+              n=$((n+1))
+              echo "$pkg"
+          done > changed-packages-list
+          echo "changed-packages-list has $n"
+          rc=0
+          grep --fixed-strings --line-regexp \
+              --file=changed-packages-list all-packages-list \
+              > packages-to-build || rc=$?
+          tobuild=$(wc -l < packages-to-build)
+          if [ $rc -eq 0 ]; then
+              echo "build these $tobuild packages in order"
+              sed 's/^/> /' packages-to-build
+              set -- $(cat packages-to-build)
+          elif [ $rc -eq 1 ]; then
+              echo "packages-to-build is empty - did not find any changed packages"
+              set --
+          else
+              echo "ERROR: unexpected error $rc from grep"
+              exit 1
+          fi
+          printf "packages=%s\n" "$*" > "$GITHUB_OUTPUT"
 
   build:
     name: Test building of packages


### PR DESCRIPTION
'Build package list' determines the order in which to build packages by first running 'wolfictl text' to create a list to build all packages and then getting the intersection of that list with the list of packages that had changed.

The 'all-packages' list is currently ~2570 and creating that list takes somewhere between 5 and 30 seconds.

The previous solution looped over each of the changed packages for each of the 2570 total packages.  That took 8 minutes in one pr with 145 packages changed.

On my laptop, even a simple loop like this would take over 1 minute to run:
```
   time sh -c '
      p=$(seq 1 145);
      for f in $(seq 1 2570); do
         for n in ${p}; do
            n=$(echo n);
         done;
         echo $f;
      done'
    real   0m54.332s
    user   0m31.770s
    sys    0m32.135s
```

If you're curious, the real cause of pain is the fork 'n=$(echo n)'. Dropping just the fork makes the above finish in ~ .15s real.

The big change here is to just let 'grep' handle it all, and it does that well.

```
    time bash -c '
      changed=$(seq 100 245 | sed 's,$,.yaml,');
      seq 1 2570 > all-packages;
      for f in ${changed}; do
         pkg=${f##*/};
         pkg=${pkg%.yaml};
         pkg=${pkg%.melange.yaml};
         echo $pkg ; done > changed-packages;
      grep --fixed-strings --line-regexp \
        --file=changed-packages all-packages'

    real  0m0.007s
    user  0m0.004s
    sys   0m0.004s
```