### PR TITLE
only run GHA presubmit if 'github-build' label is applied

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -114,6 +114,7 @@ jobs:
           egress-policy: audit
 
       - name: Free up runner disk space
+        if: contains(github.event.pull_request.labels.*.name, 'github-build')
         run: |
           set -x
           printf "==> Available space before cleanup\n"

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -3,6 +3,7 @@ name: CI build action
 on:
   pull_request:
     branches: ["main"]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   push:
     branches:
       - gh-readonly-queue/main/**
@@ -151,6 +152,12 @@ jobs:
 
       - name: "Build Wolfi"
         uses: ./.github/actions/docker-run
+        # Only build with GitHub Actions workflow if the PR has the 'github-build' label.
+        # Otherwise, this step will be skipped and all remaining steps will either be skipped or
+        # will succeed, and the check will pass.
+        # This means we rely on elastic-build to build the packages in the PR, but we have
+        # a fallback in case its results are unreliable.
+        if: contains(github.event.pull_request.labels.*.name, 'github-build')
         with:
           opts: "-v /temp:/temp -v /var/run/docker.sock:/var/run/docker.sock"
           run: |
@@ -167,27 +174,6 @@ jobs:
             for package in ${{needs.changes.outputs.packages}}; do
               make MELANGE_EXTRA_OPTS="--create-build-log --cache-dir=.melangecache" REPO="./packages" package/$package -j1
               make MELANGE_EXTRA_OPTS="--runner docker" REPO="./packages" "test/$package" -j1
-            done
-
-      - name: "Check that packages can be installed with apk add"
-        uses: ./.github/actions/docker-run
-        with:
-          run: |
-            # Create a fake linux fs under /tmp/emptyroot to pass to `apk --root`.
-            mkdir -p /tmp/emptyroot/etc/apk
-            cp -r /etc/apk/* /tmp/emptyroot/etc/apk/
-            cat /dev/null > /tmp/emptyroot/etc/apk/world
-
-            mkdir -p /tmp/emptyroot/lib/apk/db
-            touch /tmp/emptyroot/lib/apk/db/{installed,lock,scripts.tar,triggers}
-
-            mkdir -p /tmp/emptyroot/var/cache/apk
-            apk update --root /tmp/emptyroot
-
-            # Find .apk files and add them to the string
-            for f in $(find packages -name '*.apk'); do
-                tar -Oxf "$f" .PKGINFO
-                apk add --root /tmp/emptyroot --repository "./packages" --allow-untrusted --simulate "$f"
             done
 
       - name: Reset file permissions
@@ -218,6 +204,28 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
           touch packages.log
+
+      - name: "Check that packages can be installed with apk add"
+        if: steps.file_check.outputs.exists == 'true'
+        uses: ./.github/actions/docker-run
+        with:
+          run: |
+            # Create a fake linux fs under /tmp/emptyroot to pass to `apk --root`.
+            mkdir -p /tmp/emptyroot/etc/apk
+            cp -r /etc/apk/* /tmp/emptyroot/etc/apk/
+            cat /dev/null > /tmp/emptyroot/etc/apk/world
+
+            mkdir -p /tmp/emptyroot/lib/apk/db
+            touch /tmp/emptyroot/lib/apk/db/{installed,lock,scripts.tar,triggers}
+
+            mkdir -p /tmp/emptyroot/var/cache/apk
+            apk update --root /tmp/emptyroot
+
+            # Find .apk files and add them to the string
+            for f in $(find packages -name '*.apk'); do
+                tar -Oxf "$f" .PKGINFO
+                apk add --root /tmp/emptyroot --repository "./packages" --allow-untrusted --simulate "$f"
+            done
 
       - name: Check diff
         if: steps.file_check.outputs.exists == 'true'

--- a/ko.yaml
+++ b/ko.yaml
@@ -1,7 +1,7 @@
 package:
   name: ko
   version: 0.16.0
-  epoch: 3
+  epoch: 4
   description: Simple, fast container image builder for Go applications.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
This PR updates the GitHub Actions CI workflow to skip the main build step if the `github-build` label is _not_ applied.

Elastic builds are unaffected, and will run in either case.

The intention is to default to _not_ running the GitHub Actions workflow, and to rely on elastic builds, but to still have an option to run the classic GitHub Actions workflow to check for differences, and to get that classic flavor back.

This should ~halve our cost to run CI builds, after ~doubling them to start running parallel elastic builds.