### PR TITLE
pdfcpu: new package

### DIFF
--- a/pdfcpu.yaml
+++ b/pdfcpu.yaml
@@ -7,9 +7,19 @@ package:
     - license: Apache-2.0
 
 pipeline:
-  - uses: go/install
+  - uses: git-checkout
     with:
-      package: github.com/pdfcpu/pdfcpu/cmd/pdfcpu@v${{package.version}}
+      repository: https://github.com/pdfcpu/pdfcpu
+      tag: v${{package.version}}
+      expected-commit: 66fee128b03945bd75ad2f12663331f0f7b189b2
+
+  - uses: go/build
+    with:
+      modroot: .
+      packages: ./cmd/pdfcpu
+      output: pdfcpu
+      # From https://github.com/pdfcpu/pdfcpu/blob/b1b9f998d7edf68f25fcbb51f2cf091fda141d16/.goreleaser.yml#L5
+      ldflags: -X main.version=${{package.version}} -X github.com/pdfcpu/pdfcpu/pkg/pdfcpu.VersionStr=v${{package.version}} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date ${SOURCE_DATE_EPOCH:+ -d@${SOURCE_DATE_EPOCH}} "+%Y-%m-%dT%H:%M:%SZ") -X main.builtBy=melange
 
 update:
   enabled: true
@@ -21,4 +31,5 @@ test:
   pipeline:
     - runs: |
         set -x
+        pdfcpu version
         pdfcpu help 2>&1 | grep "Usage:"

--- a/pdfcpu.yaml
+++ b/pdfcpu.yaml
@@ -1,0 +1,24 @@
+package:
+  name: pdfcpu
+  version: 0.8.1
+  epoch: 0
+  description: A Go PDF processor and CLI
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: go/install
+    with:
+      package: github.com/pdfcpu/pdfcpu/cmd/pdfcpu@v${{package.version}}
+
+update:
+  enabled: true
+  github:
+    identifier: pdfcpu/pdfcpu
+    strip-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        set -x
+        pdfcpu help 2>&1 | grep "Usage:"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Gotenberg now wants pdfcpu as a dependency with their latest version update. This adds the package so the following PR can be resolved. 

Related: https://github.com/chainguard-dev/enterprise-packages/pull/8477

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [x] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (pdfcpu is NOT present on `endoflife.date`)
