### PR TITLE
feat(package): docker-selenium-hub addition and selenium-chromium cleanup

### DIFF
--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -42,6 +42,7 @@ environment:
       - openjdk-11-jre
       - openssl
       - yq
+      - x11vnc
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
     TC: UTC
@@ -123,16 +124,6 @@ subpackages:
   # we can skip adding chromium, Xvfb, fluxbox, and related font packages.
   - name: docker-selenium-hub
     description: Docker Selenium Hub
-    dependencies:
-      runtime:
-        - bash
-        - busybox
-        - coreutils
-        - openjdk-11
-        - selenium-server-compat
-        - sudo-rs
-        - supervisor
-        - tzdata
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bin
@@ -149,11 +140,8 @@ subpackages:
     dependencies:
       runtime:
         - Xvfb
-        - bash
-        - busybox
         - chromium
         - chromium-docker-selenium-compat
-        - coreutils
         - fluxbox
         - font-ipa
         - font-liberation
@@ -174,11 +162,7 @@ subpackages:
         - novnc
         - openjdk-11
         - pulseaudio
-        - selenium-server-compat
-        - sudo-rs
-        - supervisor
         - ttf-dejavu
-        - tzdata
         - websockify
         - x11vnc
         - xauth
@@ -194,31 +178,32 @@ subpackages:
       - working-directory: NodeBase
         pipeline:
           - runs: |
-              install -Dm755 start-selenium-node.sh ${{targets.subpkgdir}}/opt/bin/
-              install -Dm755 start-xvfb.sh ${{targets.subpkgdir}}/opt/bin/
-              install -Dm755 selenium.conf ${{targets.subpkgdir}}/etc/supervisor/conf.d/
-              install -Dm755 start-vnc.sh ${{targets.subpkgdir}}/opt/bin/
-              install -Dm755 start-novnc.sh ${{targets.subpkgdir}}/opt/bin/
-              install -Dm755 selenium_grid_logo.png ${{targets.subpkgdir}}/usr/share/images/fluxbox/ubuntu-light.png
-              install -Dm755 generate_config ${{targets.subpkgdir}}/opt/bin/generate_config
+              mkdir -p ${{targets.subpkgdir}}/etc/supervisor/conf.d
+              mkdir -p ${{targets.subpkgdir}}/usr/share/images/fluxbox
+              cp start-selenium-node.sh ${{targets.subpkgdir}}/opt/bin/
+              cp start-xvfb.sh ${{targets.subpkgdir}}/opt/bin/
+              cp selenium.conf ${{targets.subpkgdir}}/etc/supervisor/conf.d/
+              cp start-vnc.sh ${{targets.subpkgdir}}/opt/bin/
+              cp start-novnc.sh ${{targets.subpkgdir}}/opt/bin/
+              cp selenium_grid_logo.png ${{targets.subpkgdir}}/usr/share/images/fluxbox/ubuntu-light.png
 
               mkdir -p ${{targets.subpkgdir}}/home/$SEL_USER/.fluxbox
               mkdir -p ${{targets.subpkgdir}}/tmp/.X11-unix
               mkdir -p ${{targets.subpkgdir}}/home/$SEL_USER/.vnc
               mkdir -p ${{targets.subpkgdir}}/opt/selenium
-              x11vnc -storepasswd $(cat ${{targets.subpkgdir}}/opt/selenium/initialPasswd) ${{targets.subpkgdir}}/home/$SEL_USER/.vnc/passwd
+              mkdir -p ${{targets.subpkgdir}}/opt/selenium
+              echo "${SEL_PASSWD}" | x11vnc -storepasswd - ${{targets.subpkgdir}}/home/$SEL_USER/.vnc/passwd
       # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/NodeChrome/Dockerfile
       - working-directory: NodeChrome
         pipeline:
           - runs: |
