### PR TITLE
falco: pin to grpc-1.66

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco
   version: 0.39.1 # on update check if we can remove the 'Patch falcosecurity-libs' pipeline below if https://github.com/falcosecurity/libs/pull/2079 is merged
-  epoch: 0
+  epoch: 1
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -33,7 +33,9 @@ environment:
       - cxxopts-dev
       - elfutils-dev
       - git
-      - grpc-dev
+      # <= 0.39.1 is incompatible with grpc 1.67 due to a removal of deprecated symbols falco was relying on.
+      # We should remove this pinning once falco is updated to use the new abseil API.
+      - grpc-1.66-dev
       - icu-dev
       - jq-dev
       - jsoncpp-dev


### PR DESCRIPTION
grpc removed a deprecated log library in 1.67 in favor of absl equivalents: https://github.com/grpc/grpc/commit/245941e0da74afa3e5446105ca3baad2f3bd8a70

Falco however still relies on the gpr_log library, and is currently incompatible with the latest grpc.

```
2024-10-09T14:15:46.9966448Z 2024/10/09 14:15:46 WARN /home/build/userspace/falco/grpc_server.cpp:57:13: error: variable or field 'gpr_log_dispatcher_func' declared void
2024-10-09T14:15:46.9968903Z 2024/10/09 14:15:46 WARN    57 | static void gpr_log_dispatcher_func(gpr_log_func_args* args) {
2024-10-09T14:15:46.9970049Z 2024/10/09 14:15:46 WARN       |             ^~~~~~~~~~~~~~~~~~~~~~~
2024-10-09T14:15:47.0346119Z 2024/10/09 14:15:47 WARN /home/build/userspace/falco/grpc_server.cpp:57:37: error: 'gpr_log_func_args' was not declared in this scope
2024-10-09T14:15:47.0348162Z 2024/10/09 14:15:47 WARN    57 | static void gpr_log_dispatcher_func(gpr_log_func_args* args) {
2024-10-09T14:15:47.0350347Z 2024/10/09 14:15:47 WARN       |                                     ^~~~~~~~~~~~~~~~~
2024-10-09T14:15:47.0491399Z 2024/10/09 14:15:47 WARN /home/build/userspace/falco/grpc_server.cpp:57:56: error: 'args' was not declared in this scope
2024-10-09T14:15:47.0493143Z 2024/10/09 14:15:47 WARN    57 | static void gpr_log_dispatcher_func(gpr_log_func_args* args) {
2024-10-09T14:15:47.0494382Z 2024/10/09 14:15:47 WARN       |                                                        ^~~~
2024-10-09T14:15:47.1267912Z 2024/10/09 14:15:47 WARN /home/build/userspace/falco/grpc_server.cpp: In member function 'void falco::grpc::server::init(const std::string&, int, const std::string&, const std::string&, const std::string&, const std::string&)':
2024-10-09T14:15:47.1270882Z 2024/10/09 14:15:47 WARN /home/build/userspace/falco/grpc_server.cpp:142:39: error: 'GPR_LOG_SEVERITY_ERROR' was not declared in this scope
2024-10-09T14:15:47.1272738Z 2024/10/09 14:15:47 WARN   142 |                 gpr_set_log_verbosity(GPR_LOG_SEVERITY_ERROR);
2024-10-09T14:15:47.1273799Z 2024/10/09 14:15:47 WARN       |                                       ^~~~~~~~~~~~~~~~~~~~~~
2024-10-09T14:15:47.2006546Z 2024/10/09 14:15:47 WARN /home/build/userspace/falco/grpc_server.cpp:142:17: error: 'gpr_set_log_verbosity' was not declared in this scope
2024-10-09T14:15:47.2008189Z 2024/10/09 14:15:47 WARN   142 |                 gpr_set_log_verbosity(GPR_LOG_SEVERITY_ERROR);
2024-10-09T14:15:47.2009073Z 2024/10/09 14:15:47 WARN       |                 ^~~~~~~~~~~~~~~~~~~~~
2024-10-09T14:15:47.2777336Z 2024/10/09 14:15:47 WARN /home/build/userspace/falco/grpc_server.cpp:145:39: error: 'GPR_LOG_SEVERITY_DEBUG' was not declared in this scope
2024-10-09T14:15:47.2779297Z 2024/10/09 14:15:47 WARN   145 |                 gpr_set_log_verbosity(GPR_LOG_SEVERITY_DEBUG);
2024-10-09T14:15:47.2780457Z 2024/10/09 14:15:47 WARN       |                                       ^~~~~~~~~~~~~~~~~~~~~~
2024-10-09T14:15:47.3520850Z 2024/10/09 14:15:47 WARN /home/build/userspace/falco/grpc_server.cpp:150:39: error: 'GPR_LOG_SEVERITY_INFO' was not declared in this scope
2024-10-09T14:15:47.3522970Z 2024/10/09 14:15:47 WARN   150 |                 gpr_set_log_verbosity(GPR_LOG_SEVERITY_INFO);
2024-10-09T14:15:47.3524115Z 2024/10/09 14:15:47 WARN       |                                       ^~~~~~~~~~~~~~~~~~~~~
2024-10-09T14:15:47.4291820Z 2024/10/09 14:15:47 WARN /home/build/userspace/falco/grpc_server.cpp:153:9: error: 'gpr_log_verbosity_init' was not declared in this scope
2024-10-09T14:15:47.4293436Z 2024/10/09 14:15:47 WARN   153 |         gpr_log_verbosity_init();
2024-10-09T14:15:47.4294306Z 2024/10/09 14:15:47 WARN       |         ^~~~~~~~~~~~~~~~~~~~~~
2024-10-09T14:15:47.5085355Z 2024/10/09 14:15:47 WARN /home/build/userspace/falco/grpc_server.cpp:154:30: error: 'gpr_log_dispatcher_func' was not declared in this scope
2024-10-09T14:15:47.5087290Z 2024/10/09 14:15:47 WARN   154 |         gpr_set_log_function(gpr_log_dispatcher_func);
2024-10-09T14:15:47.5088453Z 2024/10/09 14:15:47 WARN       |                              ^~~~~~~~~~~~~~~~~~~~~~~
2024-10-09T14:15:47.5799866Z 2024/10/09 14:15:47 WARN /home/build/userspace/falco/grpc_server.cpp:154:9: error: 'gpr_set_log_function' was not declared in this scope
2024-10-09T14:15:47.5802086Z 2024/10/09 14:15:47 WARN   154 |         gpr_set_log_function(gpr_log_dispatcher_func);
2024-10-09T14:15:47.5803449Z 2024/10/09 14:15:47 WARN       |         ^~~~~~~~~~~~~~~~~~~~
```

This pins Falco to grpc-1.66 version stream, which is still technically supported (grpc supports n-1 minor releases). Once falco is updated upstream, we should remove this pin.

https://github.com/grpc/grpc/commit/245941e0da74afa3e5446105ca3baad2f3bd8a70

Related: https://github.com/wolfi-dev/os/pull/30312

