### PR TITLE
ensure fluent-operators config can replace

### DIFF
--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-operator
   version: 3.2.0
-  epoch: 0
+  epoch: 1
   description: Operate Fluent Bit and Fluentd in the Kubernetes way - Previously known as FluentBit Operator
   copyright:
     - license: Apache-2.0
@@ -29,8 +29,6 @@ pipeline:
 subpackages:
   - name: fluent-watcher
     pipeline:
-      - runs: |
-          mkdir -p "${{targets.contextdir}}"/fluent-bit/config
       - uses: go/build
         with:
           packages: ./cmd/fluent-watcher/fluentbit
@@ -50,20 +48,42 @@ subpackages:
             tempfile=$(mktemp)
             fluent-watcher > "$tempfile" 2>&1 &
 
-            # Capture the PID of fluent-watcher
-            FLUENT_WATCHER_PID=$!
-
             sleep 5
 
             # Use grep to filter the output
             cat "$tempfile" | grep -i "fluent-bit started"
 
-            # Wait for fluent-watcher to finish (optional)
-            kill $FLUENT_WATCHER_PID
-
-            # Clean up the temporary file
-            rm "$tempfile"
             fluent-watcher --help
+
+  - name: fluent-watcher-config
+    dependencies:
+      replaces:
+        # A "replaces" must match the package origin's full name. Since we use
+        # a version stream for fluent-bit, we must append fluent-bit-3.1
+        # exactly.
+        #
+        # Our automation has no way of linking fluent-operator to
+        # fluent-bit updates, so to ensure this doesn't silently fail when
+        # fluent-bit rolls forward, we have a test stanza below that ensures
+        # fluent-operator can always be installed alongside fluent-bit.
+        #
+        # When this test fails, that likely means fluent-bit rolled forward to
+        # a new version stream anad must be updated in the "replaces" block
+        # below
+        - fluent-bit-3.1
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/fluent-bit/etc
+          cp conf/fluent-bit.conf conf/fluent-bit.yaml conf/parsers.conf \
+            conf/fluent-bit.conf "${{targets.contextdir}}"/fluent-bit/etc
+    test:
+      environment:
+        contents:
+          packages:
+            - fluent-bit
+      pipeline:
+        - runs: |
+            cat /fluent-bit/etc/parsers.conf
 
   - name: fluent-watcher-compat
     pipeline:


### PR DESCRIPTION
this adds a new `fluent-watcher-config` subpackage to `fluent-operator` to replicate the upstream behavior of using a different config file for `fluent-watcher`.

Since `fluent-watcher` depends on `fluent-bit`, both of which provide valid `/fluent-bit/etc/{fluent.conf,parsers.conf,fluent-bit.yaml}`, we use a `replaces` block here to ensure `fluent-watcher` prefers its own config.