### PR TITLE
Add py3-hatch-requirements-txt

### DIFF
--- a/py3-hatch-requirements-txt.yaml
+++ b/py3-hatch-requirements-txt.yaml
@@ -1,0 +1,73 @@
+# Generated from https://pypi.org/project/hatch-requirements-txt/
+package:
+  name: py3-hatch-requirements-txt
+  version: 0.4.1
+  epoch: 0
+  description: Hatchling plugin to read project dependencies from requirements.txt
+  copyright:
+    - license: MIT
+  dependencies:
+    provider-priority: "0"
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+      - py3-supported-hatchling
+
+vars:
+  module_name: hatch_requirements_txt
+  pypi-package: hatch-requirements-txt
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "310"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 2809dc9e2d13a45272d5c74cdf5741d2af30f9a8
+      repository: https://github.com/repo-helper/hatch-requirements-txt
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - name: Python Build
+        uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-hatchling
+        - py${{range.key}}-packaging
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    test:
+      pipeline:
+        - name: Import Test
+          uses: python/import
+          with:
+            import: ${{vars.module_name}}
+            python: python${{range.key}}
+
+test:
+  environment: {}
+  pipeline:
+    - name: Import Test
+      uses: python/import
+      with:
+        import: ${{vars.module_name}}
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: repo-helper/hatch-requirements-txt
+    strip-prefix: v


### PR DESCRIPTION
This needed by py3-pymongo when using hatchling (py/pip-build-install).
