### PR TITLE
Add py3-supported-build-base package

### DIFF
--- a/py3-aiofiles.yaml
+++ b/py3-aiofiles.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-aiofiles
   version: 24.1.0
-  epoch: 1
+  epoch: 2
   description: File support for asyncio.
   copyright:
     - license: Apache-2.0
@@ -10,10 +10,7 @@ package:
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - wolfi-base
+      - py3-build-base
   environment:
     # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
     SOURCE_DATE_EPOCH: 315532800

--- a/py3-aiohttp.yaml
+++ b/py3-aiohttp.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-aiohttp
   version: 3.10.8
-  epoch: 1
+  epoch: 2
   description: Async http client/server framework (asyncio)
   copyright:
     - license: Apache-2.0
@@ -23,17 +23,12 @@ data:
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
       - cython
       - llhttp-dev
       - openssf-compiler-options
+      - py3-supported-build-base-dev
       - py3-supported-cython
       - py3-supported-multidict
-      - py3-supported-pip
-      - py3-supported-python-dev
-      - wolfi-base
 
 pipeline:
   - uses: git-checkout

--- a/py3-anyio.yaml
+++ b/py3-anyio.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-anyio
   version: 4.6.0
-  epoch: 1
+  epoch: 2
   description: High level compatibility layer for multiple asynchronous event loop implementations
   copyright:
     - license: MIT
@@ -23,16 +23,7 @@ data:
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-supported-build
-      - py3-supported-installer
-      - py3-supported-pip
-      - py3-supported-python
-      - py3-supported-setuptools
-      - py3-supported-setuptools-scm
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout

--- a/py3-supported-python.yaml
+++ b/py3-supported-python.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-supported-python
   version: 1
-  epoch: 2
+  epoch: 3
   description: metapackage to install all supported versions of python
   copyright:
     - license: "MIT"
@@ -15,8 +15,15 @@ package:
 environment:
   contents:
     packages:
-      - build-base
       - busybox
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 subpackages:
   - name: ${{package.name}}-dev
@@ -27,6 +34,39 @@ subpackages:
         - python-3.11-base-dev
         - python-3.12-base-dev
         - python-3.13-base-dev
+
+  - range: py-versions
+    name: py${{range.key}}-build-base
+    description: ${{vars.pypi-package}} core/base build packages.
+    dependencies:
+      runtime:
+        - py${{range.key}}-build
+        - py${{range.key}}-installer
+        - py${{range.key}}-pip-base
+        - py${{range.key}}-setuptools
+        - py${{range.key}}-setuptools-scm
+        - py${{range.key}}-wheel
+      provides:
+        - py3-build-base
+      provider-priority: ${{range.value}}
+
+  - name: py3-supported-build-base
+    description: "metapackage for common python build-deps"
+    dependencies:
+      runtime:
+        - busybox
+        - py3.10-build-base
+        - py3.11-build-base
+        - py3.12-build-base
+        - py3.13-build-base
+
+  - name: py3-supported-build-base-dev
+    description: "metapackage for common python build-deps with C extensions"
+    dependencies:
+      runtime:
+        - build-base
+        - py3-supported-build-base
+        - py3-supported-python-dev
 
 update:
   enabled: false


### PR DESCRIPTION
This will allow us to simplify the build environment dependencies
similar to the way 'build-base' does for C.

