### PR TITLE
vitess-20: rename to vitess-20.0 to sync with version stream

### DIFF
--- a/vitess-20.0.yaml
+++ b/vitess-20.0.yaml
@@ -1,5 +1,5 @@
 package:
-  name: vitess-20
+  name: vitess-20.0
   version: 20.0.2
   epoch: 0
   description: Autoscaling components for Kubernetes


### PR DESCRIPTION
Upstream was following `X.0` instead of just `X`: https://vitess.io/docs/releases/