### PR TITLE
compat package for secret-store-csi-driver-aws

### DIFF
--- a/secrets-store-csi-driver-provider-aws.yaml
+++ b/secrets-store-csi-driver-provider-aws.yaml
@@ -1,7 +1,7 @@
 package:
   name: secrets-store-csi-driver-provider-aws
   version: 0.3.9
-  epoch: 3
+  epoch: 4
   description: AWS Secrets Manager and AWS Systems Manager Parameter Store provider for the Secret Store CSI Driver.
   copyright:
     - license: Apache-2.0
@@ -33,6 +33,15 @@ pipeline:
       cp _output/secrets-store-csi-driver-provider-aws-* ${{targets.destdir}}/usr/bin/secrets-store-csi-driver-provider-aws
 
   - uses: strip
+
+subpackages:
+  # create a compat package where you create a smylink between /usr/bin and /bin
+  - name: ${{package.name}}-compat
+    description: Compatibility package for secrets-store-csi-driver-provider-aws
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/bin/
+          ln -sf /usr/bin/secrets-store-csi-driver-provider-aws ${{targets.contextdir}}/bin/secrets-store-csi-driver-provider-aws
 
 update:
   enabled: true


### PR DESCRIPTION
They seem using the binary from a /bin folder in their entrypoint:

- https://github.com/aws/secrets-store-csi-driver-provider-aws/blob/eec8172bd6de8c97c45bdef9d8681c32d16c326b/Dockerfile#L11

so we need to create a -compat package for providing this compatibility between images.