### PR TITLE
opentofu: fix expected commit

### DIFF
--- a/opentofu.yaml
+++ b/opentofu.yaml
@@ -12,7 +12,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 4bdffd1a9b94e27bc06b1e89beb29cf444fb8cd1
+      expected-commit: 68c124a7cae47bc97e5ec7674d833576abff8fe9
       repository: https://github.com/opentofu/opentofu
       tag: v${{package.version}}
 


### PR DESCRIPTION
```
[git checkout] FAIL Expected commit 4bdffd1a9b94e27bc06b1e89beb29cf444fb8cd1 for v1.8.4, found 68c124a7cae47bc97e5ec7674d833576abff8fe9
```