### PR TITLE
python 3.13 - batch 13 packages.

### DIFF
--- a/py3-cassandra-driver.yaml
+++ b/py3-cassandra-driver.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-driver
   version: 3.29.2
-  epoch: 1
+  epoch: 2
   description: DataStax Driver for Apache Cassandra
   copyright:
     - license: Apache-2.0
@@ -20,14 +20,15 @@ environment:
       - py3-supported-wheel
 
 vars:
-  pypi-package: cassandra
+  pypi-package: cassandra-driver
 
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 pipeline:
   - uses: git-checkout
@@ -38,7 +39,7 @@ pipeline:
 
 subpackages:
   - range: py-versions
-    name: py${{range.key}}-cassandra-driver
+    name: py${{range.key}}-${{vars.pypi-package}}
     description: ${{vars.pypi-package}} installed for python${{range.key}}
     dependencies:
       runtime:
@@ -57,7 +58,16 @@ subpackages:
         - uses: python/import
           with:
             python: python${{range.key}}
-            import: ${{vars.pypi-package}}
+            import: cassandra
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-poetry.yaml
+++ b/py3-poetry.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-poetry
   version: 1.8.3
-  epoch: 2
+  epoch: 3
   description: Python dependency management and packaging made easy.
   copyright:
     - license: MIT
@@ -17,9 +17,10 @@ vars:
 data:
   - name: py-versions
     items:
-      3.10: "310"
-      3.11: "311"
-      3.12: "312"
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -107,6 +108,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: python/import


### PR DESCRIPTION
This just adds python 3.13 to builds of a set of
multi-versioned py3-* packages.

The change here for cassandra-driver was to correctly name the pypi package 'cassandra-driver' , which causes the 'import' change needed.
