### PR TITLE
draft openssl 3.4 rebuild test

### DIFF
--- a/R-s2.yaml
+++ b/R-s2.yaml
@@ -1,7 +1,7 @@
 package:
   name: R-s2
   version: 1.1.7
-  epoch: 0
+  epoch: 1
   description: Spherical Geometry Operators Using the S2 Geometry Library
   copyright:
     - license: Apache-2.0

--- a/R.yaml
+++ b/R.yaml
@@ -2,7 +2,7 @@
 package:
   name: R
   version: 4.3.1
-  epoch: 5
+  epoch: 6
   description: Language and environment for statistical computing
   copyright:
     - license: ( GPL-2.0-only OR GPL-3.0-only ) AND LGPL-2.1-or-later

--- a/aerospike-7.yaml
+++ b/aerospike-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: aerospike-7
   version: 7.2.0.1
-  epoch: 0
+  epoch: 1
   description: Aerospike Database Server - flash-optimized, in-memory, nosql database
   copyright:
     - license: AGPL-3.0-only

--- a/aerospike.yaml
+++ b/aerospike.yaml
@@ -1,7 +1,7 @@
 package:
   name: aerospike
   version: 6.4.0.25
-  epoch: 0
+  epoch: 1
   description: Aerospike Database Server - flash-optimized, in-memory, nosql database
   copyright:
     - license: AGPL-3.0-only

--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-arrow
   version: 17.0.0
-  epoch: 2
+  epoch: 3
   description: "multi-language toolbox for accelerated data interchange and in-memory processing"
   copyright:
     - license: Apache-2.0

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi
   version: 1.27.0
-  epoch: 2
+  epoch: 3
   description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
   copyright:
     - license: Apache-2.0

--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache2
   version: 2.4.62
-  epoch: 3
+  epoch: 4
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0

--- a/apk-tools.yaml
+++ b/apk-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: apk-tools
   version: 2.14.4
-  epoch: 0
+  epoch: 1
   description: "apk-tools (Wolfi package manager)"
   copyright:
     - license: GPL-2.0-only

--- a/apr-util.yaml
+++ b/apr-util.yaml
@@ -1,7 +1,7 @@
 package:
   name: apr-util
   version: 1.6.3
-  epoch: 2
+  epoch: 3
   description: The Apache Portable Runtime Utility Library
   copyright:
     # Some files also contain RSA-MD.

--- a/aws-c-auth.yaml
+++ b/aws-c-auth.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-auth
   version: 0.7.31
-  epoch: 0
+  epoch: 1
   description: "C99 library implementation of AWS client-side authentication: standard credentials providers and signing"
   copyright:
     - license: Apache-2.0

--- a/aws-c-cal.yaml
+++ b/aws-c-cal.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-cal
   version: 0.7.4
-  epoch: 1
+  epoch: 2
   description: "AWS Crypto Abstraction Layer: Cross-Platform, C99 wrapper for cryptography primitives"
   copyright:
     - license: Apache-2.0

--- a/aws-c-event-stream.yaml
+++ b/aws-c-event-stream.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-event-stream
   version: 0.4.3
-  epoch: 1
+  epoch: 2
   description: "AWS C99 implementation of the vnd.amazon.eventstream content-type"
   copyright:
     - license: Apache-2.0

--- a/aws-c-io.yaml
+++ b/aws-c-io.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-io
   version: 0.14.20
-  epoch: 0
+  epoch: 1
   description: Module for the AWS SDK for C handling all IO and TLS work for application protocols
   copyright:
     - license: Apache-2.0

--- a/aws-c-mqtt.yaml
+++ b/aws-c-mqtt.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-mqtt
   version: 0.10.7
-  epoch: 0
+  epoch: 1
   description: AWS C99 implementation of the MQTT 3.1.1 specification
   copyright:
     - license: Apache-2.0

--- a/berg.yaml
+++ b/berg.yaml
@@ -1,7 +1,7 @@
 package:
   name: berg
   version: 0.3.5
-  epoch: 2
+  epoch: 3
   description: "CLI Tool for Codeberg similar to gh and glab"
   copyright:
     - license: AGPL-3.0-only

--- a/bind.yaml
+++ b/bind.yaml
@@ -1,7 +1,7 @@
 package:
   name: bind
   version: 9.18.31
-  epoch: 0
+  epoch: 1
   description: The ISC DNS server
   copyright:
     - license: MPL-2.0

--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -2,7 +2,7 @@ package:
   name: ca-certificates
   # manual: update java-cacerts
   version: "20241010"
-  epoch: 0
+  epoch: 1
   description: "CA certificates from the Mozilla trusted root program"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/cargo-c.yaml
+++ b/cargo-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: cargo-c
   version: 0.10.5
-  epoch: 0
+  epoch: 1
   description: build and install C-compatible libraries
   copyright:
     - license: MIT

--- a/cassandra-reaper.yaml
+++ b/cassandra-reaper.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-reaper
   version: 3.6.1
-  epoch: 0
+  epoch: 1
   description: Automated Repair Awesomeness for Apache Cassandra
   copyright:
     - license: Apache-2.0

--- a/clamav-1.4.yaml
+++ b/clamav-1.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav-1.4
   version: 1.4.1
-  epoch: 0
+  epoch: 1
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only

--- a/clamav.yaml
+++ b/clamav.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav
   version: 1.4.1
-  epoch: 0
+  epoch: 1
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only

--- a/cmake-bootstrap.yaml
+++ b/cmake-bootstrap.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake-bootstrap
   version: 3.29.0
-  epoch: 1
+  epoch: 2
   description: "Bootstrap CMake without using system libraries, enabling to use CMake to build system libraries used by CMake"
   dependencies:
     provider-priority: 5

--- a/cmake.yaml
+++ b/cmake.yaml
@@ -1,7 +1,7 @@
 package:
   name: cmake
   version: 3.29.0
-  epoch: 2
+  epoch: 3
   description: "CMake is an open-source, cross-platform family of tools designed to build, test and package software"
   dependencies:
     provider-priority: 10

--- a/collectd.yaml
+++ b/collectd.yaml
@@ -6,7 +6,7 @@
 package:
   name: collectd
   version: 5.12.0
-  epoch: 2
+  epoch: 3
   description: "The system statistics collection daemon."
   copyright:
     - license: MIT

--- a/coreutils.yaml
+++ b/coreutils.yaml
@@ -1,7 +1,7 @@
 package:
   name: coreutils
   version: "9.5"
-  epoch: 2
+  epoch: 3
   description: "GNU core utilities"
   copyright:
     - license: GPL-3.0-or-later

--- a/couchdb-3.3.yaml
+++ b/couchdb-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: couchdb-3.3
   version: 3.3.3
-  epoch: 4
+  epoch: 5
   description: Seamless multi-master syncing database with an intuitive HTTP/JSON API, designed for reliability
   copyright:
     - license: Apache-2.0

--- a/cryptsetup.yaml
+++ b/cryptsetup.yaml
@@ -2,7 +2,7 @@
 package:
   name: cryptsetup
   version: 2.7.5
