### PR TITLE
python multi-version py3-ruamel-yaml-clib and py3-onetimepass

### DIFF
--- a/py3-onetimepass.yaml
+++ b/py3-onetimepass.yaml
@@ -1,24 +1,29 @@
-# Generated from https://pypi.org/project/onetimepass/
 package:
   name: py3-onetimepass
   version: 1.0.1
-  epoch: 0
+  epoch: 1
   description: Module for generating and validating HOTP and TOTP tokens
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: onetimepass
+  import: onetimepass
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -27,10 +32,44 @@ pipeline:
       repository: https://github.com/tadeck/onetimepass
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-six
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: false

--- a/py3-ruamel-yaml-clib.yaml
+++ b/py3-ruamel-yaml-clib.yaml
@@ -1,26 +1,32 @@
 package:
   name: py3-ruamel-yaml-clib
   version: 0.2.12
-  epoch: 0
-  description: "C version of reader, parser and emitter for ruamel.yaml derived from libyaml."
+  epoch: 1
+  description: C version of reader, parser and emitter for ruamel.yaml derived from libyaml.
   copyright:
     - license: MIT
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: ruamel-yaml-clib
+  import: _ruamel_yaml
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
       - gcc~13
       - openssf-compiler-options
-      - py3-gpep517
-      - py3-pip
-      - py3-setuptools
-      - py3-wheel
-      - python3
-      - python3-dev
-      - wolfi-base
+      - py3-supported-build-base-dev
+      - py3-supported-gpep517
 
 pipeline:
   - uses: fetch
@@ -28,13 +34,48 @@ pipeline:
       uri: https://files.pythonhosted.org/packages/source/r/ruamel.yaml.clib/ruamel.yaml.clib-${{package.version}}.tar.gz
       expected-sha256: 6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f
 
-  - uses: py/pip-build-install
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - py${{range.key}}-ruamel-yaml
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ruamel.yaml.cyaml
 
-  - runs: |
-      install -Dm644 LICENSE \
-        "${{targets.destdir}}"/usr/share/licenses/${{package.name}}/LICENSE
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
-  - uses: strip
+test:
+  environment:
+    contents:
+      packages:
+        - py3-ruamel-yaml
+  pipeline:
+    - uses: python/import
+      with:
+        import: ruamel.yaml.cyaml
 
 update:
   enabled: true


### PR DESCRIPTION
The only interesting thing here is that in order to test ruamel-yaml-clib I had to install ruamel-yaml.
