### PR TITLE
emissary-oci-entrypoint: Remove dependency.

### DIFF
--- a/emissary.yaml
+++ b/emissary.yaml
@@ -1,7 +1,7 @@
 package:
   name: emissary
   version: 3.9.1
-  epoch: 0
+  epoch: 1
   description: "open source Kubernetes-native API gateway for microservices built on the Envoy Proxy"
   copyright:
     - license: Apache-2.0
@@ -138,9 +138,6 @@ subpackages:
 
   - name: ${{package.name}}-oci-entrypoint
     description: Entrypoint for ${{package.name}}
-    dependencies:
-      runtime:
-        - emissary
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/bin/


### PR DESCRIPTION
Remove the dependency to make it easier to install this along side fips and non-fips versions.

```
2024/10/16 19:26:57 ERRO failed to test package: unable to build guest: unable to generate image: installing apk packages: error getting package dependencies: solving “emissary-oci-entrypoint” constraint: resolving “emissary-oci-entrypoint-3.9.1-r0.apk” deps:
212
solving “emissary” constraint:   emissary-3.9.1-r0.apk disqualified because emissary-fips-3.9.1-r0.apk already provides cmd:busyambassador
```

Note: this makes the package unusable by itself. I'm not sure if there's a better way to do this. :(

Related:  https://github.com/chainguard-dev/image-requests/issues/3494
