### PR TITLE
pyarrow - make multi-version python

### DIFF
--- a/pyarrow.yaml
+++ b/pyarrow.yaml
@@ -1,26 +1,32 @@
 package:
   name: pyarrow
   version: 17.0.0
-  epoch: 1
+  epoch: 2
   description: "Apache Arrow Python bindings"
   copyright:
     - license: Apache-2.0
+
+vars:
+  pypi-package: pyarrow
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
       - apache-arrow-dev
-      - build-base
-      - busybox
-      - ca-certificates-bundle
       - cmake
       - cython
-      - numpy
       - openssl-dev
-      - py3-pip
-      - py3-setuptools
-      - python3
-      - python3-dev
+      - py3-supported-build-base-dev
+      - py3-supported-cython
+      - py3-supported-numpy
 
 pipeline:
   - uses: git-checkout
@@ -30,16 +36,45 @@ pipeline:
       tag: apache-arrow-${{package.version}}
       expected-commit: 6a2e19a852b367c72d7b12da4d104456491ed8b7
 
-  - name: Build python
-    working-directory: /home/build/apache-arrow/python
-    runs: |
-      export PYARROW_PARALLEL=4
-      python setup.py build_ext --inplace \
-        --with-acero \
-        --with-parquet
-      _py3ver=$(python3 -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
-      mkdir -p ${{targets.destdir}}/usr/lib/python"$_py3ver"/site-packages
-      cp -R pyarrow ${{targets.destdir}}/usr/lib/python"$_py3ver"/site-packages
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-numpy
+    pipeline:
+      - working-directory: /home/build/apache-arrow/python
+        environment:
+          PYARROW_PARALLEL: "4"
+          PYARROW_WITH_PARQUET: "1"
+          PYARROW_WITH_ACERO: "1"
+        pipeline:
+          - uses: py/pip-build-install
+            with:
+              python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import pyarrow
+              from pyarrow import acero
+              from pyarrow import parquet
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true


### PR DESCRIPTION
This
 * makes multi-version
 * adds some import tests.
 * adds runtime dep on numpy

the changes from `--with-acero` to PYARROW_WITH_ACERO allow us to utilize the py/pip-build-install pipeline.
