### PR TITLE
openssf-compiler-options: complete conversion for most cmake packages

### DIFF
--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: abseil-cpp
   version: "20240722.0"
-  epoch: 0
+  epoch: 1
   description: Abseil Common Libraries (C++)
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - gtest-dev
+      - openssf-compiler-options
       - samurai
 
 pipeline:

--- a/aerospike-7.yaml
+++ b/aerospike-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: aerospike-7
   version: 7.1.0.6
-  epoch: 0
+  epoch: 1
   description: Aerospike Database Server - flash-optimized, in-memory, nosql database
   copyright:
     - license: AGPL-3.0-only
@@ -19,6 +19,7 @@ environment:
       - coreutils
       - gmp-dev
       - libtool
+      - openssf-compiler-options
       - openssl-dev
       - zlib-dev
 

--- a/aerospike.yaml
+++ b/aerospike.yaml
@@ -1,7 +1,7 @@
 package:
   name: aerospike
   version: 6.4.0.23
-  epoch: 0
+  epoch: 1
   description: Aerospike Database Server - flash-optimized, in-memory, nosql database
   copyright:
     - license: AGPL-3.0-only
@@ -19,6 +19,7 @@ environment:
       - coreutils
       - gmp-dev
       - libtool
+      - openssf-compiler-options
       - openssl-dev
       - zlib-dev
 

--- a/amazon-corretto-crypto-provider.yaml
+++ b/amazon-corretto-crypto-provider.yaml
@@ -1,7 +1,7 @@
 package:
   name: amazon-corretto-crypto-provider
   version: 2.4.1
-  epoch: 0
+  epoch: 1
   description: |
     The Amazon Corretto Crypto Provider (ACCP) is a collection of high-performance cryptographic implementations exposed via the standard JCA/JCE interfaces.
   copyright:
@@ -18,6 +18,7 @@ environment:
       - cmake
       - go
       - openjdk-11
+      - openssf-compiler-options
 
 pipeline:
   - uses: git-checkout

--- a/aom.yaml
+++ b/aom.yaml
@@ -5,7 +5,7 @@
 package:
   name: aom
   version: 3.9.1
-  epoch: 0
+  epoch: 1
   description: Alliance for Open Media (AOM) AV1 codec SDK
   copyright:
     - license: BSD-2-Clause
@@ -19,6 +19,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - openssf-compiler-options
       - perl
       - python3
       - samurai

--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-arrow
   version: 17.0.0
-  epoch: 0
+  epoch: 1
   description: "multi-language toolbox for accelerated data interchange and in-memory processing"
   copyright:
     - license: Apache-2.0
@@ -29,6 +29,7 @@ environment:
       - libprotoc
       - libzstd1
       - lz4-dev
+      - openssf-compiler-options
       - openssl-dev
       - protobuf
       - protobuf-dev

--- a/apache-orc.yaml
+++ b/apache-orc.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-orc
   version: 2.0.2
-  epoch: 0
+  epoch: 1
   description: "the smallest, fastest columnar storage for Hadoop workloads"
   copyright:
     - license: Apache-2.0
@@ -12,6 +12,7 @@ environment:
       - build-base
       - cmake
       - lz4-dev
+      - openssf-compiler-options
       - protobuf-dev
       - samurai
       - snappy-dev

--- a/binaryen.yaml
+++ b/binaryen.yaml
@@ -1,7 +1,7 @@
 package:
   name: binaryen
   version: "119"
-  epoch: 0
+  epoch: 1
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - openssf-compiler-options
       - samurai
 
 pipeline:

--- a/cilium-1.16.yaml
+++ b/cilium-1.16.yaml
@@ -2,7 +2,7 @@
 package:
   name: cilium-1.16
   version: 1.16.1
-  epoch: 2
+  epoch: 3
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -54,6 +54,7 @@ environment:
       - llvm17-dev
       - mpc-dev
       - openjdk-11
+      - openssf-compiler-options
       - patch
       - python3-dev
       - samurai

--- a/clamav-1.4.yaml
+++ b/clamav-1.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav-1.4
   version: 1.4.1
