### PR TITLE
add tests for stakater-reloader

### DIFF
--- a/stakater-reloader.yaml
+++ b/stakater-reloader.yaml
@@ -44,3 +44,20 @@ update:
     identifier: stakater/Reloader
     strip-prefix: v
     use-tag: true
+
+test:
+  pipeline:
+    - uses: test/kwok/cluster
+    - name: help output from manager binary
+      runs: /usr/bin/manager --help
+    - name: "run manager binary"
+      uses: test/daemon-check-output
+      with:
+        start: /usr/bin/manager
+        timeout: 30
+        expected_output: |
+          Starting Reloader
+          created controller for: secrets
+          Starting Controller to watch resource type: secrets
+          created controller for: configMaps
+          Starting Controller to watch resource type: configMaps


### PR DESCRIPTION
In test we run the manager binary using test/daemon-check-output pipeline. 