-              install -Dm755 wrap_chrome_binary ${{targets.subpkgdir}}/opt/bin/wrap_chrome_binary
+              cp wrap_chrome_binary ${{targets.subpkgdir}}/opt/bin/wrap_chrome_binary
       # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/Standalone/Dockerfile
       - working-directory: Standalone
         pipeline:
           - runs: |
-              install -Dm755 start-selenium-standalone.sh ${{targets.subpkgdir}}/opt/bin/start-selenium-standalone.sh
-              install -Dm755 selenium.conf ${{targets.subpkgdir}}/etc/supervisor/conf.d/
-              install -Dm755 generate_config ${{targets.subpkgdir}}/opt/bin/generate_config
+              cp start-selenium-standalone.sh ${{targets.subpkgdir}}/opt/bin/start-selenium-standalone.sh
+              cp selenium.conf ${{targets.subpkgdir}}/etc/supervisor/conf.d/
 
 update:
   enabled: true

--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -41,8 +41,8 @@ environment:
       - openjdk-11-default-jvm
       - openjdk-11-jre
       - openssl
-      - yq
       - x11vnc
+      - yq
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
     TC: UTC
@@ -204,6 +204,7 @@ subpackages:
           - runs: |
               cp start-selenium-standalone.sh ${{targets.subpkgdir}}/opt/bin/start-selenium-standalone.sh
               cp selenium.conf ${{targets.subpkgdir}}/etc/supervisor/conf.d/
+              cp generate_config ${{targets.subpkgdir}}/opt/bin/generate_config
 
 update:
   enabled: true

--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -162,6 +162,7 @@ subpackages:
         - novnc
         - openjdk-11
         - pulseaudio
+        - pulseaudio-utils
         - ttf-dejavu
         - websockify
         - x11vnc
@@ -186,6 +187,7 @@ subpackages:
               cp start-vnc.sh ${{targets.subpkgdir}}/opt/bin/
               cp start-novnc.sh ${{targets.subpkgdir}}/opt/bin/
               cp selenium_grid_logo.png ${{targets.subpkgdir}}/usr/share/images/fluxbox/ubuntu-light.png
+              cp generate_relay_config ${{targets.subpkgdir}}/opt/bin/generate_relay_config
 
               mkdir -p ${{targets.subpkgdir}}/home/$SEL_USER/.fluxbox
               mkdir -p ${{targets.subpkgdir}}/tmp/.X11-unix

--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -127,6 +127,7 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/opt/bin
+          mkdir -p ${{targets.subpkgdir}}/opt/selenium
       # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/Hub/Dockerfile
       - working-directory: Hub
         pipeline:
@@ -134,6 +135,7 @@ subpackages:
               mkdir -p ${{targets.subpkgdir}}/etc/supervisor/conf.d
               cp selenium-grid-hub.conf ${{targets.subpkgdir}}/etc/supervisor/conf.d/
               install -Dm755 start-selenium-grid-hub.sh ${{targets.subpkgdir}}/opt/bin/
+              cp example-config.toml ${{targets.subpkgdir}}/opt/selenium/config.toml
 
   - name: docker-selenium-standalone-chrome
     description: Docker Selenium supervisor configuration

--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -5,7 +5,7 @@ package:
   # 'package format error' when trying to install the package. The workaround is
   # to replace '-' with '.', then mangling the version to replace back.
   version: 4.25.0.20240922
-  epoch: 0
+  epoch: 1
   description: Provides a simple way to run Selenium Grid with Chrome, Firefox, and Edge using Docker, making it easier to perform browser automation
   copyright:
     - license: Apache-2.0
@@ -15,44 +15,14 @@ package:
     - x86_64
   dependencies:
     runtime:
-      - Xvfb
       - bash
       - busybox
-      - chromium
-      - chromium-docker-selenium-compat
       - coreutils
