### PR TITLE
vitess-20: start version stream and reduce package size by splitting binaries to subpkg

### DIFF
--- a/vitess-20.yaml
+++ b/vitess-20.yaml
@@ -6,6 +6,8 @@ package:
   copyright:
     - license: Apache-2.0
   dependencies:
+    provides:
+      - vitess=${{package.full-version}}
     runtime:
       # Vitess supports multiple versions of MySQL and percona-server: 5.7 and 8.0
       # So those runtime dependencies will be added in the image build to properly
@@ -111,6 +113,9 @@ pipeline:
 subpackages:
   - name: "${{package.name}}-compat"
     description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    dependencies:
+      provides:
+        - vitess-compat=${{package.full-version}}
     pipeline:
       - runs: |
           # https://github.com/vitessio/vitess/blob/2592c5932b3036647868299b6df76f8ef28dfbc8/docker/lite/Dockerfile.percona80#L42-L56
@@ -123,6 +128,9 @@ subpackages:
 
   - name: "${{package.name}}-binaries"
     description: "All the binaries built by Vitess"
+    dependencies:
+      provides:
+        - vitess-binaries=${{package.full-version}}
     pipeline:
       - name: Copy all binaries
         runs: |

--- a/vitess-20.yaml
+++ b/vitess-20.yaml
@@ -57,16 +57,17 @@ pipeline:
     with:
       deps: google.golang.org/grpc@v1.64.1
 
-  - name: Build binaries
-    runs: |
-      # This build more than 40 binaries located in the `./go/cmd` and `./go/tools` directories.
-      # It runs `go build ./go/...` under the hood but our `go/build` pipeline does not support
-      # building multiple binaries at once.
-      # To use system-wide nvm and npm, we will build the web UI in the next step; so we disable it here.
-      NOVTADMINBUILD=1 make build
-
-      mkdir -p "${{targets.contextdir}}"/usr/bin
-      install -m 755 ./bin/* "${{targets.contextdir}}"/usr/bin
+  - uses: go/build
+    with:
+      packages: ./go/...
+      output: " " # Workaround: set to non-empty string to build all binaries at once
+      ldflags: |
+        -w
+        -X 'vitess.io/vitess/go/vt/servenv.buildHost=$(hostname)'
+        -X 'vitess.io/vitess/go/vt/servenv.buildUser=$(whoami)'
+        -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=$(git rev-parse --short HEAD)'
+        -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=$(git rev-parse --abbrev-ref HEAD)'
+        -X 'vitess.io/vitess/go/vt/servenv.buildTime=$(date +"%a %b %d %T %Z %Y")'
 
   - name: Build web UI
     working-directory: web/vtadmin
@@ -120,6 +121,78 @@ subpackages:
             ln -sf /usr/bin/$(basename $bin) "${{targets.contextdir}}"/vt/bin/
           done
 
+  - name: "${{package.name}}-binaries"
+    description: "All the binaries built by Vitess"
+    pipeline:
+      - name: Copy all binaries
+        runs: |
+          mkdir -p ${{targets.contextdir}}/usr/bin
+          cp -r ${{targets.destdir}}/usr/bin/* ${{targets.contextdir}}/usr/bin
+      - name: Remove redundant binaries
+        runs: |
+          # Remove the binaries that are not needed: https://github.com/vitessio/vitess/blob/2592c5932b3036647868299b6df76f8ef28dfbc8/Makefile#L142
+          keep_binaries="mysqlctl mysqlctld vtorc vtadmin vtctl vtctld vtctlclient vtctldclient vtgate vttablet vtbackup vtexplain"
+          for bin in $(ls ${{targets.destdir}}/usr/bin); do
+            if [[ ! " ${keep_binaries} " =~ " ${bin} " ]]; then
+              rm -f ${{targets.destdir}}/usr/bin/${bin}
+            fi
+          done
+    test:
+      pipeline:
+        - name: Smoke test for vitess binaries
+          runs: |
+            autogenerate --version
+            autogenerate --help
+            demo --version
+            demo --help
+            docgen --version
+            docgen --help
+            example --help
+            go-upgrade --help
+            maketestdata --help
+            mysqlctl --version
+            mysqlctl --help
+            mysqlctld --version
+            mysqlctld --help
+            rulesctl --version
+            rulesctl --help
+            topo2topo --version
+            topo2topo --help
+            vtaclcheck --version
+            vtaclcheck --help
+            vtadmin --version
+            vtadmin --help
+            vtbackup --version
+            vtbackup --help
+            vtbench --version
+            vtbench --help
+            vtclient --version
+            vtclient --help
+            vtcombo --version
+            vtcombo --help
+            vtctl --version
+            vtctl --help
+            vtctlclient --version
+            vtctlclient --help
+            vtctld --version
+            vtctld --help
+            vtctldclient --version
+            vtctldclient --help
+            vterrorsgen --version
+            vterrorsgen --help
+            vtexplain --version
+            vtexplain --help
+            vtgate --version
+            vtgate --help
+            vtgateclienttest --help
+            vtorc --version
+            vtorc --help
+            vttablet --version
+            vttablet --help
+            vttestserver --version
+            vttestserver --help
+            vttlstest --help
+
 update:
   enabled: true
   github:
@@ -136,38 +209,14 @@ test:
   pipeline:
     - name: Smoke test for vitess binaries
       runs: |
-        for bin in $(ls /vt/bin | grep ^vt); do
-          $bin --help 2>&1 > /dev/null
-        done
-        autogenerate --version
-        autogenerate --help
-        demo --version
-        demo --help
-        docgen --version
-        docgen --help
-        example --help
-        go-upgrade --help
-        maketestdata --help
         mysqlctl --version
         mysqlctl --help
         mysqlctld --version
         mysqlctld --help
-        rulesctl --version
-        rulesctl --help
-        topo2topo --version
-        topo2topo --help
-        vtaclcheck --version
-        vtaclcheck --help
         vtadmin --version
         vtadmin --help
         vtbackup --version
         vtbackup --help
-        vtbench --version
-        vtbench --help
-        vtclient --version
-        vtclient --help
-        vtcombo --version
-        vtcombo --help
         vtctl --version
         vtctl --help
         vtctlclient --version
@@ -176,22 +225,11 @@ test:
         vtctld --help
         vtctldclient --version
         vtctldclient --help
-        vterrorsgen --version
-        vterrorsgen --help
         vtexplain --version
         vtexplain --help
         vtgate --version
         vtgate --help
-        vtgateclienttest --help
         vtorc --version
         vtorc --help
         vttablet --version
         vttablet --help
-        vttestserver --version
-        vttestserver --help
-        vttlstest --help
-        zk --help
-        zkctl --version
-        zkctl --help
-        zkctld --version
-        zkctld --help

--- a/vitess-20.yaml
+++ b/vitess-20.yaml
@@ -1,7 +1,7 @@
 package:
-  name: vitess
+  name: vitess-20
   version: 20.0.2
-  epoch: 5
+  epoch: 0
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -126,6 +126,7 @@ update:
     identifier: vitessio/vitess
     strip-prefix: v
     use-tag: true
+    tag-filter: v20.
 
 test:
   environment:


### PR DESCRIPTION
See: https://vitess.io/docs/releases/

* Upstream maintain multiple major versions, so it should be version-streamed.
* Upstream doesn't use all binaries, so get rid of some them to reduce package size
* Use `go/build` pipeline