### PR TITLE
cilium: explicitly use clang-17 in runtime dep

### DIFF
--- a/cilium-1.16.yaml
+++ b/cilium-1.16.yaml
@@ -2,7 +2,7 @@
 package:
   name: cilium-1.16
   version: 1.16.2
-  epoch: 0
+  epoch: 1
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ package:
     runtime:
       - bpftool
       # cilium does compilations at runtime on the node.
-      - clang
+      - clang-17
       - cni-plugins-loopback
       # iptables packages are needed at build time because cilium-iptables
       # has a script that changes based on the presences of these packages

--- a/cilium-1.16.yaml
+++ b/cilium-1.16.yaml
@@ -119,6 +119,10 @@ pipeline:
     with:
       patches: toolchains-paths.patch
 
+  - uses: patch
+    with:
+      patches: envoy-55b0fc45cfdc2c0df002690606853540cf794fab.patch
+
   - runs: |
       # Bazel errors out on toolchain stanza
       sed -i '/$toolchain /d' go.mod

--- a/cilium-1.16/envoy-55b0fc45cfdc2c0df002690606853540cf794fab.patch
+++ b/cilium-1.16/envoy-55b0fc45cfdc2c0df002690606853540cf794fab.patch
@@ -1,0 +1,43 @@
+diff --git a/WORKSPACE b/WORKSPACE
+index 026838fc..cea6a2e9 100644
+--- a/envoy/WORKSPACE
++++ b/envoy/WORKSPACE
+@@ -37,2 +37,3 @@ git_repository(
+         "@//patches:0003-tcp_proxy-Add-filter-state-proxy_read_before_connect.patch",
+         "@//patches:0004-listener-add-socket-options.patch",
++        "@//patches:55b0fc45cfdc2c0df002690606853540cf794fab.patch",
+ 
+diff --git a/patches/55b0fc45cfdc2c0df002690606853540cf794fab.patch b/patches/55b0fc45cfdc2c0df002690606853540cf794fab.patch
+new file mode 100644
+index 00000000..b85899c7
+--- /dev/null
++++ b/envoy/patches/55b0fc45cfdc2c0df002690606853540cf794fab.patch
+@@ -0,0 +1,28 @@
++From 55b0fc45cfdc2c0df002690606853540cf794fab Mon Sep 17 00:00:00 2001
++From: alyssawilk <alyssar@chromium.org>
++Date: Wed, 9 Oct 2024 16:23:02 -0400
++Subject: [PATCH] ci: change googleurl dep (#36515)
++
++backing file temporarily deleted and re-updated (with a new hash)
++
++Signed-off-by: Alyssa Wilk <alyssar@chromium.org>
++---
++ bazel/repository_locations.bzl | 4 ++--
++ 1 file changed, 2 insertions(+), 2 deletions(-)
++
++diff --git a/bazel/repository_locations.bzl b/bazel/repository_locations.bzl
++index b6e02d489b31..e42a6e7e2fd3 100644
++--- a/bazel/repository_locations.bzl
+++++ b/bazel/repository_locations.bzl
++@@ -1222,9 +1222,9 @@ REPOSITORY_LOCATIONS_SPEC = dict(
++         project_name = "Chrome URL parsing library",
++         project_desc = "Chrome URL parsing library",
++         project_url = "https://quiche.googlesource.com/googleurl",
++-        # Static snapshot of https://quiche.googlesource.com/googleurl/+archive/dd4080fec0b443296c0ed0036e1e776df8813aa7.tar.gz
++         version = "dd4080fec0b443296c0ed0036e1e776df8813aa7",
++-        sha256 = "59f14d4fb373083b9dc8d389f16bbb817b5f936d1d436aa67e16eb6936028a51",
+++        sha256 = "fc694942e8a7491dcc1dde1bddf48a31370a1f46fef862bc17acf07c34dc6325",
+++        # Static snapshot of https://quiche.googlesource.com/googleurl/+archive/dd4080fec0b443296c0ed0036e1e776df8813aa7.tar.gz
++         urls = ["https://storage.googleapis.com/quiche-envoy-integration/{version}.tar.gz"],
++         use_category = ["controlplane", "dataplane_core"],
++         extensions = [],


### PR DESCRIPTION
Since we are already depending on llvm17.

Also apply https://github.com/envoyproxy/envoy/pull/36515