### PR TITLE
apache2-compat: Fix httpd-ssl.conf to match upstream image

### DIFF
--- a/apache2.yaml
+++ b/apache2.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache2
   version: 2.4.62
-  epoch: 3
+  epoch: 4
   description: "Apache HTTP Server"
   copyright:
     - license: Apache-2.0
@@ -148,6 +148,7 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/conf
           mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/var/run/apache2
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/apache2/logs
 
           # Install necessary config files
           mkdir -p "${{targets.subpkgdir}}"/etc/
@@ -197,7 +198,8 @@ subpackages:
 
           ### Modify other paths
           sed -ri \
-            -e 's|etc/|usr/share/local/apache2/conf/|g' \
+            -e 's|etc/|usr/local/apache2/conf/|g' \
+            -e 's|/var/run/apache2/|usr/local/apache2/logs/|g' \
             "${{targets.subpkgdir}}"/etc/extra/httpd-ssl.conf;
     test:
       environment:


### PR DESCRIPTION
apache2-compat: Fix httpd-ssl.conf to match upstream.