### PR TITLE
Updated commons-io dependency in required opensearch-2 subpackages: GHSA-78wr-2p64-hpwj

### DIFF
--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -5,7 +5,7 @@
 package:
   name: opensearch-2
   version: 2.17.1
-  epoch: 0
+  epoch: 1
   description: Open source distributed and RESTful search engine.
   copyright:
     - license: Apache-2.0
@@ -77,11 +77,11 @@ data:
       neural-search: ""
       notifications: ""
       observability: ""
-      performance-analyzer: ""
+      performance-analyzer: "analyzer-commons-io-gradle-build.patch"
       reporting: ""
       security: ""
       security-analytics: ""
-      sql: ""
+      sql: "sql-commons-io.patch"
 
 pipeline:
   - uses: git-checkout

--- a/opensearch-2/analyzer-commons-io-gradle-build.patch
+++ b/opensearch-2/analyzer-commons-io-gradle-build.patch
@@ -1,0 +1,15 @@
+diff --git a/build.gradle b/build.gradle
+index 4433815..1c98868 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -495,6 +495,10 @@ task buildRca() {
+     }
+ 
+     doLast {
++        exec {
++            workingDir("$rcaProjectDir")
++            commandLine 'git', 'apply', '../../analyzer-commons-io.patch'
++        }
+         exec {
+             workingDir("$rcaProjectDir")
+             if (buildVersionQualifier == null || buildVersionQualifier == '' || buildVersionQualifier == 'null') {

--- a/opensearch-2/analyzer-commons-io.patch
+++ b/opensearch-2/analyzer-commons-io.patch
@@ -1,0 +1,13 @@
+diff --git a/build.gradle b/build.gradle
+index eee6761d..8b7c1d42 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -367,7 +367,7 @@ dependencies {
+     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: "${log4jVersion}"
+     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: "${log4jVersion}"
+     implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${commonslangVersion}"
+-    implementation group: 'commons-io', name: 'commons-io', version: '2.7'
++    implementation group: 'commons-io', name: 'commons-io', version: '2.17.0'
+     implementation group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.9.0'
+     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: "${protobufVersion}"
+     implementation 'io.grpc:grpc-netty:1.56.1'

--- a/opensearch-2/sql-commons-io.patch
+++ b/opensearch-2/sql-commons-io.patch
@@ -1,0 +1,39 @@
+diff --git a/async-query/build.gradle b/async-query/build.gradle
+index 53fdcbe29..30567555d 100644
+--- a/async-query/build.gradle
++++ b/async-query/build.gradle
+@@ -28,7 +28,7 @@ dependencies {
+     implementation group: 'org.json', name: 'json', version: '20231013'
+     api group: 'com.amazonaws', name: 'aws-java-sdk-emr', version: "${aws_java_sdk_version}"
+     api group: 'com.amazonaws', name: 'aws-java-sdk-emrserverless', version: "${aws_java_sdk_version}"
+-    implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
++    implementation group: 'commons-io', name: 'commons-io', version: '2.17.0'
+ 
+     testImplementation(platform("org.junit:junit-bom:5.9.3"))
+ 
+diff --git a/datasources/build.gradle b/datasources/build.gradle
+index 9bd233e1f..334bdaf96 100644
+--- a/datasources/build.gradle
++++ b/datasources/build.gradle
+@@ -21,7 +21,7 @@ dependencies {
+     implementation group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
+     implementation group: 'org.opensearch', name: 'opensearch-x-content', version: "${opensearch_version}"
+     implementation group: 'org.opensearch', name: 'common-utils', version: "${opensearch_build}"
+-    implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
++    implementation group: 'commons-io', name: 'commons-io', version: '2.17.0'
+     implementation 'com.amazonaws:aws-encryption-sdk-java:2.4.1'
+     implementation group: 'commons-validator', name: 'commons-validator', version: '1.7'
+ 
+diff --git a/spark/build.gradle b/spark/build.gradle
+index d9d5c9641..a35b1d190 100644
+--- a/spark/build.gradle
++++ b/spark/build.gradle
+@@ -21,7 +21,7 @@ dependencies {
+     implementation group: 'org.json', name: 'json', version: '20231013'
+     api group: 'com.amazonaws', name: 'aws-java-sdk-emr', version: "${aws_java_sdk_version}"
+     api group: 'com.amazonaws', name: 'aws-java-sdk-emrserverless', version: "${aws_java_sdk_version}"
+-    implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
++    implementation group: 'commons-io', name: 'commons-io', version: '2.17.0'
+ 
+     testImplementation(platform("org.junit:junit-bom:5.9.3"))
+ 


### PR DESCRIPTION
This is a more complicated package build than what is regularly seen, opensearch-2 has many plugins that exist in both its own repository and outside of it. For example one of the commons-io vulnerabilities is brought in via [performance-analyzer-rca](https://github.com/opensearch-project/performance-analyzer-rca) however performance-analyzer-rca is built as part of the [performance-analyzer
](https://github.com/opensearch-project/performance-analyzer) (Different repo) build process and requires injecting a patch into the build.gradle that references another patch. 