### PR TITLE
ruby3.2-pry: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-pry.yaml
+++ b/ruby3.2-pry.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-pry
   version: 0.14.2
-  epoch: 2
+  epoch: 3
   description: A runtime developer console and IRB alternative with powerful introspection capabilities
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-pry-0.14.2-r2.apk ruby3.2-pry.yaml
--- ruby3.2-pry-0.14.2-r2.apk
+++ ruby3.2-pry.yaml
@@ -9,6 +9,7 @@
 builddate = 1721404986
 license = MIT
 depend = cmd:ruby
+depend = ruby-3.2
 depend = ruby3.2-coderay
 depend = ruby3.2-method_source
 provides = cmd:pry=0.14.2-r2
```
