### PR TITLE
bison: rebuild for new melange SCA metadata binary depend

### DIFF
--- a/bison.yaml
+++ b/bison.yaml
@@ -1,7 +1,7 @@
 package:
   name: bison
   version: 3.8.2
-  epoch: 3
+  epoch: 4
   description: "The GNU general-purposes parser generator"
   copyright:
     - license: GPL-3.0-or-later


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff bison-3.8.2-r3.apk bison.yaml
--- bison-3.8.2-r3.apk
+++ bison.yaml
@@ -8,6 +8,7 @@
 commit = f80bdceccb85da3c49f615c141c8fe82e80ec1dc
 license = GPL-3.0-or-later
 depend = m4
+depend = so:ld-linux-x86-64.so.2
 depend = so:libc.so.6
 provides = cmd:bison=3.8.2-r3
 provides = cmd:yacc=3.8.2-r3
```
