### PR TITLE
jitsucom-jitsu/GHSA-pxg6-pf52-xh8x fix

### DIFF
--- a/jitsucom-jitsu.yaml
+++ b/jitsucom-jitsu.yaml
@@ -1,7 +1,7 @@
 package:
   name: jitsucom-jitsu
   version: 2.8.2
-  epoch: 1
+  epoch: 2
   description: Jitsu is an open-source Segment alternative. Fully-scriptable data ingestion engine for modern data teams. Set-up a real-time data pipeline in minutes, not days
   copyright:
     - license: MIT

--- a/jitsucom-jitsu/upgrade-deps.patch
+++ b/jitsucom-jitsu/upgrade-deps.patch
@@ -2,7 +2,7 @@ diff --git a/package.json b/package.json
 index 40a2078..fd5df42 100644
 --- a/package.json
 +++ b/package.json
-@@ -54,5 +54,19 @@
+@@ -54,5 +54,20 @@
      "services/*",
      "cli/*",
      "libs/*"
@@ -19,7 +19,8 @@ index 40a2078..fd5df42 100644
 +      "esbuild": "^0.20.2",
 +      "@grpc/grpc-js": "^1.9.15",
 +      "axios": "^1.7.4",
-+      "next": "^14.2.10"
++      "next": "^14.2.10",
++      "cookie": "0.7.0"
 +    }
 +  }
  }


### PR DESCRIPTION
Simple version bump for dependency cookie v0.6.0 to v0.7.0. Kept the version pinned to above what is upstream but did not allow the open upper ceiling of a '^' indicator as there is major version bump that requires investigation that would fall in otherwise.
