### PR TITLE
py3-google-apis-common-protos - multiversion; py3-protobuf minor updates

### DIFF
--- a/py3-googleapis-common-protos.yaml
+++ b/py3-googleapis-common-protos.yaml
@@ -1,24 +1,29 @@
 package:
   name: py3-googleapis-common-protos
   version: 1.65.0
-  epoch: 0
+  epoch: 1
   description: Common protobufs used in Google APIs
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - protobuf
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: googleapis-common-protos
+  import: google.type.date_pb2
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -27,13 +32,44 @@ pipeline:
       expected-commit: f30115b7302afc91bf06f210a270a6530b7fafdf
       tag: v${{package.version}}
 
-  - name: Python Build
-    runs: python setup.py build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-protobuf
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - name: Python Install
-    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-protobuf.yaml
+++ b/py3-protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-protobuf
   version: 5.28.2
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-3-Clause
   dependencies:
@@ -9,6 +9,7 @@ package:
 
 vars:
   pypi-package: protobuf
+  import: google.protobuf
 
 data:
   - name: py-versions
@@ -21,16 +22,8 @@ data:
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
       - protobuf-dev
-      - py3-supported-pip
-      - py3-supported-python
-      - py3-supported-python-dev
-      - py3-supported-setuptools
-      - py3-supported-wheel
-      - wolfi-base
+      - py3-supported-build-base-dev
 
 pipeline:
   - uses: fetch
@@ -56,8 +49,7 @@ subpackages:
         - uses: python/import
           with:
             python: python${{range.key}}
-            imports: |
-              from google import ${{vars.pypi-package}}
+            import: ${{vars.import}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -67,6 +59,12 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        import: ${{vars.import}}
 
 update:
   enabled: true


### PR DESCRIPTION
Add multiversion python for py3-googleapis-common-protos. Update py3-protobuf to use use py3-supported-build-base-dev package and the 'import' name to import.
