### PR TITLE
vitess: properly handle symlinks

### DIFF
--- a/vitess-20.0.yaml
+++ b/vitess-20.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: vitess-20.0
   version: 20.0.2
-  epoch: 0
+  epoch: 1
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -47,6 +47,8 @@ environment:
       - nvm
   environment:
     VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS: "true"
+    # Binaries we only need: https://github.com/vitessio/vitess/blob/2592c5932b3036647868299b6df76f8ef28dfbc8/Makefile#L142
+    KEEP_BINARIES: "mysqlctl mysqlctld vtorc vtadmin vtctl vtctld vtctlclient vtctldclient vtgate vttablet vtbackup vtexplain"
 
 pipeline:
   - uses: git-checkout
@@ -65,8 +67,6 @@ pipeline:
       output: " " # Workaround: set to non-empty string to build all binaries at once
       ldflags: |
         -w
-        -X 'vitess.io/vitess/go/vt/servenv.buildHost=$(hostname)'
-        -X 'vitess.io/vitess/go/vt/servenv.buildUser=$(whoami)'
         -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=$(git rev-parse --short HEAD)'
         -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=$(git rev-parse --abbrev-ref HEAD)'
         -X 'vitess.io/vitess/go/vt/servenv.buildTime=$(date +"%a %b %d %T %Z %Y")'
@@ -122,9 +122,20 @@ subpackages:
           mkdir -p "${{targets.contextdir}}"/vt/bin
           mkdir -p "${{targets.contextdir}}"/vt/config
           mkdir -p "${{targets.contextdir}}"/vt/vtdataroot
-          for bin in ${{targets.destdir}}/usr/bin/*; do
-            ln -sf /usr/bin/$(basename $bin) "${{targets.contextdir}}"/vt/bin/
+          # symlink only ${KEEP_BINARIES}
+          for bin in ${KEEP_BINARIES}; do
+            ln -sf /usr/bin/$bin "${{targets.contextdir}}"/vt/bin/
           done
+    test:
+      environment:
+        contents:
+          packages:
+            - vitess
+      pipeline:
+        - name: Ensure symlinks are valid
+          runs: |
+            #!/bin/bash
+            find /vt/bin -type l ! -exec test -e {} \; -print
 
   - name: "${{package.name}}-binaries"
     description: "All the binaries built by Vitess"
@@ -138,10 +149,8 @@ subpackages:
           cp -r ${{targets.destdir}}/usr/bin/* ${{targets.contextdir}}/usr/bin
       - name: Remove redundant binaries
         runs: |
-          # Remove the binaries that are not needed: https://github.com/vitessio/vitess/blob/2592c5932b3036647868299b6df76f8ef28dfbc8/Makefile#L142
-          keep_binaries="mysqlctl mysqlctld vtorc vtadmin vtctl vtctld vtctlclient vtctldclient vtgate vttablet vtbackup vtexplain"
           for bin in $(ls ${{targets.destdir}}/usr/bin); do
-            if [[ ! " ${keep_binaries} " =~ " ${bin} " ]]; then
+            if [[ ! " ${KEEP_BINARIES} " =~ " ${bin} " ]]; then
               rm -f ${{targets.destdir}}/usr/bin/${bin}
             fi
           done


### PR DESCRIPTION
The `-compat` packge was building before we `rm` the `$KEEP_BINARIES`, so it was resulting broken symlinks under `/vt/bin/*`, so handle symlinks better now.