### PR TITLE
sqlpad/GHSA-pxg6-pf52-xh8x fix update express

### DIFF
--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -1,7 +1,7 @@
 package:
   name: sqlpad
   version: 7.5.0 # when updating check the patch below as it contains dependency version updates which may downgrade if upstream upgrades them
-  epoch: 1
+  epoch: 2
   description: Web-based SQL editor. Legacy project in maintenance mode.
   copyright:
     - license: MIT
@@ -35,7 +35,7 @@ pipeline:
         jq ".resolutions.${override}" package.json > temp.json && mv temp.json package.json
       done
 
-      for dep in '"express"="4.20.0"' '"body-parser"="1.20.3"' '"send"="0.19.0"' '"mysql2"="3.9.8"'; do
+      for dep in '"express"="4.21.1"' '"body-parser"="1.20.3"' '"send"="0.19.0"' '"mysql2"="3.9.8"'; do
         jq ".dependencies.${dep}" package.json > temp.json && mv temp.json package.json
       done
 

--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -31,7 +31,7 @@ pipeline:
     runs: |
       # Create "resolutions" section of package.json
       jq '.resolutions |= (if . then . else {} end)' package.json > temp.json && mv temp.json package.json
-      for override in '"semver"="6.3.1"' '"@node-saml/node-saml"="4.0.5"' '"ip"="2.0.1"' '"jose"="4.15.5"' '"xlsx"="https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"' '"tar"="6.2.1"' '"@azure/identity"="4.2.1"' '"@azure/msal-node"="2.9.2"' '"send"="0.19.0"'; do
+      for override in '"semver"="6.3.1"' '"@node-saml/node-saml"="4.0.5"' '"ip"="2.0.1"' '"jose"="4.15.5"' '"xlsx"="https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"' '"tar"="6.2.1"' '"@azure/identity"="4.2.1"' '"@azure/msal-node"="2.9.2"' '"send"="0.19.0"' '"cookie"="0.7.0"'; do
         jq ".resolutions.${override}" package.json > temp.json && mv temp.json package.json
       done
 


### PR DESCRIPTION
Bumping the express version from v4.20.0 to the latest version (v4.21.0) remediates the GHSA-pxg6-pf52-xh8x as the CVE was being flagged by the transitive dependency cookie 0.6.0 which was updated in the most recent version of express.