### PR TITLE
Sonarqube Fixes For Various CVEs

### DIFF
--- a/sonarqube-10.yaml
+++ b/sonarqube-10.yaml
@@ -1,7 +1,7 @@
 package:
   name: sonarqube-10
   version: 10.7.0.96327
-  epoch: 0
+  epoch: 1
   description: SonarQube is an open source platform for continuous inspection of code quality
   copyright:
     - license: LGPL-3.0-or-later
@@ -39,6 +39,10 @@ pipeline:
       repository: https://github.com/SonarSource/sonarqube
       tag: ${{package.version}}
       expected-commit: 9e1fded16c1dc80f886af1db4413cbe78a245d7f
+
+  - uses: patch
+    with:
+      patches: elastic-search-server.patch
 
   - name: build
     runs: |

--- a/sonarqube-10/elastic-search-server.patch
+++ b/sonarqube-10/elastic-search-server.patch
@@ -1,0 +1,23 @@
+From 2cfa8a1c1355a04bd6212928451d58c6f2c6bfed Mon Sep 17 00:00:00 2001
+From: Matteo Mara <matteo.mara@sonarsource.com>
+Date: Thu, 3 Oct 2024 17:33:37 +0200
+Subject: [PATCH] SONAR-23133 Upgrade ElasticSearch server from 8.14.1 to
+ 8.15.2
+
+---
+ gradle.properties | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gradle.properties b/gradle.properties
+index 879a737b46c..ed397c125b2 100644
+--- a/gradle.properties
++++ b/gradle.properties
+@@ -12,7 +12,7 @@ projectTitle=SonarQube
+ org.gradle.jvmargs=-Xmx2048m
+ org.gradle.caching=true
+ org.gradle.vfs.watch=true
+-elasticSearchServerVersion=8.14.1
++elasticSearchServerVersion=8.15.2
+ projectType=application
+ artifactoryUrl=https://repox.jfrog.io/repox
+ jre_release_name=jdk-17.0.11+9


### PR DESCRIPTION
fixes in this PR are for the following CVEs: GHSA-5jpm-x58v-624v/GHSA-m44j-cfrm-g8qc/GHSA-8xfc-gm6g-vgpv/GHSA-v435-xc8x-wvr9/GHSA-4h8f-2wvx-gg5w 
This PR bumps the elasticSearchServerVersion from 8.14.1 to 8.15.2 which is the most current version and what [exists in the upstream repository](https://github.com/SonarSource/sonarqube/commit/2cfa8a1c1355a04bd6212928451d58c6f2c6bfed) just waiting release. 