### PR TITLE
Add dependency on libgcc

### DIFF
--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,10 +1,13 @@
 package:
   name: apache2
   version: 2.4.62
-  epoch: 2
+  epoch: 3
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - libgcc
 
 environment:
   contents:


### PR DESCRIPTION
Fixes this warning/issue about libgcc:

libgcc_s.so.1 must be installed for pthread_exit to work