### PR TITLE
rancher-partner-charts: update commit

### DIFF
--- a/rancher-partner-charts.yaml
+++ b/rancher-partner-charts.yaml
@@ -1,7 +1,7 @@
 #nolint:git-checkout-must-use-github-updates,valid-pipeline-git-checkout-tag
 package:
   name: rancher-partner-charts
-  version: 0_git20241022
+  version: 0_git20241023
   epoch: 0
   description: Complete container management platform - partner charts
   copyright:
@@ -19,7 +19,7 @@ pipeline:
       repository: https://github.com/rancher/partner-charts
       branch: main
       destination: ./charts
-      expected-commit: 9fbed37e1f4c6567b9f6ad7a373cb8827aafe613
+      expected-commit: 47a366cfd1aba33eacdca4bf99786946f29e14c0
 
   - working-directory: ./charts
     runs: |


### PR DESCRIPTION
The repo seems to have been updated since the PR was tested and approved, and it fails in postsubmit.

```
[git checkout] FAIL expected commit 9fbed37e1f4c6567b9f6ad7a373cb8827aafe613 on main, got 47a366cfd1aba33eacdca4bf99786946f29e14c0, set depth to -1 to attempt a reset
```