### PR TITLE
multi-version and Identify and test py3-beautifulsoup4 / py3-soupsiev…

### DIFF
--- a/py3-beautifulsoup4.yaml
+++ b/py3-beautifulsoup4.yaml
@@ -1,28 +1,30 @@
-# Generated from https://pypi.org/project/beautifulsoup4/
 package:
   name: py3-beautifulsoup4
   version: 4.12.3
-  epoch: 0
+  epoch: 1
   description: Screen-scraping library
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - py3-soupsieve
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: beautifulsoup4
+  import: beautifulsoup4
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: fetch
@@ -30,29 +32,48 @@ pipeline:
       expected-sha256: 74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051
       uri: https://files.pythonhosted.org/packages/source/b/beautifulsoup4/beautifulsoup4-${{package.version}}.tar.gz
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-soupsieve
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true
   ignore-regex-patterns:
-    - 'b\d+'
+    - b\d+
   release-monitor:
     identifier: 3779
-
-test:
-  pipeline:
-    - runs: |
-        LIBRARY="beautifulsoup4"
-        IMPORT_STATEMENT="from bs4 import BeautifulSoup"
-
-        if ! python -c "$IMPORT_STATEMENT"; then
-            echo "Failed to import library '$LIBRARY'."
-            python -c "$IMPORT_STATEMENT" 2>&1
-            exit 1
-        else
-            echo "Library '$LIBRARY' is installed and can be imported successfully."
-            exit 0
-        fi

--- a/py3-soupsieve.yaml
+++ b/py3-soupsieve.yaml
@@ -1,27 +1,30 @@
-# Generated from https://pypi.org/project/soupsieve/
 package:
   name: py3-soupsieve
-  version: "2.6"
-  epoch: 0
+  version: '2.6'
+  epoch: 1
   description: A modern CSS selector implementation for Beautiful Soup.
   copyright:
-    - license: "MIT"
+    - license: MIT
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: soupsieve
+  import: soupsieve
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -30,10 +33,52 @@ pipeline:
       repository: https://github.com/facelessuser/soupsieve
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - py${{vars.pypi-package}}-beautifulsoup4
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  # pypi sieve reports no dependencies but does require beautifulsoup4
+  # to avoid cyclic dep we do that here too.
+  environment:
+    contents:
+      packages:
+        - py${{vars.pypi-package}}-beautifulsoup4
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true
@@ -42,13 +87,3 @@ update:
     - 2.3.2.post1
   github:
     identifier: facelessuser/soupsieve
-
-test:
-  environment:
-    contents:
-      packages:
-        - python-3
-        - py3-beautifulsoup4
-  pipeline:
-    - runs: |
-        python -c "import soupsieve; print(soupsieve.__version__)"


### PR DESCRIPTION
…e cycle

soupsieve declares in pypi that they have 'null' requirements_dist. An attempt to use soupsieve without beautifulsoup4 will result in import error.

beautifulsoup4 in pypi identifies they need soupsieve. An attempt to import beautifulsoup4 (bs4) without soupsieve will runtime-warn.
