### PR TITLE
ruby3.2-redis-namespace: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-redis-namespace.yaml
+++ b/ruby3.2-redis-namespace.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-redis-namespace
   version: 1.11.0
-  epoch: 4
+  epoch: 5
   description: Adds a Redis::Namespace class which can be used to namespace calls to Redis. This is useful when using a single instance of Redis with multiple, different applications.
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-redis-namespace-1.11.0-r4.apk ruby3.2-redis-namespace.yaml
--- ruby3.2-redis-namespace-1.11.0-r4.apk
+++ ruby3.2-redis-namespace.yaml
@@ -8,5 +8,6 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-redis
 datahash = b449e9838b173ba94a67450688aa84d64e719eeddab9cee2aebd55f9f5adc22c
```
