### PR TITLE
fix npmrc that gets shipped by default from npm

### DIFF
--- a/npm.yaml
+++ b/npm.yaml
@@ -1,7 +1,7 @@
 package:
   name: npm
   version: 10.9.0
-  epoch: 0
+  epoch: 1
   description: "the npm package manager for javascript, mainline"
   copyright:
     - license: Artistic-2.0

--- a/npm.yaml
+++ b/npm.yaml
@@ -66,6 +66,7 @@ pipeline:
       install -dDm755 "$destdir"
       rsync -av --exclude melange-out /home/build/ "$destdir"
       chmod 755 "$destdir"
+      echo 'globalconfig=/etc/npmrc' > "${{targets.destdir}}"/usr/lib/node_modules/npm/npmrc
 
   - working-directory: ${{targets.destdir}}/usr/bin
     runs: |


### PR DESCRIPTION
by default as of now, we bundle this npmrc config as of now which comes from npm itself.

```bash
/ # cat /usr/lib/node_modules/npm/npmrc
# Do not modify this file - use /etc/npmrc instead!

globalconfig=/etc/npmrc
globalignorefile=/etc/npmignore
prefix=/usr/local
python=/usr/bin/python3
```

considering FHS guidelines, we shouldn't ship things in `/usr/local` being a vendor. 

**This commit updates the `npmrc` config and after this modification the prefix is set to `/usr` now.** 
```bash
[sdk] ❯ apk add --allow-untrusted ./packages/x86_64/npm-10.9.0-r0.apk
fetch https://packages.cgr.dev/extras/x86_64/APKINDEX.tar.gz
fetch https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz
(1/6) Installing libbrotlienc1 (1.1.0-r4)
(2/6) Installing c-ares (1.33.1-r1)
(3/6) Installing icu (75.1-r0)
(4/6) Installing libuv (1.49.0-r0)
(5/6) Installing nodejs-22 (22.9.0-r0)
(6/6) Installing npm (10.9.0-r0)
OK: 1582 MiB in 102 packages
[sdk] ❯ npm prefix -g
/usr
```

- the benefit of this change would be that when we ship libraries like express and more then `npm` would be able to detect that. In the current context, that is not the case.

```bash
/ # apk add npm vite
# truncated output
(13/13) Installing vite (5.4.8-r0)
OK: 155 MiB in 27 packages
/ # npm list -g
/usr/local/lib
`-- (empty)
```
- npm out the box, looks at `/usr/local/lib` and given it's not able to find those libraries, it'll download things from the internet which breaks our moto of packagaing the javascript framework like express. I tried looking for a while if npm can work with two prefixes `/usr` and `/usr/local` but I think that's not the case from my attempt of searching and reading npm docs. Happy to take that route if it's possible. 

This is required because we have some requirement where we need to package some popular javascript framework e.g. [express](https://github.com/wolfi-dev/os/pull/29883) 

In the current context, we have some packages which ships to `/usr/local` by disabling the `usrlocal` check that comes from melange. 

refs:
https://github.com/wolfi-dev/os/blob/68137f9db16e3c70ac8dc09ed64eb954631ef684/lerna.yaml#L10
https://github.com/wolfi-dev/os/blob/68137f9db16e3c70ac8dc09ed64eb954631ef684/renovate.yaml#L10
https://github.com/wolfi-dev/os/blob/68137f9db16e3c70ac8dc09ed64eb954631ef684/npm-async.yaml#L10
https://github.com/wolfi-dev/os/blob/68137f9db16e3c70ac8dc09ed64eb954631ef684/npm-lodash.yaml#L10

After this gets merged, I intend to update the packages above and install that in the correct location.
This also goes well with our current melange `npm/install` pipeline where we set prefix to `/usr` https://github.com/chainguard-dev/melange/blob/283c45ea7df95c04d1065393b79d396782790146/pkg/build/pipelines/npm/install.yaml#L19-L22 
