### PR TITLE
python/multi-version batch 15

### DIFF
--- a/py3-libcst.yaml
+++ b/py3-libcst.yaml
@@ -1,30 +1,31 @@
-# Generated from https://pypi.org/project/libcst/
 package:
   name: py3-libcst
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7, 3.8, 3.9, and 3.10 programs.
   copyright:
     - license: MIT AND PSF-2.0
   dependencies:
-    runtime:
-      - py3-typing-extensions
-      - py3-typing-inspect
-      - py3-pyyaml
-      - python-3
-      - glibc
+    provider-priority: 0
+
+vars:
+  pypi-package: libcst
+  import: libcst
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - py3-setuptools-rust
-      - python-3
+      - py3-supported-build-base-dev
+      - py3-supported-setuptools-rust
       - rust
-      - wolfi-base
 
 pipeline:
   - uses: git-checkout
@@ -33,10 +34,47 @@ pipeline:
       repository: https://github.com/Instagram/LibCST
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-typing-extensions
+        - py${{range.key}}-typing-inspect
+        - py${{range.key}}-pyyaml
+        - glibc
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true
@@ -44,9 +82,3 @@ update:
   github:
     identifier: Instagram/LibCST
     strip-prefix: v
-
-test:
-  pipeline:
-    - uses: python/import
-      with:
-        import: libcst

--- a/py3-opt-einsum.yaml
+++ b/py3-opt-einsum.yaml
@@ -1,24 +1,32 @@
 package:
   name: py3-opt-einsum
   version: 3.4.0
-  epoch: 0
+  epoch: 1
   description: Optimizing numpys einsum function
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - numpy
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: opt-einsum
+  import: opt_einsum
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-hatch-fancy-pypi-readme
+      - py3-supported-hatch-vcs
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -27,20 +35,51 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: c15aec2c7dbbcaf5b9790b980f699bf295baa7d9
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - numpy
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
-
-update:
-  enabled: true
-  github:
-    identifier: dgasmith/opt_einsum
-    strip-prefix: v
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:
     - uses: python/import
       with:
         imports: |
+          import ${{vars.import}}
+    - uses: python/import
+      with:
+        imports: |
           import opt_einsum
+
+update:
+  enabled: true
+  github:
+    identifier: dgasmith/opt_einsum
+    strip-prefix: v

--- a/py3-py4j.yaml
+++ b/py3-py4j.yaml
@@ -1,43 +1,34 @@
 package:
   name: py3-py4j
   version: 0.10.9.7
-  epoch: 2
+  epoch: 3
   description: Enables Python programs to dynamically access arbitrary Java objects
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: py4j
+  import: py4j
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-11-openjdk
   contents:
     packages:
       - bash
-      - build-base
-      - busybox
-      - ca-certificates-bundle
       - gradle
       - openjdk-11
-      - py3-alabaster
-      - py3-babel
-      - py3-docutils
-      - py3-imagesize
-      - py3-jinja2
-      - py3-packaging
-      - py3-pygments
-      - py3-requests
-      - py3-setuptools
-      - py3-snowballstemmer
-      - py3-sphinx
-      - py3-sphinxcontrib-applehelp
-      - py3-sphinxcontrib-devhelp
-      - py3-sphinxcontrib-htmlhelp
-      - py3-sphinxcontrib-jsmath
-      - py3-sphinxcontrib-qthelp
-      - py3-sphinxcontrib-serializinghtml
-      - py3-wheel
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -51,18 +42,42 @@ pipeline:
       # To fix this error `Reason: UndefinedError("'style' is undefined")`
       patches: disable-copyWebJavadocPython.patch
 
-  - runs: |
-      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
-      cd py4j-java
-      ./gradlew buildPython
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - name: Python Build
-    runs: python setup.py build
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
-  - name: Python Install
-    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
-
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-pydot.yaml
+++ b/py3-pydot.yaml
@@ -1,27 +1,31 @@
 package:
   name: py3-pydot
   version: 3.0.2
-  epoch: 0
+  epoch: 1
   description: Python interface to Graphviz's Dot
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - py3-parsing
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: pydot
+  import: pydot
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-gpep517
-      - py3-parsing
-      - py3-setuptools
-      - py3-wheel
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-gpep517
+      - py3-supported-pyparsing
 
 pipeline:
   - uses: git-checkout
@@ -30,11 +34,44 @@ pipeline:
       expected-commit: 754f3e8ace78706371490ece5af2eda4ded2e31f
       tag: v${{package.version}}
 
-  - runs: |
-      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 1
-      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-pyparsing
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true
@@ -43,9 +80,3 @@ update:
     use-tag: true
     tag-filter: v
     strip-prefix: v
-
-test:
-  pipeline:
-    - uses: python/import
-      with:
-        import: pydot


### PR DESCRIPTION
Convert packages to python multi-version.

This is part of a series of programatic changes to add the ability to support python packages for multiple python versions.
