### PR TITLE
fix(ncurses): bump version as this one disappeared

### DIFF
--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
-  version: 6.5_p20240629
-  epoch: 2
+  version: 6.5_p20241006
+  epoch: 3
   description: "console display library"
   copyright:
     - license: MIT
@@ -28,7 +28,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{vars.mangled-package-version}}.tgz
-      expected-sha512: 2bc631d564d94a6a3218e3d2d4a69c84236e8ddbebeb407571b36f12495e3e8f27392498e365a7943ae605444db2f69d3591b382e10fdd446330f1c6d0374030
+      expected-sha512: 60ca1c6e1797feade55306f7c9be57e546ddbdad36fa09a914f8884c628fbd8683660f895899a419172518b78e3edd49257c0fb7b6d4d83705f494f4766aa066
 
   - name: Configure
     runs: |


### PR DESCRIPTION
Version `20240629` disappeared from their website, leading to 404 and failing CI of melange, and generally of the builds.
Bumping to `20241006`