### PR TITLE
Add otel-plugin-nginx, otel-cpp

### DIFF
--- a/opentelemetry-cpp.yaml
+++ b/opentelemetry-cpp.yaml
@@ -1,0 +1,49 @@
+package:
+  name: opentelemetry-cpp
+  version: 1.17.0
+  epoch: 0
+  description: The OpenTelemetry C++ Client
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - abseil-cpp-dev
+      - benchmark-dev
+      - busybox
+      - c-ares-dev
+      - cmake
+      - gcc
+      - glibc-dev
+      - grpc-dev
+      - gtest-dev
+      - icu-dev
+      - make
+      - openssl-dev
+      - pkgconf
+      - protobuf-dev
+      - re2-dev
+      - systemd-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/open-telemetry/opentelemetry-cpp
+      tag: v${{package.version}}
+      expected-commit: fa0a5200ddbe9ae6f487a228e658aedc102dab56
+
+  - runs: |
+      mkdir build
+      cd build
+      cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=ON -DWITH_OTLP_GRPC=ON -DWITH_ABSEIL=ON ..
+      cmake --build . --target all
+      cmake --install . --prefix ${{targets.contextdir}}/usr
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: open-telemetry/opentelemetry-cpp
+    strip-prefix: v

--- a/opentelemetry-cpp.yaml
+++ b/opentelemetry-cpp.yaml
@@ -32,13 +32,25 @@ pipeline:
       repository: https://github.com/open-telemetry/opentelemetry-cpp
       tag: v${{package.version}}
       expected-commit: fa0a5200ddbe9ae6f487a228e658aedc102dab56
+
   - uses: cmake/configure
     with:
       opts: -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=ON -DWITH_OTLP_GRPC=ON -DWITH_ABSEIL=ON
+
   - uses: cmake/build
+
   - uses: cmake/install
 
   - uses: strip
+
+subpackages:
+  - name: opentelemetry-cpp-dev
+    description: The OpenTelemetry C++ Client development files
+    dependencies:
+      runtime:
+        - opentelemetry-cpp
+    pipeline:
+      - uses: split/dev
 
 update:
   enabled: true

--- a/opentelemetry-cpp.yaml
+++ b/opentelemetry-cpp.yaml
@@ -32,13 +32,11 @@ pipeline:
       repository: https://github.com/open-telemetry/opentelemetry-cpp
       tag: v${{package.version}}
       expected-commit: fa0a5200ddbe9ae6f487a228e658aedc102dab56
-
-  - runs: |
-      mkdir build
-      cd build
-      cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=ON -DWITH_OTLP_GRPC=ON -DWITH_ABSEIL=ON ..
-      cmake --build . --target all
-      cmake --install . --prefix ${{targets.contextdir}}/usr
+  - uses: cmake/configure
+    with:
+      opts: -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=ON -DWITH_OTLP_GRPC=ON -DWITH_ABSEIL=ON
+  - uses: cmake/build
+  - uses: cmake/install
 
   - uses: strip
 

