### PR TITLE
Identify and test py3-beautifulsoup4 / py3-soupsieve cycle

### DIFF
--- a/py3-beautifulsoup4.yaml
+++ b/py3-beautifulsoup4.yaml
@@ -2,27 +2,18 @@
 package:
   name: py3-beautifulsoup4
   version: 4.12.3
-  epoch: 0
+  epoch: 1
   description: Screen-scraping library
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - py3-soupsieve
-      - python-3
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
+      - py3-build-base
 
 pipeline:
   - uses: fetch
@@ -35,24 +26,16 @@ pipeline:
 
   - uses: strip
 
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          from bs4 import BeautifulSoup
+
 update:
   enabled: true
   ignore-regex-patterns:
     - 'b\d+'
   release-monitor:
     identifier: 3779
-
-test:
-  pipeline:
-    - runs: |
-        LIBRARY="beautifulsoup4"
-        IMPORT_STATEMENT="from bs4 import BeautifulSoup"
-
-        if ! python -c "$IMPORT_STATEMENT"; then
-            echo "Failed to import library '$LIBRARY'."
-            python -c "$IMPORT_STATEMENT" 2>&1
-            exit 1
-        else
-            echo "Library '$LIBRARY' is installed and can be imported successfully."
-            exit 0
-        fi

--- a/py3-soupsieve.yaml
+++ b/py3-soupsieve.yaml
@@ -2,26 +2,18 @@
 package:
   name: py3-soupsieve
   version: "2.6"
-  epoch: 0
+  epoch: 1
   description: A modern CSS selector implementation for Beautiful Soup.
   copyright:
     - license: "MIT"
   dependencies:
     runtime:
-      - python-3
+      - py3-beautifulsoup4
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
+      - py3-build-base
 
 pipeline:
   - uses: git-checkout
@@ -35,6 +27,13 @@ pipeline:
 
   - uses: strip
 
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import soupsieve
+
 update:
   enabled: true
   manual: false
@@ -42,13 +41,3 @@ update:
     - 2.3.2.post1
   github:
     identifier: facelessuser/soupsieve
-
-test:
-  environment:
-    contents:
-      packages:
-        - python-3
-        - py3-beautifulsoup4
-  pipeline:
-    - runs: |
-        python -c "import soupsieve; print(soupsieve.__version__)"


### PR DESCRIPTION
soupsieve declares in pypi that they have 'null' requirements_dist. An attempt to use soupsieve without beautifulsoup4 will result in import error.

beautifulsoup4 in pypi identifies they need soupsieve. An attempt to import beautifulsoup4 (bs4) without soupsieve will runtime-warn.
