### PR TITLE
datadog-agent-extra-integrations-compat: add extra integrations installation compat package

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -53,6 +53,7 @@ environment:
       - python3-dev~3.11 # strictly requires python3.11
       - systemd-dev
       - wget # Required for downloading clang-12 and kernel headers from debian
+      - rsync # Required to generate diffs for compat packages
   environment:
     # CGo allows Go programs to call C code
     CGO_ENABLED: "1"
@@ -264,14 +265,30 @@ subpackages:
               python3.11 -m venv .venv
               . .venv/bin/activate
 
+              mkdir /usr/share/datadog-agent
+              sed -i "s|$(pwd)/.venv|/usr/share/datadog-agent|g" .venv/pyvenv.cfg
+              sed -i "s|$(pwd)/.venv|/usr/share/datadog-agent|g" .venv/bin/*
+
+              # Dump the packages.
+              mkdir site-packages
+              rsync -az /usr/share/datadog-agent/lib/python3.11/site-packages/ ./site-packages/
+
               # Install check downloader, needed by the `agent integration install` command.
               pip install "./datadog_checks_downloader[deps]"
 
-              # Include dependencies.
+              # Cleanup.
               find .venv -name "*.pyc" -delete
               find .venv -name "__pycache__" -exec rm -rf {} +
-              mkdir -p ${{targets.contextdir}}/usr/share/datadog-agent/lib/python3.11/site-packages/
-              cp -r .venv/lib/python3.11/site-packages/* ${{targets.contextdir}}/usr/share/datadog-agent/lib/python3.11/site-packages/
+
+              # Prepare the package content.
+              diff_packages=$(rsync --include='*/' --exclude='*' --ignore-existing -rv --dry-run /usr/share/datadog-agent/lib/python3.11/site-packages/ ./site-packages/ | grep -v "sending incremental file list" | grep -v -E "^\./$|^sent .+ bytes|total size|^$")
+
+              # Include the new packages.
+              packages_dir="${{targets.contextdir}}/usr/share/datadog-agent/lib/python3.11/site-packages/"
+              mkdir -p "${packages_dir}"
+              for package in $diff_packages; do
+                cp -vr "/usr/share/datadog-agent/lib/python3.11/site-packages/${package}" $packages_dir;
+              done
 
   - name: datadog-agent-core-integrations
     dependencies:
@@ -313,10 +330,6 @@ subpackages:
 
               mkdir -p ${{targets.contextdir}}/opt/datadog-agent
               .venv/bin/pip freeze > ${{targets.contextdir}}/opt/datadog-agent/final_constraints-py3.txt
-
-              # Install virtual environment
-              mkdir -p ${{targets.contextdir}}/usr/share/datadog-agent
-              cp -r .venv/* ${{targets.contextdir}}/usr/share/datadog-agent/
 
               # Include the agent's requirements for the core integrations.
               cp requirements-agent-release.txt ${{targets.contextdir}}/opt/datadog-agent/

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -51,9 +51,9 @@ environment:
       - py3.11-pip
       - py3.11-semver
       - python3-dev~3.11 # strictly requires python3.11
+      - rsync # Required to generate diffs for compat packages
       - systemd-dev
       - wget # Required for downloading clang-12 and kernel headers from debian
-      - rsync # Required to generate diffs for compat packages
   environment:
     # CGo allows Go programs to call C code
     CGO_ENABLED: "1"

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -244,6 +244,35 @@ subpackages:
 
           cp -r Dockerfiles/agent/entrypoint.d ${{targets.subpkgdir}}/opt/entrypoints
 
+  - name: datadog-agent-extra-integrations-compat
+    dependencies:
+      runtime:
+        - python-3.11
+    pipeline:
+      - working-directory: /home/integrations
+        pipeline:
+          - uses: git-checkout
+            with:
+              repository: https://github.com/DataDog/integrations-core
+              tag: ${{package.version}}
+              expected-commit: 32f78c0c8aae400ecc1c14a5369e7f702be7b572 # needs to be updated with each new release
+          - runs: |
+              # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
+              SOURCE_DATE_EPOCH=315532800
+
+              # Create virtual environment
+              python3.11 -m venv .venv
+              . .venv/bin/activate
+
+              # Install check downloader, needed by the `agent integration install` command.
+              pip install "./datadog_checks_downloader[deps]"
+
+              # Include dependencies.
+              find .venv -name "*.pyc" -delete
+              find .venv -name "__pycache__" -exec rm -rf {} +
+              mkdir -p ${{targets.contextdir}}/usr/share/datadog-agent/lib/python3.11/site-packages/
+              cp -r .venv/lib/python3.11/site-packages/* ${{targets.contextdir}}/usr/share/datadog-agent/lib/python3.11/site-packages/
+
   - name: datadog-agent-core-integrations
     dependencies:
       runtime:
@@ -284,6 +313,10 @@ subpackages:
 
               mkdir -p ${{targets.contextdir}}/opt/datadog-agent
               .venv/bin/pip freeze > ${{targets.contextdir}}/opt/datadog-agent/final_constraints-py3.txt
+
+              # Install virtual environment
+              mkdir -p ${{targets.contextdir}}/usr/share/datadog-agent
+              cp -r .venv/* ${{targets.contextdir}}/usr/share/datadog-agent/
 
               # Include the agent's requirements for the core integrations.
               cp requirements-agent-release.txt ${{targets.contextdir}}/opt/datadog-agent/

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -277,8 +277,8 @@ subpackages:
               pip install "./datadog_checks_downloader[deps]"
 
               # Cleanup.
-              find .venv -name "*.pyc" -delete
-              find .venv -name "__pycache__" -exec rm -rf {} +
+              find /usr/share/datadog-agent -name "*.pyc" -delete
+              find /usr/share/datadog-agent -name "__pycache__" -exec rm -rf {} +
 
               # Prepare the package content.
               diff_packages=$(rsync --include='*/' --exclude='*' --ignore-existing -rv --dry-run /usr/share/datadog-agent/lib/python3.11/site-packages/ ./site-packages/ | grep -v "sending incremental file list" | grep -v -E "^\./$|^sent .+ bytes|total size|^$")

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -261,33 +261,25 @@ subpackages:
               # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
               SOURCE_DATE_EPOCH=315532800
 
