### PR TITLE
Make py3-rich installation get python 3.12, not 3.13

### DIFF
--- a/py3-rich.yaml
+++ b/py3-rich.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rich
   version: 13.9.2
-  epoch: 0
+  epoch: 1
   description: "Rich is a Python library for rich text and beautiful formatting in the terminal."
   copyright:
     - license: LGPL-2.1-or-later
@@ -17,7 +17,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "313"
+      3.13: "300"
 
 environment:
   contents:

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -40,3 +40,9 @@ datadog-agent-oci-compat-7.57.1-r1.apk
 datadog-agent-s6-overlay-7.57.1-r1.apk
 datadog-cluster-agent-7.57.1-r1.apk
 datadog-cluster-agent-oci-compat-7.57.1-r1.apk
+py3-rich-13.9.2-r0.apk
+py3-supported-rich-13.9.2-r0.apk
+py3.10-rich-13.9.2-r0.apk
+py3.11-rich-13.9.2-r0.apk
+py3.12-rich-13.9.2-r0.apk
+py3.13-rich-13.9.2-r0.apk


### PR DESCRIPTION
The '313' here in the py-versions key means that installation of py3-rich will get py3.13-rich.

I noticed this because py3-hatch's test will fail. The reason for failure is that 2 different pythons are installed and the python/import test correctly expects only one to be installed.
