### PR TITLE
jitterentropy-library: add 3.5.0 provides

### DIFF
--- a/jitterentropy-library.yaml
+++ b/jitterentropy-library.yaml
@@ -1,10 +1,13 @@
 package:
   name: jitterentropy-library
   version: 3.6.0
-  epoch: 0
+  epoch: 1
   description: Jitterentropy Library
   copyright:
     - license: BSD-3-Clause
+  dependencies:
+    provides:
+      - ${{package.name}}=3.5.0
 
 environment:
   contents:
@@ -38,6 +41,9 @@ subpackages:
       - uses: split/manpages
       - uses: split/static
     description: ${{package.name}} development headers and static library
+    dependencies:
+      provides:
+        - ${{package.name}}-dev=3.5.0
 
 update:
   enabled: true

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.3.2
-  epoch: 2
+  epoch: 3
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - jitterentropy-library-dev~3.5.0
+      - jitterentropy-library~3.5.0
       - openssf-compiler-options
       - perl
   environment:


### PR DESCRIPTION
Add provides on jitterentropy-library for an old version, such that
one can build against old 3.5.0-r0 build, bypassing wolfictl text
build-dependency cycles protection.

> failed to bundle: targets: duplicate package: "jitterentropy-library" exists in both "/workspace/repo173829354/jitterentropy-library.yaml" and "/workspace/repo173829354/jitterentropy-library.yaml"

no dice.
