### PR TITLE
python 3.13 - batch 4 packages.

### DIFF
--- a/py3-anyio.yaml
+++ b/py3-anyio.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-anyio
   version: 4.6.0
-  epoch: 0
+  epoch: 1
   description: High level compatibility layer for multiple asynchronous event loop implementations
   copyright:
     - license: MIT
@@ -15,9 +15,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -66,6 +67,15 @@ subpackages:
           with:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-hatchling.yaml
+++ b/py3-hatchling.yaml
@@ -1,8 +1,8 @@
 package:
   name: py3-hatchling
   version: 1.25.0
-  epoch: 2
-  description: "Modern, extensible Python build backend"
+  epoch: 3
+  description: Modern, extensible Python build backend
   copyright:
     - license: BSD-3-Clause
   dependencies:
@@ -14,9 +14,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -94,6 +95,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true


### PR DESCRIPTION
This just adds python 3.13 to builds of a set of multi-versioned py3-* packages.
