### PR TITLE
checkov: Update  version to 3.2.257

### DIFF
--- a/checkov.yaml
+++ b/checkov.yaml
@@ -1,6 +1,6 @@
 package:
   name: checkov
-  version: 3.0.34
+  version: 3.2.257
   epoch: 0
   description: "static code and composition analysis tool for IaC"
   copyright:


### PR DESCRIPTION
Fixes:
Update checkov to the latest version 3.2.257 https://github.com/bridgecrewio/checkov

### Pre-review Checklist

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project supports multiple concurrent versions.
