### PR TITLE
make grpc-1.67 multi-version python.

### DIFF
--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.67
   version: 1.67.0
-  epoch: 0
+  epoch: 1
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -17,6 +17,17 @@ var-transforms:
     match: ^(\d+\.\d+)\.\d+$
     replace: "$1"
     to: major-minor-version
+
+vars:
+  pypi-package: grpcio
+  import: grpc
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
 
 environment:
   contents:
@@ -40,9 +51,8 @@ environment:
       - linux-headers
       - openssl-dev
       - protobuf-dev
-      - py3-setuptools
-      - python3
-      - python3-dev
+      - py3-supported-build-base
+      - py3-supported-python-dev
       - re2
       - re2-dev
       - samurai
@@ -82,19 +92,6 @@ pipeline:
       	-DgRPC_BUILD_TESTS=OFF
       cmake --build _build
 
-      GRPC_PYTHON_CFLAGS="-std=c++17" \
-      GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY=1 \
-      GRPC_PYTHON_BUILD_SYSTEM_CARES=1 \
-      GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
-      GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 \
-      GRPC_PYTHON_BUILD_SYSTEM_RE2=1 \
-      GRPC_PYTHON_BUILD_SYSTEM_ABSL=1 \
-      python3 setup.py build
-
-      # grpcio-tools
-      cd tools/distrib/python
-      python3 make_grpcio_tools.py
-
   - runs: |
       DESTDIR="${{targets.destdir}}" cmake --install _build
       python3 setup.py install --skip-build --root="${{targets.destdir}}"
@@ -105,17 +102,42 @@ pipeline:
       sh -c 'rm $0 && ln -s /etc/ssl/certs/ca-certificates.crt $0' "{}" \;
 
 subpackages:
-  - name: py3-grpcio-${{vars.major-minor-version}}
-    description: "gRPC Python HTTP/2-based RPC framework"
+  - range: py-versions
+    name: py${{range.key}}-grpcio-${{vars.major-minor-version}}
+    description: python${{range.key}} version of grpcio
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-grpcio-${{vars.major-minor-version}}
+        - py3-grpcio
+    pipeline:
+      - uses: py/pip-build-install
+        environment:
+          GRPC_PYTHON_CFLAGS: "-std=c++17"
+          GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
+          GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
+          GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
+          GRPC_PYTHON_BUILD_SYSTEM_ZLIB: "1"
+          GRPC_PYTHON_BUILD_SYSTEM_RE2: "1"
+          GRPC_PYTHON_BUILD_SYSTEM_ABSL: "1"
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+  - name: py3-supported-grpcio-${{vars.major-minor-version}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
     dependencies:
       runtime:
-        - py3-six
-      provides:
-        - py3-grpcio=${{package.full-version}}
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib
-          mv ${{targets.destdir}}/usr/lib/python3* ${{targets.subpkgdir}}/usr/lib/
+        - py3.10-grpcio-${{vars.major-minor-version}}
+        - py3.11-grpcio-${{vars.major-minor-version}}
+        - py3.12-grpcio-${{vars.major-minor-version}}
 
   - name: ${{package.name}}-dev
     pipeline:


### PR DESCRIPTION
Some things to note:
1. it fails build with 3.13. First error was:

   src/python/grpcio/grpc/_cython/cygrpc.cpp:6396:39: error: '_PyInterpreterState_GetConfig' was not declared in this scope; did you mean 'PyInterpreterState_GetID'

2. I dropped this stanza:

       # grpcio-tools
       cd tools/distrib/python
       python3 make_grpcio_tools.py
