### PR TITLE
fluent-plugin-detect-exceptions: rebuild for new melange SCA metadata

### DIFF
--- a/fluent-plugin-detect-exceptions.yaml
+++ b/fluent-plugin-detect-exceptions.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-detect-exceptions
   version: 0.0.15
-  epoch: 2
+  epoch: 3
   description: Fluentd output plugin which detects exception stack traces in a stream of JSON log messages and combines all single-line messages that belong to the same stack trace into one multi-line message. This is an official Google Ruby gem.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff fluent-plugin-detect-exceptions-0.0.15-r2.apk fluent-plugin-detect-exceptions.yaml
--- fluent-plugin-detect-exceptions-0.0.15-r2.apk
+++ fluent-plugin-detect-exceptions.yaml
@@ -8,5 +8,6 @@
 commit = 688915a4938a57b6c9b0899298a914dd4aa9b720
 builddate = 1721404376
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-fluentd
 datahash = 26b074b3bfe63fc26540fa2afe6c49760b0d5b24d55c530b71d1751308ec38ce
```
