### PR TITLE
heimdal: split libraries into subpackage

### DIFF
--- a/heimdal.yaml
+++ b/heimdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: heimdal
   version: 7.8.0
-  epoch: 6
+  epoch: 7
   description: "Implementation of Kerberos 5"
   copyright:
     - license: BSD-3-Clause
@@ -65,6 +65,13 @@ subpackages:
     dependencies:
       runtime:
         - heimdal
+
+  - name: "heimdal-libs"
+    description: "libraries shipped by heimdal"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/*.so.* ${{targets.contextdir}}/usr/lib
 
   - name: "heimdal-doc"
     description: "heimdal manpages"


### PR DESCRIPTION
Currently heimdal ships many useful system utilities, and shared
libraries that those utilities use.

The utilities in question have alternative implementations. For
example sudo-rs and heimdal both implement su command.

The libraries too, are generally useful outside of heimdal package,
for example for ldaps:// protocol support in curl, it links against
openldap, which links against libasn1 parsing library provided by
heimdal.

To allow one to choose arbitrary su implementations, and to install
curl at the same time, split runtime libraries from heimdal such that
one can mix-and-match keimdal-libs with arbitrary su implementation
(the heimdal one, or any alternatives).

Fixes: curl ldaps (#29924)
