### PR TITLE
multipath-tools: use usr-merged paths

### DIFF
--- a/multipath-tools.yaml
+++ b/multipath-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: multipath-tools
   version: 0.10.0
-  epoch: 0
+  epoch: 1
   description: Device Mapper Multipathing Driver
   copyright:
     - license: LGPL-2.0-only
@@ -34,8 +34,12 @@ pipeline:
       tag: ${{package.version}}
 
   - uses: autoconf/make
+    with:
+      opts: LIB=/lib exec_prefix=/usr
 
   - uses: autoconf/make-install
+    with:
+      opts: LIB=/lib exec_prefix=/usr
 
   - uses: strip
 


### PR DESCRIPTION
lib64 is a symlink, install libraries into lib. This fixes `apk audit`.

Also move all binaries and libraries /usr. In preparation for
usr-merge.
