### PR TITLE
openssl: unbreak dependency resolution at package build time

### DIFF
--- a/neon.yaml
+++ b/neon.yaml
@@ -1,7 +1,7 @@
 package:
   name: neon
   version: "6935"
-  epoch: 1
+  epoch: 0
   description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
   copyright:
     - license: Apache-2.0

--- a/neon.yaml
+++ b/neon.yaml
@@ -1,7 +1,7 @@
 package:
   name: neon
   version: "6935"
-  epoch: 0
+  epoch: 1
   description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
   copyright:
     - license: Apache-2.0

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -2,7 +2,7 @@
 package:
   name: openssl
   version: 3.4.0
-  epoch: 0
+  epoch: 1
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -149,9 +149,11 @@ subpackages:
     description: "OpenSSL headers"
     dependencies:
       runtime:
-        # TODO: for static linking only, split into openssl-static, or fix upstream
-        - jitterentropy-library-dev=3.5.0-r0
-        - jitterentropy-library=3.5.0-r0
+        # TODO: for static linking only, split into openssl-static, or
+        # fix upstream (note .so actually links 3.5.0-r0 but melange
+        # hates that here)
+        - jitterentropy-library-dev
+        - jitterentropy-library
     pipeline:
       - uses: split/dev
     test:


### PR DESCRIPTION
Static linking of libcrypto.a may still have issues.
