### PR TITLE
squid: remove old patch

### DIFF
--- a/squid.yaml
+++ b/squid.yaml
@@ -38,16 +38,6 @@ pipeline:
       repository: https://github.com/squid-cache/squid.git
       tag: SQUID_${{vars.mangled-package-version}}
 
-  - runs: |
-      set -x
-      # see https://github.com/chainguard-dev/melange/issues/1422
-      git fetch --no-tags origin master:master
-      # Fix bootstrap build with automake 1.17
-      git show 82e18891262580e1d6ea23e97283ab0dccaa8c1e -- bootstrap.sh > partial-cherry-pick.patch
-      git apply partial-cherry-pick.patch
-
-  - runs: ./bootstrap.sh
-
   - uses: autoconf/configure
     with:
       # Disabling kerberos for now, as the build fails due to our complier flags treating warnings as errors.


### PR DESCRIPTION
patch has been already released with 6.12.
