### PR TITLE
openjdk-8: rebuild for new melange SCA metadata

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.422.05 # this corresponds to same release as jdk8u422-ga / jdk8u422-b05
-  epoch: 1
+  epoch: 2
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff openjdk-8-8.422.05-r1.apk openjdk-8.yaml
--- openjdk-8-8.422.05-r1.apk
+++ openjdk-8.yaml
@@ -12,5 +12,4 @@
 depend = openjdk-8-jre
 depend = so:ld-linux-x86-64.so.2
 depend = so:libc.so.6
-depend = so:libjli.so
 datahash = 7aa94c8926b5d01505052c706f02369fc19805f2d90803146eef68fe673a975d
```