-  epoch: 2
+  epoch: 3
   description: Userspace setup tool for transparent encryption of block devices using the Linux 2.6 cryptoapi
   copyright:
     - license: GPL-2.0-or-later WITH cryptsetup-OpenSSL-exception

--- a/cups.yaml
+++ b/cups.yaml
@@ -1,7 +1,7 @@
 package:
   name: cups
   version: 2.4.11
-  epoch: 0
+  epoch: 1
   description: The CUPS Printing System
   copyright:
     - license: GPL-2.0-only

--- a/curl-rustls.yaml
+++ b/curl-rustls.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl-rustls
   version: 8.10.1
-  epoch: 0
+  epoch: 1
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT

--- a/curl.yaml
+++ b/curl.yaml
@@ -1,7 +1,7 @@
 package:
   name: curl
   version: 8.10.1
-  epoch: 1
+  epoch: 2
   description: "URL retrieval utility and library"
   copyright:
     - license: MIT

--- a/cyrus-sasl.yaml
+++ b/cyrus-sasl.yaml
@@ -1,7 +1,7 @@
 package:
   name: cyrus-sasl
   version: 2.1.28
-  epoch: 4
+  epoch: 5
   description: "Cyrus Simple Authentication Service Layer (SASL)"
   copyright:
     - license: BSD-3-Clause

--- a/dotnet-6.yaml
+++ b/dotnet-6.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-6
   version: 6.0.135
-  epoch: 0
+  epoch: 1
   description: ".NET SDK, version 6"
   copyright:
     - license: MIT

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -2,7 +2,7 @@ package:
   name: dotnet-7
   # Remove `-sb` from the git-checkout tag at the next release
   version: 7.0.120
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT

--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: 8.0.10
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT

--- a/efs-utils.yaml
+++ b/efs-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: efs-utils
   version: 2.1.0
-  epoch: 0
+  epoch: 1
   description: Utilities for Amazon Elastic File System (EFS)
   copyright:
     - license: MIT

--- a/erlang-25.yaml
+++ b/erlang-25.yaml
@@ -2,7 +2,7 @@
 package:
   name: erlang-25
   version: 25.3.2.15
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0

--- a/erlang-26.yaml
+++ b/erlang-26.yaml
@@ -1,7 +1,7 @@
 package:
   name: erlang-26
   version: 26.2.5.4
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0

--- a/erlang-27.yaml
+++ b/erlang-27.yaml
@@ -1,7 +1,7 @@
 package:
   name: erlang-27
   version: 27.1.2
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0

--- a/eudev.yaml
+++ b/eudev.yaml
@@ -1,7 +1,7 @@
 package:
   name: eudev
   version: 3.2.14
-  epoch: 3
+  epoch: 4
   description: init system agnostic fork of systemd-udev
   copyright:
     - license: GPL-2.0-only

--- a/exim.yaml
+++ b/exim.yaml
@@ -1,7 +1,7 @@
 package:
   name: exim
   version: "4.98"
-  epoch: 1
+  epoch: 2
   description: Message Transfer Agent
   copyright:
     - license: GPL-2.0-or-later

--- a/falco-libs.yaml
+++ b/falco-libs.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-libs
   version: 0.18.1
-  epoch: 1
+  epoch: 2
   description: Foundational components necessary to build Falco
   copyright:
     - license: Apache-2.0

--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-no-driver
   version: 0.39.1
-  epoch: 0
+  epoch: 1
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0

--- a/falco.yaml
+++ b/falco.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco
   version: 0.39.1 # on update check if we can remove the 'Patch falcosecurity-libs' pipeline below if https://github.com/falcosecurity/libs/pull/2079 is merged
-  epoch: 2
+  epoch: 3
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0

--- a/ffmpeg.yaml
+++ b/ffmpeg.yaml
@@ -2,7 +2,7 @@
 package:
   name: ffmpeg
   version: 7.1
-  epoch: 1
+  epoch: 2
   description: ffmpeg multimedia library
   copyright:
     - license: GPL-3.0-or-later AND LGPL-3.0-or-later

--- a/fluent-bit-3.1.yaml
+++ b/fluent-bit-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-bit-3.1
   version: 3.1.9
-  epoch: 0
+  epoch: 1
   description: Fast and Lightweight Log processor and forwarder
   copyright:
     - license: Apache-2.0

--- a/freerdp-3.yaml
+++ b/freerdp-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp-3
   version: 3.5.1
-  epoch: 3
+  epoch: 4
   description: FreeRDP client
   copyright:
     - license: Apache-2.0

--- a/freerdp.yaml
+++ b/freerdp.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp
   version: 2.11.7
-  epoch: 2
+  epoch: 3
   description: FreeRDP client
   copyright:
     - license: Apache-2.0

--- a/gdal-py3.10.yaml
+++ b/gdal-py3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdal-py3.10
   version: 3.9.3
-  epoch: 0
+  epoch: 1
   description: GDAL is an open source MIT licensed translator library for raster and vector geospatial data formats.
   copyright:
     - license: MIT

--- a/gdal.yaml
+++ b/gdal.yaml
@@ -1,7 +1,7 @@
 package:
   name: gdal
   version: 3.9.3
-  epoch: 0
+  epoch: 1
   description: GDAL is an open source MIT licensed translator library for raster and vector geospatial data formats.
   copyright:
     - license: MIT

--- a/git-bootstrap.yaml
+++ b/git-bootstrap.yaml
@@ -8,7 +8,7 @@
 package:
   name: git-bootstrap
   version: 2.47.0
-  epoch: 0
+  epoch: 1
   description: "distributed version control system"
   copyright:
     - license: GPL-2.0-or-later

--- a/git.yaml
+++ b/git.yaml
@@ -1,7 +1,7 @@
 package:
   name: git
   version: 2.47.0
-  epoch: 0
+  epoch: 1
   description: "distributed version control system"
   copyright:
     - license: GPL-2.0-or-later

--- a/gitaly-17.4.yaml
+++ b/gitaly-17.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitaly-17.4
   version: 17.4.2
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: MIT

--- a/grpc-1.66.yaml
+++ b/grpc-1.66.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.66
   version: 1.66.2
-  epoch: 0
+  epoch: 1
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.67
   version: 1.67.0
-  epoch: 0
+  epoch: 1
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/guacamole-server.yaml
+++ b/guacamole-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: guacamole-server
   version: 1.5.5
-  epoch: 1
+  epoch: 2
   description: clientless remote desktop gateway server
   copyright:
     - license: Apache-2.0

--- a/haproxy-3.0.yaml
+++ b/haproxy-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-3.0
   version: 3.0.5
-  epoch: 0
+  epoch: 1
   description: "A TCP/HTTP reverse proxy for high availability environments"
   copyright:
     - license: GPL-2.0-or-later

--- a/hickory-dns.yaml
+++ b/hickory-dns.yaml
@@ -1,7 +1,7 @@
 package:
   name: hickory-dns
   version: 0.24.1
-  epoch: 2
+  epoch: 3
   description: "A Rust based DNS client, server, and resolver"
   copyright:
     - license: MIT

--- a/hiredis.yaml
+++ b/hiredis.yaml
@@ -1,7 +1,7 @@
 package:
   name: hiredis
   version: 1.2.0
