### PR TITLE
glibc: make libc.so.6 depend on libgcc_s.so.1

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.40
-  epoch: 2
+  epoch: 3
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -16,6 +16,8 @@ package:
       # the ! constraint.
       - '!musl'
       - glibc-locale-posix
+      # Needed for some pthread functionality
+      - libgcc
       - wolfi-baselayout
   scriptlets:
     trigger:


### PR DESCRIPTION
pthread which has been merged into libc.so.6 at runtime may require
libgcc_s.so.1 without being explicitely linked to it due to bootstrap
/ dependency cycles.

Add an APK level runtime dependency between the two, like it is done
in other distributions. This may fix pthread issues in many
packages. It will introduce redundant copies of libgcc_s.so.1 in a few
places, however it is tiny 196K uncompressed.

A better SCA way of doing this would be to inspect all symbols used by
a given library or binary, and detected if pthread_* or atexit()
symbols used, which require libgcc_s support library at runtime, and
then generate a dependency on libgcc. I'm not sure if implementing
that is benefitial compared to always installing libgcc. As externally
fetched plugins may eventually require libgcc without APK level
knowledged about it.
