### PR TITLE
fluent-plugin-rewrite-tag-filter: rebuild for new melange SCA metadata

### DIFF
--- a/fluent-plugin-rewrite-tag-filter.yaml
+++ b/fluent-plugin-rewrite-tag-filter.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-rewrite-tag-filter
   version: 2.4.0
-  epoch: 3
+  epoch: 4
   description: Fluentd Output filter plugin to rewrite tags that matches specified attribute.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff fluent-plugin-rewrite-tag-filter-2.4.0-r3.apk fluent-plugin-rewrite-tag-filter.yaml
--- fluent-plugin-rewrite-tag-filter-2.4.0-r3.apk
+++ fluent-plugin-rewrite-tag-filter.yaml
@@ -8,6 +8,7 @@
 commit = 688915a4938a57b6c9b0899298a914dd4aa9b720
 builddate = 1721404376
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-fluent-config-regexp-type
 depend = ruby3.2-fluentd
 provides = ruby3.2-fluent-plugin-rewrite-tag-filter=2.4.0-r3
```
