### PR TITLE
Added patch to fix solr/GHSA-g8m5-722r-8whq

### DIFF
--- a/solr.yaml
+++ b/solr.yaml
@@ -31,8 +31,8 @@ pipeline:
   - runs: |
       sed -i -e 's|org.apache.zookeeper:\*=3.9.1|org.apache.zookeeper:\*=3.9.2|g' versions.props
       sed -i -e 's|com.jayway.jsonpath:json-path=2.8.0|com.jayway.jsonpath:json-path=2.9.0|g' versions.props
-      # Resolve CVE-2024-22201
-      sed -i -e 's|org.eclipse.jetty\*:\*=10.0.19|org.eclipse.jetty\*:\*=10.0.20|g' versions.props
+      # Resolve GHSA-g8m5-722r-8whq
+      sed -i -e 's|org.eclipse.jetty\*:\*=10.0.22|org.eclipse.jetty\*:\*=10.0.24|g' versions.props
       ./gradlew --write-locks
 
       ./gradlew dependencies


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/chainguard-dev/CVE-Dashboard/issues/13861

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
  - I believe this fix will get detected and recorded automatically? 

