### PR TITLE
python/multi-version batch 16

### DIFF
--- a/py3-azure-core.yaml
+++ b/py3-azure-core.yaml
@@ -1,29 +1,29 @@
-# Generated from https://pypi.org/project/azure-core/
 package:
   name: py3-azure-core
   version: 1.31.0
-  epoch: 0
+  epoch: 1
   description: Microsoft Azure Core Library for Python
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - py3-requests
-      - py3-six
-      - py3-typing-extensions
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: azure-core
+  import: azure.core
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - py3-wheel
-      - python3
-      - python3-dev
-      - wolfi-base
+      - py3-supported-build-base-dev
 
 pipeline:
   - uses: git-checkout
@@ -32,12 +32,47 @@ pipeline:
       repository: https://github.com/Azure/azure-sdk-for-python
       tag: azure-core_${{package.version}}
 
-  - runs: |
-      cd sdk/core/azure-core
-      python setup.py build
-      python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-requests
+        - py${{range.key}}-six
+        - py${{range.key}}-typing-extensions
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+        working-directory: sdk/core/azure-core
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-comm.yaml
+++ b/py3-comm.yaml
@@ -1,25 +1,30 @@
-# Generated from https://pypi.org/project/comm/
 package:
   name: py3-comm
   version: 0.2.2
-  epoch: 0
+  epoch: 1
   description: Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc.
   copyright:
-    - license: 'BSD-3-Clause'
+    - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-traitlets
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: comm
+  import: comm
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -28,10 +33,44 @@ pipeline:
       repository: https://github.com/ipython/comm
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-traitlets
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-contourpy.yaml
+++ b/py3-contourpy.yaml
@@ -1,29 +1,32 @@
 package:
   name: py3-contourpy
   version: 1.3.0
-  epoch: 0
+  epoch: 1
   description: Python library for calculating contours of 2D quadrilateral grids
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - numpy
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: contourpy
+  import: contourpy
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-pip
-      - py3-pybind11-dev
-      - py3-setuptools
-      - python3
-      - python3-dev
-      - wolfi-base
+      - meson
+      - py3-supported-build-base-dev
+      - py3-supported-meson-python
+      - py3-supported-pybind11
 
 pipeline:
   - uses: git-checkout
@@ -32,32 +35,47 @@ pipeline:
       expected-commit: a59061cbf00dbbee09c56d1b1c36260946c37567
       tag: v${{package.version}}
 
-  - name: Python Build
-    runs: |
-      python3 -m build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-numpy
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - runs: |
-      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true
   github:
     identifier: contourpy/contourpy
     strip-prefix: v
-
-test:
-  pipeline:
-    - runs: |
-        LIBRARY="contourpy"
-        IMPORT_STATEMENT="import contourpy"
-
-        if ! python -c "$IMPORT_STATEMENT"; then
-            echo "Failed to import library '$LIBRARY'."
-            python -c "$IMPORT_STATEMENT" 2>&1
-            exit 1
-        else
-            echo "Library '$LIBRARY' is installed and can be imported successfully."
-            exit 0
-        fi

--- a/py3-docutils.yaml
+++ b/py3-docutils.yaml
@@ -1,24 +1,30 @@
 package:
   name: py3-docutils
   version: 0.21.2
-  epoch: 1
+  epoch: 2
   description: Documentation Utilities for Python3
   copyright:
     - license: BSD-2-Clause AND GPL-3.0-or-later AND Python-2.0
   dependencies:
-    runtime:
-      - py3-pip
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: docutils
+  import: docutils
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-pip
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-flit-core
 
 pipeline:
   - uses: fetch
@@ -26,30 +32,76 @@ pipeline:
       uri: https://files.pythonhosted.org/packages/source/d/docutils/docutils-${{package.version}}.tar.gz
       expected-sha256: 3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      environment:
+        contents:
+          packages:
+            - apk-tools
+      pipeline:
+        - runs: |
+            apk info -L py${{range.key}}-${{vars.pypi-package}}-bin > "pkg.list"
+            echo "Please write a test for these:"
+            grep usr/bin/ pkg.list > bins.list
+            sed 's,^,> ,' bins.list
 