-  epoch: 1
+  epoch: 2
   description: Minimalistic C client for Redis
   copyright:
     - license: BSD-3-Clause

--- a/ingress-nginx-controller-1.11.yaml
+++ b/ingress-nginx-controller-1.11.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.11
   version: 1.11.3
   # There are manual changes to review between each package update. See 'vars:' section.
-  epoch: 1
+  epoch: 2
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0

--- a/iperf3.yaml
+++ b/iperf3.yaml
@@ -1,7 +1,7 @@
 package:
   name: iperf3
   version: 3.17.1
-  epoch: 1
+  epoch: 2
   description: A tool to measure IP bandwidth using UDP or TCP
   copyright:
     - license: BSD-3-Clause-LBNL

--- a/istio-envoy-1.23.yaml
+++ b/istio-envoy-1.23.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-envoy-1.23
   version: 1.23.2
-  epoch: 0
+  epoch: 1
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
   copyright:
     - license: Apache-2.0

--- a/kdash.yaml
+++ b/kdash.yaml
@@ -1,7 +1,7 @@
 package:
   name: kdash
   version: 0.6.1
-  epoch: 1
+  epoch: 2
   description: "A simple and fast dashboard for Kubernetes"
   copyright:
     - license: MIT

--- a/keydb.yaml
+++ b/keydb.yaml
@@ -1,7 +1,7 @@
 package:
   name: keydb
   version: 6.3.4
-  epoch: 0
+  epoch: 1
   description: A Multithreaded Fork of Redis
   copyright:
     - license: BSD-3-Clause

--- a/kmod.yaml
+++ b/kmod.yaml
@@ -1,7 +1,7 @@
 package:
   name: kmod
   version: "33"
-  epoch: 1
+  epoch: 2
   description: Linux kernel module management utilities
   copyright:
     - license: GPL-2.0-or-later

--- a/krb5.yaml
+++ b/krb5.yaml
@@ -1,7 +1,7 @@
 package:
   name: krb5
   version: 1.21.3
-  epoch: 1
+  epoch: 2
   description: The Kerberos network authentication system
   copyright:
     - license: MIT

--- a/kube-fluentd-operator.yaml
+++ b/kube-fluentd-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: kube-fluentd-operator
   version: 1.18.2
-  epoch: 17
+  epoch: 18
   description: Auto-configuration of Fluentd daemon-set based on Kubernetes metadata
   copyright:
     - license: MIT

--- a/ldns.yaml
+++ b/ldns.yaml
@@ -1,7 +1,7 @@
 package:
   name: ldns
   version: 1.8.4
-  epoch: 0
+  epoch: 1
   description: Lowlevel DNS(SEC) library
   copyright:
     - license: BSD-2-Clause

--- a/libarchive.yaml
+++ b/libarchive.yaml
@@ -1,7 +1,7 @@
 package:
   name: libarchive
   version: 3.7.7
-  epoch: 0
+  epoch: 1
   description: "multi-format archive and compression library"
   copyright:
     - license: BSD-2-Clause

--- a/libevent.yaml
+++ b/libevent.yaml
@@ -1,7 +1,7 @@
 package:
   name: libevent
   version: 2.1.12
-  epoch: 6
+  epoch: 7
   description: An event notification library
   copyright:
     - license: BSD-3-Clause

--- a/libfido2.yaml
+++ b/libfido2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libfido2
   version: 1.15.0
-  epoch: 0
+  epoch: 1
   description: library for FIDO 2.0 functionality
   copyright:
     - license: BSD-2-Clause

--- a/libgit2.yaml
+++ b/libgit2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libgit2
   version: 1.8.2
-  epoch: 0
+  epoch: 1
   description: "A cross-platform, linkable library implementation of Git that you can use in your application."
   copyright:
     - license: GPL-2.0-only WITH GCC-exception-2.0

--- a/libmamba.yaml
+++ b/libmamba.yaml
@@ -1,7 +1,7 @@
 package:
   name: libmamba
   version: 2024.08.31
-  epoch: 1
+  epoch: 2
   description: Cross-Platform Package Manager
   copyright:
     - license: BSD-3-Clause

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpulsar
   version: 3.6.0
-  epoch: 0
+  epoch: 1
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0

--- a/librdkafka.yaml
+++ b/librdkafka.yaml
@@ -1,7 +1,7 @@
 package:
   name: librdkafka
   version: 2.3.0
-  epoch: 3
+  epoch: 4
   description: "The Apache Kafka C/C++ library"
   copyright:
     - license: BSD-2-Clause

--- a/librelp.yaml
+++ b/librelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: librelp
   version: 1.11.0
-  epoch: 0
+  epoch: 1
   description: librelp is an easy-to-use library for the RELP (Reliable Event Logging Protocol)
   copyright:
     - license: GPL-3.0-or-later

--- a/libreoffice-24.8.yaml
+++ b/libreoffice-24.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: libreoffice-24.8
   version: 24.8.2.1
-  epoch: 0
+  epoch: 1
   description:
   # https://www.libreoffice.org/about-us/licenses
   copyright:

--- a/libretls.yaml
+++ b/libretls.yaml
@@ -1,7 +1,7 @@
 package:
   name: libretls
   version: 3.8.1
-  epoch: 1
+  epoch: 2
   description: "port of libtls from libressl to openssl"
   copyright:
     - license: 'ISC AND ( BSD-3-Clause OR MIT )'

--- a/libsrt.yaml
+++ b/libsrt.yaml
@@ -1,7 +1,7 @@
 package:
   name: libsrt
   version: 1.5.3
-  epoch: 2
+  epoch: 3
   description: "Secure Reliable Transport (SRT)"
   copyright:
     - license: MPL-2.0

--- a/libssh.yaml
+++ b/libssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: libssh
   version: 0.11.1
-  epoch: 0
+  epoch: 1
   description: Library for accessing ssh client services through C libraries
   copyright:
     - license: LGPL-2.1-or-later AND BSD-2-Clause

--- a/libssh2.yaml
+++ b/libssh2.yaml
@@ -1,7 +1,7 @@
 package:
   name: libssh2
   version: 1.11.1
-  epoch: 0
+  epoch: 1
   description: "A library implementing the SSH2 protocol as defined by Internet Drafts"
   copyright:
     - license: BSD-3-Clause

--- a/libvncserver.yaml
+++ b/libvncserver.yaml
@@ -1,7 +1,7 @@
 package:
   name: libvncserver
   version: 0.9.14
-  epoch: 4
+  epoch: 5
   description: Library to make writing a vnc server easy
   copyright:
     - license: GPL-2.0-or-later

--- a/libwebsockets.yaml
+++ b/libwebsockets.yaml
@@ -1,7 +1,7 @@
 package:
   name: libwebsockets
   version: 4.3.3
-  epoch: 3
+  epoch: 4
   description: C library for lightweight websocket clients and servers
   copyright:
     - license: MIT

--- a/lighttpd.yaml
+++ b/lighttpd.yaml
@@ -1,7 +1,7 @@
 package:
   name: lighttpd
   version: 1.4.76
-  epoch: 0
+  epoch: 1
   description: Secure, fast, compliant and very flexible web-server
   copyright:
     - license: BSD-3-Clause

