### PR TITLE
openssl: new release 3.4.0

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -30,8 +30,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - jitterentropy-library-dev=3.5.0-r0
       # NB! pinned to version https://csrc.nist.gov/projects/cryptographic-module-validation-program/entropy-validations/certificate/191
+      - jitterentropy-library-dev=3.5.0-r0
       - jitterentropy-library=3.5.0-r0
       - openssf-compiler-options
       - perl
@@ -147,6 +147,11 @@ subpackages:
 
   - name: "openssl-dev"
     description: "OpenSSL headers"
+    dependencies:
+      runtime:
+        # TODO: for static linking only, split into openssl-static, or fix upstream
+        - jitterentropy-library-dev=3.5.0-r0
+        - jitterentropy-library=3.5.0-r0
     pipeline:
       - uses: split/dev
     test:

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,8 @@
+#nolint:forbidden-repository-used,forbidden-keyring-used
 package:
   name: openssl
-  version: 3.3.2
-  epoch: 2
+  version: 3.4.0
+  epoch: 0
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -17,10 +18,21 @@ package:
 
 environment:
   contents:
+    # NB! accessing historic, but certified build of
+    # jitterentropy-library-dev=3.5.0-r0. In a fresh bootstrap build
+    # any version of jitternetropy-library and get an ESV certificate
+    # for it.
+    build_repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - jitterentropy-library-dev=3.5.0-r0
+      # NB! pinned to version https://csrc.nist.gov/projects/cryptographic-module-validation-program/entropy-validations/certificate/191
+      - jitterentropy-library=3.5.0-r0
       - openssf-compiler-options
       - perl
   environment:
@@ -33,11 +45,9 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/openssl/openssl.git
+      repository: https://github.com/openssl/openssl
       tag: openssl-${{package.version}}
-      expected-commit: fb7fab9fa6f4869eaa8fbb97e0d593159f03ffe4
-      cherry-picks: |
-        openssl-3.3/c0d3e4d32d2805f49bec30547f225bc4d092e1f4: CVE-2024-9143 fixes
+      expected-commit: 98acb6b02839c609ef5b837794e08d906d965335
 
   - name: Create dbg sourcecode
     runs: |
@@ -62,7 +72,9 @@ pipeline:
          --libdir=lib \
          --openssldir=/etc/ssl \
          enable-ktls \
+         enable-jitter \
          shared \
+         enable-pie \
          no-zlib \
          no-async \
          no-comp \
@@ -78,6 +90,7 @@ pipeline:
          -Wa,--noexecstack
       perl configdata.pm --dump
       make -j$(nproc)
+      make tests HARNESS_JOBS=10
 
   - uses: autoconf/make-install
 
@@ -172,8 +185,13 @@ test:
   pipeline:
     - uses: test/hardening-check
       with:
-        package-match: "^openssl$\\|libssl3\\|libcrypto3"
-      runs: |
+        package-match: "^openssl$\\|libssl3"
+    - uses: test/hardening-check
+      with:
+        # jitterentropy is without CF protection so far
+        args: "--nocfprotection"
+        package-match: "^libcrypto3$"
+    - runs: |
         openssl --version
         openssl --help
     - name: Verify curl still works


### PR DESCRIPTION
Enable jitter seed source, compiled with jitterentropy-library, using
manually fetched certified build.

Enable PIE (position independent executables).

Enable executing test-suite.

Update hardening-check to expected values, no CF protection on
libcrypto, due to jitterentroply library being linked.

Fixes: https://github.com/wolfi-dev/os/pull/31548