### PR TITLE
shadowsocks-rust: fix expected commit

### DIFF
--- a/shadowsocks-rust.yaml
+++ b/shadowsocks-rust.yaml
@@ -22,7 +22,7 @@ pipeline:
     with:
       repository: https://github.com/shadowsocks/shadowsocks-rust
       tag: v${{package.version}}
-      expected-commit: 72beacc2f4ab9f9d190ebe3dc4354ba8064a86bd
+      expected-commit: a03006a753486e64717d6e3afa91e0c6d043c557
 
   - name: Configure
     runs: |


### PR DESCRIPTION
```
[git checkout] FAIL Expected commit 72beacc2f4ab9f9d190ebe3dc4354ba8064a86bd for v1.21.2, found a03006a753486e64717d6e3afa91e0c6d043c557
```