-  epoch: 0
+  epoch: 1
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only
@@ -27,6 +27,7 @@ environment:
       - libxml2-dev
       - linux-headers
       - ncurses-dev
+      - openssf-compiler-options
       - openssl-dev
       - pcre2-dev
       - python3

--- a/clamav.yaml
+++ b/clamav.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav
   version: 1.4.1
-  epoch: 0
+  epoch: 1
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only
@@ -24,6 +24,7 @@ environment:
       - libxml2-dev
       - linux-headers
       - ncurses-dev
+      - openssf-compiler-options
       - openssl-dev
       - pcre2-dev
       - python3

--- a/clickhouse-24.8.yaml
+++ b/clickhouse-24.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: clickhouse-24.8
   version: 24.8.4.13
-  epoch: 0
+  epoch: 1
   description: ClickHouse is the fastest and most resource efficient open-source database for real-time apps and analytics.
   copyright:
     - license: Apache-2.0
@@ -32,6 +32,7 @@ environment:
       - llvm-lld-17-dev
       - nasm
       - ninja
+      - openssf-compiler-options
       - perl
       - python3
       - yasm

--- a/cmake-bootstrap.yaml
+++ b/cmake-bootstrap.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake-bootstrap
   version: 3.29.0
-  epoch: 1
+  epoch: 2
   description: "Bootstrap CMake without using system libraries, enabling to use CMake to build system libraries used by CMake"
   dependencies:
     provider-priority: 5
@@ -15,6 +15,7 @@ environment:
     packages:
       - build-base
       - busybox
+      - openssf-compiler-options
       - openssl-dev
       - samurai
 

--- a/cmake.yaml
+++ b/cmake.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake
   version: 3.29.0
-  epoch: 2
+  epoch: 3
   description: "CMake is an open-source, cross-platform family of tools designed to build, test and package software"
   dependencies:
     provider-priority: 10
@@ -22,6 +22,7 @@ environment:
       - libuv-dev
       - ncurses-dev
       - nghttp2-dev
+      - openssf-compiler-options
       - openssl-dev
       - rhash-dev
       - samurai

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent
   version: 7.57.1
-  epoch: 1
+  epoch: 2
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -44,6 +44,7 @@ environment:
       - libzip
       - linux-headers
       - ninja
+      - openssf-compiler-options
       - procps-dev
       - py3.11-pip
       - py3.11-semver

--- a/deno.yaml
+++ b/deno.yaml
@@ -1,7 +1,7 @@
 package:
   name: deno
   version: 1.46.3
-  epoch: 0
+  epoch: 1
   description: "A modern runtime for JavaScript and TypeScript."
   copyright:
     - license: MIT
@@ -17,6 +17,7 @@ environment:
       - cmake
       - glibc-dev
       - libLLVM-16
+      - openssf-compiler-options
       - posix-libc-utils
       - protobuf-dev
       - protoc

--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-6
   version: 6.0.133
-  epoch: 0
+  epoch: 1
   description: ".NET SDK, version 6"
   copyright:
     - license: MIT
@@ -33,6 +33,7 @@ environment:
       - llvm15-tools
       - lttng-ust-dev
       - ncurses-dev
+      - openssf-compiler-options
       - openssl-dev
       - python3
       - samurai

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -2,7 +2,7 @@ package:
   name: dotnet-7
   # Remove `-sb` from the git-checkout tag at the next release
   version: 7.0.120
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT
@@ -34,6 +34,7 @@ environment:
       - llvm15-tools
       - lttng-ust-dev
       - ncurses-dev
+      - openssf-compiler-options
       - openssl-dev
       - python3
       - samurai

--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: 8.0.8
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT
@@ -33,6 +33,7 @@ environment:
       - llvm15-tools
       - lttng-ust-dev
       - ncurses-dev
+      - openssf-compiler-options
       - openssl-dev
       - python3
       - samurai

--- a/envoy-1.31.yaml
+++ b/envoy-1.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: envoy-1.31
   version: 1.31.2
-  epoch: 0
+  epoch: 1
   description: Cloud-native high-performance edge/middle/service proxy
   copyright:
     - license: Apache-2.0
@@ -35,6 +35,7 @@ environment:
       - llvm15-dev
       - llvm15-tools
       - openjdk-11
