### PR TITLE
add make test-debug target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,9 @@ test/%:
 	@printf "Testing package $* with version $(pkgver) from file $(yamlfile)\n"
 	$(MELANGE) test $(yamlfile) $(MELANGE_TEST_OPTS) --source-dir ./$(*)/
 
+test-debug/%:
+	MELANGE_EXTRA_OPTS="--interactive" make test/$*
+
 dev-container:
 	docker run --privileged --rm -it \
 	    -v "${PWD}:${PWD}" \

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ test/%:
 	$(MELANGE) test $(yamlfile) $(MELANGE_TEST_OPTS) --source-dir ./$(*)/
 
 test-debug/%:
-	MELANGE_EXTRA_OPTS="--interactive" make test/$*
+	MELANGE_EXTRA_OPTS="--interactive" $(MAKE) test/$*
 
 dev-container:
 	docker run --privileged --rm -it \


### PR DESCRIPTION
    we have make debug target to debug build failures. This target will help
    in debugging test failures. make test-debug/foo will put every exit 1
    into an interactive shell.

