### PR TITLE
python 3.13 - batch 11 packages.

### DIFF
--- a/py3-keyring.yaml
+++ b/py3-keyring.yaml
@@ -2,10 +2,10 @@
 package:
   name: py3-keyring
   version: 25.4.1
-  epoch: 1
+  epoch: 2
   description: Store and access your passwords safely.
   copyright:
-    - license: "MIT"
+    - license: MIT
   dependencies:
     provider-priority: 0
 
@@ -15,9 +15,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -83,7 +84,16 @@ subpackages:
         - runs: |
             keyring --help
 
-# These test that the meta package i.e. py3-keyring gives a function binary and python module
+  # These test that the meta package i.e. py3-keyring gives a function binary and python module
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
 test:
   pipeline:
     - runs: |

--- a/py3-pandas.yaml
+++ b/py3-pandas.yaml
@@ -1,10 +1,10 @@
 package:
   name: py3-pandas
   version: 2.2.3
-  epoch: 2
+  epoch: 3
   description: Powerful data structures for data analysis, time series, and statistics
   copyright:
-    - license: 'BSD-3-Clause'
+    - license: BSD-3-Clause
   dependencies:
     provider-priority: 0
 
@@ -14,9 +14,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -74,6 +75,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: python/import

--- a/py3-pkgconfig.yaml
+++ b/py3-pkgconfig.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pkgconfig
   version: 1.5.5
-  epoch: 4
+  epoch: 5
   description: Interface Python with pkg-config
   copyright:
     - license: MIT
@@ -14,10 +14,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
-      3.13: "313"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -62,6 +62,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-pywinpty.yaml
+++ b/py3-pywinpty.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pywinpty
   version: 2.0.13
-  epoch: 1
+  epoch: 2
   description: Pseudo terminal support for Windows from Python.
   copyright:
     - license: MIT
@@ -15,9 +15,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -65,6 +66,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: python/import

--- a/py3-rapidfuzz.yaml
+++ b/py3-rapidfuzz.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-rapidfuzz
   version: 3.10.0
-  epoch: 0
+  epoch: 1
   description: rapid fuzzy string matching
   copyright:
     - license: MIT
@@ -15,9 +15,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -58,6 +59,15 @@ subpackages:
           with:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-scikit-build-core.yaml
+++ b/py3-scikit-build-core.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-scikit-build-core
   version: 0.10.7
-  epoch: 0
+  epoch: 1
   description: Build backend for CMake based projects
   copyright:
     - license: APACHE-2.0
@@ -63,6 +63,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: python/import
@@ -73,9 +74,10 @@ subpackages:
 data:
   - name: py-versions
     items:
-      "3.10": "310"
-      "3.11": "311"
-      "3.12": "312"
+      '3.10': '310'
+      '3.11': '311'
+      '3.12': '312'
+      '3.13': '300'
 
 update:
   enabled: true

--- a/py3-scipy.yaml
+++ b/py3-scipy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scipy
   version: 1.14.1
-  epoch: 1
+  epoch: 2
   description: Fundamental algorithms for scientific computing in Python
   copyright:
     - license: BSD-3-Clause
@@ -14,9 +14,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -82,6 +83,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: python/import

--- a/py3-wcwidth.yaml
+++ b/py3-wcwidth.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-wcwidth
   version: 0.2.13
-  epoch: 2
+  epoch: 3
   description: Measures the displayed width of unicode strings in a terminal
   copyright:
     - license: MIT
@@ -27,9 +27,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 pipeline:
   - uses: git-checkout
@@ -55,6 +56,15 @@ subpackages:
           with:
             python: python${{range.key}}
             import: ${{vars.pypi-package}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true


### PR DESCRIPTION
This just adds python 3.13 to builds of a set of
multi-versioned py3-* packages.
