### PR TITLE
use go/build pipeline instead of make for kaniko packages

### DIFF
--- a/kaniko.yaml
+++ b/kaniko.yaml
@@ -1,7 +1,7 @@
 package:
   name: kaniko
   version: 1.23.2
-  epoch: 2
+  epoch: 3
   description: Build Container Images In Kubernetes
   copyright:
     - license: Apache-2.0
@@ -25,23 +25,20 @@ pipeline:
       deps: github.com/opencontainers/runc@v1.1.12 google.golang.org/grpc@v1.64.1
       tidy: false
 
-  - runs: |
-      go mod tidy
-      go mod vendor
-      mkdir -p "${{targets.destdir}}"/usr/bin
-      make out/executor
-      install -m755 -D out/executor "${{targets.destdir}}"/usr/bin/executor
-
-  - uses: strip
+  - uses: go/build
+    with:
+      output: executor
+      packages: ./cmd/executor
+      ldflags: -X github.com/GoogleContainerTools/kaniko/pkg/version.Version=v${{package.version}}
 
 subpackages:
   - name: kaniko-warmer
     pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/bin
-          make out/warmer
-          install -m755 -D out/warmer "${{targets.subpkgdir}}"/usr/bin/warmer
-      - uses: strip
+      - uses: go/build
+        with:
+          output: warmer
+          packages: ./cmd/warmer
+          ldflags: -X github.com/GoogleContainerTools/kaniko/pkg/version.Version=v${{package.version}}
     test:
       pipeline:
         - runs: |


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
