### PR TITLE
Update clang to provide clang=<version>

### DIFF
--- a/clang-16.yaml
+++ b/clang-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-16
   version: 16.0.6
-  epoch: 3
+  epoch: 4
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -11,6 +11,8 @@ package:
   dependencies:
     runtime:
       - libLLVM-16
+    provides:
+      - clang=${{package.full-version}}
 
 environment:
   contents:

--- a/clang-17.yaml
+++ b/clang-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-17
   version: 17.0.6
-  epoch: 0
+  epoch: 1
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -11,6 +11,8 @@ package:
   dependencies:
     runtime:
       - libLLVM-17
+    provides:
+      - clang=${{package.full-version}}
 
 environment:
   contents:
@@ -20,6 +22,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - cmake
+      - gcc-13 # https://github.com/llvm/llvm-project/issues/78691
       - help2man
       - libLLVM-17
       - libffi-dev
@@ -74,7 +77,9 @@ pipeline:
         -DCLANG_VENDOR=Wolfi \
         -DENABLE_LINKER_BUILD_ID=ON \
         -DLIBCLANG_BUILD_STATIC=ON \
-        -DLLVM_INCLUDE_DIRS=/usr/lib/llvm${{vars.major-version}}/include
+        -DLLVM_INCLUDE_DIRS=/usr/lib/llvm${{vars.major-version}}/include \
+        -DCMAKE_C_COMPILER=/usr/bin/gcc-13 \
+        -DCMAKE_CXX_COMPILER=/usr/bin/g++-13
 
   - runs: |
       cmake --build build --target clang-tblgen

--- a/clang-18.yaml
+++ b/clang-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-18
   version: 18.1.8
-  epoch: 3
+  epoch: 4
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,7 @@ package:
       - libclang-cpp-18
       - llvm-18
     provides:
-      - clang-18-dev=${{package.full-version}}
+      - clang=${{package.full-version}}
 
 environment:
   contents:

--- a/clang-19.yaml
+++ b/clang-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-19
   version: 19.1.2
-  epoch: 0
+  epoch: 1
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -16,7 +16,7 @@ package:
       - libclang-cpp-19
       - llvm-19
     provides:
-      - clang-19-dev=${{package.full-version}}
+      - clang=${{package.full-version}}
 
 environment:
   contents:

--- a/falco.yaml
+++ b/falco.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco
   version: 0.39.1 # on update check if we can remove the 'Patch falcosecurity-libs' pipeline below if https://github.com/falcosecurity/libs/pull/2079 is merged
-  epoch: 1
+  epoch: 2
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,7 @@ environment:
       - busybox
       - c-ares-dev
       - ca-certificates-bundle
-      - clang-${{vars.llvm-vers}}-dev
+      - clang-${{vars.llvm-vers}}
       - cmake
       - cpp-httplib
       - curl-dev

--- a/mozjs91.yaml
+++ b/mozjs91.yaml
@@ -1,7 +1,7 @@
 package:
   name: mozjs91
   version: 91.13.0
-  epoch: 5
+  epoch: 6
   description:
   copyright:
     - license: MPL-2.0
@@ -16,7 +16,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - clang-${{vars.llvm-vers}}
-      - clang-${{vars.llvm-vers}}-dev
       - curl
       - erlang-dev
       - icu

--- a/scudo-malloc.yaml
+++ b/scudo-malloc.yaml
@@ -1,13 +1,16 @@
 package:
   name: scudo-malloc
   version: 19.1.2
-  epoch: 0
+  epoch: 1
   description: "scudo-malloc aims at providing additional mitigation against heap based vulnerabilities, while maintaining good performance"
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - libstdc++
+
+vars:
+  llvm-vers: 19
 
 environment:
   contents:
@@ -16,8 +19,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang-18
-      - clang-18-dev
+      - clang-${{vars.llvm-vers}}
       - coreutils
       - linux-headers
       - wolfi-base

--- a/snmalloc.yaml
+++ b/snmalloc.yaml
@@ -1,13 +1,17 @@
 package:
   name: snmalloc
   version: "0.6.2"
-  epoch: 0
+  epoch: 1
   description: "snmalloc is a high-performance, message passing based allocator."
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - glibc
+
+vars:
+  # https://github.com/microsoft/snmalloc/issues/669
+  llvm-vers: 18
 
 environment:
   contents:
@@ -17,12 +21,11 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang-18
-      - clang-18-dev
-      - clang-18-extras
+      - clang-${{vars.llvm-vers}}
+      - clang-${{vars.llvm-vers}}-extras
       - cmake
       - coreutils
-      - llvm-lld-18
+      - llvm-lld-${{vars.llvm-vers}}
       - samurai
       - scanelf
       - wolfi-base

--- a/wasi-sdk.yaml
+++ b/wasi-sdk.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasi-sdk
   version: "24"
-  epoch: 2
+  epoch: 4
   description: "WASI-enabled WebAssembly C/C++ toolchain"
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - clang-${{vars.llvm-vers}}
-      - clang-${{vars.llvm-vers}}-dev
       - cmake
       - llvm-${{vars.llvm-vers}}
       - openssf-compiler-options

--- a/wasmedge.yaml
+++ b/wasmedge.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasmedge
   version: 0.14.1
-  epoch: 2
+  epoch: 3
   description: WasmEdge is a lightweight, high-performance, and extensible WebAssembly runtime for cloud native, edge, and decentralized applications.
   copyright:
     - license: Apache-2.0
@@ -19,7 +19,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - clang-${{vars.llvm-vers}}
-      - clang-${{vars.llvm-vers}}-dev
       - cmake
       - libLLVM-${{vars.llvm-vers}}
       - libxml2-dev

--- a/zed.yaml
+++ b/zed.yaml
@@ -1,10 +1,13 @@
 package:
   name: zed
   version: 0.156.1
-  epoch: 0
+  epoch: 1
   description: Code at the speed of thought – Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.
   copyright:
     - license: GPL-3.0-only
+
+vars:
+  llvm-vers: 18
 
 environment:
   contents:
@@ -14,7 +17,7 @@ environment:
       - build-base
       - busybox
       - cargo-auditable
-      - clang-18-dev
+      - clang-${{vars.llvm-vers}}
       - cmake
       - curl-dev
       - fontconfig-dev

--- a/zig.yaml
+++ b/zig.yaml
@@ -1,7 +1,7 @@
 package:
   name: zig
   version: 0.13.0
-  epoch: 2
+  epoch: 3
   description: "General-purpose programming language designed for robustness, optimality, and maintainability"
   copyright:
     - license: MIT
@@ -15,7 +15,6 @@ environment:
       - build-base
       - busybox
       - clang-${{vars.llvm-vers}}
-      - clang-${{vars.llvm-vers}}-dev
       - cmake
       - libstdc++
       - libxml2-dev


### PR DESCRIPTION
Also paramterise and remove the clang-dev package which isn't needed anymore.

Fixes: https://github.com/chainguard-dev/internal-dev/issues/1642