### PR TITLE
py3-psycopg2: Add multi-python version support. Fix FTBFS on 3.13

### DIFF
--- a/py3-psycopg2.yaml
+++ b/py3-psycopg2.yaml
@@ -1,28 +1,30 @@
-# Generated from https://pypi.org/project/psycopg2/
 package:
   name: py3-psycopg2
   version: 2.9.9
-  epoch: 1
+  epoch: 2
   description: psycopg2 - Python-PostgreSQL Database Adapter
   copyright:
     - license: LGPL-3.0-or-later
   dependencies:
-    runtime:
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: psycopg2
+  import: psycopg2
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
       - postgresql-dev
-      - py3-build
-      - py3-installer
-      - py3-setuptools
-      - python3
-      - python3-dev
-      - wolfi-base
+      - py3-supported-build-base-dev
 
 pipeline:
   - uses: git-checkout
@@ -30,41 +32,53 @@ pipeline:
       repository: https://github.com/psycopg/psycopg2
       tag: ${{package.version}}
       expected-commit: ad5bee7054519d87f25bc5828c502b2ebe197049
+      cherry-picks: |
+        master/829a7a2be93f5d0fb1edbc0feb104181f208efc6: Fix FTBFS with 3.13
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
-
-update:
-  enabled: true
-  version-separator: _
-  github:
-    identifier: psycopg/psycopg2
-    use-tag: true
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
-  environment:
-    contents:
-      packages:
-        - postgresql
-        - postgresql-client
-        - wolfi-base
-        - shadow
-        - sudo-rs
-        - glibc-locales
-    environment:
-      PGDATA: /tmp/test_db
-      PGUSER: wolfi
   pipeline:
-    - name: "Test database creation"
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+    - name: Test database creation
       runs: |
         useradd $PGUSER
         sudo -u $PGUSER initdb -D /tmp/test_db
         sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start
         sudo -u $PGUSER createdb testdb
         psql -lqt | cut -d \| -f 1 | grep -qw testdb
-    - name: "Test psycopg2"
+    - name: Test psycopg2
     - runs: |
         cat <<'EOF' >> /tmp/test.py
         import psycopg2
@@ -103,3 +117,10 @@ test:
             main()
         EOF
         python3 /tmp/test.py
+
+update:
+  enabled: true
+  version-separator: _
+  github:
+    identifier: psycopg/psycopg2
+    use-tag: true

--- a/py3-psycopg2.yaml
+++ b/py3-psycopg2.yaml
@@ -73,7 +73,7 @@ test:
         - postgresql-client
         - wolfi-base
         - shadow
-        - sudo-rs
+        - sudo
         - glibc-locales
     environment:
       PGDATA: /tmp/test_db
@@ -85,8 +85,6 @@ test:
           import ${{vars.import}}
     - name: Test database creation
       runs: |
-        export PGUSER=wolfi
-        export PGDATA=/tmp/test_db
         useradd $PGUSER
         sudo -u $PGUSER initdb -D /tmp/test_db
         sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start

--- a/py3-psycopg2.yaml
+++ b/py3-psycopg2.yaml
@@ -85,6 +85,8 @@ test:
           import ${{vars.import}}
     - name: Test database creation
       runs: |
+        export PGUSER=wolfi
+        export PGDATA=/tmp/test_db
         useradd $PGUSER
         sudo -u $PGUSER initdb -D /tmp/test_db
         sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start

--- a/py3-psycopg2.yaml
+++ b/py3-psycopg2.yaml
@@ -79,6 +79,10 @@ test:
       PGDATA: /tmp/test_db
       PGUSER: wolfi
   pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
     - name: Test database creation
       runs: |
         useradd $PGUSER
@@ -86,45 +90,46 @@ test:
         sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start
         sudo -u $PGUSER createdb testdb
         psql -lqt | cut -d \| -f 1 | grep -qw testdb
-    - name: Test psycopg2
-    - runs: |
-        cat <<'EOF' >> /tmp/test.py
-        import psycopg2
+    - uses: py/one-python
+       with:
+         content: |
+           cat <<'EOF' >> /tmp/test.py
+           import psycopg2
 
-        def main():
-            conn = psycopg2.connect(dbname="testdb", user="wolfi")
-            cursor = conn.cursor()
+           def main():
+               conn = psycopg2.connect(dbname="testdb", user="wolfi")
+               cursor = conn.cursor()
 
-            try:
-                # Create Table
-                cursor.execute("""
-                    CREATE TABLE IF NOT EXISTS example_table (
-                        id SERIAL PRIMARY KEY,
-                        message TEXT
-                    )
-                """)
+               try:
+                   # Create Table
+                   cursor.execute("""
+                       CREATE TABLE IF NOT EXISTS example_table (
+                           id SERIAL PRIMARY KEY,
+                           message TEXT
+                       )
+                   """)
 
-                # Insert value
-                cursor.execute("INSERT INTO example_table (message) VALUES (%s)", ("Hello Wolfy!",))
-                conn.commit()
+                   # Insert value
+                   cursor.execute("INSERT INTO example_table (message) VALUES (%s)", ("Hello Wolfy!",))
+                   conn.commit()
 
