### PR TITLE
feat: add management-api-for-apache-cassandra-5.0 package

### DIFF
--- a/management-api-for-apache-cassandra-5.0.yaml
+++ b/management-api-for-apache-cassandra-5.0.yaml
@@ -1,0 +1,83 @@
+package:
+  name: management-api-for-apache-cassandra-5.0
+  version: 0.1.87
+  epoch: 0
+  description: RESTful / Secure Management Sidecar for Apache Cassandra
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - procps
+    provides:
+      - management-api-for-apache-cassandra=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - maven
+      - openjdk-11
+      - openjdk-11-default-jvm
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-11-openjdk
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/k8ssandra/management-api-for-apache-cassandra
+      expected-commit: 30be84dcdbfd39314ab320366a08710ad80a9b92
+      tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      patches: upgrade-deps.patch GHSA-5jpm-x58v-624v.patch
+
+  - runs: |
+      echo "Running build..."
+      MAAC_PATH="${{targets.contextdir}}"/opt/management-api
+      mkdir -p "${{targets.contextdir}}"/usr/local/bin
+      mkdir -p "${{targets.contextdir}}"/opt/management-api
+      mvn -q -ff package -Dskip.surefire.tests -DskipTests -DskipOpenApi
+
+      cp ./cassandra/scripts/docker-entrypoint.sh "${{targets.contextdir}}"/usr/local/bin/
+      find . -type f -name "datastax-*.jar" -exec mv -t $MAAC_PATH -i '{}' +
+      chmod +x "${{targets.contextdir}}"/usr/local/bin/docker-entrypoint.sh
+
+subpackages:
+  - name: ${{package.name}}-compat
+    dependencies:
+      # Backwards compatibility with previous package name.
+      provides:
+        - management-api-for-apache-cassandra-compat=${{package.full-version}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/opt/management-api
+          mkdir -p ${{targets.contextdir}}/bin
+          ln -s /opt/management-api/datastax-mgmtapi-agent-5.0.x-0.1.0-SNAPSHOT.jar ${{targets.contextdir}}/opt/management-api/datastax-mgmtapi-agent.jar
+          ln -s /opt/management-api/datastax-mgmtapi-server-0.1.0-SNAPSHOT.jar ${{targets.contextdir}}/opt/management-api/datastax-mgmtapi-server.jar
+          ln -sf /usr/local/bin/docker-entrypoint.sh ${{targets.contextdir}}/docker-entrypoint.sh
+
+          # the reason why we need to do this is because the java code hard-codes /bin/ps
+          ln -s /usr/bin/ps ${{targets.contextdir}}/bin/ps
+          # the reason why we need to do this is because the java code hard-codes /bin/which
+          ln -s /usr/bin/which ${{targets.contextdir}}/bin/which
+
+update:
+  enabled: true
+  github:
+    identifier: k8ssandra/management-api-for-apache-cassandra
+    # Upstream doesn't use tags to differentiate between supported cassandra
+    # releases. Each new tag cut supports multiple Cassandra versions.
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - management-api-for-apache-cassandra-compat
+        - openjdk-11
+        - openjdk-11-default-jvm
+  pipeline:
+    - runs: |
+        java -jar /opt/management-api/datastax-mgmtapi-server.jar --help

--- a/management-api-for-apache-cassandra-5.0.yaml
+++ b/management-api-for-apache-cassandra-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: management-api-for-apache-cassandra-5.0
   version: 0.1.87
-  epoch: 0
+  epoch: 1
   description: RESTful / Secure Management Sidecar for Apache Cassandra
   copyright:
     - license: Apache-2.0

--- a/management-api-for-apache-cassandra-5.0/GHSA-5jpm-x58v-624v.patch
+++ b/management-api-for-apache-cassandra-5.0/GHSA-5jpm-x58v-624v.patch
@@ -1,0 +1,13 @@
+diff --git a/management-api-agent-5.0.x/pom.xml b/management-api-agent-5.0.x/pom.xml
+index 58b9de6..8633e6b 100644
+--- a/management-api-agent-5.0.x/pom.xml
++++ b/management-api-agent-5.0.x/pom.xml
+@@ -17,7 +17,7 @@
+   <artifactId>datastax-mgmtapi-agent-5.0.x</artifactId>
+   <properties>
+     <cassandra5.version>5.0.1</cassandra5.version>
+-    <netty.http.codec.version>4.1.96.Final</netty.http.codec.version>
++    <netty.http.codec.version>4.1.108.Final</netty.http.codec.version>
+   </properties>
+   <dependencies>
+     <dependency>

--- a/management-api-for-apache-cassandra-5.0/upgrade-deps.patch
+++ b/management-api-for-apache-cassandra-5.0/upgrade-deps.patch
@@ -1,0 +1,55 @@
+From ced3dc07c8a3cfa3277b4088b102fc05c2a343f4 Mon Sep 17 00:00:00 2001
+From: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+Date: Sun, 14 Jan 2024 20:08:54 +0300
+Subject: [PATCH] upgrade deps
+
+Signed-off-by: Batuhan Apaydin <batuhan.apaydin@chainguard.dev>
+---
+ management-api-server/pom.xml | 4 ++--
+ pom.xml                       | 6 +++---
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/management-api-server/pom.xml b/management-api-server/pom.xml
+index f2b9659..79efc80 100644
+--- a/management-api-server/pom.xml
++++ b/management-api-server/pom.xml
+@@ -17,10 +17,10 @@
+   <artifactId>datastax-mgmtapi-server</artifactId>
+   <properties>
+     <rsapi.version>2.1.1</rsapi.version>
+-    <guava.version>30.1.1-jre</guava.version>
++    <guava.version>32.0.0-jre</guava.version>
+     <airline.version>2.7.0</airline.version>
+     <jaxrs.version>2.1.6</jaxrs.version>
+-    <resteasy.version>4.5.9.Final</resteasy.version>
++    <resteasy.version>4.6.1.Final</resteasy.version>
+     <awaitility.version>4.0.3</awaitility.version>
+     <assertj.version>3.17.2</assertj.version>
+     <servelet.version>3.1.0</servelet.version>
+diff --git a/pom.xml b/pom.xml
+index 6d7696c..1390a8d 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -16,7 +16,7 @@
+   <properties>
+     <build.version.file>build_version.sh</build.version.file>
+     <revision>0.1.0-SNAPSHOT</revision>
+-    <driver.version>4.15.0</driver.version>
++    <driver.version>4.17.0</driver.version>
+     <cassandra3.version>3.11.17</cassandra3.version>
+     <cassandra4.version>4.0.12</cassandra4.version>
+     <docker.java.version>3.3.6</docker.java.version>
+@@ -25,8 +25,8 @@
+     <bytebuddy.version>1.12.19</bytebuddy.version>
+     <build.version.file>build_version.sh</build.version.file>
+     <slf4j.version>1.7.25</slf4j.version>
+-    <logback.version>1.2.9</logback.version>
+-    <netty.version>4.1.78.Final</netty.version>
++    <logback.version>1.2.13</logback.version>
++    <netty.version>4.1.108.Final</netty.version>
+     <mockito.version>3.5.13</mockito.version>
+     <prometheus.version>0.16.0</prometheus.version>
+     <!-- This old version is used by Cassandra 4.x -->
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
Upstream doesn't use tags to differentiate between supported Cassandra releases. Each new tag cut supports multiple Cassandra versions. Since latest cassandra is 5.0.1, we are adding this package, in a follow up PR, we are going to remove the existing v4
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
