### PR TITLE
use a variable for php version (phpMM) and utilize pipelines in php files.

### DIFF
--- a/php-8.1-amqp.yaml
+++ b/php-8.1-amqp.yaml
@@ -1,15 +1,21 @@
 package:
   name: php-8.1-amqp
   version: 2.1.2
-  epoch: 1
+  epoch: 2
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
       - rabbitmq-c
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,8 +23,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
       - rabbitmq-c-dev
 
 pipeline:

--- a/php-8.1-apcu.yaml
+++ b/php-8.1-apcu.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.1-apcu
   version: 5.1.24
-  epoch: 0
+  epoch: 1
   description: "PHP extension for User Cache"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.1-ddtrace.yaml
+++ b/php-8.1-ddtrace.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.1-ddtrace
   version: 1.4.2
-  epoch: 1
+  epoch: 2
   description: "Datadog PHP Clients"
   copyright:
     - license: Apache-2.0 OR BSD-3-Clause
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -18,8 +24,8 @@ environment:
       - busybox
       - curl-dev
       - openssf-compiler-options
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
       - posix-libc-utils
       - rust
 
@@ -53,7 +59,7 @@ test:
   environment:
     contents:
       packages:
-        - php-8.1
+        - php-${{vars.phpMM}}
   pipeline:
     - name: Verify Extension is Loaded
       runs: |

--- a/php-8.1-decimal.yaml
+++ b/php-8.1-decimal.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.1-decimal
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: Correctly-rounded, arbitrary-precision decimal arithmetic for PHP
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,8 +23,8 @@ environment:
       - build-base
       - busybox
       - mpdecimal-dev
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.1-ds.yaml
+++ b/php-8.1-ds.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.1-ds
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: "An extension providing efficient data structures for PHP"
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.1-excimer.yaml
+++ b/php-8.1-excimer.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.1-excimer
   version: 1.2.2
-  epoch: 0
+  epoch: 1
   description: "Excimer is a PHP extension that provides an interrupting timer and a low-overhead sampling profiler."
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.1-grpc.yaml
+++ b/php-8.1-grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-grpc
   version: 1.67.1
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for gRPC"
   copyright:
     - license: Apache-2.0
@@ -9,7 +9,13 @@ package:
     runtime:
       - ${{package.name}}-config
       - grpc
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -18,8 +24,8 @@ environment:
       - build-base
       - busybox
       - grpc-dev
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.1-igbinary.yaml
+++ b/php-8.1-igbinary.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.1-igbinary
   version: 3.2.16
-  epoch: 0
+  epoch: 1
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.1-imagick.yaml
+++ b/php-8.1-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-imagick
   version: 3.7.0
-  epoch: 1
+  epoch: 2
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01
@@ -9,7 +9,13 @@ package:
     runtime:
       - ${{package.name}}-config
       - imagemagick
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -18,8 +24,8 @@ environment:
       - build-base
       - busybox
       - imagemagick-dev
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.1-memcached.yaml
+++ b/php-8.1-memcached.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.1-memcached
   version: 3.3.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for Memcached"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,9 +23,9 @@ environment:
       - build-base
       - busybox
       - libmemcached-dev
-      - php-8.1
-      - php-8.1-dev
-      - php-8.1-igbinary-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-igbinary-dev
       - zlib-dev
 
 pipeline:

--- a/php-8.1-msgpack.yaml
+++ b/php-8.1-msgpack.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.1-msgpack
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.1-opentelemetry.yaml
+++ b/php-8.1-opentelemetry.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.1-opentelemetry
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: "OpenTelemetry PHP auto-instrumentation extension"
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.1-pdo_snowflake.yaml
+++ b/php-8.1-pdo_snowflake.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pdo_snowflake
   version: 3.0.2
-  epoch: 1
+  epoch: 2
   description: "Snowflake driver that uses the PHP Data Objects (PDO) extension"
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,13 @@ package:
     - x86_64
   dependencies:
     runtime:
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -28,9 +34,9 @@ environment:
       - gcc
       - libtool
       - openssf-compiler-options
-      - php-8.1
-      - php-8.1-dev
-      - php-8.1-pdo
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-pdo
       - unixodbc-dev
       - zlib-dev
 

--- a/php-8.1-pecl-http.yaml
+++ b/php-8.1-pecl-http.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.1-pecl-http
   version: 4.2.4
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.1 HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
   dependencies:
     runtime:
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -25,8 +31,8 @@ environment:
       - libtool
       - openssf-compiler-options
       - openssl-dev
-      - php-8.1-dev
-      - php-8.1-pecl-raphf
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-pecl-raphf
       - zlib-dev
 
 pipeline:

--- a/php-8.1-pecl-http.yaml
+++ b/php-8.1-pecl-http.yaml
@@ -39,14 +39,9 @@ pipeline:
 
   - uses: autoconf/make
 
-  # TODO: This is a temporary workaround until the pecl/install pipelines
-  # propagates through.
-  # https://github.com/chainguard-dev/melange/pull/1068
-  - name: Install
-    runs: |
-      make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php/conf.d
-      echo "extension=http.so" > ${{targets.destdir}}/etc/php/conf.d/http.ini
+  - uses: pecl/install
+    with:
+      extension: "http"
 
   - uses: strip
 