-      - fluxbox
-      - font-ipa
-      - font-liberation
-      - font-misc-cyrillic
-      - font-noto-emoji
-      - font-ubuntu
-      - font-wqy-zenhei
-      - fontconfig
-      - freetype
-      - glib
-      - glibc-locale-en
-      - libfontconfig1
-      - libgcc
-      - libnss
-      - libnss-tools
-      - libxcb
-      - mcookie
-      - novnc
       - openjdk-11
-      - pulseaudio
       - selenium-server-compat
       - sudo-rs
       - supervisor
-      - ttf-dejavu
       - tzdata
-      - websockify
-      - x11vnc
-      - xauth
-      - xkbcomp
-      - xkeyboard-config
-      - xmessage
-      - xvfb-run
 
 environment:
   contents:
@@ -71,7 +41,6 @@ environment:
       - openjdk-11-default-jvm
       - openjdk-11-jre
       - openssl
-      - x11vnc
       - yq
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
@@ -129,38 +98,6 @@ pipeline:
             io.netty:netty-codec-http:4.1.108.Final \
             io.grpc:grpc-netty:${GRPC_VERSION} > ${{targets.destdir}}/external_jars/.classpath.txt
 
-  # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/NodeBase/Dockerfile
-  - working-directory: NodeBase
-    pipeline:
-      - runs: |
-          install -Dm755 start-selenium-node.sh ${{targets.destdir}}/opt/bin/
-          install -Dm755 start-xvfb.sh ${{targets.destdir}}/opt/bin/
-          install -Dm755 selenium.conf ${{targets.destdir}}/etc/supervisor/conf.d/
-          install -Dm755 start-vnc.sh ${{targets.destdir}}/opt/bin/
-          install -Dm755 start-novnc.sh ${{targets.destdir}}/opt/bin/
-          install -Dm755 selenium_grid_logo.png ${{targets.destdir}}/usr/share/images/fluxbox/ubuntu-light.png
-          install -Dm755 generate_config ${{targets.destdir}}/opt/bin/generate_config
-
-          mkdir -p ${{targets.destdir}}/home/$SEL_USER/.fluxbox
-          mkdir -p ${{targets.destdir}}/tmp/.X11-unix
-          mkdir -p ${{targets.destdir}}/home/$SEL_USER/.vnc
-          mkdir -p ${{targets.destdir}}/opt/selenium
-          x11vnc -storepasswd $(cat ${{targets.destdir}}/opt/selenium/initialPasswd) ${{targets.destdir}}/home/$SEL_USER/.vnc/passwd
-
-  # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/NodeChrome/Dockerfile
-  - working-directory: NodeChrome
-    pipeline:
-      - runs: |
-          install -Dm755 wrap_chrome_binary ${{targets.destdir}}/opt/bin/wrap_chrome_binary
-
-  # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/Standalone/Dockerfile
-  - working-directory: Standalone
-    pipeline:
-      - runs: |
-          install -Dm755 start-selenium-standalone.sh ${{targets.destdir}}/opt/bin/start-selenium-standalone.sh
-          install -Dm755 selenium.conf ${{targets.destdir}}/etc/supervisor/conf.d/
-          install -Dm755 generate_config ${{targets.destdir}}/opt/bin/generate_config
-
   - uses: strip
 
 subpackages:
@@ -181,6 +118,107 @@ subpackages:
           # jason@ copied this directly from https://serverfault.com/a/238964
           # The extra 0 is to unset the setuid bit apparently.
           chmod 00775 ${{targets.subpkgdir}}/etc/supervisord.conf
