### PR TITLE
bump the jdk to 21 for cloudwatch-exporter

### DIFF
--- a/cloudwatch-exporter.yaml
+++ b/cloudwatch-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudwatch-exporter
   version: 0.16.0 # Check if the version bump in the mvn command is still needed next time this package is updated
-  epoch: 0
+  epoch: 1
   description: Metrics exporter for Amazon AWS CloudWatch
   copyright:
     - license: Apache-2.0
@@ -15,8 +15,8 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-21
+      - openjdk-21-default-jvm
 
 pipeline:
   - uses: git-checkout

--- a/cloudwatch-exporter/pombump-deps.yaml
+++ b/cloudwatch-exporter/pombump-deps.yaml
@@ -3,3 +3,14 @@ patches:
     artifactId: netty-codec-http
     version: 4.1.108.Final
     scope: import
+  - groupId: org.eclipse.jetty
+    artifactId: jetty-servlet
+    version: 11.0.24
+    scope: import
+  # - groupId: org.eclipse.jetty
+  #   artifactId: jetty-http
+  #   version: 12.0.12
+  #   scope: import
+
+# GHSA-qh8g-58pp-2wxh
+# GHSA-g8m5-722r-8whq


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

I'm going to create an advisory entry for the CVE because when I tried to bump the dependency to the fixed version but the compilation failed.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
