### PR TITLE
Update SDK image digest to latest

### DIFF
--- a/.github/actions/docker-run/action.yaml
+++ b/.github/actions/docker-run/action.yaml
@@ -6,7 +6,7 @@ inputs:
     required: true
   image:
     description: "The image to use"
-    default: "ghcr.io/wolfi-dev/sdk:latest@sha256:e8c9680e3262d27b28c38e84f51f8a8587c84dc192b0f198b96b11de27aafc34"
+    default: "ghcr.io/wolfi-dev/sdk:latest@sha256:6c001d29fe246547dd24b52682770e4d7770ced4d1f25e534f31237d7308a1ce"
     required: false
   workdir:
     description: "The images working directory"


### PR DESCRIPTION
While troubleshooting the `wolfictl check diff` panics in #29705, I noticed that the SDK image digest was fairly out of date (3+ weeks). 

This means that all of the recent `bincapz`/`malcontent` changes were not captured, including [this](https://github.com/chainguard-dev/malcontent/pull/462) PR which resolves panics like the one seen in the aforementioned PR.

This PR updates the SDK image digest to an image with the latest version of `malcontent` and the most recent `wolfictl` [commit](https://github.com/wolfi-dev/wolfictl/commit/8f6fc7a3b0a6662a8f4772a0ff1a700a79f4bac2) which will correctly locate the `malcontent` binary in SDK containers.