--- a/php-8.1-pecl-mcrypt.yaml
+++ b/php-8.1-pecl-mcrypt.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.1-pecl-mcrypt
   version: 1.0.7
-  epoch: 3
+  epoch: 4
   description: "Provides PHP 8.1 bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -23,7 +29,7 @@ environment:
       - libmcrypt-dev
       - libtool
       - openssf-compiler-options
-      - php-8.1-dev
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: fetch

--- a/php-8.1-pecl-mongodb.yaml
+++ b/php-8.1-pecl-mongodb.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.1-pecl-mongodb
   version: 1.20.0
-  epoch: 1
+  epoch: 2
   description: "PHP 8.1 MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -25,7 +31,7 @@ environment:
       - libtool
       - openssf-compiler-options
       - openssl-dev>3
-      - php-8.1-dev
+      - php-${{vars.phpMM}}-dev
       - snappy-dev
       - zstd-dev
 

--- a/php-8.1-pecl-pdosqlsrv.yaml
+++ b/php-8.1-pecl-pdosqlsrv.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.1-pecl-pdosqlsrv
   version: 5.12.0
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.1 Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -22,7 +28,7 @@ environment:
       - gcc
       - libtool
       - openssf-compiler-options
-      - php-8.1-dev
+      - php-${{vars.phpMM}}-dev
       - unixodbc-dev
 
 pipeline:

--- a/php-8.1-pecl-pdosqlsrv.yaml
+++ b/php-8.1-pecl-pdosqlsrv.yaml
@@ -35,14 +35,9 @@ pipeline:
 
   - uses: autoconf/make
 
-  # TODO: This is a temporary workaround until the pecl/install pipelines
-  # propagates through.
-  # https://github.com/chainguard-dev/melange/pull/1068
-  - name: Install
-    runs: |
-      make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php/conf.d
-      echo "extension=pdo_sqlsrv.so" > ${{targets.destdir}}/etc/php/conf.d/pdo_sqlsrv.ini
+  - uses: pecl/install
+    with:
+      extension: "pdo_sqlsrv"
 
   - uses: strip
 

--- a/php-8.1-pecl-raphf.yaml
+++ b/php-8.1-pecl-raphf.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.1-pecl-raphf
   version: 2.0.1
-  epoch: 4
+  epoch: 5
   description: "Provides PHP 8.1 resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -22,7 +28,7 @@ environment:
       - gcc
       - libtool
       - openssf-compiler-options
-      - php-8.1-dev
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: fetch

--- a/php-8.1-pecl-raphf.yaml
+++ b/php-8.1-pecl-raphf.yaml
@@ -38,11 +38,10 @@ pipeline:
     with:
       extension: "raphf"
 
-  # PHP initialization is order dependent. So we will explicitly
-  # load this by prefixing the file with 10- so it runs before
-  # other modules which start with letters
-  # starts.
   - runs: |
+      # PHP initialization is order dependent. So we will explicitly
+      # load this by prefixing the file with 10- so it runs before
+      # other modules which start with letters starts.
       mv ${{targets.destdir}}/etc/php/conf.d/raphf.ini ${{targets.destdir}}/etc/php/conf.d/10-raphf.ini
 
   - uses: strip

--- a/php-8.1-pecl-raphf.yaml
+++ b/php-8.1-pecl-raphf.yaml
@@ -34,14 +34,9 @@ pipeline:
 
   - uses: autoconf/make
 
-  # TODO: This is a temporary workaround until the pecl/install pipelines
-  # propagates through.
-  # https://github.com/chainguard-dev/melange/pull/1068
-  - name: Install
-    runs: |
-      make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php/conf.d
-      echo "extension=raphf.so" > ${{targets.destdir}}/etc/php/conf.d/raphf.ini
+  - uses: pecl/install
+    with:
+      extension: "raphf"
 
   # PHP initialization is order dependent. So we will explicitly
   # load this by prefixing the file with 10- so it runs before

--- a/php-8.1-pecl-sqlsrv.yaml
+++ b/php-8.1-pecl-sqlsrv.yaml
@@ -35,14 +35,9 @@ pipeline:
 
   - uses: autoconf/make
 
-  # TODO: This is a temporary workaround until the pecl/install pipelines
-  # propagates through.
-  # https://github.com/chainguard-dev/melange/pull/1068
-  - name: Install
-    runs: |
-      make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php/conf.d
-      echo "extension=sqlsrv.so" > ${{targets.destdir}}/etc/php/conf.d/sqlsrv.ini
+  - uses: pecl/install
+    with:
+      extension: "sqlsrv"
 
   - uses: strip
 

--- a/php-8.1-pecl-sqlsrv.yaml
+++ b/php-8.1-pecl-sqlsrv.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.1-pecl-sqlsrv
   version: 5.12.0
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.1 Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -22,7 +28,7 @@ environment:
       - gcc
       - libtool
       - openssf-compiler-options
-      - php-8.1-dev
+      - php-${{vars.phpMM}}-dev
       - unixodbc-dev
 
 pipeline:

--- a/php-8.1-protobuf.yaml
+++ b/php-8.1-protobuf.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.1-protobuf
   version: 4.28.3
-  epoch: 0
+  epoch: 1
   description: "Protocol Buffers - Google's data interchange format"
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
       - protobuf-dev
 
 pipeline:

