### PR TITLE
unixodbc: correct build

### DIFF
--- a/unixodbc.yaml
+++ b/unixodbc.yaml
@@ -2,7 +2,7 @@
 package:
   name: unixodbc
   version: 2.3.12
-  epoch: 0
+  epoch: 4
   description: ODBC is an open specification to access Data Sources
   copyright:
     - license: LGPL-2.0-or-later
@@ -17,6 +17,7 @@ environment:
       - ca-certificates-bundle
       - libtool
       - m4
+      - openssf-compiler-options
       - pkgconf-dev
       - readline-dev
 
@@ -27,10 +28,12 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: c335dbf3fa25b524e935e98cf26b96a2e13f5c81
 
+  - runs: autoupdate
+
   - uses: autoconf/configure
     with:
       opts: |
-        -disable-nls \
+        --disable-nls \
         --enable-gui=no \
         --enable-static
 


### PR DESCRIPTION
Enable hardening options, correct configure option, refresh autotools.

But crutially bump epoch to above what is currently published. As
melange files point at epoch 0, whilst latest published build is epoch
3.
