### PR TITLE
New package libsdl3

### DIFF
--- a/libsdl2.yaml
+++ b/libsdl2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsdl2
   version: 2.30.8
-  epoch: 0
+  epoch: 1
   description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
   copyright:
     - license: Zlib
@@ -27,15 +27,15 @@ pipeline:
 
   - uses: cmake/install
 
+  - runs: |
+      rm ${{targets.destdir}}/usr/share/licenses/SDL2/LICENSE.txt
+      rm -r ${{targets.destdir}}/usr/share
+
 subpackages:
   - name: ${{package.name}}-dev
     dependencies:
       runtime:
         - libsdl2
-    pipeline:
-      - uses: split/dev
-
-  - name: ${{package.name}}-doc
     pipeline:
       - uses: split/dev
 

--- a/libsdl3.yaml
+++ b/libsdl3.yaml
@@ -1,0 +1,59 @@
+package:
+  name: libsdl3
+  version: 3.1.3
+  epoch: 0
+  description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
+  copyright:
+    - license: Zlib
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - openssf-compiler-options
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/libsdl-org/SDL
+      tag: preview-${{package.version}}
+      expected-commit: e292d1f5ace469f718d7b6b4dec8c28e37dcaa0e
+
+  - uses: cmake/configure
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+subpackages:
+  - name: ${{package.name}}-dev
+    dependencies:
+      runtime:
+        - libsdl3
+    pipeline:
+      - uses: split/dev
+
+  - name: ${{package.name}}-doc
+    pipeline:
+      - uses: split/dev
+
+update:
+  enabled: true
+  github:
+    identifier: libsdl-org/SDL
+    strip-prefix: preview-
+    tag-filter-prefix: preview
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - ${{package.name}}-dev
+        - pkgconf
+  pipeline:
+    - runs: |
+        set -euo pipefail
+        pkg-config --modversion sdl3 | grep -q "${{package.version}}"

--- a/libsdl3.yaml
+++ b/libsdl3.yaml
@@ -27,15 +27,15 @@ pipeline:
 
   - uses: cmake/install
 
+  - runs: |
+      rm ${{targets.destdir}}/usr/share/licenses/SDL3/LICENSE.txt
+      rm -r ${{targets.destdir}}/usr/share
+
 subpackages:
   - name: ${{package.name}}-dev
     dependencies:
       runtime:
         - libsdl3
-    pipeline:
-      - uses: split/dev
-
-  - name: ${{package.name}}-doc
     pipeline:
       - uses: split/dev
 


### PR DESCRIPTION
Whilst it is pre-release, it has declared to have stable abi https://github.com/libsdl-org/SDL/releases/tag/preview-3.1.3

And we are starting to see cutting edge software releases that require
libsdl3. It is likely that libsdl2 will be required for a long time,
even when libsdl3 goes stable.

Package both during this transition period.

Needed for:
- https://github.com/wolfi-dev/os/pull/27343