--- a/php-8.1-redis.yaml
+++ b/php-8.1-redis.yaml
@@ -1,21 +1,21 @@
 package:
   name: php-8.1-redis
   version: 6.1.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for Redis"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-${{vars.php-version}}
-      - php-${{vars.php-version}}-igbinary
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-igbinary
 
 var-transforms:
   - from: ${{package.name}}
     match: ^php-(\d+\.\d+)-.*$
     replace: "$1"
-    to: php-version
+    to: phpMM
 
 environment:
   contents:
@@ -24,9 +24,9 @@ environment:
       - build-base
       - busybox
       - openssf-compiler-options
-      - php-${{vars.php-version}}
-      - php-${{vars.php-version}}-dev
-      - php-${{vars.php-version}}-igbinary-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-igbinary-dev
 
 pipeline:
   - uses: git-checkout
@@ -58,7 +58,7 @@ subpackages:
           echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.php-version}} redis development headers
+    description: PHP ${{vars.phpMM}} redis development headers
     dependencies:
       provides:
         - php-redis-dev=${{package.full-version}}
@@ -74,7 +74,7 @@ test:
   environment:
     contents:
       packages:
-        - php-${{vars.php-version}}
+        - php-${{vars.phpMM}}
   pipeline:
     - name: Verify Extension is Loaded
       runs: |

--- a/php-8.1-ssh2.yaml
+++ b/php-8.1-ssh2.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.1-ssh2
   version: 1.4.1
-  epoch: 0
+  epoch: 1
   description: "Bindings for the libssh2 library"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,8 +23,8 @@ environment:
       - build-base
       - busybox
       - libssh2-dev
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.1-swoole.yaml
+++ b/php-8.1-swoole.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-swoole
   version: 5.1.5
-  epoch: 0
+  epoch: 1
   description: "Coroutine-based concurrency library for PHP"
   copyright:
     - license: Apache-2.0
@@ -9,7 +9,13 @@ package:
     runtime:
       - ${{package.name}}-config
       - brotli
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -18,8 +24,8 @@ environment:
       - brotli-dev
       - build-base
       - busybox
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.1-xdebug.yaml
+++ b/php-8.1-xdebug.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.1-xdebug
   version: 3.3.2
-  epoch: 0
+  epoch: 1
   description: "Step Debugger for PHP"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.1-zstd.yaml
+++ b/php-8.1-zstd.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.1-zstd
   version: 0.13.3
-  epoch: 0
+  epoch: 1
   description: Zstd Extension for PHP
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.1
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,8 +23,8 @@ environment:
       - build-base
       - busybox
       - file
-      - php-8.1
-      - php-8.1-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
       - zstd-dev
 
 pipeline:

--- a/php-8.2-amqp.yaml
+++ b/php-8.2-amqp.yaml
@@ -1,15 +1,21 @@
 package:
   name: php-8.2-amqp
   version: 2.1.2
-  epoch: 1
+  epoch: 2
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
       - rabbitmq-c
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,8 +23,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
       - rabbitmq-c-dev
 
 pipeline:

--- a/php-8.2-apcu.yaml
+++ b/php-8.2-apcu.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.2-apcu
   version: 5.1.24
-  epoch: 0
+  epoch: 1
   description: "PHP extension for User Cache"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.2-ddtrace.yaml
+++ b/php-8.2-ddtrace.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.2-ddtrace
   version: 1.4.2
-  epoch: 0
+  epoch: 1
   description: "Datadog PHP Clients"
   copyright:
     - license: Apache-2.0 OR BSD-3-Clause
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,8 +23,8 @@ environment:
       - build-base
       - busybox
       - curl-dev
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
       - posix-libc-utils
       - rust
 
@@ -52,7 +58,7 @@ test:
   environment:
     contents:
       packages:
-        - php-8.2
+        - php-${{vars.phpMM}}
   pipeline:
     - name: Verify Extension is Loaded
       runs: |

--- a/php-8.2-decimal.yaml
+++ b/php-8.2-decimal.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.2-decimal
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: Correctly-rounded, arbitrary-precision decimal arithmetic for PHP
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,8 +23,8 @@ environment:
       - build-base
       - busybox
       - mpdecimal-dev
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.2-ds.yaml
+++ b/php-8.2-ds.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.2-ds
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: "An extension providing efficient data structures for PHP"
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.2-excimer.yaml
+++ b/php-8.2-excimer.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.2-excimer
   version: 1.2.2
-  epoch: 0
+  epoch: 1
   description: "Excimer is a PHP extension that provides an interrupting timer and a low-overhead sampling profiler."
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.2-grpc.yaml
+++ b/php-8.2-grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-grpc
   version: 1.67.1
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for gRPC"
   copyright:
     - license: Apache-2.0
@@ -9,7 +9,13 @@ package:
     runtime:
       - ${{package.name}}-config
       - grpc
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -18,8 +24,8 @@ environment:
       - build-base
       - busybox
       - grpc-dev
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.2-igbinary.yaml
+++ b/php-8.2-igbinary.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.2-igbinary
   version: 3.2.16
-  epoch: 0
+  epoch: 1
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.2-imagick.yaml
+++ b/php-8.2-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-imagick
   version: 3.7.0
