### PR TITLE
python 3.13 - batch 5 packages.

### DIFF
--- a/py3-annotated-types.yaml
+++ b/py3-annotated-types.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-annotated-types
   version: 0.7.0
-  epoch: 1
+  epoch: 2
   description: Reusable constraint types to use with typing.Annotated
   copyright:
     - license: MIT
@@ -16,9 +16,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -66,6 +67,15 @@ subpackages:
           with:
             python: python${{range.key}}
             import: ${{vars.module-name}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-colorama.yaml
+++ b/py3-colorama.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-colorama
   version: 0.4.6
-  epoch: 6
+  epoch: 7
   description: Simple cross-platform colored terminal text
   copyright:
     - license: BSD-3-Clause
@@ -24,9 +24,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 pipeline:
   - uses: git-checkout
@@ -54,6 +55,15 @@ subpackages:
           with:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-expandvars.yaml
+++ b/py3-expandvars.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-expandvars
   version: 0.12.0
-  epoch: 0
+  epoch: 1
   description: Expand system variables Unix style
   copyright:
-    - license: 'MIT'
+    - license: MIT
   dependencies:
     provider-priority: 0
 
@@ -15,9 +15,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -63,6 +64,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: python/import

--- a/py3-hatch-fancy-pypi-readme.yaml
+++ b/py3-hatch-fancy-pypi-readme.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-hatch-fancy-pypi-readme
   version: 24.1.0
-  epoch: 0
+  epoch: 1
   description: Fancy PyPI READMEs with Hatch
   copyright:
     - license: MIT
@@ -16,9 +16,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -91,6 +92,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-hatch-vcs.yaml
+++ b/py3-hatch-vcs.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-hatch-vcs
   version: 0.4.0
-  epoch: 0
+  epoch: 1
   description: Hatch plugin for versioning with your preferred VCS
   copyright:
     - license: MIT
@@ -20,9 +20,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -72,6 +73,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-pygments.yaml
+++ b/py3-pygments.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pygments
   version: 2.18.0
-  epoch: 1
+  epoch: 2
   description: Syntax highlighting package written in Python
   copyright:
     - license: BSD-2-Clause
@@ -14,9 +14,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -49,6 +50,10 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+      - name: "move usr/bin executables for -bin"
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
       - uses: strip
     test:
       pipeline:
@@ -56,6 +61,21 @@ subpackages:
           with:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+      provides:
+        - py3-${{vars.pypi-package}}-bin
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
 
   - name: py3-${{vars.pypi-package}}-doc
     description: py3-pygments manpages
@@ -75,6 +95,15 @@ subpackages:
           # by py-sphinx
           cp -R ./doc/docs/* "$destdir"/
       - uses: split/manpages
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true


### PR DESCRIPTION
This just adds python 3.13 to builds of a set of multi-versioned py3-* packages.
