### PR TITLE
fluent-plugin-splunk-hec: rebuild for new melange SCA metadata

### DIFF
--- a/fluent-plugin-splunk-hec.yaml
+++ b/fluent-plugin-splunk-hec.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-plugin-splunk-hec
   version: 1.3.3
-  epoch: 11
+  epoch: 12
   description: This is the Fluentd output plugin for sending events to Splunk via HEC
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff fluent-plugin-splunk-hec-1.3.3-r11.apk fluent-plugin-splunk-hec.yaml
--- fluent-plugin-splunk-hec-1.3.3-r11.apk
+++ fluent-plugin-splunk-hec.yaml
@@ -8,6 +8,7 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-fluentd
 depend = ruby3.2-json-jwt
 depend = ruby3.2-multi_json
```
