### PR TITLE
openjdk-10: rebuild for new melange SCA metadata

### DIFF
--- a/openjdk-10.yaml
+++ b/openjdk-10.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-10
   version: 10.0.2
-  epoch: 5
+  epoch: 6
   description: "Oracle OpenJDK 10"
   copyright:
     - license: GPL-2.0-with-classpath-exception


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff openjdk-10-jre-base-10.0.2-r5.apk openjdk-10.yaml
--- openjdk-10-jre-base-10.0.2-r5.apk
+++ openjdk-10.yaml
@@ -12,6 +12,5 @@
 depend = java-common
 depend = so:ld-linux-x86-64.so.2
 depend = so:libc.so.6
-depend = so:libjli.so
 depend = so:libz.so.1
 datahash = b17ba973cf1365bc838d475e5324b265abc935a94bc7b7c9d73861092d666a1c
diff openjdk-10-10.0.2-r5.apk openjdk-10.yaml
--- openjdk-10-10.0.2-r5.apk
+++ openjdk-10.yaml
@@ -12,5 +12,4 @@
 depend = openjdk-10-jre
 depend = so:ld-linux-x86-64.so.2
 depend = so:libc.so.6
-depend = so:libjli.so
 datahash = 9daf9ae25234b9b8a54591eef16667c27f52dc845d76d0fa2d5372ce91bc03e2
```
