### PR TITLE
fluent-plugin-cloudwatch-logs: rebuild for new melange SCA metadata

### DIFF
--- a/fluent-plugin-cloudwatch-logs.yaml
+++ b/fluent-plugin-cloudwatch-logs.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-cloudwatch-logs
   version: 0.14.3
-  epoch: 3
+  epoch: 4
   description: CloudWatch Logs Plugin for Fluentd
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff fluent-plugin-cloudwatch-logs-0.14.3-r3.apk fluent-plugin-cloudwatch-logs.yaml
--- fluent-plugin-cloudwatch-logs-0.14.3-r3.apk
+++ fluent-plugin-cloudwatch-logs.yaml
@@ -8,6 +8,7 @@
 commit = 688915a4938a57b6c9b0899298a914dd4aa9b720
 builddate = 1721404376
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-aws-sdk-cloudwatchlogs
 depend = ruby3.2-fluentd
 datahash = 76d320f15c1afc74b3594874738056d4f436764ce106a35afa13842572717f37
```