-  epoch: 1
+  epoch: 2
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01
@@ -9,7 +9,13 @@ package:
     runtime:
       - ${{package.name}}-config
       - imagemagick
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -18,8 +24,8 @@ environment:
       - build-base
       - busybox
       - imagemagick-dev
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.2-memcached.yaml
+++ b/php-8.2-memcached.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.2-memcached
   version: 3.3.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for Memcached"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,9 +23,9 @@ environment:
       - build-base
       - busybox
       - libmemcached-dev
-      - php-8.2
-      - php-8.2-dev
-      - php-8.2-igbinary-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-igbinary-dev
       - zlib-dev
 
 pipeline:

--- a/php-8.2-msgpack.yaml
+++ b/php-8.2-msgpack.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.2-msgpack
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.2-opentelemetry.yaml
+++ b/php-8.2-opentelemetry.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.2-opentelemetry
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: "OpenTelemetry PHP auto-instrumentation extension"
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.2-pdo_snowflake.yaml
+++ b/php-8.2-pdo_snowflake.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pdo_snowflake
   version: 3.0.2
-  epoch: 1
+  epoch: 2
   description: "Snowflake driver that uses the PHP Data Objects (PDO) extension"
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,13 @@ package:
     - x86_64
   dependencies:
     runtime:
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -28,9 +34,9 @@ environment:
       - gcc
       - libtool
       - openssf-compiler-options
-      - php-8.2
-      - php-8.2-dev
-      - php-8.2-pdo
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-pdo
       - unixodbc-dev
       - zlib-dev
 

--- a/php-8.2-pecl-http.yaml
+++ b/php-8.2-pecl-http.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.2-pecl-http
   version: 4.2.4
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.2 HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
   dependencies:
     runtime:
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -25,8 +31,8 @@ environment:
       - libtool
       - openssf-compiler-options
       - openssl-dev
-      - php-8.2-dev
-      - php-8.2-pecl-raphf
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-pecl-raphf
       - zlib-dev
 
 pipeline:

--- a/php-8.2-pecl-http.yaml
+++ b/php-8.2-pecl-http.yaml
@@ -39,14 +39,9 @@ pipeline:
 
   - uses: autoconf/make
 
-  # TODO: This is a temporary workaround until the pecl/install pipelines
-  # propagates through.
-  # https://github.com/chainguard-dev/melange/pull/1068
-  - name: Install
-    runs: |
-      make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php/conf.d
-      echo "extension=http.so" > ${{targets.destdir}}/etc/php/conf.d/http.ini
+  - uses: pecl/install
+    with:
+      extension: "http"
 
   - uses: strip
 

--- a/php-8.2-pecl-mcrypt.yaml
+++ b/php-8.2-pecl-mcrypt.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.2-pecl-mcrypt
   version: 1.0.7
-  epoch: 3
+  epoch: 4
   description: "Provides PHP 8.2 bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -23,7 +29,7 @@ environment:
       - libmcrypt-dev
       - libtool
       - openssf-compiler-options
-      - php-8.2-dev
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: fetch

--- a/php-8.2-pecl-mongodb.yaml
+++ b/php-8.2-pecl-mongodb.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.2-pecl-mongodb
   version: 1.20.0
-  epoch: 1
+  epoch: 2
   description: "PHP 8.2 MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -25,7 +31,7 @@ environment:
       - libtool
       - openssf-compiler-options
       - openssl-dev>3
-      - php-8.2-dev
+      - php-${{vars.phpMM}}-dev
       - snappy-dev
       - zstd-dev
 

--- a/php-8.2-pecl-pdosqlsrv.yaml
+++ b/php-8.2-pecl-pdosqlsrv.yaml
@@ -35,14 +35,9 @@ pipeline:
 
   - uses: autoconf/make
 
-  # TODO: This is a temporary workaround until the pecl/install pipelines
-  # propagates through.
-  # https://github.com/chainguard-dev/melange/pull/1068
-  - name: Install
-    runs: |
-      make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php/conf.d
-      echo "extension=pdo_sqlsrv.so" > ${{targets.destdir}}/etc/php/conf.d/pdo_sqlsrv.ini
+  - uses: pecl/install
+    with:
+      extension: "pdo_sqlsrv"
 
   - uses: strip
 

--- a/php-8.2-pecl-pdosqlsrv.yaml
+++ b/php-8.2-pecl-pdosqlsrv.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.2-pecl-pdosqlsrv
   version: 5.12.0
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.2 Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -22,7 +28,7 @@ environment:
       - gcc
       - libtool
       - openssf-compiler-options
-      - php-8.2-dev
+      - php-${{vars.phpMM}}-dev
       - unixodbc-dev
 
 pipeline:

--- a/php-8.2-pecl-raphf.yaml
+++ b/php-8.2-pecl-raphf.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.2-pecl-raphf
   version: 2.0.1
-  epoch: 3
+  epoch: 4
   description: "Provides PHP 8.2 resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -22,7 +28,7 @@ environment:
       - gcc
       - libtool
       - openssf-compiler-options
-      - php-8.2-dev
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: fetch

--- a/php-8.2-pecl-raphf.yaml
+++ b/php-8.2-pecl-raphf.yaml
@@ -38,11 +38,10 @@ pipeline:
     with:
       extension: "raphf"
 
