### PR TITLE
net-snmp: rebuild for new melange SCA metadata binary depend

### DIFF
--- a/net-snmp.yaml
+++ b/net-snmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: net-snmp
   version: 5.9.4
-  epoch: 1
+  epoch: 2
   description: Simple Network Management Protocol
   copyright:
     - license: Net-SNMP


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff net-snmp-dev-5.9.4-r1.apk net-snmp.yaml
--- net-snmp-dev-5.9.4-r1.apk
+++ net-snmp.yaml
@@ -10,4 +10,10 @@
 license = Net-SNMP
 depend = net-snmp
 depend = openssl-dev
+depend = so:libnetsnmp.so.40
+depend = so:libnetsnmpagent.so.40
+depend = so:libnetsnmphelpers.so.40
+depend = so:libnetsnmpmibs.so.40
+depend = so:libnetsnmptrapd.so.40
+depend = so:libsnmp.so.40
 datahash = f42813dd8e8f21e0586b9778c55d950d754d710cb42fa2b3cea2ebd96055dabf
```
