### PR TITLE
exiftool: rebuild for new melange SCA metadata

### DIFF
--- a/exiftool.yaml
+++ b/exiftool.yaml
@@ -1,7 +1,7 @@
 package:
   name: exiftool
   version: 12.70
-  epoch: 0
+  epoch: 1
   description: ExifTool meta information reader/writer
   copyright:
     - license: GPL-3.0-only


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff exiftool-12.70-r0.apk exiftool.yaml
--- exiftool-12.70-r0.apk
+++ exiftool.yaml
@@ -8,6 +8,7 @@
 commit = 57fa9fda5311b7e2f22c204f3c12509edfbddc43
 builddate = 1711286993
 license = GPL-3.0-only
+depend = cmd:perl
 depend = perl
 provides = cmd:exiftool=12.70-r0
 datahash = 719e1a1ff13da8e3d4d6199bcec7363552733280b3a88d9df55dee79b2fb7379
```
