### PR TITLE
checkov: update dependency to python-3.12

### DIFF
--- a/checkov.yaml
+++ b/checkov.yaml
@@ -7,7 +7,7 @@ package:
     - license: MIT
   dependencies:
     runtime:
-      - python-3.11
+      - python-3.12
 
 environment:
   contents:
@@ -17,7 +17,7 @@ environment:
       - glibc
       - linux-headers
       - posix-libc-utils
-      - python-3.11
+      - python-3.12
       - wolfi-base
       - wolfi-baselayout
 


### PR DESCRIPTION
The current version of checkov depends on Python 3.11. however, the latest version is Python 3.12 https://pypi.org/project/checkov, and it should be updated

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
Update the dependency of checkov to be python-3.12

### Pre-review Checklist

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [x] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [x] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

