### PR TITLE
gpsd: rebuild for new melange SCA metadata

### DIFF
--- a/gpsd.yaml
+++ b/gpsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: gpsd
   version: "3.25"
-  epoch: 1
+  epoch: 2
   description: GPS daemon
   copyright:
     - license: BSD-2-Clause

--- a/gpsd.yaml
+++ b/gpsd.yaml
@@ -37,7 +37,7 @@ pipeline:
       scons -j${JOBS:-1} \
       	prefix=/usr \
       	target_python=python3 \
-      	python_shebang=/usr/bin/python3 \
+      	python_shebang=/usr/bin/python3.12 \
       	dbus_export=no \
       	systemd=no
 


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff gpsd-dev-3.25-r1.apk gpsd.yaml
--- gpsd-dev-3.25-r1.apk
+++ gpsd.yaml
@@ -11,5 +11,5 @@
 depend = gpsd
 depend = so:libgps.so.30
 depend = so:libgpsdpacket.so.30
-provides = pc:libgps=3.25
+provides = pc:libgps=3.25-r1
 datahash = 2b8643d28d63285cb8ccf7e59ee8c8866457727d5549755aa4608c55a607343d
diff py3-gpsd-3.25-r1.apk gpsd.yaml
--- py3-gpsd-3.25-r1.apk
+++ gpsd.yaml
@@ -8,7 +8,7 @@
 commit = a67be2c8863dbc697dbab89d90b7ec7f77db09b8
 builddate = 1707250164
 license = BSD-2-Clause
-depend = python3~3.12
+depend = python-3.12-base
 provides = cmd:gpscat=3.25-r1
 provides = cmd:gpsfake=3.25-r1
 provides = cmd:gpsprof=3.25-r1
```

Also

- **Fix shebang for the current style of depends**