### PR TITLE
protobuf: disable upb

### DIFF
--- a/protobuf.yaml
+++ b/protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf
   version: 3.27.4
-  epoch: 0
+  epoch: 1
   description: Library for extensible, efficient structure packing
   copyright:
     - license: BSD-3-Clause
@@ -47,7 +47,8 @@ pipeline:
         -DBUILD_SHARED_LIBS=True \
         -DCMAKE_BUILD_TYPE=Release \
         -Dprotobuf_ABSL_PROVIDER=package \
-        -Dprotobuf_BUILD_TESTS=OFF
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -Dprotobuf_BUILD_LIBUPB=OFF
       ninja -C build
       DESTDIR=${{targets.destdir}} ninja -C build install
 
@@ -127,15 +128,3 @@ test:
   pipeline:
     - runs: |
         protoc --help
-        protoc-gen-upb --version
-        protoc-gen-upb --help
-        protoc-gen-upb-27.4.0 --version
-        protoc-gen-upb-27.4.0 --help
-        protoc-gen-upb_minitable --version
-        protoc-gen-upb_minitable --help
-        protoc-gen-upb_minitable-27.4.0 --version
-        protoc-gen-upb_minitable-27.4.0 --help
-        protoc-gen-upbdefs --version
-        protoc-gen-upbdefs --help
-        protoc-gen-upbdefs-27.4.0 --version
-        protoc-gen-upbdefs-27.4.0 --help


### PR DESCRIPTION
Removes upb which is causing issues with downstream dependencies (otel-nginx - see https://github.com/wolfi-dev/os/pull/30305). This is documented as being an [internal dependency of grpc](https://github.com/protocolbuffers/protobuf/blob/6690ab42d855ea19d9a24cd99b0375910ea772ca/cmake/libupb.cmake#L14-L15).
I did a spot check locally and py3-protobuf and php-protobuf can still build.

Related: https://github.com/chainguard-dev/image-requests/issues/4407, https://github.com/wolfi-dev/os/pull/30305

There is a newer version of protobuf available, but this breaks other packages and requires additional changes.