### PR TITLE
fluent-plugin-newrelic: rebuild for new melange SCA metadata

### DIFF
--- a/fluent-plugin-newrelic.yaml
+++ b/fluent-plugin-newrelic.yaml
@@ -2,7 +2,7 @@
 package:
   name: fluent-plugin-newrelic
   version: "1.2.2_git20230928"
-  epoch: 3
+  epoch: 4
   description: Sends FluentD events to New Relic
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff fluent-plugin-newrelic-1.2.2_git20230928-r3.apk fluent-plugin-newrelic.yaml
--- fluent-plugin-newrelic-1.2.2_git20230928-r3.apk
+++ fluent-plugin-newrelic.yaml
@@ -8,5 +8,6 @@
 commit = 688915a4938a57b6c9b0899298a914dd4aa9b720
 builddate = 1721404376
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-fluentd
 datahash = 3646274b0e517c2677bc938b8ab92add038ee73a417b7dc027ed5945615f670b
```
