### PR TITLE
test/cryptsetup: update benchmark test case

### DIFF
--- a/cryptsetup.yaml
+++ b/cryptsetup.yaml
@@ -111,4 +111,7 @@ test:
         cryptsetup luksDump container
     - name: "Test cryptsetup benchmark"
       runs: |
-        cryptsetup benchmark
+        cryptsetup benchmark --cipher aes-xts
+        cryptsetup benchmark --pbkdf pbkdf2 --hash sha256
+        cryptsetup benchmark --pbkdf argon2i
+        cryptsetup benchmark --pbkdf argon2id


### PR DESCRIPTION
Currently benchmark tests for obsolete and slow cryptography which are
often not available on modern kernels.

Test only the best current practice ciphers for general purpose, and
FIPS.