--- a/lychee.yaml
+++ b/lychee.yaml
@@ -1,7 +1,7 @@
 package:
   name: lychee
   version: 0.15.1
-  epoch: 2
+  epoch: 3
   description: "Fast, async, stream-based link checker written in Rust"
   copyright:
     - license: Apache-2.0 AND MIT

--- a/lynx.yaml
+++ b/lynx.yaml
@@ -2,7 +2,7 @@
 package:
   name: lynx
   version: 2.9.2
-  epoch: 0
+  epoch: 1
   description: Cross-platform text-based browser
   copyright:
     - license: GPL-2.0-only

--- a/malcontent.yaml
+++ b/malcontent.yaml
@@ -1,7 +1,7 @@
 package:
   name: malcontent
   version: 1.2.0
-  epoch: 0
+  epoch: 1
   description: enumerate file capabilities, including malicious behaviors
   copyright:
     - license: Apache-2.0

--- a/mariadb-11.5.yaml
+++ b/mariadb-11.5.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-11.5
   version: 11.5.2
-  epoch: 3
+  epoch: 4
   description: "The MariaDB open source relational database"
   copyright:
     - license: GPL-3.0-or-later

--- a/mariadb-connector-c.yaml
+++ b/mariadb-connector-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: mariadb-connector-c
   version: 3.4.1
-  epoch: 0
+  epoch: 1
   description: The MariaDB Native Client library (C driver)
   copyright:
     - license: LGPL-2.1-or-later

--- a/mdbook.yaml
+++ b/mdbook.yaml
@@ -1,7 +1,7 @@
 package:
   name: mdbook
   version: 0.4.40
-  epoch: 1
+  epoch: 2
   description: "Create book from markdown files. Like Gitbook but implemented in Rust."
   copyright:
     - license: MPL-2.0

--- a/memtier-benchmark.yaml
+++ b/memtier-benchmark.yaml
@@ -1,7 +1,7 @@
 package:
   name: memtier-benchmark
   version: 2.1.1
-  epoch: 0
+  epoch: 1
   description: "NoSQL Redis and Memcache traffic generation and benchmarking tool."
   copyright:
     - license: "GPL-2.0-or-later"

--- a/mold.yaml
+++ b/mold.yaml
@@ -1,7 +1,7 @@
 package:
   name: mold
   version: 2.34.1
-  epoch: 0
+  epoch: 1
   description: "mold linker"
   copyright:
     - license: MIT

--- a/mosquitto.yaml
+++ b/mosquitto.yaml
@@ -1,7 +1,7 @@
 package:
   name: mosquitto
   version: 2.0.20
-  epoch: 0
+  epoch: 1
   description: open source MQTT broker
   copyright:
     - license: EPL-1.0

--- a/mysql-9.1.yaml
+++ b/mysql-9.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: mysql-9.1
   version: 9.1.0
-  epoch: 0
+  epoch: 1
   description: "The MySQL open source relational database"
   copyright:
     - license: GPL-2.0-only # https://downloads.mysql.com/docs/licenses/mysqld-9.0-gpl-en.pdf

--- a/mysql-connector-cpp.yaml
+++ b/mysql-connector-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: mysql-connector-cpp
   version: 9.1.0
-  epoch: 0
+  epoch: 1
   description: MySQL Connector/C++ is a MySQL database connector for C++
   copyright:
     - license: GPL-3.0-or-later

--- a/neon.yaml
+++ b/neon.yaml
@@ -1,7 +1,7 @@
 package:
   name: neon
   version: "6935"
-  epoch: 0
+  epoch: 1
   description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
   copyright:
     - license: Apache-2.0

--- a/net-snmp.yaml
+++ b/net-snmp.yaml
@@ -1,7 +1,7 @@
 package:
   name: net-snmp
   version: 5.9.4
-  epoch: 2
+  epoch: 3
   description: Simple Network Management Protocol
   copyright:
     - license: Net-SNMP

--- a/nghttp2.yaml
+++ b/nghttp2.yaml
@@ -1,7 +1,7 @@
 package:
   name: nghttp2
   version: 1.64.0
-  epoch: 0
+  epoch: 1
   description: "experimental HTTP/2 client, server and library"
   copyright:
     - license: MIT

--- a/nginx-mainline.yaml
+++ b/nginx-mainline.yaml
@@ -2,7 +2,7 @@ package:
   name: nginx-mainline
   # Must also bump njs at the same time
   version: 1.27.2
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (mainline version)
   copyright:
     - license: BSD-2-Clause

--- a/nginx-stable.yaml
+++ b/nginx-stable.yaml
@@ -1,7 +1,7 @@
 package:
   name: nginx-stable
   version: 1.26.2
-  epoch: 0
+  epoch: 1
   description: HTTP and reverse proxy server (stable version)
   copyright:
     - license: BSD-2-Clause

--- a/njs.yaml
+++ b/njs.yaml
@@ -1,7 +1,7 @@
 package:
   name: njs
   version: 0.8.7
-  epoch: 0
+  epoch: 1
   description: njs scripting language CLI utility
   copyright:
     - license: BSD-2-Clause

--- a/nmap.yaml
+++ b/nmap.yaml
@@ -1,7 +1,7 @@
 package:
   name: nmap
   version: 7.94
-  epoch: 1
+  epoch: 2
   description: "network discovery and security auditing tool"
   copyright:
     - license: GPL-2.0-or-later

--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-16
   version: 16.20.2
-  epoch: 6
+  epoch: 7
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-18
   version: 18.20.4
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT

--- a/nodejs-19.yaml
+++ b/nodejs-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-19
   version: 19.9.0
-  epoch: 8
+  epoch: 9
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-20
   version: 20.18.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   dependencies:
     provides:

--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-21
   version: 21.7.3
-  epoch: 3
+  epoch: 4
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-22
   version: 22.10.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-23.yaml
+++ b/nodejs-23.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-23
   version: 23.0.0
-  epoch: 1
+  epoch: 2
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nsd.yaml
+++ b/nsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: nsd
   version: 4.10.1
-  epoch: 0
+  epoch: 1
   description: "The NLnet Labs Name Server Daemon (NSD) is an authoritative, RFC compliant DNS nameserver."
   copyright:
     - license: BSD-3-Clause

--- a/openipmi.yaml
+++ b/openipmi.yaml
@@ -1,7 +1,7 @@
 package:
   name: openipmi
   version: 2.0.36
-  epoch: 0
+  epoch: 1
   description: IPMI (Intelligent Platform Management Interface) library and tools
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later OR BSD-3-Clause

--- a/openldap.yaml
+++ b/openldap.yaml
@@ -1,7 +1,7 @@
 package:
   name: openldap
   version: 2.6.8
-  epoch: 5
+  epoch: 6
   description: LDAP Server
   copyright:
     - license: OLDAP-2.8

--- a/openresty.yaml
+++ b/openresty.yaml
@@ -1,7 +1,7 @@
 package:
   name: openresty
   version: 1.25.3.2
-  epoch: 1
+  epoch: 2
   description: High Performance Web Platform Based on Nginx and LuaJIT
   dependencies:
     runtime:

