### PR TITLE
Added patch to fix spark-3.5/GHSA-g8m5-722r-8whq

### DIFF
--- a/spark-3.5/pombump-properties.yaml
+++ b/spark-3.5/pombump-properties.yaml
@@ -17,3 +17,5 @@ properties:
     value: "4.1.108.Final"
   - property: zookeeper.version
     value: "3.8.4"
+  - property: jetty.version
+    value: "9.4.56.v20240826"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/chainguard-dev/CVE-Dashboard/issues/13968

### Pre-review Checklist

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
  - I believe this fix will get detected and recorded automatically? 

