### PR TITLE
Add pipeline for populating /etc/passwd,group; use in py3-breezy test

### DIFF
--- a/pipelines/test/populated-etc-passwd.yaml
+++ b/pipelines/test/populated-etc-passwd.yaml
@@ -1,0 +1,48 @@
+# When melange test runs the bubblewrap runner, the user (1000)
+# is not present in /etc/passwd. That can cause problems for any
+# program that does a getpwent.
+name: Ensure that /etc/passwd is populated
+
+needs:
+  packages:
+    - busybox
+
+inputs:
+  content:
+    description: |
+      what do you want to run. content will be executed as if it were 'run' section.
+    required: true
+
+pipeline:
+  - name: "add uid to /etc/passwd /etc/group"
+    runs: |
+      set +x
+      fail() { echo "ERROR:" "$@" 1>&2; exit 1; }
+
+      groupn="test-group"
+      usern="test-user"
+      # add entry for this user to /etc/passwd if not present.
+      uid=$(id -u) || { echo "ERROR: id -u failed"; exit 1; }
+      gid=$(id -g) || { echo "ERROR: id -g failed"; exit 1; }
+      added=""
+
+      if ! uout=$(id -un 2>/dev/null); then
+        added=user
+        echo "$usern:x:$uid:$gid:test user:${HOME:-$PWD}:/bin/sh" >>/etc/passwd
+        uout=$(id -un 2>&1) && [ "$uout" = "$usern" ] ||
+           fail "adding user to /etc/passwd didn't work: $uout"
+      fi
+
+      if ! gout=$(id -gn 2>/dev/null); then
+        added="$added group"
+        echo "$groupn:x:$gid:$usern" >>/etc/group
+        gout=$(id -gn 2>&1) && [ "$gout" = "$groupn" ] ||
+           fail "adding group $groupn to /etc/group didn't work: $gout"
+      fi
+
+      echo "running as uid=$uid gid=$gid" \
+        "name=$uout group=$gout${added:+ [added ${added# }]}"
+
+  - name: "execute content"
+    runs: |
+      ${{inputs.content}}

--- a/py3-breezy.yaml
+++ b/py3-breezy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-breezy
   version: 3.3.9
-  epoch: 0
+  epoch: 1
   description: Friendly distributed version control system
   copyright:
     - license: GPL-2.0-or-later
@@ -123,27 +123,20 @@ test:
         git-remote-bzr --help
         brz --help
     - name: "create repo test"
-      runs: |
-        # add entry for this user to /etc/passwd if not present.
-        # breezy/lockdir.py calls 'pwd.getuid()' which will stacktrace without.
-        uid=$(id -u) || { echo "ERROR: id -u failed"; exit 1; }
-        if ! out=$(id -un 2>/dev/null); then
-          echo "test-user:x:$uid:$(id -g):test user:${HOME:-$PWD}:/bin/sh" >>/etc/passwd
-          [ "$(id -un)" = "test-user" ] ||
-            { echo "ERROR: adding user to /etc/passwd didn't work"; exit 1; }
-        fi
-
-        mkdir test
-        cd test
-        brz init-repo .
-        brz init
-        cat > hello.txt <<'EOF'
-        Hello
-        EOF
-        brz add hello.txt
-        brz whoami 'Test test@chainguard.dev'
-        brz commit -m 'Test commit'
-        brz log
+      uses: test/populated-etc-passwd
+      with:
+        content: |
+          mkdir test
+          cd test
+          brz init-repo .
+          brz init
+          cat > hello.txt <<'EOF'
+          Hello
+          EOF
+          brz add hello.txt
+          brz whoami 'Test test@chainguard.dev'
+          brz commit -m 'Test commit'
+          brz log
 
 update:
   enabled: true


### PR DESCRIPTION
Convert the blob of code that adds a user to /etc/passwd into a pipeline.  The pipeline allows you to ensure that the user is present in /etc/passwd and /etc/group when you execute the content provided.

The test here will now pass like:

    make test/py3-breezy MELANGE_EXTRA_OPTS=--runner=bubblewrap

It feels like py3-breezy might not be the only package who have hit this.  I recently saw it in libreoffice also.
I'm not updating libreoffice here to skip 1 hour builds in any discussion that  might occur. That can be done in follow-on.
