### PR TITLE
dagger: set the engine tag

### DIFF
--- a/dagger.yaml
+++ b/dagger.yaml
@@ -19,7 +19,10 @@ pipeline:
 
   - uses: go/build
     with:
-      ldflags: -s -w  -X github.com/dagger/dagger/engine.Version=v${{package.version}}
+      ldflags: |
+        -s -w
+        -X github.com/dagger/dagger/engine.Version=v${{package.version}}
+        -X github.com/dagger/dagger/engine.Tag=v${{package.version}}
       output: dagger
       packages: ./cmd/dagger
 

--- a/dagger.yaml
+++ b/dagger.yaml
@@ -1,7 +1,7 @@
 package:
   name: dagger
   version: 0.13.5
-  epoch: 0
+  epoch: 1
   description: Application Delivery as Code that Runs Anywhere
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
make sure to set the engine tag when building the dagger CLI.

copied from https://github.com/dagger/dagger/blob/v0.13.6/.goreleaser.common.yml#L14-L17

Previously we had:

```
$ dagger version
dagger v0.13.5 (registry.dagger.io/engine:) linux/arm64
```

and now:

```
$ dagger version
dagger v0.13.5 (registry.dagger.io/engine:v0.13.5) linux/arm64
```

This is important, because it changes the behavior of Dagger. Without this field, dagger thinks it's a "dev build", cf https://github.com/dagger/dagger/blob/v0.13.6/engine/consts.go#L41 - So it won't do the same thing as a proper official release.
Setting the Tag field will fix it.

### Pre-review Checklist

- [x] I've bumped the `epoch` field