--- a/openscap.yaml
+++ b/openscap.yaml
@@ -1,7 +1,7 @@
 package:
   name: openscap
   version: 1.4.0
-  epoch: 2
+  epoch: 3
   description: NIST Certified SCAP 1.2 toolkit
   copyright:
     - license: LGPL-2.1-or-later

--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssh
   version: 9.9_p1
-  epoch: 0
+  epoch: 1
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
   version: 3.4.0
-  epoch: 0
+  epoch: 1
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -43,19 +43,21 @@ pipeline:
       tag: openssl-${{package.version}}
       expected-commit: 98acb6b02839c609ef5b837794e08d906d965335
 
-  - if: ${{build.arch}} == 'aarch64'
-    uses: fetch
-    with:
-      uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
-      expected-sha256: "32f42bd6fe32aee1718e382a6533bed413dd452cbb7f180166eb4709c362c09c"
-      extract: false
-
-  - if: ${{build.arch}} == 'x86_64'
-    uses: fetch
-    with:
-      uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
-      expected-sha256: "0e59f969478959dd7bdb1198faa034c12808ea0f79390bc21a8323812d9c4df1"
-      extract: false
+  - assertions:
+      required-steps: 1
+    pipeline:
+      - if: ${{build.arch}} == 'aarch64'
+        uses: fetch
+        with:
+          uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
+          expected-sha256: "32f42bd6fe32aee1718e382a6533bed413dd452cbb7f180166eb4709c362c09c"
+          extract: false
+      - if: ${{build.arch}} == 'x86_64'
+        uses: fetch
+        with:
+          uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
+          expected-sha256: "0e59f969478959dd7bdb1198faa034c12808ea0f79390bc21a8323812d9c4df1"
+          extract: false
 
   - name: Extract certified jitter entropy
     runs: |

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
-  version: 3.3.2
-  epoch: 2
+  version: 3.4.0
+  epoch: 0
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -30,14 +30,37 @@ environment:
     CXXFLAGS: ""
     LDFLAGS: ""
 
+vars:
+  # Certified version of jitter library to fetch. Note wolfictl text
+  # prohibits listing old '- jitterentropy-library-dev=3.5.0-r0' in
+  # environment above
+  jitter-pkg: "jitterentropy-library-dev-3.5.0-r0.apk"
+
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/openssl/openssl.git
+      repository: https://github.com/openssl/openssl
       tag: openssl-${{package.version}}
-      expected-commit: fb7fab9fa6f4869eaa8fbb97e0d593159f03ffe4
-      cherry-picks: |
-        openssl-3.3/c0d3e4d32d2805f49bec30547f225bc4d092e1f4: CVE-2024-9143 fixes
+      expected-commit: 98acb6b02839c609ef5b837794e08d906d965335
+
+  - if: ${{build.arch}} == 'aarch64'
+    uses: fetch
+    with:
+      uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
+      expected-sha256: "32f42bd6fe32aee1718e382a6533bed413dd452cbb7f180166eb4709c362c09c"
+      extract: false
+
+  - if: ${{build.arch}} == 'x86_64'
+    uses: fetch
+    with:
+      uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
+      expected-sha256: "0e59f969478959dd7bdb1198faa034c12808ea0f79390bc21a8323812d9c4df1"
+      extract: false
+
+  - name: Extract certified jitter entropy
+    runs: |
+      mkdir -p jitter/
+      tar -C jitter -x -f ${{vars.jitter-pkg}} 2>/dev/null
 
   - name: Create dbg sourcecode
     runs: |
@@ -62,7 +85,11 @@ pipeline:
          --libdir=lib \
          --openssldir=/etc/ssl \
          enable-ktls \
+         enable-jitter \
+         --with-jitter-include=jitter/usr/include \
+         --with-jitter-lib=jitter/usr/lib \
          shared \
+         enable-pie \
          no-zlib \
          no-async \
          no-comp \
@@ -78,6 +105,7 @@ pipeline:
          -Wa,--noexecstack
       perl configdata.pm --dump
       make -j$(nproc)
+      make tests HARNESS_JOBS=10
 
   - uses: autoconf/make-install
 
@@ -172,8 +200,13 @@ test:
   pipeline:
     - uses: test/hardening-check
       with:
-        package-match: "^openssl$\\|libssl3\\|libcrypto3"
-      runs: |
+        package-match: "^openssl$\\|libssl3"
+    - uses: test/hardening-check
+      with:
+        # jitterentropy is without CF protection so far
+        args: "--nocfprotection"
+        package-match: "^libcrypto3$"
+    - runs: |
         openssl --version
         openssl --help
     - name: Verify curl still works

--- a/opentelemetry-cpp.yaml
+++ b/opentelemetry-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: opentelemetry-cpp
   version: 1.17.0
-  epoch: 1
+  epoch: 2
   description: The OpenTelemetry C++ Client
   copyright:
     - license: Apache-2.0

--- a/openvpn.yaml
+++ b/openvpn.yaml
@@ -1,7 +1,7 @@
 package:
   name: openvpn
   version: 2.6.12
-  epoch: 0
+  epoch: 1
   description: Robust, and highly configurable VPN (Virtual Private Network)
   copyright:
     - license: GPL-2.0-or-later

--- a/oranda.yaml
+++ b/oranda.yaml
@@ -1,7 +1,7 @@
 package:
   name: oranda
   version: 0.6.5
-  epoch: 0
+  epoch: 1
   description: generate beautiful landing pages for your developer tools
   copyright:
     - license: MIT

--- a/percona-server-8.4.yaml
+++ b/percona-server-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-server-8.4
   version: 8.4.0.1
-  epoch: 1
+  epoch: 2
   description: "Percona Server for MySQL is a free, fully compatible, enhanced, and open source drop-in replacement for any MySQL database. It provides superior performance, scalability, and instrumentation."
   copyright:
     - license: GPL-3.0-or-later

--- a/pgbouncer.yaml
+++ b/pgbouncer.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgbouncer
   version: 1.22.1
-  epoch: 1
+  epoch: 2
   description: lightweight connection pooler for PostgreSQL
   copyright:
     - license: ISC

--- a/php-8.1-pecl-http.yaml
+++ b/php-8.1-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-http
   version: 4.2.4
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.1 HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause

--- a/php-8.1-pecl-mongodb.yaml
+++ b/php-8.1-pecl-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-mongodb
   version: 1.20.0
-  epoch: 1
+  epoch: 2
   description: "PHP 8.1 MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01

--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: 8.1.30
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/php-8.2-pecl-http.yaml
+++ b/php-8.2-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-http
   version: 4.2.4
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.2 HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause

--- a/php-8.2-pecl-mongodb.yaml
+++ b/php-8.2-pecl-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-mongodb
   version: 1.20.0
-  epoch: 1
+  epoch: 2
   description: "PHP 8.2 MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: 8.2.24
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/php-8.3-pecl-http.yaml
+++ b/php-8.3-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pecl-http
   version: 4.2.4
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.3 HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause

--- a/php-8.3-pecl-mongodb.yaml
+++ b/php-8.3-pecl-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pecl-mongodb
   version: 1.20.0
-  epoch: 1
+  epoch: 2
   description: "PHP 8.3 MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01

