### PR TITLE
wavefront-proxy/GHSA-r7pg-v2c8-mfg3 fix

### DIFF
--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: wavefront-proxy
   version: "13.7" # When version is bumped, check if patches are still needed to address CVE-2023-1428
-  epoch: 1
+  epoch: 2
   description: Wavefront Proxy Project
   copyright:
     - license: Apache-2.0

--- a/wavefront-proxy/proxy/pombump-deps.yaml
+++ b/wavefront-proxy/proxy/pombump-deps.yaml
@@ -34,3 +34,7 @@ patches:
     version: 3.25.5
     scope: import
     type: pom
+  # Fixes GHSA-r7pg-v2c8-mfg3
+  - groupId: org.apache.avro
+    artifactId: avro
+    version: 1.11.4


### PR DESCRIPTION
Adding avro to the pombump-deps file allows the version to be upgraded from 1.11.3 to 1.11.4. This fixes GHSA-r7pg-v2c8-mfg3