### PR TITLE
protobuf: bump to 3.28.2, disable upb.

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco
   version: 0.39.1 # on update check if we can remove the 'Patch falcosecurity-libs' pipeline below if https://github.com/falcosecurity/libs/pull/2079 is merged
-  epoch: 0
+  epoch: 1
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0

--- a/grpc.yaml
+++ b/grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc
-  version: 1.66.2
-  epoch: 0
+  version: 1.67.0
+  epoch: 2
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -48,7 +48,7 @@ pipeline:
     with:
       repository: https://github.com/grpc/grpc
       tag: v${{package.version}}
-      expected-commit: f686ffe7e703fb1440dabea419579e566a8becc3
+      expected-commit: 74f245857247b4b3e28a753d85d06ae2d5a55434
 
   - runs: |
       cd third_party

--- a/php-8.1-grpc.yaml
+++ b/php-8.1-grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-grpc
-  version: 1.66.2
-  epoch: 1
+  version: 1.67.0
+  epoch: 0
   description: "A PHP extension for gRPC"
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ pipeline:
     with:
       repository: https://github.com/grpc/grpc
       tag: "v${{package.version}}"
-      expected-commit: f686ffe7e703fb1440dabea419579e566a8becc3
+      expected-commit: 74f245857247b4b3e28a753d85d06ae2d5a55434
 
   - name: Prepare build
     runs: cd src/php/ext/grpc && phpize

--- a/php-8.2-grpc.yaml
+++ b/php-8.2-grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-grpc
-  version: 1.66.2
-  epoch: 1
+  version: 1.67.0
+  epoch: 0
   description: "A PHP extension for gRPC"
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ pipeline:
     with:
       repository: https://github.com/grpc/grpc
       tag: "v${{package.version}}"
-      expected-commit: f686ffe7e703fb1440dabea419579e566a8becc3
+      expected-commit: 74f245857247b4b3e28a753d85d06ae2d5a55434
 
   - name: Prepare build
     runs: cd src/php/ext/grpc && phpize

--- a/php-8.3-grpc.yaml
+++ b/php-8.3-grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-grpc
-  version: 1.66.2
-  epoch: 1
+  version: 1.67.0
+  epoch: 0
   description: "A PHP extension for gRPC"
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ pipeline:
     with:
       repository: https://github.com/grpc/grpc
       tag: "v${{package.version}}"
-      expected-commit: f686ffe7e703fb1440dabea419579e566a8becc3
+      expected-commit: 74f245857247b4b3e28a753d85d06ae2d5a55434
 
   - name: Prepare build
     runs: cd src/php/ext/grpc && phpize

--- a/protobuf-c.yaml
+++ b/protobuf-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf-c
   version: 1.5.0
-  epoch: 9
+  epoch: 11
   description: Protocol Buffers implementation in C
   copyright:
     - license: BSD-2-Clause

--- a/protobuf.yaml
+++ b/protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf
-  version: 3.27.4
-  epoch: 0
+  version: 3.28.2
+  epoch: 2
   description: Library for extensible, efficient structure packing
   copyright:
     - license: BSD-3-Clause
@@ -34,7 +34,7 @@ pipeline:
     with:
       repository: https://github.com/protocolbuffers/protobuf
       tag: v${{package.version}}
-      expected-commit: 80d48ae92d3007caac5eab0a8f8ee4e57f3a921e
+      expected-commit: 9fff46d7327c699ef970769d5c9fd0e44df08fc7
 
   - runs: |
       cd third_party
@@ -47,7 +47,8 @@ pipeline:
         -DBUILD_SHARED_LIBS=True \
         -DCMAKE_BUILD_TYPE=Release \
         -Dprotobuf_ABSL_PROVIDER=package \
-        -Dprotobuf_BUILD_TESTS=OFF
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -Dprotobuf_BUILD_LIBUPB=OFF
       ninja -C build
       DESTDIR=${{targets.destdir}} ninja -C build install
 
@@ -79,8 +80,8 @@ subpackages:
         - name: Verify protoc installation
           runs: |
             protoc --version || exit 1
-            protoc-27.4.0 --version
-            protoc-27.4.0 --help
+            protoc-28.2.0 --version
+            protoc-28.2.0 --help
         - name: Compile sample proto file
           runs: |
             echo 'syntax = "proto3"; message Test { string name = 1; }' > test.proto
@@ -127,15 +128,3 @@ test:
   pipeline:
     - runs: |
         protoc --help
-        protoc-gen-upb --version
-        protoc-gen-upb --help
-        protoc-gen-upb-27.4.0 --version
-        protoc-gen-upb-27.4.0 --help
-        protoc-gen-upb_minitable --version
-        protoc-gen-upb_minitable --help
-        protoc-gen-upb_minitable-27.4.0 --version
-        protoc-gen-upb_minitable-27.4.0 --help
-        protoc-gen-upbdefs --version
-        protoc-gen-upbdefs --help
-        protoc-gen-upbdefs-27.4.0 --version
-        protoc-gen-upbdefs-27.4.0 --help


### PR DESCRIPTION
I don't know why automation didn't handle this, but bumps protobuf to latest released version.

Also removes upb which is causing issues with downstream dependencies (otel-nginx - see https://github.com/wolfi-dev/os/pull/30305). I did a spot check locally and py3-protobuf and php-protobuf can still build.

Originally from: https://github.com/wolfi-dev/os/pull/30305 (couldn't include there since build was referencing older subpackage versions)

Related: https://github.com/chainguard-dev/image-requests/issues/4407

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0

