### PR TITLE
libreoffice-24.2 - use boost lib bundled by libreoffice.

### DIFF
--- a/libreoffice-24.2.yaml
+++ b/libreoffice-24.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libreoffice-24.2
   version: 24.2.7.1
-  epoch: 1
+  epoch: 2
   description:
   # https://www.libreoffice.org/about-us/licenses
   copyright:
@@ -14,7 +14,6 @@ package:
   dependencies:
     runtime:
       - argon2
-      - boost
       - cairo
       - cups-libs
       - dbus-libs
@@ -47,7 +46,6 @@ environment:
       - automake
       - bash
       - bison
-      - boost-dev
       - build-base
       - busybox
       - cairo-dev
@@ -139,7 +137,6 @@ pipeline:
       --with-system-openssl
       --with-system-cairo
       --with-system-zlib
-      --with-system-boost
       --with-system-curl
       --host=${{host.triplet.gnu}}
       --build=${{host.triplet.gnu}}
@@ -181,3 +178,18 @@ test:
   pipeline:
     - runs: |
         /usr/lib/libreoffice/program/soffice.bin --help
+    - name: convert a csv to pdf
+      runs: |
+        set -- /usr/lib/libreoffice/program/soffice.bin --convert-to pdf my.csv
+        printf "#%s\n%s\n" "#dist,vulns,happiness" "wolfi,0,100" > my.csv
+        set -x
+        cat my.csv
+        # We do have to run this twice.  The first time creates .config
+        # ~/.config/libreofficedev/ but then does nothing.
+        "$@" || echo "'$*' exited $? the first time.  that is probably ok"
+        "$@" || {
+          echo "FAIL: '$*' exited $? the second time."
+          exit 1
+        }
+        [ -f my.pdf ] ||
+          { echo "FAIL: Expected my.pdf file does not exist"; exit 1; }


### PR DESCRIPTION
We saw bug using convert with the system boost (currently 1.86.0). Switching to using libreoffice's bundled version fixed.

The problem was as easy to recreate as:

    $ echo "1,scott,taco" > my.csv
    $ /usr/lib/libreoffice/program/soffice.bin --convert-to pdf my.csv
    Unspecified Application Error
    $ echo $?
    1

After compiling with `--enable-dbgutil`, then we got some more information out that pointed me in this direction.

    warn:legacy.tools:249:249:sfx2/source/appl/appuno.cxx:452:
      invalid type for Stream
    warn:sal.osl:249:249:sal/osl/unx/module.cxx:100:
      dlopen(/binds/libreoffice/instdir/program/libscfiltlo.so, 1):
       /binds/libreoffice/instdir/program/liborcus-0.18.so.0:
         undefined symbol: _ZN5boost9iostreams4zlib10stream_endE
    warn:sal.osl:249:249:sal/osl/unx/module.cxx:100:
      dlopen(libscfiltlo.so, 1):
       /binds/libreoffice/instdir/program/liborcus-0.18.so.0:
        undefined symbol: _ZN5boost9iostreams4zlib10stream_endE
    soffice.bin: /binds/libreoffice/sc/source/ui/docshell/impex.cxx:2668:
       ScFormatFilter::Get()::<lambda()>: Assertion `false' failed.
