### PR TITLE
emissary: breakout apiext into its own subpackage.

### DIFF
--- a/emissary.yaml
+++ b/emissary.yaml
@@ -1,7 +1,7 @@
 package:
   name: emissary
   version: 3.9.1
-  epoch: 1
+  epoch: 2
   description: "open source Kubernetes-native API gateway for microservices built on the Envoy Proxy"
   copyright:
     - license: Apache-2.0
@@ -41,11 +41,6 @@ pipeline:
   - uses: go/bump
     with:
       deps: golang.org/x/net@v0.23.0 google.golang.org/protobuf@v1.33.0 k8s.io/kubernetes@v1.28.12 k8s.io/apiserver@v0.28.12
-
-  - uses: go/build
-    with:
-      packages: ./cmd/apiext
-      output: apiext
 
   - uses: go/build
     with:
@@ -146,6 +141,14 @@ subpackages:
     test:
       pipeline:
         - runs: stat /usr/bin/entrypoint.sh
+
+  - name: ${{package.name}}-apiext
+    description: Emissary-ingress apiext webhook conversion server
+    pipeline:
+      - uses: go/build
+        with:
+          packages: ./cmd/apiext
+          output: apiext
 
 update:
   enabled: true


### PR DESCRIPTION
This is shipped as its own image, so we should separate it out into a separate package to isolate it.

See https://github.com/emissary-ingress/emissary/blob/master/docker/apiext/Dockerfile

Related: https://github.com/chainguard-dev/image-requests/issues/3494
