### PR TITLE
datawire-envoy: add setcap subpackage

### DIFF
--- a/datawire-envoy-1.31.yaml
+++ b/datawire-envoy-1.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: datawire-envoy-1.31
   version: 1.31.2
-  epoch: 0
+  epoch: 1
   description: Ambassador fork of Envoy Proxy.
   copyright:
     - license: Apache-2.0
@@ -25,6 +25,7 @@ environment:
       - cmake
       - coreutils
       - git
+      - libcap-utils
       - libtool
       - llvm-libcxx-15
       - llvm-libcxx-15-dev
@@ -68,6 +69,16 @@ pipeline:
       rm -rf ../.cache/bazel/_bazel_root
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-privileged
+    # See https://github.com/emissary-ingress/emissary/blob/ac2dc64c6621cd8ec5617f3328544364bdd3fb01/build-aux/Dockerfile#L129-L132
+    description: Envoy binary with privileged capabilities enabled, required for downstream Ambassador usage.
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          cp -p ${{targets.destdir}}/usr/bin/envoy ${{targets.subpkgdir}}/usr/bin/envoy
+          setcap cap_net_bind_service=ei ${{targets.subpkgdir}}/usr/bin/envoy
 
 update:
   enabled: true


### PR DESCRIPTION
This adds a subpackage that runs setcap to enable certain capabilities on the binary. This is a requirement for downstream Ambassador dependencies (see
https://github.com/emissary-ingress/emissary/blob/ac2dc64c6621cd8ec5617f3328544364bdd3fb01/build-aux/Dockerfile#L129-L132).

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/chainguard-dev/image-requests/issues/3494

