### PR TITLE
ruby3.2-swd: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-swd.yaml
+++ b/ruby3.2-swd.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-swd
   version: 2.0.3
-  epoch: 2
+  epoch: 3
   description: SWD (Simple Web Discovery) Client Library
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-swd-2.0.3-r2.apk ruby3.2-swd.yaml
--- ruby3.2-swd-2.0.3-r2.apk
+++ ruby3.2-swd.yaml
@@ -8,6 +8,7 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-activesupport
 depend = ruby3.2-attr_required
 depend = ruby3.2-faraday
```
