### PR TITLE
rename keda-adapter package to keda-metrics-apiserver

### DIFF
--- a/keda-2.15.yaml
+++ b/keda-2.15.yaml
@@ -42,6 +42,7 @@ subpackages:
       runtime:
         - tzdata
       provides:
+        - keda-adapter=${{package.full-version}}
         - keda-metrics-apiserver=${{package.full-version}}
     pipeline:
       - runs: |

--- a/keda-2.15.yaml
+++ b/keda-2.15.yaml
@@ -1,7 +1,7 @@
 package:
   name: keda-2.15
   version: 2.15.1
-  epoch: 2
+  epoch: 3
   description: KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes
   copyright:
     - license: Apache-2.0
@@ -36,13 +36,12 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "${{package.name}}-adapter"
+  - name: "${{package.name}}-metrics-apiserver"
     description: "Metrics adapter for Keda"
     dependencies:
       runtime:
         - tzdata
       provides:
-        - keda-adapter=${{package.full-version}}
         - keda-metrics-apiserver=${{package.full-version}}
     pipeline:
       - runs: |


### PR DESCRIPTION
follow up from : https://github.com/wolfi-dev/os/pull/29693

renaming the package because I ran into resolving issues. 

`resolving apk packages: for arch "amd64": solving "keda-2.15-metrics-apiserver" constraint: could not find package that provides keda-2.15-metrics-apiserver in indexes` 

we can solve it using terraform but looking at it from longer term perspective, renaming is easier and more maintainable.