### PR TITLE
ruby3.2-validate_url: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-validate_url.yaml
+++ b/ruby3.2-validate_url.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-validate_url
   version: 1.0.15
-  epoch: 5
+  epoch: 6
   description: Library for validating urls in Rails.
   dependencies:
     runtime:


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-validate_url-1.0.15-r5.apk ruby3.2-validate_url.yaml
--- ruby3.2-validate_url-1.0.15-r5.apk
+++ ruby3.2-validate_url.yaml
@@ -8,6 +8,7 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-activemodel
 depend = ruby3.2-public_suffix
 datahash = 43415314cd3b7dd2f17aed8cfa92771a33a086e277665840a29b727f540cf254
```