+      - openssf-compiler-options
       - patch
       - python3-dev
       - samurai

--- a/falco-libs.yaml
+++ b/falco-libs.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-libs
   version: 0.18.0
-  epoch: 0
+  epoch: 1
   description: Foundational components necessary to build Falco
   copyright:
     - license: Apache-2.0
@@ -40,6 +40,7 @@ environment:
       - luajit
       - m4
       - make
+      - openssf-compiler-options
       - openssl-dev
       - patch
       - perl

--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-no-driver
   version: 0.38.2
-  epoch: 0
+  epoch: 1
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -31,6 +31,7 @@ environment:
       - libelf-static
       - libtool
       - mpc-dev
+      - openssf-compiler-options
       - openssl-dev
       - pkgconf
       - protobuf-dev

--- a/falco.yaml
+++ b/falco.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco
   version: 0.37.1
-  epoch: 5
+  epoch: 6
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -43,6 +43,7 @@ environment:
       - llvm16
       - m4
       - make
+      - openssf-compiler-options
       - openssl-dev
       - patch
       - perl

--- a/freerdp-3.yaml
+++ b/freerdp-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp-3
   version: 3.5.1
-  epoch: 3
+  epoch: 4
   description: FreeRDP client
   copyright:
     - license: Apache-2.0
@@ -43,6 +43,7 @@ environment:
       - libxslt
       - libxv-dev
       - linux-headers
+      - openssf-compiler-options
       - openssl-dev>3
       - pkcs11-helper-dev
       - samurai

--- a/freerdp.yaml
+++ b/freerdp.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp
   version: 2.11.7
-  epoch: 2
+  epoch: 3
   description: FreeRDP client
   copyright:
     - license: Apache-2.0
@@ -33,6 +33,7 @@ environment:
       - libxrender-dev
       - libxv-dev
       - linux-headers
+      - openssf-compiler-options
       - openssl-dev>3
       - samurai
 

--- a/glew.yaml
+++ b/glew.yaml
@@ -1,7 +1,7 @@
 package:
   name: glew
   version: 2.2.0
-  epoch: 0
+  epoch: 1
   description: "A cross-platform C/C++ extension loading library"
   copyright:
     - license: GPL-2.0-or-later
@@ -18,6 +18,7 @@ environment:
       - libxmu-dev
       - mesa-dev
       - mesa-gl
+      - openssf-compiler-options
       - wolfi-base
 
 pipeline:

--- a/grpc.yaml
+++ b/grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc
   version: 1.65.5
-  epoch: 1
+  epoch: 2
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -29,6 +29,7 @@ environment:
       - libsystemd
       - libtool
       - linux-headers
+      - openssf-compiler-options
       - openssl-dev
       - protobuf-dev
       - py3-setuptools

--- a/gst-plugins-bad.yaml
+++ b/gst-plugins-bad.yaml
@@ -1,7 +1,7 @@
 package:
   name: gst-plugins-bad
   version: 1.24.8
-  epoch: 0
+  epoch: 1
   description: GStreamer streaming media framework bad plug-ins
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.0-or-later
@@ -39,6 +39,7 @@ environment:
       - mesa-gles
       - mesa-libgallium
       - meson
+      - openssf-compiler-options
       - opus-dev
       - orc-compiler
       - orc-dev

--- a/gst-plugins-base.yaml
+++ b/gst-plugins-base.yaml
@@ -1,7 +1,7 @@
 package:
   name: gst-plugins-base
   version: 1.24.7
-  epoch: 0
+  epoch: 1
   description: GStreamer streaming media framework base plug-ins
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.0-or-later
@@ -37,6 +37,7 @@ environment:
       - mesa-glapi
       - mesa-gles
       - meson
+      - openssf-compiler-options
       - opus-dev
       - orc-compiler
       - orc-dev

--- a/gtk-4.yaml
+++ b/gtk-4.yaml
@@ -1,7 +1,7 @@
 package:
   name: gtk-4
   version: 4.16.2
-  epoch: 0
+  epoch: 1
   description: The GTK+ Toolkit (v4)
   copyright:
     - license: LGPL-2.1-or-later
