### PR TITLE
ffmpeg: Encode latest dependenices

### DIFF
--- a/ffmpeg.yaml
+++ b/ffmpeg.yaml
@@ -2,10 +2,20 @@
 package:
   name: ffmpeg
   version: 7.1
-  epoch: 0
+  epoch: 1
   description: ffmpeg multimedia library
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later
+  dependencies:
+    runtime:
+      - libavcodec61=${{package.full-version}}
+      - libavdevice61=${{package.full-version}}
+      - libavfilter10=${{package.full-version}}
+      - libavformat61=${{package.full-version}}
+      - libavutil59=${{package.full-version}}
+      - libswresample5=${{package.full-version}}
+      - libswscale8=${{package.full-version}}
+      - libpostproc58=${{package.full-version}}
   resources:
     cpu: 16
     memory: 16Gi


### PR DESCRIPTION
Currently `apk add ffmpeg` is borked. Instead of adding latest
software versions it resolves things like so:

(3/14) Installing libavutil58 (7.0-r0)
(4/14) Installing libswresample4 (7.0-r0)
(8/14) Installing libavcodec60 (7.0-r0)
(9/14) Installing libavformat60 (7.0-r0)
(10/14) Installing libpostproc58 (7.1-r0)
(11/14) Installing libswscale7 (7.0-r0)
(12/14) Installing libavfilter9 (7.0-r0)
(13/14) Installing libavdevice60 (7.0-r0)
(14/14) Installing ffmpeg (7.0.2-r2)

Note what a missmatch of versions it is.

Note some package versions of libavdevice60 provide abi of
so:libavdevice.so.61 which is buggy.

And sometimes ffmpeg uses newer symbols from the same library, thus
encode strictly to use the same library version as the ffmpeg was
built with. As a workaround whilst we consider to withdraw or rename
some of these library packages.
