### PR TITLE
openjdk-12: rebuild for new melange SCA metadata

### DIFF
--- a/openjdk-12.yaml
+++ b/openjdk-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-12
   version: 12.0.2.10
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: GPL-2.0-only


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff openjdk-12-jre-base-12.0.2.10-r4.apk openjdk-12.yaml
--- openjdk-12-jre-base-12.0.2.10-r4.apk
+++ openjdk-12.yaml
@@ -12,6 +12,5 @@
 depend = java-common
 depend = so:ld-linux-x86-64.so.2
 depend = so:libc.so.6
-depend = so:libjli.so
 depend = so:libz.so.1
 datahash = 5cb579a779a4c970f6991cbbbc0db31ef475ab9c89f3246efdc33d9966a4d69c
diff openjdk-12-12.0.2.10-r4.apk openjdk-12.yaml
--- openjdk-12-12.0.2.10-r4.apk
+++ openjdk-12.yaml
@@ -11,5 +11,4 @@
 depend = openjdk-12-jre
 depend = so:ld-linux-x86-64.so.2
 depend = so:libc.so.6
-depend = so:libjli.so
 datahash = 25fd362e5f277d1de387b6def58a407ba2a631066d03ad1e011125fc6b92d81d
```
