### PR TITLE
ruby3.2-fluent-config-regexp-type: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-fluent-config-regexp-type.yaml
+++ b/ruby3.2-fluent-config-regexp-type.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-fluent-config-regexp-type
   version: 1.0.0
-  epoch: 3
+  epoch: 4
   description: Backport regex type for fluentd
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-fluent-config-regexp-type-1.0.0-r3.apk ruby3.2-fluent-config-regexp-type.yaml
--- ruby3.2-fluent-config-regexp-type-1.0.0-r3.apk
+++ ruby3.2-fluent-config-regexp-type.yaml
@@ -8,5 +8,6 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-fluentd
 datahash = 37484e2ea9628af81601390ded5d34e4ec10919bc0a9edb9da8deffa4e759cbe
```
