### PR TITLE
rust-1.81: rebuild with new SDK image

### DIFF
--- a/rust-1.81.yaml
+++ b/rust-1.81.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.81
   version: 1.81.0
-  epoch: 0
+  epoch: 1
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.81.yaml
+++ b/rust-1.81.yaml
@@ -120,6 +120,10 @@ pipeline:
       ln -srft usr/lib   usr/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.so
       ln -srft usr/lib32 usr/lib/rustlib/i686-unknown-linux-gnu/lib/*.so
 
+  - name: ensure libraries are executable for melange SCA provides generation
+    runs: |
+      chmod +x ${{targets.destdir}}/usr/lib/*.so
+
 update:
   enabled: true
   github:

--- a/rust-1.81.yaml
+++ b/rust-1.81.yaml
@@ -112,14 +112,6 @@ pipeline:
       rm ${{targets.destdir}}/usr/lib/rustlib/uninstall.sh
       rm ${{targets.destdir}}/usr/lib/rustlib/manifest-*
 
-  # rustbuild always installs copies of the shared libraries to /usr/lib,
-  # overwrite them with symlinks to the per-architecture versions
-  - runs: |
-      mkdir -p ${{targets.destdir}}/usr/lib32
-      cd ${{targets.destdir}}
-      ln -srft usr/lib   usr/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.so
-      ln -srft usr/lib32 usr/lib/rustlib/i686-unknown-linux-gnu/lib/*.so
-
   - name: ensure libraries are executable for melange SCA provides generation
     runs: |
       chmod +x ${{targets.destdir}}/usr/lib/*.so


### PR DESCRIPTION
Rebuild rust with new SDK image with wolfictl that has melange with
https://github.com/chainguard-dev/melange/pull/1526 to hopefully
address https://github.com/chainguard-dev/melange/issues/1536
