### PR TITLE
chore(mtr): Rename gtk to mtr-gtk, withdraw gtk

### DIFF
--- a/mtr.yaml
+++ b/mtr.yaml
@@ -1,7 +1,7 @@
 package:
   name: mtr
   version: 0.95
-  epoch: 1
+  epoch: 2
   description: Full screen ncurses traceroute tool
   copyright:
     - license: GPL-2.0-only
@@ -57,14 +57,14 @@ pipeline:
       	"${{targets.destdir}}"/usr/share/pixmaps/mtr_icon.xpm
 
 subpackages:
-  - name: "mtr-doc"
-    description: "mtr documentation"
+  - name: "${{package.name}}-doc"
+    description: "${{package.name}} documentation"
     pipeline:
       - uses: split/manpages
       - uses: split/infodir
 
-  - name: "gtk"
-    description: "The GTK+ interface for mtr"
+  - name: "${{package.name}}-gtk"
+    description: "The GTK+ interface for ${{package.name}}"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/sbin "${{targets.subpkgdir}}"/usr/share
@@ -79,8 +79,8 @@ subpackages:
             mtr-packet-gtk --version
             mtr-packet-gtk --help
 
-  - name: "mtr-bash-completion"
-    description: "bash completion for mtr"
+  - name: "${{package.name}}-bash-completion"
+    description: "bash completion for ${{package.name}}"
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/share/bash-completion

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -4,3 +4,4 @@ py3.10-rich-13.9.1-r1.apk
 py3.11-rich-13.9.1-r1.apk
 py3.12-rich-13.9.1-r1.apk
 py3.13-rich-13.9.1-r1.apk
+gtk-0.95-r1.apk


### PR DESCRIPTION
This is the interface for mtr and not gtk itself, rename to mtr-gtk to avoid any confusion