### PR TITLE
python 3.13 - batch 8.5 packages.

### DIFF
--- a/py3-cffi.yaml
+++ b/py3-cffi.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cffi
   version: 1.17.1
-  epoch: 1
+  epoch: 2
   description: Foreign Function Interface for Python calling C code.
   copyright:
     - license: MIT
@@ -15,9 +15,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -71,6 +72,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: python/import

--- a/py3-jsonschema.yaml
+++ b/py3-jsonschema.yaml
@@ -1,8 +1,8 @@
 package:
   name: py3-jsonschema
   version: 4.23.0
-  epoch: 2
-  description: "Python Classes Without Boilerplate."
+  epoch: 3
+  description: Python Classes Without Boilerplate.
   copyright:
     - license: MIT
   dependencies:
@@ -14,9 +14,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -90,6 +91,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: python/import


### PR DESCRIPTION
This just adds python 3.13 to builds of a set of
multi-versioned py3-* packages.
