### PR TITLE
percona-xtrabackup-8.4: use system dependecies

### DIFF
--- a/percona-xtrabackup-8.4.yaml
+++ b/percona-xtrabackup-8.4.yaml
@@ -37,8 +37,6 @@ environment:
       - libfido2-dev
       - libgcrypt-dev
       - lz4-dev
-      - mariadb-dev
-      - mariadb-dev
       - numactl-dev
       - procps-dev
       - protobuf-dev

--- a/percona-xtrabackup-8.4.yaml
+++ b/percona-xtrabackup-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-xtrabackup-8.4
   version: 8.4.0.1
-  epoch: 0
+  epoch: 1
   description: Open source hot backup tool for InnoDB and XtraDB databases
   copyright:
     - license: Apache-2.0
@@ -21,59 +21,31 @@ var-transforms:
 environment:
   contents:
     packages:
-      - autoconf
-      - automake
-      - bash
+      - abseil-cpp-dev
       - bison
-      - bpftool
       - build-base
       - busybox
-      - c-ares-dev
       - ca-certificates
-      - clang-18
-      - clang-18-dev
-      - clang-18-extras
+      - clang-extras
       - cmake
-      - curl
       - curl-dev
-      - elfutils-dev
-      - eudev-dev
-      - gcc-12-default
-      - git
-      - grpc-dev
       - hardening-check
-      - isl-dev
+      - icu-dev
       - libaio-dev
-      - libbpf
-      - libbpf-dev
-      - libcurl-openssl4
-      - libelf-static
+      - libedit-dev
       - libev-dev
+      - libfido2-dev
       - libgcrypt-dev
-      - liblz4-1
-      - librtmp
-      - libtool
-      - lsb-release-minimal
-      - lz4
       - lz4-dev
-      - mpc-dev
-      - ncurses-dev
+      - mariadb-dev
+      - mariadb-dev
       - numactl-dev
-      - openldap-dev
-      - openssl-dev
-      - pkgconf
       - procps-dev
       - protobuf-dev
-      - py3-docutils
       - py3-sphinx
-      - qpress
-      - rsync
-      - rtmpdump-dev
-      - socat
-      - vim
-      - yaml-cpp-dev
+      - vim # xxd
       - zlib-dev
-      - zstd
+      - zstd-dev
 
 pipeline:
   - uses: git-checkout
@@ -87,12 +59,20 @@ pipeline:
       mkdir build && cd build
       cmake \
         -DCMAKE_INSTALL_PREFIX=/usr \
-        -DCMAKE_INSTALL_LIBDIR=lib \
-        -DCMAKE_BUILD_TYPE=MinSizeRel \
         -DWITH_BOOST=PATH-TO-BOOST-LIBRARY \
         -DDOWNLOAD_BOOST=ON \
         -DBUILD_CONFIG=xtrabackup_release \
-        -DWITH_MAN_PAGES=OFF \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DWITH_EDITLINE=system \
+        -DWITH_FIDO=system \
+        -DWITH_ICU=system \
+        -DWITH_LIBEVENT=system \
+        -DWITH_LZ4=system \
+        -DWITH_PROTOBUF=system \
+        -DWITH_SSL=system \
+        -DWITH_ZLIB=system \
+        -DWITH_ZSTD=system \
+        -DINSTALL_MANDIR="/usr/share/man" \
         ..
       make -j$(nproc)
 
@@ -115,10 +95,6 @@ subpackages:
     pipeline:
       - uses: split/manpages
       - uses: split/infodir
-      - runs: |
-          mkdir -p "${{targets.contextdir}}"/usr/share/man/man1
-          mv "${{targets.destdir}}"/usr/man/man1/* "${{targets.contextdir}}"/usr/share/man/man1/
-          rm -rf "${{targets.destdir}}"/usr/man
     description: ${{package.name}} manpages
 
   - name: "${{package.name}}-test"


### PR DESCRIPTION
Percona XtraBackup 8.4 was using bundled dependencies. This PR changes it to use system dependencies instead.