### PR TITLE
flink-1.20: rebuild for new melange SCA metadata

### DIFF
--- a/flink-1.20.yaml
+++ b/flink-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: flink-1.20
   version: 1.20.0
-  epoch: 0
+  epoch: 1
   description: Apache Flink is an open source stream processing framework with powerful stream- and batch-processing capabilities.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff flink-1.20-1.20.0-r0.apk flink-1.20.yaml
--- flink-1.20-1.20.0-r0.apk
+++ flink-1.20.yaml
@@ -10,6 +10,7 @@
 license = Apache-2.0
 depend = bash
 depend = busybox
+depend = cmd:bash
 depend = gettext
 depend = gosu
 depend = openjdk-11-default-jvm
```