-  # PHP initialization is order dependent. So we will explicitly
-  # load this by prefixing the file with 10- so it runs before
-  # other modules which start with letters
-  # starts.
   - runs: |
+      # PHP initialization is order dependent. So we will explicitly
+      # load this by prefixing the file with 10- so it runs before
+      # other modules which start with letters starts.
       mv ${{targets.destdir}}/etc/php/conf.d/raphf.ini ${{targets.destdir}}/etc/php/conf.d/10-raphf.ini
 
   - uses: strip

--- a/php-8.2-pecl-raphf.yaml
+++ b/php-8.2-pecl-raphf.yaml
@@ -34,14 +34,9 @@ pipeline:
 
   - uses: autoconf/make
 
-  # TODO: This is a temporary workaround until the pecl/install pipelines
-  # propagates through.
-  # https://github.com/chainguard-dev/melange/pull/1068
-  - name: Install
-    runs: |
-      make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php/conf.d
-      echo "extension=raphf.so" > ${{targets.destdir}}/etc/php/conf.d/raphf.ini
+  - uses: pecl/install
+    with:
+      extension: "raphf"
 
   # PHP initialization is order dependent. So we will explicitly
   # load this by prefixing the file with 10- so it runs before

--- a/php-8.2-pecl-sqlsrv.yaml
+++ b/php-8.2-pecl-sqlsrv.yaml
@@ -35,14 +35,9 @@ pipeline:
 
   - uses: autoconf/make
 
-  # TODO: This is a temporary workaround until the pecl/install pipelines
-  # propagates through.
-  # https://github.com/chainguard-dev/melange/pull/1068
-  - name: Install
-    runs: |
-      make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php/conf.d
-      echo "extension=sqlsrv.so" > ${{targets.destdir}}/etc/php/conf.d/sqlsrv.ini
+  - uses: pecl/install
+    with:
+      extension: "sqlsrv"
 
   - uses: strip
 

--- a/php-8.2-pecl-sqlsrv.yaml
+++ b/php-8.2-pecl-sqlsrv.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.2-pecl-sqlsrv
   version: 5.12.0
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.2 Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -22,7 +28,7 @@ environment:
       - gcc
       - libtool
       - openssf-compiler-options
-      - php-8.2-dev
+      - php-${{vars.phpMM}}-dev
       - unixodbc-dev
 
 pipeline:

--- a/php-8.2-protobuf.yaml
+++ b/php-8.2-protobuf.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.2-protobuf
   version: 4.28.3
-  epoch: 0
+  epoch: 1
   description: "Protocol Buffers - Google's data interchange format"
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
       - protobuf-dev
 
 pipeline:

--- a/php-8.2-redis.yaml
+++ b/php-8.2-redis.yaml
@@ -1,21 +1,21 @@
 package:
   name: php-8.2-redis
   version: 6.1.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for Redis"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-${{vars.php-version}}
-      - php-${{vars.php-version}}-igbinary
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-igbinary
 
 var-transforms:
   - from: ${{package.name}}
     match: ^php-(\d+\.\d+)-.*$
     replace: "$1"
-    to: php-version
+    to: phpMM
 
 environment:
   contents:
@@ -23,9 +23,9 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-${{vars.php-version}}
-      - php-${{vars.php-version}}-dev
-      - php-${{vars.php-version}}-igbinary-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-igbinary-dev
 
 pipeline:
   - uses: git-checkout
@@ -54,7 +54,7 @@ subpackages:
           echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.php-version}} redis development headers
+    description: PHP ${{vars.phpMM}} redis development headers
     pipeline:
       - uses: split/dev
 
@@ -67,7 +67,7 @@ test:
   environment:
     contents:
       packages:
-        - php-${{vars.php-version}}
+        - php-${{vars.phpMM}}
   pipeline:
     - name: Verify Extension is Loaded
       runs: |

--- a/php-8.2-ssh2.yaml
+++ b/php-8.2-ssh2.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.2-ssh2
   version: 1.4.1
-  epoch: 0
+  epoch: 1
   description: "Bindings for the libssh2 library"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,8 +23,8 @@ environment:
       - build-base
       - busybox
       - libssh2-dev
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.2-swoole.yaml
+++ b/php-8.2-swoole.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-swoole
   version: 5.1.5
-  epoch: 0
+  epoch: 1
   description: "Coroutine-based concurrency library for PHP"
   copyright:
     - license: Apache-2.0
@@ -9,7 +9,13 @@ package:
     runtime:
       - ${{package.name}}-config
       - brotli
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -18,8 +24,8 @@ environment:
       - brotli-dev
       - build-base
       - busybox
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.2-xdebug.yaml
+++ b/php-8.2-xdebug.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.2-xdebug
   version: 3.3.2
-  epoch: 0
+  epoch: 1
   description: "Step Debugger for PHP"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.2-zstd.yaml
+++ b/php-8.2-zstd.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.2-zstd
   version: 0.13.3
-  epoch: 0
+  epoch: 1
   description: Zstd Extension for PHP
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.2
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,8 +23,8 @@ environment:
       - build-base
       - busybox
       - file
-      - php-8.2
-      - php-8.2-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
       - zstd-dev
 
 pipeline:

