### PR TITLE
Add a missing `provides` for `grafana-oci-compat`

### DIFF
--- a/grafana-11.2.yaml
+++ b/grafana-11.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-11.2
   version: 11.2.1
-  epoch: 0
+  epoch: 1
   description: The open and composable observability and data visualization platform.
   copyright:
     - license: AGPL-3.0-or-later
@@ -62,6 +62,9 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-oci-compat
+    dependencies:
+      provides:
+        - grafana-oci-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/grafana


### PR DESCRIPTION
Our public images builds weren't updated to reflect this change, so they were still picking up a stale version of things.

ref: https://github.com/wolfi-dev/os/pull/28327