### PR TITLE
fix(chromium): Depend on gtk 3 at runtime

### DIFF
--- a/chromium.yaml
+++ b/chromium.yaml
@@ -7,7 +7,7 @@
 package:
   name: chromium
   version: 129.0.6668.100
-  epoch: 0
+  epoch: 1
   description: "Open souce version of Google's chrome web browser"
   copyright:
     - license: BSD-3-Clause
@@ -20,7 +20,7 @@ package:
     runtime:
       - font-opensans
       - fontconfig
-      - gtk
+      - gtk-3
       - icu-data-full
       - libnss
       - mesa


### PR DESCRIPTION
Our current gtk package, confusingly, references the gtk interface for mtr. We were transitively also pulling in gtk. Explicitly depend on gtk 3 at runtime to prevent also pulling in the interface for mtr
