### PR TITLE
trino cve fixes

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
   version: "462"
-  epoch: 0
+  epoch: 1
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0

--- a/trino/pombump-deps.yaml
+++ b/trino/pombump-deps.yaml
@@ -14,5 +14,3 @@ patches:
     - groupId: com.google.protobuf
       artifactId: protobuf-java
       version: 3.25.5
-      scope: import
-      type: pom


### PR DESCRIPTION
```
🔎 Scanning "/tmp/artifacts-1/packages/x86_64/trino-plugin-kudu-462-r0.apk"
└── 📄 /usr/lib/trino/lib/org.apache.kudu_kudu-client-1.17.0.jar
        📦 protobuf-java 3.21.12 (java-archive)
            High CVE-2024-7254 GHSA-735f-pc8j-v9w8 fixed in 3.25.5
```