### PR TITLE
Added patch to fix kafka-3.8/GHSA-g8m5-722r-8whq

### DIFF
--- a/kafka-3.8.yaml
+++ b/kafka-3.8.yaml
@@ -2,7 +2,7 @@ package:
   name: kafka-3.8
   # When bumping check to see if the CVE mitigation can be removed.
   version: 3.8.0
-  epoch: 4
+  epoch: 5
   description: Apache Kafka is a distributed event streaming platform
   copyright:
     - license: Apache-2.0
@@ -38,6 +38,10 @@ pipeline:
       repository: https://github.com/apache/kafka
       tag: ${{package.version}}
       expected-commit: 771b9576b00ecf5b64ab6e8bedf04156fbdb5cd6
+
+  - uses: patch
+    with:
+      patches: jetty.patch
 
   - runs: |
       gradle clean releaseTarGz

--- a/kafka-3.8/jetty.patch
+++ b/kafka-3.8/jetty.patch
@@ -1,0 +1,44 @@
+diff --git a/gradle/dependencies.gradle b/gradle/dependencies.gradle
+index f87cbd4f24..54deb3d2f9 100644
+--- a/gradle/dependencies.gradle
++++ b/gradle/dependencies.gradle
+@@ -106,7 +106,7 @@ versions += [
+   jackson: "2.16.2",
+   jacoco: "0.8.10",
+   javassist: "3.29.2-GA",
+-  jetty: "9.4.54.v20240208",
++  jetty: "9.4.56.v20240826",
+   jersey: "2.39.1",
+   jline: "3.25.1",
+   jmh: "1.37",
+diff --git a/LICENSE-binary b/LICENSE-binary
+index fc765315cd..6ea82fe124 100644
+--- a/LICENSE-binary
++++ b/LICENSE-binary
+@@ -229,16 +229,16 @@ jackson-module-scala_2.13-2.16.2
+ jackson-module-scala_2.12-2.16.2
+ jakarta.validation-api-2.0.2
+ javassist-3.29.2-GA
+-jetty-client-9.4.54.v20240208
+-jetty-continuation-9.4.54.v20240208
+-jetty-http-9.4.54.v20240208
+-jetty-io-9.4.54.v20240208
+-jetty-security-9.4.54.v20240208
+-jetty-server-9.4.54.v20240208
+-jetty-servlet-9.4.54.v20240208
+-jetty-servlets-9.4.54.v20240208
+-jetty-util-9.4.54.v20240208
+-jetty-util-ajax-9.4.54.v20240208
++jetty-client-9.4.56.v20240826
++jetty-continuation-9.4.56.v20240826
++jetty-http-9.4.56.v20240826
++jetty-io-9.4.56.v20240826
++jetty-security-9.4.56.v20240826
++jetty-server-9.4.56.v20240826
++jetty-servlet-9.4.56.v20240826
++jetty-servlets-9.4.56.v20240826
++jetty-util-9.4.56.v20240826
++jetty-util-ajax-9.4.56.v20240826
+ jose4j-0.9.4
+ lz4-java-1.8.0
+ maven-artifact-3.9.6


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/chainguard-dev/CVE-Dashboard/issues/13839

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
  - I believe this fix will get detected and recorded automatically? 

