### PR TITLE
fix cves and upgrade opensearch-dashboards-2

### DIFF
--- a/opensearch-dashboards-2.yaml
+++ b/opensearch-dashboards-2.yaml
@@ -1,6 +1,6 @@
 package:
   name: opensearch-dashboards-2
-  version: 2.17.0 # when updating please check if we can remove the patched package.json for the reporting plugin
+  version: 2.17.1 # when updating please check if we can remove the patched package.json for the reporting plugin
   epoch: 0
   description: Open source visualization dashboards for OpenSearch
   copyright:
@@ -20,6 +20,7 @@ environment:
       - gcc-12
       - gcc-12-default
       - git
+      - jq
       - node-gyp
       - nodejs-18
       - npm
@@ -54,7 +55,7 @@ pipeline:
     with:
       repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
       tag: ${{package.version}}
-      expected-commit: 66369eb405516ab49de56f0d86ef4c5fb8ea031d
+      expected-commit: 62cc0320399aef63aa09689aaaf000adafbedeef
       cherry-picks: |
         main/5e19749ec40230316ba2688c38e5c62f74ddb71d: CVE-2024-37890
 
@@ -76,7 +77,17 @@ pipeline:
       # Our commond LDFLAGS cause some issues when building for aarch64. We
       # unset our global flags to allow the build to succeed.
       unset LDFLAGS
-      yarn osd bootstrap --allow-root
+
+      # fix CVE-2024-47764
+      resolutions='{"**/cookie": "^0.7.0"}'
+      jq --argjson resolutions "$resolutions" '.resolutions += $resolutions' package.json > temp.json && mv temp.json package.json
+
+      # fix CVE-2024-45801
+      devDependencies='{"dompurify": "^3.1.3"}'
+      jq --argjson devDependencies "$devDependencies" '.devDependencies += $devDependencies' package.json > temp.json && mv temp.json package.json
+
+      yarn osd bootstrap --allow-root --silent 2>/dev/null
+
       yarn build-platform --skip-os-packages --skip-archives --release --allow-root
 
       # Delete the node directory to ensure we use the system node.
@@ -99,7 +110,7 @@ subpackages:
           repository: https://github.com/opensearch-project/opensearch-build
           tag: ${{package.version}}
           destination: opensearch-build
-          expected-commit: 1ffb57f9588a9ec06062cdac2304eb355e5656de # will need to be manually updated when opensearch dashboard auto update happens
+          expected-commit: d0abadc62f63b10a6ed683950451a65f5c2cd457 # will need to be manually updated when opensearch dashboard auto update happens
       - runs: |
           install -Dm755 opensearch-build/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-2.x.sh ${{targets.contextdir}}/usr/share/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
           install -Dm655 opensearch-build/config/opensearch_dashboards-2.x.yml ${{targets.contextdir}}/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml
@@ -118,16 +129,17 @@ subpackages:
           tag: ${{package.version}}.0
           destination: ./plugins/${{range.value}}
       - runs: |
-          # fix CVE-2024-37890
+          # fix cve CVE-2024-45801
+          cd ./plugins/${{range.value}}
           if [ ${{range.value}} = "reportsDashboards" ]
           then
-            # Modify package.json using sed
-            sed -i 's/"ws": "^7.4.6"/"ws": "^7.5.10"/' ./plugins/${{range.value}}/package.json
+            # Define the dependencies
+            dependencies='{"dompurify": "^3.1.3"}'
+            # Apply the dependencies
+            jq --argjson dependencies "$dependencies" '.dependencies += $dependencies' package.json > temp.json && mv temp.json package.json
           fi
 
-          yarn osd bootstrap --allow-root
-          cd ./plugins/${{range.value}}
-
+          yarn osd bootstrap --allow-root --silent 2>/dev/null
           node /home/build/scripts/plugin_helpers build --allow-root --skip-archive
 
           if [ ${{range.value}} = "reportsDashboards" ]


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
