### PR TITLE
jaeger-all-in-one: conflicts with the jaeger-agent which was removed

### DIFF
--- a/jaeger-all-in-one.yaml
+++ b/jaeger-all-in-one.yaml
@@ -1,7 +1,7 @@
 package:
   name: jaeger-all-in-one
   version: 1.61.0
-  epoch: 0
+  epoch: 1
   description: Jaeger, a Distributed Tracing Platform
 
 environment:


### PR DESCRIPTION
related to https://github.com/wolfi-dev/os/pull/29229/ 

Jager-agent was removed but not withdrawn causing issues with sub packages 