### PR TITLE
ruby3.2-sinatra: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-sinatra.yaml
+++ b/ruby3.2-sinatra.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-sinatra
   version: 4.0.0
-  epoch: 2
+  epoch: 3
   description: Sinatra is a DSL for quickly creating web applications in Ruby with minimal effort.
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-sinatra-4.0.0-r2.apk ruby3.2-sinatra.yaml
--- ruby3.2-sinatra-4.0.0-r2.apk
+++ ruby3.2-sinatra.yaml
@@ -8,6 +8,7 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-mustermann
 depend = ruby3.2-rack-2.2
 depend = ruby3.2-rack-protection
```
