### PR TITLE
py3-mako: update to 1.3.6

### DIFF
--- a/py3-mako.yaml
+++ b/py3-mako.yaml
@@ -1,7 +1,6 @@
 package:
   name: py3-mako
   version: 1.3.6
-
   epoch: 0
   description: Python3 fast templating language
   copyright:

--- a/py3-mako.yaml
+++ b/py3-mako.yaml
@@ -1,7 +1,8 @@
 package:
   name: py3-mako
-  version: 1.3.5
-  epoch: 1
+  version: 1.3.6
+
+  epoch: 0
   description: Python3 fast templating language
   copyright:
     - license: MIT
@@ -30,8 +31,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 48dbc20568c1d276a2698b36d968fa76161bf127194907ea6fc594fa81f943bc
-      uri: https://files.pythonhosted.org/packages/source/M/Mako/Mako-${{package.version}}.tar.gz
+      expected-sha256: 9ec3a1583713479fae654f83ed9fa8c9a4c16b7bb0daba0e6bbebff50c0d983d
+      uri: https://files.pythonhosted.org/packages/source/M/Mako/mako-${{package.version}}.tar.gz
 
 subpackages:
   - range: py-versions


### PR DESCRIPTION
Update py3-mako to 1.3.6 and update URI for to resolve auto-updates.