### PR TITLE
ruby3.2-mail: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-mail.yaml
+++ b/ruby3.2-mail.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-mail
   version: 2.8.1
-  epoch: 4
+  epoch: 5
   description: A really Ruby Mail handler.
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-mail-2.8.1-r4.apk ruby3.2-mail.yaml
--- ruby3.2-mail-2.8.1-r4.apk
+++ ruby3.2-mail.yaml
@@ -8,6 +8,7 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-mini_mime
 depend = ruby3.2-net-imap
 datahash = f98ad257daa361cb9daef1b90636a472790e7217f7590e663df032f35ad469de
```
