### PR TITLE
add linkerd2 controller package

### DIFF
--- a/linkerd2-controller-edge.yaml
+++ b/linkerd2-controller-edge.yaml
@@ -1,0 +1,48 @@
+package:
+  name: linkerd2-controller-edge
+  version: 24.10.2
+  epoch: 0
+  description: "Kubernetes controller for Linkerd service mesh"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 3a78e22f92fc30b7357f6e241d29ae38f99a69f4
+      repository: https://github.com/linkerd/linkerd2/
+      tag: edge-${{package.version}}
+
+  - runs: |
+      go generate -mod=readonly ./pkg/charts/static
+
+  - uses: go/build
+    with:
+      packages: ./controller/cmd/main.go
+      tags: prod
+      output: controller
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "upstream image have executable placed at /"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          ln -sf /usr/bin/controller ${{targets.contextdir}}/controller
+
+update:
+  enabled: true
+  github:
+    identifier: linkerd/linkerd2
+    tag-filter: edge-
+    strip-prefix: edge-
+
+test:
+  pipeline:
+    - name: check presence of required files
+      runs: |
+        # executable doesn't have help or version flag.
+        stat /usr/bin/controller

--- a/linkerd2-controller.yaml
+++ b/linkerd2-controller.yaml
@@ -1,5 +1,5 @@
 package:
-  name: linkerd2-controller-edge
+  name: linkerd2-controller
   version: 24.10.2
   epoch: 0
   description: "Kubernetes controller for Linkerd service mesh"


### PR DESCRIPTION
adds linkerd2 core controller package. 

`-edge` is suffixed because we are building from edge releases. 