### PR TITLE
ant: remove runtime dependency on jre

### DIFF
--- a/ant.yaml
+++ b/ant.yaml
@@ -1,13 +1,10 @@
 package:
   name: ant
   version: 1.10.15
-  epoch: 0
+  epoch: 1
   description: A Java build tool
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - openjdk-8-jre
 
 environment:
   contents:
@@ -48,6 +45,9 @@ update:
 
 test:
   environment:
+    contents:
+      packages:
+        - openjdk-8-jre
     environment:
       JAVA_HOME: /usr/lib/jvm/java-1.8-openjdk
   pipeline:


### PR DESCRIPTION
Note that all other java tools do not depend on any specific jre, and
can run with any.

If we really want build tools to pull in any jre, we should update
runtime dependency on all of them to depend on default-jre virtual
package which can be satisfied by any jre.

Currently because of this runtime dependency ant images for jdk 11+
pull in duplicate jre's.
