### PR TITLE
ruby3.2-faraday-excon: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-faraday-excon.yaml
+++ b/ruby3.2-faraday-excon.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-faraday-excon
   version: 2.1.0
-  epoch: 3
+  epoch: 4
   description: Faraday adapter for Excon
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-faraday-excon-2.1.0-r3.apk ruby3.2-faraday-excon.yaml
--- ruby3.2-faraday-excon-2.1.0-r3.apk
+++ ruby3.2-faraday-excon.yaml
@@ -8,6 +8,7 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-excon
 depend = ruby3.2-faraday
 datahash = fb27fc2587e846b41a850b40912e09dfffdc67ecbf8a31bc5b3bd6e7e32c2b31
```
