### PR TITLE
cronie: rebuild for new melange SCA metadata PKGDESC

### DIFF
--- a/cronie.yaml
+++ b/cronie.yaml
@@ -1,7 +1,7 @@
 package:
   name: cronie
   version: 1.7.2
-  epoch: 0
+  epoch: 1
   description: Cron daemon for executing programs at set times
   copyright:
     - license: ISC


### PR DESCRIPTION
> [!IMPORTANT]
> `melange scan --diff` changes detected

```diff
diff cronie-1.7.2-r0.apk cronie.yaml
--- cronie-1.7.2-r0.apk
+++ cronie.yaml
@@ -3,7 +3,7 @@
 arch = x86_64
 size = 280174
 origin = cronie
-pkgdesc = Library for extensible, efficient structure packing
+pkgdesc = Cron daemon for executing programs at set times
 url =
 commit = cbbc5395c5cec520643923725ea7d1c118327a6f
 builddate = 1712570034
```