--- a/php-8.3-amqp.yaml
+++ b/php-8.3-amqp.yaml
@@ -1,17 +1,23 @@
 package:
   name: php-8.3-amqp
   version: 2.1.2
-  epoch: 1
+  epoch: 2
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
       - rabbitmq-c
     provides:
       - php-amqp=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -19,8 +25,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
       - rabbitmq-c-dev
 
 pipeline:

--- a/php-8.3-amqp.yaml
+++ b/php-8.3-amqp.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-amqp
   version: 2.1.2
-  epoch: 1 # NB intentionally meant to be picked over previous php-amqp
+  epoch: 1
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01

--- a/php-8.3-apcu.yaml
+++ b/php-8.3-apcu.yaml
@@ -1,16 +1,22 @@
 package:
   name: php-8.3-apcu
   version: 5.1.24
-  epoch: 0
+  epoch: 1
   description: "PHP extension for User Cache"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
     provides:
       - php-apcu=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -18,8 +24,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.3-ddtrace.yaml
+++ b/php-8.3-ddtrace.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.3-ddtrace
   version: 1.4.2
-  epoch: 0
+  epoch: 1
   description: "Datadog PHP Clients"
   copyright:
     - license: Apache-2.0 OR BSD-3-Clause
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,8 +23,8 @@ environment:
       - build-base
       - busybox
       - curl-dev
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
       - posix-libc-utils
       - rust
 
@@ -52,7 +58,7 @@ test:
   environment:
     contents:
       packages:
-        - php-8.3
+        - php-${{vars.phpMM}}
   pipeline:
     - name: Verify Extension is Loaded
       runs: |

--- a/php-8.3-decimal.yaml
+++ b/php-8.3-decimal.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.3-decimal
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: Correctly-rounded, arbitrary-precision decimal arithmetic for PHP
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,8 +23,8 @@ environment:
       - build-base
       - busybox
       - mpdecimal-dev
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.3-ds.yaml
+++ b/php-8.3-ds.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.3-ds
   version: 1.5.0
-  epoch: 0
+  epoch: 1
   description: "An extension providing efficient data structures for PHP"
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.3-excimer.yaml
+++ b/php-8.3-excimer.yaml
@@ -1,16 +1,22 @@
 package:
   name: php-8.3-excimer
   version: 1.2.2
-  epoch: 0
+  epoch: 1
   description: "Excimer is a PHP extension that provides an interrupting timer and a low-overhead sampling profiler."
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
     provides:
       - php-excimer=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -18,8 +24,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.3-grpc.yaml
+++ b/php-8.3-grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-grpc
   version: 1.67.1
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for gRPC"
   copyright:
     - license: Apache-2.0
@@ -9,9 +9,15 @@ package:
     runtime:
       - ${{package.name}}-config
       - grpc
-      - php-8.3
+      - php-${{vars.phpMM}}
     provides:
       - php-grpc=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -20,8 +26,8 @@ environment:
       - build-base
       - busybox
       - grpc-dev
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.3-igbinary.yaml
+++ b/php-8.3-igbinary.yaml
@@ -1,16 +1,22 @@
 package:
   name: php-8.3-igbinary
   version: 3.2.16
-  epoch: 0
+  epoch: 1
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
     provides:
       - php-igbinary=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -18,8 +24,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.3-imagick.yaml
+++ b/php-8.3-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-imagick
   version: 3.7.0
-  epoch: 1
+  epoch: 2
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01
@@ -9,9 +9,15 @@ package:
     runtime:
       - ${{package.name}}-config
       - imagemagick
-      - php-8.3
+      - php-${{vars.phpMM}}
     provides:
       - php-imagick=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -20,8 +26,8 @@ environment:
       - build-base
       - busybox
       - imagemagick-dev
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.3-memcached.yaml
+++ b/php-8.3-memcached.yaml
@@ -1,16 +1,22 @@
 package:
   name: php-8.3-memcached
   version: 3.3.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for Memcached"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
     provides:
       - php-memcached=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -19,9 +25,9 @@ environment:
       - build-base
       - busybox
       - libmemcached-dev
-      - php-8.3
-      - php-8.3-dev
-      - php-8.3-igbinary-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-igbinary-dev
       - zlib-dev
 
 pipeline:

--- a/php-8.3-msgpack.yaml
+++ b/php-8.3-msgpack.yaml
@@ -1,16 +1,22 @@
 package:
   name: php-8.3-msgpack
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
     provides:
       - php-msgpack=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -18,8 +24,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.3-opentelemetry.yaml
+++ b/php-8.3-opentelemetry.yaml
@@ -1,16 +1,22 @@
 package:
   name: php-8.3-opentelemetry
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: "OpenTelemetry PHP auto-instrumentation extension"
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
     provides:
       - php-opentelemetry=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -18,8 +24,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.3-pdo_snowflake.yaml
+++ b/php-8.3-pdo_snowflake.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pdo_snowflake
   version: 3.0.2
-  epoch: 0
+  epoch: 1
   description: "Snowflake driver that uses the PHP Data Objects (PDO) extension"
   copyright:
     - license: Apache-2.0
@@ -11,7 +11,13 @@ package:
     - x86_64
   dependencies:
     runtime:
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -28,9 +34,9 @@ environment:
       - gcc
       - libtool
       - openssf-compiler-options
