### PR TITLE
k8s-metadata-injection package build

### DIFF
--- a/newrelic-k8s-metadata-action.yaml
+++ b/newrelic-k8s-metadata-action.yaml
@@ -1,0 +1,62 @@
+package:
+  name: newrelic-k8s-metadata-action
+  version: 1.29.2
+  epoch: 0
+  description: Kubernetes metadata injection for New Relic APM to make a linkage between APM and Infrastructure data.
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: e6f20cf4380670fe07ee250b189598b712cdac0d
+      repository: https://github.com/newrelic/k8s-metadata-injection
+      tag: v${{package.version}}
+
+  - runs: |
+      mkdir -p ${{targets.contextdir}}/app
+      install -Dm755 entrypoint.sh ${{targets.contextdir}}/app/entrypoint.sh
+
+  - uses: go/build
+    with:
+      output: k8s-metadata-injection
+      packages: ./cmd/server
+
+update:
+  enabled: true
+  github:
+    identifier: newrelic/k8s-metadata-injection
+    strip-prefix: v
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/app
+          ln -sf /usr/bin/k8s-metadata-injection ${{targets.contextdir}}/app/k8s-metadata-injection
+    description: Compatibility symlink for ${{package.name}}
+
+test:
+  environment:
+    contents:
+      packages:
+        - mkcert
+        - curl
+  pipeline:
+    - uses: test/kwok/cluster
+    - name: test the webhook
+      runs: |
+        mkdir -p /etc/tls-key-cert-pair
+        mkcert -install
+        mkcert -key-file /etc/tls-key-cert-pair/tls.key -cert-file /etc/tls-key-cert-pair/tls.crt localhost
+        k8s-metadata-injection &
+        sleep 1
+        STATUS=$(curl -v -k -s -o /dev/null -w "%{http_code}" http://localhost:8080/health)
+        # if the status code is 200, exit 0, otherwise exit 1
+        if [ "$STATUS" -eq 200 ]; then
+            echo "Health check passed with status code 200"
+            exit 0
+        else
+            echo "Health check failed with status code $STATUS"
+            exit 1
+        fi


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev><!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
