### PR TITLE
OpenJDK with crac enabled

### DIFF
--- a/openjdk-crac-17.yaml
+++ b/openjdk-crac-17.yaml
@@ -1,0 +1,301 @@
+package:
+  name: openjdk-crac-17
+  version: 17.0.25
+  epoch: 0
+  description:
+  copyright:
+    - license: GPL-2.0-only
+  dependencies:
+    runtime:
+      - openjdk-crac-17-jre
+
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d+)\.\d+\.(\d+)
+    replace: $1
+    to: mangled-package-version
+
+environment:
+  contents:
+    packages:
+      - alsa-lib-dev
+      - autoconf
+      - automake
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cups-dev
+      - file
+      - fontconfig-dev
+      - freetype-dev
+      - giflib-dev
+      - lcms2-dev
+      - libffi-dev
+      - libjpeg-turbo-dev
+      - libx11-dev
+      - libxext-dev
+      - libxi-dev
+      - libxrandr-dev
+      - libxrender-dev
+      - libxt-dev
+      - libxtst-dev
+      - openjdk-16
+      - openjdk-16-default-jvm
+      - zip
+      - crac-criu
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/openjdk/crac.git
+      branch: crac-${{vars.mangled-package-version}}
+      expected-commit: d3ea8456815ebd161bbecac8fd8b4810a4c19443
+
+  - working-directory: /home/build/googletest
+    pipeline:
+      - uses: fetch
+        with:
+          uri: https://github.com/google/googletest/archive/release-1.8.1.tar.gz
+          expected-sha512: e6283c667558e1fd6e49fa96e52af0e415a3c8037afe1d28b7ff1ec4c2ef8f49beb70a9327b7fc77eb4052a58c4ccad8b5260ec90e4bceeac7a46ff59c4369d7
+
+  - uses: patch
+    with:
+      patches: FixNullPtrCast.patch
+
+  - runs: chmod +x configure
+
+  # Note that despite using --with-extra-cflags, --with-extra-cxxflags, and
+  # --with-extra-ldflags, the configure still produces warnings like:
+  # https://github.com/wolfi-dev/os/issues/18747
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --with-extra-cflags="$CFLAGS" \
+        --with-extra-cxxflags="$CXXFLAGS" \
+        --with-extra-ldflags="$LDFLAGS" \
+        --with-boot-jdk=/usr/lib/jvm/java-16-openjdk \
+        --prefix=/usr/lib/jvm/java-17-openjdk \
+        --with-vendor-name=wolfi \
+        --with-vendor-url=https://wolfi.dev \
+        --with-vendor-bug-url=https://github.com/wolfi-dev/os/issues \
+        --with-version-opt="wolfi-r${{package.epoch}}" \
+        --disable-warnings-as-errors \
+        --disable-precompiled-headers \
+        --enable-dtrace=no \
+        --with-zlib=system \
+        --with-debug-level=release \
+        --with-native-debug-symbols=internal \
+        --with-jvm-variants=server \
+        --with-jtreg=no  \
+        --with-libpng=system \
+        --with-jvm-variants=server \
+        --with-libjpeg=system \
+        --with-giflib=system \
+        --with-lcms=system \
+        --with-gtest="/home/build/googletest" \
+        --with-version-string=""
+
+  - runs: make jdk-image
+
+  # Check we built something valid
+  - runs: |
+      _java_bin="./build/*-server-release/images/jdk/bin"
+
+      $_java_bin/javac -d . HelloWorld.java
+      $_java_bin/java HelloWorld
+
+      # NOTE: Disable flakey tests for now as we're seeing builds hang on aarch64
+      # # run the gtest unittest suites
+      # make test-hotspot-gtest
+
+  - runs: |
+      _java_home="usr/lib/jvm/java-17-openjdk"
+
+      mkdir -p "${{targets.destdir}}"/$_java_home
+      cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
+      rm "${{targets.destdir}}"/$_java_home/lib/src.zip
+  
+  - name: "Copy CRIU to JDK"
+    runs: |
+     _java_home="usr/lib/jvm/java-17-openjdk"
+     mkdir -p "${{targets.destdir}}"/$_java_home/lib
+     cp /usr/sbin/criu "${{targets.destdir}}"/$_java_home/lib
+
+subpackages:
+  - name: "openjdk-crac-17-dbg"
+    description: "OpenJDK 17 Java Debug Symbols"
+    pipeline:
+      - uses: split/debug
+    dependencies:
+      runtime:
+        - openjdk-crac-17
+
+  - name: "openjdk-crac-17-jre"
+    description: "OpenJDK 17 Java Runtime Environment"
+    dependencies:
+      runtime:
+        - freetype
+        - libfontconfig1
+        - openjdk-crac-17-jre-base
+    pipeline:
+      - runs: |
+          _java_home="usr/lib/jvm/java-17-openjdk"
+
+          mkdir -p "${{targets.subpkgdir}}"/$_java_home/lib
+          mv "${{targets.destdir}}"/$_java_home/lib/libawt_xawt.so \
+              "${{targets.destdir}}"/$_java_home/lib/libfontmanager.so \
+              "${{targets.destdir}}"/$_java_home/lib/libjavajpeg.so \
+              "${{targets.destdir}}"/$_java_home/lib/libjawt.so \
+              "${{targets.destdir}}"/$_java_home/lib/libjsound.so \
+              "${{targets.destdir}}"/$_java_home/lib/liblcms.so \
+              "${{targets.destdir}}"/$_java_home/lib/libsplashscreen.so \
+              "${{targets.subpkgdir}}"/$_java_home/lib
+
+  - name: "openjdk-crac-17-jre-base"
+    description: "OpenJDK 17 Java Runtime Environment (headless)"
+    dependencies:
+      runtime:
+        - java-common
+        - java-cacerts
+    pipeline:
+      - runs: |
+          _java_home="usr/lib/jvm/java-17-openjdk"
+
+          mkdir -p "${{targets.subpkgdir}}"/$_java_home
+          mv "${{targets.destdir}}"/$_java_home/lib \
+             "${{targets.subpkgdir}}"/$_java_home
+
+          mkdir -p "${{targets.subpkgdir}}"/$_java_home/bin
+          for i in java \
+                    jfr \
+                    jrunscript \
+                    keytool \
+                    rmiregistry; do
+            mv "${{targets.destdir}}"/$_java_home/bin/$i "${{targets.subpkgdir}}"/$_java_home/bin/$i
+          done
+
+          mv "${{targets.destdir}}"/$_java_home/legal "${{targets.subpkgdir}}"/$_java_home
+          mv "${{targets.destdir}}"/$_java_home/conf "${{targets.subpkgdir}}"/$_java_home
+          mv "${{targets.destdir}}"/$_java_home/release "${{targets.subpkgdir}}"/$_java_home
+          cp ASSEMBLY_EXCEPTION \
+              LICENSE \
+              README.md \
+             "${{targets.subpkgdir}}"/$_java_home
+
+          # symlink to shared java cacerts store
+          rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
+          ln -sf /etc/ssl/certs/java/cacerts \
+            "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
+
+          # symlink for `java-common` to work (which expects jre in $_java_home/jre)
+          ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
+
+  - name: "openjdk-crac-17-jmods"
+    description: "OpenJDK 17 jmods"
+    dependencies:
+      provides:
+        - openjdk-crac-jmods=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-17-openjdk/jmods \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
+
+  - name: "openjdk-crac-17-doc"
+    description: "OpenJDK 17 Documentation"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-17-openjdk/man \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
+
+  - name: "openjdk-crac-17-demos"
+    description: "OpenJDK 17 Demos"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
+          mv "${{targets.destdir}}"/usr/lib/jvm/java-17-openjdk/demo \
+             "${{targets.subpkgdir}}"/usr/lib/jvm/java-17-openjdk
+
+  - name: "openjdk-crac-17-default-jvm"
+    description: "Use the openjdk-17 JVM as the default JVM"
+    dependencies:
+      runtime:
+        - openjdk-crac-17-jre
+      provides:
+        - default-crac-jvm=1.17
+        - default-crac-jvm-lts=1.17
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-17-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
+
+  - name: "openjdk-crac-17-default-jdk"
+    description: "Use the openjdk-17 JVM as the default JVM with the JDK installed"
+    dependencies:
+      runtime:
+        - openjdk-crac-17-default-jvm
+        - openjdk-crac-17
+      provides:
+        - default-crac-jdk=1.17
+        - default-crac-jdk-lts=1.17
+
+# OpenJDK versions use an interesting versioning approach.  You can read the Timeline section https://wiki.openjdk.org/display/JDKUpdates/JDK17u
+# The OpenJDK repo uses tags for prereleases and GA releases https://github.com/openjdk/jdk17u/tags
+# 1. Pre-releases are tagged with a tag like jdk-17.0.10+1
+# 2. GA releases are tagged with a tag like jdk-17.0.10-ga
+# 3. Patch releases are tagged with a tag like jdk-17.0.10+2
+# 4. The jdk-17.0.10-ga tag is updated to point to the new patch release commit
+update:
+  enabled: true
+  shared: true
+  github:
+    identifier: openjdk/crac
+    strip-prefix: jdk-
+    strip-suffix: -ga
+    tag-filter-contains: -ga
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - openjdk-crac-17-default-jdk
+        - openjdk-crac-17-jmods
+    environment:
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+  pipeline:
+    # Test a basic Hello World
+    - working-directory: basic
+      runs: |
+        javac HelloWorld.java
+        java HelloWorld | grep -qi "Hello World!"
+    # Test a basic HTTP connection
+    - working-directory: basic
+      runs: |
+        javac RequestTest.java
+        java RequestTest | grep -qi "Successfully connected to example.org"
+    # Test modules
+    - working-directory: advanced/module-project
+      runs: |
+        mkdir output
+        javac -d output --module-source-path modules $(find modules -name "*.java")
+
+        # Create a jar with the compiled classes
+        jar --verbose --create --file app.jar \
+          --main-class dev.chainguard.module.main.Main \
+          --module-version 1.0 \
+          -C output/test.modules . \
+          -C output/main.app .
+
+        # Test the jar
+        java -jar app.jar
+
+        # Test jlink
+        jlink --verbose --module-path "app.jar:$JAVA_HOME/jmods" \
+          --add-modules test.modules \
+          --output test-project-jre
+
+        # Test custom JRE
+        test-project-jre/bin/java -jar app.jar

