### PR TITLE
trafficserver-9: rebuild for new melange SCA metadata

### DIFF
--- a/trafficserver-9.yaml
+++ b/trafficserver-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: trafficserver-9
   version: 9.2.4
-  epoch: 1
+  epoch: 2
   description: Apache Traffic Server™ is a fast, scalable and extensible HTTP/1.1 and HTTP/2 compliant caching proxy server.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff trafficserver-9-9.2.4-r1.apk trafficserver-9.yaml
--- trafficserver-9-9.2.4-r1.apk
+++ trafficserver-9.yaml
@@ -8,6 +8,8 @@
 commit = f614d15df6abc202ebfb9f52af2bfa824aa0f4a6
 builddate = 1724845058
 license = Apache-2.0
+depend = cmd:bash
+depend = cmd:perl
 depend = so:ld-linux-x86-64.so.2
 depend = so:libc.so.6
 depend = so:libcrypto.so.3
@@ -30,7 +32,7 @@
 provides = cmd:trafficserver=9.2.4-r1
 provides = cmd:tspush=9.2.4-r1
 provides = cmd:tsxs=9.2.4-r1
-provides = pc:trafficserver=9.2.4
+provides = pc:trafficserver=9.2.4-r1
 provides = so:libtscore.so.9=9
 provides = so:libtscppapi.so.9=9
 provides = so:libtscpputil.so.9=9
```
