### PR TITLE
fluent-bit-3.1: fix FTBFS

### DIFF
--- a/fluent-bit-3.1.yaml
+++ b/fluent-bit-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-bit-3.1
   version: 3.1.9
-  epoch: 0
+  epoch: 1
   description: Fast and Lightweight Log processor and forwarder
   copyright:
     - license: Apache-2.0
@@ -22,7 +22,6 @@ environment:
       - dpkg
       - flex
       - glibc
-      - libpq-16
       - openssf-compiler-options
       - openssl-dev
       - postgresql-dev


### PR DESCRIPTION
postgresql-dev has a matching runtime dependency on libpq. Thus
specifying hardcoded version of libpq is redundant, and breaks builds
upon postgresql major version upgrade (like now to 17).

Rebuild fluent-bit-3.1 against postgresql 17.
