### PR TITLE
karpenter: version stream and add test

### DIFF
--- a/karpenter-1.0.yaml
+++ b/karpenter-1.0.yaml
@@ -1,10 +1,14 @@
 package:
-  name: karpenter
+  name: karpenter-1.0
   version: 1.0.6
   epoch: 0
   description: Karpenter is a Kubernetes Node Autoscaler built for flexibility, performance, and simplicity.
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - karpenter=${{package.full-version}}
+      - karpenter-provider-aws=${{package.full-version}}
 
 pipeline:
   - uses: git-checkout
@@ -23,4 +27,14 @@ update:
   enabled: true
   github:
     identifier: aws/karpenter-provider-aws
+    tag-filter: v1.0.
     strip-prefix: v
+
+test:
+  environment:
+    environment:
+      # Required for test, otherwise application returns error when running --help.
+      SYSTEM_NAMESPACE: default
+  pipeline:
+    - name: Check application responds to --help command
+      runs: controller --help


### PR DESCRIPTION
Start version stream for `kapenter`, add test and also provide the package as `karpenter-provider-aws` since upstream renamed it after version 1.