### PR TITLE
python/multi-version batch 21

### DIFF
--- a/py3-google-cloud-core.yaml
+++ b/py3-google-cloud-core.yaml
@@ -1,26 +1,29 @@
-# Generated from https://pypi.org/project/google-cloud-core/
 package:
   name: py3-google-cloud-core
   version: 2.4.1
-  epoch: 1
+  epoch: 2
   description: Google Cloud API client core library
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - py3-google-api-core
-      - py3-google-auth
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: google-cloud-core
+  import: google.cloud
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -29,10 +32,45 @@ pipeline:
       repository: https://github.com/googleapis/python-cloud-core
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-google-api-core
+        - py${{range.key}}-google-auth
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-hyperopt.yaml
+++ b/py3-hyperopt.yaml
@@ -1,31 +1,29 @@
 package:
   name: py3-hyperopt
   version: 0.2.7
-  epoch: 2
+  epoch: 3
   description: Distributed Asynchronous Hyperparameter Optimization
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - numpy
-      - py3-cloudpickle
-      - py3-future
-      - py3-networkx
-      - py3-py4j
-      - py3-scipy
-      - py3-six
-      - py3-tqdm
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: hyperopt
+  import: hyperopt
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -34,13 +32,73 @@ pipeline:
       expected-commit: dfdb48d1dd9917fad347316a7818a9dcd160f200
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      runtime:
+        - numpy
+        - py${{range.key}}-cloudpickle
+        - py${{range.key}}-future
+        - py${{range.key}}-networkx
+        - py${{range.key}}-py4j
+        - py${{range.key}}-scipy
+        - py${{range.key}}-setuptools
+        - py${{range.key}}-six
+        - py${{range.key}}-tqdm
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - name: Python Install
-    uses: python/install
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      pipeline:
+        - runs: |
+            hyperopt-mongo-worker --help
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-ipykernel.yaml
+++ b/py3-ipykernel.yaml
@@ -1,40 +1,31 @@
-# Generated from https://pypi.org/project/ipykernel/
 package:
   name: py3-ipykernel
   version: 6.29.5
-  epoch: 0
+  epoch: 1
   description: IPython Kernel for Jupyter
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-appnope
-      - py3-comm
-      - py3-debugpy
-      - py3-ipython
-      - py3-jupyter-client
-      - py3-jupyter-core
-      - py3-matplotlib-inline
-      - py3-nest-asyncio
-      - py3-packaging
-      - py3-psutil
-      - py3-pyzmq
-      - py3-tornado
-      - py3-traitlets
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: ipykernel
+  import: ipykernel
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
+      - py3-supported-build-base
+      - py3-supported-hatchling
+      - py3-supported-jupyter-client
 
 pipeline:
   - uses: fetch
@@ -42,18 +33,58 @@ pipeline:
       expected-sha256: f093a22c4a40f8828f8e330a9c297cb93dcab13bd9678ded6de8e5cf81c56215
       uri: https://files.pythonhosted.org/packages/source/i/ipykernel/ipykernel-${{package.version}}.tar.gz
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-appnope
+        - py${{range.key}}-comm
+        - py${{range.key}}-debugpy
+        - py${{range.key}}-ipython
+        - py${{range.key}}-jupyter-client
+        - py${{range.key}}-jupyter-core
+        - py${{range.key}}-matplotlib-inline
+        - py${{range.key}}-nest-asyncio
+        - py${{range.key}}-packaging
+        - py${{range.key}}-psutil
+        - py${{range.key}}-pyzmq
+        - py${{range.key}}-tornado
+        - py${{range.key}}-traitlets
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
-
-update:
-  enabled: true
-  release-monitor:
-    identifier: 10514
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:
     - uses: python/import
       with:
-        import: ipykernel
+        imports: |
+          import ${{vars.import}}
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 10514

--- a/py3-nbclient.yaml
+++ b/py3-nbclient.yaml
@@ -1,31 +1,30 @@
-# Generated from https://pypi.org/project/nbclient/
 package:
   name: py3-nbclient
   version: 0.10.0
-  epoch: 0
+  epoch: 1
   description: A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor.
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-jupyter-client
-      - py3-jupyter-core
-      - py3-nbformat
-      - py3-traitlets
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: nbclient
+  import: nbclient
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -34,10 +33,83 @@ pipeline:
       repository: https://github.com/jupyter/nbclient
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      runtime:
+        - py${{range.key}}-jupyter-client
+        - py${{range.key}}-jupyter-core
+        - py${{range.key}}-nbformat
+        - py${{range.key}}-traitlets
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      environment:
+        contents:
+          packages:
+            - apk-tools
+      pipeline:
+        - runs: |
+            apk info -L py${{range.key}}-${{vars.pypi-package}}-bin > "pkg.list"
+            echo "Please write a test for these:"
+            grep usr/bin/ pkg.list > bins.list
+            sed 's,^,> ,' bins.list
+
+            while read line; do
+              echo == /$line ==
+              /$line --help && echo exited 0 || echo "exited $?"
+            done < bins.list
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+    - runs: |
+        jupyter-execute --version
+        jupyter-execute --help
 
 update:
   enabled: true
@@ -45,9 +117,3 @@ update:
   github:
     identifier: jupyter/nbclient
     strip-prefix: v
-
-test:
-  pipeline:
-    - runs: |
-        jupyter-execute --version
-        jupyter-execute --help

--- a/py3-oauth2client.yaml
+++ b/py3-oauth2client.yaml
@@ -1,29 +1,29 @@
-# Generated from https://pypi.org/project/oauth2client/
 package:
   name: py3-oauth2client
   version: 4.1.3
-  epoch: 3
+  epoch: 4
   description: OAuth 2.0 client library
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - py3-httplib2
-      - py3-pyasn1
-      - py3-pyasn1-modules
-      - py3-rsa
-      - py3-six
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: oauth2client
+  import: oauth2client
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -32,10 +32,48 @@ pipeline:
       repository: https://github.com/google/oauth2client
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-httplib2
+        - py${{range.key}}-pyasn1
+        - py${{range.key}}-pyasn1-modules
+        - py${{range.key}}-rsa
+        - py${{range.key}}-six
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true
@@ -43,12 +81,3 @@ update:
   github:
     identifier: google/oauth2client
     strip-prefix: v
-
-test:
-  environment:
-    contents:
-      packages:
-        - python-3
-  pipeline:
-    - runs: |
-        python -c "import oauth2client; print(oauth2client.__version__)"


### PR DESCRIPTION
Convert packages to python multi-version.

This is part of a series of programatic changes to
add the ability to support python packages for multiple
python versions.