--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: 8.3.12
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/pixi.yaml
+++ b/pixi.yaml
@@ -1,7 +1,7 @@
 package:
   name: pixi
   version: 0.34.0
-  epoch: 0
+  epoch: 1
   description: "Package management made easy"
   copyright:
     - license: BSD-3-Clause

--- a/pkcs11-helper.yaml
+++ b/pkcs11-helper.yaml
@@ -1,7 +1,7 @@
 package:
   name: pkcs11-helper
   version: 1.30.0
-  epoch: 1
+  epoch: 2
   description: PKCS#11 Helper library that simplifies the interaction with PKCS#11 providers for end-user applications
   copyright:
     - license: GPL-2.0-or-later

--- a/postfix.yaml
+++ b/postfix.yaml
@@ -1,7 +1,7 @@
 package:
   name: postfix
   version: 3.9.0
-  epoch: 1
+  epoch: 2
   description: Secure and fast drop-in replacement for Sendmail (MTA)
   copyright:
     - license: IPL-1.0 OR EPL-2.0

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.4"
-  epoch: 3
+  epoch: 4
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-17
   version: "17.0"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/powershell.yaml
+++ b/powershell.yaml
@@ -1,7 +1,7 @@
 package:
   name: powershell
   version: 7.4.1
-  epoch: 0
+  epoch: 1
   description: 'cross-platform automation and configuration tool/framework'
   copyright:
     - license: MIT

--- a/proxysql.yaml
+++ b/proxysql.yaml
@@ -1,7 +1,7 @@
 package:
   name: proxysql
   version: 2.7.1
-  epoch: 0
+  epoch: 1
   description: High-performance MySQL proxy with a GPL license
   copyright:
     - license: GPL-3.0-or-later

--- a/pulseaudio.yaml
+++ b/pulseaudio.yaml
@@ -2,7 +2,7 @@
 package:
   name: pulseaudio
   version: "17.0"
-  epoch: 0
+  epoch: 1
   description: featureful, general-purpose sound server
   copyright:
     - license: LGPL-2.1-or-later

--- a/py3-awscrt.yaml
+++ b/py3-awscrt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-awscrt
   version: 0.22.1
-  epoch: 0
+  epoch: 1
   description: Python bindings for the AWS Common Runtime
   copyright:
     - license: Apache-2.0

--- a/py3-awslambdaric.yaml
+++ b/py3-awslambdaric.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-awslambdaric
   version: 2.2.1
-  epoch: 2
+  epoch: 3
   description: AWS Lambda Runtime Interface Client for Python
   copyright:
     - license: Apache-2.0

--- a/py3-cryptography.yaml
+++ b/py3-cryptography.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cryptography
   version: 43.0.3
-  epoch: 0
+  epoch: 1
   description: cryptography is a package which provides cryptographic recipes and primitives to Python developers.
   copyright:
     - license: Apache-2.0 OR BSD-3-Clause

--- a/py3-ml-metadata.yaml
+++ b/py3-ml-metadata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ml-metadata
   version: 1.16.0
-  epoch: 3
+  epoch: 4
   description: For recording and retrieving metadata associated with ML developer and data scientist workflows.
   copyright:
     - license: MIT

--- a/py3-pycurl.yaml
+++ b/py3-pycurl.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pycurl
   version: 7.45.3
-  epoch: 1
+  epoch: 2
   description: PycURL -- A Python Interface To The cURL library
   copyright:
     - license: LGPL-2.1-or-later AND MIT

--- a/py3-tkinter.yaml
+++ b/py3-tkinter.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tkinter
   version: 3.11.10
-  epoch: 0
+  epoch: 1
   description: A graphical user interface for the Python programming language
   copyright:
     - license: PSF-2.0

--- a/py3-xmlsec.yaml
+++ b/py3-xmlsec.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-xmlsec
   version: 1.3.14
-  epoch: 2
+  epoch: 3
   description: About Python bindings for the XML Security Library
   copyright:
     - license: MIT

--- a/py3.10-tensorflow-core.yaml
+++ b/py3.10-tensorflow-core.yaml
@@ -2,7 +2,7 @@ package:
   name: py3.10-tensorflow-core
   description: Framework for data-graph oriented computing (core libraries, oneDNN build)
   version: 2.17.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   resources:

--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: 3.10.15
-  epoch: 2
+  epoch: 3
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: 3.11.10
-  epoch: 3
+  epoch: 4
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: 3.12.7
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: 3.13.0
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0

--- a/qpdf.yaml
+++ b/qpdf.yaml
@@ -1,7 +1,7 @@
 package:
   name: qpdf
   version: 11.9.1
-  epoch: 1
+  epoch: 2
   description: Command-line tools and library for transforming PDF files
   copyright:
     - license: Apache-2.0

--- a/qt5-qtbase.yaml
+++ b/qt5-qtbase.yaml
@@ -2,7 +2,7 @@
 package:
   name: qt5-qtbase
   version: 5.15.15
-  epoch: 1
+  epoch: 2
   description: Qt5 - QtBase components
   copyright:
     - license: LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0

--- a/rabbitmq-c.yaml
+++ b/rabbitmq-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: rabbitmq-c
   version: 0.14.0
-  epoch: 1
+  epoch: 2
   description: "RabbitMQ C client"
   copyright:
     - license: MIT

--- a/rapidjson.yaml
+++ b/rapidjson.yaml
@@ -1,7 +1,7 @@
 package:
   name: rapidjson
   version: 1.1.0
-  epoch: 3
+  epoch: 4
   description: Fast JSON parser/generator for C++ with both SAX/DOM style API
   copyright:
     - license: BSD-2-Clause

--- a/rethinkdb.yaml
+++ b/rethinkdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: rethinkdb
   version: 2.4.4
-  epoch: 5
+  epoch: 6
   description: The open-source database for the realtime web.
   copyright:
     - license: Apache-2.0

--- a/rhash.yaml
+++ b/rhash.yaml
@@ -1,7 +1,7 @@
 package:
   name: rhash
   version: 1.4.5
-  epoch: 0
+  epoch: 1
   description: "cross-platform asynchronous I/O library"
   copyright:
     - license: 0BSD

--- a/riemann-c-client.yaml
+++ b/riemann-c-client.yaml
@@ -2,7 +2,7 @@
 package:
   name: riemann-c-client
   version: 2.1.0
-  epoch: 0
+  epoch: 1
   description: A C client library for the Riemann monitoring system
   copyright:
     - license: LGPL-3.0-or-later

--- a/rpm.yaml
+++ b/rpm.yaml
@@ -2,7 +2,7 @@
 package:
   name: rpm
   version: 4.19.1
-  epoch: 1
+  epoch: 2
   description: Redhat Package Management utilities (RPM)
   copyright:
     - license: GPL-2.0-or-later OR LGPL-2.0-or-later

--- a/rstudio.yaml
+++ b/rstudio.yaml
@@ -1,7 +1,7 @@
 package:
   name: rstudio
   version: 2023.12.1_p402
-  epoch: 1
+  epoch: 2
   description: RStudio is an integrated development environment (IDE) for R
   copyright:
     - license: GPL-3.0-or-later

