### PR TITLE
py3-supported-python - add some deps and a py3-build-base-deev

### DIFF
--- a/py3-supported-python.yaml
+++ b/py3-supported-python.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-supported-python
   version: 1
-  epoch: 3
+  epoch: 4
   description: metapackage to install all supported versions of python
   copyright:
     - license: "MIT"
@@ -40,6 +40,7 @@ subpackages:
     description: ${{vars.pypi-package}} core/base build packages.
     dependencies:
       runtime:
+        - busybox
         - py${{range.key}}-build
         - py${{range.key}}-installer
         - py${{range.key}}-pip-base
@@ -54,18 +55,32 @@ subpackages:
     description: "metapackage for common python build-deps"
     dependencies:
       runtime:
-        - busybox
         - py3.10-build-base
         - py3.11-build-base
         - py3.12-build-base
         - py3.13-build-base
+
+  - range: py-versions
+    name: py${{range.key}}-build-base-dev
+    description: ${{vars.pypi-package}} core/base build packages.
+    dependencies:
+      runtime:
+        - py${{range.key}}-build-base
+        - python-${{range.key}}-base-dev
+        - build-base
+      provides:
+        - py3-build-base-dev
+      provider-priority: ${{range.value}}
 
   - name: py3-supported-build-base-dev
     description: "metapackage for common python build-deps with C extensions"
     dependencies:
       runtime:
         - build-base
-        - py3-supported-build-base
+        - py3.10-build-base-dev
+        - py3.11-build-base-dev
+        - py3.12-build-base-dev
+        - py3.13-build-base-dev
         - py3-supported-python-dev
 
 update:


### PR DESCRIPTION
this makes it easier to use these from a non-multiversioned world.

Now:
 * you can use py3-build-base-dev to get a compiler and python headers.
 * py3-build-base will get you busybox
