### PR TITLE
ruby3.2-aws-sdk-s3: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-aws-sdk-s3.yaml
+++ b/ruby3.2-aws-sdk-s3.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-aws-sdk-s3
   version: 1.156.0
-  epoch: 3
+  epoch: 4
   description: Official AWS Ruby gem for Amazon Simple Storage Service (Amazon S3). This gem is part of the AWS SDK for Ruby.
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-aws-sdk-s3.yaml
+++ b/ruby3.2-aws-sdk-s3.yaml
@@ -29,6 +29,7 @@ pipeline:
       expected-commit: 761b5a43e8c97577e5fbb9f1eceb47cbde56be65
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
+      depth: -1
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-aws-sdk-s3-1.156.0-r3.apk ruby3.2-aws-sdk-s3.yaml
--- ruby3.2-aws-sdk-s3-1.156.0-r3.apk
+++ ruby3.2-aws-sdk-s3.yaml
@@ -8,6 +8,7 @@
 commit = 15ba047ebfa4bbd01eec278ce3c431689e9f4c27
 builddate = 1721838743
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-aws-sdk-core
 depend = ruby3.2-aws-sdk-kms
 depend = ruby3.2-aws-sigv4
```
