### PR TITLE
py3-libevdev: rebuild for new melange SCA metadata

### DIFF
--- a/py3-libevdev.yaml
+++ b/py3-libevdev.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-libevdev
   version: "0.11"
-  epoch: 0
+  epoch: 1
   description: Python3 wrapper around the evdev library
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff py3-libevdev-0.11-r0.apk py3-libevdev.yaml
--- py3-libevdev-0.11-r0.apk
+++ py3-libevdev.yaml
@@ -8,5 +8,5 @@
 commit = 62705cf43b048c7344829ce62f38fe505084076d
 builddate = 1708138038
 license = MIT
-depend = python3~3.12
+depend = python-3.12-base
 datahash = a14787f271b6caa4070dac47c7a0453ebe6ce3593d56b7f974baae54eaf83e2b
```
