### PR TITLE
test wolfictl text

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,3 +1,4 @@
+#nolint:forbidden-repository-used,forbidden-keyring-used
 package:
   name: openssl
   version: 3.4.0
@@ -17,10 +18,21 @@ package:
 
 environment:
   contents:
+    # NB! accessing historic, but certified build of
+    # jitterentropy-library-dev=3.5.0-r0. In a fresh bootstrap build
+    # any version of jitternetropy-library and get an ESV certificate
+    # for it.
+    build_repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - jitterentropy-library-dev=3.5.0-r0
+      # NB! pinned to version https://csrc.nist.gov/projects/cryptographic-module-validation-program/entropy-validations/certificate/191
+      - jitterentropy-library=3.5.0-r0
       - openssf-compiler-options
       - perl
   environment:
@@ -30,39 +42,12 @@ environment:
     CXXFLAGS: ""
     LDFLAGS: ""
 
-vars:
-  # Certified version of jitter library to fetch. Note wolfictl text
-  # prohibits listing old '- jitterentropy-library-dev=3.5.0-r0' in
-  # environment above
-  jitter-pkg: "jitterentropy-library-dev-3.5.0-r0.apk"
-
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/openssl/openssl
       tag: openssl-${{package.version}}
       expected-commit: 98acb6b02839c609ef5b837794e08d906d965335
-
-  - assertions:
-      required-steps: 1
-    pipeline:
-      - if: ${{build.arch}} == 'aarch64'
-        uses: fetch
-        with:
-          uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
-          expected-sha256: "32f42bd6fe32aee1718e382a6533bed413dd452cbb7f180166eb4709c362c09c"
-          extract: false
-      - if: ${{build.arch}} == 'x86_64'
-        uses: fetch
-        with:
-          uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
-          expected-sha256: "0e59f969478959dd7bdb1198faa034c12808ea0f79390bc21a8323812d9c4df1"
-          extract: false
-
-  - name: Extract certified jitter entropy
-    runs: |
-      mkdir -p jitter/
-      tar -C jitter -x -f ${{vars.jitter-pkg}} 2>/dev/null
 
   - name: Create dbg sourcecode
     runs: |
@@ -88,8 +73,6 @@ pipeline:
          --openssldir=/etc/ssl \
          enable-ktls \
          enable-jitter \
-         --with-jitter-include=jitter/usr/include \
-         --with-jitter-lib=jitter/usr/lib \
          shared \
          enable-pie \
          no-zlib \

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -43,19 +43,21 @@ pipeline:
       tag: openssl-${{package.version}}
       expected-commit: 98acb6b02839c609ef5b837794e08d906d965335
 
-  - if: ${{build.arch}} == 'aarch64'
-    uses: fetch
-    with:
-      uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
-      expected-sha256: "32f42bd6fe32aee1718e382a6533bed413dd452cbb7f180166eb4709c362c09c"
-      extract: false
-
-  - if: ${{build.arch}} == 'x86_64'
-    uses: fetch
-    with:
-      uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
-      expected-sha256: "0e59f969478959dd7bdb1198faa034c12808ea0f79390bc21a8323812d9c4df1"
-      extract: false
+  - assertions:
+      required-steps: 1
+    pipeline:
+      - if: ${{build.arch}} == 'aarch64'
+        uses: fetch
+        with:
+          uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
+          expected-sha256: "32f42bd6fe32aee1718e382a6533bed413dd452cbb7f180166eb4709c362c09c"
+          extract: false
+      - if: ${{build.arch}} == 'x86_64'
+        uses: fetch
+        with:
+          uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
+          expected-sha256: "0e59f969478959dd7bdb1198faa034c12808ea0f79390bc21a8323812d9c4df1"
+          extract: false
 
   - name: Extract certified jitter entropy
     runs: |

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssl
-  version: 3.3.2
-  epoch: 2
+  version: 3.4.0
+  epoch: 0
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -30,14 +30,37 @@ environment:
     CXXFLAGS: ""
     LDFLAGS: ""
 
+vars:
+  # Certified version of jitter library to fetch. Note wolfictl text
+  # prohibits listing old '- jitterentropy-library-dev=3.5.0-r0' in
+  # environment above
+  jitter-pkg: "jitterentropy-library-dev-3.5.0-r0.apk"
+
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/openssl/openssl.git
+      repository: https://github.com/openssl/openssl
       tag: openssl-${{package.version}}
-      expected-commit: fb7fab9fa6f4869eaa8fbb97e0d593159f03ffe4
-      cherry-picks: |
-        openssl-3.3/c0d3e4d32d2805f49bec30547f225bc4d092e1f4: CVE-2024-9143 fixes
+      expected-commit: 98acb6b02839c609ef5b837794e08d906d965335
+
+  - if: ${{build.arch}} == 'aarch64'
+    uses: fetch
+    with:
+      uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
+      expected-sha256: "32f42bd6fe32aee1718e382a6533bed413dd452cbb7f180166eb4709c362c09c"
+      extract: false
+
+  - if: ${{build.arch}} == 'x86_64'
+    uses: fetch
+    with:
+      uri: "https://packages.wolfi.dev/os/${{build.arch}}/${{vars.jitter-pkg}}"
+      expected-sha256: "0e59f969478959dd7bdb1198faa034c12808ea0f79390bc21a8323812d9c4df1"
+      extract: false
+
+  - name: Extract certified jitter entropy
+    runs: |
+      mkdir -p jitter/
+      tar -C jitter -x -f ${{vars.jitter-pkg}} 2>/dev/null
 
   - name: Create dbg sourcecode
     runs: |
@@ -62,7 +85,11 @@ pipeline:
          --libdir=lib \
          --openssldir=/etc/ssl \
          enable-ktls \
+         enable-jitter \
+         --with-jitter-include=jitter/usr/include \
+         --with-jitter-lib=jitter/usr/lib \
          shared \
+         enable-pie \
          no-zlib \
          no-async \
          no-comp \
@@ -78,6 +105,7 @@ pipeline:
          -Wa,--noexecstack
       perl configdata.pm --dump
       make -j$(nproc)
+      make tests HARNESS_JOBS=10
 
   - uses: autoconf/make-install
 
@@ -172,8 +200,13 @@ test:
   pipeline:
     - uses: test/hardening-check
       with:
-        package-match: "^openssl$\\|libssl3\\|libcrypto3"
-      runs: |
+        package-match: "^openssl$\\|libssl3"
+    - uses: test/hardening-check
+      with:
+        # jitterentropy is without CF protection so far
+        args: "--nocfprotection"
+        package-match: "^libcrypto3$"
+    - runs: |
         openssl --version
         openssl --help
     - name: Verify curl still works


### PR DESCRIPTION
- **openssl: new release 3.4.0**
  Enable jitter seed source, compiled with jitterentropy-library, using
  manually fetched certified build.
  
  Enable PIE (position independent executables).
  
  Enable executing test-suite.
  
  Update hardening-check to expected values, no CF protection on
  libcrypto, due to jitterentroply library being linked.
  
  Fixes: https://github.com/wolfi-dev/os/pull/31548
  

- **Use sub-pipeline**
  

- **use build-repositories to break dependency cycle**
  