### PR TITLE
vitess: withdrawn old versions

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -13,3 +13,9 @@ modelmesh-runtime-adapter-triton-adapter-0.12.0-r1.apk
 py3.12-google-cloud-sdk-496.0.0-r0.apk
 newrelic-k8s-metadata-action-compat-1.29.2-r0.apk
 newrelic-k8s-metadata-action-1.29.2-r0.apk
+# Renamed to vitess-20.0
+vitess-compat-20.0.2-r5.apk
+vitess-20.0.2-r5.apk
+vitess-20-compat-20.0.2-r0.apk
+vitess-20-20.0.2-r0.apk
+vitess-20-binaries-20.0.2-r0.apk


### PR DESCRIPTION
Now its renamed to `vitess-20.0`, old packages creates non-exist symlinks under `/vt/bin/*` when installing with `apk add vitess vitess-compat`, since it fetches `20.0.2-r5` instead of `(20.0.2-r1)`.