--- a/openjdk-crac-17/FixNullPtrCast.patch
+++ b/openjdk-crac-17/FixNullPtrCast.patch
@@ -1,0 +1,26 @@
+From df2ed9ce06bca29adbb38d18bbe87902182cb167 Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Mon, 30 Sep 2024 20:53:23 +0300
+Subject: [PATCH] Fix cast errors with latest GCC
+
+Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+---
+ src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp b/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
+index f5970adc412..fc3617371c2 100644
+--- a/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
++++ b/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
+@@ -267,7 +267,7 @@ class SlowSignatureHandler
+ 
+   virtual void pass_object() {
+     intptr_t* addr = single_slot_addr();
+-    intptr_t value = *addr == 0 ? NULL : (intptr_t)addr;
++    intptr_t value = *addr == 0 ? (intptr_t) 0 : (intptr_t)addr;
+     if (pass_gpr(value) < 0) {
+       pass_stack<>(value);
+     }
+-- 
+2.39.3 (Apple Git-146)
+

--- a/openjdk-crac-17/HelloWorld.java
+++ b/openjdk-crac-17/HelloWorld.java
@@ -1,0 +1,3 @@
+public class HelloWorld {
+  public static void main(String[] args) { System.out.println("Hello World!"); }
+}

--- a/openjdk-crac-17/advanced/module-project/modules/main.app/dev/chainguard/module/main/Main.java
+++ b/openjdk-crac-17/advanced/module-project/modules/main.app/dev/chainguard/module/main/Main.java
@@ -1,0 +1,9 @@
+package dev.chainguard.module.main;
+
+import dev.chainguard.module.test.Test;
+
+public class Main {
+    public static void main(String[] args) {
+        Test.doTest();
+    }
+}

--- a/openjdk-crac-17/advanced/module-project/modules/main.app/module-info.java
+++ b/openjdk-crac-17/advanced/module-project/modules/main.app/module-info.java
@@ -1,0 +1,3 @@
+module main.app {
+    requires test.modules;
+}

--- a/openjdk-crac-17/advanced/module-project/modules/test.modules/dev.chainguard.module.test/Test.java
+++ b/openjdk-crac-17/advanced/module-project/modules/test.modules/dev.chainguard.module.test/Test.java
@@ -1,0 +1,7 @@
+package dev.chainguard.module.test;
+
+public class Test {
+    public static void doTest() {
+        System.out.println("testing a module output");
+    }
+}

--- a/openjdk-crac-17/advanced/module-project/modules/test.modules/module-info.java
+++ b/openjdk-crac-17/advanced/module-project/modules/test.modules/module-info.java
@@ -1,0 +1,3 @@
+module test.modules {
+    exports dev.chainguard.module.test;
+}

--- a/openjdk-crac-17/basic/HelloWorld.java
+++ b/openjdk-crac-17/basic/HelloWorld.java
@@ -1,0 +1,3 @@
+public class HelloWorld {
+  public static void main(String[] args) { System.out.println("Hello World!"); }
+}

--- a/openjdk-crac-17/basic/RequestTest.java
+++ b/openjdk-crac-17/basic/RequestTest.java
@@ -1,0 +1,26 @@
+import javax.management.RuntimeErrorException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class RequestTest {
+    public static void main(String[] args) throws Exception {
+        // Remote connections can flake, so try a few times
+        int attempt = 0;
+        while (true) {
+            URL url = new URL("http://example.org");
+            HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+            if (urlConnection.getResponseCode() == HttpURLConnection.HTTP_OK) {
+                break;
+            }
+
+            Thread.sleep(5000); // 5 seconds in millis is 5000
+
+            if (attempt++ >= 5) {
+                throw new RuntimeException("Failed to check connection to example.org");
+            }
+        }
+
+        System.out.println("Successfully connected to example.org");
+    }
+}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
