### PR TITLE
drop runtime deps for -compat packages in kaniko

### DIFF
--- a/kaniko.yaml
+++ b/kaniko.yaml
@@ -1,7 +1,7 @@
 package:
   name: kaniko
   version: 1.23.2
-  epoch: 3
+  epoch: 4
   description: Build Container Images In Kubernetes
   copyright:
     - license: Apache-2.0
@@ -50,9 +50,6 @@ subpackages:
           # Symlink the binary from usr/bin to /kaniko/
           mkdir -p ${{targets.subpkgdir}}/kaniko/
           ln -sf /usr/bin/executor ${{targets.subpkgdir}}/kaniko/
-    dependencies:
-      runtime:
-        - kaniko
 
   - name: kaniko-warmer-compat
     pipeline:
@@ -60,9 +57,6 @@ subpackages:
           # Symlink the binary from usr/bin to /kaniko/
           mkdir -p ${{targets.subpkgdir}}/kaniko/
           ln -sf /usr/bin/warmer ${{targets.subpkgdir}}/kaniko/
-    dependencies:
-      runtime:
-        - kaniko-warmer
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

We mostly do not duplicate -compat sub-packages for the FIPS variant of the packages so which means that we reuse these -compat sub-packages in FIPS variants so we should not specify the actual packages as a runtime deps here that causes an issue like:
- `kaniko-1.23.2-r3.apk disqualified because kaniko-fips-1.23.2-r0.apk already provides cmd:executor`