### PR TITLE
Removing the hard requirement to build for x86 only

### DIFF
--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -5,14 +5,10 @@ package:
   # 'package format error' when trying to install the package. The workaround is
   # to replace '-' with '.', then mangling the version to replace back.
   version: 4.25.0.20241024
-  epoch: 2
+  epoch: 3
   description: Provides a simple way to run Selenium Grid with Chrome, Firefox, and Edge using Docker, making it easier to perform browser automation
   copyright:
     - license: Apache-2.0
-  target-architecture:
-    # TODO: Enable aarch64
-    # Requires aarch64 variant of Chromedriver
-    - x86_64
   dependencies:
     runtime:
       - bash


### PR DESCRIPTION
We were previously building for only x86_64 because of chrome driver which is not available for macOS. Since there is no direct build for chrome, this requirement is no longer needed. This also allows us build images for both aarch and x86