### PR TITLE
dns-root-hints: rebuild for new melange SCA metadata LICENSE change

### DIFF
--- a/dns-root-hints.yaml
+++ b/dns-root-hints.yaml
@@ -1,7 +1,7 @@
 package:
   name: dns-root-hints
   version: "2022062901"
-  epoch: 0
+  epoch: 1
   description: The DNS root hint(s)
   copyright:
     - license: CC-PDDC


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff dns-root-hints-2022062901-r0.apk dns-root-hints.yaml
--- dns-root-hints-2022062901-r0.apk
+++ dns-root-hints.yaml
@@ -6,6 +6,6 @@
 pkgdesc = The DNS root hint(s)
 url =
 commit = e7eecc035ff8c77af54c17904cbd68b51815acc8
-license = Public-Domain
+license = CC-PDDC
 provides = cmd:update-dns-root-hints=2022062901-r0
 datahash = 300eade764636b6275bebc1afb233422e1883e692732b9d7926fd936c45a42be
```
