### PR TITLE
Fix cyrus-sasl's FTBFS with gcc-14. 

### DIFF
--- a/cyrus-sasl.yaml
+++ b/cyrus-sasl.yaml
@@ -1,7 +1,7 @@
 package:
   name: cyrus-sasl
   version: 2.1.28
-  epoch: 3
+  epoch: 4
   description: "Cyrus Simple Authentication Service Layer (SASL)"
   copyright:
     - license: BSD-3-Clause
@@ -21,6 +21,8 @@ environment:
       - py3-sphinx
       - sqlite-dev
       - wolfi-base
+  environment:
+    CFLAGS: "-Wno-error=implicit-function-declaration"
 
 pipeline:
   - uses: git-checkout

--- a/cyrus-sasl.yaml
+++ b/cyrus-sasl.yaml
@@ -85,6 +85,9 @@ subpackages:
     dependencies:
       runtime:
         - cyrus-sasl
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
   - name: "cyrus-sasl-doc"
     description: "cyrus-sasl manpages"


### PR DESCRIPTION
See https://github.com/wolfi-dev/os/issues/26522

Setting the CFLAGS seemed better than pinning the build on gcc-13.