### PR TITLE
Make empty package for typing-extensions in python > 3.11

### DIFF
--- a/py3-typing-extensions.yaml
+++ b/py3-typing-extensions.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-typing-extensions
   version: 4.12.2
-  epoch: 5
+  epoch: 6
   description: Backported and Experimental Type Hints for Python 3.7+
   copyright:
     - license: PSF-2.0
@@ -17,6 +17,9 @@ data:
   - name: py-versions
     items:
       3.10: "310"
+
+  - name: py-noops
+    items:
       3.11: "311"
       3.12: "312"
       3.13: "300"
@@ -57,6 +60,16 @@ subpackages:
     test:
       pipeline:
         - runs: python${{range.key}} -c "from ${{vars.module_name}} import TypeAlias, TypeGuard"
+
+  - range: py-noops
+    name: py${{range.key}}-${{vars.pypi-package}}
+    # typing-extensions is only needed for 3.10.  Its empty dep for others
+    # as it is part of the stdlib.
+    description: ${{vars.pypi-package}} empty dep for python${{range.key}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.


### PR DESCRIPTION
typing-extensions is part of the stdlib for 3.11+. it is needed for packages that use it and use python 3.10, but not necessary for 3.11+.

So we provide an empty package
