### PR TITLE
py3-sqlalchemy - allow updates, multi-version

### DIFF
--- a/py3-sqlalchemy.yaml
+++ b/py3-sqlalchemy.yaml
@@ -1,49 +1,87 @@
 package:
   name: py3-sqlalchemy
-  version: 2.0.20
-  epoch: 3
+  version: 2.0.35
+  epoch: 0
   description: Database Abstraction Library
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - python3
+    provider-priority: 0
 
-# transform melange version 2.0.20 => 2_0_20
-var-transforms:
-  - from: ${{package.version}}
-    match: \.
-    replace: _
-    to: mangled-package-version
+vars:
+  pypi-package: sqlalchemy
+  import: sqlalchemy
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/sqlalchemy/sqlalchemy
-      expected-commit: a52103c44f3989d53edf4c76abb92afd3ca724c9
+      expected-commit: ca501d9d38d50dc4eda52c82ebc9c51766bc141b
       tag: rel_${{vars.mangled-package-version}}
 
-  - name: Python Build
-    runs: python setup.py build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-typing-extensions
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - name: Python Install
-    runs: python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
-  enabled: false
-  manual: true
-  exclude-reason: This requires manual updates because of the strange tagging scheme.
+  enabled: true
+  version-transform:
+    - match: rel_(\d+)_(\d+)_(\d+)
+      replace: $1.$2.$3
   github:
     identifier: sqlalchemy/sqlalchemy
+    tag-filter: rel_
+
+var-transforms:
+  - from: ${{package.version}}
+    match: \.
+    replace: _
+    to: mangled-package-version


### PR DESCRIPTION
The change here to 'update' section allows picking up updates. The other changes move to multi-version.  2.0.35 supports python 3.13 when the older version did not.
