### PR TITLE
add jnl required libs

### DIFF
--- a/sonarqube-10.yaml
+++ b/sonarqube-10.yaml
@@ -1,7 +1,7 @@
 package:
   name: sonarqube-10
   version: 10.7.0.96327
-  epoch: 1
+  epoch: 2
   description: SonarQube is an open source platform for continuous inspection of code quality
   copyright:
     - license: LGPL-3.0-or-later
@@ -12,6 +12,9 @@ package:
       - bash
       - bash-binsh # some operations depend on /bin/sh
       - sonarqube-startup
+      # java native library used on startup
+      - systemd-dev
+      - zstd-dev
 
 environment:
   contents:
@@ -23,6 +26,7 @@ environment:
       - npm
       - openjdk-17-default-jvm
       - yarn
+      - zstd-dev
   environment:
     LANG: en_US.UTF-8
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk


### PR DESCRIPTION
without these, the image fails on startup when introspecting the host:

```
    Suppressed: java.io.IOException: Native library (linux-aarch64/libzstd.so) not found in resource path ()
        at com.sun.jna.Native.extractFromResourcePath(Native.java:1145) ~[jna-5.12.1.jar:?]
        at com.sun.jna.NativeLibrary.loadLibrary(NativeLibrary.java:281) ~[jna-5.12.1.jar:?]
        at com.sun.jna.NativeLibrary.getInstance(NativeLibrary.java:467) ~[jna-5.12.1.jar:?]
        at com.sun.jna.Native.register(Native.java:1774) ~[jna-5.12.1.jar:?]
        at org.elasticsearch.nativeaccess.jna.JnaZstdLibrary.<init>(JnaZstdLibrary.java:32) ~[?:?]
        at org.elasticsearch.nativeaccess.lib.NativeLibraryProvider.getLibrary(NativeLibraryProvider.java:58) ~[elasticsearch-native-8.15.2.jar:?]
        at org.elasticsearch.nativeaccess.AbstractNativeAccess.<init>(AbstractNativeAccess.java:29) ~[elasticsearch-native-8.15.2.jar:?]
        at org.elasticsearch.nativeaccess.PosixNativeAccess.<init>(PosixNativeAccess.java:28) ~[elasticsearch-native-8.15.2.jar:?]
        at org.elasticsearch.nativeaccess.LinuxNativeAccess.<init>(LinuxNativeAccess.java:19) ~[elasticsearch-native-8.15.2.jar:?]
        at org.elasticsearch.nativeaccess.NativeAccessHolder.<clinit>(NativeAccessHolder.java:28) ~[elasticsearch-native-8.15.2.jar:?]
        at org.elasticsearch.nativeaccess.NativeAccess.instance(NativeAccess.java:22) ~[elasticsearch-native-8.15.2.jar:?]
        at org.elasticsearch.bootstrap.Elasticsearch.initializeNatives(Elasticsearch.java:285) ~[elasticsearch-8.15.2.jar:?]
        at org.elasticsearch.bootstrap.Elasticsearch.initPhase2(Elasticsearch.java:170) ~[elasticsearch-8.15.2.jar:?]
        at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:75) ~[elasticsearch-8.15.2.jar:?]
2024.10.18 15:38:07 WARN  es[][o.e.n.NativeAccess] Cannot check if running as root because native access is not available
```