### PR TITLE
pdftk: fix build, now needs openjdk-8

### DIFF
--- a/pdftk.yaml
+++ b/pdftk.yaml
@@ -2,7 +2,7 @@
 package:
   name: pdftk
   version: 3.3.3
-  epoch: 0
+  epoch: 1
   description: Command-line tool for working with PDFs
   copyright:
     - license: GPL-2.0-or-later
@@ -17,6 +17,7 @@ environment:
       - build-base
       - busybox
       - gradle-8
+      - openjdk-8
       - openjdk-8-default-jvm
   environment:
     JAVA_HOME: /usr/lib/jvm/java-1.8-openjdk


### PR DESCRIPTION
Package is failing on post submit

fixes:

```
org.gradle.api.GradleException: Toolchain installation '/usr/lib/jvm/java-1.8-openjdk' does not provide the required capabilities: [JAVA_COMPILER]
```
