### PR TITLE
Fix manual pc provides, without suffix

### DIFF
--- a/libpng.yaml
+++ b/libpng.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpng
   version: 1.6.44
-  epoch: 1
+  epoch: 2
   description: Portable Network Graphics library
   copyright:
     - license: Libpng
@@ -55,7 +55,7 @@ subpackages:
         # install locations, which are very libpng specific. Support
         # such install layout with melange SCA by augumenting the
         # necessory provides, which is installed as a symlink.
-        - pc:libpng.pc
+        - pc:libpng
       runtime:
         - libpng
     description: libpng dev

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
   version: 6.5_p20240629
-  epoch: 1
+  epoch: 2
   description: "console display library"
   copyright:
     - license: MIT
@@ -84,7 +84,7 @@ subpackages:
       provides:
         # Unusually this is a symlink, that currently melange SCA does
         # not consider for provides
-        - pc:ncurses.pc
+        - pc:ncurses
       runtime:
         - ncurses
     test:


### PR DESCRIPTION
Manual provides for the pc files were incorrectly encoded they should
be without suffix.

Or maybe symlinked pc files should be made natively supported in
melange, as in theory they should not be cross-package.
