### PR TITLE
druid avro fix for GHSA-r7pg-v2c8-mfg3

### DIFF
--- a/druid.yaml
+++ b/druid.yaml
@@ -1,7 +1,7 @@
 package:
   name: druid
   version: 30.0.1
-  epoch: 1
+  epoch: 2
   description: Apache Druid is a high performance real-time analytics database.
   copyright:
     - license: Apache-2.0
@@ -34,6 +34,10 @@ pipeline:
   - uses: patch
     with:
       patches: protobuf-3.25.5.patch
+
+  - uses: maven/pombump
+    with:
+      properties-file: pombump-properties.yaml
 
   - runs: |
       mvn -B -ff -q \

--- a/druid/pombump-properties.yaml
+++ b/druid/pombump-properties.yaml
@@ -1,0 +1,3 @@
+properties:
+  - property: avro.version
+    value: "1.11.4"


### PR DESCRIPTION
Resolve what can be fixed for druid/GHSA-r7pg-v2c8-mfg3 there still is a avro dependency as a part of hadoop-client-runtime however we are not able to remedy that. The avro dependency is referred throughout the various druid build components so it is set as a property variable in the parent pom.xml. To bump that env variable we use the maven/pombump properties flag.