### PR TITLE
fix(qemu): fix failing test pipeline when using qemu runner, tests do not have a qemu user

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: 0.13.6
-  epoch: 0
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0

--- a/melange/init
+++ b/melange/init
@@ -58,7 +58,9 @@ if [ -e /dev/vda ]; then
 fi
 
 # Fix home permissions from cpio command
-chown -R build:build /home/build
+if grep -q build /etc/passwd; then
+	chown -R build:build /home/build
+fi
 
 # Setup default network
 interface_name="$(ip -o link show | grep 'BROADCAST,MULTICAST' | head -n 1 | cut -d':' -f2 | tr -d ' ')"
@@ -80,7 +82,9 @@ mkdir -p -m 0700 /root/.ssh/ /home/build/.ssh/
 echo "${SSHKEY}" > /root/.ssh/authorized_keys
 echo "${SSHKEY}" > /home/build/.ssh/authorized_keys
 chmod 0400 /root/.ssh/authorized_keys /home/build/.ssh/authorized_keys
-chown -R build:build /home/build/.ssh/
+if grep -q build /etc/passwd; then
+	chown -R build:build /home/build/.ssh/
+fi
 # Setting up AcceptEnv
 echo "AcceptEnv *" >> /etc/ssh/sshd_config
 ssh-keygen -A


### PR DESCRIPTION
Make build user optional, this will fix running `melange test`