### PR TITLE
Fix /usr/src permissions

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.3.2
-  epoch: 1
+  epoch: 2
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -45,6 +45,10 @@ pipeline:
       cp -r . $SRCDIR/
       mkdir -p ${{targets.destdir}}-dbg/usr/src/
       mv $SRCDIR ${{targets.destdir}}-dbg/usr/src/${{package.name}}
+      # Note that mktemp -d created it as 700, whilst the contents
+      # inside is 644 for files and 755 for dirs, without this gdb
+      # doesn't work for non-root user, fix this up.
+      chmod 755 ${{targets.destdir}}-dbg/usr/src/${{package.name}}
 
   - name: Configure and build
     runs: |


### PR DESCRIPTION
Once all of these teething issues are fixed, this should probably
become a reusable pipeline, as it is tricky.

Fix permissions on the /usr/src/${{package.name}} directory, as mktemp
creates it as 700, despite contents being 644 or 755 as
appropriate. Without this fixup gdb does not work with source code
access for non-root users. Discovered in testing a custom image, as
non-root, with openssl-dbg pre-installed.

Fixes:
- https://github.com/wolfi-dev/os/pull/30691