### PR TITLE
update trino to 462; dont build new module target

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -86,7 +86,6 @@ data:
       kafka: kafka
       kinesis: kinesis
       kudu: kudu
-      local-file: local-file
       mariadb: mariadb
       memory: memory
       ml: ml

--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
-  version: "453"
-  epoch: 3
+  version: "462"
+  epoch: 0
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0
@@ -33,7 +33,7 @@ pipeline:
     with:
       repository: https://github.com/trinodb/trino.git
       tag: ${{package.version}}
-      expected-commit: a5ee92c2d6ece4f19c2a35ab41e60f7168a8f1bf
+      expected-commit: c4a5675d25ff875b614f150549181962e7ad1ac3
 
   - uses: maven/pombump
 
@@ -48,7 +48,7 @@ pipeline:
 
       export JAVA_HOME=/usr/lib/jvm/java-22-openjdk
 
-      ./mvnw package -q -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all -T 8  -pl '!:trino-docs,!:trino-server-rpm,!:trino-tests,!:trino-product-tests,!:trino-product-tests-launcher' -am
+      ./mvnw package -q -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all -T 8  -pl '!:trino-docs,!:trino-server-rpm,!:trino-tests,!:trino-product-tests,!:trino-product-tests-launcher,!:trino-web-ui' -am
 
       mkdir -p ${{targets.destdir}}/usr/lib/trino
       cp ./core/trino-server/target/trino-server-${{package.version}}/NOTICE ${{targets.destdir}}/usr/lib/trino/

--- a/trino.yaml
+++ b/trino.yaml
@@ -65,7 +65,6 @@ data:
   - name: plugins
     items:
       accumulo: accumulo
-      atop: atop
       bigquery: bigquery
       blackhole: blackhole
       cassandra: cassandra

--- a/trino.yaml
+++ b/trino.yaml
@@ -98,7 +98,6 @@ data:
       pinot: pinot
       postgresql: postgresql
       prometheus: prometheus
-      raptor-legacy: raptor-legacy
       redis: redis
       redshift: redshift
       resource-group-managers: resource-group-managers

--- a/trino/pombump-deps.yaml
+++ b/trino/pombump-deps.yaml
@@ -15,16 +15,6 @@ patches:
       scope: import
       type: jar
     - groupId: org.apache.commons
-      artifactId: commons-compress
-      version: 1.26.0
-      scope: import
-      type: jar
-    - groupId: org.postgresql
-      artifactId: postgresql
-      version: 42.7.2
-      scope: import
-      type: jar
-    - groupId: org.apache.commons
       artifactId: commons-configuration2
       version: 2.10.1
       scope: import

--- a/trino/pombump-deps.yaml
+++ b/trino/pombump-deps.yaml
@@ -1,33 +1,6 @@
 patches:
-    - groupId: org.json
-      artifactId: json
-      version: "20231013"
-      scope: import
-      type: jar
     - groupId: ch.qos.logback
       artifactId: logback-core
       version: '[1.4.12,2.0.0)'
       scope: import
       type: jar
-    - groupId: io.projectreactor.netty
-      artifactId: reactor-netty-http
-      version: 1.0.39
-      scope: import
-      type: jar
-    - groupId: org.apache.commons
-      artifactId: commons-configuration2
-      version: 2.10.1
-      scope: import
-      type: jar
-    - groupId: io.netty
-      artifactId: netty-codec-http
-      version: 4.1.108.Final
-    - groupId: org.apache.calcite
-      artifactId: calcite-core
-      version: 1.32.0
-    - groupId: org.apache.calcite.avatica
-      artifactId: avatica-core
-      version: 1.22.0
-    - groupId: json-path
-      artifactId: json-path
-      version: 2.9.0

--- a/trino/pombump-deps.yaml
+++ b/trino/pombump-deps.yaml
@@ -4,3 +4,13 @@ patches:
       version: '[1.4.12,2.0.0)'
       scope: import
       type: jar
+    - groupId: org.apache.commons
+      artifactId: commons-configuration2
+      version: 2.10.1
+      scope: import
+      type: jar
+    - groupId: com.google.protobuf
+      artifactId: protobuf-java
+      version: 3.25.5
+      scope: import
+      type: jar

--- a/trino/pombump-deps.yaml
+++ b/trino/pombump-deps.yaml
@@ -4,13 +4,15 @@ patches:
       version: '[1.4.12,2.0.0)'
       scope: import
       type: jar
+    # Fixes CVE-2024-29133 CVE-2024-29131
     - groupId: org.apache.commons
       artifactId: commons-configuration2
       version: 2.10.1
       scope: import
       type: jar
+    # Fixes CVE-2024-7254
     - groupId: com.google.protobuf
       artifactId: protobuf-java
       version: 3.25.5
       scope: import
-      type: jar
+      type: pom

--- a/trino/pombump-properties-es.yaml
+++ b/trino/pombump-properties-es.yaml
@@ -1,3 +1,3 @@
 properties:
   - property: dep.elasticsearch.version
-    value: "7.17.23"
+    value: "7.17.24"


### PR DESCRIPTION
trino-web-ui is a new build module, added july 31, exclude for time being; https://github.com/trinodb/trino/pull/22892

- remove obsolete plugins
- remove obsolete deps
- update elastic search version
