### PR TITLE
grpc: Version-streamify grpc-1.66

### DIFF
--- a/grpc-1.66.yaml
+++ b/grpc-1.66.yaml
@@ -12,6 +12,12 @@ package:
     provides:
       - grpc=${{package.full-version}}
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: major-minor-version
+
 environment:
   contents:
     packages:
@@ -99,7 +105,7 @@ pipeline:
       sh -c 'rm $0 && ln -s /etc/ssl/certs/ca-certificates.crt $0' "{}" \;
 
 subpackages:
-  - name: ${{package.name}}-py3-grpcio
+  - name: py3-grpcio-${{vars.major-minor-version}}
     description: "gRPC Python HTTP/2-based RPC framework"
     dependencies:
       runtime:

--- a/grpc-1.66.yaml
+++ b/grpc-1.66.yaml
@@ -1,5 +1,5 @@
 package:
-  name: grpc
+  name: grpc-1.66
   version: 1.66.2
   epoch: 0
   description: The C based gRPC
@@ -8,6 +8,9 @@ package:
   resources:
     cpu: 24
     memory: 24Gi
+  dependencies:
+    provides:
+      - grpc=${{package.full-version}}
 
 environment:
   contents:
@@ -96,22 +99,26 @@ pipeline:
       sh -c 'rm $0 && ln -s /etc/ssl/certs/ca-certificates.crt $0' "{}" \;
 
 subpackages:
-  - name: py3-grpcio
+  - name: ${{package.name}}-py3-grpcio
     description: "gRPC Python HTTP/2-based RPC framework"
     dependencies:
       runtime:
         - py3-six
+      provides:
+        - py3-grpcio=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv ${{targets.destdir}}/usr/lib/python3* ${{targets.subpkgdir}}/usr/lib/
 
-  - name: grpc-dev
+  - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
     dependencies:
       runtime:
-        - grpc
+        - ${{package.name}}
+      provides:
+        - grpc-dev=${{package.full-version}}
     description: grpc dev
 
 update:

--- a/grpc-1.66.yaml
+++ b/grpc-1.66.yaml
@@ -127,3 +127,4 @@ update:
     identifier: grpc/grpc
     strip-prefix: v
     use-tag: true
+    tag-filter-prefix: v1.66.


### PR DESCRIPTION
There are breaking changes in grpc-1.67 that break falco. [grpc support policy says that they support n-1 versions](https://grpc.io/docs/what-is-grpc/faq/#how-long-are-grpc-releases-supported-for), so version-streamify the existing grpc-1.66 package in preparation for a separate grpc-1.67 package.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [x] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

Note: Had to deviate from the naming conventions somewhat for py3 subpackage. lmk if there's a better way to do this.
