### PR TITLE
Make withdraw safe again

### DIFF
--- a/.github/workflows/withdraw-packages.yaml
+++ b/.github/workflows/withdraw-packages.yaml
@@ -54,14 +54,6 @@ jobs:
           sudo mkdir -p /etc/apk/keys
           sudo cp ./wolfi-signing.rsa.pub /etc/apk/keys/wolfi-signing.rsa.pub
 
-      - name: Withdraw from index
-        run: |
-          set -euo pipefail
-          for arch in x86_64 aarch64; do
-            mkdir -p $arch
-            curl https://packages.wolfi.dev/os/$arch/APKINDEX.tar.gz | wolfictl withdraw $(grep -v '\#' withdrawn-packages.txt) --signing-key="${{ github.workspace }}/wolfi-signing.rsa" > $arch/APKINDEX.tar.gz
-          done
-
       # We use a different GSA for our interaction with GCS.
       - uses: google-github-actions/auth@62cf5bd3e4211a0a0b51f2c6d6a37129d828611d # v2.1.5
         with:
@@ -72,6 +64,23 @@ jobs:
         with:
           project_id: "prod-images-c6e5"
 
+      - name: Withdraw from index
+        run: |
+          set -euo pipefail
+          for arch in x86_64 aarch64; do
+            mkdir -p $arch
+            curl -v https://packages.wolfi.dev/os/$arch/APKINDEX.tar.gz 2>verbose | wolfictl withdraw $(grep -v '\#' withdrawn-packages.txt) --signing-key="${{ github.workspace }}/wolfi-signing.rsa" > $arch/APKINDEX.tar.gz
+
+            # Parse the object generation from the -v output.
+            GEN=$(grep "x-goog-generation" verbose | cut -d' ' -f3)
+            echo "APKINDEX.tar.gz object generation for ${arch} was ${GEN}"
+
+            # This will fail if the APKINDEX is modified between when we download it and when we upload the modified version.
+            # That's totally fine, just re-run the withdrawl workflow.
+            # This is a bit of a hack until we drop this APKINDEX entirely.
+            gcloud storage cp --if-generation-match="${GEN}" --cache-control="no-store" $arch/APKINDEX.tar.gz gs://wolfi-production-registry-destination/os/$arch/APKINDEX.tar.gz
+          done
+
       - name: Delete withdrawn packages
         run: |
           set -euo pipefail
@@ -80,13 +89,6 @@ jobs:
               echo "=> $pkg"
               gsutil -m rm -f gs://wolfi-production-registry-destination/os/$arch/$pkg || true
             done
-          done
-
-      - name: Upload modified index
-        run: |
-          set -euxo pipefail
-          for arch in x86_64 aarch64; do
-            gsutil -h "Cache-Control:no-store" cp $arch/APKINDEX.tar.gz gs://wolfi-production-registry-destination/os/$arch/APKINDEX.tar.gz || true
           done
 
       - name: Upload full withdrawn packages list


### PR DESCRIPTION
This uses object generations to make the withdrawal workflow fail if something else concurrently modifies the APKINDEX (to avoid data loss).