### PR TITLE
buck2: Remove uneeded llvm dep

### DIFF
--- a/buck2.yaml
+++ b/buck2.yaml
@@ -5,7 +5,7 @@ package:
   # - https://github.com/facebook/buck2/blob/<VERSION>/HACKING.md
   # Get the version, and update vars.rust-version below.
   version: 20241001
-  epoch: 0
+  epoch: 1
   description: "Build system, successor to Buck"
   copyright:
     - license: MIT
@@ -20,7 +20,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cargo-auditable
-      - libLLVM-18
       - rustup
       - wolfi-base
 


### PR DESCRIPTION
Related: https://github.com/chainguard-dev/internal-dev/issues/1545