### PR TITLE
datadog-agent-core-integrations: include the agent integrations requirements

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: 7.58.0
-  epoch: 0
+  epoch: 1
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -285,6 +285,9 @@ subpackages:
               mkdir -p ${{targets.contextdir}}/opt/datadog-agent
               .venv/bin/pip freeze > ${{targets.contextdir}}/opt/datadog-agent/final_constraints-py3.txt
 
+              # Include the agent's requirements for the core integrations.
+              cp requirements-agent-release.txt ${{targets.contextdir}}/opt/datadog-agent/
+
               # Use Python in virtual environment
               sed -i "s|$(pwd)/.venv|/usr/share/datadog-agent|g" .venv/pyvenv.cfg
               sed -i "s|$(pwd)/.venv|/usr/share/datadog-agent|g" .venv/bin/*
@@ -523,6 +526,9 @@ test:
     environment:
       PYTHONPATH: "/usr/share/datadog-agent/lib/python3.11/site-packages"
   pipeline:
+    - name: Ensure the agent's requirements.txt for integrations is included
+      runs: |
+        ls /opt/datadog-agent/requirements-agent-release.txt
     - name: Ensure checks can be loaded
       runs: |
         python -c "import datadog_checks.base"


### PR DESCRIPTION
The agent integrations requirements.txt is expected by the agent integration subcommands, for instance to install extra integrations.

Fixes: #31887
