### PR TITLE
fluent-plugin-record-modifier: rebuild for new melange SCA metadata

### DIFF
--- a/fluent-plugin-record-modifier.yaml
+++ b/fluent-plugin-record-modifier.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-record-modifier
   version: 2.2.0
-  epoch: 3
+  epoch: 4
   description: Filter plugin for modifying event record
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff fluent-plugin-record-modifier-2.2.0-r3.apk fluent-plugin-record-modifier.yaml
--- fluent-plugin-record-modifier-2.2.0-r3.apk
+++ fluent-plugin-record-modifier.yaml
@@ -8,5 +8,6 @@
 commit = 688915a4938a57b6c9b0899298a914dd4aa9b720
 builddate = 1721404376
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-fluentd
 datahash = e61681e1792c6eddbc7ea77b532d643dceefd2296935fef19031128e517bda5c
```
