### PR TITLE
Revert "Make empty package for typing-extensions in python > 3.11 (#30427)"

### DIFF
--- a/py3-typing-extensions.yaml
+++ b/py3-typing-extensions.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-typing-extensions
   version: 4.12.2
-  epoch: 6
+  epoch: 7
   description: Backported and Experimental Type Hints for Python 3.7+
   copyright:
     - license: PSF-2.0
@@ -17,9 +17,6 @@ data:
   - name: py-versions
     items:
       3.10: "310"
-
-  - name: py-noops
-    items:
       3.11: "311"
       3.12: "312"
       3.13: "300"
@@ -60,16 +57,6 @@ subpackages:
     test:
       pipeline:
         - runs: python${{range.key}} -c "from ${{vars.module_name}} import TypeAlias, TypeGuard"
-
-  - range: py-noops
-    name: py${{range.key}}-${{vars.pypi-package}}
-    # typing-extensions is only needed for 3.10.  Its empty dep for others
-    # as it is part of the stdlib.
-    description: ${{vars.pypi-package}} empty dep for python${{range.key}}
-    dependencies:
-      provides:
-        - py3-${{vars.pypi-package}}
-      provider-priority: ${{range.value}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.


### PR DESCRIPTION
This reverts commit 7f37d38ae65ae33e38675ee5409f9983422c9e41.

Bumps epoch

Note typing-extensions is explicitly used/imported in non-versioned ways
and is not simply a backport package.
