### PR TITLE
datadog-jmxfetch: fix update config block

### DIFF
--- a/datadog-jmxfetch.yaml
+++ b/datadog-jmxfetch.yaml
@@ -34,7 +34,7 @@ pipeline:
 update:
   enabled: true
   github:
-    identifier: https://github.com/DataDog/jmxfetch
+    identifier: DataDog/jmxfetch
 
 test:
   pipeline:


### PR DESCRIPTION
Presubmit check should have caught this, that's now been fixed so future checks will fail..
