### PR TITLE
python-3.13: enable opt-in JIT

### DIFF
--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: 3.13.0_rc3
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -82,6 +82,7 @@ pipeline:
          --enable-loadable-sqlite-extensions \
          --enable-optimizations \
          --enable-shared \
+         --enable-experimental-jit=yes-off \
          --without-lto \
          --with-computed-gotos \
          --with-dbmliborder=gdbm:ndbm \


### PR DESCRIPTION
Python 3.13 features [an experimental just-in-time (JIT) compiler](https://docs.python.org/3.13/whatsnew/3.13.html#whatsnew313-jit-compiler).

Compile support for it, but keep it disabled by default at runtime,
allowing users to opt into it.

> The --enable-experimental-jit option takes these (optional) values, defaulting to yes if --enable-experimental-jit is present without the optional value.
> yes-off: Build the JIT but disable it by default. To enable the JIT at runtime, pass the environment variable PYTHON_JIT=1.
