### PR TITLE
remove the cve related dependency pinning

### DIFF
--- a/spark-operator.yaml
+++ b/spark-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: spark-operator
-  version: 1.4.6
-  epoch: 1
+  version: 2.0.2
+  epoch: 0
   description: Kubernetes operator for managing the lifecycle of Apache Spark applications on Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -22,31 +22,28 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator
-      tag: spark-operator-chart-${{package.version}}
-      expected-commit: 4108f5493706f463cc2ceb823b66b5e6ac8fb1ca
-
-  - runs: |
-      # Remediate GHSA-8mjg-8c8g-6h85 drop v1.19.5 to upgrade kubernetes version accordingly.
-      go mod edit -dropreplace k8s.io/kubernetes
+      repository: https://github.com/kubeflow/spark-operator
+      tag: v${{package.version}}
+      expected-commit: ef9a2a134b80f8c5368db53615d9aa766c67ad0a
 
   - uses: go/bump
     with:
-      deps: k8s.io/kubernetes@v1.29.7
+      deps: k8s.io/kubernetes@v1.30.3
 
-  - runs: |
-      mkdir -p ${{targets.destdir}}/usr/bin
-      go build -trimpath -ldflags "-w" -o ${{targets.destdir}}/usr/bin/spark-operator .
+  - uses: go/build
+    with:
+      packages: ./cmd/
+      output: spark-operator
 
   - uses: strip
 
 subpackages:
   - name: "sparkctl"
     pipeline:
-      - runs: |
-          cd sparkctl
-          mkdir -p ${{targets.subpkgdir}}/usr/bin
-          go build -trimpath -ldflags "-w" -buildvcs=false -o ${{targets.subpkgdir}}/usr/bin/sparkctl .
+      - uses: go/build
+        with:
+          packages: ./sparkctl
+          output: sparkctl
       - uses: strip
     test:
       pipeline:
@@ -78,10 +75,9 @@ subpackages:
 update:
   enabled: true
   github:
-    identifier: GoogleCloudPlatform/spark-on-k8s-operator
-    strip-prefix: spark-operator-chart-
+    identifier: kubeflow/spark-operator
+    strip-prefix: v
     use-tag: true
-    tag-filter: "spark-operator-chart-"
 
 test:
   pipeline:


### PR DESCRIPTION
upstream have remediated these and we're needlessly pinning to the sdk 2 versions behind