### PR TITLE
add missing file for crossplane-provider-sql

### DIFF
--- a/crossplane-provider-sql.yaml
+++ b/crossplane-provider-sql.yaml
@@ -1,10 +1,21 @@
 package:
   name: crossplane-provider-sql
   version: 0.9.0
-  epoch: 0
+  epoch: 1
   description: Official SQL Provider for Crossplane by Upbound
   copyright:
     - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - gzip
+      - up
+  environment:
+    CGO_ENABLED: 0
 
 pipeline:
   - uses: git-checkout
@@ -23,6 +34,11 @@ pipeline:
     with:
       output: crossplane-sql-provider
       packages: ./cmd/provider
+
+  - runs: |
+      up xpkg xp-extract xpkg.upbound.io/crossplane-contrib/provider-sql:v${{package.version}}
+      mkdir -p "${{targets.destdir}}"
+      gunzip out.gz -c > "${{targets.destdir}}"/package.yaml
 
 update:
   enabled: true


### PR DESCRIPTION
when deploying the image

```
Status:
  Conditions:
    Last Transition Time:  2024-10-16T11:46:39Z
    Message:               cannot initialize parser backend: couldn't find "package.yaml" file after checking 108 files in the archive (annotated layer: false): EOF
    Reason:                UnhealthyPackageRevision
    Status:                False
    Type:                  Healthy
    Last Transition Time:  2024-10-16T11:46:35Z
    Reason:                ActivePackageRevision
    Status:                True
    Type:                  Installed
```