### PR TITLE
openssl: fetch a pinned build of jitterentropy-library

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.3.2
-  epoch: 2
+  epoch: 3
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -30,6 +30,12 @@ environment:
     CXXFLAGS: ""
     LDFLAGS: ""
 
+vars:
+  # Certified version of jitter library to fetch. Note wolfictl text
+  # prohibits listing old '- jitterentropy-library-dev=3.5.0-r0' in
+  # environment above
+  jitter-pkg: "jitterentropy-library-dev-3.5.0-r0.apk"
+
 pipeline:
   - uses: git-checkout
     with:
@@ -38,6 +44,25 @@ pipeline:
       expected-commit: fb7fab9fa6f4869eaa8fbb97e0d593159f03ffe4
       cherry-picks: |
         openssl-3.3/c0d3e4d32d2805f49bec30547f225bc4d092e1f4: CVE-2024-9143 fixes
+
+  - if: ${{build.arch}} == 'aarch64'
+    uses: fetch
+    with:
+      uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
+      expected-sha256: "32f42bd6fe32aee1718e382a6533bed413dd452cbb7f180166eb4709c362c09c"
+      extract: false
+
+  - if: ${{build.arch}} == 'x86_64'
+    uses: fetch
+    with:
+      uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
+      expected-sha256: "0e59f969478959dd7bdb1198faa034c12808ea0f79390bc21a8323812d9c4df1"
+      extract: false
+
+  - name: Extract certified jitter entropy
+    runs: |
+      mkdir -p jitter/
+      tar -C jitter -x -f ${{vars.jitter-pkg}} 2>/dev/null
 
   - name: Create dbg sourcecode
     runs: |
@@ -76,6 +101,8 @@ pipeline:
          no-seed \
          no-weak-ssl-ciphers \
          -Wa,--noexecstack
+      # TODO v3.4.0 build will add
+      # --with-jitter-include=jitter/usr/include --with-jitter-library=jitter/usr/lib
       perl configdata.pm --dump
       make -j$(nproc)
 


### PR DESCRIPTION
Fetch a pinned build of certified jitterentropy-library. Note
currently only 3.5.0-r0 has been certified. Will be used by OpenSSL
3.4.0.
