### PR TITLE
py3-zope.interface: Use github-checkout instead of fetch pipeline.

### DIFF
--- a/py3-zope.interface.yaml
+++ b/py3-zope.interface.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-zope.interface
-  version: 7.1.0
+  version: 7.1.1
   epoch: 0
   description: Interfaces for Python
   copyright:
@@ -26,10 +26,11 @@ environment:
       - py3-supported-build-base-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 3f005869a1a05e368965adb2075f97f8ee9a26c61898a9e52a9764d93774f237
-      uri: https://files.pythonhosted.org/packages/source/z/zope.interface/zope_interface-${{package.version}}.tar.gz
+      expected-commit: 98296bdbc1173dc83a8ad89764f2dc37c6f2463c
+      repository: https://github.com/zopefoundation/zope.interface
+      tag: ${{package.version}}
 
 subpackages:
   - range: py-versions


### PR DESCRIPTION
Use 'github-checkout' pipeline instead of 'fetch' pipeline, which fixes updatebot failures.
