### PR TITLE
Spark 3.5 CVE-GHSA-r7pg-v2c8-mfg3 and enabled testing

### DIFF
--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-3.5
   version: 3.5.3
-  epoch: 2
+  epoch: 3
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0
@@ -42,7 +42,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: make-distribution.patch
+      patches: make-distribution.patch internal-access.patch
 
   - uses: maven/pombump
 
@@ -89,82 +89,78 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/lib/spark
           mkdir -p ${{targets.contextdir}}/usr/lib/spark/work-dir
           mv dist/* ${{targets.contextdir}}/usr/lib/spark/
+    test:
+      environment:
+        contents:
+          packages:
+            - python3
+            - openjdk-${{range.key}}-default-jvm
+            - R
+        environment:
+          LANG: en_US.UTF-8
+          JAVA_HOME: /usr/lib/jvm/${{range.value}}
+      pipeline:
+        - name: Test ${{package.name}} with OpenJDK ${{range.key}}
+          pipeline:
+            - name: Check spark-shell --version
+            - runs: /usr/lib/spark/bin/spark-shell --version
+            - name: Check spark-submit --version
+            - runs: /usr/lib/spark/bin/spark-submit --version
+            - name: Check pyspark --version
+            - runs: /usr/lib/spark/bin/pyspark --version
+            - name: Check spark-sql --version
+            - runs: /usr/lib/spark/bin/spark-sql --version
+            - name: Test entrypoint
+              runs: timeout 10 /opt/entrypoint.sh /opt/spark/bin/spark-shell > spark_log.txt 2>&1 || [ $? -eq 143 ] && grep "Spark session available" spark_log.txt && exit_code=0 || exit_code=$? && echo $exit_code
+            - name: Run a simple Scala test script
+              runs: |
+                cat <<EOF > SimpleJob.scala
+                val data = Seq(1, 2, 3, 4, 5)
+                val rdd = spark.sparkContext.parallelize(data)
+                val sum = rdd.reduce(_ + _)
+                assert(sum == 15)
+                EOF
+                cat SimpleJob.scala | /usr/lib/spark/bin/spark-shell
+            - name: Run a simple Spark job in Python
+              runs: |
+                cat <<EOF > simple_job.py
+                from pyspark.sql import SparkSession
+                spark = SparkSession.builder.appName("SimpleJob").getOrCreate()
+                data = [1, 2, 3, 4, 5]
+                rdd = spark.sparkContext.parallelize(data)
+                sum = rdd.reduce(lambda x, y: x + y)
+                assert sum == 15
+                EOF
+                /usr/lib/spark/bin/spark-submit simple_job.py --jars /usr/lib/spark/jars/guava-32.0.1-jre.jar
+            - name: Perform SQL query on DataFrame in Scala
+              runs: |
+                cat <<EOF > SQLTest.scala
+                import org.apache.spark.sql.SparkSession
+                val spark = SparkSession.builder.appName("SQLTest").getOrCreate()
+                import spark.implicits._
+                val df = Seq((1, "Alice"), (2, "Bob")).toDF("id", "name")
+                df.createOrReplaceTempView("people")
+                val result = spark.sql("SELECT name FROM people WHERE id = 2")
+                assert(result.count() == 1 && result.first().getString(0) == "Bob")
+                EOF
+                cat SQLTest.scala | /usr/lib/spark/bin/spark-shell
+            - name: Run basic SQL query with spark-sql
+              runs: |
+                echo 'CREATE OR REPLACE TEMP VIEW test AS SELECT 1 AS id;' > test.sql
+                echo 'SELECT * FROM test;' >> test.sql
+                /usr/lib/spark/bin/spark-sql -f test.sql
+            - name: Run SparkR script
+              runs: |
+                cat <<EOF > sparkr_test.R
+                library(SparkR)
+                sparkR.session()
+                df <- as.DataFrame(data.frame(id = c(1, 2), name = c("Alice", "Bob")))
+                createOrReplaceTempView(df, "people")
+                df2 <- sql("SELECT * FROM people WHERE id > 1")
+                stopifnot(count(df2) == 1)
+                EOF
+                /usr/lib/spark/bin/spark-submit sparkr_test.R
 
-  # These tests were never functional and should not have ever been merged. Only passed CI previously due to parsing bug.
-  # Adequate image level tests exist which is the only reason it is deemed plausable to comment these out at this time.
-  # The test.environment.contents.packages range.key has been fixed and this will be ready to uncomment and verify function when the following
-  # PR is released in melange: https://github.com/chainguard-dev/melange/pull/1519
-  # Also had to move this outside the correct placement under the above run block due to yam linting mangling the comments into the run lines.
-  #
-  #test:
-  #  environment:
-  #    contents:
-  #      packages:
-  #        - python3
-  #        - openjdk-${{range.key}}-default-jvm
-  #        - R
-  #    environment:
-  #      LANG: en_US.UTF-8
-  #      JAVA_HOME: /usr/lib/jvm/${{range.value}}
-  #  pipeline:
-  #    - name: Test ${{package.name}} with OpenJDK ${{range.key}}
-  #      pipeline:
-  #        - runs: /usr/lib/spark/bin/spark-shell --version
-  #        - runs: /usr/lib/spark/bin/spark-submit --version
-  #        - runs: /usr/lib/spark/bin/pyspark --version
-  #        - runs: /usr/lib/spark/bin/spark-sql --version
-  #        - name: Test entrypoint
-  #          runs: timeout 10 /opt/entrypoint.sh /opt/spark/bin/spark-shell > spark_log.txt 2>&1 || [ $? -eq 143 ] && grep "Spark session available" spark_log.txt && exit_code=0 || exit_code=$? && echo $exit_code
-  #        - name: Run a simple Scala test script
-  #          runs: cat ./scala-test | /usr/lib/spark/bin/spark-shell
-  #        - name: Run a simple Spark job in Scala
-  #          runs: |
-  #            cat <<EOF > SimpleJob.scala
-  #            val data = Seq(1, 2, 3, 4, 5)
-  #            val rdd = spark.sparkContext.parallelize(data)
-  #            val sum = rdd.reduce(_ + _)
-  #            assert(sum == 15)
-  #            EOF
-  #            cat SimpleJob.scala | /usr/lib/spark/bin/spark-shell
-  #        - name: Run a simple Spark job in Python
-  #          runs: |
-  #            cat <<EOF > simple_job.py
-  #            from pyspark.sql import SparkSession
-  #            spark = SparkSession.builder.appName("SimpleJob").getOrCreate()
-  #            data = [1, 2, 3, 4, 5]
-  #            rdd = spark.sparkContext.parallelize(data)
-  #            sum = rdd.reduce(lambda x, y: x + y)
-  #            assert sum == 15
-  #            EOF
-  #            /usr/lib/spark/bin/spark-submit simple_job.py
-  #        - name: Perform SQL query on DataFrame in Scala
-  #          runs: |
-  #            cat <<EOF > SQLTest.scala
-  #            import org.apache.spark.sql.SparkSession
-  #            val spark = SparkSession.builder.appName("SQLTest").getOrCreate()
-  #            import spark.implicits._
-  #            val df = Seq((1, "Alice"), (2, "Bob")).toDF("id", "name")
-  #            df.createOrReplaceTempView("people")
-  #            val result = spark.sql("SELECT name FROM people WHERE id = 2")
-  #            assert(result.count() == 1 && result.first().getString(0) == "Bob")
-  #            EOF
-  #            cat SQLTest.scala | /usr/lib/spark/bin/spark-shell
-  #        - name: Run basic SQL query with spark-sql
-  #          runs: |
-  #            echo 'CREATE OR REPLACE TEMP VIEW test AS SELECT 1 AS id;' > test.sql
-  #            echo 'SELECT * FROM test;' >> test.sql
-  #            /usr/lib/spark/bin/spark-sql -f test.sql
-  #        - name: Run SparkR script
-  #          runs: |
-  #            cat <<EOF > sparkr_test.R
-  #            library(SparkR)
-  #            sparkR.session()
-  #            df <- as.DataFrame(data.frame(id = c(1, 2), name = c("Alice", "Bob")))
-  #            createOrReplaceTempView(df, "people")
-  #            df2 <- sql("SELECT * FROM people WHERE id > 1")
-  #            stopifnot(count(df2) == 1)
-  #            EOF
-  #            /usr/lib/spark/bin/spark-submit sparkr_test.R: |
   - name: ${{package.name}}-compat
     description: "Compatibility package to place binaries in the location expected by upstream image"
     pipeline:

--- a/spark-3.5/internal-access.patch
+++ b/spark-3.5/internal-access.patch
@@ -1,0 +1,68 @@
+diff --git a/core/pom.xml b/core/pom.xml
+index 17004f87586..49b32dba1d3 100644
+--- a/core/pom.xml
++++ b/core/pom.xml
+@@ -593,6 +593,7 @@
+               <include>org.eclipse.jetty:jetty-util</include>
+               <include>org.eclipse.jetty:jetty-server</include>
+               <include>com.google.guava:guava</include>
++              <include>com.google.guava:failureaccess</include>
+               <include>com.google.protobuf:*</include>
+             </includes>
+           </artifactSet>
+diff --git a/dev/deps/spark-deps-hadoop-3-hive-2.3 b/dev/deps/spark-deps-hadoop-3-hive-2.3
+index a9d63c1ad0f..0cca419e3d8 100644
+--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
++++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
+@@ -33,6 +33,7 @@ bonecp/0.8.0.RELEASE//bonecp-0.8.0.RELEASE.jar
+ breeze-macros_2.12/2.1.0//breeze-macros_2.12-2.1.0.jar
+ breeze_2.12/2.1.0//breeze_2.12-2.1.0.jar
+ cats-kernel_2.12/2.1.1//cats-kernel_2.12-2.1.1.jar
++checker-qual/3.42.0//checker-qual-3.42.0.jar
+ chill-java/0.10.0//chill-java-0.10.0.jar
+ chill_2.12/0.10.0//chill_2.12-0.10.0.jar
+ commons-cli/1.5.0//commons-cli-1.5.0.jar
+@@ -61,11 +62,13 @@ datasketches-java/3.3.0//datasketches-java-3.3.0.jar
+ datasketches-memory/2.1.0//datasketches-memory-2.1.0.jar
+ derby/10.14.2.0//derby-10.14.2.0.jar
+ dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar
++error_prone_annotations/2.26.1//error_prone_annotations-2.26.1.jar
++failureaccess/1.0.2//failureaccess-1.0.2.jar
+ flatbuffers-java/1.12.0//flatbuffers-java-1.12.0.jar
+ gcs-connector/hadoop3-2.2.14/shaded/gcs-connector-hadoop3-2.2.14-shaded.jar
+ gmetric4j/1.0.10//gmetric4j-1.0.10.jar
+ gson/2.2.4//gson-2.2.4.jar
+-guava/14.0.1//guava-14.0.1.jar
++guava/33.2.1-jre//guava-33.2.1-jre.jar
+ hadoop-aliyun/3.3.4//hadoop-aliyun-3.3.4.jar
+ hadoop-annotations/3.3.4//hadoop-annotations-3.3.4.jar
+ hadoop-aws/3.3.4//hadoop-aws-3.3.4.jar
+@@ -75,7 +78,7 @@ hadoop-client-api/3.3.4//hadoop-client-api-3.3.4.jar
+ hadoop-client-runtime/3.3.4//hadoop-client-runtime-3.3.4.jar
+ hadoop-cloud-storage/3.3.4//hadoop-cloud-storage-3.3.4.jar
+ hadoop-openstack/3.3.4//hadoop-openstack-3.3.4.jar
+-hadoop-shaded-guava/1.1.1//hadoop-shaded-guava-1.1.1.jar
++hadoop-shaded-guava/1.2.0//hadoop-shaded-guava-1.2.0.jar
+ hadoop-yarn-server-web-proxy/3.3.4//hadoop-yarn-server-web-proxy-3.3.4.jar
+ hive-beeline/2.3.9//hive-beeline-2.3.9.jar
+ hive-cli/2.3.9//hive-cli-2.3.9.jar
+@@ -174,6 +177,7 @@ lapack/3.0.3//lapack-3.0.3.jar
+ leveldbjni-all/1.8//leveldbjni-all-1.8.jar
+ libfb303/0.9.3//libfb303-0.9.3.jar
+ libthrift/0.12.0//libthrift-0.12.0.jar
++listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
+ log4j-1.2-api/2.20.0//log4j-1.2-api-2.20.0.jar
+ log4j-api/2.20.0//log4j-api-2.20.0.jar
+ log4j-core/2.20.0//log4j-core-2.20.0.jar
+diff --git a/pom.xml b/pom.xml
+index c005af470cc..222b35efe88 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -3328,6 +3328,7 @@
+             <includes>
+               <include>org.spark-project.spark:unused</include>
+               <include>com.google.guava:guava</include>
++              <include>com.google.guava:failureaccess</include>
+               <include>org.jpmml:*</include>
+             </includes>
+           </artifactSet>

--- a/spark-3.5/pombump-properties.yaml
+++ b/spark-3.5/pombump-properties.yaml
@@ -6,13 +6,13 @@ properties:
   - property: ivy.version
     value: "2.5.2"
   - property: avro.version
-    value: "1.11.3"
+    value: "1.11.4"
   - property: snappy.version
     value: "1.1.10.5"
   - property: commons-compress.version
     value: "1.26.0"
   - property: guava.version
-    value: "32.0.1-jre"
+    value: "33.2.1-jre"
   - property: netty.version
     value: "4.1.108.Final"
   - property: zookeeper.version


### PR DESCRIPTION
Enabled the tests again after an accidental close of a PR and fixed the way the tests pull in the openjdk-default-jvm. Tests are in line with basic testing from the setup documentation [outlined here.](https://github.com/apache/spark#:~:text=Interactive%20Scala%20Shell) Due to the guava upgrade, I had to also bring along [the missing method](https://github.com/apache/spark/blob/1f24b2d72ed6821a6cc6d1d22683d2f3ba2326a2/pom.xml#L3423) from an upstream commit. The PR I took for [guidance can be found here](https://github.com/apache/spark/commit/1f24b2d72ed6821a6cc6d1d22683d2f3ba2326a2#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R3423). The internal-access patch should be removed when v4.0.0 releases. This missing method integration should have been done when guava was bumped from 14.x to 32.0.1 and would have been caught if the testing was functional. In the future we consider not introducing major test changes and major version dependency changes in the same PR unless we are able to prove the efficacy of the test. Bumped the avro version from 1.11.3 to 1.11.4
