### PR TITLE
ruby3.2-manticore: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-manticore.yaml
+++ b/ruby3.2-manticore.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-manticore
   version: 0.9.1
-  epoch: 2
+  epoch: 3
   description: Manticore is an HTTP client built on the Apache HttpCore components
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-manticore-0.9.1-r2.apk ruby3.2-manticore.yaml
--- ruby3.2-manticore-0.9.1-r2.apk
+++ ruby3.2-manticore.yaml
@@ -8,5 +8,6 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-openssl_pkcs8_pure
 datahash = 8d8bcb7b7a59dabdd1e07b12c92f8762369620111574a6918941fb7a44fac41a
```
