### PR TITLE
ruby3.2-kubeclient - Loosen restriction on recursive-open-struct version

### DIFF
--- a/ruby3.2-kubeclient.yaml
+++ b/ruby3.2-kubeclient.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-kubeclient
   version: 4.12.0
-  epoch: 1
+  epoch: 2
   description: An efficient, thread safe LRU cache.
   copyright:
     - license: MIT
@@ -29,6 +29,10 @@ pipeline:
       repository: https://github.com/ManageIQ/kubeclient
       tag: v${{package.version}}
       expected-commit: 0feda1d7de6bdab96286c81eb0f2ccc2127040cf
+
+  - uses: patch
+    with:
+      patches: bump-recursive-open-struct.patch
 
   - uses: ruby/build
     with:

--- a/ruby3.2-kubeclient/bump-recursive-open-struct.patch
+++ b/ruby3.2-kubeclient/bump-recursive-open-struct.patch
@@ -1,0 +1,35 @@
+From 0eb594296597e45011d8e4090244597f76d06d53 Mon Sep 17 00:00:00 2001
+From: Scott Moser <scott.moser@chainguard.dev>
+Date: Fri, 25 Oct 2024 12:55:29 -0400
+Subject: [PATCH] Try bumping recursive-open-struct
+
+recursive-open-struct moved forward to 1.3 on 2024-10-03 and then
+immediately forward to 2.0 which does include this entry in changelog:
+
+  * BREAKING: Restore #72, which is an API-breaking change because it changes
+    what data is serialized with marshalling.
+
+I proposed https://github.com/ManageIQ/kubeclient/pull/640 upstream
+to see if it is plausible to do this versus adding
+ruby3.2-recursive-open-struct-1.3 .
+
+---
+ kubeclient.gemspec | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kubeclient.gemspec b/kubeclient.gemspec
+index 4df0014..f1b9911 100644
+--- a/kubeclient.gemspec
++++ b/kubeclient.gemspec
+@@ -37,6 +37,6 @@ Gem::Specification.new do |spec|
+ 
+   spec.add_dependency 'jsonpath', '~> 1.0'
+   spec.add_dependency 'rest-client', '~> 2.0'
+-  spec.add_dependency 'recursive-open-struct', '~> 1.1', '>= 1.1.1'
++  spec.add_dependency 'recursive-open-struct', '> 1.1.1', '< 3.0'
+   spec.add_dependency 'http', '>= 3.0', '< 6.0'
+ end
+
+-- 
+2.47.0
+


### PR DESCRIPTION
ruby3.2-kubeclient is currently not passing a test. That means it can't get any new version should one be created. I hit this when trying to create ruby 3.3 versions of it.

If this does not work, then we will need to create a ruby3.2-recursive-open-struct-1.3 package and depend on it.

I proposed upstream https://github.com/ManageIQ/kubeclient/pull/640.

Fixes: https://github.com/wolfi-dev/os/issues/31938

Note, that  currently https://github.com/aetherknight/recursive-open-struct does not have any maintenance branches.  Each of the versions are just tags on main.