### PR TITLE
python multi-version sphinxcontrib packages that are deps of sphinx.

### DIFF
--- a/py3-sphinxcontrib-applehelp.yaml
+++ b/py3-sphinxcontrib-applehelp.yaml
@@ -1,23 +1,30 @@
 package:
   name: py3-sphinxcontrib-applehelp
   version: 2.0.0
-  epoch: 1
+  epoch: 2
   description: sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books
   copyright:
     - license: BSD-2-Clause
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: sphinxcontrib-applehelp
+  import: sphinxcontrib.applehelp
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-pip
-      - py3-setuptools
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-flit-core
 
 pipeline:
   - uses: git-checkout
@@ -26,14 +33,42 @@ pipeline:
       expected-commit: f4f9d900b238d03da601bf7c75cff5bcbcee6d7c
       tag: ${{package.version}}
 
-  - name: Python Build
-    runs: |
-      python3 -m build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
 
-  - runs: |
-      python3 -m installer -d "${{targets.destdir}}" dist/sphinxcontrib_applehelp*.whl
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
 
 update:
   enabled: true

--- a/py3-sphinxcontrib-devhelp.yaml
+++ b/py3-sphinxcontrib-devhelp.yaml
@@ -1,23 +1,30 @@
 package:
   name: py3-sphinxcontrib-devhelp
   version: 2.0.0
-  epoch: 1
+  epoch: 2
   description: sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp documents
   copyright:
     - license: BSD-2-Clause
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: sphinxcontrib-devhelp
+  import: sphinxcontrib.devhelp
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-pip
-      - py3-setuptools
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-flit-core
 
 pipeline:
   - uses: git-checkout
@@ -26,14 +33,42 @@ pipeline:
       expected-commit: 0177fb44f165305f27b34e69e6e7e5ed6f24d752
       tag: ${{package.version}}
 
-  - name: Python Build
-    runs: |
-      python3 -m build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
 
-  - runs: |
-      python3 -m installer -d "${{targets.destdir}}" dist/sphinxcontrib_devhelp*.whl
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
 
 update:
   enabled: true

--- a/py3-sphinxcontrib-htmlhelp.yaml
+++ b/py3-sphinxcontrib-htmlhelp.yaml
@@ -1,23 +1,30 @@
 package:
   name: py3-sphinxcontrib-htmlhelp
   version: 2.1.0
-  epoch: 1
+  epoch: 2
   description: sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files
   copyright:
     - license: BSD-2-Clause
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: sphinxcontrib-htmlhelp
+  import: sphinxcontrib.htmlhelp
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-pip
-      - py3-setuptools
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-flit-core
 
 pipeline:
   - uses: git-checkout
@@ -26,14 +33,42 @@ pipeline:
       expected-commit: f7f5d4ecf27fad97e2454fbeda94c6a105c994ff
       tag: ${{package.version}}
 
-  - name: Python Build
-    runs: |
-      python3 -m build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
 
-  - runs: |
-      python3 -m installer -d "${{targets.destdir}}" dist/sphinxcontrib_htmlhelp*.whl
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
 
 update:
   enabled: true

--- a/py3-sphinxcontrib-jsmath.yaml
+++ b/py3-sphinxcontrib-jsmath.yaml
@@ -1,23 +1,29 @@
 package:
   name: py3-sphinxcontrib-jsmath
   version: 1.0.1
-  epoch: 5
+  epoch: 6
   description: A sphinx extension which renders display math in HTML via JavaScript
   copyright:
     - license: BSD-3-Clause
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: sphinxcontrib-jsmath
+  import: sphinxcontrib.jsmath
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-pip
-      - py3-setuptools
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -26,14 +32,42 @@ pipeline:
       expected-commit: e4c69dd2180c7f18330d5c3fb9300ea0e8461911
       tag: ${{package.version}}
 
-  - name: Python Build
-    runs: |
-      python3 -m build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
 
-  - runs: |
-      python3 -m installer -d "${{targets.destdir}}" dist/sphinxcontrib_jsmath*.whl
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
 
 update:
   enabled: true

--- a/py3-sphinxcontrib-qthelp.yaml
+++ b/py3-sphinxcontrib-qthelp.yaml
@@ -1,23 +1,30 @@
 package:
   name: py3-sphinxcontrib-qthelp
   version: 2.0.0
-  epoch: 1
+  epoch: 2
   description: sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp documents
   copyright:
     - license: BSD-2-Clause
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: sphinxcontrib-qthelp
+  import: sphinxcontrib.qthelp
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-pip
-      - py3-setuptools
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-flit-core
 
 pipeline:
   - uses: git-checkout
@@ -26,14 +33,42 @@ pipeline:
       expected-commit: 783caf58e9ba9cf0450746b7f65d4bc8229ccd8f
       tag: ${{package.version}}
 
-  - name: Python Build
-    runs: |
-      python3 -m build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
 
-  - runs: |
-      python3 -m installer -d "${{targets.destdir}}" dist/sphinxcontrib_qthelp*.whl
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
 
 update:
   enabled: true

--- a/py3-sphinxcontrib-serializinghtml.yaml
+++ b/py3-sphinxcontrib-serializinghtml.yaml
@@ -1,23 +1,30 @@
 package:
   name: py3-sphinxcontrib-serializinghtml
   version: 2.0.0
-  epoch: 1
+  epoch: 2
   description: sphinxcontrib-serializinghtml is a sphinx extension which outputs "serialized" HTML files (json and pickle)
   copyright:
     - license: BSD-2-Clause
+  dependencies:
+    provider-priority: 0
+
+vars:
+  pypi-package: sphinxcontrib-serializinghtml
+  import: sphinxcontrib.serializinghtml
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-pip
-      - py3-setuptools
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-flit-core
 
 pipeline:
   - uses: git-checkout
@@ -26,14 +33,42 @@ pipeline:
       expected-commit: f0f3b15b2e6bb47570d605ebd5687643d7a85b9d
       tag: ${{package.version}}
 
-  - name: Python Build
-    runs: |
-      python3 -m build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
 
-  - runs: |
-      python3 -m installer -d "${{targets.destdir}}" dist/sphinxcontrib_serializinghtml*.whl
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
-  - uses: strip
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          # import ${{vars.import}} # AVOID_DEP_CYCLE(sphinx)
 
 update:
   enabled: true


### PR DESCRIPTION
These modules are all dependencies of sphinx and also depend on sphinx for even a simple import test.

So, in order to get this in we continue to not record the depencency and do not attempt an import test.
