### PR TITLE
rancher-webhook-0.5: switch to git update config as there are lots of pre-releases which means graphql doesn't find the v0.5 stream

### DIFF
--- a/rancher-webhook-0.5.yaml
+++ b/rancher-webhook-0.5.yaml
@@ -38,7 +38,6 @@ pipeline:
 
 update:
   enabled: true
-  github:
-    identifier: rancher/webhook
+  git:
     strip-prefix: v
     tag-filter-prefix: v0.5.


### PR DESCRIPTION
Update check is expected to fail, the bot will create a followup package update PR once the config is fixed