### PR TITLE
ffmpeg: enable svtav1

### DIFF
--- a/ffmpeg.yaml
+++ b/ffmpeg.yaml
@@ -1,7 +1,7 @@
 package:
   name: ffmpeg
   version: 7.0.2
-  epoch: 2
+  epoch: 3
   description: ffmpeg multimedia library
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later
@@ -39,6 +39,7 @@ environment:
       - snappy-dev
       - soxr-dev
       - speex-dev
+      - svt-av1-dev
       - wolfi-baselayout
       - x264-dev
       - x265-dev
@@ -74,6 +75,7 @@ pipeline:
         --enable-libsnappy \
         --enable-libsrt \
         --enable-libssh \
+        --enable-libsvtav1 \
         --enable-libvorbis \
         --enable-libwebp \
         --enable-libxml2 \


### PR DESCRIPTION
This should complete getting ffmpeg to reasonable/modern codecs parity
with other distros.
