### PR TITLE
feat(new-package): adds azuredisk-csi-1.31

### DIFF
--- a/azuredisk-csi-1.31.yaml
+++ b/azuredisk-csi-1.31.yaml
@@ -1,5 +1,5 @@
 package:
-  name: azuredisk-csi
+  name: azuredisk-csi-1.31
   version: 1.31.0
   epoch: 0
   description: Azure Disk CSI Driver
@@ -36,27 +36,16 @@ update:
   github:
     identifier: kubernetes-sigs/azuredisk-csi-driver
     strip-prefix: v
+    tag-filter: v1.31.
 
 test:
   pipeline:
-    - runs: |
-        # Run the azurediskplugin binary in the background
-        /usr/bin/azurediskplugin &
-
-        # Capture the process ID of azurediskplugin
-        AZUREDISKPLUGIN_PID=$!
-
-        # Sleep for a short time to allow the binary to start
-        sleep 2
-
-        # Check the process using a compatible method for BusyBox
-        if ps | grep -q '[a]zurediskplugin'; then
-          echo "azurediskplugin started successfully"
-        else
-          echo "azurediskplugin failed to start" >&2
-          exit 1
-        fi
-
-        # Kill the process once we have confirmed it started successfully
-        kill $AZUREDISKPLUGIN_PID
-        echo "azurediskplugin terminated after successful start"
+    # Run the azurediskplugin binary and verify its startup
+    - name: Run and test `azurediskplugin`
+      uses: test/daemon-check-output
+      with:
+        start: /usr/bin/azurediskplugin
+        timeout: 30
+        expected_output: |
+          Enabling controller service capability: CREATE_DELETE_VOLUME
+          Enabling volume access mode: SINGLE_NODE_WRITER

--- a/azuredisk-csi.yaml
+++ b/azuredisk-csi.yaml
@@ -1,0 +1,71 @@
+package:
+  name: azuredisk-csi
+  version: 1.31.0
+  epoch: 0
+  description: Azure Disk CSI Driver
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 81f73ae6e758c2dd5efbaf127014e80d01d39f66
+      repository: https://github.com/kubernetes-sigs/azuredisk-csi-driver
+      tag: v${{package.version}}
+
+  - uses: go/build
+    with:
+      ldflags: |
+        -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.driverVersion=v${{package.version}}
+        -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.gitCommit=$(git rev-parse HEAD)
+        -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.buildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        -extldflags "-static"
+      output: azurediskplugin
+      tags: azurediskv2
+      packages: ./pkg/azurediskplugin
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          ln -sf /usr/bin/azurediskplugin ${{targets.subpkgdir}}/azurediskplugin
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes-sigs/azuredisk-csi-driver
+    strip-prefix: v
+    tag-filter: v
+    use-tag: true
+
+test:
+  pipeline:
+    - runs: |
+        # Run the azurediskplugin binary in the background
+        /usr/bin/azurediskplugin &
+
+        # Capture the process ID of azurediskplugin
+        AZUREDISKPLUGIN_PID=$!
+
+        # Sleep for a short time to allow the binary to start
+        sleep 2
+
+        # Check the process using a compatible method for BusyBox
+        if ps | grep -q '[a]zurediskplugin'; then
+          echo "azurediskplugin started successfully"
+        else
+          echo "azurediskplugin failed to start" >&2
+          exit 1
+        fi
+
+        # Kill the process once we have confirmed it started successfully
+        kill $AZUREDISKPLUGIN_PID
+        echo "azurediskplugin terminated after successful start"

--- a/azuredisk-csi.yaml
+++ b/azuredisk-csi.yaml
@@ -6,10 +6,6 @@ package:
   copyright:
     - license: Apache-2.0
 
-environment:
-  environment:
-    CGO_ENABLED: "0"
-
 pipeline:
   - uses: git-checkout
     with:
@@ -23,12 +19,9 @@ pipeline:
         -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.driverVersion=v${{package.version}}
         -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.gitCommit=$(git rev-parse HEAD)
         -X sigs.k8s.io/azuredisk-csi-driver/pkg/azuredisk.buildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-        -extldflags "-static"
       output: azurediskplugin
       tags: azurediskv2
       packages: ./pkg/azurediskplugin
-
-  - uses: strip
 
 subpackages:
   - name: "${{package.name}}-compat"
@@ -43,8 +36,6 @@ update:
   github:
     identifier: kubernetes-sigs/azuredisk-csi-driver
     strip-prefix: v
-    tag-filter: v
-    use-tag: true
 
 test:
   pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
