### PR TITLE
python/multi-version batch 07

### DIFF
--- a/py3-face.yaml
+++ b/py3-face.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-face
   version: 22.0.0
-  epoch: 3
+  epoch: 4
   description: A command-line application framework (and CLI parser). Friendly for users, full-featured for developers.
   copyright:
     - license: BSD-3-Clause
@@ -40,7 +40,6 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       provides:
-        - ${{package.name}}
         - py3-${{vars.pypi-package}}
       runtime:
         - py${{range.key}}-boltons

--- a/py3-google-resumable-media.yaml
+++ b/py3-google-resumable-media.yaml
@@ -1,25 +1,29 @@
-# Generated from https://pypi.org/project/google-resumable-media/
 package:
   name: py3-google-resumable-media
   version: 2.7.2
-  epoch: 0
+  epoch: 1
   description: Utilities for Google Media Downloads and Resumable Uploads
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - py3-google-crc32c
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: google-resumable-media
+  import: google.resumable_media
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -28,10 +32,44 @@ pipeline:
       repository: https://github.com/googleapis/google-resumable-media-python
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-google-crc32c
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-ldap3.yaml
+++ b/py3-ldap3.yaml
@@ -1,25 +1,29 @@
-# Generated from https://pypi.org/project/ldap3/
 package:
   name: py3-ldap3
   version: 2.9.1
-  epoch: 0
+  epoch: 1
   description: A strictly RFC 4510 conforming LDAP V3 pure Python client library
   copyright:
     - license: LGPL-3.0-or-later
   dependencies:
-    runtime:
-      - py3-pyasn1
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: ldap3
+  import: ldap3
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -28,10 +32,44 @@ pipeline:
       repository: https://github.com/cannatag/ldap3
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-pyasn1
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-license-expression.yaml
+++ b/py3-license-expression.yaml
@@ -1,25 +1,29 @@
-# Generated from https://pypi.org/project/license-expression/
 package:
   name: py3-license-expression
   version: 30.3.1
-  epoch: 0
+  epoch: 1
   description: license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - py3-boolean.py
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: license-expression
+  import: license_expression
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -28,10 +32,44 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 265415a2651c682157bd688a251093c1e7a2ee15
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-boolean.py
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-msal.yaml
+++ b/py3-msal.yaml
@@ -1,25 +1,29 @@
-# Generated from https://pypi.org/project/msal/
 package:
   name: py3-msal
   version: 1.31.0
-  epoch: 0
+  epoch: 1
   description: The Microsoft Authentication Library (MSAL) for Python library enables your app to access the Microsoft Cloud by supporting authentication of users with Microsoft Azure Active Directory accounts (AAD) and Microsoft Accounts (MSA) using industry standard OAuth2 and OpenID Connect.
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - py3-requests
-      - py3-pyjwt
-      - py3-cryptography
-      - py3-mock
+    provider-priority: 0
+
+vars:
+  pypi-package: msal
+  import: msal
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -28,13 +32,47 @@ pipeline:
       repository: https://github.com/AzureAD/microsoft-authentication-library-for-python
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-requests
+        - py${{range.key}}-pyjwt
+        - py${{range.key}}-cryptography
+        - py${{range.key}}-mock
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
     - uses: python/import
       with:
         imports: |

--- a/py3-requests-oauthlib.yaml
+++ b/py3-requests-oauthlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-requests-oauthlib
   version: 2.0.0
-  epoch: 1
+  epoch: 2
   description: OAuthlib authentication support for Requests.
   copyright:
     - license: ISC
@@ -41,7 +41,6 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       provides:
-        - ${{package.name}}
         - py3-${{vars.pypi-package}}
       runtime:
         - py${{range.key}}-oauthlib

--- a/py3-trio.yaml
+++ b/py3-trio.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-trio
   version: 0.26.2
-  epoch: 1
+  epoch: 2
   description: A friendly Python library for async concurrency and I/O
   copyright:
     - license: MIT
@@ -40,7 +40,6 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       provides:
-        - ${{package.name}}
         - py3-${{vars.pypi-package}}
       runtime:
         - py${{range.key}}-attrs


### PR DESCRIPTION
Convert packages to python multi-version.

This is part of a series of programatic changes to
add the ability to support python packages for multiple
python versions.

Other changes to py3-face.yaml, py3-requests-oauthlib.yaml, py3-trio.yaml
were to drop an additional 'provides'.  That was only supposed to be
added if the package was not 'py3-<pypi-pkgname>' and for these it is.