### PR TITLE
kafka-3.8: fix bitnami compat

### DIFF
--- a/kafka-3.8.yaml
+++ b/kafka-3.8.yaml
@@ -2,7 +2,7 @@ package:
   name: kafka-3.8
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.8.0
-  epoch: 3
+  epoch: 4
   description: Apache Kafka is a distributed event streaming platform
   copyright:
     - license: Apache-2.0
@@ -50,6 +50,9 @@ pipeline:
       mv kafka_2.13-${{package.version}}/libs ${{targets.destdir}}/usr/lib/kafka
       mv kafka_2.13-${{package.version}}/config ${{targets.destdir}}/usr/lib/kafka
 
+      mv ${{targets.destdir}}/usr/lib/kafka/config/server.properties ${{targets.destdir}}/usr/lib/kafka/config/server.properties.original
+      mkdir -p ${{targets.destdir}}/docker-entrypoint-initdb.d/
+
       # Clean up Windows scripts
       rm -rf ${{targets.destdir}}/usr/lib/kafka/bin/*.bat
       rm -rf ${{targets.destdir}}/usr/lib/kafka/windows
@@ -66,7 +69,7 @@ subpackages:
       - uses: bitnami/compat
         with:
           image: kafka
-          version-path: 3.8/debian-12
+          version-path: ${{vars.major-minor-version}}/debian-12
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bitnami/kafka/
           ln -s /usr/lib/kafka/bin ${{targets.subpkgdir}}/opt/bitnami/kafka/bin
@@ -91,6 +94,8 @@ test:
         ZK_PID=$!
 
         # Start Kafka
+        mv config/server.properties.original config/server.properties
+
         bin/kafka-server-start.sh config/server.properties &
         KAFKA_PID=$!
         sleep 5

--- a/kafka-3.8.yaml
+++ b/kafka-3.8.yaml
@@ -3,7 +3,7 @@ package:
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.8.0
   epoch: 3
-  description: Apache Kafka is a distributed event streaming platformm
+  description: Apache Kafka is a distributed event streaming platform
   copyright:
     - license: Apache-2.0
   dependencies:


### PR DESCRIPTION
- FQIW the server.properties file states it is to be used in ZK mode and the server.properties in /opt/bitnami/kafka/config/kraft states it must be used with kraft mode.
- Its mostly a permission related issue and this change works (as confirmed by the package level tests, image-level tests(locally) and docker-compose test). When the image is ran as kafka, a new server.properties is created with proper ownership and permissions after the entrypoint scripts runs.