### PR TITLE
py-nh3: new package - html santization using ammonia (Rust)

### DIFF
--- a/py3-nh3.yaml
+++ b/py3-nh3.yaml
@@ -1,0 +1,77 @@
+package:
+  name: py3-nh3
+  version: 0.2.18
+  epoch: 0
+  description: Python binding to Ammonia HTML sanitizer Rust crate 
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: nh3
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - maturin
+      - py3-supported-maturin
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - rust
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: ba2b2748e472c18f5595200438be55ed1f943f45
+      repository: https://github.com/messense/nh3
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: messense/nh3
+    strip-prefix: v

--- a/py3-nh3.yaml
+++ b/py3-nh3.yaml
@@ -2,7 +2,7 @@ package:
   name: py3-nh3
   version: 0.2.18
   epoch: 0
-  description: Python binding to Ammonia HTML sanitizer Rust crate 
+  description: Python binding to Ammonia HTML sanitizer Rust crate
   copyright:
     - license: Apache-2.0
   dependencies:


### PR DESCRIPTION
The bleach module is deprecated and many projects are moving to nh3

See: https://github.com/mozilla/bleach/issues/698

Signed-off-by: Pris Nasrat <pris.nasrat@chainguard.dev>
