### PR TITLE
wait-for-it: rebuild for new melange SCA metadata

### DIFF
--- a/wait-for-it.yaml
+++ b/wait-for-it.yaml
@@ -1,7 +1,7 @@
 package:
   name: wait-for-it
   version: 0.20200823
-  epoch: 4
+  epoch: 5
   description: Pure bash script to test and wait on the availability of a TCP host and port
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff wait-for-it-0.20200823-r4.apk wait-for-it.yaml
--- wait-for-it-0.20200823-r4.apk
+++ wait-for-it.yaml
@@ -9,6 +9,7 @@
 builddate = 1716472603
 license = MIT
 depend = bash
+depend = cmd:bash
 depend = coreutils
 provides = cmd:wait-for-it=0.20200823-r4
 datahash = b4b395e7b5d2d763fabfc794e6a9bcef07c77e5880ce27b9be6942178a7198b1
```
