### PR TITLE
wavefront-proxy/GHSA-735f-pc8j-v9w8

### DIFF
--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: wavefront-proxy
   version: "13.7" # When version is bumped, check if patches are still needed to address CVE-2023-1428
-  epoch: 0
+  epoch: 1
   description: Wavefront Proxy Project
   copyright:
     - license: Apache-2.0

--- a/wavefront-proxy/proxy/pombump-deps.yaml
+++ b/wavefront-proxy/proxy/pombump-deps.yaml
@@ -28,3 +28,9 @@ patches:
     version: 1.12.725
     scope: compile
     type: jar
+  # Fixes GHSA-735f-pc8j-v9w8
+  - groupId: com.google.protobuf
+    artifactId: protobuf-bom
+    version: 3.25.5
+    scope: import
+    type: pom


### PR DESCRIPTION
Minor patch version bump v3.25.3 -> v3.25.5 for protobuf package CVE remediation. Due to pom.xml being the defining version structure we are able to simply use the relevant pombump file to annotate the changes required.