### PR TITLE
Rebuild packages for missing pc: provides

### DIFF
--- a/Catch2.yaml
+++ b/Catch2.yaml
@@ -1,7 +1,7 @@
 package:
   name: Catch2
   version: 3.7.1
-  epoch: 0
+  epoch: 1
   description: "A modern, C++-native, test framework"
   copyright:
     - license: 'BSL-1.0'

--- a/audit.yaml
+++ b/audit.yaml
@@ -1,7 +1,7 @@
 package:
   name: audit
   version: 4.0.2
-  epoch: 0
+  epoch: 1
   description: User space tools for kernel auditing
   copyright:
     - license: LGPL-2.1-or-later

--- a/bash-completion.yaml
+++ b/bash-completion.yaml
@@ -1,7 +1,7 @@
 package:
   name: bash-completion
   version: 2.14.0
-  epoch: 1
+  epoch: 2
   description: "Programmable completion functions for bash"
   copyright:
     - license: GPL-2.0-only

--- a/cli11.yaml
+++ b/cli11.yaml
@@ -1,7 +1,7 @@
 package:
   name: cli11
   version: 2.4.2
-  epoch: 1
+  epoch: 2
   description: command line parser for C++11
   copyright:
     - license: BSD-3-Clause

--- a/eigen.yaml
+++ b/eigen.yaml
@@ -1,7 +1,7 @@
 package:
   name: eigen
   version: 3.4.0
-  epoch: 3
+  epoch: 4
   description: "Eigen is a C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms."
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND Minpack AND MPL-2.0

--- a/eudev.yaml
+++ b/eudev.yaml
@@ -1,7 +1,7 @@
 package:
   name: eudev
   version: 3.2.14
-  epoch: 2
+  epoch: 3
   description: init system agnostic fork of systemd-udev
   copyright:
     - license: GPL-2.0-only

--- a/fish.yaml
+++ b/fish.yaml
@@ -2,7 +2,7 @@
 package:
   name: fish
   version: 3.7.1
-  epoch: 1
+  epoch: 2
   description: Modern interactive commandline shell
   copyright:
     - license: GPL-2.0-only

--- a/gi-docgen.yaml
+++ b/gi-docgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: gi-docgen
   version: "2024.1"
-  epoch: 0
+  epoch: 1
   description: A documentation generator for GObject-based libraries
   copyright:
     - license: Apache-2.0 OR GPL-3.0-or-later

--- a/gtk-doc.yaml
+++ b/gtk-doc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gtk-doc
   version: 1.34.0
-  epoch: 0
+  epoch: 1
   description: Documentation tool for public library API
   copyright:
     - license: GPL-2.0-or-later AND GFDL-1.1-or-later

--- a/hicolor-icon-theme.yaml
+++ b/hicolor-icon-theme.yaml
@@ -1,7 +1,7 @@
 package:
   name: hicolor-icon-theme
   version: "0.18"
-  epoch: 0
+  epoch: 1
   description: Freedesktop.org Hicolor icon theme
   copyright:
     - license: GPL-2.0-only

--- a/hwdata.yaml
+++ b/hwdata.yaml
@@ -2,7 +2,7 @@
 package:
   name: hwdata
   version: "0.388"
-  epoch: 0
+  epoch: 1
   description: Hardware identification and configuration data
   copyright:
     - license: GPL-2.0-or-later OR XFree86-1.1

--- a/iso-codes.yaml
+++ b/iso-codes.yaml
@@ -1,7 +1,7 @@
 package:
   name: iso-codes
   version: 4.17.0
-  epoch: 0
+  epoch: 1
   description: ISO codes and their translations
   copyright:
     - license: LGPL-2.1-or-later

--- a/kmod.yaml
+++ b/kmod.yaml
@@ -1,7 +1,7 @@
 package:
   name: kmod
   version: "33"
