### PR TITLE
jitsucom-jitsu/GHSA-gp8f-8m3g-qvj9 remediation

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: 2.8.2
-  epoch: 0
+  epoch: 1
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT

--- a/jitsucom-jitsu/upgrade-deps.patch
+++ b/jitsucom-jitsu/upgrade-deps.patch
@@ -2,7 +2,7 @@ diff --git a/package.json b/package.json
 index 40a2078..fd5df42 100644
 --- a/package.json
 +++ b/package.json
-@@ -54,5 +54,18 @@
+@@ -54,5 +54,19 @@
      "services/*",
      "cli/*",
      "libs/*"
@@ -18,7 +18,8 @@ index 40a2078..fd5df42 100644
 +      "@sentry/nextjs": "^7.77.0",
 +      "esbuild": "^0.20.2",
 +      "@grpc/grpc-js": "^1.9.15",
-+      "axios": "^1.7.4"
++      "axios": "^1.7.4",
++      "next": "^14.2.10"
 +    }
 +  }
  }


### PR DESCRIPTION
Added the next npm package and the fix version to the overrides section of the patch file. Only patch version changes from next @ 14.2.5 > 14.2.10. Remaining CVE in subpackage jitsucom-jitsu-console-2.8.2-r0 (html-minifier 4.0.0 (npm) CVE-2022-37620) existed before this dependency version update and has no fix, will require advisory to be filed.
