### PR TITLE
Revert "feat(makefile): set default melange runner to docker"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,6 @@ KEY ?= local-melange.rsa
 REPO ?= $(shell pwd)/packages
 CACHE_DIR ?= gs://wolfi-sources/
 
-# Default Melange runner is Docker.
-MELANGE_RUNNER ?= docker
-
 MELANGE_OPTS += --repository-append ${REPO}
 MELANGE_OPTS += --keyring-append ${KEY}.pub
 MELANGE_OPTS += --signing-key ${KEY}
@@ -24,7 +21,6 @@ MELANGE_OPTS += --license 'Apache-2.0'
 MELANGE_OPTS += --git-repo-url 'https://github.com/wolfi-dev/os'
 MELANGE_OPTS += --generate-index false # TODO: This false gets parsed as argv not flag value!!!
 MELANGE_OPTS += --pipeline-dir ./pipelines/
-MELANGE_OPTS += --runner=$(MELANGE_RUNNER)
 MELANGE_OPTS += ${MELANGE_EXTRA_OPTS}
 
 # Enter interactive mode on failure for debug
@@ -45,7 +41,6 @@ MELANGE_TEST_OPTS += --repository-append https://packages.wolfi.dev/os
 MELANGE_TEST_OPTS += --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
 MELANGE_TEST_OPTS += --test-package-append wolfi-base
 MELANGE_TEST_OPTS += --debug
-MELANGE_TEST_OPTS += --runner=$(MELANGE_RUNNER)
 MELANGE_TEST_OPTS += ${MELANGE_EXTRA_OPTS}
 
 ifeq (${USE_CACHE}, yes)


### PR DESCRIPTION
Reverts wolfi-dev/os#32207

We're seeing errors on PRs

```
 ERRO failed to build package: unable to start pod: Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /github/home/.melangecache
```

https://github.com/wolfi-dev/os/actions/runs/11578666199/job/32233101978?pr=32221