### PR TITLE
py3-argon2-cffi-bindings - fix import error, add test.

### DIFF
--- a/py3-argon2-cffi-bindings.yaml
+++ b/py3-argon2-cffi-bindings.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-argon2-cffi-bindings
   version: 21.2.0
-  epoch: 3
+  epoch: 4
   description: Low-level CFFI bindings for Argon2
   copyright:
     - license: MIT
@@ -10,7 +10,7 @@ package:
 
 vars:
   pypi-package: argon2-cffi-bindings
-  import: no-valid-import
+  import: _argon2_cffi_bindings
 
 data:
   - name: py-versions
@@ -26,6 +26,7 @@ environment:
       - argon2
       - argon2-dev
       - py3-supported-build-base-dev
+      - py3-supported-cffi
   environment:
     ARGON2_CFFI_USE_SYSTEM: 1
 
@@ -43,7 +44,6 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       provides:
-        - ${{package.name}}
         - py3-${{vars.pypi-package}}
       runtime:
         - py${{range.key}}-cffi
@@ -52,6 +52,13 @@ subpackages:
         with:
           python: python${{range.key}}
       - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -61,6 +68,13 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true


### PR DESCRIPTION
This module has both a runtime and buildtime dependency on py3-cffi.

The import test is re-added here.  It would fail without the fix and passes with it.

Also drop the duplicate 'provides' (py3-)
 py3-argon2-cffi-bindings == ${{package.name}} == py3-${{vars.pypi-package}}
