### PR TITLE
[GenAI] TigerBeetle Package Tests

### DIFF
--- a/tigerbeetle.yaml
+++ b/tigerbeetle.yaml
@@ -43,4 +43,3 @@ test:
     - name: Check if TigerBeetle was installed
       runs: |
         tigerbeetle --help
-        

--- a/tigerbeetle.yaml
+++ b/tigerbeetle.yaml
@@ -43,3 +43,4 @@ test:
     - name: Check if TigerBeetle was installed
       runs: |
         tigerbeetle --help
+        

--- a/tigerbeetle.yaml
+++ b/tigerbeetle.yaml
@@ -1,6 +1,6 @@
 package:
   name: tigerbeetle
-  version: 0.16.5
+  version: 0.16.9
   epoch: 0
   description: "The distributed financial accounting database designed for mission critical safety and performance."
   copyright:
@@ -19,7 +19,7 @@ pipeline:
     with:
       repository: https://github.com/tigerbeetledb/tigerbeetle
       tag: ${{package.version}}
-      expected-commit: 2d5d5e68de71c0723d82896f003fc4dc87a7f763
+      expected-commit: a082ff0237d5083f35e70d56c550ce271b6e4bf7
 
   - runs: |
       zig build -Drelease

--- a/tigerbeetle.yaml
+++ b/tigerbeetle.yaml
@@ -1,6 +1,6 @@
 package:
   name: tigerbeetle
-  version: 0.16.5
+  version: 0.16.9
   epoch: 0
   description: "The distributed financial accounting database designed for mission critical safety and performance."
   copyright:
@@ -19,7 +19,7 @@ pipeline:
     with:
       repository: https://github.com/tigerbeetledb/tigerbeetle
       tag: ${{package.version}}
-      expected-commit: 2d5d5e68de71c0723d82896f003fc4dc87a7f763
+      expected-commit: a082ff0237d5083f35e70d56c550ce271b6e4bf7
 
   - runs: |
       zig build -Drelease
@@ -37,9 +37,3 @@ update:
     use-tag: true
     # There are some prereleases with a weird WEEKLY format.
     tag-filter: 0.
-
-test:
-  pipeline:
-    - name: Check if TigerBeetle was installed
-      runs: |
-        tigerbeetle --help

--- a/tigerbeetle.yaml
+++ b/tigerbeetle.yaml
@@ -1,6 +1,6 @@
 package:
   name: tigerbeetle
-  version: 0.16.9
+  version: 0.16.5
   epoch: 0
   description: "The distributed financial accounting database designed for mission critical safety and performance."
   copyright:
@@ -19,7 +19,7 @@ pipeline:
     with:
       repository: https://github.com/tigerbeetledb/tigerbeetle
       tag: ${{package.version}}
-      expected-commit: a082ff0237d5083f35e70d56c550ce271b6e4bf7
+      expected-commit: 2d5d5e68de71c0723d82896f003fc4dc87a7f763
 
   - runs: |
       zig build -Drelease
@@ -37,3 +37,9 @@ update:
     use-tag: true
     # There are some prereleases with a weird WEEKLY format.
     tag-filter: 0.
+
+test:
+  pipeline:
+    - name: Check if TigerBeetle was installed
+      runs: |
+        tigerbeetle --help


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Tests if--help can be run on tigerbeetle after installation

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
