### PR TITLE
openssl: basic dbg package

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.3.2
-  epoch: 0
+  epoch: 1
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -25,7 +25,7 @@ environment:
       - perl
   environment:
     # Using openssf-compiler-options instead
-    CFLAGS: ""
+    CFLAGS: "-g -ffile-prefix-map=/home/build=/usr/src/${{package.name}}"
     CPPFLAGS: ""
     CXXFLAGS: ""
     LDFLAGS: ""
@@ -36,6 +36,13 @@ pipeline:
       repository: https://github.com/openssl/openssl.git
       tag: openssl-${{package.version}}
       expected-commit: fb7fab9fa6f4869eaa8fbb97e0d593159f03ffe4
+
+  - name: Create dbg sourcecode
+    runs: |
+      SRCDIR=$(mktemp -d)
+      cp -r . $SRCDIR/
+      mkdir -p ${{targets.destdir}}-dbg/usr/src/
+      mv $SRCDIR ${{targets.destdir}}-dbg/usr/src/${{package.name}}
 
   - name: Configure and build
     runs: |
@@ -85,8 +92,6 @@ pipeline:
       # This also removes the need to have things coupled with
       # openssl-config-fipshardened going forward.
 
-  - uses: strip
-
 data:
   - name: engines
     items:
@@ -95,6 +100,11 @@ data:
       padlock: VIA Padlock engine
 
 subpackages:
+  - name: "openssl-dbg"
+    description: "OpenSSL debug symbols"
+    pipeline:
+      - uses: split/debug
+
   - name: "openssl-doc"
     description: "OpenSSL documentation"
     pipeline:


### PR DESCRIPTION
Add a basic manual dbg package for openssl.

Install source code into /usr/src/${{package.name}} (maybe needs a
pipeline like that).

Use -g to create debug symbols and file-prefix-map to encode all
source code references in the debug symbols to that destination.

Use split/debug as the first subpackage to detach all debug.

Note build-ids are not set by split/debug pipeline, meaning these
debug symbols are not suitable to upload into debuginfod server. See
https://sourceware.org/elfutils/Debuginfod.html

But this will do for now, installing openssl-dbg allows gdb to just
work. This is needed to stream-line security lab assesments, but also
to debug OpenSSL features and bugs.

Sample gdb session:

```
Reading symbols from openssl...
Reading symbols from /usr/lib/debug//usr/bin/openssl.debug...
(gdb) break main
warning: could not convert 'main' from the host encoding (ISO-8859-1) to UTF-32.
This normally should not happen, please file a bug report.
Breakpoint 1 at 0x499a0: file apps/openssl.c, line 236.
(gdb) run
Starting program: /usr/bin/openssl 
warning: Error disabling address space randomization: Operation not permitted
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/libthread_db.so.1".

Breakpoint 1, main (argc=1, argv=0x7ffd74888238) at apps/openssl.c:236
236	{
(gdb) l
231	
232	static char *help_argv[] = { "help", NULL };
233	static char *version_argv[] = { "version", NULL };
234	
235	int main(int argc, char *argv[])
236	{
237	    FUNCTION f, *fp;
238	    LHASH_OF(FUNCTION) *prog = NULL;
239	    char *pname;
240	    const char *fname;
(gdb) 
```
