### PR TITLE
cryptsetup: fix install location

### DIFF
--- a/cryptsetup.yaml
+++ b/cryptsetup.yaml
@@ -2,7 +2,7 @@
 package:
   name: cryptsetup
   version: 2.7.5
-  epoch: 0
+  epoch: 1
   description: Userspace setup tool for transparent encryption of block devices using the Linux 2.6 cryptoapi
   copyright:
     - license: GPL-2.0-or-later WITH cryptsetup-OpenSSL-exception
@@ -45,7 +45,7 @@ pipeline:
         --build="$CBUILD" \
         --host="$CHOST" \
         --prefix=/usr \
-        --libdir=/lib \
+        --libdir=/usr/lib \
         --sbindir=/sbin \
         --disable-static \
         --enable-libargon2 \
@@ -61,6 +61,9 @@ subpackages:
   - name: cryptsetup-dev
     pipeline:
       - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
     dependencies:
       runtime:
         - cryptsetup


### PR DESCRIPTION
Development and runtime libraries and pkgconfig all should be in
/usr/lib. Otherwise pkgconf fails to find them.
