### PR TITLE
fix(gitlab-toolbox-scripts): Correct directory for scripts

### DIFF
--- a/gitlab-cng-17.3.yaml
+++ b/gitlab-cng-17.3.yaml
@@ -33,7 +33,7 @@ var-transforms:
 package:
   name: gitlab-cng-17.3
   version: 17.3.4
-  epoch: 0
+  epoch: 1
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -96,6 +96,10 @@ subpackages:
             mkdir -p ${{targets.subpkgdir}}/$(dirname $x)
             cp -r $x ${{targets.subpkgdir}}/$x
           done
+          if [[ "${{range.key}}" == "toolbox" ]]; then
+            mv ${{targets.subpkgdir}}/scripts/bin/* ${{targets.subpkgdir}}/scripts/
+            rm -rf ${{targets.subpkgdir}}/scripts/bin
+          fi
 
   - name: gitlab-shell-scripts-compat-${{vars.major-minor-version}}
     dependencies:

--- a/gitlab-cng-17.4.yaml
+++ b/gitlab-cng-17.4.yaml
@@ -34,7 +34,7 @@ package:
   name: gitlab-cng-17.4
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
   version: 17.4.0
-  epoch: 0
+  epoch: 1
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -97,6 +97,10 @@ subpackages:
             mkdir -p ${{targets.subpkgdir}}/$(dirname $x)
             cp -r $x ${{targets.subpkgdir}}/$x
           done
+          if [[ "${{range.key}}" == "toolbox" ]]; then
+            mv ${{targets.subpkgdir}}/scripts/bin/* ${{targets.subpkgdir}}/scripts/
+            rm -rf ${{targets.subpkgdir}}/scripts/bin
+          fi
 
   - name: gitlab-shell-scripts-compat-${{vars.major-minor-version}}
     dependencies:


### PR DESCRIPTION
The scripts for GitLab toolbox are nested in a bin directory. Move these toplevel to /scripts