### PR TITLE
add runtime dep on python3 for clang-18-extras, needed for a shipped binary

### DIFF
--- a/clang-18.yaml
+++ b/clang-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-18
   version: 18.1.8
-  epoch: 2
+  epoch: 3
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -192,6 +192,9 @@ subpackages:
           mv "${{targets.destdir}}"/usr/share/clang/run-find-all-symbols.py "${{targets.subpkgdir}}"/usr/share/clang/
 
           mv "${{targets.destdir}}"/usr/share/emacs "${{targets.subpkgdir}}"/usr/share/
+    dependencies:
+      runtime:
+        - python3
 
   - name: "py3-clang-18"
     description: "Clang 18 Python bindings"


### PR DESCRIPTION
The automated testing that I'm building identified a missing running time dependency on python3 in clang-18-extras, which ships a python script, run-clang-tidy