### PR TITLE
openjdk-7: rebuild for new melange SCA metadata

### DIFF
--- a/openjdk-7.yaml
+++ b/openjdk-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-7
   version: 7.321.2.6.28
-  epoch: 4
+  epoch: 5
   description: "IcedTea distribution of OpenJDK 7 (UNSUPPORTED)"
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff openjdk-7-jre-7.321.2.6.28-r4.apk openjdk-7.yaml
--- openjdk-7-jre-7.321.2.6.28-r4.apk
+++ openjdk-7.yaml
@@ -16,7 +16,6 @@
 depend = so:libXi.so.6
 depend = so:libXrender.so.1
 depend = so:libXtst.so.6
-depend = so:libawt.so
 depend = so:libc.so.6
 depend = so:libfontconfig.so.1
 depend = so:libfreetype.so.6
@@ -24,8 +23,6 @@
 depend = so:libgio-2.0.so.0
 depend = so:libglib-2.0.so.0
 depend = so:libgobject-2.0.so.0
-depend = so:libjava.so
-depend = so:libjli.so
 depend = so:libjpeg.so.8
 depend = so:libm.so.6
 depend = so:libpng16.so.16
diff openjdk-7-7.321.2.6.28-r4.apk openjdk-7.yaml
--- openjdk-7-7.321.2.6.28-r4.apk
+++ openjdk-7.yaml
@@ -13,7 +13,6 @@
 depend = so:ld-linux-x86-64.so.2
 depend = so:libc.so.6
 depend = so:libgcc_s.so.1
-depend = so:libjli.so
 depend = so:libm.so.6
 depend = so:libstdc++.so.6
 datahash = f3a16e844aa7c38dd6c424b55cbb02103ce8777c5a816bd455858ac619bf9318
```
