### PR TITLE
ruby3.2-aws-sigv4: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-aws-sigv4.yaml
+++ b/ruby3.2-aws-sigv4.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-aws-sigv4
   version: 1.9.0
-  epoch: 0
+  epoch: 1
   description: Amazon Web Services Signature Version 4 signing library. Generates sigv4 signature for HTTP requests.
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-aws-sigv4.yaml
+++ b/ruby3.2-aws-sigv4.yaml
@@ -27,6 +27,7 @@ pipeline:
       expected-commit: 761b5a43e8c97577e5fbb9f1eceb47cbde56be65
       repository: https://github.com/aws/aws-sdk-ruby
       branch: version-3
+      depth: -1
 
   - uses: ruby/build
     with:


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-aws-sigv4-1.9.0-r0.apk ruby3.2-aws-sigv4.yaml
--- ruby3.2-aws-sigv4-1.9.0-r0.apk
+++ ruby3.2-aws-sigv4.yaml
@@ -8,5 +8,6 @@
 commit = 15ba047ebfa4bbd01eec278ce3c431689e9f4c27
 builddate = 1721838743
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-aws-eventstream
 datahash = 7528d5dc29e314da1b1b05cceb8e9046937207124bd6b012af09ad0718bdb9cc
```
