### PR TITLE
fix(firefox): Don't provide bundled libraries

### DIFF
--- a/firefox.yaml
+++ b/firefox.yaml
@@ -1,10 +1,13 @@
 package:
   name: firefox
   version: "131.0"
-  epoch: 0
+  epoch: 1
   description: Firefox web browser
   copyright:
     - license: GPL-3.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND MPL-2.0
+  options:
+    # Firefox bundles libraries
+    no-provides: true
   dependencies:
     runtime:
       - mesa-gl


### PR DESCRIPTION
Set no-provides to true as Firefox bundles libraries that the resolver resolves to

I.E., instead of installing nss, Chromium was installing Firefox as it currently provides libfreeblpriv3.so