### PR TITLE
exim: add subpackages, for lookups, scripts and utils.

### DIFF
--- a/exim.yaml
+++ b/exim.yaml
@@ -1,7 +1,7 @@
 package:
   name: exim
   version: "4.98"
-  epoch: 2
+  epoch: 3
   description: Message Transfer Agent
   copyright:
     - license: GPL-2.0-or-later

--- a/exim.yaml
+++ b/exim.yaml
@@ -9,6 +9,13 @@ package:
     disabled:
       - setuidgid
 
+data:
+  - name: exim-lookups-with-deps
+    items:
+      mysql: "mariadb-connector-c"
+      sqlite: "sqlite-libs"
+      pgsql: "libpq"
+
 environment:
   contents:
     packages:
@@ -35,7 +42,7 @@ environment:
   accounts:
     users:
       - username: exim
-        uid: 1001
+        uid: 65332
 
 pipeline:
   - uses: fetch
@@ -74,9 +81,57 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - range: exim-lookups-with-deps
+    name: exim-${{range.key}}
+    description: "EXIM extension: ${{range.key}}"
+    pipeline:
+      - runs: |
+          install -D -m 755 ./build-Linux-${{build.arch}}/lookups/${{range.key}}.so ${{targets.subpkgdir}}/usr/lib/${{package.name}}/${{range.key}}.so
+      - uses: strip
+    dependencies:
+      runtime:
+        - exim=${{package.full-version}}
+        - ${{range.value}}
+
+  - name: exim-dnsdb
+    description: "EXIM extension: dnsdb"
+    pipeline:
+      - runs: |
+          install -D -m 755 ./build-Linux-${{build.arch}}/lookups/dnsdb.so ${{targets.subpkgdir}}/usr/lib/${{package.name}}/dnsdb.so
+      - uses: strip
+    dependencies:
+      runtime:
+        - exim=${{package.full-version}}
+
+  - name: exim-dbmdb
+    description: "EXIM extension: dbmdb"
+    pipeline:
+      - runs: |
+          install -D -m 755 ./build-Linux-${{build.arch}}/lookups/dbmdb.so ${{targets.subpkgdir}}/usr/lib/${{package.name}}/dbmdb.so
+      - uses: strip
+    dependencies:
+      runtime:
+        - exim=${{package.full-version}}
+
+  - name: exim-cdb
+    description: "EXIM extension: cdb"
+    pipeline:
+      - runs: |
+          install -D -m 755 ./build-Linux-${{build.arch}}/lookups/cdb.so ${{targets.subpkgdir}}/usr/lib/${{package.name}}/cdb.so
+      - uses: strip
+    dependencies:
+      runtime:
+        - exim=${{package.full-version}}
 
 test:
   environment:
+    accounts:
+      users:
+        - username: exim
+          uid: 65332
+      groups:
+        - groupname: exim
+          gid: 65332
     contents:
       packages:
         - shadow
@@ -85,7 +140,6 @@ test:
   pipeline:
     - name: "Test exim is installed and working"
       runs: |
-        useradd exim
         if ! command -v exim &> /dev/null; then
           echo "Exim is not installed."
           exit 1

--- a/exim.yaml
+++ b/exim.yaml
@@ -118,6 +118,27 @@ subpackages:
     pipeline:
       - runs: |
           install -D -m 755 ./build-Linux-${{build.arch}}/lookups/cdb.so ${{targets.subpkgdir}}/usr/lib/${{package.name}}/cdb.so
+
+  - name: exim-scripts
+    description: "EXIM scripts"
+    pipeline:
+      - runs: |
+          make	DESTDIR="${{targets.subpkgdir}}" INSTALL_ARG="exicyclog exim_checkaccess eximstats exiqgrep exigrep exinext exiqsumm exipick exiwhat convert4r3 convert4r4 exim_msgdate exim_id_update" install
+          rm -fr "${{targets.subpkgdir}}/etc"
+      - uses: strip
+    dependencies:
+      runtime:
+        - exim=${{package.full-version}}
+        - perl
+        - perl-file-fcntllock
+
+  - name: exim-utils
+    description: "EXIM utils"
+    pipeline:
+      - runs: |
+          install -d "${{targets.subpkgdir}}/etc/mail"
+          make DESTDIR="${{targets.subpkgdir}}" INSTALL_ARG="exim_dbmbuild exim_dumpdb exim_tidydb exim_fixdb exim_lock" install
+          rm -fr "${{targets.subpkgdir}}/etc"
       - uses: strip
     dependencies:
       runtime:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

This PR adds sub-packages that are present in the alpine package (https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/exim/APKBUILD) that weren't in the Wolfi package. Specifically it adds sub-packages for lookups (postgres, mysql and others) as well as packaging the `exim-utils` and `exim-scripts` too. 
Additionally, as also present in the alpine package, it adds a pre-install script to configure the `exim` user upon package installation.


<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
* https://github.com/wolfi-dev/os/issues/29568


### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
