### PR TITLE
Resolve test failure with dpkg

### DIFF
--- a/dpkg.yaml
+++ b/dpkg.yaml
@@ -126,6 +126,7 @@ test:
         mkdir -p test/data
         echo "brew" > test/data/homebrew.txt
         mkdir -p test/DEBIAN
+        chmod 0755 test/DEBIAN
         arch=$(uname -m | sed -e "s/x86_64/amd64/" -e "s/aarch64/arm64/")
         cat <<EOF > test/DEBIAN/control
         Package: test


### PR DESCRIPTION
dpkg test's were failing with the following error:

2024/10/16 19:57:57 WARN dpkg-deb: error: control directory has bad permissions 2755 (must be >=0755 and <=0775) name="Create a sample Debian package"
2024/10/16 19:57:57 INFO ERROR: failed to test package. the test environment has been preserved:
2024/10/16 19:57:57 INFO   workspace dir: /home/user/tmp/melange-workspace-218698215
2024/10/16 19:57:57 INFO   guest dir: /home/user/tmp/melange-guest-2482552154
2024/10/16 19:57:57 ERRO failed to test package: unable to run pipeline: unable to run pipeline: exit status 2
