### PR TITLE
ruby3.2-webfinger: rebuild for new melange SCA metadata

### DIFF
--- a/ruby3.2-webfinger.yaml
+++ b/ruby3.2-webfinger.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-webfinger
   version: 2.1.2
-  epoch: 5
+  epoch: 6
   description: Ruby WebFinger client library
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff ruby3.2-webfinger-2.1.2-r5.apk ruby3.2-webfinger.yaml
--- ruby3.2-webfinger-2.1.2-r5.apk
+++ ruby3.2-webfinger.yaml
@@ -8,6 +8,7 @@
 commit = 6c3e34c97c3fc70a86207abd16afe6de997cd7c6
 builddate = 1721404986
 license = MIT
+depend = ruby-3.2
 depend = ruby3.2-activesupport
 depend = ruby3.2-faraday
 depend = ruby3.2-faraday-follow_redirects
```
