### PR TITLE
ruby3.2-openid_connect: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-openid_connect.yaml
+++ b/ruby3.2-openid_connect.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-openid_connect
   version: 2.3.0
-  epoch: 4
+  epoch: 5
   description: OpenID Connect Server & Client Library
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-openid_connect-2.3.0-r4.apk ruby3.2-openid_connect.yaml
--- ruby3.2-openid_connect-2.3.0-r4.apk
+++ ruby3.2-openid_connect.yaml
@@ -8,6 +8,7 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-activemodel
 depend = ruby3.2-attr_required
 depend = ruby3.2-faraday
```
