### PR TITLE
apache-nifi: fix `Could not acquire read lock` on postsubmit builds

### DIFF
--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi
   version: 1.27.0
-  epoch: 2
+  epoch: 3
   description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
   copyright:
     - license: Apache-2.0
@@ -60,15 +60,9 @@ pipeline:
       properties-file: pombump-properties.yaml
 
   - runs: |
-      # Use single thread on x86_64
-      if [[ "${{build.arch}}" == "x86_64" ]]; then
-        MAVEN_THREADS=1
-      else
-        MAVEN_THREADS=$(nproc)
-      fi
-
       # Build NiFi
-      ./mvnw -T${MAVEN_THREADS}C -q package \
+      # Note, using -T for multi-threaded builds can cause cannot obtain lock errors
+      ./mvnw -q package \
         --no-snapshot-updates \
         --no-transfer-progress \
         --fail-fast \


### PR DESCRIPTION
We are seeing lots of errors in postsubmit builds:

```
java.lang.IllegalStateException: Attempt 1: Could not acquire read lock for 'artifact:org.apache.nifi:nifi-api:1.27.0' in 30 SECONDS
```

By removing parallel threads for arm as well this seems to make the build more reliable.
