### PR TITLE
bash: enable system-wide bashrc

### DIFF
--- a/bash-default-config.yaml
+++ b/bash-default-config.yaml
@@ -1,0 +1,25 @@
+package:
+  name: bash-default-config
+  version: 1.0.0
+  epoch: 0
+  description: "Bash default configuration"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - bash
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.destdir}}"/etc
+      cp bashrc "${{targets.contextdir}}"/etc/bash.bashrc
+
+# It is just the config file local in this repo, so we don't need any update
+update:
+  enabled: false

--- a/bash-default-config/bashrc
+++ b/bash-default-config/bashrc
@@ -1,0 +1,25 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+# see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+# for examples
+
+# If not running interactively, don't do anything
+case $- in
+    *i*) ;;
+      *) return;;
+esac
+
+
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+if ! shopt -oq posix; then
+  if [ -f /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+  elif [ -f /etc/bash_completion ]; then
+    . /etc/bash_completion
+  fi
+fi

--- a/bash.yaml
+++ b/bash.yaml
@@ -1,7 +1,7 @@
 package:
   name: bash
   version: 5.2.37
-  epoch: 0
+  epoch: 1
   description: "GNU bourne again shell"
   copyright:
     - license: GPL-3.0-or-later
@@ -17,10 +17,11 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/bash/bash-${{package.version}}.tar.gz
+      uri: https://ftp.fu-berlin.de/unix/gnu/bash/bash-${{package.version}}.tar.gz
       expected-sha256: 9599b22ecd1d5787ad7d3b7bf0c59f312b3396d1e281175dd1f8a4014da621ff
 
   - runs: |
+      export CFLAGS="${CFLAGS} -DSYS_BASHRC='\"/etc/bash.bashrc\"' -DSYS_BASH_LOGOUT='\"/etc/bash.bash_logout\"'"
       ./configure \
         --host=${{host.triplet.gnu}} \
         --target=${{host.triplet.gnu}} \


### PR DESCRIPTION
Enables that bash reads `/etc/bash.bashrc` like any other linux distro and there is now by default a config file to turn on bash completion if installed.

Therefore: `apk add git git-completion bash bash-completion`

and then start a bash shell and git completion just works 😍 

requires https://github.com/wolfi-dev/os/pull/29544 for git


Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
