### PR TITLE
Fix missing "pc=" provides that are otherwise referenced as Required

### DIFF
--- a/jsoncpp.yaml
+++ b/jsoncpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: jsoncpp
   version: 1.9.6
-  epoch: 1
+  epoch: 2
   description: "C++ library for parsing JSON"
   copyright:
     - license: 'CC-PDDC OR MIT'

--- a/leptonica.yaml
+++ b/leptonica.yaml
@@ -1,7 +1,7 @@
 package:
   name: leptonica
   version: 1.84.1
-  epoch: 2
+  epoch: 3
   description: Leptonica is an open source library containing software that is broadly useful for image processing and image analysis applications.
   copyright:
     - license: BSD-2-Clause
@@ -37,6 +37,12 @@ pipeline:
   - uses: cmake/build
 
   - uses: cmake/install
+
+  # Rename pc file without CMAKE_BUILD_TYPE suffix, as dependant
+  # pc files use it as lept.pc, and so do other distros
+  - runs: |
+      cd ${{targets.contextdir}}/usr/lib/pkgconfig/
+      mv lept_Release.pc lept.pc
 
   - uses: strip
 

--- a/libpng.yaml
+++ b/libpng.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpng
   version: 1.6.44
-  epoch: 0
+  epoch: 1
   description: Portable Network Graphics library
   copyright:
     - license: Libpng
@@ -50,6 +50,12 @@ subpackages:
     pipeline:
       - uses: split/dev
     dependencies:
+      provides:
+        # Upstream has interesting setup for versioned and unversioned
+        # install locations, which are very libpng specific. Support
+        # such install layout with melange SCA by augumenting the
+        # necessory provides, which is installed as a symlink.
+        - pc:libpng.pc
       runtime:
         - libpng
     description: libpng dev

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
   version: 6.5_p20240629
-  epoch: 0
+  epoch: 1
   description: "console display library"
   copyright:
     - license: MIT
@@ -81,6 +81,10 @@ subpackages:
       - runs: |
           mv "${{targets.destdir}}"/usr/lib/lib*.so "${{targets.subpkgdir}}"/usr/lib/
     dependencies:
+      provides:
+        # Unusually this is a symlink, that currently melange SCA does
+        # not consider for provides
+        - pc:ncurses.pc
       runtime:
         - ncurses
     test:

--- a/shared-mime-info.yaml
+++ b/shared-mime-info.yaml
@@ -1,7 +1,7 @@
 package:
   name: shared-mime-info
   version: "2.4"
-  epoch: 1
+  epoch: 2
   description: Freedesktop.org Shared MIME Info
   copyright:
     - license: GPL-2.0-or-later

--- a/utmps.yaml
+++ b/utmps.yaml
@@ -1,7 +1,7 @@
 package:
   name: utmps
   version: 0.1.2.3
-  epoch: 0
+  epoch: 1
   description: A secure utmp/wtmp implementation
   copyright:
     - license: ISC
@@ -23,8 +23,6 @@ pipeline:
       repository: https://github.com/skarnet/utmps
       expected-commit: 01774a9bfd9565b914196442425008f46fa87098
       tag: v${{package.version}}
-
-  - runs: sed -i -e 's|@@VERSION@@|${{package.version}}|' utmps.pc
 
   - uses: autoconf/configure
     with:
@@ -52,7 +50,6 @@ pipeline:
       install -D -m644 wtmpd.logrotate "${{targets.destdir}}"/etc/logrotate.d/wtmpd
       install -D -m644 btmpd.logrotate "${{targets.destdir}}"/etc/logrotate.d/btmpd
       install -D -m755 setup-utmp "${{targets.destdir}}"/sbin/setup-utmp
-      install -D -m644 utmps.pc "${{targets.destdir}}"/usr/lib/pkgconfig/utmps.pc
 
       mkdir -p "${{targets.destdir}}/usr/share/doc"
       cp -a "$builddir/doc" "${{targets.destdir}}/usr/share/doc/${{package.name}}"

