### PR TITLE
logstash/CVE-GHSA-r7pg-v2c8-mfg3 fix

### DIFF
--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-8
   version: 8.15.2
-  epoch: 2
+  epoch: 3
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -71,6 +71,7 @@ pipeline:
       echo "gem 'fugit', '1.11.1'" >> Gemfile.template
       echo "gem 'rexml', '3.3.6'" >> Gemfile.template
       echo "gem 'puma', '6.4.3'" >> Gemfile.template
+      echo "gem 'logstash-integration-kafka', '11.5.2'" >> Gemfile.template
       # Disable the logstash-integration-jdbc plugin download as we build and
       # package it separately
       jq 'del(.["logstash-integration-jdbc"])' rakelib/plugins-metadata.json > /tmp/plugins-metadata.json


### PR DESCRIPTION
The vulnerable avro v1.11.3 dependency exists within logstash-integration-kafka v11.5.1 and bumping that dependency to v11.5.2 remediates this CVE.
