### PR TITLE
add rtmpdump

### DIFF
--- a/rtmpdump.yaml
+++ b/rtmpdump.yaml
@@ -1,0 +1,99 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: rtmpdump
+  version: 2.6_git20241005
+  epoch: 0
+  description: rtmpdump is a toolkit for RTMP streams
+  copyright:
+    - license: LGPL-2.0-only
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - gcc
+      - glibc-dev
+      - gmp-dev
+      - gnutls-dev
+      - nettle-dev
+      - openssl-dev
+      - wolfi-base
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://git.ffmpeg.org/rtmpdump.git
+      expected-commit: 6f6bb1353fc84f4cc37138baa99f586750028a01
+      branch: master
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-dev
+    description: headers for ${{package.name}}
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - ${{package.name}}
+        - gmp-dev
+        - gnutls-dev
+        - nettle-dev
+        - zlib-dev
+
+  - name: ${{package.name}}-doc
+    description: ${{package.name}} documentation
+    pipeline:
+      - uses: split/manpages
+      - uses: split/infodir
+
+  - name: librtmp
+    description: RTMP library
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv librtmp/*.so* "${{targets.subpkgdir}}"/usr/lib/
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: daily
+    reason: Upstream doesn't provide new releases on their http://rtmpdump.mplayerhq.hu/download/ page anymore.
+
+test:
+  environment:
+    contents:
+      packages:
+        - posix-libc-utils
+        - rtmpdump-dev
+        - librtmp
+        - gcc
+        - glibc-dev
+  pipeline:
+    - name: Smoke test for rtmpdump binary
+      runs: rtmpdump --help
+    - name: "Check shared library"
+      runs: ldd /usr/lib/librtmp.so.1
+    - name: Compile and link a simple C program
+      runs: |
+        cat <<EOF > test_rtmp.c
+        #include <librtmp/rtmp.h>
+        #include <stdio.h>
+        int main() {
+          RTMP *rtmp = RTMP_Alloc();
+          if (rtmp) {
+            printf("RTMP allocation successful\n");
+            RTMP_Free(rtmp);
+            return 0;
+          }
+          return 1;
+        }
+        EOF
+        gcc -o test_rtmp test_rtmp.c -lrtmp
+        ./test_rtmp | grep -qi "RTMP allocation successful"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
