### PR TITLE
multi-version some python packages

### DIFF
--- a/py3-jupyter-packaging.yaml
+++ b/py3-jupyter-packaging.yaml
@@ -1,30 +1,32 @@
-# Generated from https://pypi.org/project/jupyterlab-packaging/
 package:
   name: py3-jupyter-packaging
   version: 0.12.3
-  epoch: 2
+  epoch: 3
   description: Tools to help build and install Jupyter Python packages
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: jupyter-packaging
+  import: jupyter_packaging
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-gpep517
-      - py3-hatchling
-      - py3-setuptools
-      - py3-tomlkit
-      - python-3
-      - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
+      - py3-supported-build-base
+      - py3-supported-gpep517
+      - py3-supported-hatchling
+      - py3-supported-tomlkit
 
 pipeline:
   - uses: git-checkout
@@ -33,10 +35,48 @@ pipeline:
       repository: https://github.com/jupyter/jupyter-packaging
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-deprecation
+        - py${{range.key}}-packaging
+        - py${{range.key}}-setuptools
+        - py${{range.key}}-tomlkit
+        - py${{range.key}}-wheel
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-termcolor.yaml
+++ b/py3-termcolor.yaml
@@ -1,28 +1,31 @@
 package:
   name: py3-termcolor
   version: 2.5.0
-  epoch: 0
+  epoch: 1
   description: ANSI color formatting for output in terminal
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: termcolor
+  import: termcolor
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-setuptools
-      - python-3
-      - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
+      - py3-supported-build-base
+      - py3-supported-hatch-vcs
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -31,28 +34,53 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 2654f7f2ae120aa2be69414d161867ec6ebf6f0a
 
-  - runs: |
-      python3 -m build
-      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
-      find ${{targets.destdir}} -name '*.pyc' -print -exec rm \{} \;
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+    - name: Test colored output
+      uses: py/one-python
+      with:
+        content: |
+          python3 -c '
+          from termcolor import colored;
+          print(colored("Hello, World!", "red"))' |
+              grep -q "Hello, World!" || exit 1
 
 update:
   enabled: true
   github:
     identifier: termcolor/termcolor
     use-tag: true
-
-test:
-  environment:
-    contents:
-      packages:
-        - python-3
-  pipeline:
-    - name: Verify installation
-      runs: |
-        python3 -c "import termcolor" || exit 1
-    - name: Test colored output
-      runs: |
-        python3 -c 'from termcolor import colored; print(colored("Hello, World!", "red"))' | grep -q "Hello, World!" || exit 1

--- a/py3-tinydb.yaml
+++ b/py3-tinydb.yaml
@@ -1,23 +1,30 @@
 package:
   name: py3-tinydb
   version: 4.8.2
-  epoch: 0
+  epoch: 1
   description: A tiny, document-oriented database
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: tinydb
+  import: tinydb
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-poetry
 
 pipeline:
   - uses: git-checkout
@@ -26,10 +33,46 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 10644a0e07ad180c5b756aba272ee6b0dbd12df8
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+    - uses: py/one-python
+      with:
+        content: |
+          python3 ./test.py
 
 update:
   enabled: true
@@ -37,9 +80,3 @@ update:
     identifier: msiemens/tinydb
     strip-prefix: v
     use-tag: true
-
-test:
-  pipeline:
-    - runs: |
-        python3 ./test.py > output.out 2>&1
-        grep -E "ERROR|None" output.out && exit 1

--- a/py3-tomli-w.yaml
+++ b/py3-tomli-w.yaml
@@ -1,25 +1,30 @@
-# Generated from https://pypi.org/project/tomli-w/
 package:
   name: py3-tomli-w
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: A lil' TOML writer
   copyright:
-    - license: "MIT"
+    - license: MIT
   dependencies:
-    runtime:
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: tomli-w
+  import: tomli_w
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - busybox
-      - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-setuptools
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-flit-core
 
 pipeline:
   - uses: git-checkout
@@ -28,42 +33,58 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 179105660c367874818f2cdd1e06ed98eea668f1
 
