### PR TITLE
fix(CI): do not fail CVE scan and soname check if only build for one arch

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -278,12 +278,29 @@ jobs:
         with:
           name: packages-x86_64
           path: /tmp/artifacts-1/
+        continue-on-error: true
 
       - name: "Retrieve aarch64 packages"
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: packages-aarch64
           path: /tmp/artifacts-2/
+        continue-on-error: true
+
+      - name: "Check if artifacts were downloaded"
+        run: |
+          x86_exists=false
+          aarch64_exists=false
+          if [ -d "/tmp/artifacts-1/" ]; then
+            x86_exists=true
+          fi
+          if [ -d "/tmp/artifacts-2/" ]; then
+            aarch64_exists=true
+          fi
+          if [ "$x86_exists" = false ] && [ "$aarch64_exists" = false ]; then
+            echo "Both artifacts are missing. Failing the build."
+            exit 1
+          fi
 
       - name: "Collect packages from all architectures into one place"
         run: |
@@ -325,12 +342,32 @@ jobs:
         with:
           name: packages-x86_64
           path: /tmp/artifacts-1/
+        continue-on-error: true
 
       - name: "Retrieve aarch64 packages"
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: packages-aarch64
           path: /tmp/artifacts-2/
+        continue-on-error: true
+
+      - name: "Check if artifacts were downloaded"
+        run: |
+          x86_exists=false
+          aarch64_exists=false
+
+          if [ -d "/tmp/artifacts-1/" ]; then
+            x86_exists=true
+          fi
+
+          if [ -d "/tmp/artifacts-2/" ]; then
+            aarch64_exists=true
+          fi
+
+          if [ "$x86_exists" = false ] && [ "$aarch64_exists" = false ]; then
+            echo "Both artifacts are missing. Failing the build."
+            exit 1
+          fi
 
       - name: "Collect packages from all architectures into one place"
         run: |


### PR DESCRIPTION
If a package is only build for one arch(x86_64), the CVE scan CI fail because of the artifact is missing from any of one arch. With these change the Ci will not fail if ony one artifact is present it will only fail if no artifact is present

We have already changes the CI pipeline in enterprise. https://github.com/chainguard-dev/enterprise-packages/pull/7273

/CC @hectorj2f 