### PR TITLE
Removing runtime dependency

### DIFF
--- a/kubernetes-1.31.yaml
+++ b/kubernetes-1.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.31
   version: 1.31.1
-  epoch: 2
+  epoch: 3
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0

--- a/kubernetes-1.31.yaml
+++ b/kubernetes-1.31.yaml
@@ -189,9 +189,6 @@ subpackages:
 
   - name: kube-proxy-${{vars.kubernetes-version}}-default-compat
     description: kube-proxy-default compatibility package
-    dependencies:
-      runtime:
-        - kube-proxy-${{vars.kubernetes-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/local/bin


### PR DESCRIPTION
Need to remove runtime dependency in non FIPs packages.
```
resolving apk packages: for arch "arm64": solving "kube-proxy-fips-1.28-default-compat" constraint: resolving "kube-proxy-fips-1.28-default-compat-1.28.14-r1.apk" deps:
│ solving "kube-proxy-1.28" constraint:   kube-proxy-1.28-1.28.14-r2.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
│   kube-proxy-1.28-1.28.13-r2.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
│   kube-proxy-1.28-1.28.8-r1.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
│   kube-proxy-1.28-1.28.8-r0.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
│   kube-proxy-1.28-1.28.14-r0.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
│   kube-proxy-1.28-1.28.11-r1.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
│   kube-proxy-1.28-1.28.10-r1.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
│   kube-proxy-1.28-1.28.14-r1.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
│   kube-proxy-1.28-1.28.9-r0.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
│   kube-proxy-1.28-1.28.9-r1.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
│   kube-proxy-1.28-1.28.10-r0.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
│   kube-proxy-1.28-1.28.11-r0.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
│   kube-proxy-1.28-1.28.13-r1.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
│   kube-proxy-1.28-1.28.13-r0.apk disqualified because kube-proxy-fips-1.28-1.28.14-r1.apk already provides cmd:kube-proxy-1.28
```