### PR TITLE
qt6-qtbase: update to llvm-19 and parameterize llvm version

### DIFF
--- a/qt6-qtbase.yaml
+++ b/qt6-qtbase.yaml
@@ -3,7 +3,7 @@
 package:
   name: qt6-qtbase
   version: 6.8.0
-  epoch: 0
+  epoch: 1
   description: qt
   copyright:
     - license: LGPL-3.0-or-later
@@ -11,15 +11,17 @@ package:
     cpu: 16
     memory: 16Gi
 
+vars:
+  llvm-vers: 19
+
 environment:
   contents:
     packages:
       - bison
       - build-base
       - busybox
-      - clang-16
-      - clang-16-dev
-      - clang-16-extras
+      - clang-${{vars.llvm-vers}}
+      - clang-${{vars.llvm-vers}}-extras
       - cmake
       - cups-dev
       - dbus-dev
@@ -27,7 +29,6 @@ environment:
       - fontconfig
       - glib-dev
       - gperf
-      - libLLVM-16
       - libdrm-dev
       - libnspr-dev
       - libnss-dev
@@ -37,8 +38,8 @@ environment:
       - libxkbcommon
       - libxkbcommon-dev
       - libxxf86vm-dev
-      - llvm16
-      - llvm16-dev
+      - llvm-${{vars.llvm-vers}}
+      - llvm-${{vars.llvm-vers}}-dev
       - mesa
       - mesa-dev
       - mesa-egl
@@ -67,8 +68,9 @@ pipeline:
       pip install html5lib
 
   - runs: |
+      ln -s /usr/lib/llvm-19/lib/LLVMgold.so /usr/lib/ # I cannot convince ld to find this here
       # Needed to find our llvm libs
-      export CXXFLAGS="$CXXFLAGS -I/usr/lib/llvm16/include"
+      export CXXFLAGS="$CXXFLAGS -I/usr/lib/llvm-${{vars.llvm-vers}}/include"
       export CC=clang
       export CXX=clang++
 


### PR DESCRIPTION
Related: https://github.com/chainguard-dev/internal-dev/issues/1818