### PR TITLE
php-pcov: init at 1.0.11

### DIFF
--- a/php-8.1-pcov.yaml
+++ b/php-8.1-pcov.yaml
@@ -1,0 +1,52 @@
+package:
+  name: php-8.1-pcov
+  version: 1.0.11
+  epoch: 1
+  description: "CodeCoverage compatible driver for PHP"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.1
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.1
+      - php-8.1-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/krakjoe/pcov.git
+      tag: v${{package.version}}
+      expected-commit: a497e8318801bdc515b468abd15a320c04387c66
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure --enable-pcov
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=pcov.so" > "${{targets.subpkgdir}}/etc/php/conf.d/pcov.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: krakjoe/pcov
+    use-tag: true
+    strip-prefix: v

--- a/php-8.2-pcov.yaml
+++ b/php-8.2-pcov.yaml
@@ -1,0 +1,52 @@
+package:
+  name: php-8.2-pcov
+  version: 1.0.11
+  epoch: 1
+  description: "CodeCoverage compatible driver for PHP"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.2
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.2
+      - php-8.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/krakjoe/pcov.git
+      tag: v${{package.version}}
+      expected-commit: a497e8318801bdc515b468abd15a320c04387c66
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure --enable-pcov
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=pcov.so" > "${{targets.subpkgdir}}/etc/php/conf.d/pcov.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: krakjoe/pcov
+    use-tag: true
+    strip-prefix: v

--- a/php-8.3-pcov.yaml
+++ b/php-8.3-pcov.yaml
@@ -1,0 +1,52 @@
+package:
+  name: php-8.3-pcov
+  version: 1.0.11
+  epoch: 1
+  description: "CodeCoverage compatible driver for PHP"
+  copyright:
+    - license: PHP-3.01
+  dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - php-8.3
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - build-base
+      - busybox
+      - php-8.3
+      - php-8.3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/krakjoe/pcov.git
+      tag: v${{package.version}}
+      expected-commit: a497e8318801bdc515b468abd15a320c04387c66
+
+  - name: Prepare build
+    runs: phpize
+
+  - name: Configure
+    runs: ./configure --enable-pcov
+
+  - uses: autoconf/make
+
+  - name: Make install
+    runs: INSTALL_ROOT="${{targets.destdir}}" DESTDIR="${{targets.destdir}}" make install
+
+subpackages:
+  - name: ${{package.name}}-config
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
+          echo "extension=pcov.so" > "${{targets.subpkgdir}}/etc/php/conf.d/pcov.ini"
+
+update:
+  enabled: true
+  github:
+    identifier: krakjoe/pcov
+    use-tag: true
+    strip-prefix: v


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
