### PR TITLE
kargo: bundle ui within binary

### DIFF
--- a/kargo.yaml
+++ b/kargo.yaml
@@ -54,7 +54,6 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin
           ln -sf /usr/bin/kargo ${{targets.subpkgdir}}/usr/local/bin/kargo
-          ln -sf /usr/share/kargo/ui ${{targets.subpkgdir}}/
           ln -sf /usr/bin/grpc-health-probe ${{targets.subpkgdir}}/usr/local/bin/grpc_health_probe
 
 update:

--- a/kargo.yaml
+++ b/kargo.yaml
@@ -30,21 +30,16 @@ pipeline:
     with:
       deps: github.com/docker/docker@v26.1.5
 
+  - runs: |
+      cd ui
+      pnpm install
+      NODE_ENV='production' pnpm run build
+
   - uses: go/build
     with:
       packages: ./cmd/controlplane
       output: kargo
       ldflags: "-w -s -X github.com/akuity/kargo/internal/version.version=${{package.version}} -X github.com/akuity/kargo/internal/version.gitCommit=$(git rev-parse HEAD)"
-
-  - runs: |
-      export COREPACK_ENABLE_STRICT=0
-      cd ui
-      pnpm install
-      NODE_ENV='production' pnpm run build
-
-      mkdir -p ${{targets.destdir}}/usr/share/kargo/ui
-
-      mv build ${{targets.destdir}}/usr/share/kargo/ui
 
   - uses: strip
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->
This one basically move the build UI step above go/build since kargo now bundles its UI component within the binary itself so `ui/build` folder has to be there before go/build

Not sure how to add tests for this? Maybe we can do it in images project?

Fixes: https://github.com/wolfi-dev/os/issues/29695

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