-update:
-  enabled: true
-  release-monitor:
-    identifier: 3849
+            while read line; do
+              echo == /$line ==
+              /$line --help && echo exited 0 || echo "exited $?"
+            done < bins.list
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
     - runs: |
-        LIBRARY="docutils"
-        IMPORT_STATEMENT="from docutils import nodes"
-
-        if ! python -c "$IMPORT_STATEMENT"; then
-            echo "Failed to import library '$LIBRARY'."
-            python -c "$IMPORT_STATEMENT" 2>&1
-            exit 1
-        else
-            echo "Library '$LIBRARY' is installed and can be imported successfully."
-            exit 0
-        fi
         docutils --version
         docutils --help
         rst2html --version
@@ -72,3 +124,8 @@ test:
         rst2xetex --help
         rst2xml --version
         rst2xml --help
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 3849

--- a/py3-jupyter-events.yaml
+++ b/py3-jupyter-events.yaml
@@ -1,34 +1,30 @@
-# Generated from https://pypi.org/project/jupyter-events/
 package:
   name: py3-jupyter-events
   version: 0.10.0
-  epoch: 0
+  epoch: 1
   description: Jupyter Event System library
   copyright:
-    - license: 'BSD-3-Clause'
+    - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-jsonschema
-      - py3-python-json-logger
-      - py3-pyyaml
-      - py3-referencing
-      - py3-rfc3339-validator
-      - py3-rfc3986-validator
-      - py3-traitlets
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: jupyter-events
+  import: jupyter_events
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: fetch
@@ -36,10 +32,83 @@ pipeline:
       expected-sha256: 670b8229d3cc882ec782144ed22e0d29e1c2d639263f92ca8383e66682845e22
       uri: https://files.pythonhosted.org/packages/source/j/jupyter-events/jupyter_events-${{package.version}}.tar.gz
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      runtime:
+        - py${{range.key}}-jsonschema
+        - py${{range.key}}-python-json-logger
+        - py${{range.key}}-pyyaml
+        - py${{range.key}}-referencing
+        - py${{range.key}}-rfc3339-validator
+        - py${{range.key}}-rfc3986-validator
+        - py${{range.key}}-traitlets
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      environment:
+        contents:
+          packages:
+            - apk-tools
+      pipeline:
+        - runs: |
+            apk info -L py${{range.key}}-${{vars.pypi-package}}-bin > "pkg.list"
+            echo "Please write a test for these:"
+            grep usr/bin/ pkg.list > bins.list
+            sed 's,^,> ,' bins.list
+
+            while read line; do
+              echo == /$line ==
+              /$line --help && echo exited 0 || echo "exited $?"
+            done < bins.list
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-jupyter-telemetry.yaml
+++ b/py3-jupyter-telemetry.yaml
@@ -1,28 +1,29 @@
-# Generated from https://pypi.org/project/jupyter-telemetry/
 package:
   name: py3-jupyter-telemetry
   version: 0.1.0
-  epoch: 0
+  epoch: 1
   description: Jupyter telemetry library
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-jsonschema
-      - py3-python-json-logger
-      - py3-traitlets
-      - py3-ruamel-yaml
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: jupyter-telemetry
+  import: jupyter_telemetry
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: fetch
@@ -30,10 +31,47 @@ pipeline:
       expected-sha256: 445c613ae3df70d255fe3de202f936bba8b77b4055c43207edf22468ac875314
       uri: https://files.pythonhosted.org/packages/source/j/jupyter_telemetry/jupyter_telemetry-${{package.version}}.tar.gz
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-jsonschema
+        - py${{range.key}}-python-json-logger
+        - py${{range.key}}-traitlets
+        - py${{range.key}}-ruamel-yaml
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-libcst.yaml
+++ b/py3-libcst.yaml
@@ -1,30 +1,31 @@
-# Generated from https://pypi.org/project/libcst/
 package:
   name: py3-libcst
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7, 3.8, 3.9, and 3.10 programs.
   copyright:
     - license: MIT AND PSF-2.0
   dependencies:
-    runtime:
-      - py3-typing-extensions
-      - py3-typing-inspect
-      - py3-pyyaml
-      - python-3
-      - glibc
+    provider-priority: 0
+
+vars:
+  pypi-package: libcst
+  import: libcst
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - py3-setuptools-rust
-      - python-3
+      - py3-supported-build-base-dev
+      - py3-supported-setuptools-rust
       - rust
