### PR TITLE
Add new python package - py3-propcache

### DIFF
--- a/py3-propcache.yaml
+++ b/py3-propcache.yaml
@@ -1,0 +1,84 @@
+package:
+  name: py3-propcache
+  version: 0.2.0
+  epoch: 0
+  description: Fast property caching
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: propcache
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - py3-supported-cython
+      - py3-supported-expandvars
+      - py3-supported-pip
+      - py3-supported-python-dev
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: f157b0a7b0b3a3c755764b9f03f4d90c43ee5cda
+      repository: https://github.com/aio-libs/propcache
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-idna
+        - py${{range.key}}-multidict
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: ${{vars.pypi-package}}
+
+update:
+  enabled: true
+  github:
+    identifier: aio-libs/propcache
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
Adds a new python package: py3-propcache. The primary reason for adding this, was due to a new buildtime dependency introduced by the following (existing) package: https://github.com/wolfi-dev/os/pull/30252.

Theres more info about the buildtime [dependency introduction here](https://github.com/aio-libs/yarl/pull/1169). 
