### PR TITLE
ca-certificates-bundle: add compat with Fedora-like expectations

### DIFF
--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -2,7 +2,7 @@ package:
   name: ca-certificates
   # manual: update java-cacerts
   version: "20240705"
-  epoch: 0
+  epoch: 1
   description: "CA certificates from the Mozilla trusted root program"
   copyright:
     - license: MPL-2.0 AND MIT
@@ -62,6 +62,9 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/etc/ssl/certs
           mv "${{targets.destdir}}"/etc/ssl/certs/ca-certificates.crt "${{targets.subpkgdir}}"/etc/ssl/certs
           ln -s certs/ca-certificates.crt "${{targets.subpkgdir}}"/etc/ssl/cert.pem
+          # Provide Fedora compatible location for the bundle (fixes compat with Dart lang)
+          mkdir -p ${{targets.subpkgdir}}/etc/pki/tls/certs/
+          ln -s ../../../ssl/certs/ca-certificates.crt ${{targets.subpkgdir}}/etc/pki/tls/certs/ca-bundle.crt
 
 test:
   environment:
@@ -70,7 +73,13 @@ test:
         - curl
         - wolfi-base
   pipeline:
-    - runs: curl --ipv4 -v https://packages.wolfi.dev
+    - runs: |
+        # Test no cert
+        ! SSL_CERT_FILE=/dev/null curl --ipv4 -v https://packages.wolfi.dev
+        # Test Debian-like compat path
+        SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt curl --ipv4 -v https://packages.wolfi.dev
+        # Test Fedora-like compat path
+        SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt curl --ipv4 -v https://packages.wolfi.dev
 
 update:
   enabled: true


### PR DESCRIPTION
Currently Chainguard Images universally set SSL_CERT_FILE pointing at
a Debian-like path of the bundle.

A cert directory with by-c_rehash symlinks of certificates is not
shipped by default, as it is incompatible with apko image building
which prohibits executing any package scriplets. Also by-c_rehash is
incompatible with incert solution to append/extend certificates.

Add one more symlink to support any Fedora-like hardcoded expectations
for certificate bundles.

This fixes out of the box compat with dart-lang, which doesn't by
default support SSL_CERT_FILE variable like golang does.

References:
- https://github.com/dart-lang/sdk/blob/4fe2944776a0f8b24a7b8a63f67c06b82a808070/runtime/bin/security_context_linux.cc#L65
- https://github.com/golang/go/blob/95936844387c0158b773afa4ee6f99bd430791cf/src/crypto/x509/root_unix.go#L19
- https://askubuntu.com/questions/342484/etc-pki-tls-certs-ca-bundle-crt-not-found
