### PR TITLE
hugo: new upstream release, and build with extended tag.

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,6 +1,6 @@
 package:
   name: hugo
-  version: 0.135.0
+  version: 0.136.0
   epoch: 0
   description: The world's fastest framework for building websites.
   copyright:
@@ -18,12 +18,13 @@ pipeline:
     with:
       repository: https://github.com/gohugoio/hugo
       tag: v${{package.version}}
-      expected-commit: f30603c47f5205e30ef83c70419f57d7eb7175ab
+      expected-commit: 2939270a3bb78b3799973345c0dab7fa239cef9d
 
   - uses: go/build
     with:
       packages: .
       output: hugo
+      tags: extended
 
   - uses: strip
 


### PR DESCRIPTION
Build hugo with the extended tag, and updates to the new upstream release.