--- a/utmps/utmps.pc
+++ b/utmps/utmps.pc
@@ -1,7 +1,0 @@
-Name: utmps
-Description: A secure implementation of the utmp mechanism.
-URL: https://skarnet.org/software/utmps/
-Version: @@VERSION@@
-Requires.private: skalibs
-Libs: -lutmps
-Cflags: -I/usr/include/utmps

--- a/xorgproto.yaml
+++ b/xorgproto.yaml
@@ -1,7 +1,7 @@
 package:
   name: xorgproto
   version: "2024.1"
-  epoch: 1
+  epoch: 2
   description: Combined X.Org X11 protocol headers
   copyright:
     - license: BSD-2-Clause AND MIT AND X11


### PR DESCRIPTION
- **jsoncpp: rebuild with fixed melange cmake pipeline to get valid build and valid .pc**
  

- **libpng: provide manual SCA .pc provides for an unusual symlinked .pc**
  

- **utmps: remove custom .pc file, not shipped by upstream and it has invalid requirements**
  

- **xorgproto: rebuild with fixed melange SCA to generate proto.pc files**
  

- **leptonic: rebuild with fixed melange cmake pipeline to get a valid .pc**
  

- **xorgproto: rebuild with fixed melange SCA to generate .pc provide**
  

- **ncurses: provide manual SCA .pc provides for an unusual symlinked .pc**
  

Fix all remaining cases of missing "pc=" provides, which are referenced by any currently available .pc file in wolfi. Landing this change, unblocks turning on melange SCA option to start generating depends on "pc=" files. I.e. such that installing a -dev package, correctly installs all of it's build time dependencies.

Newly added correct pc files:
- https://apk.dag.dev/https/apk.cgr.dev/wolfi-presubmit/eec5a43a76d4963b00261f5d337d0324e59e741e/aarch64/jsoncpp-dev-1.9.6-r2.apk@etag:8b0192ec32ea153fd8967f4283bcca51/.PKGINFO
- https://apk.dag.dev/https/apk.cgr.dev/wolfi-presubmit/eec5a43a76d4963b00261f5d337d0324e59e741e/aarch64/leptonica-dev-1.84.1-r3.apk@etag:6a2393009bd5bef85ef5d463bf3f469e/.PKGINFO
- https://apk.dag.dev/https/apk.cgr.dev/wolfi-presubmit/eec5a43a76d4963b00261f5d337d0324e59e741e/aarch64/libpng-dev-1.6.44-r1.apk@etag:760f765d10791557f38042659b960af6/.PKGINFO
- https://apk.dag.dev/https/apk.cgr.dev/wolfi-presubmit/eec5a43a76d4963b00261f5d337d0324e59e741e/aarch64/ncurses-dev-6.5_p20240629-r1.apk@etag:c174b563176a62be4bd67cbcc2dab54c/.PKGINFO
- https://apk.dag.dev/https/apk.cgr.dev/wolfi-presubmit/eec5a43a76d4963b00261f5d337d0324e59e741e/aarch64/shared-mime-info-2.4-r2.apk@etag:a97167888e9ffaed89eeed6fad3e1def/.PKGINFO
- https://apk.dag.dev/https/apk.cgr.dev/wolfi-presubmit/eec5a43a76d4963b00261f5d337d0324e59e741e/aarch64/xorgproto-2024.1-r2.apk@etag:264dea4b3321f6812ee88c943fcc6123/.PKGINFO

Remove broken pc file:
- https://apk.dag.dev/https/apk.cgr.dev/wolfi-presubmit/eec5a43a76d4963b00261f5d337d0324e59e741e/aarch64/utmps-dev-0.1.2.3-r1.apk@etag:bd555f57bf5bfb5d689989f250ab4937/.PKGINFO

Landing this change will allow to enable automatic provides in https://github.com/chainguard-dev/melange/pull/1522