### PR TITLE
ruby3.2-net-protocol: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-net-protocol.yaml
+++ b/ruby3.2-net-protocol.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-net-protocol
   version: 0.2.2
-  epoch: 5
+  epoch: 6
   description: The abstract interface for net-* client.
   copyright:
     - license: Ruby


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-net-protocol-0.2.2-r5.apk ruby3.2-net-protocol.yaml
--- ruby3.2-net-protocol-0.2.2-r5.apk
+++ ruby3.2-net-protocol.yaml
@@ -9,5 +9,6 @@
 builddate = 1721404986
 license = Ruby
 license = BSD-2-Clause
+depend = ruby-3.2
 depend = ruby3.2-timeout
 datahash = fa08d8c4b283ee18dcdc5a3a9ce21e6bbd6d42b58474daa2ff15860cdcbab887
```
