### PR TITLE
crac-criu

### DIFF
--- a/crac-criu.yaml
+++ b/crac-criu.yaml
@@ -16,6 +16,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - coreutils
+      - docbook-xml
       - gnutls-dev
       - iproute2
       - libaio-dev

--- a/crac-criu.yaml
+++ b/crac-criu.yaml
@@ -9,38 +9,39 @@ package:
 environment:
   contents:
     packages:
+      - asciidoc
       - autoconf
       - automake
       - build-base
-      - coreutils
       - busybox
       - ca-certificates-bundle
+      - coreutils
       - gnutls-dev
       - iproute2
-      - libbpf-dev
-      - libnl3
-      - libnl3-dev
       - libaio-dev
+      - libbpf-dev
       - libbsd-dev
       - libcap-dev
-      - py3-pyyaml
       - libdrm
       - libdrm-dev
       - libnet-dev
+      - libnl3
+      - libnl3-dev
       - libprotobuf
-      - protoc
+      - libxml2-utils
       - nftables
       - nftables-dev
+      - pkgconf-dev
       - protobuf-c-dev
       - protobuf-dev
-      - py3-protobuf
+      - protoc
       - py3-future
       - py3-ipaddress
+      - py3-protobuf
+      - py3-pyyaml
       - python3
       - python3-dev
       - xmlto
-      - asciidoc
-      - pkgconf-dev
 
 pipeline:
   - uses: git-checkout
@@ -53,7 +54,6 @@ pipeline:
       # shellcheck disable=SC2001
       export CFLAGS=$(echo "$CFLAGS" | sed 's/-Wp,-D_FORTIFY_SOURCE=[0-9]//g')
       make criu crit amdgpu_plugin docs
-
 
   - uses: strip
 

--- a/crac-criu.yaml
+++ b/crac-criu.yaml
@@ -1,0 +1,64 @@
+package:
+  name: crac-criu
+  version: 1.4
+  epoch: 0
+  description: A project to implement checkpoint/restore functionality for Linux
+  copyright:
+    - license: GPL-2.0-only
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - coreutils
+      - busybox
+      - ca-certificates-bundle
+      - gnutls-dev
+      - iproute2
+      - libbpf-dev
+      - libnl3
+      - libnl3-dev
+      - libaio-dev
+      - libbsd-dev
+      - libcap-dev
+      - py3-pyyaml
+      - libdrm
+      - libdrm-dev
+      - libnet-dev
+      - libprotobuf
+      - protoc
+      - nftables
+      - nftables-dev
+      - protobuf-c-dev
+      - protobuf-dev
+      - py3-protobuf
+      - py3-future
+      - py3-ipaddress
+      - python3
+      - python3-dev
+      - xmlto
+      - asciidoc
+      - pkgconf-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: d62b80e84022ed4da31edac6251f27de41c37bf1
+      repository: https://github.com/CRaC/criu/
+      tag: release-${{package.version}}
+
+  - runs: |
+      # shellcheck disable=SC2001
+      export CFLAGS=$(echo "$CFLAGS" | sed 's/-Wp,-D_FORTIFY_SOURCE=[0-9]//g')
+      make criu crit amdgpu_plugin docs
+
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: CRaC/criu
+    strip-prefix: release-

--- a/crac-criu.yaml
+++ b/crac-criu.yaml
@@ -28,6 +28,7 @@ environment:
       - libnet-dev
       - libnl3
       - libnl3-dev
+      - libnl3-static
       - libprotobuf
       - libxml2-utils
       - nftables
@@ -52,9 +53,7 @@ pipeline:
       tag: release-${{package.version}}
 
   - runs: |
-      # shellcheck disable=SC2001
-      export CFLAGS=$(echo "$CFLAGS" | sed 's/-Wp,-D_FORTIFY_SOURCE=[0-9]//g')
-      make criu crit amdgpu_plugin docs
+      make DESTDIR=${{targets.destdir}} PREFIX=/usr install-criu V=1
 
   - uses: strip
 
@@ -63,3 +62,12 @@ update:
   github:
     identifier: CRaC/criu
     strip-prefix: release-
+
+test:
+  pipeline:
+    - runs: |
+        # check at least if the binary is there in usr/sbin/criu
+        if [ ! -f "/usr/sbin/criu" ]; then
+          echo "criu binary not found"
+          exit 1
+        fi

--- a/libnl3.yaml
+++ b/libnl3.yaml
@@ -1,7 +1,7 @@
 package:
   name: libnl3
   version: 3.10.0
-  epoch: 0
+  epoch: 1
   description: Library for applications dealing with netlink sockets
   copyright:
     - license: LGPL-2.1-or-later
@@ -46,7 +46,7 @@ pipeline:
         --sysconfdir=/etc \
         --mandir=/usr/share/man \
         --localstatedir=/var \
-        --disable-static \
+        --enable-static \
         --enable-unit-tests
 
   - uses: autoconf/make

--- a/libnl3.yaml
+++ b/libnl3.yaml
@@ -56,6 +56,11 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: "libnl3-static"
+    description: "static library for libnl3"
+    pipeline:
+      - uses: split/static
+
   - name: "libnl3-dev"
     description: "headers for libnl3"
     pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

For the build I followed up here https://github.com/CRaC/criu/blob/e7aefe4f9e499597ddf484394d29fc4752b674dd/.github/workflows/ccpp.yml#L50-L51 because the project seems a bit different than the upstream one [checkpoint-restore/criu](https://github.com/checkpoint-restore/criu) but the final binary is there because I tested it if it exists according to the notes here: https://github.com/openjdk/crac#build

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
