### PR TITLE
autoconf: rebuild for new melange SCA metadata

### DIFF
--- a/autoconf.yaml
+++ b/autoconf.yaml
@@ -1,7 +1,7 @@
 package:
   name: autoconf
   version: "2.72"
-  epoch: 0
+  epoch: 1
   description: "GNU tool for generating configure scripts"
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff autoconf-2.72-r0.apk autoconf.yaml
--- autoconf-2.72-r0.apk
+++ autoconf.yaml
@@ -8,6 +8,7 @@
 commit = 6ee43e286f3cbc891b396bea0540a4189b3a295c
 builddate = 1703285141
 license = GPL-3.0-or-later
+depend = cmd:perl
 depend = m4
 depend = perl
 provides = cmd:autoconf=2.72-r0
```
