### PR TITLE
jitterentropy-library: resurrect 3.5.0 build

### DIFF
--- a/jitterentropy-library-latest.yaml
+++ b/jitterentropy-library-latest.yaml
@@ -1,10 +1,13 @@
 package:
-  name: jitterentropy-library
-  version: 3.5.0
-  epoch: 0
+  name: jitterentropy-library-latest
+  version: 3.6.0
+  epoch: 1
   description: Jitterentropy Library
   copyright:
     - license: BSD-3-Clause
+  dependencies:
+    provides:
+      - jitterentropy-library=${{package.full-version}}
 
 environment:
   contents:
@@ -16,7 +19,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/smuellerDD/jitterentropy-library
-      expected-commit: 48b2ffc128af776ff3658a70e5d7bb4a82180189
+      expected-commit: 7199c8959347b0e8342df7dc6e0c1fc4b484d2fb
       tag: v${{package.version}}
 
   - runs: |
@@ -38,7 +41,13 @@ subpackages:
       - uses: split/manpages
       - uses: split/static
     description: ${{package.name}} development headers and static library
+    dependencies:
+      provides:
+        - jitterentropy-library-dev=${{package.full-version}}
 
 update:
-  enabled: false
-  exclude-reason: Certified build https://csrc.nist.gov/projects/cryptographic-module-validation-program/entropy-validations/certificate/191
+  enabled: true
+  github:
+    identifier: smuellerDD/jitterentropy-library
+    strip-prefix: v
+    use-tag: true

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.3.2
-  epoch: 2
+  epoch: 3
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - jitterentropy-library-dev=3.5.0-r0
+      - jitterentropy-library=3.5.0-r0
       - openssf-compiler-options
       - perl
   environment:


### PR DESCRIPTION
"revert" jitterentropy-library.yaml back to 3.5.0, move 3.6.0 builds
to -latest.yaml instead.

This pacifies wolfictl text complaints w.r.t. allowing builds against
older versions of a given package.
