### PR TITLE
Do not leave tmp.XXXXX directories around on each 'make' invocation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,23 +144,23 @@ dev-container:
 	    ghcr.io/wolfi-dev/sdk:latest@sha256:6c001d29fe246547dd24b52682770e4d7770ced4d1f25e534f31237d7308a1ce
 
 PACKAGES_CONTAINER_FOLDER ?= /work/packages
-TMP_REPOSITORIES_DIR := $(shell mktemp -d)
-TMP_REPOSITORIES_FILE := $(TMP_REPOSITORIES_DIR)/repositories
 # This target spins up a docker container that is helpful for testing local
 # changes to the packages. It mounts the local packages folder as a read-only,
 # and sets up the necessary keys for you to run `apk add` commands, and then
 # test the packages however you see fit.
 local-wolfi:
-	@echo "https://packages.wolfi.dev/os" > $(TMP_REPOSITORIES_FILE)
-	@echo "$(PACKAGES_CONTAINER_FOLDER)" >> $(TMP_REPOSITORIES_FILE)
+	$(eval TMP_REPOS_DIR := $(shell mktemp --tmpdir -d "$@.XXXXXX"))
+	$(eval TMP_REPOS_FILE := $(TMP_REPOS_DIR)/repositories)
+	@echo "https://packages.wolfi.dev/os" > $(TMP_REPOS_FILE)
+	@echo "$(PACKAGES_CONTAINER_FOLDER)" >> $(TMP_REPOS_FILE)
 	docker run --rm -it \
 		--mount type=bind,source="${PWD}/packages",destination="$(PACKAGES_CONTAINER_FOLDER)",readonly \
 		--mount type=bind,source="${PWD}/local-melange.rsa.pub",destination="/etc/apk/keys/local-melange.rsa.pub",readonly \
-		--mount type=bind,source="$(TMP_REPOSITORIES_FILE)",destination="/etc/apk/repositories",readonly \
+		--mount type=bind,source="$(TMP_REPOS_FILE)",destination="/etc/apk/repositories",readonly \
 		-w "$(PACKAGES_CONTAINER_FOLDER)" \
 		cgr.dev/chainguard/wolfi-base:latest
-	@rm "$(TMP_REPOSITORIES_FILE)"
-	@rmdir "$(TMP_REPOSITORIES_DIR)"
+	@rm "$(TMP_REPOS_FILE)"
+	@rmdir "$(TMP_REPOS_DIR)"
 
 # This target spins up a docker container that is helpful for building images
 # using local packages.
@@ -193,19 +193,21 @@ local-wolfi:
 # docker load -i /tmp/out/conda-test.tar
 # docker run -it
 OUT_LOCAL_DIR ?= /work/out
-OUT_DIR ?= $(shell mktemp -d)
 OS_LOCAL_DIR ?= /work/os
 OS_DIR ?= ${PWD}
 dev-container-wolfi:
-	@echo "https://packages.wolfi.dev/os" > $(TMP_REPOSITORIES_FILE)
-	@echo "$(PACKAGES_CONTAINER_FOLDER)" >> $(TMP_REPOSITORIES_FILE)
+	$(eval TMP_REPOS_DIR := $(shell mktemp --tmpdir -d "$@.XXXXXX"))
+	$(eval TMP_REPOS_FILE := $(TMP_REPOS_DIR)/repositories)
+	$(eval OUT_DIR := $(shell echo $${OUT_DIR:-$$(mktemp --tmpdir -d "$@-out.XXXXXX")}))
+	@echo "https://packages.wolfi.dev/os" > $(TMP_REPOS_FILE)
+	@echo "$(PACKAGES_CONTAINER_FOLDER)" >> $(TMP_REPOS_FILE)
 	docker run --rm -it \
 		--mount type=bind,source="${OUT_DIR}",destination="$(OUT_LOCAL_DIR)" \
 		--mount type=bind,source="${OS_DIR}",destination="$(OS_LOCAL_DIR)",readonly \
 		--mount type=bind,source="${PWD}/packages",destination="$(PACKAGES_CONTAINER_FOLDER)",readonly \
 		--mount type=bind,source="${PWD}/local-melange.rsa.pub",destination="/etc/apk/keys/local-melange.rsa.pub",readonly \
-		--mount type=bind,source="$(TMP_REPOSITORIES_FILE)",destination="/etc/apk/repositories",readonly \
+		--mount type=bind,source="$(TMP_REPOS_FILE)",destination="/etc/apk/repositories",readonly \
 		-w "$(PACKAGES_CONTAINER_FOLDER)" \
 		ghcr.io/wolfi-dev/sdk:latest@sha256:6c001d29fe246547dd24b52682770e4d7770ced4d1f25e534f31237d7308a1ce
-	@rm "$(TMP_REPOSITORIES_FILE)"
-	@rmdir "$(TMP_REPOSITORIES_DIR)"
+	@rm "$(TMP_REPOS_FILE)"
+	@rmdir "$(TMP_REPOS_DIR)"


### PR DESCRIPTION
Every time `make` was invoked we would create:
 * a temp dir for local-wolfi repos
 * a temp dir for dev-container-wolfi repos
 * a temp dir for dev-container-out

Now, instead of always creating them, create them only if you're in the
given target.  The use of `--tmpdir` allows us to provide a template
(`$@.XXXXXX`) while respecting TMPDIR.  The template means that we get tmpdirs
named `local-wolfi.5Sr9nC` rather than just `tmp.5Sr9nC`.

I don't love the complexity in the setting of OUT_DIR, but it appears
that the ?= operator in make will still evaluate the right side of that
conditional assignment even if its set.
    
    FOO ?= $(shell echo bar; echo this-gets-called-even-if-FOO-is-set 1>&2)

So, without the shell magic, `make OUT_DIR=./my.out-dir` would still create the
temp dir while respecting and keeping OUT_DIR.

We *do* leak OUT_DIR tmp directories. I can fix that if someone wants
it fixed. Not bothering as the intent of OUT_DIR is to have data from
inside the container persisted after the container exist.

