### PR TITLE
Adding compat subpackage for kube-proxy

### DIFF
--- a/kubernetes-1.31.yaml
+++ b/kubernetes-1.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.31
   version: 1.31.1
-  epoch: 0
+  epoch: 1
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.31.yaml
+++ b/kubernetes-1.31.yaml
@@ -187,6 +187,19 @@ subpackages:
           mkdir -p ${{targets.subpkgdir}}/usr/bin
           ln -s ${{range.key}}-${{vars.kubernetes-version}} ${{targets.subpkgdir}}/usr/bin/${{range.key}}
 
+  - name: kube-proxy-${{vars.kubernetes-version}}-default-compat
+    description: kube-proxy-default compatibility package
+    dependencies:
+      runtime:
+        - kube-proxy-${{vars.kubernetes-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          ln -s kube-proxy-${{vars.kubernetes-version}} ${{targets.subpkgdir}}/usr/local/bin/kube-proxy
+    test:
+      pipeline:
+        - runs: stat /usr/local/bin/kube-proxy
+
   - name: kubernetes-${{vars.kubernetes-version}}-default
     description: "Compatibility package to set ${{vars.kubernetes-version}} as the default kubernetes, and add packages to their shortened path"
     dependencies:
@@ -196,6 +209,7 @@ subpackages:
         - kubelet-${{vars.kubernetes-version}}-default
         - kube-scheduler-${{vars.kubernetes-version}}-default
         - kube-proxy-${{vars.kubernetes-version}}-default
+        - kube-proxy-${{vars.kubernetes-version}}-default-compat
         - kube-controller-manager-${{vars.kubernetes-version}}-default
         - kube-apiserver-${{vars.kubernetes-version}}-default
     checks:


### PR DESCRIPTION
kube-proxy deployments assume the binary sits at
/usr/local/bin/kube-proxy (see
https://github.com/kubernetes/kubernetes/blob/a35bca903e24ea3cdbecb743c001b4c8f4db9e9c/cmd/kubeadm/app/phases/addons/proxy/manifests.go#L79). This adds a compat package based off of kube-proxy-default (which installs the binary at /usr/bin/kube-proxy) to add a symlink to /usr/local/bin.

Kube-proxy pod expects the binary at` /usr/local/bin`.

logs from kube-proxy-pod:
  `Normal   Created    13s (x3 over 27s)  kubelet            Created container kube-proxy Warning  Failed     13s (x3 over 26s)  kubelet            Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/usr/local/bin/kube-proxy": stat /usr/local/bin/kube-proxy: no such file or directory: unknown`