### PR TITLE
vitess: mitigate some node CVEs

### DIFF
--- a/vitess-20.0.yaml
+++ b/vitess-20.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: vitess-20.0
   version: 20.0.2
-  epoch: 1
+  epoch: 2
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -56,6 +56,10 @@ pipeline:
       repository: https://github.com/vitessio/vitess
       tag: v${{package.version}}
       expected-commit: 2592c5932b3036647868299b6df76f8ef28dfbc8
+
+  - uses: patch
+    with:
+      patches: mitigate-CVEs.patch
 
   - uses: go/bump
     with:

--- a/vitess-20.0/mitigate-CVEs.patch
+++ b/vitess-20.0/mitigate-CVEs.patch
@@ -1,0 +1,76 @@
+From 658569d183da84d55816c9ee599ac664224af036 Mon Sep 17 00:00:00 2001
+From: Dentrax <furkan.turkal@chainguard.dev>
+Date: Fri, 18 Oct 2024 21:03:39 +0300
+Subject: [PATCH] mitigate CVEs
+
+Signed-off-by: Dentrax <furkan.turkal@chainguard.dev>
+---
+ web/vtadmin/package-lock.json | 26 +++++++++++++-------------
+ 1 file changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/web/vtadmin/package-lock.json b/web/vtadmin/package-lock.json
+index cda1061d5d..3e1ed7219f 100644
+--- a/web/vtadmin/package-lock.json
++++ b/web/vtadmin/package-lock.json
+@@ -14130,9 +14130,9 @@
+       }
+     },
+     "node_modules/path-to-regexp": {
+-      "version": "6.2.2",
+-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
++      "version": "6.3.0",
++      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
++      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+       "dev": true
+     },
+     "node_modules/path-type": {
+@@ -15538,9 +15538,9 @@
+       "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+     },
+     "node_modules/react-router/node_modules/path-to-regexp": {
+-      "version": "1.8.0",
+-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
++      "version": "1.9.0",
++      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
++      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+       "dependencies": {
+         "isarray": "0.0.1"
+       }
+@@ -16009,9 +16009,9 @@
+       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
+     },
+     "node_modules/rollup": {
+-      "version": "3.29.4",
+-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+-      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
++      "version": "3.29.5",
++      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
++      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+       "dev": true,
+       "bin": {
+         "rollup": "dist/bin/rollup"
+@@ -17768,9 +17768,9 @@
+       }
+     },
+     "node_modules/vite-plugin-eslint/node_modules/rollup": {
+-      "version": "2.79.1",
+-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
++      "version": "2.79.2",
++      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
++      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+       "dev": true,
+       "bin": {
+         "rollup": "dist/bin/rollup"
+@@ -18312,4 +18312,4 @@
+       }
+     }
+   }
+-}
++}
+\ No newline at end of file
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
Mitigates:
```
│/vt/web/vtadmin/node_modules/path-to-regexp/package.json
│       📦 path-to-regexp 6.2.2 (npm)
│           High CVE-2024-45296 GHSA-9wv6-86v2-598j fixed in 6.3.0
├── 📄 /vt/web/vtadmin/node_modules/react-router/node_modules/path-to-regexp/package.json
│       📦 path-to-regexp 1.8.0 (npm)
│           High CVE-2024-45296 GHSA-9wv6-86v2-598j fixed in 1.9.0
├── 📄 /vt/web/vtadmin/node_modules/rollup/package.json
│       📦 rollup 3.29.4 (npm)
│           High CVE-2024-47068 GHSA-gcx4-mw62-g8wm fixed in 3.29.5
├── 📄 /vt/web/vtadmin/node_modules/vite-plugin-eslint/node_modules/rollup/package.json
│       📦 rollup 2.79.1 (npm)
│           High CVE-2024-47068 GHSA-gcx4-mw62-g8wm fixed in 2.79.2
```