### PR TITLE
kubernetes-1.31: Add kube-proxy-default-compat subpackage.

### DIFF
--- a/kubernetes-1.31.yaml
+++ b/kubernetes-1.31.yaml
@@ -34,7 +34,7 @@ var-transforms:
     to: pause-version
   - from: ${{package.name}}
     match: '.*-(\d+\.\d+).*'
-    replace: '$1'
+    replace: "$1"
     to: kubernetes-version
 
 vars:
@@ -187,7 +187,7 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           ln -s ${{range.key}}-${{vars.kubernetes-version}} ${{targets.subpkgdir}}/usr/bin/${{range.key}}
 
-  - name: kube-proxy-default-compat
+  - name: kube-proxy-${{vars.kubernetes-version}}-default-compat
     description: kube-proxy-default compatibility package
     dependencies:
       runtime:

--- a/kubernetes-1.31.yaml
+++ b/kubernetes-1.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.31
   version: 1.31.1
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -186,6 +186,21 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           ln -s ${{range.key}}-${{vars.kubernetes-version}} ${{targets.subpkgdir}}/usr/bin/${{range.key}}
+
+  - name: kube-proxy-default-compat
+    description: kube-proxy-default compatibility package
+    dependencies:
+      runtime:
+        - kube-proxy-${{vars.kubernetes-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          # kube-proxy deployments usually use /usr/local/bin/kube-proxy
+          # See https://github.com/kubernetes/kubernetes/blob/a35bca903e24ea3cdbecb743c001b4c8f4db9e9c/cmd/kubeadm/app/phases/addons/proxy/manifests.go#L79
+          ln -s kube-proxy-${{vars.kubernetes-version}} ${{targets.subpkgdir}}/usr/local/bin/kube-proxy
+    test:
+      pipeline:
+        - runs: stat /usr/local/bin/kube-proxy
 
   - name: kubernetes-${{vars.kubernetes-version}}-default
     description: "Compatibility package to set ${{vars.kubernetes-version}} as the default kubernetes, and add packages to their shortened path"


### PR DESCRIPTION
kube-proxy deployments assume the binary sits at
`/usr/local/bin/kube-proxy` (see
https://github.com/kubernetes/kubernetes/blob/a35bca903e24ea3cdbecb743c001b4c8f4db9e9c/cmd/kubeadm/app/phases/addons/proxy/manifests.go#L79). This adds a compat package based off of `kube-proxy-default` (which installs the binary at `/usr/bin/kube-proxy`) to add a symlink to `/usr/local/bin`.

Related: https://github.com/chainguard-dev/image-requests/issues/3667

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->