### PR TITLE
py3-pamela - multi-version

### DIFF
--- a/py3-pamela.yaml
+++ b/py3-pamela.yaml
@@ -1,24 +1,29 @@
-# Generated from https://pypi.org/project/pamela/
 package:
   name: py3-pamela
   version: 1.2.0
-  epoch: 0
+  epoch: 1
   description: PAM interface using ctypes
   copyright:
     - license: MIT
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: pamela
+  import: pamela
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -27,10 +32,45 @@ pipeline:
       repository: https://github.com/minrk/pamela
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        # pamela dlopens "pam" (CDLL(find_library("pam")))
+        - linux-pam
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true


### PR DESCRIPTION
pamela uses 'find_library("pam")', so melange does not notice the runtime dependency.

