### PR TITLE
fixes kserve-modelmesh-compat subpackage

### DIFF
--- a/kserve-modelmesh.yaml
+++ b/kserve-modelmesh.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve-modelmesh
   version: 0.12.0
-  epoch: 1
+  epoch: 2
   description: The ModelMesh framework is a mature, general-purpose model serving management/routing layer designed for high-scale, high-density and frequently-changing model use cases.
   dependencies:
     runtime:
@@ -29,14 +29,17 @@ pipeline:
     runs: |
       export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
       mvn -B package -Dfile.encoding=UTF8 -DskipTests=true --file pom.xml
+      mkdir -p ${{targets.destdir}}/opt/kserve/mmesh
+      mv /home/build/target/dockerhome ${{targets.destdir}}/opt/kserve/mmesh/
+      chmod -R 775 ${{targets.destdir}}/opt/kserve/mmesh/dockerhome
 
 subpackages:
   - name: kserve-modelmesh-compat
     description: "compat package with kserve/modelmesh image"
     pipeline:
       - runs: |
-          mkdir -p ${{targets.destdir}}/opt/kserve/mmesh
-          cp -r /home/build/target/dockerhome/ ${{targets.destdir}}/opt/kserve/mmesh/
+          mkdir -p "${{targets.contextdir}}/usr/share/dockerhome"
+          ln -s /opt/kserve/mmesh/dockerhome "${{targets.contextdir}}/usr/share/dockerhome"
 
 test:
   pipeline:


### PR DESCRIPTION
- corrects empty compat package(keeping the compat package as the image build for kserve components uses compat package )
- Adds +x permissions to entrypoint scripts and stop.sh


