### PR TITLE
strimzi-kafka-operator/GHSA-78wr-2p64-hpwj

### DIFF
--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: strimzi-kafka-operator
   version: 0.43.0
-  epoch: 2
+  epoch: 3
   description: Apache Kafka® running on Kubernetes
   copyright:
     - license: Apache-2.0
@@ -62,6 +62,10 @@ pipeline:
       patch-file: ""
       properties-file: pombump-deps.yaml
       pom: docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+  
+  - uses: maven/pombump
+    with:
+      properties-file: pombump-properties.yaml
 
   - runs: |
       export JAVA_HOME="/usr/lib/jvm/java-17-openjdk"

--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -62,7 +62,7 @@ pipeline:
       patch-file: ""
       properties-file: pombump-deps.yaml
       pom: docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
-  
+
   - uses: maven/pombump
     with:
       properties-file: pombump-properties.yaml

--- a/strimzi-kafka-operator/pombump-deps.yaml
+++ b/strimzi-kafka-operator/pombump-deps.yaml
@@ -29,3 +29,7 @@ patches:
     version: 9.37.2
     scope: import
     type: pom
+    # Fixes CVE-2023-52428
+  - groupId: commons-io
+    artifactId: commons-io
+    version: 2.17.0

--- a/strimzi-kafka-operator/pombump-properties.yaml
+++ b/strimzi-kafka-operator/pombump-properties.yaml
@@ -1,0 +1,3 @@
+properties:
+  - property: commons-codec.version
+    value: "1.17.1"


### PR DESCRIPTION
Updated and added the required changes to remediate commons-io dependencies. Both the commons-codec.version and the commons-io in the parent pom.xml have been changed. 