@@ -58,6 +58,7 @@ environment:
       - mesa-dev
       - meson
       - ninja
+      - openssf-compiler-options
       - orc-compiler
       - orc-dev
       - pango-dev

--- a/hdf5.yaml
+++ b/hdf5.yaml
@@ -2,7 +2,7 @@ package:
   name: hdf5
   description: Library for accessing Hierarchical Data Format version 5 files
   version: 1.14.2
-  epoch: 0
+  epoch: 1
   url: https://www.hdfgroup.org/solutions/hdf5/
   copyright:
     - license: BSD-3-Clause
@@ -15,6 +15,7 @@ environment:
       - cmake
       - gfortran
       - libaec-dev
+      - openssf-compiler-options
       - perl
       - wolfi-baselayout
       - zlib-dev

--- a/ingress-nginx-controller-1.11.yaml
+++ b/ingress-nginx-controller-1.11.yaml
@@ -2,7 +2,7 @@
 package:
   name: ingress-nginx-controller-1.11
   version: 1.11.2
-  epoch: 3
+  epoch: 4
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -107,6 +107,7 @@ environment:
       - mimalloc
       - modsecurity
       - msgpack
+      - openssf-compiler-options
       - openssh-client
       - openssl
       - openssl-dev

--- a/istio-envoy-1.23.yaml
+++ b/istio-envoy-1.23.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-envoy-1.23
   version: 1.23.2
-  epoch: 0
+  epoch: 1
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
   copyright:
     - license: Apache-2.0
@@ -37,6 +37,7 @@ environment:
       - llvm15-dev
       - llvm15-tools
       - openjdk-11
+      - openssf-compiler-options
       - openssl-dev
       - patch
       - python3-dev

--- a/json-c.yaml
+++ b/json-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: json-c
   version: "0.18"
-  epoch: 0
+  epoch: 1
   description: A JSON implementation in C
   copyright:
     - license: MIT
@@ -14,6 +14,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - doxygen
+      - openssf-compiler-options
       - samurai
 
 pipeline:

--- a/lean4.yaml
+++ b/lean4.yaml
@@ -1,7 +1,7 @@
 package:
   name: lean4
   version: 4.11.0
-  epoch: 0
+  epoch: 1
   description: "Secure Reliable Transport (SRT)"
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - gmp-dev
+      - openssf-compiler-options
       - wolfi-base
 
 pipeline:

--- a/libavif.yaml
+++ b/libavif.yaml
@@ -1,7 +1,7 @@
 package:
   name: libavif
   version: 1.1.1
-  epoch: 0
+  epoch: 1
   description: Library for encoding and decoding .avif files
   copyright:
     - license: BSD-2-Clause
@@ -19,6 +19,7 @@ environment:
       - dav1d-dev
       - libjpeg-turbo-dev
       - libpng-dev
+      - openssf-compiler-options
       - samurai
       - zlib-dev
 

--- a/libcld2.yaml
+++ b/libcld2.yaml
@@ -4,7 +4,7 @@ package:
   description: Compact Language Detector 2
   url: https://github.com/CLD2Owners/cld2
   version: 0_git20240911
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:
@@ -21,6 +21,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - libtool
+      - openssf-compiler-options
       - wolfi-baselayout
   environment:
     CXXFLAGS: "-fPIC"

--- a/libfido2.yaml
+++ b/libfido2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libfido2
   version: 1.15.0
-  epoch: 0
+  epoch: 1
   description: library for FIDO 2.0 functionality
   copyright:
     - license: BSD-2-Clause
@@ -14,6 +14,7 @@ environment:
       - eudev-dev
       - libcbor-dev
       - linux-headers
+      - openssf-compiler-options
       - openssl-dev
       - zlib-dev
 

--- a/libinput.yaml
+++ b/libinput.yaml
@@ -2,7 +2,7 @@
 package:
   name: libinput
   version: 1.26.2
-  epoch: 0
+  epoch: 1
   description: Library for handling input devices
   copyright:
     - license: MIT
@@ -20,6 +20,7 @@ environment:
       - libevdev-dev
       - meson
       - mtdev-dev
+      - openssf-compiler-options
       - py3-libevdev
       - py3-pyyaml
       - py3-udev

