### PR TITLE
fluent-plugin-s3: rebuild for new melange SCA metadata

### DIFF
--- a/fluent-plugin-s3.yaml
+++ b/fluent-plugin-s3.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-s3
   version: 1.7.2
-  epoch: 3
+  epoch: 4
   description: Amazon S3 output plugin for Fluentd event collector
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff fluent-plugin-s3-1.7.2-r3.apk fluent-plugin-s3.yaml
--- fluent-plugin-s3-1.7.2-r3.apk
+++ fluent-plugin-s3.yaml
@@ -8,6 +8,7 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-aws-sdk-s3
 depend = ruby3.2-aws-sdk-sqs
 depend = ruby3.2-fluentd
```
