### PR TITLE
Rebuild openjdk-8 to fix bad depends

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.422.05 # this corresponds to same release as jdk8u422-ga / jdk8u422-b05
-  epoch: 1
+  epoch: 2
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
openjdk-8 was last built with bad SCA dependencies, rebuild to drop
bogus depends.
