### PR TITLE
Add additional provides to grpc-1.67 python builds.

### DIFF
--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.67
   version: 1.67.0
-  epoch: 1
+  epoch: 2
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -110,6 +110,7 @@ subpackages:
       provides:
         - py3-grpcio-${{vars.major-minor-version}}
         - py3-grpcio
+        - py${{range.key}}-grpcio
     pipeline:
       - uses: py/pip-build-install
         environment:


### PR DESCRIPTION
The py3.XX-grpcio-1.67 package need to provide the un-versioned
py3.XX-grpcio so that python packages can depend on that.
