### PR TITLE
add falco-exporter

### DIFF
--- a/falco-exporter.yaml
+++ b/falco-exporter.yaml
@@ -1,0 +1,60 @@
+package:
+  name: falco-exporter
+  version: 0.8.7
+  epoch: 0
+  description: Prometheus Metrics Exporter for Falco output events
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 573cccb096fab90874747607522e30f7b09cb4b1
+      repository: https://github.com/falcosecurity/falco-exporter
+      tag: v${{package.version}}
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/net@v0.23.0
+
+  - uses: go/build
+    with:
+      packages: ./cmd/falco-exporter
+      output: falco-exporter
+
+update:
+  enabled: true
+  github:
+    identifier: falcosecurity/falco-exporter
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+  pipeline:
+    - name: "Verify Installation"
+      runs: |
+        set +e
+        falco-exporter --help
+        if [ $? -ne 2 ]; then
+          echo "expected 2, got $?"
+          exit 1
+        fi
+    - name: "start daemon"
+      uses: test/daemon-check-output
+      with:
+        start: falco-exporter
+        timeout: 60
+        setup: ""
+        expected_output: |
+          listening on
+        post: |
+          #!/bin/sh -e
+          response=$(curl -s localhost:9376/metrics)
+          if ! echo "$response" | grep -q 'promhttp_metric_handler_requests_total'; then
+            echo "expected metric not found"
+            echo "$response"
+            exit 1
+          fi


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
