### PR TITLE
clang-15: rebuild for new melange SCA metadata

### DIFF
--- a/clang-15.yaml
+++ b/clang-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-15
   version: 15.0.7
-  epoch: 3
+  epoch: 4
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff clang-analyzer-15.0.7-r3.apk clang-15.yaml
--- clang-analyzer-15.0.7-r3.apk
+++ clang-15.yaml
@@ -8,6 +8,7 @@
 commit = bc1d4911b13c0b8f341ba6ccd3ee82d11685217d
 builddate = 1706154996
 license = Apache-2.0
+depend = cmd:perl
 depend = perl
 depend = python3
 provides = cmd:analyze-build=15.0.7-r3
diff py3-clang-15.0.7-r3.apk clang-15.yaml
--- py3-clang-15.0.7-r3.apk
+++ clang-15.yaml
@@ -10,5 +10,5 @@
 license = Apache-2.0
 depend = libLLVM-15
 depend = libclang-cpp-15
-depend = python3~3.12
+depend = python-3.12-base
 datahash = 9441a49eabee9fa216c4c8bdca32a749175d414b51a970b128d7b1c29c11d1f9
```
