### PR TITLE
volume-modifier-for-k8s: update to 0.3.1

### DIFF
--- a/volume-modifier-for-k8s.yaml
+++ b/volume-modifier-for-k8s.yaml
@@ -1,7 +1,7 @@
 package:
   name: volume-modifier-for-k8s
-  version: 0.2.1
-  epoch: 8
+  version: 0.3.1
+  epoch: 0
   description: volume-modifier-for-k8s is a sidecar deployed alongside CSI drivers to enable volume modification through annotations on the PVC.
   copyright:
     - license: Apache-2.0
@@ -15,13 +15,13 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 641cdd2ce1e4b62fa54f71671caba8ef22c48c29
+      expected-commit: f821ed52f3b2ea8edce1d8a98b9ae1cda53c6ffb
       repository: https://github.com/awslabs/volume-modifier-for-k8s
       tag: v${{package.version}}
 
   - uses: go/bump
     with:
-      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.46.0 google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4 golang.org/x/net@v0.23.0
+      deps: google.golang.org/grpc@v1.64.1
       modroot: .
 
   - uses: go/build
@@ -39,6 +39,7 @@ update:
     identifier: awslabs/volume-modifier-for-k8s
     strip-prefix: v
     tag-filter: v
+    use-tag: true
 
 test:
   pipeline:


### PR DESCRIPTION
This PR updates the volume-modifier-for-k8s to the latest 0.3.1 version.

It also aligns the update policy with the upstream one. Specifically, the `awslabs/volume-modifier-for-k8s` [1] didn't create Github releases for the past two releases `v0.3.0` and `v0.3.1`.
Nevertheless upstream consumers like the official Helm chart for the EBS CSI driver already pins the `v0.3.0` in the latest version [2].

[1] https://github.com/awslabs/volume-modifier-for-k8s
[2] https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/e6dae6132fc8383340024440fc639a135bebd4ba/charts/aws-ebs-csi-driver/values.yaml#L153