### PR TITLE
amazon-ecr-credential-helper: init at 0.9.0

### DIFF
--- a/amazon-ecr-credential-helper.yaml
+++ b/amazon-ecr-credential-helper.yaml
@@ -1,0 +1,45 @@
+package:
+  name: amazon-ecr-credential-helper
+  version: 0.9.0
+  epoch: 0
+  description: |
+    Automatically gets credentials for Amazon ECR on docker push/docker pull
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/awslabs/amazon-ecr-credential-helper
+      expected-commit: bef5bd9384b752e5c645659165746d5af23a098a
+      tag: v${{package.version}}
+
+  - runs: |
+      ./scripts/build_variant.sh linux amd64 ${{ package.version }} $(git rev-parse --short=7 HEAD)
+    if: ${{build.arch}} == 'x86_64'
+
+  - runs: |
+      ./scripts/build_variant.sh linux arm64 ${{ package.version }} $(git rev-parse --short=7 HEAD)
+    if: ${{build.arch}} == 'aarch64'
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/bin
+      mv bin/*/docker-credential-ecr-login ${{targets.destdir}}/usr/bin/docker-credential-ecr-login
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: awslabs/amazon-ecr-credential-helper
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
amazon-ecr-credential-helper allows to get the docker credentials to authenticate with ecr

Fixes:

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [X] The upstream project actually supports multiple concurrent versions.
- [X] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [X] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [X] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