-      - php-8.3
-      - php-8.3-dev
-      - php-8.3-pdo
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-pdo
       - unixodbc-dev
       - zlib-dev
 

--- a/php-8.3-pecl-http.yaml
+++ b/php-8.3-pecl-http.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.3-pecl-http
   version: 4.2.4
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.3 HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
   dependencies:
     runtime:
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -25,8 +31,8 @@ environment:
       - libtool
       - openssf-compiler-options
       - openssl-dev
-      - php-8.3-dev
-      - php-8.3-pecl-raphf
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-pecl-raphf
       - zlib-dev
 
 pipeline:

--- a/php-8.3-pecl-http.yaml
+++ b/php-8.3-pecl-http.yaml
@@ -39,14 +39,9 @@ pipeline:
 
   - uses: autoconf/make
 
-  # TODO: This is a temporary workaround until the pecl/install pipelines
-  # propagates through.
-  # https://github.com/chainguard-dev/melange/pull/1068
-  - name: Install
-    runs: |
-      make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php/conf.d
-      echo "extension=http.so" > ${{targets.destdir}}/etc/php/conf.d/http.ini
+  - uses: pecl/install
+    with:
+      extension: "http"
 
   - uses: strip
 

--- a/php-8.3-pecl-mcrypt.yaml
+++ b/php-8.3-pecl-mcrypt.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.3-pecl-mcrypt
   version: 1.0.7
-  epoch: 1
+  epoch: 2
   description: "Provides PHP 8.3 bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -23,7 +29,7 @@ environment:
       - libmcrypt-dev
       - libtool
       - openssf-compiler-options
-      - php-8.3-dev
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: fetch

--- a/php-8.3-pecl-mongodb.yaml
+++ b/php-8.3-pecl-mongodb.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.3-pecl-mongodb
   version: 1.20.0
-  epoch: 1
+  epoch: 2
   description: "PHP 8.3 MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -25,7 +31,7 @@ environment:
       - libtool
       - openssf-compiler-options
       - openssl-dev>3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}-dev
       - snappy-dev
       - zstd-dev
 

--- a/php-8.3-pecl-pdosqlsrv.yaml
+++ b/php-8.3-pecl-pdosqlsrv.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.3-pecl-pdosqlsrv
   version: 5.12.0
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.3 Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -22,7 +28,7 @@ environment:
       - gcc
       - libtool
       - openssf-compiler-options
-      - php-8.3-dev
+      - php-${{vars.phpMM}}-dev
       - unixodbc-dev
 
 pipeline:

--- a/php-8.3-pecl-pdosqlsrv.yaml
+++ b/php-8.3-pecl-pdosqlsrv.yaml
@@ -35,14 +35,9 @@ pipeline:
 
   - uses: autoconf/make
 
-  # TODO: This is a temporary workaround until the pecl/install pipelines
-  # propagates through.
-  # https://github.com/chainguard-dev/melange/pull/1068
-  - name: Install
-    runs: |
-      make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php/conf.d
-      echo "extension=pdo_sqlsrv.so" > ${{targets.destdir}}/etc/php/conf.d/pdo_sqlsrv.ini
+  - uses: pecl/install
+    with:
+      extension: "pdo_sqlsrv"
 
   - uses: strip
 

--- a/php-8.3-pecl-raphf.yaml
+++ b/php-8.3-pecl-raphf.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.3-pecl-raphf
   version: 2.0.1
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.3 resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -22,7 +28,7 @@ environment:
       - gcc
       - libtool
       - openssf-compiler-options
-      - php-8.3-dev
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: fetch

--- a/php-8.3-pecl-raphf.yaml
+++ b/php-8.3-pecl-raphf.yaml
@@ -38,11 +38,10 @@ pipeline:
     with:
       extension: "raphf"
 
-  # PHP initialization is order dependent. So we will explicitly
-  # load this by prefixing the file with 10- so it runs before
-  # other modules which start with letters
-  # starts.
   - runs: |
+      # PHP initialization is order dependent. So we will explicitly
+      # load this by prefixing the file with 10- so it runs before
+      # other modules which start with letters starts.
       mv ${{targets.destdir}}/etc/php/conf.d/raphf.ini ${{targets.destdir}}/etc/php/conf.d/10-raphf.ini
 
   - uses: strip

--- a/php-8.3-pecl-raphf.yaml
+++ b/php-8.3-pecl-raphf.yaml
@@ -34,14 +34,9 @@ pipeline:
 
   - uses: autoconf/make
 
-  # TODO: This is a temporary workaround until the pecl/install pipelines
-  # propagates through.
-  # https://github.com/chainguard-dev/melange/pull/1068
-  - name: Install
-    runs: |
-      make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php/conf.d
-      echo "extension=raphf.so" > ${{targets.destdir}}/etc/php/conf.d/raphf.ini
+  - uses: pecl/install
+    with:
+      extension: "raphf"
 
   # PHP initialization is order dependent. So we will explicitly
   # load this by prefixing the file with 10- so it runs before

--- a/php-8.3-pecl-sqlsrv.yaml
+++ b/php-8.3-pecl-sqlsrv.yaml
@@ -35,14 +35,9 @@ pipeline:
 
   - uses: autoconf/make
 
