### PR TITLE
ruby3.2-net-http-persistent: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-net-http-persistent.yaml
+++ b/ruby3.2-net-http-persistent.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-net-http-persistent
   version: 4.0.2
-  epoch: 5
+  epoch: 6
   description: Manages persistent connections using Net::HTTP including a thread pool for connecting to multiple hosts.
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-net-http-persistent-4.0.2-r5.apk ruby3.2-net-http-persistent.yaml
--- ruby3.2-net-http-persistent-4.0.2-r5.apk
+++ ruby3.2-net-http-persistent.yaml
@@ -8,5 +8,6 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-connection_pool
 datahash = 9d137e351cfd83ec4f765a391a665b40e2262521bb2b60a20a80b06679c53dc1
```
