### PR TITLE
py3-pymongo - multi-version , py3-hatch-requirements-txt - add supported

### DIFF
--- a/py3-hatch-requirements-txt.yaml
+++ b/py3-hatch-requirements-txt.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-hatch-requirements-txt
   version: 0.4.1
-  epoch: 0
+  epoch: 1
   description: Hatchling plugin to read project dependencies from requirements.txt
   copyright:
     - license: MIT
@@ -56,6 +56,15 @@ subpackages:
           with:
             import: ${{vars.module_name}}
             python: python${{range.key}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   environment: {}

--- a/py3-pymongo.yaml
+++ b/py3-pymongo.yaml
@@ -1,29 +1,31 @@
-# Generated from https://pypi.org/project/pymongo/
 package:
   name: py3-pymongo
   version: 4.10.1
-  epoch: 0
+  epoch: 1
   description: Python driver for MongoDB <http://www.mongodb.org>
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - py3-dnspython
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: pymongo
+  import: pymongo
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - python3-dev
-      - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
+      - py3-supported-build-base-dev
+      - py3-supported-hatch-requirements-txt
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -32,10 +34,44 @@ pipeline:
       repository: https://github.com/mongodb/mongo-python-driver
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-dnspython
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true


### PR DESCRIPTION
I failed to add the 'supported' package to py3-hatch-requirements-txt so it wasn't really able  to be used from py3-mongo build.
