### PR TITLE
openscap: rebuild for new melange SCA metadata

### DIFF
--- a/openscap.yaml
+++ b/openscap.yaml
@@ -1,7 +1,7 @@
 package:
   name: openscap
   version: 1.4.0
-  epoch: 1
+  epoch: 2
   description: NIST Certified SCAP 1.2 toolkit
   copyright:
     - license: LGPL-2.1-or-later


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff openscap-1.4.0-r1.apk openscap.yaml
--- openscap-1.4.0-r1.apk
+++ openscap.yaml
@@ -8,6 +8,7 @@
 commit = 9228e478f6e3e8f3707c696e1a270294b6e35350
 builddate = 1726601722
 license = LGPL-2.1-or-later
+depend = cmd:bash
 depend = python-3.12-base
 depend = so:ld-linux-x86-64.so.2
 depend = so:libacl.so.1
```
