### PR TITLE
Remove unnecessary setup steps from grafana's tests

### DIFF
--- a/grafana-11.2.yaml
+++ b/grafana-11.2.yaml
@@ -105,9 +105,6 @@ test:
         expected_output: |
           Starting Grafana
           HTTP Server Listen
-        setup: |
-          mkdir -p /var/lib/grafana
-          chown -R root:root /var/lib/grafana
         post: |
           curl -s http://localhost:3000/api/health
           curl -s http://localhost:3000/api/org


### PR DESCRIPTION
The chown is failing for a reason I couldn't root cause but come to find out the setup stage seems unnecessary as the tests pass without it.