### PR TITLE
new pkg: git-crypt

### DIFF
--- a/git-crypt.yaml
+++ b/git-crypt.yaml
@@ -15,8 +15,6 @@ environment:
       - docbook-xml
       - git
       - openssl-dev
-  environment:
-    CGO_ENABLED: "-DOPENSSL_API_COMPAT=0x30000000L"
 
 pipeline:
   - uses: fetch

--- a/git-crypt.yaml
+++ b/git-crypt.yaml
@@ -1,0 +1,49 @@
+package:
+  name: git-crypt
+  version: 0.7.0
+  epoch: 0
+  description: Transparent file encryption in git
+  copyright:
+    - license: GPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - docbook-xml
+      - git
+      - openssl-dev
+  environment:
+    CGO_ENABLED: "-DOPENSSL_API_COMPAT=0x30000000L"
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 2210a89588169ae9a54988c7fdd9717333f0c6053ff704d335631a387bd3bcff
+      uri: https://github.com/AGWA/git-crypt/archive/${{package.version}}.tar.gz
+
+  - runs: |
+      export CXXFLAGS="$CXXFLAGS -DOPENSSL_API_COMPAT=0x30000000L"
+      make -C . -j$(nproc) V=1
+
+  - uses: autoconf/make-install
+
+  - uses: strip
+
+subpackages:
+  - name: git-crypt-doc
+    pipeline:
+      - uses: split/manpages
+    description: git-crypt manpages
+
+test:
+  pipeline:
+    - name: Test keygen subcommand
+      runs: git-crypt keygen test.key
+
+update:
+  enabled: true
+  github:
+    identifier: AGWA/git-crypt


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/30448

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
