### PR TITLE
ruby3.2-treetop: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-treetop.yaml
+++ b/ruby3.2-treetop.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-treetop
   version: 1.6.12
-  epoch: 2
+  epoch: 3
   description: A Parsing Expression Grammar (PEG) Parser generator DSL for Ruby
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-treetop-1.6.12-r2.apk ruby3.2-treetop.yaml
--- ruby3.2-treetop-1.6.12-r2.apk
+++ ruby3.2-treetop.yaml
@@ -9,6 +9,7 @@
 builddate = 1721404986
 license = MIT
 depend = cmd:ruby
+depend = ruby-3.2
 depend = ruby3.2-polyglot
 provides = cmd:tt=1.6.12-r2
 datahash = c89b382a9d209c216dd193156ff2a863c2e58f52bf3ee4b51049c02b34736949
```
