### PR TITLE
py3-oauthenticator: rebuild for new melange SCA metadata binary depend

### DIFF
--- a/py3-oauthenticator.yaml
+++ b/py3-oauthenticator.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-oauthenticator
   version: 17.1.0
-  epoch: 0
+  epoch: 1
   description: 'OAuthenticator: Authenticate JupyterHub users with common OAuth providers'
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff py3-oauthenticator-17.1.0-r0.apk py3-oauthenticator.yaml
--- py3-oauthenticator-17.1.0-r0.apk
+++ py3-oauthenticator.yaml
@@ -8,8 +8,10 @@
 commit = 08faed95c96e3cbab9bae08d27c8134881508122
 builddate = 1728654150
 license = BSD-3-Clause
+depend = openssl
 depend = py3-jsonschema
 depend = py3-jupyterhub
+depend = py3-pyjwt
 depend = py3-requests
 depend = py3-ruamel-yaml
 depend = py3-tornado
```
