### PR TITLE
linenoise: rebuild for new melange SCA metadata binary depend

### DIFF
--- a/linenoise.yaml
+++ b/linenoise.yaml
@@ -1,7 +1,7 @@
 package:
   name: linenoise
   version: 1.0
-  epoch: 2
+  epoch: 3
   description: "minimal alternative to GNU readline"
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff linenoise-dev-1.0-r2.apk linenoise.yaml
--- linenoise-dev-1.0-r2.apk
+++ linenoise.yaml
@@ -8,4 +8,5 @@
 commit = 2c4fe39732efca0b86baecdf6485c77b50720147
 license = MIT
 depend = linenoise
+depend = so:liblinenoise.so.0
 datahash = 14f93ce2765e15bd38a6eb4c358f70f43f16065106678e07bc03ecac544c3b08
```
