### PR TITLE
ruby3.2-chronic_duration: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-chronic_duration.yaml
+++ b/ruby3.2-chronic_duration.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-chronic_duration
   version: 0.10.6
-  epoch: 2
+  epoch: 3
   description: A simple Ruby natural language parser for elapsed time. (For example, 4 hours and 30 minutes, 6 minutes 4 seconds, 3 days, etc.) Returns all results in seconds. Will return an integer unless you get tricky and need a float. (4 minutes and 13.47 seconds, for example.) The reverse can also be performed via the output method.
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-chronic_duration-0.10.6-r2.apk ruby3.2-chronic_duration.yaml
--- ruby3.2-chronic_duration-0.10.6-r2.apk
+++ ruby3.2-chronic_duration.yaml
@@ -8,5 +8,6 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-numerizer
 datahash = fc9e3c014c3a2c13e173e4cf3c410d9a41c5131a249a674ba9848d4e705c4065
```
