### PR TITLE
ruby3.2-aws-sdk-sqs: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-aws-sdk-sqs.yaml
+++ b/ruby3.2-aws-sdk-sqs.yaml
@@ -27,6 +27,7 @@ pipeline:
       expected-commit: 761b5a43e8c97577e5fbb9f1eceb47cbde56be65
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
+      depth: -1
 
   - uses: ruby/build
     with:

--- a/ruby3.2-aws-sdk-sqs.yaml
+++ b/ruby3.2-aws-sdk-sqs.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-aws-sdk-sqs
   version: 1.80.0
-  epoch: 3
+  epoch: 4
   description: Official AWS Ruby gem for Amazon Simple Queue Service (Amazon SQS). This gem is part of the AWS SDK for Ruby.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-aws-sdk-sqs-1.80.0-r3.apk ruby3.2-aws-sdk-sqs.yaml
--- ruby3.2-aws-sdk-sqs-1.80.0-r3.apk
+++ ruby3.2-aws-sdk-sqs.yaml
@@ -8,6 +8,7 @@
 commit = 15ba047ebfa4bbd01eec278ce3c431689e9f4c27
 builddate = 1721838743
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-aws-sdk-core
 depend = ruby3.2-aws-sigv4
 datahash = be13b05dbc36d33d573dc97a2879e7a2f4c269e75d58c4aea13ec8e355674984
```
