### PR TITLE
Fixes bitnami git checkout pipeline when using a commit.

### DIFF
--- a/pipelines/bitnami/compat.yaml
+++ b/pipelines/bitnami/compat.yaml
@@ -33,7 +33,7 @@ pipeline:
 
       if [ ! -z ${{inputs.commit}} ]; then
         git fetch --unshallow
-        git checkout ${{inputs.commit}}
+        git checkout -f ${{inputs.commit}}
       fi
 
       if [ ! -d "./bitnami/${{inputs.image}}/${{inputs.version-path}}" ]; then


### PR DESCRIPTION
Without this -f flag, if there are untracked files the pipeline errors out
