### PR TITLE
Prevent rebuild of libxcrypt breaking the world

### DIFF
--- a/libxcrypt.yaml
+++ b/libxcrypt.yaml
@@ -1,13 +1,15 @@
 package:
   name: libxcrypt
   version: 4.4.36
-  epoch: 7
+  epoch: 8
   description: "Modern library for one-way hashing of passwords"
   copyright:
     - license: GPL-2.0-or-later AND LGPL-2.1-or-later
   options:
-    # For apko same-origin resolution
+    # For apko same-origin resolution, see glibc libcrypt1 empty
+    # package, which provides so:libcrypt1.so
     no-provides: true
+    no-depends: true
   dependencies:
     # For apk upgrades
     replaces:
@@ -28,8 +30,6 @@ environment:
       - wolfi-base
 
 pipeline:
-  # Using Fetch instead of git checkout
-  # @kaniini : When we retire libcrypt from glibc, it will need to get built earlier than git, as git (indirectly) depends on libcrypt.
   - uses: git-checkout
     with:
       repository: https://github.com/besser82/libxcrypt


### PR DESCRIPTION
Currently if one rebuilds libxcrypt, circular dependency would be
introduced by melange sca:

```diff
diff libxcrypt-4.4.36-r7.apk libxcrypt.yaml
--- libxcrypt-4.4.36-r7.apk
+++ libxcrypt.yaml
@@ -8,5 +8,7 @@
 commit = 47793bfd95deb14489d0a0d187ff9abbd31f970a
 builddate = 1716471930
 license = GPL-2.0-or-later AND LGPL-2.1-or-later
+depend = so:libc.so.6
+depend = so:libcrypt.so.1
 replaces = libcrypt1<2.38-r15
 datahash = feb225bcfafd8f54c209f0aea74ecd9f55c652cdc756801b2c51ddd76cf2cc82
```

Disable depends generation to prevent this.

This is done because whilst libxcrypt is the one that ships
libcrypt.so.1, such provides with depends on libxcrypt is declared in
glibc libcrypt1 package. Due to same-origin preference in package
resolution in apko, it is impossible to currently move the provides to
libxcrypt package. As it results in hodling back upgrades of glibc.
