### PR TITLE
portieris: Add package

### DIFF
--- a/portieris.yaml
+++ b/portieris.yaml
@@ -1,0 +1,45 @@
+package:
+  name: portieris
+  version: 0.13.19
+  epoch: 0
+  description: A Kubernetes Admission Controller for verifying image trust.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/IBM/portieris.git
+      tag: v${{package.version}}
+      expected-commit: d0705039d060ab11b8fa598b79647ac0008af57e
+
+  - uses: go/build
+    with:
+      packages: "./cmd/portieris"
+      ldflags: "-X github.com/IBM/portieris/internal/info.Version=v${{package.version}}"
+      tags: containers_image_openpgp
+      output: portieris
+
+subpackages:
+  - name: portieris-compat
+    description: Compat package for portieris
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/
+          ln -s /usr/bin/portieris "${{targets.subpkgdir}}"/portieris
+
+update:
+  enabled: true
+  github:
+    identifier: IBM/portieris
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        which portieris
+        portieris --help


### PR DESCRIPTION
This commit adds the portieris package https://github.com/IBM/portieris

#### For new package PRs only

- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)