-      - wolfi-base
 
 pipeline:
   - uses: git-checkout
@@ -33,10 +34,47 @@ pipeline:
       repository: https://github.com/Instagram/LibCST
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-typing-extensions
+        - py${{range.key}}-typing-inspect
+        - py${{range.key}}-pyyaml
+        - glibc
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true
@@ -44,9 +82,3 @@ update:
   github:
     identifier: Instagram/LibCST
     strip-prefix: v
-
-test:
-  pipeline:
-    - uses: python/import
-      with:
-        import: libcst

--- a/py3-opt-einsum.yaml
+++ b/py3-opt-einsum.yaml
@@ -1,24 +1,32 @@
 package:
   name: py3-opt-einsum
   version: 3.4.0
-  epoch: 0
+  epoch: 1
   description: Optimizing numpys einsum function
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - numpy
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: opt-einsum
+  import: opt_einsum
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-hatch-fancy-pypi-readme
+      - py3-supported-hatch-vcs
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -27,20 +35,51 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: c15aec2c7dbbcaf5b9790b980f699bf295baa7d9
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - numpy
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
-
-update:
-  enabled: true
-  github:
-    identifier: dgasmith/opt_einsum
-    strip-prefix: v
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:
     - uses: python/import
       with:
         imports: |
+          import ${{vars.import}}
+    - uses: python/import
+      with:
+        imports: |
           import opt_einsum
+
+update:
+  enabled: true
+  github:
+    identifier: dgasmith/opt_einsum
+    strip-prefix: v

--- a/py3-py4j.yaml
+++ b/py3-py4j.yaml
@@ -1,43 +1,34 @@
 package:
   name: py3-py4j
   version: 0.10.9.7
-  epoch: 2
+  epoch: 3
   description: Enables Python programs to dynamically access arbitrary Java objects
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: py4j
+  import: py4j
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-11-openjdk
   contents:
     packages:
       - bash
-      - build-base
-      - busybox
-      - ca-certificates-bundle
       - gradle
       - openjdk-11
-      - py3-alabaster
-      - py3-babel
-      - py3-docutils
-      - py3-imagesize
-      - py3-jinja2
-      - py3-packaging
-      - py3-pygments
-      - py3-requests
-      - py3-setuptools
-      - py3-snowballstemmer
-      - py3-sphinx
-      - py3-sphinxcontrib-applehelp
-      - py3-sphinxcontrib-devhelp
-      - py3-sphinxcontrib-htmlhelp
-      - py3-sphinxcontrib-jsmath
-      - py3-sphinxcontrib-qthelp
-      - py3-sphinxcontrib-serializinghtml
-      - py3-wheel
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -51,18 +42,42 @@ pipeline:
       # To fix this error `Reason: UndefinedError("'style' is undefined")`
       patches: disable-copyWebJavadocPython.patch
 
-  - runs: |
-      export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
-      cd py4j-java
-      ./gradlew buildPython
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - name: Python Build
-    runs: python setup.py build
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
-  - name: Python Install
-    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
-
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-pydot.yaml
+++ b/py3-pydot.yaml
@@ -1,27 +1,31 @@
 package:
   name: py3-pydot
   version: 3.0.2
-  epoch: 0
+  epoch: 1
   description: Python interface to Graphviz's Dot
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - py3-parsing
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: pydot
+  import: pydot
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-gpep517
-      - py3-parsing
-      - py3-setuptools
-      - py3-wheel
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-gpep517
+      - py3-supported-pyparsing
 
 pipeline:
   - uses: git-checkout
@@ -30,11 +34,44 @@ pipeline:
       expected-commit: 754f3e8ace78706371490ece5af2eda4ded2e31f
       tag: v${{package.version}}
 
-  - runs: |
-      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 1
-      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-pyparsing
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true
@@ -43,9 +80,3 @@ update:
     use-tag: true
     tag-filter: v
     strip-prefix: v
-
-test:
-  pipeline:
-    - uses: python/import
-      with:
-        import: pydot


### PR DESCRIPTION
Convert packages to python multi-version.

This is part of a series of programatic changes to
add the ability to support python packages for multiple
python versions.