### PR TITLE
grpc: Set provider priority

### DIFF
--- a/grpc-1.66.yaml
+++ b/grpc-1.66.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.66
   version: 1.66.2
-  epoch: 0
+  epoch: 1
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -11,12 +11,17 @@ package:
   dependencies:
     provides:
       - grpc=${{package.full-version}}
+    provider-priority: ${{vars.minor-version}}
 
 var-transforms:
   - from: ${{package.version}}
     match: ^(\d+\.\d+)\.\d+$
     replace: "$1"
     to: major-minor-version
+  - from: ${{package.version}}
+    match: ^\d+\.(\d+)\.\d+$
+    replace: "$1"
+    to: minor-version
 
 environment:
   contents:

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.67
   version: 1.67.0
-  epoch: 0
+  epoch: 1
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -11,12 +11,17 @@ package:
   dependencies:
     provides:
       - grpc=${{package.full-version}}
+    provider-priority: ${{vars.minor-version}}
 
 var-transforms:
   - from: ${{package.version}}
     match: ^(\d+\.\d+)\.\d+$
     replace: "$1"
     to: major-minor-version
+  - from: ${{package.version}}
+    match: ^\d+\.(\d+)\.\d+$
+    replace: "$1"
+    to: minor-version
 
 environment:
   contents:


### PR DESCRIPTION
The 2 grpc packages are currently conflicting with each other:

```
2024/10/10 15:08:44 ERRO failed to build package: unable to build guest: unable to generate image: installing apk packages: error getting package dependencies: solving "opentelemetry-cpp-dev" constraint: resolving "opentelemetry-cpp-dev-1.17.0-r0.apk" deps:
resolving "opentelemetry-cpp-1.17.0-r0.apk" deps:
solving "so:libgpr.so.43" constraint:   grpc-1.66-1.66.2-r0.apk disqualified because grpc-1.67-1.67.0-r0.apk already provides cmd:grpc_cpp_plugin
  grpc-1.66-1.66.2-r0.apk disqualified because grpc-1.67-1.67.0-r0.apk already provides cmd:grpc_cpp_plugin
  grpc-1.66.2-r0.apk disqualified because grpc-1.67-1.67.0-r0.apk already provides cmd:grpc_cpp_plugin
```

This sets priority based on the minor version.

Related: https://github.com/wolfi-dev/os/pull/30459
