### PR TITLE
make valkey use redis-valkey pipelines

### DIFF
--- a/valkey.yaml
+++ b/valkey.yaml
@@ -1,7 +1,7 @@
 package:
   name: valkey
   version: 8.0.1
-  epoch: 0
+  epoch: 1
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause
@@ -32,23 +32,17 @@ pipeline:
     with:
       patches: 0000-Disable-protected-mode.patch
 
-  - runs: |
-      export CFLAGS="$CFLAGS -DUSE_MALLOC_USABLE_SIZE"
-        make USE_JEMALLOC=no \
-        MALLOC=libc \
-        BUILD_TLS=yes \
-        all -j$(nproc)
-      make install PREFIX=/usr INSTALL_BIN="${{targets.destdir}}/usr/bin"
+  - uses: redis-valkey/make
 
   - uses: strip
 
+# subpackage descriptions are in the build pipeline
 subpackages:
   - name: valkey-cli
     pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/valkey-cli "${{targets.subpkgdir}}"/usr/bin/valkey-cli
-    description: valkey-cli is the command line interface utility to talk with Valkey.
+      - uses: redis-valkey/subpackage-cli
+        with:
+          project: valkey
     test:
       pipeline:
         - runs: |
@@ -57,10 +51,9 @@ subpackages:
 
   - name: valkey-benchmark
     pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          mv "${{targets.destdir}}"/usr/bin/valkey-benchmark "${{targets.subpkgdir}}"/usr/bin/valkey-benchmark
-    description: valkey-benchmark utility that simulates running commands done by N clients while at the same time sending M total queries.
+      - uses: redis-valkey/subpackage-benchmark
+        with:
+          project: valkey
     test:
       pipeline:
         - runs: |
@@ -78,24 +71,6 @@ test:
       packages:
         - valkey-cli
   pipeline:
-    - runs: |
-        cat <<EOF >> /tmp/valkey.conf
-        dbfilename dump.rdb
-        pidfile /tmp/valkey_6379.pid
-        dir /tmp/
-        EOF
-
-        valkey-server /tmp/valkey.conf &
-        sleep 2 # wait for valkey to start
-        valkey-cli SET bike:1 "Process 134" || exit 1
-        valkey-cli GET bike:1 | grep 'Process 134' || exit 1
-        valkey-cli exists bike:1 | grep 1 || exit 1
-        valkey-cli exists bike:2 | grep 0 || exit 1
-        redis-check-aof --version
-        redis-check-rdb --version
-        redis-sentinel --version
-        redis-server --version
-        valkey-check-aof --version
-        valkey-check-rdb --version
-        valkey-sentinel --version
-        valkey-server --version
+    - uses: redis-valkey/tests
+      with:
+        project: valkey


### PR DESCRIPTION
Make valkey build using a shared melange `redis-valkey/make` pipeline over in https://github.com/chainguard-dev/melange/pull/1551