### PR TITLE
chore(crac-criu): Use Canonical's fork, remove Python bindings

### DIFF
--- a/crac-criu.yaml
+++ b/crac-criu.yaml
@@ -30,6 +30,7 @@ environment:
       - nftables
       - nftables-dev
       - nftables-static
+      - perl
       - pkgconf
       - protobuf-c-dev
       - protobuf-dev

--- a/crac-criu.yaml
+++ b/crac-criu.yaml
@@ -1,6 +1,6 @@
 package:
   name: crac-criu
-  version: 1.4
+  version: 1.4.3
   epoch: 0
   description: A project to implement checkpoint/restore functionality for Linux
   copyright:
@@ -9,14 +9,10 @@ package:
 environment:
   contents:
     packages:
-      - asciidoc
-      - autoconf
-      - automake
       - build-base
       - busybox
       - ca-certificates-bundle
       - coreutils
-      - docbook-xml
       - gnutls-dev
       - iproute2
       - libaio-dev
@@ -33,41 +29,40 @@ environment:
       - libxml2-utils
       - nftables
       - nftables-dev
-      - pkgconf-dev
+      - nftables-static
+      - pkgconf
       - protobuf-c-dev
       - protobuf-dev
       - protoc
-      - py3-future
-      - py3-ipaddress
-      - py3-protobuf
-      - py3-pyyaml
-      - python3
-      - python3-dev
-      - xmlto
 
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: d62b80e84022ed4da31edac6251f27de41c37bf1
-      repository: https://github.com/CRaC/criu/
-      tag: release-${{package.version}}
+      expected-commit: 352e2c730905bfca240a5e0f3e8085b6c27f606c
+      repository: https://github.com/canonical/crac-criu
+      tag: ${{package.version}}
 
-  - runs: |
-      make DESTDIR=${{targets.destdir}} PREFIX=/usr install-criu V=1
+  # Remove what isn't used by OpenJDK CRaC
+  - uses: patch
+    with:
+      patches: modify-installation.patch
+
+  - uses: autoconf/make-install
+    with:
+      opts: PREFIX=/usr
 
   - uses: strip
 
 update:
   enabled: true
   github:
-    identifier: CRaC/criu
-    strip-prefix: release-
+    identifier: canonical/crac-criu
 
 test:
   pipeline:
     - runs: |
         # check at least if the binary is there in usr/sbin/criu
-        if [ ! -f "/usr/sbin/criu" ]; then
+        if [ ! -f "/usr/sbin/crac-criu" ]; then
           echo "criu binary not found"
           exit 1
         fi

