### PR TITLE
py3-pyfarmhash - add the import test.

### DIFF
--- a/py3-pyfarmhash.yaml
+++ b/py3-pyfarmhash.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyfarmhash
   version: 0.3.2
-  epoch: 4
+  epoch: 5
   description: Google FarmHash Bindings for Python
   copyright:
     - license: MIT
@@ -10,7 +10,7 @@ package:
 
 vars:
   pypi-package: pyfarmhash
-  import: no-valid-import
+  import: farmhash
 
 data:
   - name: py-versions
@@ -45,6 +45,13 @@ subpackages:
         with:
           python: python${{range.key}}
       - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -54,6 +61,13 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: false


### PR DESCRIPTION
Something had made me think this wasn't expected to import correctly, but it does.  Add a test that insists it does.
