### PR TITLE
druid/GHSA-735f-pc8j-v9w8

### DIFF
--- a/druid.yaml
+++ b/druid.yaml
@@ -1,7 +1,7 @@
 package:
   name: druid
   version: 30.0.1
-  epoch: 0
+  epoch: 1
   description: Apache Druid is a high performance real-time analytics database.
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,10 @@ pipeline:
       expected-commit: a30af7a91d528e5c3a90356a5592abc7119191c6
       cherry-picks: |
         master/75937c98e82156d8812143a047baf3f2a8af6b72: CVE-2023-3635
+
+  - uses: patch
+    with:
+      patches: protobuf-3.25.5.patch
 
   - runs: |
       mvn -B -ff -q \

--- a/druid/protobuf-3.25.5.patch
+++ b/druid/protobuf-3.25.5.patch
@@ -1,0 +1,13 @@
+diff --git a/pom.xml b/pom.xml
+index 17cd202ea6..e62921ed8e 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -109,7 +109,7 @@
+         <netty3.version>3.10.6.Final</netty3.version>
+         <netty4.version>4.1.108.Final</netty4.version>
+         <postgresql.version>42.7.2</postgresql.version>
+-        <protobuf.version>3.24.0</protobuf.version>
++        <protobuf.version>3.25.5</protobuf.version>
+         <resilience4j.version>1.3.1</resilience4j.version>
+         <slf4j.version>1.7.36</slf4j.version>
+         <jna.version>5.13.0</jna.version>


### PR DESCRIPTION
This patch remediates the GHSA-735f-pc8j-v9w8 CVE from the package itself however druid has a protobuf transitive dependency that can not be remediated at this time so an advisory will be filed for that.
