### PR TITLE
python-3.13: cherrypick CVE-2024-9287 fixes

### DIFF
--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -53,6 +53,7 @@ pipeline:
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
       cherry-picks: |
+        3.13/9aa85f524fd276becc2a4265a9b0c00b4e7b3440: prereq for CVE-2024-9287 as it changes Lib/venv/scripts/posix/activate.csh
         3.13/e52095a0c1005a87eed2276af7a1f2f66e2b6483: CVE-2024-9287
 
   - name: Force use of system libraries

--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: 3.13.0
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -52,6 +52,8 @@ pipeline:
       expected-commit: 60403a5409ff2c3f3b07dd2ca91a7a3e096839c7
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
+      cherry-picks: |
+        3.13/e52095a0c1005a87eed2276af7a1f2f66e2b6483: CVE-2024-9287
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
https://mail.python.org/archives/list/security-announce@python.org/thread/RSPJ2B5JL22FG3TKUJ7D7DQ4N5JRRBZL/