### PR TITLE
boost: rebuild for new melange SCA metadata PKGDESC

### DIFF
--- a/boost.yaml
+++ b/boost.yaml
@@ -1,7 +1,7 @@
 package:
   name: boost
   version: 1.86.0
-  epoch: 0
+  epoch: 1
   description: "Free peer-reviewed portable C++ source libraries"
   copyright:
     - license: "BSL-1.0"


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff boost-1.86.0-r0.apk boost.yaml
--- boost-1.86.0-r0.apk
+++ boost.yaml
@@ -3,7 +3,7 @@
 arch = x86_64
 size = 6949456
 origin = boost
-pkgdesc = A library for interacting with the Linux kernel's Berkeley Packet Filter (BPF) facility from user space
+pkgdesc = Free peer-reviewed portable C++ source libraries
 url =
 commit = ded406965caf802353d15dd2655446ae3acd24a0
 builddate = 1723662494
```
