### PR TITLE
use tags for determining latest grafana

### DIFF
--- a/grafana-11.2.yaml
+++ b/grafana-11.2.yaml
@@ -76,6 +76,7 @@ update:
     identifier: grafana/grafana
     strip-prefix: v
     tag-filter-prefix: v11.2.
+    use-tag: true
 
 test:
   environment:


### PR DESCRIPTION
apparently upstream is now cutting releases with tags without the github release: https://github.com/grafana/grafana/tree/v11.2.2

I'll keep this PR scoped to just the `update` block, and handle the actual update in a follow up