### PR TITLE
py3-soupsieve - multi-version

### DIFF
--- a/py3-soupsieve.yaml
+++ b/py3-soupsieve.yaml
@@ -1,27 +1,33 @@
-# Generated from https://pypi.org/project/soupsieve/
+# Note: soupseive has circular dependency with beautifulsoup
+#       so there is no import test here as it would not run
+#       without running a runtime dep on py3-beautifulsoup.
 package:
   name: py3-soupsieve
-  version: "2.6"
-  epoch: 0
+  version: '2.6'
+  epoch: 1
   description: A modern CSS selector implementation for Beautiful Soup.
   copyright:
-    - license: "MIT"
+    - license: MIT
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: soupsieve
+  import: soupsieve
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -30,10 +36,28 @@ pipeline:
       repository: https://github.com/facelessuser/soupsieve
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true
@@ -42,13 +66,3 @@ update:
     - 2.3.2.post1
   github:
     identifier: facelessuser/soupsieve
-
-test:
-  environment:
-    contents:
-      packages:
-        - python-3
-        - py3-beautifulsoup4
-  pipeline:
-    - runs: |
-        python -c "import soupsieve; print(soupsieve.__version__)"


### PR DESCRIPTION
Note:
 soupseive has circular dependency with beautifulsoup
 so there is no import test here as it would not run
 without running a runtime dep on py3-beautifulsoup.

See https://github.com/wolfi-dev/os/pull/30668
and https://github.com/wolfi-dev/os/pull/30667 for example of attempts to recognize the dependency.
