### PR TITLE
ruby3.2-logstash-mixin-ecs_compatibility_support: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-logstash-mixin-ecs_compatibility_support.yaml
+++ b/ruby3.2-logstash-mixin-ecs_compatibility_support.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-logstash-mixin-ecs_compatibility_support
   version: 1.3.0
-  epoch: 3
+  epoch: 4
   description: Support for the ECS-Compatibility mode targeting Logstash 7.7, for plugins wishing to use this API on older Logstashes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-logstash-mixin-ecs_compatibility_support-1.3.0-r3.apk ruby3.2-logstash-mixin-ecs_compatibility_support.yaml
--- ruby3.2-logstash-mixin-ecs_compatibility_support-1.3.0-r3.apk
+++ ruby3.2-logstash-mixin-ecs_compatibility_support.yaml
@@ -8,5 +8,6 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = Apache-2.0
+depend = ruby-3.2
 depend = ruby3.2-logstash-core
 datahash = df9450d19567c99de1cf4b1cb90ddac628dcd0db967f71e47ba577e4749c278b
```
