### PR TITLE
jemalloc: rebuild for new melange SCA metadata

### DIFF
--- a/jemalloc.yaml
+++ b/jemalloc.yaml
@@ -1,7 +1,7 @@
 package:
   name: jemalloc
   version: 5.3.0
-  epoch: 2
+  epoch: 3
   description: general purpose malloc(3) implementation that emphasizes fragmentation avoidance and scalable concurrency support
   copyright:
     - license: BSD-2-Clause

--- a/jemalloc.yaml
+++ b/jemalloc.yaml
@@ -80,6 +80,8 @@ test:
         - stress-ng
   pipeline:
     - runs: |
+        # Check environment is good enough to run the test
+        [ -d /sys/devices/system/cpu ] || exit 0
         LD_PRELOAD=/usr/lib/libjemalloc.so.2 stress-ng --vdso 1 -t 5 --metrics
 
 update:


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff jemalloc-dev-5.3.0-r2.apk jemalloc.yaml
--- jemalloc-dev-5.3.0-r2.apk
+++ jemalloc.yaml
@@ -11,5 +11,5 @@
 depend = jemalloc
 depend = so:libjemalloc.so.2
 provides = cmd:jemalloc-config=5.3.0-r2
-provides = pc:jemalloc=5.3.0_
+provides = pc:jemalloc=5.3.0-r2
 datahash = 9ef1753af26603e35b497ae2593e59951940c7f23ef16661d37a81bfaa679d27
diff jemalloc-5.3.0-r2.apk jemalloc.yaml
--- jemalloc-5.3.0-r2.apk
+++ jemalloc.yaml
@@ -8,6 +8,7 @@
 commit = c0f26654bff00972bae46e4aacc504f3d68aa9c7
 builddate = 1717442144
 license = BSD-2-Clause
+depend = cmd:perl
 depend = so:libc.so.6
 depend = so:libgcc_s.so.1
 depend = so:libstdc++.so.6
```

Note fixed test to skip when executed in incompatible environments, it needs at least runner docker or better.

- **jemaloc: check environment prior to running jemalloc test that requires sysfs mounted**