### PR TITLE
kube-fluentd-operator/GHSA-6f62-3596-g6w7 & GHSA-735f-pc8j-v9w8 Remediation 

### DIFF
--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 16
+  epoch: 18
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT
@@ -74,6 +74,10 @@ pipeline:
       echo "gem 'activemodel', '7.0.7.2'" >> Gemfile
       # Bump json-jwt to mitigate GHSA-c8v6-786g-vjx6
       echo "gem 'json-jwt', '1.15.3.1'" >> Gemfile
+      # bump google-protobuf to mitigate GHSA-735f-pc8j-v9w8
+      echo "gem 'google-protobuf', '3.25.5'" >> Gemfile
+      # bump webrick to mitigate GHSA-6f62-3596-g6w7
+      echo "gem 'webrick', '1.8.2'" >> Gemfile
       # Bump rack to mitigate GHSA-xj5v-6v4g-jfw6
       bundle update rack
       bundle install
@@ -94,7 +98,7 @@ pipeline:
       # Moving to grpc 1.58.3 causes a dependency resolution issue as grpc >= 1.55.0, < 1.59.0 requires
       # google-protobuf ~> 3.23 but fluent-plugin-google-cloud had pinned google-protobuf to version 3.22.1.
       # Bumping google-protobuf to 3.23 solves this.
-      sed -e "s/'google-protobuf', '3.22.1'/'google-protobuf', '3.23'/g" -i fluent-plugin-google-cloud.gemspec
+      sed -e "s/'google-protobuf', '3.22.1'/'google-protobuf', '3.25.5'/g" -i fluent-plugin-google-cloud.gemspec
 
       bundle config set --local path ${GEM_DIR}
       bundle config set --local without 'development test'

--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 18
+  epoch: 17
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT


### PR DESCRIPTION
Bumped fluent-plugin-google-cloud's google-protobuf version from 3.23 to 3.25.5 as well as kube-fluentd-operator's google-protobuf 3.24 dependency to the same higher version resolved GHSA-735f-pc8j-v9w8. Bumping webrick from 1.8.1 to 1.8.2 remediates GHSA-6f62-3596-g6w7