### PR TITLE
imath: Remove uneeded llvm dep

### DIFF
--- a/imath.yaml
+++ b/imath.yaml
@@ -1,7 +1,7 @@
 package:
   name: imath
   version: 3.1.12
-  epoch: 1
+  epoch: 2
   description: C++ and python library of 2D and 3D vector, matrix, and math operations for computer graphics
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,6 @@ environment:
       - ca-certificates-bundle
       - cmake
       - doxygen
-      - llvm-18-dev
       - numpy
       - openssf-compiler-options
       - python3-dev
@@ -57,6 +56,11 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/lib/
           mv "${{targets.destdir}}"/usr/lib/python3* "${{targets.subpkgdir}}"/usr/lib/
           mv "${{targets.destdir}}"/usr/lib/libPy* "${{targets.subpkgdir}}"/usr/lib/
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            import: imath
 
 update:
   enabled: true


### PR DESCRIPTION
It's been here from first time the package was imported but it doesn't seem to be used.

Related: https://github.com/chainguard-dev/internal-dev/issues/1545