### PR TITLE
py3-elfdeps: correct build deps

### DIFF
--- a/py3-elfdeps.yaml
+++ b/py3-elfdeps.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-elfdeps
   version: 0.2.0
-  epoch: 0
+  epoch: 1
   description: Python implementation of RPM elfdeps
   copyright:
     - license: Apache-2.0
@@ -27,6 +27,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - py3-supported-pip
+      - py3-supported-setuptools
+      - py3-supported-setuptools-scm
       - wolfi-base
 
 pipeline:


### PR DESCRIPTION
Adds missing setuptools and setuptools-scm

Signed-off-by: Pris Nasrat <pris.nasrat@chainguard.dev>
