### PR TITLE
ruby3.2-aws-sdk-kms: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-aws-sdk-kms.yaml
+++ b/ruby3.2-aws-sdk-kms.yaml
@@ -27,6 +27,7 @@ pipeline:
       expected-commit: 761b5a43e8c97577e5fbb9f1eceb47cbde56be65
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
+      depth: -1
 
   - uses: ruby/build
     with:

--- a/ruby3.2-aws-sdk-kms.yaml
+++ b/ruby3.2-aws-sdk-kms.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-aws-sdk-kms
   version: 1.88.0
-  epoch: 2
+  epoch: 3
   description: Official AWS Ruby gem for AWS Key Management Service (KMS). This gem is part of the AWS SDK for Ruby.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-aws-sdk-kms-1.88.0-r2.apk ruby3.2-aws-sdk-kms.yaml
--- ruby3.2-aws-sdk-kms-1.88.0-r2.apk
+++ ruby3.2-aws-sdk-kms.yaml
@@ -8,6 +8,7 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-aws-sdk-core
 depend = ruby3.2-aws-sigv4
 datahash = 688b869f039752ed797bb2424d1d50a230d2aef2f913ac5caadf8e7f3498bf4d
```
