### PR TITLE
akhq/GHSA-r7pg-v2c8-mfg3 fix

### DIFF
--- a/akhq.yaml
+++ b/akhq.yaml
@@ -1,7 +1,7 @@
 package:
   name: akhq
   version: 0.25.1
-  epoch: 0
+  epoch: 1
   description: "Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more"
   copyright:
     - license: Apache-2.0
@@ -29,7 +29,7 @@ pipeline:
 
   - uses: patch
     with:
-      patches: gradle.patch
+      patches: gradle.patch avro-1.12.0.patch
 
   - runs: |
       ./gradlew build -x test -x startTestKafkaCluster --parallel --no-daemon

--- a/akhq/avro-1.12.0.patch
+++ b/akhq/avro-1.12.0.patch
@@ -1,0 +1,32 @@
+From 205f42b46560de2bdbe28e553b6639379b90bb2a Mon Sep 17 00:00:00 2001
+From: "dependabot[bot]" <49699333+dependabot[bot]@users.noreply.github.com>
+Date: Mon, 5 Aug 2024 12:59:29 +0000
+Subject: [PATCH] chore(deps): bump org.apache.avro:avro from 1.11.3 to 1.12.0
+
+Bumps org.apache.avro:avro from 1.11.3 to 1.12.0.
+
+---
+updated-dependencies:
+- dependency-name: org.apache.avro:avro
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+---
+ build.gradle | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build.gradle b/build.gradle
+index d9d4fa7ad..7a99ea44d 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -136,7 +136,7 @@ dependencies {
+     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+ 
+     // avro
+-    implementation 'org.apache.avro:avro:1.11.3'
++    implementation 'org.apache.avro:avro:1.12.0'
+ 
+     // jackson-module-scala
+     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-scala_2.13', version: '2.17.1'


### PR DESCRIPTION
Bumping the version of avro 1.11.3 to 1.12.0 is a patch that has been merged upstream and was simply applied here. This remediates GHSA-r7pg-v2c8-mfg3 in akhq. This can be seen [here](https://github.com/tchiotludo/akhq/pull/1895/commits/205f42b46560de2bdbe28e553b6639379b90bb2a).