### PR TITLE
fix: crossplane-provider-sql github update location

### DIFF
--- a/crossplane-provider-sql.yaml
+++ b/crossplane-provider-sql.yaml
@@ -43,7 +43,7 @@ pipeline:
 update:
   enabled: true
   github:
-    identifier: crossplane/provider-sql
+    identifier: crossplane-contrib/provider-sql
     strip-prefix: v
 
 test:


### PR DESCRIPTION
Upstream location has moved no epoch is needed for this change 

```
      expected-commit: afdf5802c7445e6ed42db11b35e1a45d8f2771dd
      repository: https://github.com/crossplane-contrib/provider-sql
      tag: v${{package.version}}
```