### PR TITLE
kubeflow-centraldashboard/GHSA-pppg-cpfq-h7wr fix

### DIFF
--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-centraldashboard
   version: 1.9.1
-  epoch: 1
+  epoch: 2
   description: Landing page and central dashboard for Kubeflow deployments
   copyright:
     - license: MIT
@@ -55,7 +55,8 @@ pipeline:
         "@grpc/grpc-js": "^1.10.9",
         "path-to-regexp": "0.1.10",
         "serve-static": "^1.16.0",
-        "cookie": "0.7.0"
+        "cookie": "0.7.0",
+        "jsonpath-plus": "10.0.0"
       }'
 
       # Apply the overrides


### PR DESCRIPTION
Simple addition of an override to remediate the transitive dependency jsonpath-plus. Remaining CVEs that may populate during the build currently have no fix versions/are no longer maintained and will need advisories filed for them.