-  epoch: 0
+  epoch: 1
   description: Linux kernel module management utilities
   copyright:
     - license: GPL-2.0-or-later

--- a/libeconf.yaml
+++ b/libeconf.yaml
@@ -1,7 +1,7 @@
 package:
   name: libeconf
   version: 0.7.4
-  epoch: 0
+  epoch: 1
   description: Enhanced Config File Parser
   copyright:
     - license: MIT

--- a/libvterm.yaml
+++ b/libvterm.yaml
@@ -1,7 +1,7 @@
 package:
   name: libvterm
   version: 0.3.3
-  epoch: 0
+  epoch: 1
   description: "Abstract library implementation of a VT220/xterm/ECMA-48 terminal emulator"
   copyright:
     - license: MIT

--- a/neon.yaml
+++ b/neon.yaml
@@ -1,7 +1,7 @@
 package:
   name: neon
   version: "6812"
-  epoch: 0
+  epoch: 1
   description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
   copyright:
     - license: Apache-2.0

--- a/nlohmann-json.yaml
+++ b/nlohmann-json.yaml
@@ -2,7 +2,7 @@
 package:
   name: nlohmann-json
   version: 3.11.3
-  epoch: 1
+  epoch: 2
   description: JSON for Modern C++
   copyright:
     - license: MIT

--- a/reflex.yaml
+++ b/reflex.yaml
@@ -1,7 +1,7 @@
 package:
   name: reflex
   version: 0.6.2
-  epoch: 0
+  epoch: 1
   description: "Web apps in pure Python"
   copyright:
     - license: Apache-2.0

--- a/scdoc.yaml
+++ b/scdoc.yaml
@@ -1,7 +1,7 @@
 package:
   name: scdoc
   version: 1.11.3
-  epoch: 0
+  epoch: 1
   description: "simple man page generator written for POSIX systems with C99"
   copyright:
     - license: MIT

--- a/shared-mime-info.yaml
+++ b/shared-mime-info.yaml
@@ -1,7 +1,7 @@
 package:
   name: shared-mime-info
   version: "2.4"
-  epoch: 2
+  epoch: 3
   description: Freedesktop.org Shared MIME Info
   copyright:
     - license: GPL-2.0-or-later

--- a/spirv-headers.yaml
+++ b/spirv-headers.yaml
@@ -2,7 +2,7 @@
 package:
   name: spirv-headers
   version: 1.3.261.1
-  epoch: 2
+  epoch: 3
   description: Machine-readable files for the SPIR-V Registry
   copyright:
     - license: GPL-3.0-or-later

--- a/subversion.yaml
+++ b/subversion.yaml
@@ -1,7 +1,7 @@
 package:
   name: subversion
   version: 1.14.4
-  epoch: 0
+  epoch: 1
   description: Replacement for CVS, another versioning system (svn)
   copyright:
     - license: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND HPND-Markus-Kuhn AND MIT AND Unicode-DFS-2015 AND FSFAP

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "256.7"
-  epoch: 0
+  epoch: 1
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later

--- a/util-macros.yaml
+++ b/util-macros.yaml
@@ -1,7 +1,7 @@
 package:
   name: util-macros
   version: 1.20.1
-  epoch: 0
+  epoch: 1
   description: X.Org Autotools macros
   copyright:
     - license: MIT

--- a/wayland-protocols.yaml
+++ b/wayland-protocols.yaml
@@ -1,7 +1,7 @@
 package:
   name: wayland-protocols
   version: "1.37"
-  epoch: 0
+  epoch: 1
   description: Protocols and protocol extensions complementing the Wayland core protocol
   copyright:
     - license: MIT
@@ -13,6 +13,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - meson
+      - python3-dev
       - wayland-dev
 
 pipeline:

--- a/xbitmaps.yaml
+++ b/xbitmaps.yaml
@@ -1,7 +1,7 @@
 package:
   name: xbitmaps
   version: 1.1.3
