### PR TITLE
sca diff cython 0.yaml

### DIFF
--- a/cython-0.yaml
+++ b/cython-0.yaml
@@ -15,9 +15,9 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-setuptools
-      - python3
-      - python3-dev
+      - py3.12-setuptools
+      - python-3.12
+      - python-3.12-dev
 
 pipeline:
   - uses: git-checkout
@@ -27,8 +27,8 @@ pipeline:
       tag: ${{package.version}}
 
   - runs: |
-      python setup.py build
-      python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+      python3.12 setup.py build
+      python3.12 setup.py install --prefix=/usr --root="${{targets.destdir}}"
 
   - uses: strip
 

--- a/cython-0.yaml
+++ b/cython-0.yaml
@@ -1,7 +1,7 @@
 package:
   name: cython-0
   version: 0.29.37.1
-  epoch: 0
+  epoch: 1
   description: Cython is an optimising static compiler for both the Python & the extended Cython programming languages.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
- **cython-0: rebuild for new melange SCA metadata**
  > [!IMPORTANT]
  > `melange scan --diff` changes detected
  
  ```diff
  diff cython-0-0.29.37.1-r0.apk cython-0.yaml
  --- cython-0-0.29.37.1-r0.apk
  +++ cython-0.yaml
  @@ -8,7 +8,7 @@
   commit = 002a76dd4ae1d29cf64824bb48d6022451d6aaca
   builddate = 1702990317
   license = Apache-2.0
  -depend = python3~3.12
  +depend = python-3.12-base
   depend = so:libc.so.6
   provides = cmd:cygdb=0.29.37.1-r0
   provides = cmd:cython=0.29.37.1-r0
  ```
  

- **Fix she-bang lines to use an explicit single python**
  Note this cython-0 appears to only be used as build-dependency in a
  couple of packages. Majority of things use multi-version py3-cython
  v3.
  