### PR TITLE
python jit bootstrap

### DIFF
--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -82,14 +82,13 @@ pipeline:
          --enable-loadable-sqlite-extensions \
          --enable-optimizations \
          --enable-shared \
-         --without-lto \
+         --with-lto \
          --with-computed-gotos \
          --with-dbmliborder=gdbm:ndbm \
          --with-system-expat \
          --with-system-libmpdec \
          --without-ensurepip \
          --with-builtin-hashlib-hashes=blake2 \
-         --with-lto \
          --with-wheel-pkg-dir=/usr/share/python-wheels
 
   - uses: autoconf/make

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -71,6 +71,41 @@ pipeline:
     with:
       patches: gh-118224.patch
 
+  # Needed to regen files and build JIT
+  # See https://github.com/python/cpython/issues/124967
+  - name: Bootstrap Python
+    working-directory: bootstrap-build
+    runs: |
+      ../configure \
+         --host=${{host.triplet.gnu}} \
+         --build=${{host.triplet.gnu}} \
+         --target=${{host.triplet.gnu}} \
+         --prefix=/usr \
+         --enable-ipv6 \
+         --enable-loadable-sqlite-extensions \
+         --enable-optimizations \
+         --enable-shared \
+         --with-lto \
+         --with-computed-gotos \
+         --with-dbmliborder=gdbm:ndbm \
+         --with-system-expat \
+         --with-system-libmpdec \
+         --without-ensurepip \
+         --with-builtin-hashlib-hashes=blake2 \
+         --with-wheel-pkg-dir=/usr/share/python-wheels
+
+  - uses: autoconf/make
+    with:
+      dir: bootstrap-build
+
+  - uses: autoconf/make-install
+    with:
+      dir: bootstrap-build
+      opts: DESTDIR=''
+
+  - name: Remove bootstrap build
+    runs: rm -rf bootstrap-build
+
   - name: Configure
     runs: |
       ./configure \

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: 3.13.0_rc3
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -22,6 +22,7 @@ environment:
       - busybox
       - bzip2-dev
       - ca-certificates-bundle
+      - clang-18
       - expat-dev
       - gdbm-dev
       - libffi-dev
@@ -117,6 +118,7 @@ pipeline:
          --enable-loadable-sqlite-extensions \
          --enable-optimizations \
          --enable-shared \
+         --enable-experimental-jit=yes-off \
          --with-lto \
          --with-computed-gotos \
          --with-dbmliborder=gdbm:ndbm \


### PR DESCRIPTION
- **python-3.13: with or without you**
  LTO was specified as both without and with. Last one wins, deduplicate
  to avoid any confusion.
  

- **python-3.13: build and install bootstrap python**
  This allows one to regenerate build files created with python, and
  enables one build python with JIT enabled.
  

- **python-3.13: enable opt-in JIT**
  Python 3.13 features [an experimental just-in-time (JIT) compiler](https://docs.python.org/3.13/whatsnew/3.13.html#whatsnew313-jit-compiler).
  
  Compile support for it, but keep it disabled by default at runtime,
  allowing users to opt into it.
  
  > The --enable-experimental-jit option takes these (optional) values, defaulting to yes if --enable-experimental-jit is present without the optional value.
  > yes-off: Build the JIT but disable it by default. To enable the JIT at runtime, pass the environment variable PYTHON_JIT=1.
  