--- a/rtmpdump.yaml
+++ b/rtmpdump.yaml
@@ -2,7 +2,7 @@
 package:
   name: rtmpdump
   version: 2.6_git20241022
-  epoch: 0
+  epoch: 1
   description: rtmpdump is a toolkit for RTMP streams
   copyright:
     - license: LGPL-2.0-only

--- a/ruby-3.0.yaml
+++ b/ruby-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.0
   version: 3.0.7
-  epoch: 4
+  epoch: 5
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.6
-  epoch: 5
+  epoch: 6
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: 3.2.5
-  epoch: 4
+  epoch: 5
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.3
   version: 3.3.5
-  epoch: 3
+  epoch: 4
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/rust-1.69.yaml
+++ b/rust-1.69.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.69
   version: 1.69.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software. (version 1.69.0)"
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.70.yaml
+++ b/rust-1.70.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.70
   version: 1.70.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software. (version 1.70.0)"
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.71.yaml
+++ b/rust-1.71.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.71
   version: 1.71.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software. (version 1.71.0)"
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.72.yaml
+++ b/rust-1.72.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.72
   version: 1.72.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software. (version 1.72.0)"
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.73.yaml
+++ b/rust-1.73.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.73
   version: 1.73.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software. (version 1.73.0)"
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.74.yaml
+++ b/rust-1.74.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.74
   version: 1.74.1
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software. (version 1.74.1)"
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.75.yaml
+++ b/rust-1.75.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.75
   version: 1.75.0
-  epoch: 0
+  epoch: 1
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.76.yaml
+++ b/rust-1.76.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.76
   version: 1.76.0
-  epoch: 0
+  epoch: 1
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.77.yaml
+++ b/rust-1.77.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.77
   version: 1.77.2
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.78.yaml
+++ b/rust-1.78.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.78
   version: 1.78.0
-  epoch: 5
+  epoch: 6
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.79.yaml
+++ b/rust-1.79.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.79
   version: 1.79.0
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.80.yaml
+++ b/rust-1.80.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.80
   version: 1.80.1
-  epoch: 1
+  epoch: 2
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.81.yaml
+++ b/rust-1.81.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.81
   version: 1.81.0
-  epoch: 2
+  epoch: 3
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-1.82.yaml
+++ b/rust-1.82.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-1.82
   version: 1.82.0
-  epoch: 0
+  epoch: 1
   description: "Empowering everyone to build reliable and efficient software."
   copyright:
     - license: Apache-2.0 AND MIT

--- a/rust-analyzer.yaml
+++ b/rust-analyzer.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-analyzer
   version: 20240722
-  epoch: 1
+  epoch: 2
   description: A Rust compiler front-end for IDEs
   copyright:
     - license: Apache-2.0

--- a/rustup.yaml
+++ b/rustup.yaml
@@ -1,7 +1,7 @@
 package:
   name: rustup
   version: 1.27.1
-  epoch: 2
+  epoch: 3
   description: "rustup is an installer for the systems programming language Rust"
   copyright:
     - license: MIT

--- a/rye.yaml
+++ b/rye.yaml
@@ -1,7 +1,7 @@
 package:
   name: rye
   version: 0.42.0
-  epoch: 0
+  epoch: 1
   description: "An Experimental Package Management Solution for Python"
   copyright:
     - license: Apache-2.0

--- a/s2n-tls.yaml
+++ b/s2n-tls.yaml
@@ -1,7 +1,7 @@
 package:
   name: s2n-tls
   version: 1.5.5
-  epoch: 0
+  epoch: 1
   description: AWS C99 implementation of the TLS/SSL protocols
   copyright:
     - license: Apache-2.0

--- a/sccache.yaml
+++ b/sccache.yaml
@@ -1,7 +1,7 @@
 package:
   name: sccache
   version: 0.8.2
-  epoch: 0
+  epoch: 1
   description: sccache is ccache with cloud storage
   copyright:
     - license: Apache-2.0

--- a/sdp-k8s-injector.yaml
+++ b/sdp-k8s-injector.yaml
@@ -1,7 +1,7 @@
 package:
   name: sdp-k8s-injector
   version: 1.3.5
-  epoch: 0
+  epoch: 1
   description: "SDP Client for Kubernetes"
   copyright:
     - license: MIT

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1,7 +1,7 @@
 package:
   name: semgrep
   version: 1.92.0
-  epoch: 0
+  epoch: 1
   description: "Lightweight static analysis for many languages. Find bug variants with patterns that look like source code."
   copyright:
     - license: LGPL-2.1-or-later

--- a/serf.yaml
+++ b/serf.yaml
@@ -1,7 +1,7 @@
 package:
   name: serf
   version: 1.3.10
-  epoch: 0
+  epoch: 1
   description: High-Performance Asynchronous HTTP Client Library
   copyright:
     - license: Apache-2.0 AND Zlib

--- a/socat.yaml
+++ b/socat.yaml
@@ -1,7 +1,7 @@
 package:
   name: socat
   version: 1.8.0.1
-  epoch: 1
+  epoch: 2
   description: Multipurpose relay for binary protocols
   copyright:
     - license: GPL-2.0-only

--- a/softhsm.yaml
+++ b/softhsm.yaml
@@ -2,7 +2,7 @@
 package:
   name: softhsm
   version: 2.6.1
-  epoch: 3
+  epoch: 4
   description: 'cryptographic store accessible through a PKCS #11'
   copyright:
     - license: BSD-2-Clause

--- a/spin.yaml
+++ b/spin.yaml
@@ -1,7 +1,7 @@
 package:
   name: spin
   version: 2.7.0
-  epoch: 1
+  epoch: 2
   description: "Spin is the open source developer tool for building and running serverless applications powered by WebAssembly."
   copyright:
     - license: Apache-2.0

--- a/squid.yaml
+++ b/squid.yaml
@@ -2,7 +2,7 @@
 package:
   name: squid
   version: "6.12"
-  epoch: 0
+  epoch: 1
   description: Full-featured Web proxy cache server
   copyright:
     - license: GPL-2.0-or-later

--- a/ssl_client.yaml
+++ b/ssl_client.yaml
@@ -1,7 +1,7 @@
 package:
   name: ssl_client
   version: 3.20.3
-  epoch: 0
+  epoch: 1
   description: ssl_client from alpine busybox
   copyright:
     - license: GPL-2.0-only

--- a/strongswan.yaml
+++ b/strongswan.yaml
@@ -1,7 +1,7 @@
 package:
   name: strongswan
   version: 5.9.14
-  epoch: 0
+  epoch: 1
   description: IPsec-based VPN solution focused on security and ease of use, supporting IKEv1/IKEv2 and MOBIKE
   copyright:
     # GPL-2.0-or-later WITH OpenSSL-Exception

--- a/stunnel.yaml
+++ b/stunnel.yaml
@@ -1,7 +1,7 @@
 package:
   name: stunnel
   version: "5.73"
-  epoch: 0
+  epoch: 1
   description: SSL encryption wrapper between network client and server
   copyright:
     - license: GPL-2.0-or-later

--- a/sudo-rs.yaml
+++ b/sudo-rs.yaml
@@ -1,7 +1,7 @@
 package:
   name: sudo-rs
   version: 0.2.3
