### PR TITLE
mesa: update for llvm-19

### DIFF
--- a/mesa.yaml
+++ b/mesa.yaml
@@ -1,10 +1,13 @@
 package:
   name: mesa
   version: 24.2.4
-  epoch: 0
+  epoch: 1
   description: Mesa DRI OpenGL library
   copyright:
     - license: MIT AND SGI-B-2.0 AND BSL-1.0
+
+vars:
+  llvm-ver: 19
 
 environment:
   contents:
@@ -39,8 +42,8 @@ environment:
       - libxrender-dev
       - libxshmfence-dev
       - libxxf86vm-dev
-      - llvm-18
-      - llvm-18-dev
+      - llvm-${{vars.llvm-ver}}
+      - llvm-${{vars.llvm-ver}}-dev
       - meson
       - py3-mako
       - py3-markupsafe
@@ -72,7 +75,6 @@ pipeline:
       _vulkan_drivers="amd,swrast"
       _vulkan_layers="device-select,overlay"
 
-      PATH="$PATH:/usr/lib/llvm$_llvmver/bin" \
       meson \
         --prefix=/usr \
         -Ddri-drivers-path=$_dri_driverdir \


### PR DESCRIPTION
The patch variable is leftover from being imported from alpine and we never set it. We don't need it for our builds.

Related: https://github.com/chainguard-dev/internal-dev/issues/1545
