### PR TITLE
py3-beautifulsoup4: rebuild for new melange SCA metadata LICENSE change

### DIFF
--- a/py3-beautifulsoup4.yaml
+++ b/py3-beautifulsoup4.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-beautifulsoup4
   version: 4.12.3
-  epoch: 0
+  epoch: 1
   description: Screen-scraping library
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff py3-beautifulsoup4-4.12.3-r0.apk py3-beautifulsoup4.yaml
--- py3-beautifulsoup4-4.12.3-r0.apk
+++ py3-beautifulsoup4.yaml
@@ -7,7 +7,7 @@
 url =
 commit = e5dbd44241833d8fb891a96b90a7a6039bec8004
 builddate = 1705515686
-license = MIT License
+license = MIT
 depend = py3-soupsieve
 depend = python-3
 datahash = f76b3f021ec93221e14ef78fd3ec54688f0c17510cd0e43e9311d7bbe41565c8
```
