### PR TITLE
zookeeper-3.9: update commons-io to 2.14.0 to address  CVE-2024-47554

### DIFF
--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.9
   version: 3.9.2.0
-  epoch: 3
+  epoch: 4
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,10 @@ pipeline:
 
   - runs: |
       # Patch netty version for CVE-2023-4586 CVE-2023-44487
-      mvn install -DskipTests -Dnetty.version=4.1.108.Final
+      # -Dnetty.version=4.1.108.Final
+      # Patch commons-io version GHSA-78wr-2p64-hpwj/CVE-2024-47554
+      # -Dcommons-io.version=2.14.0 moved from 2.11.0 https://github.com/apache/zookeeper/blob/release-3.9.2/pom.xml#L574C5-L574C52
+      mvn install -DskipTests -Dnetty.version=4.1.108.Final -Dcommons-io.version=2.14.0
       tar -xf zookeeper-assembly/target/apache-zookeeper-${{vars.short-package-version}}-bin.tar.gz
 
       # Cleanup Windows files


### PR DESCRIPTION
update commons-io to 2.14.0 fixes GHSA-78wr-2p64-hpwj  / CVE-2024-47554
https://www.openwall.com/lists/oss-security/2024/10/03/2