### PR TITLE
py3-llhttp - multi-version python for py3-llhttp

### DIFF
--- a/py3-llhttp.yaml
+++ b/py3-llhttp.yaml
@@ -1,25 +1,30 @@
-# Generated from https://pypi.org/project/llhttp/
 package:
   name: py3-llhttp
   version: 6.0.9.0
-  epoch: 1
+  epoch: 2
   description: llhttp in python
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: llhttp
+  import: llhttp
+
+data:
+  - name: py-versions
+    items:
+      ## https://github.com/pallas/pyllhttp/issues/5
+      # 3.13: '300'
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python3
-      - python3-dev
-      - wolfi-base
+      - py3-supported-build-base-dev
 
 pipeline:
   - uses: fetch
@@ -27,13 +32,41 @@ pipeline:
       expected-sha256: 701e93cbc53189bdf06550b82820bb87b795f4a62716d861b8418679dce9a792
       uri: https://files.pythonhosted.org/packages/source/l/llhttp/llhttp-${{package.version}}.tar.gz
 
-  - name: Python Build
-    runs: python setup.py build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - name: Python Install
-    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
 
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true


### PR DESCRIPTION
This currently does not have python 3.13 support.
More information on that at
https://github.com/pallas/pyllhttp/issues/5
