### PR TITLE
openjdk-N: fix build by ignoring new gcc-14 warnigns

### DIFF
--- a/openjdk-10.yaml
+++ b/openjdk-10.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-10
   version: 10.0.2
-  epoch: 4
+  epoch: 5
   description: "Oracle OpenJDK 10"
   copyright:
     - license: GPL-2.0-with-classpath-exception
@@ -40,6 +40,8 @@ environment:
       - wolfi-base
       - zip
       - zlib-dev
+  environment:
+    CFLAGS: -Wno-int-conversion
 
 pipeline:
   - uses: fetch
@@ -55,11 +57,10 @@ pipeline:
 
   - uses: patch
     with:
-      patches: aarch64.patch JDK-8241296.patch JDK-8245051.patch fix-bootjdk-check.patch gcc10-compilation-fix.patch gcc11.patch make-4.3.patch
+      patches: aarch64.patch JDK-8241296.patch JDK-8245051.patch fix-bootjdk-check.patch gcc10-compilation-fix.patch gcc11.patch make-4.3.patch extend-currency-check-to-100-years.patch
 
   - runs: |
-      CFLAGS='' CXXFLAGS='' LDFLAGS='' \
-        bash ./configure \
+      bash ./configure \
         --openjdk-target=${{host.triplet.gnu}} \
         --prefix=/usr/lib/jvm/java-10-openjdk \
         --sysconfdir=/etc \
@@ -86,11 +87,11 @@ pipeline:
         --with-vendor-url="https://wolfi.dev" \
         --with-vendor-bug-url="https://github.com/wolfi-dev/os/issues" \
         --with-vendor-vm-bug-url="https://github.com/wolfi-dev/os/issues" \
-        --with-extra-cflags="-fno-delete-null-pointer-checks -fno-strict-aliasing" \
+        --with-extra-cflags="-fno-delete-null-pointer-checks -fno-strict-aliasing -Wno-int-conversion" \
         --with-extra-cxxflags="-fno-delete-null-pointer-checks -fno-strict-aliasing" \
         --with-extra-ldflags="$LDFLAGS"
 
-      MAKEFLAGS='' make jdk-image
+      make JOBS=$(nproc) jdk-image
 
   # Check we built something valid
   - runs: |

--- a/openjdk-10/extend-currency-check-to-100-years.patch
+++ b/openjdk-10/extend-currency-check-to-100-years.patch
@@ -1,0 +1,15 @@
+diff --git a/make/jdk/src/classes/build/tools/generatecurrencydata/GenerateCurrencyData.java b/make/jdk/src/classes/build/tools/generatecurrencydata/GenerateCurrencyData.java
+index ae861c5ab..602a82076 100644
+--- a/make/jdk/src/classes/build/tools/generatecurrencydata/GenerateCurrencyData.java
++++ b/make/jdk/src/classes/build/tools/generatecurrencydata/GenerateCurrencyData.java
+@@ -284,8 +284,8 @@ public class GenerateCurrencyData {
+             checkCurrencyCode(newCurrency);
+             String timeString = currencyInfo.substring(4, length - 4);
+             long time = format.parse(timeString).getTime();
+-            if (Math.abs(time - System.currentTimeMillis()) > ((long) 10) * 365 * 24 * 60 * 60 * 1000) {
+-                throw new RuntimeException("time is more than 10 years from present: " + time);
++            if (Math.abs(time - System.currentTimeMillis()) > ((long) 100) * 365 * 24 * 60 * 60 * 1000) {
++                throw new RuntimeException("time is more than 100 years from present: " + time);
+             }
+             specialCaseCutOverTimes[specialCaseCount] = time;
+             specialCaseOldCurrencies[specialCaseCount] = oldCurrency;

--- a/openjdk-12.yaml
+++ b/openjdk-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-12
   version: 12.0.2.10
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-only
@@ -40,6 +40,8 @@ environment:
       - openjdk-11-default-jvm
       - zip
       - zlib-dev
+  environment:
+    CFLAGS: -Wno-int-conversion
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL
 var-transforms:

--- a/openjdk-7.yaml
+++ b/openjdk-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-7
   version: 7.321.2.6.28
-  epoch: 3
+  epoch: 4
   description: "IcedTea distribution of OpenJDK 7 (UNSUPPORTED)"
   copyright:
     - license: GPL-2.0-or-later
@@ -62,6 +62,8 @@ environment:
       - util-linux-dev
       - wolfi-base
       - zip
+  environment:
+    CFLAGS: -Wno-incompatible-pointer-types -Wno-int-conversion
 
 pipeline:
   - uses: fetch

--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.422.05 # this corresponds to same release as jdk8u422-ga / jdk8u422-b05
-  epoch: 0
+  epoch: 1
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later
@@ -65,6 +65,8 @@ environment:
       - wolfi-base
       - zip
       - zlib-dev
+  environment:
+    CFLAGS: -Wno-int-conversion -Wno-incompatible-pointer-types
 
 pipeline:
   - uses: fetch


### PR DESCRIPTION
Related: https://github.com/wolfi-dev/os/issues/26401