--- a/crac-criu/modify-installation.patch
+++ b/crac-criu/modify-installation.patch
@@ -1,0 +1,104 @@
+Description: Modify installation scripts for Ubuntu
+  The crac-criu package current serves as a dependency
+  for the openjdk-*-crac packages only. This patch
+  reduces the installation to only what the latter need
+  i.e. the usr/sbin/crac-criu binary. Other components
+  like crac-compel, shared libraries, man pages and the
+  Python bindings (crit) are not installed.
+Author: Pushkar Kulkarni <pushkar.kulkarni@canonical.com>
+Forwarded: not-needed
+Last-Update: 2024-08-09
+
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -2,7 +2,7 @@
+ CRIU_A			:= libcrac-criu.a
+ UAPI_HEADERS		:= lib/c/criu.h images/rpc.proto images/rpc.pb-c.h criu/include/version.h
+ 
+-all-y	+= lib-c lib-a lib-py
++all-y	+= lib-c lib-a
+ 
+ #
+ # C language bindings.
+@@ -35,13 +35,12 @@
+ 
+ clean-lib:
+ 	$(Q) $(MAKE) $(build)=lib/c clean
+-	$(Q) $(MAKE) $(build)=lib/py clean
+ .PHONY: clean-lib
+ clean: clean-lib
+ cleanup-y	+= lib/c/$(CRIU_SO) lib/c/$(CRIU_A) lib/c/criu.pc
+ mrproper: clean
+ 
+-install: lib-c lib-a lib-py crit/crit lib/c/criu.pc.in
++install: lib-c lib-a lib/c/criu.pc.in
+ 	$(E) "  INSTALL " lib
+ 	$(Q) mkdir -p $(DESTDIR)$(LIBDIR)
+ 	$(Q) install -m 755 lib/c/$(CRIU_SO) $(DESTDIR)$(LIBDIR)/$(CRIU_SO).$(CRIU_SO_VERSION_MAJOR).$(CRIU_SO_VERSION_MINOR)
+@@ -54,10 +53,6 @@
+ 	$(Q) mkdir -p $(DESTDIR)$(LIBDIR)/pkgconfig
+ 	$(Q) sed -e 's,@version@,$(CRIU_VERSION),' -e 's,@libdir@,$(LIBDIR),' -e 's,@includedir@,$(dir $(INCLUDEDIR)/crac-criu/criu/),' lib/c/criu.pc.in > lib/c/criu.pc
+ 	$(Q) install -m 644 lib/c/criu.pc $(DESTDIR)$(LIBDIR)/pkgconfig/crac-criu.pc
+-ifeq ($(PYTHON),python3)
+-	$(E) "  INSTALL " crit
+-	$(Q) $(PYTHON) -m pip install --no-build-isolation --no-index --no-deps --progress-bar off --upgrade --force-reinstall --prefix=$(DESTDIR)$(PREFIX) ./crit
+-endif
+ .PHONY: install
+ 
+ uninstall:
+@@ -69,8 +64,4 @@
+ 	$(Q) $(RM) $(addprefix $(DESTDIR)$(INCLUDEDIR)/crac-criu/criu/,$(notdir $(UAPI_HEADERS)))
+ 	$(E) " UNINSTALL" pkgconfig/crac-criu.pc
+ 	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBDIR)/pkgconfig/,crac-criu.pc)
+-ifeq ($(PYTHON),python3)
+-	$(E) " UNINSTALL" crit
+-	$(Q) $(PYTHON) ./scripts/uninstall_module.py --prefix=$(DESTDIR)$(PREFIX) crit
+-endif
+ .PHONY: uninstall
+--- a/crit/Makefile
++++ b/crit/Makefile
+@@ -1,8 +1,8 @@
+ 
+ all-y	+= crit
+ 
+-crit/crit: crit/crit-$(PYTHON)
+-	$(Q) cp $^ $@
++crit/crit:
++
+ crit: crit/crit
+ .PHONY: crit
+ 
+--- a/Makefile.install
++++ b/Makefile.install
+@@ -50,7 +50,7 @@
+ 	$(Q) $(MAKE) $(build)=compel/plugins install
+ .PHONY: install-compel
+ 
+-install: install-man install-lib install-criu install-compel install-amdgpu_plugin ;
++install: install-criu ;
+ .PHONY: install
+ 
+ uninstall:
+--- a/criu/Makefile
++++ b/criu/Makefile
+@@ -141,10 +141,6 @@
+ 	$(E) "  INSTALL " $(obj)/criu
+ 	$(Q) mkdir -p $(DESTDIR)$(SBINDIR)
+ 	$(Q) install -m 755 $(obj)/criu $(DESTDIR)$(SBINDIR)/crac-criu
+-	$(Q) mkdir -p $(DESTDIR)$(INCLUDEDIR)/crac-criu/criu/
+-	$(Q) install -m 644 $(UAPI_HEADERS) $(DESTDIR)$(INCLUDEDIR)/crac-criu/criu/
+-	$(Q) mkdir -p $(DESTDIR)$(LIBEXECDIR)/criu/scripts
+-	$(Q) install -m 755 scripts/systemd-autofs-restart.sh $(DESTDIR)$(LIBEXECDIR)/criu/scripts
+ ifeq ($(PYTHON),python3)
+ 	$(E) "  INSTALL " scripts/criu-ns
+ 	$(Q) install -m 755 scripts/criu-ns $(DESTDIR)$(SBINDIR)/crac-criu-ns
+@@ -154,9 +150,6 @@
+ uninstall:
+ 	$(E) " UNINSTALL" criu
+ 	$(Q) $(RM) $(addprefix $(DESTDIR)$(SBINDIR)/,crac-criu)
+-	$(Q) $(RM) $(addprefix $(DESTDIR)$(SBINDIR)/,crac-criu-ns)
+-	$(Q) $(RM) $(addprefix $(DESTDIR)$(INCLUDEDIR)/crac-criu/criu/,$(notdir $(UAPI_HEADERS)))
+-	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBEXECDIR)/criu/scripts/,systemd-autofs-restart.sh)
+ .PHONY: uninstall
+ 
+ all-y += check-packages $(obj)/criu


### PR DESCRIPTION
This updates CRaC CRIU to track Canonical's fork instead of upstream as it is more actively maintained and LTS IoenJDK CRaC releases will track Canonical's OoenJDK CRaC forks, ensuring CRaC CRIU is compatible with any changes Canonical may make

Additionally disable everything that isn't directly needed for OpenJDK CRaC, including Python bindings, as this isn't useful elsewhere. Upstream CRIU should be packaged and used if needed elsewhere. CRaC CRIU is only needed for CRaC OpenJDK so there is no reason to provide support for anything that isn't directly used by it