### PR TITLE
provides keda-metrics-apiserver

### DIFF
--- a/keda-2.15.yaml
+++ b/keda-2.15.yaml
@@ -1,7 +1,7 @@
 package:
   name: keda-2.15
   version: 2.15.1
-  epoch: 1
+  epoch: 2
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -43,6 +43,7 @@ subpackages:
         - tzdata
       provides:
         - keda-adapter=${{package.full-version}}
+        - keda-metrics-apiserver=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/usr/bin"


### PR DESCRIPTION
using provides here instead of renaming the `keda-adapter` to `keda-metrics-apiserver` because upstream still uses both words interchangeably. 

e.g. the binary is still named `keda-adapter` 

ref: https://github.com/kedacore/keda/blob/69a9cb9869012bd487972fcbb55bed960b678926/Makefile#L204-L205 

