### PR TITLE
use go/build pipeline instead of make for vault-csi-provider

### DIFF
--- a/vault-csi-provider.yaml
+++ b/vault-csi-provider.yaml
@@ -1,7 +1,7 @@
 package:
   name: vault-csi-provider
   version: 1.4.0
-  epoch: 17
+  epoch: 18
   description: CSI (Container Storage Interface) plugin for HashiCorp Vault
   copyright:
     - license: MPL-2.0
@@ -26,18 +26,20 @@ pipeline:
       deps: golang.org/x/crypto@v0.17.0 sigs.k8s.io/secrets-store-csi-driver@v1.3.3 google.golang.org/grpc@v1.56.3 google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0 github.com/hashicorp/go-retryablehttp@v0.7.7
       modroot: vault-csi
 
-  - runs: |
-      cd vault-csi
-      # Our builtin LDFLAGS conflict with some makefile defined Go-specific ones.
-      unset LDFLAGS
+  - uses: go/build
+    with:
+      packages: .
+      modroot: vault-csi
+      output: vault-csi-provider
+      ldflags: -X 'github.com/hashicorp/vault-csi-provider/internal/version.BuildVersion=${{package.version}}' -X 'github.com/hashicorp/vault-csi-provider/internal/version.GoVersion=$(go version)' -X 'github.com/hashicorp/vault-csi-provider/internal/version.BuildDate=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ")'
 
-      make build GOARCH=$(go env GOARCH) VERSION=${{package.version}}
-
-  - runs: |
-      mkdir -p ${{targets.destdir}}/usr/bin
-      install -m755 -D vault-csi/dist/vault-csi-provider "${{targets.destdir}}/usr/bin/"
-
-  - uses: strip
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/bin
+          ln -sf /usr/bin/vault-csi-provider ${{targets.contextdir}}/bin/vault-csi-provider
 
 update:
   enabled: false


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

Refactors the current vault-csi-provider package by using the go/build pipeline instead of running `make build` and added a new -compat sub-package for providing compatibility between binary locations.

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
