### PR TITLE
add vault-benchmark

### DIFF
--- a/vault-benchmark.yaml
+++ b/vault-benchmark.yaml
@@ -1,0 +1,50 @@
+package:
+  name: vault-benchmark
+  version: 0.3.0
+  epoch: 0
+  description: A tool for benchmarking usage of Vault
+  copyright:
+    - license: MPL-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/hashicorp/vault-benchmark
+      tag: v${{package.version}}
+      expected-commit: f4cb30dfe849e8a96ef6dbeb646c01c44022dc4d
+
+  - uses: go/bump
+    with:
+      deps: github.com/hashicorp/go-retryablehttp@v0.7.7
+
+  - uses: go/build
+    with:
+      packages: .
+      output: vault-benchmark
+      ldflags: |
+        -X github.com/hashicorp/vault-benchmark/version.GitCommit=$(git rev-parse HEAD)
+        -X github.com/hashicorp/vault-benchmark/version.BuildDate=$(date +%F-%T)
+        -X github.com/hashicorp/vault-benchmark/version.Version=${{package.version}}
+
+  - runs: install -D -m644 LICENSE "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    pipeline:
+      - runs: |
+          # https://github.com/hashicorp/vault-benchmark/blob/81a5e54e9f7e0d1fa9b7226d1ad447e312e3c707/Dockerfile#L68C14-L71
+          mkdir -p "${{targets.contextdir}}"/bin
+          mkdir -p "${{targets.contextdir}}"/usr/share/doc/${{package.name}}
+          ln -sf /usr/bin/vault-benchmark "${{targets.contextdir}}"/bin/vault-benchmark
+          ln -sf /usr/share/licenses/${{package.name}}/LICENSE "${{targets.contextdir}}"/usr/share/doc/${{package.name}}/LICENSE.txt
+
+update:
+  enabled: true
+  github:
+    identifier: hashicorp/vault-benchmark
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: vault-benchmark --version


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