-  - name: Python Build
-    runs: |
-      python -m build
-      python3 -m installer -d "${{targets.destdir}}" dist/*.whl
-      find ${{targets.destdir}} -name "*.pyc" -exec rm -rf '{}' +
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+    - name: Test Basic TOML Writing
+      uses: py/one-python
+      with:
+        content: |
+          #!/usr/bin/env python3
+          import tomli_w
+          data = {"name": "test", "version": "1.0.0"}
+          output = tomli_w.dumps(data)
+          print("Generated TOML:")
+          print(output)
+          assert 'name = "test"' in output, f"Expected 'name = \"test\"' but got: {output}"
+          assert 'version = "1.0.0"' in output, f"Expected 'version = \"1.0.0\"' but got: {output}"
+          print("TOML writing test passed.")
 
 update:
   enabled: true
   github:
     identifier: hukkin/tomli-w
     use-tag: true
-
-test:
-  environment:
-    contents:
-      packages:
-        - busybox
-        - python3
-        - py3-tomli-w
-  pipeline:
-    - name: Verify Installation
-      runs: |
-        # Ensure that the tomli_w package is installed
-        python3 -c "import tomli_w" || exit 1
-        echo "tomli_w package is installed."
-    - name: Test Basic TOML Writing
-      runs: |
-        python3 <<-EOF
-        import tomli_w
-        data = {"name": "test", "version": "1.0.0"}
-        output = tomli_w.dumps(data)
-        print("Generated TOML:")
-        print(output)
-        assert 'name = "test"' in output, f"Expected 'name = \"test\"' but got: {output}"
-        assert 'version = "1.0.0"' in output, f"Expected 'version = \"1.0.0\"' but got: {output}"
-        print("TOML writing test passed.")
-        EOF

--- a/py3-vcrpy.yaml
+++ b/py3-vcrpy.yaml
@@ -1,28 +1,29 @@
-# Generated from https://pypi.org/project/vcrpy/
 package:
   name: py3-vcrpy
   version: 6.0.2
-  epoch: 0
+  epoch: 1
   description: Automatically mock your HTTP interactions to simplify and speed up testing
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - py3-pyyaml
-      - py3-wrapt
-      - py3-yarl
-      - py3-urllib3
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: vcrpy
+  import: vcr
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -31,19 +32,47 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 1d100dda25dd5f15da87b5c5214a88d74620c663
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-pyyaml
+        - py${{range.key}}-wrapt
+        - py${{range.key}}-yarl
+        - py${{range.key}}-urllib3
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
-  environment:
-    contents:
-      packages:
-        - python3
   pipeline:
-    - runs: |
-        /usr/bin/python3 -c 'import vcr'
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-wcmatch.yaml
+++ b/py3-wcmatch.yaml
@@ -1,26 +1,31 @@
 package:
   name: py3-wcmatch
-  version: "10.0"
-  epoch: 0
-  description: "Wilcard File Name matching library."
+  version: '10.0'
+  epoch: 1
+  description: Wilcard File Name matching library.
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - py3-bracex
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: wcmatch
+  import: wcmatch
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - busybox
-      - ca-certificates-bundle
-      - py3-gpep517
-      - py3-pip
-      - py3-setuptools
-      - py3-wheel
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-gpep517
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -29,59 +34,75 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 0be4cfb81792c6f8295bcb7d393dc0e786967563
 
-  - runs: |
-      # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-      export SOURCE_DATE_EPOCH=315532800
-      python3 -m pip install -U hatchling
-      python3 -m gpep517 build-wheel \
-        --wheel-dir dist \
-        --output-fd 3 3>&1 >&2
-      python3 -m installer \
-        -d "${{targets.destdir}}" \
-        dist/wcmatch-${{package.version}}-*.whl
-      install -Dm644 LICENSE.md \
-        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-bracex
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+    - uses: py/one-python
+      with:
+        content: |
+          # Create test files
+          touch test_file.txt
+          touch another_test_file.txt
+
+          # Test basic file matching with wcmatch
+          python3 -c '
+          import wcmatch
+          from wcmatch import glob
+          # Test glob functionality
+          matched_files = glob.glob("test_file.txt")
+          print("Matched files:", matched_files)
+          assert "test_file.txt" in matched_files
+          print("wcmatch glob test passed")
+          '
+
+          python3 -c '
+          # Test multiple file matching with wcmatch
+          import wcmatch
+          from wcmatch import glob
+          # Test glob functionality with multiple files
+          matched_files = glob.glob("*.txt")
+          print("Matched .txt files:", matched_files)
+          assert "test_file.txt" in matched_files
+          assert "another_test_file.txt" in matched_files
+          print("wcmatch multiple file glob test passed")
+          '
 
 update:
   enabled: true
   github:
     identifier: facelessuser/wcmatch
-
-test:
-  environment:
-    contents:
-      packages:
-        - py3-pip
-  pipeline:
-    - runs: |
-        # Test import of wcmatch
-        python3 -c 'import wcmatch; print("wcmatch imported successfully")'
-    - runs: |
-        # Create test files
-        touch test_file.txt
-        touch another_test_file.txt
-    - runs: |
-        # Test basic file matching with wcmatch
-        python3 -c '
-        import wcmatch
-        from wcmatch import glob
-        # Test glob functionality
-        matched_files = glob.glob("test_file.txt")
-        print("Matched files:", matched_files)
-        assert "test_file.txt" in matched_files
-        print("wcmatch glob test passed")
-        '
-    - runs: |
-        # Test multiple file matching with wcmatch
-        python3 -c '
-        import wcmatch
-        from wcmatch import glob
-        # Test glob functionality with multiple files
-        matched_files = glob.glob("*.txt")
-        print("Matched .txt files:", matched_files)
-        assert "test_file.txt" in matched_files
-        assert "another_test_file.txt" in matched_files
-        print("wcmatch multiple file glob test passed")
-        '

--- a/py3-zaproxy.yaml
+++ b/py3-zaproxy.yaml
@@ -1,22 +1,30 @@
 package:
   name: py3-zaproxy
   version: 0.3.2
-  epoch: 1
+  epoch: 2
   description: ZAP Python API
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - py3-requests
-      - py3-six
+    provider-priority: 0
+
+vars:
+  pypi-package: zaproxy
+  import: zapv2
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-poetry
 
 pipeline:
   - uses: git-checkout
@@ -25,22 +33,50 @@ pipeline:
       expected-commit: a779d751b3d7c20cb629c760c4cef0da0796dc6f
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-requests
+        - py${{range.key}}-six
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:
     - uses: python/import
       with:
         imports: |
-          import zapv2
+          import ${{vars.import}}
 
 update:
   enabled: true
   ignore-regex-patterns:
-    - '.*\.dev1$'
+    - .*\.dev1$
   github:
     identifier: zaproxy/zap-api-python
     use-tag: true


### PR DESCRIPTION
py3-zaproxy - straight forward
py3-wcmatch - update tests to use py/one-python
py3-jupyter-packaging
 - fix runtime dependencies (per pypi at 0.12.3)
