### PR TITLE
kubeflow-centraldashboard/GHSA-pxg6-pf52-xh8x fix

### DIFF
--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-centraldashboard
   version: 1.9.1
-  epoch: 0
+  epoch: 1
   description: Landing page and central dashboard for Kubeflow deployments
   copyright:
     - license: MIT
@@ -54,7 +54,8 @@ pipeline:
         "express": "^4.20.0",
         "@grpc/grpc-js": "^1.10.9",
         "path-to-regexp": "0.1.10",
-        "serve-static": "^1.16.0"
+        "serve-static": "^1.16.0",
+        "cookie": "0.7.0"
       }'
 
       # Apply the overrides


### PR DESCRIPTION
The affected dependency has been bumped from cookie 0.6.0 to 0.7.0. This remediates the CVE without bumping the major version which would require much more investigation in regards to compatibility. 
