### PR TITLE
ruby3.2-redis-client: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-redis-client.yaml
+++ b/ruby3.2-redis-client.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-redis-client
   version: 0.22.2
-  epoch: 2
+  epoch: 3
   description: Simple low-level client for Redis 6+
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-redis-client-0.22.2-r2.apk ruby3.2-redis-client.yaml
--- ruby3.2-redis-client-0.22.2-r2.apk
+++ ruby3.2-redis-client.yaml
@@ -8,5 +8,6 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-connection_pool
 datahash = 46867c8e88b14ea5c43b3b76ae0cd6c8ecbf73e576e7b6d84e477308c1b2eaf0
```
