### PR TITLE
smartypants: rebuild for new melange SCA metadata

### DIFF
--- a/smartypants.yaml
+++ b/smartypants.yaml
@@ -1,7 +1,7 @@
 package:
   name: smartypants
   version: 2.0.1
-  epoch: 1
+  epoch: 2
   description: Translate plain ASCII punctuation characters into “smart” typographic punctuation HTML entities
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff smartypants-2.0.1-r1.apk smartypants.yaml
--- smartypants-2.0.1-r1.apk
+++ smartypants.yaml
@@ -8,6 +8,6 @@
 commit = 88cacd3ba3edaf2b7b0707e8c1f24262628fee5e
 builddate = 1706044004
 license = BSD-3-Clause
-depend = python3~3.12
+depend = python-3.12-base
 provides = cmd:smartypants=2.0.1-r1
 datahash = 26b9125de3873c9c3dddc0ae408d47245deb73ff2f9059d971bff20c18a837b4
```
