### PR TITLE
mitmproxy: rebuild for new melange SCA metadata binary depend

### DIFF
--- a/mitmproxy.yaml
+++ b/mitmproxy.yaml
@@ -2,7 +2,7 @@
 package:
   name: mitmproxy
   version: 9.0.1
-  epoch: 0
+  epoch: 1
   description: Interactive TLS-capable intercepting HTTP proxy
   copyright:
     - license: MIT


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff mitmproxy-9.0.1-r0.apk mitmproxy.yaml
--- mitmproxy-9.0.1-r0.apk
+++ mitmproxy.yaml
@@ -8,6 +8,7 @@
 commit = 35674823d81b7240e8b61859bbd2c30c635f0349
 builddate = 1689464681
 license = MIT
+depend = python-3.11-base
 provides = cmd:mitmdump=9.0.1-r0
 provides = cmd:mitmproxy=9.0.1-r0
 provides = cmd:mitmweb=9.0.1-r0
```
