### PR TITLE
rebuids test

### DIFF
--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: 8.0.10
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT

--- a/falco-no-driver.yaml
+++ b/falco-no-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco-no-driver
   version: 0.39.1
-  epoch: 0
+  epoch: 1
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0

--- a/fluent-bit-3.1.yaml
+++ b/fluent-bit-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-bit-3.1
   version: 3.1.9
-  epoch: 0
+  epoch: 1
   description: Fast and Lightweight Log processor and forwarder
   copyright:
     - license: Apache-2.0

--- a/freerdp.yaml
+++ b/freerdp.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp
   version: 2.11.7
-  epoch: 2
+  epoch: 3
   description: FreeRDP client
   copyright:
     - license: Apache-2.0

--- a/guacamole-server.yaml
+++ b/guacamole-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: guacamole-server
   version: 1.5.5
-  epoch: 1
+  epoch: 2
   description: clientless remote desktop gateway server
   copyright:
     - license: Apache-2.0

--- a/istio-envoy-1.23.yaml
+++ b/istio-envoy-1.23.yaml
@@ -1,7 +1,7 @@
 package:
   name: istio-envoy-1.23
   version: 1.23.2
-  epoch: 0
+  epoch: 1
   description: Envoy with additional Istio plugins (wasm, telemetry, etc)
   copyright:
     - license: Apache-2.0

--- a/libpulsar.yaml
+++ b/libpulsar.yaml
@@ -1,7 +1,7 @@
 package:
   name: libpulsar
   version: 3.6.0
-  epoch: 0
+  epoch: 1
   description: Optimizer and compiler/toolchain library for WebAssembly
   copyright:
     - license: Apache-2.0

--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-16
   version: 16.20.2
-  epoch: 6
+  epoch: 7
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-19.yaml
+++ b/nodejs-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-19
   version: 19.9.0
-  epoch: 8
+  epoch: 9
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -30,8 +30,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - jitterentropy-library-dev=3.5.0-r0
       # NB! pinned to version https://csrc.nist.gov/projects/cryptographic-module-validation-program/entropy-validations/certificate/191
+      - jitterentropy-library-dev=3.5.0-r0
       - jitterentropy-library=3.5.0-r0
       - openssf-compiler-options
       - perl
@@ -147,6 +147,11 @@ subpackages:
 
   - name: "openssl-dev"
     description: "OpenSSL headers"
+    dependencies:
+      runtime:
+        # TODO: for static linking only, split into openssl-static, or fix upstream
+        - jitterentropy-library-dev=3.5.0-r0
+        - jitterentropy-library=3.5.0-r0
     pipeline:
       - uses: split/dev
     test:

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -1,7 +1,8 @@
+#nolint:forbidden-repository-used,forbidden-keyring-used
 package:
   name: openssl
-  version: 3.3.2
-  epoch: 2
+  version: 3.4.0
+  epoch: 0
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -17,10 +18,21 @@ package:
 
 environment:
   contents:
+    # NB! accessing historic, but certified build of
+    # jitterentropy-library-dev=3.5.0-r0. In a fresh bootstrap build
+    # any version of jitternetropy-library and get an ESV certificate
+    # for it.
+    build_repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     packages:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - jitterentropy-library-dev=3.5.0-r0
+      # NB! pinned to version https://csrc.nist.gov/projects/cryptographic-module-validation-program/entropy-validations/certificate/191
+      - jitterentropy-library=3.5.0-r0
       - openssf-compiler-options
       - perl
   environment:
@@ -33,11 +45,9 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/openssl/openssl.git
+      repository: https://github.com/openssl/openssl
       tag: openssl-${{package.version}}
-      expected-commit: fb7fab9fa6f4869eaa8fbb97e0d593159f03ffe4
-      cherry-picks: |
-        openssl-3.3/c0d3e4d32d2805f49bec30547f225bc4d092e1f4: CVE-2024-9143 fixes
+      expected-commit: 98acb6b02839c609ef5b837794e08d906d965335
 
   - name: Create dbg sourcecode
     runs: |
@@ -62,7 +72,9 @@ pipeline:
          --libdir=lib \
          --openssldir=/etc/ssl \
          enable-ktls \
+         enable-jitter \
          shared \
+         enable-pie \
          no-zlib \
          no-async \
          no-comp \
@@ -78,6 +90,7 @@ pipeline:
          -Wa,--noexecstack
       perl configdata.pm --dump
       make -j$(nproc)
+      make tests HARNESS_JOBS=10
 
   - uses: autoconf/make-install
 
@@ -172,8 +185,13 @@ test:
   pipeline:
     - uses: test/hardening-check
       with:
-        package-match: "^openssl$\\|libssl3\\|libcrypto3"
-      runs: |
+        package-match: "^openssl$\\|libssl3"
+    - uses: test/hardening-check
+      with:
+        # jitterentropy is without CF protection so far
+        args: "--nocfprotection"
+        package-match: "^libcrypto3$"
+    - runs: |
         openssl --version
         openssl --help
     - name: Verify curl still works

--- a/powershell.yaml
+++ b/powershell.yaml
@@ -1,7 +1,7 @@
 package:
   name: powershell
   version: 7.4.1
-  epoch: 0
+  epoch: 1
   description: 'cross-platform automation and configuration tool/framework'
   copyright:
     - license: MIT

--- a/pulseaudio.yaml
+++ b/pulseaudio.yaml
@@ -2,7 +2,7 @@
 package:
   name: pulseaudio
   version: "17.0"
-  epoch: 0
+  epoch: 1
   description: featureful, general-purpose sound server
   copyright:
     - license: LGPL-2.1-or-later

--- a/py3-tkinter.yaml
+++ b/py3-tkinter.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tkinter
   version: 3.11.10
-  epoch: 0
+  epoch: 1
   description: A graphical user interface for the Python programming language
   copyright:
     - license: PSF-2.0

--- a/tcl-tls.yaml
+++ b/tcl-tls.yaml
@@ -1,7 +1,7 @@
 package:
   name: tcl-tls
   version: 1.7.22
-  epoch: 0
+  epoch: 1
   description: OpenSSL extension to Tcl
   copyright:
     - license: TCL


### PR DESCRIPTION
- **openssl: new release 3.4.0**
  Enable jitter seed source, compiled with jitterentropy-library, using
  manually fetched certified build.
  
  Enable PIE (position independent executables).
  
  Enable executing test-suite.
  
  Update hardening-check to expected values, no CF protection on
  libcrypto, due to jitterentroply library being linked.
  
  Fixes: https://github.com/wolfi-dev/os/pull/31548
  

- **Add jitterentropy**
  

- **rebuild failures**
  