### PR TITLE
mariadb-11.5: rebuild for new melange SCA metadata

### DIFF
--- a/mariadb-11.5.yaml
+++ b/mariadb-11.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-11.5
   version: 11.5.2
-  epoch: 1
+  epoch: 2
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff mariadb-11.5-dev-11.5.2-r1.apk mariadb-11.5.yaml
--- mariadb-11.5-dev-11.5.2-r1.apk
+++ mariadb-11.5.yaml
@@ -10,5 +10,5 @@
 license = GPL-3.0-or-later
 depend = so:libmariadbd.so.19
 provides = mariadb-dev=11.5.2-r1
-provides = pc:mariadb=11.5.2
+provides = pc:mariadb=11.5.2-r1
 datahash = 5546ab680d7149b0ceca739b682c9ba65e56594b724c42c8622d93bd0b765880
diff mariadb-11.5-11.5.2-r1.apk mariadb-11.5.yaml
--- mariadb-11.5-11.5.2-r1.apk
+++ mariadb-11.5.yaml
@@ -8,6 +8,7 @@
 commit = 7776a5a0e4e5358c6f8135b616d881ae9717fd8a
 builddate = 1724239102
 license = GPL-3.0-or-later
+depend = cmd:bash
 depend = cmd:perl
 depend = pwgen
 depend = so:ld-linux-x86-64.so.2
```
