### PR TITLE
Update malcontent to v1.2.0

### DIFF
--- a/malcontent.yaml
+++ b/malcontent.yaml
@@ -1,6 +1,6 @@
 package:
   name: malcontent
-  version: 1.1.1
+  version: 1.2.0
   epoch: 0
   description: enumerate file capabilities, including malicious behaviors
   copyright:
@@ -21,7 +21,7 @@ pipeline:
     with:
       repository: https://github.com/chainguard-dev/malcontent
       tag: v${{package.version}}
-      expected-commit: 0acb2e0e98915c8fee1d6723dfbf1a29d861ed5c
+      expected-commit: 6a0315f82e33b44142e270b44872d2e3fad5864b
 
   - uses: go/build
     with:


### PR DESCRIPTION
Quick update PR to unblock a Wolfictl PR that changes the flags we use for `diff`.