### PR TITLE
set file capabilities on some iptables executables

### DIFF
--- a/iptables.yaml
+++ b/iptables.yaml
@@ -72,7 +72,7 @@ pipeline:
 
 subpackages:
   - name: iptables-cap_set_admin
-    description: iptables with extra file capabilities on executables in /sbin only to be used with linkerd.
+    description: iptables with cap_net_raw and cap_net_admin file capabilities on executables in /sbin
     options:
       no-provides: true
     pipeline:

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -77,9 +77,7 @@ subpackages:
       no-provides: true
     pipeline:
       - runs: |
-          mkdir -p ${{targets.contextdir}}/sbin
-          cp ${{targets.destdir}}/sbin/xtables-legacy-multi ${{targets.contextdir}}/sbin/xtables-legacy-multi
-          cp ${{targets.destdir}}/sbin/xtables-nft-multi ${{targets.contextdir}}/sbin/xtables-nft-multi
+          cp -r ${{targets.destdir}} ${{targets.contextdir}}
           setcap cap_net_raw,cap_net_admin+eip ${{targets.contextdir}}/sbin/xtables-legacy-multi
           setcap cap_net_raw,cap_net_admin+eip ${{targets.contextdir}}/sbin/xtables-nft-multi
 

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -1,7 +1,7 @@
 package:
   name: iptables
   version: 1.8.10
-  epoch: 4
+  epoch: 5
   description: Linux kernel firewall, NAT and packet mangling tools
   copyright:
     - license: GPL-2.0-or-later
@@ -17,6 +17,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - flex
+      - libcap-utils
       - libmnl-dev
       - libnftnl-dev
       - libtool
@@ -70,6 +71,18 @@ pipeline:
       install -D -m644 ebtables.confd "${{targets.destdir}}"/etc/conf.d/ebtables
 
 subpackages:
+  - name: iptables-privileged
+    description: iptables with extra file capabilities on executables in /sbin only to be used with linkerd.
+    options:
+      no-provides: true
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/sbin
+          cp ${{targets.destdir}}/sbin/xtables-legacy-multi ${{targets.contextdir}}/sbin/xtables-legacy-multi
+          cp ${{targets.destdir}}/sbin/xtables-nft-multi ${{targets.contextdir}}/sbin/xtables-nft-multi
+          setcap cap_net_raw,cap_net_admin+eip ${{targets.contextdir}}/sbin/xtables-legacy-multi
+          setcap cap_net_raw,cap_net_admin+eip ${{targets.contextdir}}/sbin/xtables-nft-multi
+
   - name: iptables-doc
     description: iptables documentation
     pipeline:

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -71,8 +71,8 @@ pipeline:
       install -D -m644 ebtables.confd "${{targets.destdir}}"/etc/conf.d/ebtables
 
 subpackages:
-  - name: iptables-cap_set_admin
-    description: iptables with cap_net_raw and cap_net_admin file capabilities on executables in /sbin
+  - name: iptables-xtables-privileged
+    description: iptables with cap_net_raw and cap_net_admin capabilities set for xtables
     options:
       no-provides: true
     pipeline:

--- a/iptables.yaml
+++ b/iptables.yaml
@@ -71,7 +71,7 @@ pipeline:
       install -D -m644 ebtables.confd "${{targets.destdir}}"/etc/conf.d/ebtables
 
 subpackages:
-  - name: iptables-privileged
+  - name: iptables-cap_set_admin
     description: iptables with extra file capabilities on executables in /sbin only to be used with linkerd.
     options:
       no-provides: true


### PR DESCRIPTION
these file capabilities are required by linkerd-proxy-init at runtime to run as non-root user with UID of 65532. 