--- a/libmcrypt.yaml
+++ b/libmcrypt.yaml
@@ -2,7 +2,7 @@
 package:
   name: libmcrypt
   version: 2.5.8
-  epoch: 0
+  epoch: 1
   description: "A library which provides a uniform interface to several symmetric encryption algorithms"
   copyright:
     - license: LGPL-2.1-or-later
@@ -19,6 +19,7 @@ environment:
       - cmake
       - gcc
       - libtool
+      - openssf-compiler-options
 
 pipeline:
   - uses: fetch

--- a/libpsl-native.yaml
+++ b/libpsl-native.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpsl-native
   version: 7.4.0
-  epoch: 3
+  epoch: 4
   description: this library provides functionality missing from .NET Core via system calls
   copyright:
     - license: MIT
@@ -12,6 +12,7 @@ environment:
       - build-base
       - cmake
       - gtest-dev
+      - openssf-compiler-options
       - wolfi-base
 
 pipeline:

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpulsar
   version: 3.6.0
-  epoch: 0
+  epoch: 1
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,7 @@ environment:
       - curl-dev
       - gmock
       - gtest-dev
+      - openssf-compiler-options
       - openssl-dev
       - protobuf-dev
       - python3

--- a/libssh.yaml
+++ b/libssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: libssh
   version: 0.11.1
-  epoch: 0
+  epoch: 1
   description: Library for accessing ssh client services through C libraries
   copyright:
     - license: LGPL-2.1-or-later AND BSD-2-Clause
@@ -13,6 +13,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - openssf-compiler-options
       - openssl-dev
       - samurai
       - xz

--- a/mariadb-11.5.yaml
+++ b/mariadb-11.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-11.5
   version: 11.5.2
-  epoch: 1
+  epoch: 2
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later
@@ -22,6 +22,7 @@ environment:
       - libevent-dev
       - linux-pam-dev
       - ncurses-dev
+      - openssf-compiler-options
       - openssl-dev
       - pcre2-dev
       - readline-dev

--- a/mariadb-connector-c.yaml
+++ b/mariadb-connector-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-connector-c
   version: 3.4.1
-  epoch: 0
+  epoch: 1
   description: The MariaDB Native Client library (C driver)
   copyright:
     - license: LGPL-2.1-or-later
@@ -15,6 +15,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - openssf-compiler-options
       - openssl-dev
       - samurai
       - zlib-dev

--- a/mold.yaml
+++ b/mold.yaml
@@ -1,7 +1,7 @@
 package:
   name: mold
   version: 2.33.0
-  epoch: 0
+  epoch: 1
   description: "mold linker"
   copyright:
     - license: MIT
@@ -18,6 +18,7 @@ environment:
       - cmake
       - libtbb-dev
       - mimalloc2-dev
+      - openssf-compiler-options
       - openssl-dev
       - samurai
       - wolfi-baselayout

--- a/ndctl.yaml
+++ b/ndctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: ndctl
   version: "79"
-  epoch: 0
+  epoch: 1
   description: "Utility library for managing the libnvdimm (non-volatile memory device) sub-system in the Linux kernel."
   copyright:
     - license: "GPL-2.0-only AND LGPL-2.1-only"
@@ -23,6 +23,7 @@ environment:
       - libtracefs-dev
       - linux-headers
       - meson
+      - openssf-compiler-options
       - systemd-dev
       - util-linux-dev
       - wolfi-base

--- a/neon.yaml
+++ b/neon.yaml
@@ -1,7 +1,7 @@
 package:
   name: neon
   version: "6694"
-  epoch: 0
+  epoch: 1
   description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,7 @@ environment:
       - libpq-16
       - libseccomp-dev
       - libtool
+      - openssf-compiler-options
       - openssl-dev
       - perl
       - pkgconf

--- a/ollama.yaml
+++ b/ollama.yaml
@@ -1,7 +1,7 @@
 package:
   name: ollama
   version: 0.3.11
-  epoch: 0
+  epoch: 1
   description: Get up and running with Llama 2 and other large language models locally
   copyright:
     - license: MIT
