### PR TITLE
apache-nifi/GHSA-r7pg-v2c8-mfg3 fix

### DIFF
--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi
   version: 1.27.0
-  epoch: 1
+  epoch: 3
   description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
   copyright:
     - license: Apache-2.0
@@ -54,6 +54,10 @@ pipeline:
       expected-commit: e0c4461d90bd4f6e5f2b81765bcff5cd97ed3e18
 
   - uses: maven/pombump
+
+  - uses: maven/pombump
+    with:
+      properties-file: pombump-properties.yaml
 
   - runs: |
       # Use single thread on x86_64

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi
   version: 1.27.0
-  epoch: 3
+  epoch: 2
   description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
   copyright:
     - license: Apache-2.0

--- a/apache-nifi/pombump-properties.yaml
+++ b/apache-nifi/pombump-properties.yaml
@@ -1,0 +1,3 @@
+properties:
+  - property: avro.version
+    value: "1.11.4"


### PR DESCRIPTION
Remediating apache-nifi GHSA-r7pg-v2c8-mfg3 regarding avro 1.11.3 is fixed by bumping the version to 1.11.4. In this instance the property avro.version is used in more than one place in the parent pom.xml file so it is set as a property. The following changes are the current implementation of bumping a maven project's property value.