### PR TITLE
percona-server-8.4: use system dependecies

### DIFF
--- a/percona-server-8.4.yaml
+++ b/percona-server-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-server-8.4
   version: 8.4.0.1
-  epoch: 0
+  epoch: 1
   description: "Percona Server for MySQL is a free, fully compatible, enhanced, and open source drop-in replacement for any MySQL database. It provides superior performance, scalability, and instrumentation."
   copyright:
     - license: GPL-3.0-or-later
@@ -30,13 +30,17 @@ environment:
       - clang-extras
       - cmake
       - curl-dev
+      - icu-dev
       - libaio-dev
-      - libedit
+      - libedit-dev
       - libevent-dev
+      - libfido2-dev
       - libtirpc-dev
       - linux-pam-dev
+      - lz4-dev
       - ncurses-dev
       - nfs-utils
+      - ninja
       - openldap-dev
       - openssl-dev
       - pcre2-dev
@@ -49,6 +53,7 @@ environment:
       - wolfi-baselayout
       - xz-dev
       - zlib-dev
+      - zstd-dev
 
 pipeline:
   # This package requires boost 1.77 and we are not building that version.
@@ -74,9 +79,8 @@ pipeline:
 
   - name: "Cmake"
     runs: |
-      mkdir /var/tmp
+      mkdir build && cd build
       cmake . -G Ninja \
-        -DFORCE_INSOURCE_BUILD=1 \
         -DBUILD_CONFIG=mysql_release \
         -DWITH_EDITLINE=system \
         -DCMAKE_INSTALL_PREFIX=/usr \
@@ -94,17 +98,22 @@ pipeline:
         -DINSTALL_SUPPORTFILESDIR=share/${{package.name}} \
         -DINSTALL_DOCDIR=share/doc/${{package.name}} \
         -DWITH_ROCKSDB=YES \
-        -DTMPDIR=/var/tmp \
         -DWITH_ASAN=OFF \
         -DWITH_EXTRA_CHARSETS=complex \
         -DWITH_SYSTEMD=no \
         -DWITH_SSL=system \
+        -DWITH_LZ4=system \
+        -DWITH_ICU=system \
+        -DWITH_FIDO=system \
         -DWITH_VALGRIND=OFF \
         -DWITH_ZLIB=system \
-        -DWITH_BOOST=/home/build/boost \
+        -DWITH_ZSTD=system \
+        -DWITH_TEST=off \
+        ..
 
   - name: "Install"
     runs: |
+      cd build
       DESTDIR="${{targets.destdir}}" ninja install
 
   - name: "Remove extras"


### PR DESCRIPTION
Percona Server 8.4 was using bundled dependencies. This PR changes it to use system dependencies instead.