### PR TITLE
druid/GHSA-78wr-2p64-hpwj fix

### DIFF
--- a/druid.yaml
+++ b/druid.yaml
@@ -36,9 +36,8 @@ pipeline:
       patches: protobuf-3.25.5.patch commons.io.patch
 
   - uses: maven/pombump
-
-  - uses: maven/pombump
     with:
+      patch-file: "pombump-deps.yaml"
       properties-file: pombump-properties.yaml
 
   - runs: |

--- a/druid.yaml
+++ b/druid.yaml
@@ -40,6 +40,7 @@ pipeline:
   - uses: maven/pombump
     with:
       properties-file: pombump-properties.yaml
+
   - runs: |
       mvn -B -ff -q \
       install \

--- a/druid.yaml
+++ b/druid.yaml
@@ -1,7 +1,7 @@
 package:
   name: druid
   version: 30.0.1
-  epoch: 2
+  epoch: 3
   description: Apache Druid is a high performance real-time analytics database.
   copyright:
     - license: Apache-2.0
@@ -33,12 +33,13 @@ pipeline:
 
   - uses: patch
     with:
-      patches: protobuf-3.25.5.patch
+      patches: protobuf-3.25.5.patch commons.io.patch
+
+  - uses: maven/pombump
 
   - uses: maven/pombump
     with:
       properties-file: pombump-properties.yaml
-
   - runs: |
       mvn -B -ff -q \
       install \

--- a/druid/commons.io.patch
+++ b/druid/commons.io.patch
@@ -1,0 +1,102 @@
+From 93b5a8326bfcde747b43b481064096e01b7a407f Mon Sep 17 00:00:00 2001
+From: Shivam Garg <shigarg@visa.com>
+Date: Fri, 4 Oct 2024 13:26:56 +0530
+Subject: [PATCH] Upgrade commons-io to 2.17.0 (#17227)
+
+---
+ .../DruidPeonClientIntegrationTest.java        |  4 ++--
+ extensions-core/protobuf-extensions/pom.xml    |  2 +-
+ licenses.yaml                                  | 18 ++----------------
+ pom.xml                                        |  2 +-
+ 4 files changed, 6 insertions(+), 20 deletions(-)
+
+diff --git a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
+index e2d97accc97f..44570fac2d2d 100644
+--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
++++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
+@@ -50,8 +50,8 @@
+ import org.junit.jupiter.api.io.TempDir;
+ 
+ import java.io.File;
+-import java.io.IOException;
+ import java.io.InputStream;
++import java.io.UncheckedIOException;
+ import java.nio.charset.StandardCharsets;
+ import java.nio.file.Path;
+ import java.nio.file.Paths;
+@@ -147,7 +147,7 @@ public void testDeployingSomethingToKind(@TempDir Path tempDir) throws Exception
+                                  .map(Integer::parseInt)
+                                  .collect(Collectors.toList()));
+       }
+-      catch (IOException e) {
++      catch (UncheckedIOException e) {
+         throw new RuntimeException(e);
+       }
+     });
+diff --git a/extensions-core/protobuf-extensions/pom.xml b/extensions-core/protobuf-extensions/pom.xml
+index 2c7c82cd34a5..61ba13eb9b85 100644
+--- a/extensions-core/protobuf-extensions/pom.xml
++++ b/extensions-core/protobuf-extensions/pom.xml
+@@ -35,7 +35,7 @@
+   </parent>
+ 
+   <properties>
+-    <commons-io.version>2.11.0</commons-io.version>
++    <commons-io.version>2.17.0</commons-io.version>
+     <okio.version>3.6.0</okio.version>
+   </properties>
+ 
+diff --git a/licenses.yaml b/licenses.yaml
+index a5e48c7d010e..3dcc0424d6f1 100644
+--- a/licenses.yaml
++++ b/licenses.yaml
+@@ -546,13 +546,13 @@ name: Apache Commons IO
+ license_category: binary
+ module: java-core
+ license_name: Apache License version 2.0
+-version: 2.11.0
++version: 2.17.0
+ libraries:
+   - commons-io: commons-io
+ notices:
+   - commons-io: |
+       Apache Commons IO
+-      Copyright 2002-2021 The Apache Software Foundation
++      Copyright 2002-2024 The Apache Software Foundation
+ 
+ ---
+ 
+@@ -2521,20 +2521,6 @@ notices:
+ 
+ ---
+ 
+-name: Apache Commons IO
+-license_category: binary
+-module: hadoop-client
+-license_name: Apache License version 2.0
+-version: 2.4
+-libraries:
+-  - commons-io: commons-io
+-notices:
+-  - commons-io: |
+-      Apache Commons IO
+-      Copyright 2002-2012 The Apache Software Foundation
+-
+----
+-
+ name: Apache Commons Logging
+ license_category: binary
+ module: hadoop-client
+diff --git a/pom.xml b/pom.xml
+index 0a2dfab66c81..cc5c87d8f8f6 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -294,7 +294,7 @@
+             <dependency>
+                 <groupId>commons-io</groupId>
+                 <artifactId>commons-io</artifactId>
+-                <version>2.11.0</version>
++                <version>2.17.0</version>
+             </dependency>
+             <dependency>
+                 <groupId>commons-logging</groupId>

--- a/druid/pombump-deps.yaml
+++ b/druid/pombump-deps.yaml
@@ -1,0 +1,5 @@
+patches:  
+  # Fixes GHSA-78wr-2p64-hpwj
+  - groupId: commons-io
+    artifactId: commons-io
+    version: 2.17.0


### PR DESCRIPTION
The commons-io dependency that is not shaded can be updated with the upstream patch. The shaded dependencies however are not able to updated and the CVE check will fail so an advisory will need to be filed for those common-io instances 
