### PR TITLE
sca diff mercurial.yaml

### DIFF
--- a/mercurial.yaml
+++ b/mercurial.yaml
@@ -1,7 +1,7 @@
 package:
   name: mercurial
   version: 6.8.1
-  epoch: 1
+  epoch: 2
   description: "Scalable distributed SCM tool"
   copyright:
     - license: GPL-2.0-or-later
@@ -39,7 +39,7 @@ pipeline:
       python3 -m installer -d "${{targets.destdir}}" \
         dist/*.whl
 
-      install -Dm755 contrib/hgk contrib/hg-ssh hgeditor -t "${{targets.destdir}}"/usr/bin
+      install -Dm755 contrib/hg-ssh hgeditor -t "${{targets.destdir}}"/usr/bin
 
       for man in doc/*.?; do
         install -Dm644 "$man" \

--- a/mercurial.yaml
+++ b/mercurial.yaml
@@ -1,7 +1,7 @@
 package:
   name: mercurial
   version: 6.8.1
-  epoch: 0
+  epoch: 1
   description: "Scalable distributed SCM tool"
   copyright:
     - license: GPL-2.0-or-later


### PR DESCRIPTION
- **mercurial: rebuild for new melange SCA metadata**
  > [!IMPORTANT]
  > `melange scan --diff` changes detected
  
  ```diff
  diff mercurial-6.8.1-r0.apk mercurial.yaml
  --- mercurial-6.8.1-r0.apk
  +++ mercurial.yaml
  @@ -8,6 +8,7 @@
   commit = c90afaa3648126122a82e9ceede66be60e5d43c4
   builddate = 1722597309
   license = GPL-2.0-or-later
  +depend = cmd:wish
   depend = python3
   depend = so:libc.so.6
   provides = cmd:hg-ssh=6.8.1-r0
  ```
  

- **mercurial: do not install hgk (tk GUI) resolves FTBFS**
  Skip installing hgk (tk-based GUI) as that pulls in graphical TK
  stack, and is unlikely to be useful.
  
  This prevents rebuild of this package generating uninstallable
  dependency on cmd:wish (tk stack), thus fixing a FTBFS.
  