### PR TITLE
datawire-envoy-privileged: Add provides

### DIFF
--- a/datawire-envoy-1.31.yaml
+++ b/datawire-envoy-1.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: datawire-envoy-1.31
   version: 1.31.2
-  epoch: 1
+  epoch: 2
   description: Ambassador fork of Envoy Proxy.
   copyright:
     - license: Apache-2.0
@@ -79,6 +79,9 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           cp -p ${{targets.destdir}}/usr/bin/envoy ${{targets.subpkgdir}}/usr/bin/envoy
           setcap cap_net_bind_service=ei ${{targets.subpkgdir}}/usr/bin/envoy
+    dependencies:
+      provides:
+        - datawire-envoy-privileged=${{package.full-version}}
 
 update:
   enabled: true


### PR DESCRIPTION
Allows subpackage to provide non-versioned prefix name.

Related: https://github.com/chainguard-dev/image-requests/issues/3494

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->
