### PR TITLE
fix(makefile): make QEMU easier to use, fetch kernel and set env variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,15 @@ list-yaml:
 	$(info $(addsuffix .yaml,$(shell $(PKGLISTCMD))))
 	@printf ''
 
+fetch-kernel:
+	$(eval KERNEL_PKG := $(shell curl -sL https://dl-cdn.alpinelinux.org/alpine/edge/main/$(ARCH)/APKINDEX.tar.gz | tar -Oxz APKINDEX | awk -F':' '$$1 == "P" {printf "%s-", $$2} $$1 == "V" {printf "%s.apk\n", $$2}' | grep "linux-virt" | grep -v dev))
+	@curl -s -LSo linux-virt.apk "https://dl-cdn.alpinelinux.org/alpine/edge/main/$(ARCH)/$(KERNEL_PKG)"
+	@mkdir -p /tmp/kernel
+	@tar -xf ./linux-virt.apk -C /tmp/kernel/ 2>/dev/null
+	export QEMU_KERNEL_IMAGE=/tmp/kernel/boot/vmlinuz-virt
+	export QEMU_KERNEL_MODULES=/tmp/kernel/lib/modules/
+	export MELANGE_OPTS="--runner=qemu"
+
 package/%:
 	$(eval yamlfile := $*.yaml)
 	@if [ -z "$(yamlfile)" ]; then \


### PR DESCRIPTION
Use:

`eval $(make fetch-kernel` or just `make fetch-kernel` and do the exports printed manually

then you can simply use

`make package/foo` and it will use QEMU with local downloaded kernel