### PR TITLE
node-gyp: rebuild for new melange SCA metadata

### DIFF
--- a/node-gyp.yaml
+++ b/node-gyp.yaml
@@ -1,7 +1,7 @@
 package:
   name: node-gyp
   version: 10.2.0
-  epoch: 0
+  epoch: 1
   description: "the npm package manager for javascript, mainline"
   copyright:
     - license: Artistic-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff node-gyp-10.2.0-r0.apk node-gyp.yaml
--- node-gyp-10.2.0-r0.apk
+++ node-gyp.yaml
@@ -8,4 +8,5 @@
 commit = 479e37369d6692461fdf91cd998265763616b6b4
 builddate = 1720624343
 license = Artistic-2.0
+depend = cmd:node
 datahash = c79b0627086345e4c6f2e5309ad334bdf8fae4b4061d95361f6e1eb5cd206e04
```
