### PR TITLE
py3-ml-metadata - multi-versionize

### DIFF
--- a/py3-ml-metadata.yaml
+++ b/py3-ml-metadata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ml-metadata
   version: 1.16.0
-  epoch: 0
+  epoch: 2
   description: For recording and retrieving metadata associated with ML developer and data scientist workflows.
   copyright:
     - license: MIT
@@ -9,24 +9,31 @@ package:
     cpu: 14
     memory: 50Gi
   dependencies:
-    runtime:
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: ml-metadata
+  import: ml_metadata
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
       - bash
       - bazel-6
-      - build-base
-      - busybox
-      - ca-certificates-bundle
       - cmake
       - gcc~13
       - openjdk-11
       - openssl-dev
       - patch
-      - py3-setuptools
-      - python3-dev
+      - py3-supported-build-base-dev
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
     BAZEL_CXXOPTS: -std=c++17:-w
@@ -42,15 +49,48 @@ pipeline:
     with:
       series: series
 
-  - runs: |
-      python3 setup.py build
-
-  - runs: |
-      python3 setup.py install --skip-build --root="${{targets.destdir}}"
-
-  - uses: strip
-
 subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - name: "hack python3 into path"
+        runs: |
+          # the bazel part of the build wants to find 'python3' or lets you
+          # set it with PYTHON_BIN_PATH=/path/to/executable. but we can not
+          # easily set the environment here to a range specific value.
+          # https://github.com/chainguard-dev/melange/issues/1402
+          # https://github.com/chainguard-dev/melange/issues/1548
+          mkdir -p /usr/local/bin
+          ln -svf /usr/bin/python${{range.key}} /usr/local/bin/python
+          ln -svf /usr/bin/python${{range.key}} /usr/local/bin/python3
+          out=$(which python) && echo "'which python' -> $out" || exit 1
+          out=$(which python3) && echo "'which python3' -> $out" || exit 1
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
   - name: ml-metadata-store-server
     description: ML Metadata remote gRPC server
     pipeline:
@@ -65,6 +105,13 @@ subpackages:
       pipeline:
         - runs: |
             metadata_store_server --version
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true


### PR DESCRIPTION
This was a little tricky due to the PATH hack.
bazel wants to use 'python' (and apparently 'python3') So we put that into its PATH.
