### PR TITLE
pip-build-install pipeline - add support for providing 'python3'

### DIFF
--- a/pipelines/py/pip-build-install.yaml
+++ b/pipelines/py/pip-build-install.yaml
@@ -7,12 +7,29 @@ inputs:
   dest:
     description: the destination
     default: ${{targets.contextdir}}
+  needs-exe-named-python3:
+    description: Does the build actually need 'python3' in its PATH
+    default: false
+  needs-exe-named-python:
+    description: Does the build actually need 'python' in its PATH
+    default: false
 
 pipeline:
   - name: "pip build"
     runs: |
       export SOURCE_DATE_EPOCH=315532800
       py=${{inputs.python}}
+      pyexe=${{inputs.needs-exe-named-python}}
+      py3exe=${{inputs.needs-exe-named-python3}}
+      [ "$pyexe" = "true" -o "$pyexe" = "false" ] || {
+        echo "inputs.needs-exe-named-python must be true or false, not '$pyexe'";
+        exit
+      }
+      [ "$py3exe" = "true" -o "$py3exe" = "false" ] || {
+        echo "inputs.needs-exe-named-python3 must be true or false, not '$py3exe'";
+        exit
+      }
+
       if [ "$py" = "DEFAULT" ]; then
         if p=$(command -v python3); then
           py=$p
@@ -34,6 +51,14 @@ pipeline:
           fi
         fi
       fi
+      pyfullpath=$(which "$py") || {
+        echo "ERROR: '$py' appears not in PATH. Could not 'which $py'"
+        exit 1
+      }
+      rfp=$(readlink -f "$pyfullpath") || {
+        echo "ERROR: could not resolve full path to '$pyfullpath' via 'readlink -f'"
+        exit 1
+      }
       pyver=$("$py" -c 'import sys; print("%s.%s" % (sys.version_info.major, sys.version_info.minor))')
       sitepkgd=$("$py" -c 'import site; print(site.getsitepackages()[0])')
       sitepkgd=${sitepkgd#/}
@@ -43,6 +68,24 @@ pipeline:
 
       tmpd=$(mktemp -d)
       trap "rm -Rf '$tmpd'" EXIT
+
+      if [ "$pyexe" = "true" -o "$py3exe" = "true" ]; then
+        mkdir "$tmpd/bin" || exit 1
+        export PATH="$tmpd/bin:$PATH"
+        # use a shell script with exec in the case that $py is 'python' or 'python3'
+        if [ "$pyexe" = "true" ]; then
+          echo "wrapping 'python' in PATH -> '$rfp'"
+          printf '#!/bin/sh\nexec "%s" "$@"\n' "$rfp" > "$tmpd/bin/python" &&
+            chmod 755 "$tmpd/bin/python" ||
+            { echo "ERROR: failed creating wrapper 'python'"; exit 1; }
+        fi
+        if [ "$py3exe" = "true" ]; then
+          echo "wrapping 'python3' in PATH -> '$rfp'"
+          printf '#!/bin/sh\nexec "%s" "$@"\n' "$rfp" > "$tmpd/bin/python3" &&
+            chmod 755 "$tmpd/bin/python3" ||
+            { echo "ERROR: failed creating wrapper 'python3'"; exit 1; }
+        fi
+      fi
 
       # --find-links to an empty dir and --no-index makes pip fully "offline"
       distwheelsd="$tmpd/dist-wheels"

--- a/py3-ml-metadata.yaml
+++ b/py3-ml-metadata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ml-metadata
   version: 1.16.0
-  epoch: 2
+  epoch: 3
   description: For recording and retrieving metadata associated with ML developer and data scientist workflows.
   copyright:
     - license: MIT
@@ -58,21 +58,11 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
     pipeline:
-      - name: "hack python3 into path"
-        runs: |
-          # the bazel part of the build wants to find 'python3' or lets you
-          # set it with PYTHON_BIN_PATH=/path/to/executable. but we can not
-          # easily set the environment here to a range specific value.
-          # https://github.com/chainguard-dev/melange/issues/1402
-          # https://github.com/chainguard-dev/melange/issues/1548
-          mkdir -p /usr/local/bin
-          ln -svf /usr/bin/python${{range.key}} /usr/local/bin/python
-          ln -svf /usr/bin/python${{range.key}} /usr/local/bin/python3
-          out=$(which python) && echo "'which python' -> $out" || exit 1
-          out=$(which python3) && echo "'which python3' -> $out" || exit 1
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+          needs-exe-named-python: true
+          needs-exe-named-python3: true
       - uses: strip
     test:
       pipeline:
@@ -95,6 +85,11 @@ subpackages:
     description: ML Metadata remote gRPC server
     pipeline:
       - runs: |
+          # still needs _some_ python. doc says to set PYTHON_BIN_PATH
+          # but you *still* need a 'python3'
+          export PYTHON_BIN_PATH=/usr/bin/python3.12
+          ln -s "${PYTHON_BIN_PATH}" /usr/bin/python3
+
           # Reduce the number of jobs to avoid OOM
           bazel build -c opt --define grpc_no_ares=true --jobs $(($(grep -c ^processor /proc/cpuinfo) / 2)) //ml_metadata/metadata_store:metadata_store_server
 


### PR DESCRIPTION
Apparently some build systems end up not knowing which python they should call. And generally, many things *will* assume they can call 'python3' or worse, 'python'.

This feature of pip-build-install will add a 'python3' or 'python' name to the PATH which points to the provided python3.XX.

I've seen this in one other package (py3-jupyterhub).

Pip install and other things will write a shbang of '/usr/bin/python3' if you ran 'python3 -m pip', but would get '/usr/bin/python3.12' shbang if you did 'python3.12 -m pip'. That is to say that the argv[0] does matter, and anything that is using 'python' here we want to get the full python3.XX value.

The shell script wrapper accomplishes that, when a symlink would not.
