### PR TITLE
samurai: rebuild for new melange SCA metadata binary depend

### DIFF
--- a/samurai.yaml
+++ b/samurai.yaml
@@ -1,7 +1,7 @@
 package:
   name: samurai
   version: 1.2
-  epoch: 2
+  epoch: 3
   description: "ninja-compatible build tool written in C"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff samurai-1.2-r2.apk samurai.yaml
--- samurai-1.2-r2.apk
+++ samurai.yaml
@@ -7,6 +7,7 @@
 url =
 commit = 2c4fe39732efca0b86baecdf6485c77b50720147
 license = Apache-2.0
+depend = so:ld-linux-x86-64.so.2
 depend = so:libc.so.6
 provides = cmd:samu=1.2-r2
 provides = ninja=1.9.0
```
