### PR TITLE
Add py3-supported-setuptools-gettext

### DIFF
--- a/py3-setuptools-gettext.yaml
+++ b/py3-setuptools-gettext.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-setuptools-gettext
   version: 0.1.14
-  epoch: 0
+  epoch: 1
   description: Setuptools gettext extension plugin
   copyright:
     - license: "GPL-2.0-or-later"
@@ -55,6 +55,15 @@ subpackages:
           with:
             import: ${{vars.import}}
             python: python${{range.key}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:


### PR DESCRIPTION
I failed to add the 'supported' which is needed to use it as a build-dep.
