### PR TITLE
ruby3.2-elastic-transport: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-elastic-transport.yaml
+++ b/ruby3.2-elastic-transport.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-elastic-transport
   version: 8.3.5
-  epoch: 2
+  epoch: 3
   description: |
     Low level Ruby client for Elastic. See the `elasticsearch` or `elastic-enterprise-search` gems for full integration.
   copyright:


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-elastic-transport-8.3.5-r2.apk ruby3.2-elastic-transport.yaml
--- ruby3.2-elastic-transport-8.3.5-r2.apk
+++ ruby3.2-elastic-transport.yaml
@@ -9,6 +9,7 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-faraday
 depend = ruby3.2-multi_json
 datahash = 14983408ad1c911723af38f51745515a1610c057e1e92a1e929f50a46b71dfd6
```
