### PR TITLE
py3-fastbencode: build with cython to install compiled extension

### DIFF
--- a/py3-fastbencode.yaml
+++ b/py3-fastbencode.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-fastbencode
   version: 0.3.1
-  epoch: 1
+  epoch: 2
   description: Implementation of bencode with optional fast C extensions
   copyright:
     - license: GPL-2.0-or-later
@@ -23,7 +23,11 @@ data:
 environment:
   contents:
     packages:
+      - build-base
+      - cython
       - py3-supported-build-base
+      - py3-supported-cython
+      - py3-supported-python-dev
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
This enables accerated code paths in fastbencode.

Spotted via UserWarning upon loading:

```
/usr/lib/python3.12/site-packages/fastbencode/__init__.py:51: UserWarning: failed to load compiled extension: No module named 'fastbencode._bencode_pyx' uses=python/import
```

Fixes: #31296
