### PR TITLE
ingress-nginx-opentelemetry: add nodeps subpackage

### DIFF
--- a/opentelemetry-plugin-nginx.yaml
+++ b/opentelemetry-plugin-nginx.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: opentelemetry-plugin-nginx
-  version: 0_git20241014
+  version: 0_git20241015
   epoch: 0
   description: Adds OpenTelemetry distributed tracing support to nginx. This is the otel community plugin for nginx, not the official nginx plugin for otel.
   copyright:
@@ -61,6 +61,19 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/etc/nginx
           ln -s /usr/share/nginx/modules ${{targets.contextdir}}/etc/nginx/modules
 
+  # This exists to satisfy ingress-nginx-opentelemetry, which ships an image but doesn't expect this
+  # library to work until it's copied over into another image that already has already has all
+  # other dependencies installed.
+  - name: ${{package.name}}-nodepends
+    description: "WARNING: This package is not usable by itself. This is the same as the opentelemetry-plugin-nginx package, but without any dependencies."
+    options:
+      no-depends: true
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/share/nginx/modules
+          cp -p otel_ngx_module.so ${{targets.contextdir}}/usr/share/nginx/modules/
+        working-directory: instrumentation/nginx/output
+
 update:
   enabled: true
   git: {}
@@ -73,6 +86,7 @@ test:
     contents:
       packages:
         - nginx
+        - opentelemetry-cpp
   pipeline:
     - uses: git-checkout
       with:


### PR DESCRIPTION
This is the same as the main package, but without any dependencies. This is somewhat counterintuitive, since this results in a package that is unusable by itself.

ingress-nginx ships this in an image but doesn't expect it to work until it's copied over into another image that already has already has all of the other dependencies installed. Including the other dependencies is unnecessary, since this image exists only to move bits around, not to run any code.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->


Related: https://github.com/chainguard-dev/image-requests/issues/4407, https://github.com/chainguard-images/images-private/pull/5550
