### PR TITLE
opentelemetry-plugin-nginx-compat: Remove dependency on main package

### DIFF
--- a/opentelemetry-plugin-nginx.yaml
+++ b/opentelemetry-plugin-nginx.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: opentelemetry-plugin-nginx
-  version: 0_git20241015
+  version: 0_git20241016
   epoch: 0
   description: Adds OpenTelemetry distributed tracing support to nginx. This is the otel community plugin for nginx, not the official nginx plugin for otel.
   copyright:
@@ -53,9 +53,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-compat
-    dependencies:
-      runtime:
-        - ${{package.name}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/etc/nginx


### PR DESCRIPTION
This allows the compat package to be used with either the full library or nodeps variants (alternatively we can create a `-nodeps-compat` variant as well).

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/chainguard-dev/image-requests/issues/4407