-  # TODO: This is a temporary workaround until the pecl/install pipelines
-  # propagates through.
-  # https://github.com/chainguard-dev/melange/pull/1068
-  - name: Install
-    runs: |
-      make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php/conf.d
-      echo "extension=sqlsrv.so" > ${{targets.destdir}}/etc/php/conf.d/sqlsrv.ini
+  - uses: pecl/install
+    with:
+      extension: "sqlsrv"
 
   - uses: strip
 

--- a/php-8.3-pecl-sqlsrv.yaml
+++ b/php-8.3-pecl-sqlsrv.yaml
@@ -1,13 +1,19 @@
 package:
   name: php-8.3-pecl-sqlsrv
   version: 5.12.0
-  epoch: 0
+  epoch: 1
   description: "Provides PHP 8.3 Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -22,7 +28,7 @@ environment:
       - gcc
       - libtool
       - openssf-compiler-options
-      - php-8.3-dev
+      - php-${{vars.phpMM}}-dev
       - unixodbc-dev
 
 pipeline:

--- a/php-8.3-protobuf.yaml
+++ b/php-8.3-protobuf.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.3-protobuf
   version: 4.28.3
-  epoch: 0
+  epoch: 1
   description: "Protocol Buffers - Google's data interchange format"
   copyright:
     - license: BSD-3-Clause
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
       - protobuf-dev
 
 pipeline:

--- a/php-8.3-redis.yaml
+++ b/php-8.3-redis.yaml
@@ -1,15 +1,15 @@
 package:
   name: php-8.3-redis
   version: 6.1.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for Redis"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-${{vars.php-version}}
-      - php-${{vars.php-version}}-igbinary
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-igbinary
     provides:
       - php-redis=${{package.full-version}}
 
@@ -17,7 +17,7 @@ var-transforms:
   - from: ${{package.name}}
     match: ^php-(\d+\.\d+)-.*$
     replace: "$1"
-    to: php-version
+    to: phpMM
 
 environment:
   contents:
@@ -25,9 +25,9 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-${{vars.php-version}}
-      - php-${{vars.php-version}}-dev
-      - php-${{vars.php-version}}-igbinary-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
+      - php-${{vars.phpMM}}-igbinary-dev
 
 pipeline:
   - uses: git-checkout
@@ -59,7 +59,7 @@ subpackages:
           echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.php-version}} redis development headers
+    description: PHP ${{vars.phpMM}} redis development headers
     dependencies:
       provides:
         - php-redis-dev=${{package.full-version}}
@@ -75,7 +75,7 @@ test:
   environment:
     contents:
       packages:
-        - php-${{vars.php-version}}
+        - php-${{vars.phpMM}}
   pipeline:
     - name: Verify Extension is Loaded
       runs: |

--- a/php-8.3-ssh2.yaml
+++ b/php-8.3-ssh2.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.3-ssh2
   version: 1.4.1
-  epoch: 0
+  epoch: 1
   description: "Bindings for the libssh2 library"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,8 +23,8 @@ environment:
       - build-base
       - busybox
       - libssh2-dev
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.3-swoole.yaml
+++ b/php-8.3-swoole.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-swoole
   version: 5.1.5
-  epoch: 0
+  epoch: 1
   description: "Coroutine-based concurrency library for PHP"
   copyright:
     - license: Apache-2.0
@@ -9,9 +9,15 @@ package:
     runtime:
       - ${{package.name}}-config
       - brotli
-      - php-8.3
+      - php-${{vars.phpMM}}
     provides:
       - php-swoole=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -20,8 +26,8 @@ environment:
       - brotli-dev
       - build-base
       - busybox
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.3-xdebug.yaml
+++ b/php-8.3-xdebug.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.3-xdebug
   version: 3.3.2
-  epoch: 0
+  epoch: 1
   description: "Step Debugger for PHP"
   copyright:
     - license: PHP-3.01
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -16,8 +22,8 @@ environment:
       - autoconf
       - build-base
       - busybox
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
 
 pipeline:
   - uses: git-checkout

--- a/php-8.3-zstd.yaml
+++ b/php-8.3-zstd.yaml
@@ -1,14 +1,20 @@
 package:
   name: php-8.3-zstd
   version: 0.13.3
-  epoch: 0
+  epoch: 1
   description: Zstd Extension for PHP
   copyright:
     - license: MIT
   dependencies:
     runtime:
       - ${{package.name}}-config
-      - php-8.3
+      - php-${{vars.phpMM}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d+\.\d+)-.*$
+    replace: "$1"
+    to: phpMM
 
 environment:
   contents:
@@ -17,8 +23,8 @@ environment:
       - build-base
       - busybox
       - file
-      - php-8.3
-      - php-8.3-dev
+      - php-${{vars.phpMM}}
+      - php-${{vars.phpMM}}-dev
       - zstd-dev
 
 pipeline:


### PR DESCRIPTION
Update the php-8.*-*.yaml files to have use a var transform based on package name for the php version, and then use replace any use of php version with that variable.

Also here:
 * drop a comment that causes issue with wolfictl bump 
   https://github.com/wolfi-dev/wolfictl/issues/1282
 * update to use pecl/install and pecl/phpize pipeline where possible
 * update php8.*-redis.yaml to use phpMM name, as it had already used php-version.