### PR TITLE
fix(gtk-4): Compile gschemas post-install and add subpackage

### DIFF
--- a/gtk-4.yaml
+++ b/gtk-4.yaml
@@ -1,10 +1,17 @@
 package:
   name: gtk-4
   version: 4.16.3
-  epoch: 0
+  epoch: 1
   description: The GTK+ Toolkit (v4)
   copyright:
     - license: LGPL-2.1-or-later
+  scriptlets:
+    post-install: |
+      #!/bin/sh
+      glib-compile-schemas /usr/share/glib-2.0/schemas
+
+vars:
+  gschemas: "usr/share/glib-2.0/schemas"
 
 environment:
   contents:
@@ -143,6 +150,17 @@ subpackages:
     pipeline:
       - uses: split/locales
     description: ${{package.name}} locales
+
+  - name: ${{package.name}}-compiled-gschemas
+    description: Compiled gschemas for GTK 4
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          glib-compile-schemas "${{targets.destdir}}/${{vars.gschemas}}"
+          install -Dm755 "${{targets.destdir}}/${{vars.gschemas}}/gschemas.compiled" "${{targets.contextdir}}/${{vars.gschemas}}/gschemas.compiled"
+          rm "${{targets.destdir}}/${{vars.gschemas}}/gschemas.compiled"
 
 update:
   enabled: true


### PR DESCRIPTION
gschemas need to be compiled post-install otherwise they will not be found at runtime

Additionally, add a subpackage containing the compiled schemas as post-install triggers are not ran during image assembly