### PR TITLE
py3-ply - bump epoch to cause rebuild

### DIFF
--- a/py3-calver.yaml
+++ b/py3-calver.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-calver
   version: 2022.6.26
-  epoch: 2
+  epoch: 3
   description: Setuptools extension for CalVer package versions
   copyright:
     - license: Apache-2.0

--- a/py3-cloudpickle.yaml
+++ b/py3-cloudpickle.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cloudpickle
   version: 3.0.0
-  epoch: 3
+  epoch: 4
   description: Extended pickling support for Python objects
   copyright:
     - license: BSD-3-Clause

--- a/py3-cxxfilt.yaml
+++ b/py3-cxxfilt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cxxfilt
   version: 0.3.0
-  epoch: 1
+  epoch: 2
   description: Python interface to c++filt / abi::__cxa_demangle
   copyright:
     - license: BSD-2-Clause

--- a/py3-decorator.yaml
+++ b/py3-decorator.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-decorator
   version: 5.1.1
-  epoch: 4
+  epoch: 5
   description: Decorators for Humans
   copyright:
     - license: BSD-2-Clause

--- a/py3-dill.yaml
+++ b/py3-dill.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-dill
   version: 0.3.9
-  epoch: 0
+  epoch: 1
   description: serialize all of Python
   copyright:
     - license: BSD-3-Clause

--- a/py3-distlib.yaml
+++ b/py3-distlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-distlib
   version: 0.3.8
-  epoch: 4
+  epoch: 5
   description: Distribution utilities
   copyright:
     - license: PSF-2.0

--- a/py3-humanfriendly.yaml
+++ b/py3-humanfriendly.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-humanfriendly
   version: '10.0'
-  epoch: 4
+  epoch: 5
   description: Human friendly output for text interfaces using Python
   copyright:
     - license: MIT

--- a/py3-mdurl.yaml
+++ b/py3-mdurl.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-mdurl
   version: 0.1.2
-  epoch: 4
+  epoch: 5
   description: Markdown URL utilities
   copyright:
     - license: MIT

--- a/py3-mpmath.yaml
+++ b/py3-mpmath.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-mpmath
   version: 1.3.0
-  epoch: 3
+  epoch: 4
   description: Python library for arbitrary-precision floating-point arithmetic
   copyright:
     - license: BSD-3-Clause

--- a/py3-mypy-extensions.yaml
+++ b/py3-mypy-extensions.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-mypy-extensions
   version: 1.0.0
-  epoch: 4
+  epoch: 5
   description: Type system extensions for programs checked with the mypy type checker.
   copyright:
     - license: MIT

--- a/py3-nest-asyncio.yaml
+++ b/py3-nest-asyncio.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-nest-asyncio
   version: 1.6.0
-  epoch: 3
+  epoch: 4
   description: Patch asyncio to allow nested event loops
   copyright:
     - license: BSD-3-Clause

--- a/py3-networkx.yaml
+++ b/py3-networkx.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-networkx
   version: '3.3'
-  epoch: 2
+  epoch: 3
   description: Python package for creating and manipulating graphs and networks
   copyright:
     - license: BSD-3-Clause

--- a/py3-ply.yaml
+++ b/py3-ply.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ply
   version: 3.11_git20180215
-  epoch: 4
+  epoch: 5
   description: Python Lex & Yacc
   copyright:
     - license: BSD-3-Clause

--- a/py3-pytz.yaml
+++ b/py3-pytz.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pytz
   version: 2024.1
-  epoch: 2
+  epoch: 3
   description: World timezone definitions, modern and historical
   copyright:
     - license: MIT

--- a/py3-rouge-score.yaml
+++ b/py3-rouge-score.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rouge-score
   version: 0.1.2
-  epoch: 2
+  epoch: 3
   description: Pure python implementation of ROUGE-1.5.5
   copyright:
     - license: Apache-2.0

--- a/py3-sentencepiece.yaml
+++ b/py3-sentencepiece.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sentencepiece
   version: 0.2.0
-  epoch: 2
+  epoch: 3
   description: SentencePiece is an unsupervised text tokenizer and detokenizer
   copyright:
     - license: Apache-2.0

--- a/py3-sympy.yaml
+++ b/py3-sympy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sympy
   version: 1.13.3
-  epoch: 1
+  epoch: 2
   description: Computer algebra system (CAS) in Python
   copyright:
     - license: BSD-3-Clause

--- a/py3-versioneer.yaml
+++ b/py3-versioneer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-versioneer
   version: '0.29'
-  epoch: 3
+  epoch: 4
   description: Easy VCS-based management of project version strings
   copyright:
     - license: Unlicense


### PR DESCRIPTION
A publishing problem caused some packages built when 033509273b403a358afc64374ce99fc41ffa9a8c landed to not get published.

    $ apk search py3.*ply
    py3.10-ply-3.11_git20180215-r4
    py3.11-ply-3.11_git20180215-r4
    py3.12-ply-3.11_git20180215-r4

The py3.13-ply version is missing. In order to avoid any other accidental / unnoticed loss, I'm bumping all packages that were modified in that commit.
