### PR TITLE
iperf: rebuild for new melange SCA metadata binary depend

### DIFF
--- a/iperf.yaml
+++ b/iperf.yaml
@@ -1,7 +1,7 @@
 package:
   name: iperf
   version: 2.2.0
-  epoch: 1
+  epoch: 2
   description: A tool to measure IP bandwidth using UDP or TCP
   copyright:
     - license: NCSA


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff iperf-2.2.0-r1.apk iperf.yaml
--- iperf-2.2.0-r1.apk
+++ iperf.yaml
@@ -8,6 +8,7 @@
 commit = c398e65ad6a4852bac99329832458108374c752e
 builddate = 1718913309
 license = NCSA
+depend = libgcc
 depend = so:ld-linux-x86-64.so.2
 depend = so:libc.so.6
 depend = so:libgcc_s.so.1
```
