### PR TITLE
logstash/GHSA-9hf4-67fc-4vf4

### DIFF
--- a/logstash.yaml
+++ b/logstash.yaml
@@ -69,6 +69,7 @@ pipeline:
     runs: |
       echo "gem 'fugit', '1.11.1'" >> Gemfile.template
       echo "gem 'rexml', '3.3.6'" >> Gemfile.template
+      echo "gem 'puma', '6.4.3'" >> Gemfile.template
       # Disable the logstash-integration-jdbc plugin download as we build and
       # package it separately
       jq 'del(.["logstash-integration-jdbc"])' rakelib/plugins-metadata.json > /tmp/plugins-metadata.json

--- a/logstash.yaml
+++ b/logstash.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash
   version: 8.15.2
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Simple bump of gem from puma dependency from 6.4.2 -> 6.4.3 to remediate GHSA-9hf4-67fc-4vf4. Done via replacing the value of the dependency version in the gemfile template before build.