### PR TITLE
bats: rebuild for new melange SCA metadata

### DIFF
--- a/bats.yaml
+++ b/bats.yaml
@@ -1,7 +1,7 @@
 package:
   name: bats
   version: 1.11.0
-  epoch: 0
+  epoch: 1
   description: Bash Automated Testing System
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff bats-1.11.0-r0.apk bats.yaml
--- bats-1.11.0-r0.apk
+++ bats.yaml
@@ -9,6 +9,7 @@
 builddate = 1718024668
 license = MIT
 depend = bash
+depend = cmd:bash
 depend = coreutils
 depend = ncurses
 depend = parallel
```