-  epoch: 1
+  epoch: 2
   description: A memory safe implementation of sudo and su.
   copyright:
     - license: MIT

--- a/suricata.yaml
+++ b/suricata.yaml
@@ -1,7 +1,7 @@
 package:
   name: suricata
   version: 7.0.7
-  epoch: 0
+  epoch: 1
   description: "Suricata is a network Intrusion Detection System, Intrusion Prevention System and Network Security Monitoring engine"
   copyright:
     - license: GPL-2.0-only

--- a/tcl-tls.yaml
+++ b/tcl-tls.yaml
@@ -1,7 +1,7 @@
 package:
   name: tcl-tls
   version: 1.7.22
-  epoch: 0
+  epoch: 1
   description: OpenSSL extension to Tcl
   copyright:
     - license: TCL

--- a/tcpdump.yaml
+++ b/tcpdump.yaml
@@ -1,7 +1,7 @@
 package:
   name: tcpdump
   version: 4.99.5
-  epoch: 0
+  epoch: 1
   description: A tool for network monitoring and data acquisition
   copyright:
     - license: BSD-3-Clause

--- a/teleport.yaml
+++ b/teleport.yaml
@@ -1,7 +1,7 @@
 package:
   name: teleport
   version: 16.4.3
-  epoch: 0
+  epoch: 1
   description: The easiest, and most secure way to access and protect all of your infrastructure.
   copyright:
     - license: AGPL-3.0-only

--- a/tensorflow-core.yaml
+++ b/tensorflow-core.yaml
@@ -2,7 +2,7 @@ package:
   name: tensorflow-core
   description: Framework for data-graph oriented computing (core libraries, oneDNN build)
   version: 2.17.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   resources:

--- a/thrift.yaml
+++ b/thrift.yaml
@@ -1,7 +1,7 @@
 package:
   name: thrift
   version: 0.21.0
-  epoch: 0
+  epoch: 1
   description: "Language-independent software stack for RPC implementation"
   copyright:
     - license: "Apache-2.0"

--- a/tomcat-native.yaml
+++ b/tomcat-native.yaml
@@ -1,7 +1,7 @@
 package:
   name: tomcat-native
   version: 2.0.8
-  epoch: 0
+  epoch: 1
   description: OpenSSL extension for Tomcat
   copyright:
     - license: Apache-2.0

--- a/trafficserver-9.yaml
+++ b/trafficserver-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: trafficserver-9
   version: 9.2.4
-  epoch: 2
+  epoch: 3
   description: Apache Traffic Server™ is a fast, scalable and extensible HTTP/1.1 and HTTP/2 compliant caching proxy server.
   copyright:
     - license: Apache-2.0

--- a/unbound.yaml
+++ b/unbound.yaml
@@ -1,7 +1,7 @@
 package:
   name: unbound
   version: 1.22.0
-  epoch: 0
+  epoch: 1
   description: "Unbound is a validating, recursive, and caching DNS resolver."
   copyright:
     - license: BSD-3-Clause

--- a/uv.yaml
+++ b/uv.yaml
@@ -1,7 +1,7 @@
 package:
   name: uv
   version: 0.4.25
-  epoch: 0
+  epoch: 1
   description: An extremely fast Python package installer and resolver, written in Rust.
   copyright:
     - license: MIT

--- a/valkey.yaml
+++ b/valkey.yaml
@@ -1,7 +1,7 @@
 package:
   name: valkey
   version: 8.0.1
-  epoch: 0
+  epoch: 1
   description: Advanced key-value store
   copyright:
     - license: BSD-3-Clause

--- a/vector.yaml
+++ b/vector.yaml
@@ -1,7 +1,7 @@
 package:
   name: vector
   version: 0.42.0
-  epoch: 0
+  epoch: 1
   description: End-to-end observability data pipeline
   copyright:
     - license: MPL-2.0

--- a/w3m.yaml
+++ b/w3m.yaml
@@ -2,7 +2,7 @@
 package:
   name: w3m
   version: 0.5.3.20230718
-  epoch: 3
+  epoch: 4
   description: text-based web & gopher browser, as well as pager
   copyright:
     - license: MIT

--- a/wasm-pack.yaml
+++ b/wasm-pack.yaml
@@ -1,7 +1,7 @@
 package:
   name: wasm-pack
   version: 0.13.0
-  epoch: 1
+  epoch: 2
   description: rust to wasm build tool
   copyright:
     - license: Apache-2.0

--- a/wget.yaml
+++ b/wget.yaml
@@ -1,7 +1,7 @@
 package:
   name: wget
   version: 1.24.5
-  epoch: 4
+  epoch: 5
   description: "GNU wget"
   copyright:
     - license: MPL-2.0 AND MIT

--- a/x11vnc.yaml
+++ b/x11vnc.yaml
@@ -1,7 +1,7 @@
 package:
   name: x11vnc
   version: 0.9.16
-  epoch: 1
+  epoch: 2
   description: VNC server for real X displays
   copyright:
     - license: GPL-2.0-or-later

--- a/xmlsec.yaml
+++ b/xmlsec.yaml
@@ -1,7 +1,7 @@
 package:
   name: xmlsec
   version: 1.3.4
-  epoch: 1
+  epoch: 2
   description: C based implementation for XML Signature Syntax and Processing and XML Encryption Syntax and Processing
   copyright:
     - license: MIT

--- a/xorg-server.yaml
+++ b/xorg-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: xorg-server
   version: 21.1.13
-  epoch: 3
+  epoch: 4
   description: "X Server"
   copyright:
     - license: SGI-B-2.0

--- a/yara.yaml
+++ b/yara.yaml
@@ -2,7 +2,7 @@
 package:
   name: yara
   version: 4.5.2
-  epoch: 1
+  epoch: 2
   description: The pattern matching swiss knife for malware researchers
   copyright:
     - license: BSD-3-Clause

--- a/zed.yaml
+++ b/zed.yaml
@@ -1,7 +1,7 @@
 package:
   name: zed
   version: 0.156.1
-  epoch: 1
+  epoch: 2
   description: Code at the speed of thought – Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.
   copyright:
     - license: GPL-3.0-only

--- a/zellij.yaml
+++ b/zellij.yaml
@@ -1,7 +1,7 @@
 package:
   name: zellij
   version: 0.40.1
-  epoch: 2
+  epoch: 3
   description: A terminal workspace with batteries included
   copyright:
     - license: MIT

--- a/zfs.yaml
+++ b/zfs.yaml
@@ -2,7 +2,7 @@
 package:
   name: zfs
   version: 2.2.6
-  epoch: 1
+  epoch: 2
   description: Advanced filesystem and volume manager
   copyright:
     - license: CDDL-1.0


### PR DESCRIPTION
- **openssl: new release 3.4.0**
  Enable jitter seed source, compiled with jitterentropy-library, using
  manually fetched certified build.
  
  Enable PIE (position independent executables).
  
  Enable executing test-suite.
  
  Update hardening-check to expected values, no CF protection on
  libcrypto, due to jitterentroply library being linked.
  
  Fixes: https://github.com/wolfi-dev/os/pull/31548
  

- **Use sub-pipeline**
  

- **rebuild test**
  