@@ -14,6 +14,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - go
+      - openssf-compiler-options
 
 pipeline:
   - uses: git-checkout

--- a/onetbb.yaml
+++ b/onetbb.yaml
@@ -1,7 +1,7 @@
 package:
   name: onetbb
   version: 2021.13.0
-  epoch: 1
+  epoch: 2
   description: oneAPI Threading Building Blocks
   copyright:
     - license: GPL-2.0-only
@@ -17,6 +17,7 @@ environment:
       - cmake
       - hwloc-dev
       - linux-headers
+      - openssf-compiler-options
       - py3-setuptools
       - python3-dev
       - samurai

--- a/percona-server-8.3.yaml
+++ b/percona-server-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-server-8.3
   version: 8.3.0
-  epoch: 2
+  epoch: 3
   description: "Percona Server for MySQL is a free, fully compatible, enhanced, and open source drop-in replacement for any MySQL database. It provides superior performance, scalability, and instrumentation."
   copyright:
     - license: GPL-3.0-or-later
@@ -27,6 +27,7 @@ environment:
       - ncurses-dev
       - nfs-utils
       - openldap-dev
+      - openssf-compiler-options
       - openssl-dev
       - pcre2-dev
       - perl

--- a/php-8.1-pecl-mcrypt.yaml
+++ b/php-8.1-pecl-mcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-mcrypt
   version: 1.0.7
-  epoch: 2
+  epoch: 3
   description: "Provides PHP 8.1 bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
@@ -22,6 +22,7 @@ environment:
       - gcc
       - libmcrypt-dev
       - libtool
+      - openssf-compiler-options
       - php-8.1-dev
 
 pipeline:

--- a/php-8.1-pecl-mongodb.yaml
+++ b/php-8.1-pecl-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-mongodb
   version: 1.20.0
-  epoch: 0
+  epoch: 1
   description: "PHP 8.1 MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
@@ -23,6 +23,7 @@ environment:
       - gcc
       - icu-dev
       - libtool
+      - openssf-compiler-options
       - openssl-dev>3
       - php-8.1-dev
       - snappy-dev

--- a/php-8.2-pecl-mcrypt.yaml
+++ b/php-8.2-pecl-mcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-mcrypt
   version: 1.0.7
-  epoch: 2
+  epoch: 3
   description: "Provides PHP 8.2 bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
@@ -22,6 +22,7 @@ environment:
       - gcc
       - libmcrypt-dev
       - libtool
+      - openssf-compiler-options
       - php-8.2-dev
 
 pipeline:

--- a/php-8.2-pecl-mongodb.yaml
+++ b/php-8.2-pecl-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-mongodb
   version: 1.20.0
-  epoch: 0
+  epoch: 1
   description: "PHP 8.2 MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
@@ -23,6 +23,7 @@ environment:
       - gcc
       - icu-dev
       - libtool
+      - openssf-compiler-options
       - openssl-dev>3
       - php-8.2-dev
       - snappy-dev

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -1,7 +1,7 @@
 package:
   name: poppler
   version: 24.09.0
-  epoch: 0
+  epoch: 1
   description: Poppler is a PDF rendering library based on the xpdf-3.0 code base.
   copyright:
     - license: GPL-2.0-or-later
@@ -26,6 +26,7 @@ environment:
       - libxml2-dev
       - openjpeg-dev
       - openjpeg-tools
+      - openssf-compiler-options
       - samurai
       - tiff-dev
       - zlib-dev

--- a/proj.yaml
+++ b/proj.yaml
@@ -2,7 +2,7 @@
 package:
   name: proj
   version: 9.5.0
-  epoch: 1
+  epoch: 2
   description: PROJ coordinate transformation software library
   copyright:
     - license: MIT
@@ -18,6 +18,7 @@ environment:
       - cmake
       - curl-dev
       - nlohmann-json
+      - openssf-compiler-options
       - samurai
       - sqlite
       - sqlite-dev

--- a/protobuf.yaml
+++ b/protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf
   version: 3.27.4
-  epoch: 0
+  epoch: 1
   description: Library for extensible, efficient structure packing
   copyright:
     - license: BSD-3-Clause
@@ -26,6 +26,7 @@ environment:
       - cmake
       - git
       - libtool
