### PR TITLE
ksh-1.0.10: new package

### DIFF
--- a/ksh.yaml
+++ b/ksh.yaml
@@ -36,8 +36,8 @@ test:
   environment:
     contents:
       packages:
-      - build-base
-      - busybox
+        - build-base
+        - busybox
   pipeline:
     - runs: |
         version=$(/bin/ksh -c "eval 'echo "\${.sh.version}"' 2>/dev/null")

--- a/ksh.yaml
+++ b/ksh.yaml
@@ -33,7 +33,12 @@ update:
     use-tag: true
 
 test:
+  environment:
+    contents:
+      packages:
+      - build-base
+      - busybox
   pipeline:
     - runs: |
-        ksh --version
-        ksh --help
+        version=$(/bin/ksh -c "eval 'echo "\${.sh.version}"' 2>/dev/null")
+        echo "$version" | grep "${{package.version}}"

--- a/ksh.yaml
+++ b/ksh.yaml
@@ -1,0 +1,43 @@
+package:
+  name: ksh
+  version: 1.0.10
+  epoch: 1
+  description: "KornShell 93u+m"
+  copyright:
+    - license: EPL-2.0
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - build-base
+      - busybox
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ksh93/ksh
+      tag: v${{package.version}}
+      expected-commit: f0999ab76dd2e0d977298348ec5c4535a360710d
+
+  - runs: |
+      bin/package make
+      bin/package install ${{targets.destdir}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: ksh93/ksh
+    strip-prefix: v
+    use-tag: true
+
+test:
+  pipeline:
+    - runs: |
+        ksh --version
+        ksh --help

--- a/ksh.yaml
+++ b/ksh.yaml
@@ -8,10 +8,6 @@ package:
 
 environment:
   contents:
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-    repositories:
-      - https://packages.wolfi.dev/os
     packages:
       - build-base
       - busybox

--- a/ksh.yaml
+++ b/ksh.yaml
@@ -1,7 +1,7 @@
 package:
   name: ksh
   version: 1.0.10
-  epoch: 1
+  epoch: 0
   description: "KornShell 93u+m"
   copyright:
     - license: EPL-2.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/31020

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
