### PR TITLE
ingress-nginx: Add ingress-nginx-opentelemetry

### DIFF
--- a/ingress-nginx-controller-1.11.yaml
+++ b/ingress-nginx-controller-1.11.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.11
   version: 1.11.3
   # There are manual changes to review between each package update. See 'vars:' section.
-  epoch: 0
+  epoch: 1
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -534,6 +534,43 @@ subpackages:
           output: kube-webhook-certgen
           modroot: ./images/kube-webhook-certgen/rootfs
           packages: .
+
+  - name: ingress-nginx-opentelemetry-${{vars.nginx-ingress-major-minor}}
+    description: ingress-nginx opentelemetry module installation
+    dependencies:
+      provides:
+        - ingress-nginx-opentelemetry=${{vars.nginx-ingress-major-minor}}
+      runtime:
+        - opentelemetry-plugin-nginx-compat
+    pipeline:
+      - uses: go/build
+        with:
+          output: init_module
+          # Go does not like using "." here. Not sure why, possibly because the module name is not prefixed with the repo root module.
+          packages: init_module.go
+          modroot: images/opentelemetry/rootfs
+    test:
+      pipeline:
+        - runs: |
+            mkdir -p /modules_mount/etc/nginx/modules/otel
+            /usr/bin/init_module
+            stat /modules_mount/etc/nginx/modules/otel/otel_ngx_module.so
+
+  - name: ingress-nginx-opentelemetry-compat-${{vars.nginx-ingress-major-minor}}
+    description: ingress-nginx opentelemetry module installation
+    dependencies:
+      provides:
+        - ingress-nginx-opentelemetry-compat=${{vars.nginx-ingress-major-minor}}
+      runtime:
+        - ingress-nginx-opentelemetry
+    pipeline:
+      # See https://github.com/kubernetes/ingress-nginx/blob/f6456ea86c6c330e7cf401ade70ce1faa757265b/images/opentelemetry/rootfs/Dockerfile#L43
+      - runs: |
+          mkdir -p ${{targets.contextdir}}
+          ln -s /usr/bin/init_module ${{targets.contextdir}}/init_module
+    test:
+      pipeline:
+        - runs: stat /init_module
 
 update:
   enabled: true

--- a/opentelemetry-cpp.yaml
+++ b/opentelemetry-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-cpp
   version: 1.17.0
-  epoch: 0
+  epoch: 1
   description: The OpenTelemetry C++ Client
   copyright:
     - license: Apache-2.0

--- a/opentelemetry-plugin-nginx.yaml
+++ b/opentelemetry-plugin-nginx.yaml
@@ -2,7 +2,7 @@
 package:
   name: opentelemetry-plugin-nginx
   version: 0_git20241010
-  epoch: 0
+  epoch: 1
   description: Adds OpenTelemetry distributed tracing support to nginx. This is the otel community plugin for nginx, not the official nginx plugin for otel.
   copyright:
     - license: Apache-2.0
@@ -50,6 +50,16 @@ pipeline:
     working-directory: instrumentation/nginx/output
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-compat
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/etc/nginx
+          ln -s /usr/share/nginx/modules ${{targets.contextdir}}/etc/nginx/modules
 
 update:
   enabled: true


### PR DESCRIPTION
Adds ingress-nginx-opentelemetry, which is a helper that installs nginx modules into the local image.
This assumes that the images are at /etc/nginx/modules, so add a compat package to otel-plugin-nginx to add a symlink.

otel-cpp bumped to fix build breakage introduced by grpc version streaming.

Related: https://github.com/chainguard-dev/image-requests/issues/4407

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

