### PR TITLE
ruby3.2-faraday-follow_redirects: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-faraday-follow_redirects.yaml
+++ b/ruby3.2-faraday-follow_redirects.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-faraday-follow_redirects
   version: 0.3.0
-  epoch: 6
+  epoch: 7
   description: |
     Faraday 2.x compatible extraction of FaradayMiddleware::FollowRedirects.
   copyright:


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-faraday-follow_redirects-0.3.0-r6.apk ruby3.2-faraday-follow_redirects.yaml
--- ruby3.2-faraday-follow_redirects-0.3.0-r6.apk
+++ ruby3.2-faraday-follow_redirects.yaml
@@ -9,5 +9,6 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-faraday
 datahash = b87f60d696287671bce58884309e1fbbb1a00ddf91e8f277ed52bdc761632695
```
