### PR TITLE
add nvme-cli package

### DIFF
--- a/nvme-cli.yaml
+++ b/nvme-cli.yaml
@@ -11,7 +11,6 @@ environment:
     packages:
       - bash
       - build-base
-      - json-c
       - libnvme-dev
       - meson
 
@@ -57,3 +56,8 @@ test:
   pipeline:
     - name: version test
       runs: nvme --version | grep ${{package.version}}
+    - name: more tests
+      runs: |
+        nvme list
+        nvme help | grep discover
+        nvme gen-tls-key

--- a/nvme-cli.yaml
+++ b/nvme-cli.yaml
@@ -1,0 +1,61 @@
+package:
+  name: nvme-cli
+  version: 2.10.2
+  epoch: 0
+  description: NVM-Express user space tooling for Linux
+  copyright:
+    - license: GPL-2.0-only
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - json-c
+      - libnvme
+      - libnvme
+      - libnvme-dev
+      - meson
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: eeaa08c9a0e9184f3889df0bff3d2a23db6d6294
+      repository: https://github.com/linux-nvme/nvme-cli
+      tag: v${{package.version}}
+
+  - uses: meson/configure
+    with:
+      opts: |
+        -Ddocs=man \
+        -Dudevrulesdir=/usr/lib/udev/rules.d/
+
+  - uses: meson/compile
+
+  - uses: meson/install
+
+  - runs: |
+      rm -rf ${{targets.destdir}}/usr/lib/systemd
+      rm -rf ${{targets.destdir}}/usr/lib/udev
+      rm -rf ${{targets.destdir}}/usr/share/bash-completion
+      rm -rf ${{targets.destdir}}/usr/share/zsh
+
+  - uses: strip
+
+subpackages:
+  - name: nvme-cli-doc
+    pipeline:
+      - uses: split/manpages
+    description: nvme-cli manpages
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: linux-nvme/nvme-cli
+
+test:
+  environment: {}
+  pipeline:
+    - name: Verify nvme-cli installation, please improve the test as needed
+      runs: nvme-cli --version || exit 1

--- a/nvme-cli.yaml
+++ b/nvme-cli.yaml
@@ -12,8 +12,6 @@ environment:
       - bash
       - build-base
       - json-c
-      - libnvme
-      - libnvme
       - libnvme-dev
       - meson
 
@@ -55,7 +53,6 @@ update:
     identifier: linux-nvme/nvme-cli
 
 test:
-  environment: {}
   pipeline:
-    - name: Verify nvme-cli installation, please improve the test as needed
-      runs: nvme-cli --version || exit 1
+    - name: version test
+      runs: nvme --version | grep ${{package.version}}

--- a/nvme-cli.yaml
+++ b/nvme-cli.yaml
@@ -51,6 +51,7 @@ update:
   manual: false
   github:
     identifier: linux-nvme/nvme-cli
+    strip-prefix: v
 
 test:
   pipeline:


### PR DESCRIPTION
adds nvme-cli package

depends on https://github.com/wolfi-dev/os/pull/32228 

CI will fail for now given libnvme is not available as of now until the above package is merged.