### PR TITLE
fluent-plugin-out-http: rebuild for new melange SCA metadata

### DIFF
--- a/fluent-plugin-out-http.yaml
+++ b/fluent-plugin-out-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-out-http
   version: 1.3.4
-  epoch: 4
+  epoch: 5
   description: This is the Fluentd output plugin for enabling http access to the container
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff fluent-plugin-out-http-1.3.4-r4.apk fluent-plugin-out-http.yaml
--- fluent-plugin-out-http-1.3.4-r4.apk
+++ fluent-plugin-out-http.yaml
@@ -8,6 +8,7 @@
 commit = 688915a4938a57b6c9b0899298a914dd4aa9b720
 builddate = 1721404376
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-fluentd
 depend = ruby3.2-json-jwt
 depend = ruby3.2-multi_json
```