+      - openssf-compiler-options
       - samurai
       - zlib-dev
 

--- a/py3-ml-metadata.yaml
+++ b/py3-ml-metadata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ml-metadata
   version: 1.15.0
-  epoch: 0
+  epoch: 1
   description: For recording and retrieving metadata associated with ML developer and data scientist workflows.
   copyright:
     - license: MIT
@@ -22,6 +22,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - openjdk-11
+      - openssf-compiler-options
       - openssl-dev
       - patch
       - py3-setuptools

--- a/py3-onnx.yaml
+++ b/py3-onnx.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-onnx
   version: 1.16.2
-  epoch: 0
+  epoch: 1
   description: Open Neural Network Exchange
   copyright:
     - license: Apache-2.0
@@ -28,6 +28,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - ninja
+      - openssf-compiler-options
       - protobuf-dev
       - py3-supported-pip
       - py3-supported-protobuf

--- a/py3-pulsar-client.yaml
+++ b/py3-pulsar-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pulsar-client
   version: 3.5.0
-  epoch: 1
+  epoch: 2
   description: Apache Pulsar Python client library
   copyright:
     - license: Apache-2.0
@@ -17,6 +17,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - libpulsar-dev
+      - openssf-compiler-options
       - py3-build
       - py3-installer
       - py3-pybind11-dev

--- a/pyarrow.yaml
+++ b/pyarrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: pyarrow
   version: 17.0.0
-  epoch: 0
+  epoch: 1
   description: "Apache Arrow Python bindings"
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,7 @@ environment:
       - cmake
       - cython
       - numpy
+      - openssf-compiler-options
       - openssl-dev
       - py3-pip
       - py3-setuptools

--- a/qdrant.yaml
+++ b/qdrant.yaml
@@ -1,7 +1,7 @@
 package:
   name: qdrant
   version: 1.11.4
-  epoch: 0
+  epoch: 1
   description: "High-performance, massive-scale Vector Database for the next generation of AI"
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,7 @@ environment:
       - libgit2-dev
       - llvm-cmake-16
       - llvm-lld-16-dev
+      - openssf-compiler-options
       - protobuf-dev
       - rust
       - wget

--- a/qt6-qtbase.yaml
+++ b/qt6-qtbase.yaml
@@ -3,7 +3,7 @@
 package:
   name: qt6-qtbase
   version: 6.7.2
-  epoch: 0
+  epoch: 1
   description: qt
   copyright:
     - license: LGPL-3.0-or-later
@@ -45,6 +45,7 @@ environment:
       - mesa-gl
       - mesa-gles
       - nodejs
+      - openssf-compiler-options
       - perl
       - py3-pip
       - samurai

--- a/re2.yaml
+++ b/re2.yaml
@@ -1,7 +1,7 @@
 package:
   name: re2
   version: "2024.02.01"
-  epoch: 2
+  epoch: 3
   description: Efficient, principled regular expression library
   copyright:
     - license: BSD-3-Clause
@@ -22,6 +22,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - icu-dev
+      - openssf-compiler-options
 
 pipeline:
   - uses: fetch

--- a/rstudio.yaml
+++ b/rstudio.yaml
@@ -1,7 +1,7 @@
 package:
   name: rstudio
   version: 2023.12.1_p402
-  epoch: 1
+  epoch: 2
   description: RStudio is an integrated development environment (IDE) for R
   copyright:
     - license: GPL-3.0-or-later
@@ -42,6 +42,7 @@ environment:
       - linux-pam-dev
       - nodejs
       - openjdk-8-default-jdk
+      - openssf-compiler-options
       - openssl-dev
       - posix-libc-utils
       - sqlite-dev

--- a/rust-1.79.yaml
+++ b/rust-1.79.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.79
   version: 1.79.0
-  epoch: 0
+  epoch: 1
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
@@ -30,6 +30,7 @@ environment:
       - libssh2-dev
       - llvm-18
       - llvm-18-dev
+      - openssf-compiler-options
       - openssl-dev
       - patch
       - python3

--- a/rust-1.80.yaml
+++ b/rust-1.80.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.80
   version: 1.80.1
