### PR TITLE
py3-breezy - multi-version

### DIFF
--- a/py3-breezy.yaml
+++ b/py3-breezy.yaml
@@ -1,32 +1,32 @@
-# Generated from https://pypi.org/project/breezy/
 package:
   name: py3-breezy
   version: 3.3.8
-  epoch: 0
+  epoch: 1
   description: Friendly distributed version control system
   copyright:
     - license: GPL-2.0-or-later
   dependencies:
-    runtime:
-      - python-3
-      - py3-configobj
-      - py3-dulwich
-      - py3-fastbencode
-      - py3-merge3
-      - py3-patiencediff
-      - py3-tzlocal
-      - py3-urllib3
-      - py3-pyyaml
+    provider-priority: 0
+
+vars:
+  pypi-package: breezy
+  import: breezy
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - python3-dev
+      - py3-supported-build-base-dev
+      - py3-supported-cython
+      - py3-supported-setuptools-gettext
+      - py3-supported-setuptools-rust
       - rust
-      - wolfi-base
 
 pipeline:
   - uses: fetch
@@ -34,13 +34,83 @@ pipeline:
       expected-sha256: 14d59bbdf86b66c17327eb79a5883b4c70cc7794ed34f3e8a0adfce64edc58bf
       uri: https://files.pythonhosted.org/packages/source/b/breezy/breezy-${{package.version}}.tar.gz
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      runtime:
+        - py${{range.key}}-configobj
+        - py${{range.key}}-dulwich
+        - py${{range.key}}-fastbencode
+        - py${{range.key}}-merge3
+        - py${{range.key}}-patiencediff
+        - py${{range.key}}-tzlocal
+        - py${{range.key}}-urllib3
+        - py${{range.key}}-pyyaml
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      environment:
+        contents:
+          packages:
+            - apk-tools
+      pipeline:
+        - runs: |
+            apk info -L py${{range.key}}-${{vars.pypi-package}}-bin > "pkg.list"
+            echo "Please write a test for these:"
+            grep usr/bin/ pkg.list > bins.list
+            sed 's,^,> ,' bins.list
+
+            while read line; do
+              echo == /$line ==
+              /$line --help && echo exited 0 || echo "exited $?"
+            done < bins.list
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
 
 test:
   pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
     - runs: |
         mkdir test
         cd test


### PR DESCRIPTION
    3.13 fails like this:
    
    >  error: the configured Python interpreter version (3.13) is newer than
    >  PyO3's maximum supported version (3.12)
    >  = help: please check if an updated version of PyO3 is available.
    >     Current version: 0.21.1
    >  = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check
    >     and build anyway using the stable ABI
    >  error: `cargo rustc --lib --message-format=json-render-diagnostics
    >    --manifest-path lib-rio/Cargo.toml --release -v
    >    --features pyo3/extension-module --crate-type cdylib --
    
    We can enable later.
