### PR TITLE
kafka_exporter: add compat and expand tests

### DIFF
--- a/kafka_exporter.yaml
+++ b/kafka_exporter.yaml
@@ -36,7 +36,39 @@ update:
     strip-prefix: v
 
 test:
+  environment:
+    contents:
+      packages:
+        - curl
+        - kafka
+        - uuidgen
+    environment:
+      JAVA_HOME: "/usr/lib/jvm/default-jvm"
   pipeline:
     - runs: |
         kafka_exporter --version
         kafka_exporter --help
+    - name: "Test with Kafka"
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          cd /usr/lib/kafka
+          bin/zookeeper-server-start.sh config/zookeeper.properties &
+          mv config/server.properties.original config/server.properties
+          bin/kafka-server-start.sh config/server.properties &
+          sleep 5
+          TOPIC_NAME="test-topic-$(uuidgen)"
+          PARTITIONS=1
+          REPLICATION_FACTOR=1
+          # Create a Kafka topic
+          bin/kafka-topics.sh --create --topic "${TOPIC_NAME}" --partitions "${PARTITIONS}" --replication-factor "${REPLICATION_FACTOR}" --if-not-exists --bootstrap-server localhost:9092
+          # Produce a test message
+          echo "Hello Kafka" | bin/kafka-console-producer.sh --broker-list localhost:9092 --topic "${TOPIC_NAME}"
+        start: kafka_exporter --kafka.server=0.0.0.0:9092
+        timeout: 15
+        expected_output: |
+          Starting kafka_exporter
+          Listening on
+        post: |
+          sleep 5 # Wait awhile until the Kafka metrics are scraped
+          curl http://localhost:9308/metrics | grep kafka_topic_partitions

--- a/kafka_exporter.yaml
+++ b/kafka_exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: kafka_exporter
   version: 1.8.0
-  epoch: 1
+  epoch: 2
   description: "Kafka exporter for Prometheus"
   copyright:
     - license: Apache-2.0
@@ -19,6 +19,15 @@ pipeline:
       output: kafka_exporter
 
   - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          # https://github.com/danielqsj/kafka_exporter/blob/477643dd764c46ddd804ac4bd4022be877e3085b/Dockerfile#L7
+          mkdir -p "${{targets.contextdir}}/bin"
+          ln -sf /usr/bin/kafka_exporter ${{targets.contextdir}}/bin/kafka_exporter
 
 update:
   enabled: true


### PR DESCRIPTION
Adds `-compat` for `kafka_exporter`: https://github.com/danielqsj/kafka_exporter/blob/v1.8.0/Dockerfile