### PR TITLE
always use builtin pipelines for Go builds

### DIFF
--- a/aws-ebs-csi-driver.yaml
+++ b/aws-ebs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-ebs-csi-driver
   version: 1.36.0
-  epoch: 0
+  epoch: 1
   description: CSI driver for Amazon EBS.
   copyright:
     - license: Apache-2.0
@@ -32,15 +32,15 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: e6dae6132fc8383340024440fc639a135bebd4ba
 
-  - runs: |
-      # Our global LDFLAGS conflict with a Makefile parameter
-      unset LDFLAGS
-
-      make ARCH=$(go env GOARCH)
-      mkdir -p ${{targets.destdir}}/usr/bin
-      cp bin/aws-ebs-csi-driver ${{targets.destdir}}/usr/bin/
-
-  - uses: strip
+  - uses: go/build
+    with:
+      packages: ./cmd
+      ldflags: |
+        -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.driverVersion=${{package.version}}
+        -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud.driverVersion=${{package.version}}
+        -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.gitCommit=$(git rev-parse HEAD)
+        -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.buildDate=$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%Y-%m-%dT%H:%M:%SZ")
+      output: aws-ebs-csi-driver
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Once we run the binary it outputs the driverVersion wrong, so, this PR aims to fix it.

```bash
[sdk] ❯ aws-ebs-csi-driver --version
{
  "driverVersion": "1.36.0",
  "gitCommit": "e6dae6132fc8383340024440fc639a135bebd4ba",
  "buildDate": "1970-01-01T00:00:00Z",
  "goVersion": "go1.23.2",
  "compiler": "gc",
  "platform": "linux/arm64"
}
[sdk] ❯
```

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

