### PR TITLE
ruby3.2-snaky_hash: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-snaky_hash.yaml
+++ b/ruby3.2-snaky_hash.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-snaky_hash
   version: 2.0.0
-  epoch: 2
+  epoch: 3
   description: 'A Hashie::Mash joint to make #snakelife better'
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-snaky_hash-2.0.0-r2.apk ruby3.2-snaky_hash.yaml
--- ruby3.2-snaky_hash-2.0.0-r2.apk
+++ ruby3.2-snaky_hash.yaml
@@ -8,6 +8,7 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-hashie
 depend = ruby3.2-version_gem
 datahash = 535c9fe5a929da22dffaf148b418f063ec6d54e30dea68e66499bbc4be47b4bd
```
