### PR TITLE
rarian: rebuild for new melange SCA metadata

### DIFF
--- a/rarian.yaml
+++ b/rarian.yaml
@@ -1,7 +1,7 @@
 package:
   name: rarian
   version: 0.8.5
-  epoch: 0
+  epoch: 1
   description: Documentation meta-data library, designed as a replacement for Scrollkeeper.
   copyright:
     - license: GPL-2.0-or-later OR LGPL-2.1-or-later OR Zlib


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff rarian-dev-0.8.5-r0.apk rarian.yaml
--- rarian-dev-0.8.5-r0.apk
+++ rarian.yaml
@@ -7,10 +7,11 @@
 url =
 commit = 526e42470b89a04c236d1c42e71c7b89ae892bce
 builddate = 1702130323
-license = GPL-2.0+, LGPL-2.1+, Zlib
+license = GPL-2.0-or-later OR LGPL-2.1-or-later OR Zlib
 depend = bash
+depend = cmd:bash
 depend = rarian
 depend = so:librarian.so.0
 provides = cmd:rarian-sk-config=0.8.5-r0
-provides = pc:rarian=0.8.5
+provides = pc:rarian=0.8.5-r0
 datahash = 9f3716d45724cff81ffe4f0dc7e1b6f108e232a7ec3c50b88221a07eea49d779
diff rarian-0.8.5-r0.apk rarian.yaml
--- rarian-0.8.5-r0.apk
+++ rarian.yaml
@@ -7,7 +7,8 @@
 url =
 commit = 526e42470b89a04c236d1c42e71c7b89ae892bce
 builddate = 1702130323
-license = GPL-2.0+, LGPL-2.1+, Zlib
+license = GPL-2.0-or-later OR LGPL-2.1-or-later OR Zlib
+depend = cmd:bash
 depend = so:ld-linux-x86-64.so.2
 depend = so:libc.so.6
 depend = so:libgcc_s.so.1
```
