### PR TITLE
add nginx-prometheus-exporter

### DIFF
--- a/nginx-prometheus-exporter.yaml
+++ b/nginx-prometheus-exporter.yaml
@@ -1,0 +1,60 @@
+package:
+  name: nginx-prometheus-exporter
+  version: 1.3.0
+  epoch: 0
+  description: NGINX Prometheus Exporter for NGINX and NGINX Plus
+  copyright:
+    - license: Apache-2.0
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 9522f4e39ee1aed817d7d70a89514ccc0ae1594a
+      repository: https://github.com/nginxinc/nginx-prometheus-exporter
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      ldflags: |
+        -w
+        -X=github.com/prometheus/common/version.Version=${{package.version}}
+        -X=main.version=${{package.version}}
+      output: nginx-prometheus-exporter
+      packages: .
+
+update:
+  enabled: true
+  github:
+    identifier: nginxinc/nginx-prometheus-exporter
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+        - shadow
+        - nginx
+  pipeline:
+    - name: "Verify Installation"
+      runs: nginx-prometheus-exporter --version
+    - name: "start daemon"
+      uses: test/daemon-check-output
+      with:
+        start: nginx-prometheus-exporter
+        timeout: 60
+        setup: |
+          useradd nginx
+          mkdir -p /var/lib/nginx/logs
+          mkdir -p /var/lib/nginx/tmp
+          nginx -g "daemon off;" &
+        expected_output: |
+          Listening on
+        post: |
+          #!/bin/sh -e
+          response=$(curl -s localhost:9113/metrics)
+          if ! echo "$response" | grep -q 'nginx_up'; then
+            echo "expected metric not found"
+            echo "$response"
+            exit 1
+          fi


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
