### PR TITLE
fix(gtk-3): Compile gschemas post-install and add subpackage

### DIFF
--- a/gtk-3.yaml
+++ b/gtk-3.yaml
@@ -1,10 +1,17 @@
 package:
   name: gtk-3
   version: 3.24.43
-  epoch: 1
+  epoch: 2
   description: The GTK+ Toolkit (v3)
   copyright:
     - license: LGPL-2.1-or-later
+  scriptlets:
+    post-install: |
+      #!/bin/sh
+      glib-compile-schemas /usr/share/glib-2.0/schemas
+
+vars:
+  gschemas: "usr/share/glib-2.0/schemas"
 
 # creates a new var that contains only the major and minor version to be used in the fetch URL
 # e.g. 2.46.0 will create a new var mangled-package-version=2.46
@@ -99,7 +106,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: gtk-3-dev
+  - name: ${{package.name}}-dev
     pipeline:
       - uses: split/dev
     dependencies:
@@ -116,15 +123,26 @@ subpackages:
         - wayland-dev
     description: gtk+3 dev
 
-  - name: gtk-3-doc
+  - name: ${{package.name}}-doc
     pipeline:
       - uses: split/manpages
     description: gtk+3 manpages
 
-  - name: gtk-3-lang
+  - name: ${{package.name}}-lang
     pipeline:
       - uses: split/locales
     description: gtk+3 locales
+
+  - name: ${{package.name}}-compiled-gschemas
+    description: Compiled gschemas for GTK 3
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          glib-compile-schemas "${{targets.destdir}}/${{vars.gschemas}}"
+          install -Dm755 "${{targets.destdir}}/${{vars.gschemas}}/gschemas.compiled" "${{targets.contextdir}}/${{vars.gschemas}}/gschemas.compiled"
+          rm "${{targets.destdir}}/${{vars.gschemas}}/gschemas.compiled"
 
 update:
   enabled: true


### PR DESCRIPTION
gschemas need to be compiled post-install otherwise they will not be found at runtime

Additionally, add a subpackage containing the compiled schemas as post-install triggers are not ran during image assembly