--- a/opentelemetry-plugin-nginx.yaml
+++ b/opentelemetry-plugin-nginx.yaml
@@ -1,0 +1,125 @@
+#nolint:valid-pipeline-git-checkout-tag
+package:
+  name: opentelemetry-plugin-nginx
+  version: 0_git20241009
+  epoch: 0
+  description: Adds OpenTelemetry distributed tracing support to nginx. This is the otel community plugin for nginx, not the official nginx plugin for otel.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - opentelemetry-cpp
+
+environment:
+  contents:
+    packages:
+      - abseil-cpp-dev
+      - busybox
+      - c-ares-dev
+      - cmake
+      - curl-dev
+      - gcc
+      - glibc-dev
+      - grpc-dev
+      - icu-dev
+      - make
+      - nginx
+      - opentelemetry-cpp
+      - pcre-dev
+      - protobuf-c-dev
+      - protobuf-dev
+      - re2-dev
+      - systemd-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/open-telemetry/opentelemetry-cpp-contrib
+      branch: main
+      expected-commit: f6d29426ee9b4d6b476c09ca3cb9bed3cf23906f
+
+  - runs: |
+      cd instrumentation/nginx
+
+      mkdir build
+      cd build
+      cmake ..
+      make
+
+      mkdir -p ${{targets.contextdir}}/usr/share/nginx/modules
+      cp -p otel_ngx_module.so ${{targets.contextdir}}/usr/share/nginx/modules/
+
+  - uses: strip
+
+update:
+  enabled: true
+  git: {}
+  schedule:
+    period: weekly
+    reason: shared contrib repo that doesn't maintain tags for this component
+
+test:
+  environment:
+    contents:
+      packages:
+        - nginx
+  pipeline:
+    - uses: git-checkout
+      with:
+        repository: https://github.com/open-telemetry/opentelemetry-cpp-contrib
+        branch: main
+        expected-commit: f6d29426ee9b4d6b476c09ca3cb9bed3cf23906f
+    - runs: |
+        cat <<EOF > /etc/nginx/nginx.conf
+        load_module /usr/share/nginx/modules/otel_ngx_module.so;
+
+        user nobody;
+
+        http {
+          opentelemetry_config /etc/nginx/otel-nginx.toml;
+
+          server {
+            listen 80;
+            server_name otel_example;
+
+            root /var/www/html;
+
+            location = / {
+              opentelemetry_operation_name my_example_backend;
+              opentelemetry_propagate;
+              proxy_pass http://localhost:3500/;
+            }
+          }
+        }
+        events {}
+        EOF
+
+        cat <<EOF > /etc/nginx/otel-nginx.toml
+        exporter = "otlp"
+        processor = "batch"
+
+        [exporters.otlp]
+        # Alternatively the OTEL_EXPORTER_OTLP_ENDPOINT environment variable can also be used.
+        host = "localhost"
+        port = 4317
+
+        [processors.batch]
+        max_queue_size = 2048
+        schedule_delay_millis = 5000
+        max_export_batch_size = 512
+
+        [service]
+        # Can also be set by the OTEL_SERVICE_NAME environment variable.
+        name = "nginx-proxy" # Opentelemetry resource name
+
+        [sampler]
+        name = "AlwaysOn" # Also: AlwaysOff, TraceIdRatioBased
+        ratio = 0.1
+        parent_based = false
+        EOF
+
+        # Not sure why this isn't included in main package.
+        mkdir -p /var/lib/nginx/tmp/
+    # -T: test the configuration file: nginx checks the configuration for correct syntax, and then tries to open files referred in the configuration.
+    # additionally dump configuration files to standard output (1.9.2).
+    - runs: nginx -T

--- a/opentelemetry-plugin-nginx.yaml
+++ b/opentelemetry-plugin-nginx.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: opentelemetry-plugin-nginx
-  version: 0_git20241009
+  version: 0_git20241010
   epoch: 0
   description: Adds OpenTelemetry distributed tracing support to nginx. This is the otel community plugin for nginx, not the official nginx plugin for otel.
   copyright:
@@ -24,7 +24,7 @@ environment:
       - icu-dev
       - make
       - nginx
-      - opentelemetry-cpp
+      - opentelemetry-cpp-dev
       - pcre-dev
       - protobuf-c-dev
       - protobuf-dev
@@ -40,8 +40,10 @@ pipeline:
 
   - uses: cmake/configure
     working-directory: instrumentation/nginx
+
   - uses: cmake/build
     working-directory: instrumentation/nginx
+
   - runs: |
       mkdir -p ${{targets.contextdir}}/usr/share/nginx/modules
       cp -p otel_ngx_module.so ${{targets.contextdir}}/usr/share/nginx/modules/

--- a/opentelemetry-plugin-nginx.yaml
+++ b/opentelemetry-plugin-nginx.yaml
@@ -38,16 +38,14 @@ pipeline:
       branch: main
       expected-commit: f6d29426ee9b4d6b476c09ca3cb9bed3cf23906f
 
+  - uses: cmake/configure
+    working-directory: instrumentation/nginx
+  - uses: cmake/build
+    working-directory: instrumentation/nginx
   - runs: |
-      cd instrumentation/nginx
-
-      mkdir build
-      cd build
-      cmake ..
-      make
-
       mkdir -p ${{targets.contextdir}}/usr/share/nginx/modules
       cp -p otel_ngx_module.so ${{targets.contextdir}}/usr/share/nginx/modules/
+    working-directory: instrumentation/nginx/output
 
   - uses: strip
 


### PR DESCRIPTION
- Adds opentelemetry-cpp: c++ client for otel (dependency for otel-plugin-nginx).
- Adds otel-plugin-nginx
- Modifies protobuf to disable generation of libupb. This is a static internal dependency of protobuf. If this ends up being load bearing for php and python protobuf packages, we should repackage this into a subpackage.

> [!NOTE]  
> This is the [community otel nginx plugin](https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/nginx) that was [used in ingress-nginx](https://github.com/kubernetes/ingress-nginx/blob/f369ffb0734cc63fdf85959c4e41be0606ca8f1e/images/opentelemetry/rootfs/build.sh#L129-L143). This is **not** the [official nginx otel plugin](https://github.com/nginxinc/nginx-otel).

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->


Related: https://github.com/chainguard-dev/image-requests/issues/4407

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] This PR links to the upstream project's support policy (e.g. `endoflife.date`)