### PR TITLE
qt5-qtbase: rebuild for new melange SCA metadata

### DIFF
--- a/qt5-qtbase.yaml
+++ b/qt5-qtbase.yaml
@@ -2,7 +2,7 @@
 package:
   name: qt5-qtbase
   version: 5.15.15
-  epoch: 0
+  epoch: 1
   description: Qt5 - QtBase components
   copyright:
     - license: LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff qt5-qtbase-dev-5.15.15-r0.apk qt5-qtbase.yaml
--- qt5-qtbase-dev-5.15.15-r0.apk
+++ qt5-qtbase.yaml
@@ -43,16 +43,16 @@
 depend = so:libQt5Xml.so.5
 depend = sqlite-dev
 depend = zlib-dev
-provides = pc:Qt5Concurrent=5.15.15
-provides = pc:Qt5Core=5.15.15
-provides = pc:Qt5DBus=5.15.15
-provides = pc:Qt5Gui=5.15.15
-provides = pc:Qt5Network=5.15.15
-provides = pc:Qt5OpenGL=5.15.15
-provides = pc:Qt5OpenGLExtensions=5.15.15
-provides = pc:Qt5PrintSupport=5.15.15
-provides = pc:Qt5Sql=5.15.15
-provides = pc:Qt5Test=5.15.15
-provides = pc:Qt5Widgets=5.15.15
-provides = pc:Qt5Xml=5.15.15
+provides = pc:Qt5Concurrent=5.15.15-r0
+provides = pc:Qt5Core=5.15.15-r0
+provides = pc:Qt5DBus=5.15.15-r0
+provides = pc:Qt5Gui=5.15.15-r0
+provides = pc:Qt5Network=5.15.15-r0
+provides = pc:Qt5OpenGL=5.15.15-r0
+provides = pc:Qt5OpenGLExtensions=5.15.15-r0
+provides = pc:Qt5PrintSupport=5.15.15-r0
+provides = pc:Qt5Sql=5.15.15-r0
+provides = pc:Qt5Test=5.15.15-r0
+provides = pc:Qt5Widgets=5.15.15-r0
+provides = pc:Qt5Xml=5.15.15-r0
 datahash = 6ec34ededcc40d04ab028f6abf13f1ba4ed9f3b4fd1ee765c0da9c251c9ba0f8
diff qt5-qtbase-5.15.15-r0.apk qt5-qtbase.yaml
--- qt5-qtbase-5.15.15-r0.apk
+++ qt5-qtbase.yaml
@@ -8,6 +8,7 @@
 commit = 37429759af29b7fc49403584f4b6b87afc459e21
 builddate = 1725357662
 license = LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
+depend = cmd:perl
 depend = so:ld-linux-x86-64.so.2
 depend = so:libc.so.6
 depend = so:libcrypto.so.3
```