-  epoch: 1
+  epoch: 2
   description: X.org header files with bitmaps
   copyright:
     - license: MIT

--- a/xcb-proto.yaml
+++ b/xcb-proto.yaml
@@ -1,7 +1,7 @@
 package:
   name: xcb-proto
   version: 1.17.0
-  epoch: 1
+  epoch: 2
   description: XML-XCB protocol descriptions
   copyright:
     - license: MIT

--- a/xkeyboard-config.yaml
+++ b/xkeyboard-config.yaml
@@ -2,7 +2,7 @@
 package:
   name: xkeyboard-config
   version: "2.43"
-  epoch: 0
+  epoch: 1
   description: X keyboard configuration files
   copyright:
     - license: MIT

--- a/xtrans.yaml
+++ b/xtrans.yaml
@@ -1,7 +1,7 @@
 package:
   name: xtrans
   version: 1.5.0
-  epoch: 2
+  epoch: 3
   description: X transport library
   copyright:
     - license: MIT

--- a/yajl.yaml
+++ b/yajl.yaml
@@ -1,7 +1,7 @@
 package:
   name: yajl
   version: 2.1.0
-  epoch: 4
+  epoch: 5
   description: Yet Another JSON Library (YAJL)
   copyright:
     - license: MIT


### PR DESCRIPTION
Using melange scan on all existing packages, relative older scan
results, shows that recent melange improvements to generating pc:
provides would result in these packages exposing pc: provides.

This aids in discovery of what development packages one needs to
install to query correct installation paths for Wolfi.

The following provides will be added:

```
 pc:audit=4.0.2-r0
 pc:auparse=4.0.2-r0
 pc:bash-completion=2.14.0-r1
 pc:catch2=3.7.1-r0
 pc:CLI11=2.4.2-r1
 pc:default-icon-theme=0.18-r0
 pc:eigen3=3.4.0-r3
 pc:fish=3.7.1-r1
 pc:gi-docgen=2024.1-r0
 pc:gtk-doc=1.34.0-r0
 pc:hwdata=0.388-r0
 pc:iso-codes=4.17.0-r0
 pc:kmod=33-r0
 pc:libeconf=0.7.4-r0
 pc:libecpg=6777-r0
 pc:libecpg_compat=6777-r0
 pc:libpgtypes=6777-r0
 pc:libpq=6777-r0
 pc:librtmp=2.6_git20241005-r0
 pc:libsvn_client=1.14.3-r1
 pc:libsvn_delta=1.14.3-r1
 pc:libsvn_diff=1.14.3-r1
 pc:libsvn_fs=1.14.3-r1
 pc:libsvn_fs_fs=1.14.3-r1
 pc:libsvn_fs_util=1.14.3-r1
 pc:libsvn_fs_x=1.14.3-r1
 pc:libsvn_ra=1.14.3-r1
 pc:libsvn_ra_local=1.14.3-r1
 pc:libsvn_ra_serf=1.14.3-r1
 pc:libsvn_ra_svn=1.14.3-r1
 pc:libsvn_repos=1.14.3-r1
 pc:libsvn_subr=1.14.3-r1
 pc:libsvn_wc=1.14.3-r1
 pc:nlohmann_json=3.11.3-r1
 pc:numpy=0.6.1-r0
 pc:scdoc=1.11.3-r0
 pc:shared-mime-info=2.4-r1
 pc:SPIRV-Headers=1.3.261.1-r2
 pc:systemd=256.6-r2
 pc:udev=256.6-r2
 pc:udev=3.2.14-r2
 pc:vterm=0.3.3-r0
 pc:xbitmaps=1.1.3-r1
 pc:xkeyboard-config=2.43-r0
 pc:xorg-macros=1.20.1-r0
 pc:xtrans=1.5.0-r2
 pc:yajl=2.1.0-r4
```

Reference: https://github.com/chainguard-dev/melange/pull/1522