-              # Create virtual environment
-              python3.11 -m venv .venv
-              . .venv/bin/activate
-
-              mkdir /usr/share/datadog-agent
-              sed -i "s|$(pwd)/.venv|/usr/share/datadog-agent|g" .venv/pyvenv.cfg
-              sed -i "s|$(pwd)/.venv|/usr/share/datadog-agent|g" .venv/bin/*
-
               # Dump the packages.
-              mkdir -p /usr/share/datadog-agent/lib/python3.11/site-packages site-packages 
-              rsync -az /usr/share/datadog-agent/lib/python3.11/site-packages/ ./site-packages/
+              mkdir site-packages
+              rsync -az /usr/lib/python3.11/site-packages/ ./site-packages/
 
               # Install check downloader, needed by the `agent integration install` command.
               pip install "./datadog_checks_downloader[deps]"
 
               # Cleanup.
-              find /usr/share/datadog-agent -name "*.pyc" -delete
-              find /usr/share/datadog-agent -name "__pycache__" -exec rm -rf {} +
+              find /usr/lib/python3.11 -name "*.pyc" -delete
+              find /usr/lib/python3.11 -name "__pycache__" -exec rm -rf {} +
 
               # Prepare the package content.
-              diff_packages=$(rsync --include='*/' --exclude='*' --ignore-existing -rv --dry-run /usr/share/datadog-agent/lib/python3.11/site-packages/ ./site-packages/ | grep -v "sending incremental file list" | grep -v -E "^\./$|^sent .+ bytes|total size|^$")
+              diff_packages=$(rsync --include='*/' --exclude='*' --ignore-existing -rv --dry-run /usr/lib/python3.11/site-packages/ ./site-packages/ | grep -v "sending incremental file list" | grep -v -E "^\./$|^sent .+ bytes|total size|^$")
 
               # Include the new packages.
               packages_dir="${{targets.contextdir}}/usr/share/datadog-agent/lib/python3.11/site-packages/"
               mkdir -p "${packages_dir}"
               for package in $diff_packages; do
-                cp -vr "/usr/share/datadog-agent/lib/python3.11/site-packages/${package}" $packages_dir;
+                cp -vr "/usr/lib/python3.11/site-packages/${package}" $packages_dir;
               done
 
   - name: datadog-agent-core-integrations

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -270,7 +270,7 @@ subpackages:
               sed -i "s|$(pwd)/.venv|/usr/share/datadog-agent|g" .venv/bin/*
 
               # Dump the packages.
-              mkdir site-packages
+              mkdir -p /usr/share/datadog-agent/lib/python3.11/site-packages site-packages 
               rsync -az /usr/share/datadog-agent/lib/python3.11/site-packages/ ./site-packages/
 
               # Install check downloader, needed by the `agent integration install` command.


### PR DESCRIPTION
Fixes #31928

**Additional context**

Having this subpackage avoids to ship the `datadog_checks.downloader` Python package with the `datadog-agent-core-integrations` subpackage.