### PR TITLE
valgrind: rebuild for new melange SCA metadata

### DIFF
--- a/valgrind.yaml
+++ b/valgrind.yaml
@@ -1,7 +1,7 @@
 package:
   name: valgrind
   version: 3.23.0
-  epoch: 0
+  epoch: 1
   description: "Tool to help find memory-management problems in programs"
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff valgrind-dev-3.23.0-r0.apk valgrind.yaml
--- valgrind-dev-3.23.0-r0.apk
+++ valgrind.yaml
@@ -9,5 +9,5 @@
 builddate = 1714175905
 license = GPL-2.0-or-later
 depend = valgrind
-provides = pc:valgrind=3.23.0
+provides = pc:valgrind=3.23.0-r0
 datahash = 667be43715730e4906e0a10c1658bd9c3aaa4d654b96235942cb495da094ffd8
diff valgrind-scripts-3.23.0-r0.apk valgrind.yaml
--- valgrind-scripts-3.23.0-r0.apk
+++ valgrind.yaml
@@ -8,6 +8,7 @@
 commit = 47f93ca2a88e7ae003a2c21e7e73ced53653372b
 builddate = 1714175905
 license = GPL-2.0-or-later
+depend = cmd:perl
 depend = perl
 depend = python3
 depend = valgrind
```
