### PR TITLE
py3-keras multi-version

### DIFF
--- a/py3-keras.yaml
+++ b/py3-keras.yaml
@@ -1,37 +1,77 @@
-# Generated from https://pypi.org/project/keras/
 package:
   name: py3-keras
   version: 3.6.0
-  epoch: 0
+  epoch: 1
   description: Deep learning for humans.
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+# Note per https://pypi.org/project/keras/
+# > To use keras, you should also install the backend of choice: tensorflow,
+# > jax, or torch
+# wolfi does not have any of those currently available in a way that
+# could be used from a test.
+vars:
+  pypi-package: keras
+  import: keras
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 405727525a3522ed8f9ec0b46e0667e4c65fcf714a067322c16a00d902ded41d
-      uri: https://files.pythonhosted.org/packages/source/k/keras/keras-${{package.version}}.tar.gz
+      expected-commit: 7004f526cfd0933f407f1b4f530b865079aa9bef
+      repository: https://github.com/keras-team/keras
+      tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-absl-py
+        - py${{range.key}}-numpy
+        - py${{range.key}}-rich
+        - py${{range.key}}-namex
+        - py${{range.key}}-h5py
+        - py${{range.key}}-optree
+        - py${{range.key}}-ml-dtypes
+        - py${{range.key}}-packaging
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 215741
+  github:
+    identifier: keras-team/keras
+    strip-prefix: v
+    use-tag: true


### PR DESCRIPTION
Note that there is no test added here.
Import test fails.  Per pypi:

> To use keras, you should also install the backend of choice:
> tensorflow, jax, or torch. Note that tensorflow is required for using
> certain Keras 3 features: certain preprocessing layers as well as
> tf.data pipelines.

The idea is that the user would supply the correct backend and then can configure that via KERAS_BACKEND or config file.

tensorflow is not built multi-versioned yet.
wolfi does not have torch or jax builds.

So we're not really able to even import-test this at the moment.

Also note, while that seems terrible, this is strictly better than what _was_ there, which had no test and lack of _identified_ runtime dependencies.
