### PR TITLE
tez: change the runtime to use the default jvm

### DIFF
--- a/tez.yaml
+++ b/tez.yaml
@@ -1,13 +1,13 @@
 package:
   name: tez
   version: 0.10.4
-  epoch: 0
+  epoch: 1
   description: Apache Tez
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - openjdk-8
+      - openjdk-8-default-jvm
 
 environment:
   contents:


### PR DESCRIPTION
This PR updates the runtime by replacing the JVM with the default one. 
