### PR TITLE
add cloudprober

### DIFF
--- a/cloudprober.yaml
+++ b/cloudprober.yaml
@@ -1,0 +1,45 @@
+package:
+  name: cloudprober
+  version: 0.13.7
+  epoch: 0
+  description: An active monitoring software to detect failures before your customers do.
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: faf74212e6c4479df1c6027271b71eef54ef1774
+      repository: https://github.com/cloudprober/cloudprober
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      ldflags: |
+        -w
+        -X 'main.version=${{package.version}}'
+        -X 'main.buildTimestamp=$(date +%s)'
+        -X 'main.dirty=$(git diff --shortstat 2> /dev/null | wc -l | xargs)'
+      packages: ./cmd/cloudprober
+      output: cloudprober
+
+subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          # Symlink the binary from usr/bin to /
+          mkdir -p "${{targets.contextdir}}"/
+          ln -sf /usr/bin/cloudprober ${{targets.contextdir}}/cloudprober
+
+update:
+  enabled: true
+  github:
+    identifier: cloudprober/cloudprober
+    strip-prefix: v
+
+test:
+  pipeline:
+    - name: "Verify Installation"
+      runs: |
+        cloudprober --help
+        cloudprober -buildinfo


### PR DESCRIPTION
https://github.com/cloudprober/cloudprober/tree/master

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