+
+  # selenium-hub does not handle rendering or direct interaction with browsers
+  # we can skip adding chromium, Xvfb, fluxbox, and related font packages.
+  - name: docker-selenium-hub
+    description: Docker Selenium Hub
+    dependencies:
+      runtime:
+        - bash
+        - busybox
+        - coreutils
+        - openjdk-11
+        - selenium-server-compat
+        - sudo-rs
+        - supervisor
+        - tzdata
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/opt/bin
+      # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/Hub/Dockerfile
+      - working-directory: Hub
+        pipeline:
+          - runs: |
+              mkdir -p ${{targets.subpkgdir}}/etc/supervisor/conf.d
+              cp selenium-grid-hub.conf ${{targets.subpkgdir}}/etc/supervisor/conf.d/
+              install -Dm755 start-selenium-grid-hub.sh ${{targets.subpkgdir}}/opt/bin/
+
+  - name: docker-selenium-standalone-chrome
+    description: Docker Selenium supervisor configuration
+    dependencies:
+      runtime:
+        - Xvfb
+        - bash
+        - busybox
+        - chromium
+        - chromium-docker-selenium-compat
+        - coreutils
+        - fluxbox
+        - font-ipa
+        - font-liberation
+        - font-misc-cyrillic
+        - font-noto-emoji
+        - font-ubuntu
+        - font-wqy-zenhei
+        - fontconfig
+        - freetype
+        - glib
+        - glibc-locale-en
+        - libfontconfig1
+        - libgcc
+        - libnss
+        - libnss-tools
+        - libxcb
+        - mcookie
+        - novnc
+        - openjdk-11
+        - pulseaudio
+        - selenium-server-compat
+        - sudo-rs
+        - supervisor
+        - ttf-dejavu
+        - tzdata
+        - websockify
+        - x11vnc
+        - xauth
+        - xkbcomp
+        - xkeyboard-config
+        - xmessage
+        - xvfb-run
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/etc
+          mkdir -p ${{targets.subpkgdir}}/opt/bin
+      # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/NodeBase/Dockerfile
+      - working-directory: NodeBase
+        pipeline:
+          - runs: |
+              install -Dm755 start-selenium-node.sh ${{targets.subpkgdir}}/opt/bin/
+              install -Dm755 start-xvfb.sh ${{targets.subpkgdir}}/opt/bin/
+              install -Dm755 selenium.conf ${{targets.subpkgdir}}/etc/supervisor/conf.d/
+              install -Dm755 start-vnc.sh ${{targets.subpkgdir}}/opt/bin/
+              install -Dm755 start-novnc.sh ${{targets.subpkgdir}}/opt/bin/
+              install -Dm755 selenium_grid_logo.png ${{targets.subpkgdir}}/usr/share/images/fluxbox/ubuntu-light.png
+              install -Dm755 generate_config ${{targets.subpkgdir}}/opt/bin/generate_config
+
+              mkdir -p ${{targets.subpkgdir}}/home/$SEL_USER/.fluxbox
+              mkdir -p ${{targets.subpkgdir}}/tmp/.X11-unix
+              mkdir -p ${{targets.subpkgdir}}/home/$SEL_USER/.vnc
+              mkdir -p ${{targets.subpkgdir}}/opt/selenium
+              x11vnc -storepasswd $(cat ${{targets.subpkgdir}}/opt/selenium/initialPasswd) ${{targets.subpkgdir}}/home/$SEL_USER/.vnc/passwd
+      # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/NodeChrome/Dockerfile
+      - working-directory: NodeChrome
+        pipeline:
+          - runs: |
+              install -Dm755 wrap_chrome_binary ${{targets.subpkgdir}}/opt/bin/wrap_chrome_binary
+      # https://github.com/SeleniumHQ/docker-selenium/blob/trunk/Standalone/Dockerfile
+      - working-directory: Standalone
+        pipeline:
+          - runs: |
+              install -Dm755 start-selenium-standalone.sh ${{targets.subpkgdir}}/opt/bin/start-selenium-standalone.sh
+              install -Dm755 selenium.conf ${{targets.subpkgdir}}/etc/supervisor/conf.d/
+              install -Dm755 generate_config ${{targets.subpkgdir}}/opt/bin/generate_config
 
 update:
   enabled: true


### PR DESCRIPTION
Untethering Chromium from our Docker Selenium package in this PR and adding selenium-hub

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
