### PR TITLE
fluent-plugin-elasticsearch: rebuild for new melange SCA metadata

### DIFF
--- a/fluent-plugin-elasticsearch.yaml
+++ b/fluent-plugin-elasticsearch.yaml
@@ -2,7 +2,7 @@
 package:
   name: fluent-plugin-elasticsearch
   version: 5.4.3
-  epoch: 2
+  epoch: 3
   description: Elasticsearch output plugin for Fluent event collector
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff fluent-plugin-elasticsearch-5.4.3-r2.apk fluent-plugin-elasticsearch.yaml
--- fluent-plugin-elasticsearch-5.4.3-r2.apk
+++ fluent-plugin-elasticsearch.yaml
@@ -8,6 +8,7 @@
 commit = 688915a4938a57b6c9b0899298a914dd4aa9b720
 builddate = 1721404376
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-elasticsearch
 depend = ruby3.2-excon
 depend = ruby3.2-faraday
```
