### PR TITLE
python/multi-version batch 08, Add py/one-python pipeline

### DIFF
--- a/pipelines/py/one-python.yaml
+++ b/pipelines/py/one-python.yaml
@@ -1,0 +1,66 @@
+name: Run some stuff with just one python - do not worry about the name
+
+needs:
+  packages:
+    - busybox
+
+inputs:
+  content:
+    description: |
+      what do you want to run. content will be written to file and executed.
+      If it has a shbang (#!) then it will be honored. 
+      Otherwise use '#!/bin/sh -e'
+    required: true
+
+pipeline:
+  - name: "run content"
+    runs: |
+      set +x
+      tmpd=$(mktemp -d) || { echo "failed mktemp"; exit 1; }
+      trap "rm -Rf $tmpd" EXIT
+
+      cat > "$tmpd/runner.dist" <<"END_ONE_PYTHON_CONTENT"
+      ${{inputs.content}}
+      END_ONE_PYTHON_CONTENT
+
+      if p=$(command -v python3); then
+        py=$p
+        if [ -L "$p" ]; then
+          py=$(readlink -f "$p") ||
+            { echo "ERROR: failed 'readlink -f $p'" 1>&2; exit 1; }
+        fi
+      else
+        glob="/usr/bin/python3.[0-9][0-9] /usr/bin/python3.[789]"
+        n=0
+        for p in $glob; do
+          [ -x "$p" ] && n=$((n+1)) && py=$p && found="$found $p"
+        done
+        if [ "$n" -ne 1 ]; then
+          echo "ERROR: found $n pythons matching $glob. Cannot use one-python here."
+          [ "$n" -eq 0 ] || echo "  found: $found" 1>&2
+          exit 1
+        fi
+      fi
+      echo "using python=$py for one-python"
+
+      ln -s "$py" "$tmpd/python" && ln -s "$py" "$tmpd/python3" || {
+        echo "ERROR: symlink of $py into tmpdir failed."
+        exit 1
+      }
+
+      # add shbang of #!/bin/sh -e if not present.
+      if head -n 1 "$tmpd/runner.dist" | grep -q "^#!"; then
+         cp "$tmpd/runner.dist" "$tmpd/runner"
+      else
+         echo "#!/bin/sh -e" > "$tmpd/runner"
+         cat "$tmpd/runner.dist" >> "$tmpd/runner"
+      fi
+
+      [ $? -eq 0 ] || {
+        echo "ERROR: very strange failure (failed write to runner?)"
+        exit 1
+      }
+      chmod 755 "$tmpd/runner"
+      export PATH="$tmpd:$PATH"
+
+      runner

--- a/py3-asgiref.yaml
+++ b/py3-asgiref.yaml
@@ -1,23 +1,29 @@
 package:
   name: py3-asgiref
   version: 3.8.1
-  epoch: 0
+  epoch: 1
   description: ASGI specs, helper code, and adapters
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: asgiref
+  import: asgiref
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -26,10 +32,48 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: e38d3c327c01aa82c0bf2726220700c1097ea6cc
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - ${{package.name}}
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+    - uses: py/one-python
+      with:
+        content: |
+          python3 ./test.py > output.out 2>&1
+          grep -E "ERROR|None" output.out && exit 1 || exit 0
 
 update:
   enabled: true
@@ -38,9 +82,3 @@ update:
   github:
     identifier: django/asgiref
     use-tag: true
-
-test:
-  pipeline:
-    - runs: |
-        python3 ./test.py > output.out 2>&1
-        grep -E "ERROR|None" output.out && exit 1

--- a/py3-beartype.yaml
+++ b/py3-beartype.yaml
@@ -1,26 +1,30 @@
-# Generated from https://pypi.org/project/beartype/
 package:
   name: py3-beartype
   version: 0.19.0
-  epoch: 0
+  epoch: 1
   description: Unbearably fast runtime type checking in pure Python.
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: beartype
+  import: beartype
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
-  environment:
-    SOURCE_DATE_EPOCH: "315532800"
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -29,22 +33,50 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: f17bbedf496cce90d0982926e44371d70e36c9ac
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - ${{package.name}}
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+    - uses: py/one-python
+      with:
+        content: |
+          python3 -c "import beartype; print(beartype.__version__)"
 
 update:
   enabled: true
   github:
     identifier: beartype/beartype
     strip-prefix: v
-
-test:
-  environment:
-    contents:
-      packages:
-        - python-3
-  pipeline:
-    - runs: |
-        python -c "import beartype; print(beartype.__version__)"

--- a/py3-fastbencode.yaml
+++ b/py3-fastbencode.yaml
@@ -1,22 +1,29 @@
-# Generated from https://pypi.org/project/fastbencode/
 package:
   name: py3-fastbencode
   version: 0.3.1
-  epoch: 0
+  epoch: 1
   description: Implementation of bencode with optional fast C extensions
   copyright:
     - license: GPL-2.0-or-later
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: fastbencode
+  import: fastbencode
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -25,22 +32,51 @@ pipeline:
       repository: https://github.com/breezy-team/fastbencode
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - ${{package.name}}
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:
     - uses: python/import
       with:
-        import: fastbencode
-    - runs: |
-        python <<'EOF'
-        from fastbencode import bencode, bdecode
-        assert bencode([1, 2, b'a', {b'd': 3}]) == b'li1ei2e1:ad1:di3eee'
-        assert bdecode(bencode([1, 2, b'a', {b'd': 3}])) == [1, 2, b'a', {b'd': 3}]
-        EOF
+        imports: |
+          import ${{vars.import}}
+    - uses: py/one-python
+      with:
+        content: |
+          python3 <<'EOF'
+          from fastbencode import bencode, bdecode
+          assert bencode([1, 2, b'a', {b'd': 3}]) == b'li1ei2e1:ad1:di3eee'
+          assert bdecode(bencode([1, 2, b'a', {b'd': 3}])) == [1, 2, b'a', {b'd': 3}]
+          EOF
 
 update:
   enabled: true

--- a/py3-isodate.yaml
+++ b/py3-isodate.yaml
@@ -1,27 +1,29 @@
-# Generated from https://pypi.org/project/isodate/
 package:
   name: py3-isodate
   version: 0.7.2
-  epoch: 0
+  epoch: 1
   description: An ISO 8601 date/time/duration parser and formatter
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-six
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: isodate
+  import: isodate
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-setuptools
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -30,29 +32,65 @@ pipeline:
       repository: https://github.com/gweis/isodate
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - ${{package.name}}
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-six
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+    - name: Verify Installation
+      uses: py/one-python
+      with:
+        content: |
+          # Check that the isodate package is installed
+          python3 -c "import isodate" || exit 1
+          echo "isodate package is installed."
+    - name: Test Basic Date Parsing
+      uses: py/one-python
+      with:
+        content: |
+          # Test parsing a simple ISO 8601 date string
+          python3 -c "
+          import isodate
+          dt = isodate.parse_date('2024-10-09')
+          assert dt.year == 2024 and dt.month == 10 and dt.day == 9
+          print('Date parsing passed.')"
 
 update:
   enabled: true
   github:
     use-tag: true
     identifier: gweis/isodate
-
-test:
-  pipeline:
-    - name: Verify Installation
-      runs: |
-        # Check that the isodate package is installed
-        python3 -c "import isodate" || exit 1
-        echo "isodate package is installed."
-    - name: Test Basic Date Parsing
-      runs: |
-        # Test parsing a simple ISO 8601 date string
-        python3 -c "
-        import isodate
-        dt = isodate.parse_date('2024-10-09')
-        assert dt.year == 2024 and dt.month == 10 and dt.day == 9
-        print('Date parsing passed.')"

--- a/py3-merge3.yaml
+++ b/py3-merge3.yaml
@@ -1,22 +1,29 @@
-# Generated from https://pypi.org/project/merge3/
 package:
   name: py3-merge3
   version: 0.0.15
-  epoch: 0
+  epoch: 1
   description: Python implementation of 3-way merge
   copyright:
     - license: GPL-2.0-or-later
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: merge3
+  import: merge3
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: fetch
@@ -24,27 +31,89 @@ pipeline:
       expected-sha256: d3eac213d84d56dfc9e39552ac8246c7860a940964ebeed8a8be4422f6492baf
       uri: https://files.pythonhosted.org/packages/source/m/merge3/merge3-${{package.version}}.tar.gz
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - ${{package.name}}
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      environment:
+        contents:
+          packages:
+            - apk-tools
+      pipeline:
+        - runs: |
+            apk info -L py${{range.key}}-${{vars.pypi-package}}-bin > "pkg.list"
+            echo "Please write a test for these:"
+            grep usr/bin/ pkg.list > bins.list
+            sed 's,^,> ,' bins.list
+
+            while read line; do
+              echo == /$line ==
+              /$line --help || :
+            done < bins.list
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:
     - uses: python/import
       with:
-        import: merge3
-      runs: |
-        merge3 --help
+        imports: |
+          import ${{vars.import}}
     - runs: |
-        python <<'EOF'
-        import merge3
-        m3 = merge3.Merge3(
-          ['common\n', 'base\n'],
-          ['common\n', 'a\n'],
-          ['common\n', 'b\n'])
-        assert list(m3.merge_annotated()) == ['u | common\n', '<<<<\n', 'A | a\n', '----\n', 'B | b\n', '>>>>\n']
-        EOF
+        merge3 --help
+    - uses: py/one-python
+      with:
+        content: |
+          python3 <<'EOF'
+          import merge3
+          m3 = merge3.Merge3(
+            ['common\n', 'base\n'],
+            ['common\n', 'a\n'],
+            ['common\n', 'b\n'])
+          assert list(m3.merge_annotated()) == ['u | common\n', '<<<<\n', 'A | a\n', '----\n', 'B | b\n', '>>>>\n']
+          EOF
 
 update:
   enabled: true

--- a/py3-patiencediff.yaml
+++ b/py3-patiencediff.yaml
@@ -1,22 +1,29 @@
-# Generated from https://pypi.org/project/patiencediff/
 package:
   name: py3-patiencediff
   version: 0.2.15
-  epoch: 0
+  epoch: 1
   description: Python implementation of the patiencediff algorithm
   copyright:
     - license: GPL-2.0-or-later
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: patiencediff
+  import: patiencediff
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: fetch
@@ -24,26 +31,86 @@ pipeline:
       expected-sha256: d00911efd32e3bc886c222c3a650291440313ee94ac857031da6cc3be7935204
       uri: https://files.pythonhosted.org/packages/source/p/patiencediff/patiencediff-${{package.version}}.tar.gz
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - ${{package.name}}
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      environment:
+        contents:
+          packages:
+            - apk-tools
+      pipeline:
+        - runs: |
+            apk info -L py${{range.key}}-${{vars.pypi-package}}-bin > "pkg.list"
+            echo "Please write a test for these:"
+            grep usr/bin/ pkg.list > bins.list
+            sed 's,^,> ,' bins.list
+
+            while read line; do
+              echo == /$line ==
+              /$line --help || :
+            done < bins.list
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:
     - uses: python/import
       with:
-        import: patiencediff
-      runs: |
-        patiencediff --help
-    - runs: |
-        python <<'EOF'
-        import patiencediff
-        got = ''.join(patiencediff.unified_diff(
-          ['a\n', 'b\n', 'b\n', 'c\n'],
-          ['a\n', 'c\n', 'b\n']))
-        assert '+++' in got
-        EOF
+        imports: |
+          import ${{vars.import}}
+    - uses: py/one-python
+      with:
+        content: |
+          python3 <<'EOF'
+          import patiencediff
+          got = ''.join(patiencediff.unified_diff(
+            ['a\n', 'b\n', 'b\n', 'c\n'],
+            ['a\n', 'c\n', 'b\n']))
+          assert '+++' in got
+          EOF
 
 update:
   enabled: true

--- a/py3-python-gitlab.yaml
+++ b/py3-python-gitlab.yaml
@@ -1,25 +1,30 @@
-# Generated from https://pypi.org/project/python-gitlab/
 package:
   name: py3-python-gitlab
   version: 4.13.0
-  epoch: 0
+  epoch: 1
   description: A python wrapper for the GitLab API
   url: https://python-gitlab.readthedocs.io
   copyright:
     - license: LGPL-3.0-or-later
   dependencies:
-    runtime:
-      - py3-requests
-      - py3-requests-toolbelt
+    provider-priority: 0
+
+vars:
+  pypi-package: python-gitlab
+  import: gitlab
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -28,36 +33,102 @@ pipeline:
       repository: https://github.com/python-gitlab/python-gitlab
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      runtime:
+        - py${{range.key}}-requests
+        - py${{range.key}}-requests-toolbelt
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - ${{package.name}}
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      environment:
+        contents:
+          packages:
+            - apk-tools
+      pipeline:
+        - runs: |
+            apk info -L py${{range.key}}-${{vars.pypi-package}}-bin > "pkg.list"
+            echo "Please write a test for these:"
+            grep usr/bin/ pkg.list > bins.list
+            sed 's,^,> ,' bins.list
+
+            while read line; do
+              echo == /$line ==
+              /$line --help || :
+            done < bins.list
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+    - name: Verify getting GitLab project
+      uses: py/one-python
+      with:
+        content: |
+          cat <<EOF> python-gitlab-test.py
+          import gitlab
+
+          gl = gitlab.Gitlab()
+
+          # This ID is for the upstream project containing the GitLab source code.
+          project = gl.projects.get(278964)
+
+          assert project.attributes.get("web_url") == "https://gitlab.com/gitlab-org/gitlab"
+          EOF
+
+          HOME=/home/build python3 python-gitlab-test.py
+    - name: run cli
+      runs: |
+        gitlab --version
+        gitlab --help
 
 update:
   enabled: true
   github:
     identifier: python-gitlab/python-gitlab
     strip-prefix: v
-
-test:
-  environment:
-    contents:
-      packages:
-        - python3 # in order to invoke 'python3' below versus python3.xx we need this.
-  pipeline:
-    - name: Verify getting GitLab project
-      runs: |
-        cat <<EOF> python-gitlab-test.py
-        import gitlab
-
-        gl = gitlab.Gitlab()
-
-        # This ID is for the upstream project containing the GitLab source code.
-        project = gl.projects.get(278964)
-
-        assert project.attributes.get("web_url") == "https://gitlab.com/gitlab-org/gitlab"
-        EOF
-
-        HOME=/home/build python python-gitlab-test.py
-        gitlab --version
-        gitlab --help

--- a/py3-tzlocal.yaml
+++ b/py3-tzlocal.yaml
@@ -1,22 +1,29 @@
-# Generated from https://pypi.org/project/tzlocal/
 package:
   name: py3-tzlocal
-  version: "5.2"
-  epoch: 0
+  version: '5.2'
+  epoch: 1
   description: tzinfo object for the local timezone
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - py3-tzdata
+    provider-priority: 0
+
+vars:
+  pypi-package: tzlocal
+  import: tzlocal
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: fetch
@@ -24,24 +31,54 @@ pipeline:
       expected-sha256: 8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e
       uri: https://files.pythonhosted.org/packages/source/t/tzlocal/tzlocal-${{package.version}}.tar.gz
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - ${{package.name}}
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-tzdata
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:
     - uses: python/import
       with:
-        python: python3.12
-        import: tzlocal
-    - runs: |
-        cat <<'EOF' >> /tmp/test.py
-        from tzlocal import get_localzone
-        tz = get_localzone()
-        tz
-        EOF
-        python3 /tmp/test.py
+        imports: |
+          import ${{vars.import}}
+    - uses: py/one-python
+      with:
+        content: |
+          cat <<'EOF' >> /tmp/test.py
+          from tzlocal import get_localzone
+          tz = get_localzone()
+          tz
+          EOF
+          python3 /tmp/test.py
 
 update:
   enabled: true

--- a/py3-xmltodict.yaml
+++ b/py3-xmltodict.yaml
@@ -1,24 +1,29 @@
-# Generated from https://pypi.org/project/xmltodict/
 package:
   name: py3-xmltodict
   version: 0.14.0
-  epoch: 0
+  epoch: 1
   description: Makes working with XML feel like you are working with JSON
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: xmltodict
+  import: xmltodict
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -27,10 +32,68 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 48b47c95cfd82b77c9073d1026879da0208808cc
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - ${{package.name}}
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+    - uses: py/one-python
+      with:
+        content: |
+          # Verify xmltodict is installed
+          python3 -c "import xmltodict"
+
+          # Test basic XML to dict conversion
+          python3 <<-EOF
+          import xmltodict
+
+          xml = """<root><item>value1</item><item>value2</item></root>"""
+          doc = xmltodict.parse(xml)
+          assert doc["root"]["item"] == ["value1", "value2"], "XML to dict conversion failed"
+          print("XML to dict conversion passed")
+          EOF
+
+          # Test basic dict to XML conversion
+          python3 <<-EOF
+          import xmltodict
+
+          data = {"root": {"item": ["value1", "value2"]}}
+          xml = xmltodict.unparse(data)
+          assert "<item>value1</item>" in xml and "<item>value2</item>" in xml, "Dict to XML conversion failed"
+          print("Dict to XML conversion passed")
+          EOF
 
 update:
   enabled: true
@@ -38,29 +101,3 @@ update:
     use-tag: true
     identifier: martinblech/xmltodict
     strip-prefix: v
-
-test:
-  pipeline:
-    - runs: |
-        # Verify xmltodict is installed
-        python3 -c "import xmltodict"
-
-        # Test basic XML to dict conversion
-        python3 <<-EOF
-        import xmltodict
-
-        xml = """<root><item>value1</item><item>value2</item></root>"""
-        doc = xmltodict.parse(xml)
-        assert doc["root"]["item"] == ["value1", "value2"], "XML to dict conversion failed"
-        print("XML to dict conversion passed")
-        EOF
-
-        # Test basic dict to XML conversion
-        python3 <<-EOF
-        import xmltodict
-
-        data = {"root": {"item": ["value1", "value2"]}}
-        xml = xmltodict.unparse(data)
-        assert "<item>value1</item>" in xml and "<item>value2</item>" in xml, "Dict to XML conversion failed"
-        print("Dict to XML conversion passed")
-        EOF


### PR DESCRIPTION
Convert 9 packages to multi-version python.

This 'one-python' pipeline will create a 'python3' in the PATH pointing to the one /usr/bin/python3.XX that is present.  That way the caller can be blissfully ignorant that their package didn't actually need 'python3' installed at all.

This makes an improvement here on
https://github.com/wolfi-dev/os/issues/26818
