### PR TITLE
ruby3.2-validate_email: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-validate_email.yaml
+++ b/ruby3.2-validate_email.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-validate_email
   version: 0.1.6
-  epoch: 4
+  epoch: 5
   description: Library for validating email addresses in Rails 3 models.
   dependencies:
     runtime:


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-validate_email-0.1.6-r4.apk ruby3.2-validate_email.yaml
--- ruby3.2-validate_email-0.1.6-r4.apk
+++ ruby3.2-validate_email.yaml
@@ -8,6 +8,7 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-activemodel
 depend = ruby3.2-mail
 datahash = 2c746943301e08819a6d6e9d4f0daccd36fd06bde9511b0a20b202133450a70e
```
