### PR TITLE
Add provider for csi-snapshotter 8.1

### DIFF
--- a/kubernetes-csi-external-snapshotter-8.1.yaml
+++ b/kubernetes-csi-external-snapshotter-8.1.yaml
@@ -1,0 +1,90 @@
+package:
+  name: kubernetes-csi-external-snapshotter-8.1
+  version: 8.1.0
+  epoch: 0
+  description: Sidecar container that watches Kubernetes Snapshot CRD objects and triggers CreateSnapshot/DeleteSnapshot against a CSI endpoint
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - kubernetes-csi-external-snapshotter=${{package.full-version}}
+      - kubernetes-csi-external-csi-snapshotter=${{package.full-version}}
+      - kubernetes-csi-external-csi-snapshotter-${{vars.major-minor-version}}=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/kubernetes-csi/external-snapshotter
+      tag: v${{package.version}}
+      expected-commit: d5c03dbde7ca6664707c05870eae3de4255766fb
+
+  - uses: go/bump
+    with:
+      deps: google.golang.org/grpc@v1.65.0
+
+  - uses: go/build
+    with:
+      packages: ./cmd/csi-snapshotter
+      output: csi-snapshotter
+      ldflags: -X main.version=$(git describe --long --tags --match="v*" --dirty 2>/dev/null || git rev-list -n1 HEAD) -extldflags "-static"
+
+  - uses: strip
+
+subpackages:
+  - name: kubernetes-csi-external-snapshot-controller-${{vars.major-minor-version}}
+    dependencies:
+      provides:
+        - kubernetes-csi-external-snapshot-controller=${{package.full-version}}
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/snapshot-controller
+          output: snapshot-controller
+          ldflags: -X main.version=$(git describe --long --tags --match="v*" --dirty 2>/dev/null || git rev-list -n1 HEAD) -extldflags "-static"
+      - uses: strip
+
+  - name: kubernetes-csi-external-snapshot-validation-webhook-${{vars.major-minor-version}}
+    dependencies:
+      provides:
+        - kubernetes-csi-external-snapshot-validation-webhook=${{package.full-version}}
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/snapshot-validation-webhook
+          output: snapshot-validation-webhook
+          ldflags: -X main.version=$(git describe --long --tags --match="v*" --dirty 2>/dev/null || git rev-list -n1 HEAD) -extldflags "-static"
+      - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-csi/external-snapshotter
+    strip-prefix: v
+    tag-filter: v8.1
+
+test:
+  environment:
+    contents:
+      packages:
+        - kubernetes-csi-external-snapshot-controller-${{vars.major-minor-version}}
+        - kubernetes-csi-external-snapshot-validation-webhook-${{vars.major-minor-version}}
+        - curl
+        - kubernetes-csi-driver-hostpath
+  pipeline:
+    - runs: |
+        csi-snapshotter --help
+        snapshot-controller --help
+        snapshot-validation-webhook --help
+    - uses: test/kwok/cluster
+    - runs: |
+        mkdir -p /csi
+        hostpathplugin --v=5 --endpoint="unix:///csi/csi.sock" --nodeid="node-000000" &
+        csi-snapshotter --v=5 --csi-address "/csi/csi.sock" --kubeconfig ~/.kube/config --http-endpoint ":8080" &
+        sleep 10
+        curl -Lk localhost:8080/metrics


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
Add provider for csi-snapshotter 8.1

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))



#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0


