### PR TITLE
py3-setuptools - revert - do not supply python 3.13

### DIFF
--- a/py3-setuptools.yaml
+++ b/py3-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-setuptools
   version: 75.1.0
-  epoch: 1
+  epoch: 2
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '313'
+      3.13: '300'
 
 environment:
   contents:

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -11,3 +11,8 @@ aws-k8s-cni-compat-1.18.3-r1.apk
 aws-k8s-cni-egress-cni-1.18.3-r1.apk
 aws-k8s-cni-grpc-health-probe-1.18.3-r1.apk
 aws-k8s-cni-init-compat-1.18.3-r1.apk
+py3-setuptools-75.1.0-r1.apk
+py3.13-setuptools-75.1.0-r1.apk
+py3.12-setuptools-75.1.0-r1.apk
+py3.11-setuptools-75.1.0-r1.apk
+py3.10-setuptools-75.1.0-r1.apk


### PR DESCRIPTION
py3-setuptools - reduce priority of 3.13 versions.

having setuptools at priority 313 would mean that
py3-setuptools would select python3.13 version "by default".

That isn't desired at this point as 3.13 isn't even released.

withdraw py3-setuptools packages at 75.1.0-r1
