### PR TITLE
Fix rust installed libraries mode and symlinks

### DIFF
--- a/rust-1.81.yaml
+++ b/rust-1.81.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.81
   version: 1.81.0
-  epoch: 0
+  epoch: 1
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT
@@ -111,14 +111,6 @@ pipeline:
       rm ${{targets.destdir}}/usr/lib/rustlib/rust-installer-version
       rm ${{targets.destdir}}/usr/lib/rustlib/uninstall.sh
       rm ${{targets.destdir}}/usr/lib/rustlib/manifest-*
-
-  # rustbuild always installs copies of the shared libraries to /usr/lib,
-  # overwrite them with symlinks to the per-architecture versions
-  - runs: |
-      mkdir -p ${{targets.destdir}}/usr/lib32
-      cd ${{targets.destdir}}
-      ln -srft usr/lib   usr/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.so
-      ln -srft usr/lib32 usr/lib/rustlib/i686-unknown-linux-gnu/lib/*.so
 
   - name: ensure libraries are executable for melange SCA provides generation
     runs: |

--- a/rust-1.81.yaml
+++ b/rust-1.81.yaml
@@ -120,6 +120,10 @@ pipeline:
       ln -srft usr/lib   usr/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.so
       ln -srft usr/lib32 usr/lib/rustlib/i686-unknown-linux-gnu/lib/*.so
 
+  - name: ensure libraries are executable for melange SCA provides generation
+    runs: |
+      chmod +x ${{targets.destdir}}/usr/lib/*.so
+
 update:
   enabled: true
   github:


### PR DESCRIPTION
- **rust-1.81: mark all installed libraries executable**
  This fixes missing provides for so:librustc_driver..... library

- **rust-1.81: Drop bogus symlinks**
  This paragraph appears to install symlinks for x86_64 & i686.
  
  However, this seems like a Debian-ism multi-arch stuff.
  
  Note in our x86_64 builds, no i686 build is performed, thus the command generated a broken symlink name `*.so` verbantim:
  
  ```
  curl -sL https://apk.cgr.dev/wolfi-presubmit/c30ab744952a5794072e2657bfddc529a54e6c61/x86_64/rust-1.81-1.81.0-r1.apk | tar -tvz usr/lib32
  d????????? ?/?               0 ????-??-?? ??:?? ..
  lrwxrwxrwx 0/0               0 2024-10-06 04:16 *.so -> ../lib/rustlib/i686-unknown-linux-gnu/lib/*.so
  ```
  
  On both x86_64 and arm64 builds.
  
  Lets drop these and observe what happens, and double check if
  rustbuild still installs duplicated files or not.
  