### PR TITLE
socat: rebuild for new melange SCA metadata

### DIFF
--- a/socat.yaml
+++ b/socat.yaml
@@ -1,7 +1,7 @@
 package:
   name: socat
   version: 1.8.0.1
-  epoch: 0
+  epoch: 1
   description: Multipurpose relay for binary protocols
   copyright:
     - license: GPL-2.0-only


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff socat-1.8.0.1-r0.apk socat.yaml
--- socat-1.8.0.1-r0.apk
+++ socat.yaml
@@ -8,6 +8,7 @@
 commit = d85d5854739065390f2409c04ae6ac386598ee54
 builddate = 1724527623
 license = GPL-2.0-only
+depend = cmd:bash
 depend = so:ld-linux-x86-64.so.2
 depend = so:libc.so.6
 depend = so:libcrypto.so.3
```