-  epoch: 0
+  epoch: 1
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
@@ -30,6 +30,7 @@ environment:
       - libssh2-dev
       - llvm-18
       - llvm-18-dev
+      - openssf-compiler-options
       - openssl-dev
       - patch
       - python3

--- a/scap-security-guide.yaml
+++ b/scap-security-guide.yaml
@@ -1,7 +1,7 @@
 package:
   name: scap-security-guide
   version: 0.1.74
-  epoch: 1
+  epoch: 2
   description: Security automation content in SCAP, Bash, Ansible, and other formats
   copyright:
     - license: BSD-3-Clause
@@ -16,6 +16,7 @@ environment:
       - busybox
       - libxml2-dev
       - openscap
+      - openssf-compiler-options
       - pcre2-dev
       - py3-jinja2
       - py3-lxml

--- a/snmalloc.yaml
+++ b/snmalloc.yaml
@@ -1,7 +1,7 @@
 package:
   name: snmalloc
   version: "0.6.2"
-  epoch: 0
+  epoch: 1
   description: "snmalloc is a high-performance, message passing based allocator."
   copyright:
     - license: MIT
@@ -23,6 +23,7 @@ environment:
       - cmake
       - coreutils
       - llvm-lld-18
+      - openssf-compiler-options
       - samurai
       - scanelf
       - wolfi-base
@@ -50,7 +51,6 @@ pipeline:
   #          for working with the cmake/build pipeline
   # - runs: |
   #     ctest --output-on-failure -j "$(nproc)" -C Release --timeout 400
-
   - uses: cmake/install
 
   - uses: strip

--- a/souffle.yaml
+++ b/souffle.yaml
@@ -1,7 +1,7 @@
 package:
   name: souffle
   version: 2.4.1
-  epoch: 0
+  epoch: 1
   description: Soufflé is a variant of Datalog for tool designers crafting analyses in Horn clauses. Soufflé synthesizes a native parallel C++ program from a logic specification.
   copyright:
     - license: UPL-1.0
@@ -19,6 +19,7 @@ environment:
       - flex
       - libffi-dev
       - ncurses-dev
+      - openssf-compiler-options
       - python3
       - samurai
       - sqlite-dev

--- a/ssdeep.yaml
+++ b/ssdeep.yaml
@@ -1,7 +1,7 @@
 package:
   name: ssdeep
   version: 2.14.1
-  epoch: 3
+  epoch: 4
   description: "Fuzzy hashing API and fuzzy hashing tool"
   copyright:
     - license: GPL-2.0-or-later
@@ -17,6 +17,7 @@ environment:
       - cmake
       - libtool
       - make
+      - openssf-compiler-options
       - pkgconf
       - wolfi-baselayout
 

--- a/tclap.yaml
+++ b/tclap.yaml
@@ -2,7 +2,7 @@
 package:
   name: tclap
   version: 1.4
-  epoch: 0
+  epoch: 1
   description: "Templatized command-line argument parser for C++"
   copyright:
     - license: LicenseRef-tclap
@@ -13,6 +13,7 @@ environment:
     packages:
       - build-base
       - busybox
+      - openssf-compiler-options
       - python3
 
 pipeline:

--- a/tiff.yaml
+++ b/tiff.yaml
@@ -1,7 +1,7 @@
 package:
   name: tiff
   version: 4.7.0
-  epoch: 0
+  epoch: 1
   description: Provides support for the Tag Image File Format or TIFF
   copyright:
     - license: libtiff
@@ -18,6 +18,7 @@ environment:
       - libjpeg-turbo-dev
       - libtool
       - libwebp-dev
+      - openssf-compiler-options
       - python3
       - samurai
       - zlib-dev

--- a/x265.yaml
+++ b/x265.yaml
@@ -1,7 +1,7 @@
 package:
   name: x265
   version: 4.0
-  epoch: 0
+  epoch: 1
   description: H.265/HEVC encoder
   copyright:
     - license: GPL-2.0-only
@@ -14,6 +14,7 @@ environment:
       - cmake
       - coreutils
       - nasm
+      - openssf-compiler-options
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Barring any other failures, we should be able to make cmake depend on
openssf-compiler-options.