-                # Select and print
-                cursor.execute("SELECT message FROM example_table")
-                result = cursor.fetchone()
-                message = result[0]
-                print("Message retrieved from database:", message)
+                   # Select and print
+                   cursor.execute("SELECT message FROM example_table")
+                   result = cursor.fetchone()
+                   message = result[0]
+                   print("Message retrieved from database:", message)
 
-            except Exception as e:
-                print("Error:", e)
+               except Exception as e:
+                   print("Error:", e)
 
-            finally:
-                cursor.close()
-                conn.close()
+               finally:
+                   cursor.close()
+                   conn.close()
 
-        if __name__ == "__main__":
-            main()
-        EOF
-        python3 /tmp/test.py
+           if __name__ == "__main__":
+               main()
+           EOF
+           python3 /tmp/test.py
 
 update:
   enabled: true

--- a/py3-psycopg2.yaml
+++ b/py3-psycopg2.yaml
@@ -90,46 +90,47 @@ test:
         sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start
         sudo -u $PGUSER createdb testdb
         psql -lqt | cut -d \| -f 1 | grep -qw testdb
-    - uses: py/one-python
-       with:
-         content: |
-           cat <<'EOF' >> /tmp/test.py
-           import psycopg2
+    - name: Test psycopg2
+      uses: py/one-python
+      with:
+        content: |
+          cat <<'EOF' >> /tmp/test.py
+          import psycopg2
 
-           def main():
-               conn = psycopg2.connect(dbname="testdb", user="wolfi")
-               cursor = conn.cursor()
+          def main():
+            conn = psycopg2.connect(dbname="testdb", user="wolfi")
+            cursor = conn.cursor()
 
-               try:
-                   # Create Table
-                   cursor.execute("""
-                       CREATE TABLE IF NOT EXISTS example_table (
-                           id SERIAL PRIMARY KEY,
-                           message TEXT
-                       )
-                   """)
+            try:
+                # Create Table
+                cursor.execute("""
+                    CREATE TABLE IF NOT EXISTS example_table (
+                        id SERIAL PRIMARY KEY,
+                        message TEXT
+                    )
+                """)
 
-                   # Insert value
-                   cursor.execute("INSERT INTO example_table (message) VALUES (%s)", ("Hello Wolfy!",))
-                   conn.commit()
+                # Insert value
+                cursor.execute("INSERT INTO example_table (message) VALUES (%s)", ("Hello Wolfy!",))
+                conn.commit()
 
-                   # Select and print
-                   cursor.execute("SELECT message FROM example_table")
-                   result = cursor.fetchone()
-                   message = result[0]
-                   print("Message retrieved from database:", message)
+                # Select and print
+                cursor.execute("SELECT message FROM example_table")
+                result = cursor.fetchone()
+                message = result[0]
+                print("Message retrieved from database:", message)
 
-               except Exception as e:
-                   print("Error:", e)
+            except Exception as e:
+                print("Error:", e)
 
-               finally:
-                   cursor.close()
-                   conn.close()
+            finally:
+                cursor.close()
+                conn.close()
 
-           if __name__ == "__main__":
-               main()
-           EOF
-           python3 /tmp/test.py
+          if __name__ == "__main__":
+            main()
+          EOF
+          python3 /tmp/test.py
 
 update:
   enabled: true

--- a/py3-psycopg2.yaml
+++ b/py3-psycopg2.yaml
@@ -66,11 +66,19 @@ subpackages:
         - py3.13-${{vars.pypi-package}}
 
 test:
+  environment:
+    contents:
+      packages:
+        - postgresql
+        - postgresql-client
+        - wolfi-base
+        - shadow
+        - sudo-rs
+        - glibc-locales
+    environment:
+      PGDATA: /tmp/test_db
+      PGUSER: wolfi
   pipeline:
-    - uses: python/import
-      with:
-        imports: |
-          import ${{vars.import}}
     - name: Test database creation
       runs: |
         useradd $PGUSER

--- a/py3-psycopg2.yaml
+++ b/py3-psycopg2.yaml
@@ -73,7 +73,7 @@ test:
         - postgresql-client
         - wolfi-base
         - shadow
-        - sudo
+        - sudo-rs
         - glibc-locales
     environment:
       PGDATA: /tmp/test_db
@@ -86,8 +86,8 @@ test:
     - name: Test database creation
       runs: |
         useradd $PGUSER
-        sudo -u $PGUSER initdb -D /tmp/test_db
-        sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start
+        sudo -u $PGUSER initdb -D $PGDATA
+        sudo -u $PGUSER pg_ctl -D $PGDATA -l /tmp/logfile start
         sudo -u $PGUSER createdb testdb
         psql -lqt | cut -d \| -f 1 | grep -qw testdb
     - name: Test psycopg2


### PR DESCRIPTION
 * Add multi-python version support
 * Fix FTBFS with 3.13. Cherry-pick from upstream: 829a7a2be93f5d0fb1edbc0feb104181f208efc6
