### PR TITLE
php modules - Drop virtual provides , replace remaining 8.X occurences.

### DIFF
--- a/php-8.1-amqp.yaml
+++ b/php-8.1-amqp.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-amqp
   version: 2.1.2
-  epoch: 2
+  epoch: 3
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01
@@ -51,9 +51,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-amqp-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.1-igbinary.yaml
+++ b/php-8.1-igbinary.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-igbinary
   version: 3.2.16
-  epoch: 1
+  epoch: 2
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
@@ -49,19 +49,13 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-igbinary-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.1 igbinary development headers
-    dependencies:
-      provides:
-        - php-igbinary-dev=${{package.full-version}}
+    description: PHP ${{vars.phpMM}} igbinary development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.1-memcached.yaml
+++ b/php-8.1-memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-memcached
   version: 3.3.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for Memcached"
   copyright:
     - license: PHP-3.01
@@ -55,7 +55,7 @@ subpackages:
           echo "extension=memcached.so" > "${{targets.subpkgdir}}/etc/php/conf.d/memcached.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.1 memcached development headers
+    description: PHP ${{vars.phpMM}} memcached development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.1-msgpack.yaml
+++ b/php-8.1-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-msgpack
   version: 3.0.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
@@ -53,7 +53,7 @@ subpackages:
           echo "extension=msgpack.so" > "${{targets.subpkgdir}}/etc/php/conf.d/msgpack.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.1 msgpack development headers
+    description: PHP ${{vars.phpMM}} msgpack development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.1-pecl-http.yaml
+++ b/php-8.1-pecl-http.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.1-pecl-http
   version: 4.2.4
-  epoch: 1
-  description: "Provides PHP 8.1 HTTP module for PHP Extended HTTP Support- PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/php-8.1-pecl-mcrypt.yaml
+++ b/php-8.1-pecl-mcrypt.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.1-pecl-mcrypt
   version: 1.0.7
-  epoch: 4
-  description: "Provides PHP 8.1 bindings for the unmaintained libmcrypt - PECL"
+  epoch: 5
+  description: "Provides PHP ${{vars.phpMM}} bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.1-pecl-mongodb.yaml
+++ b/php-8.1-pecl-mongodb.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.1-pecl-mongodb
   version: 1.20.0
-  epoch: 2
-  description: "PHP 8.1 MongoDB driver - PECL"
+  epoch: 3
+  description: "PHP ${{vars.phpMM}} MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.1-pecl-pdosqlsrv.yaml
+++ b/php-8.1-pecl-pdosqlsrv.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.1-pecl-pdosqlsrv
   version: 5.12.0
-  epoch: 1
-  description: "Provides PHP 8.1 Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:

--- a/php-8.1-pecl-raphf.yaml
+++ b/php-8.1-pecl-raphf.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.1-pecl-raphf
   version: 2.0.1
-  epoch: 5
-  description: "Provides PHP 8.1 resource and persistent handles factory - PECL"
+  epoch: 6
+  description: "Provides PHP ${{vars.phpMM}} resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.1-pecl-sqlsrv.yaml
+++ b/php-8.1-pecl-sqlsrv.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.1-pecl-sqlsrv
   version: 5.12.0
-  epoch: 1
-  description: "Provides PHP 8.1 Microsoft Drivers for SQL Server (SQLSRV) - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:

--- a/php-8.1-redis.yaml
+++ b/php-8.1-redis.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-redis
   version: 6.1.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for Redis"
   copyright:
     - license: PHP-3.01
@@ -49,9 +49,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-redis-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
@@ -59,9 +56,6 @@ subpackages:
 
   - name: ${{package.name}}-dev
     description: PHP ${{vars.phpMM}} redis development headers
-    dependencies:
-      provides:
-        - php-redis-dev=${{package.full-version}}
     pipeline:
       - uses: split/dev
 

--- a/php-8.2-amqp.yaml
+++ b/php-8.2-amqp.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-amqp
   version: 2.1.2
-  epoch: 2
+  epoch: 3
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01
@@ -51,9 +51,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-amqp-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.2-igbinary.yaml
+++ b/php-8.2-igbinary.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-igbinary
   version: 3.2.16
-  epoch: 1
+  epoch: 2
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
@@ -55,7 +55,7 @@ subpackages:
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.2 igbinary development headers
+    description: PHP ${{vars.phpMM}} igbinary development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.2-memcached.yaml
+++ b/php-8.2-memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-memcached
   version: 3.3.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for Memcached"
   copyright:
     - license: PHP-3.01
@@ -55,7 +55,7 @@ subpackages:
           echo "extension=memcached.so" > "${{targets.subpkgdir}}/etc/php/conf.d/memcached.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.2 memcached development headers
+    description: PHP ${{vars.phpMM}} memcached development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.2-msgpack.yaml
+++ b/php-8.2-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-msgpack
   version: 3.0.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
@@ -53,7 +53,7 @@ subpackages:
           echo "extension=msgpack.so" > "${{targets.subpkgdir}}/etc/php/conf.d/msgpack.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.2 msgpack development headers
+    description: PHP ${{vars.phpMM}} msgpack development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.2-pecl-http.yaml
+++ b/php-8.2-pecl-http.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.2-pecl-http
   version: 4.2.4
-  epoch: 1
-  description: "Provides PHP 8.2 HTTP module for PHP Extended HTTP Support- PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/php-8.2-pecl-mcrypt.yaml
+++ b/php-8.2-pecl-mcrypt.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.2-pecl-mcrypt
   version: 1.0.7
-  epoch: 4
-  description: "Provides PHP 8.2 bindings for the unmaintained libmcrypt - PECL"
+  epoch: 5
+  description: "Provides PHP ${{vars.phpMM}} bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.2-pecl-mongodb.yaml
+++ b/php-8.2-pecl-mongodb.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.2-pecl-mongodb
   version: 1.20.0
-  epoch: 2
-  description: "PHP 8.2 MongoDB driver - PECL"
+  epoch: 3
+  description: "PHP ${{vars.phpMM}} MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.2-pecl-pdosqlsrv.yaml
+++ b/php-8.2-pecl-pdosqlsrv.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.2-pecl-pdosqlsrv
   version: 5.12.0
-  epoch: 1
-  description: "Provides PHP 8.2 Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:

--- a/php-8.2-pecl-raphf.yaml
+++ b/php-8.2-pecl-raphf.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.2-pecl-raphf
   version: 2.0.1
-  epoch: 4
-  description: "Provides PHP 8.2 resource and persistent handles factory - PECL"
+  epoch: 5
+  description: "Provides PHP ${{vars.phpMM}} resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.2-pecl-sqlsrv.yaml
+++ b/php-8.2-pecl-sqlsrv.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.2-pecl-sqlsrv
   version: 5.12.0
-  epoch: 1
-  description: "Provides PHP 8.2 Microsoft Drivers for SQL Server (SQLSRV) - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:

--- a/php-8.3-amqp.yaml
+++ b/php-8.3-amqp.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-amqp
   version: 2.1.2
-  epoch: 2
+  epoch: 3
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01
@@ -10,8 +10,6 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
       - rabbitmq-c
-    provides:
-      - php-amqp=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -53,9 +51,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-amqp-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-apcu.yaml
+++ b/php-8.3-apcu.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-apcu
   version: 5.1.24
-  epoch: 1
+  epoch: 2
   description: "PHP extension for User Cache"
   copyright:
     - license: PHP-3.01
@@ -9,8 +9,6 @@ package:
     runtime:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
-    provides:
-      - php-apcu=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -48,9 +46,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-apcu-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-excimer.yaml
+++ b/php-8.3-excimer.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-excimer
   version: 1.2.2
-  epoch: 1
+  epoch: 2
   description: "Excimer is a PHP extension that provides an interrupting timer and a low-overhead sampling profiler."
   copyright:
     - license: Apache-2.0
@@ -9,8 +9,6 @@ package:
     runtime:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
-    provides:
-      - php-excimer=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -51,9 +49,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-excimer-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-grpc.yaml
+++ b/php-8.3-grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-grpc
   version: 1.67.1
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for gRPC"
   copyright:
     - license: Apache-2.0
@@ -10,8 +10,6 @@ package:
       - ${{package.name}}-config
       - grpc
       - php-${{vars.phpMM}}
-    provides:
-      - php-grpc=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -49,9 +47,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-grpc-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-igbinary.yaml
+++ b/php-8.3-igbinary.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-igbinary
   version: 3.2.16
-  epoch: 1
+  epoch: 2
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
@@ -9,8 +9,6 @@ package:
     runtime:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
-    provides:
-      - php-igbinary=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -51,19 +49,13 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-igbinary-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.3 igbinary development headers
-    dependencies:
-      provides:
-        - php-igbinary-dev=${{package.full-version}}
+    description: PHP ${{vars.phpMM}} igbinary development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-imagick.yaml
+++ b/php-8.3-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-imagick
   version: 3.7.0
-  epoch: 2
+  epoch: 3
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01
@@ -10,8 +10,6 @@ package:
       - ${{package.name}}-config
       - imagemagick
       - php-${{vars.phpMM}}
-    provides:
-      - php-imagick=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -50,9 +48,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-imagick-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-memcached.yaml
+++ b/php-8.3-memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-memcached
   version: 3.3.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for Memcached"
   copyright:
     - license: PHP-3.01
@@ -9,8 +9,6 @@ package:
     runtime:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
-    provides:
-      - php-memcached=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -51,19 +49,13 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-memcached-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=memcached.so" > "${{targets.subpkgdir}}/etc/php/conf.d/memcached.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.3 memcached development headers
-    dependencies:
-      provides:
-        - php-memcached-dev=${{package.full-version}}
+    description: PHP ${{vars.phpMM}} memcached development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-msgpack.yaml
+++ b/php-8.3-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-msgpack
   version: 3.0.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
@@ -9,8 +9,6 @@ package:
     runtime:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
-    provides:
-      - php-msgpack=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -49,19 +47,13 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-msgpack-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=msgpack.so" > "${{targets.subpkgdir}}/etc/php/conf.d/msgpack.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.3 msgpack development headers
-    dependencies:
-      provides:
-        - php-msgpack-dev=${{package.full-version}}
+    description: PHP ${{vars.phpMM}} msgpack development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-opentelemetry.yaml
+++ b/php-8.3-opentelemetry.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-opentelemetry
   version: 1.1.0
-  epoch: 1
+  epoch: 2
   description: "OpenTelemetry PHP auto-instrumentation extension"
   copyright:
     - license: Apache-2.0
@@ -9,8 +9,6 @@ package:
     runtime:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
-    provides:
-      - php-opentelemetry=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -51,9 +49,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-opentelemetry-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-pecl-http.yaml
+++ b/php-8.3-pecl-http.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.3-pecl-http
   version: 4.2.4
-  epoch: 1
-  description: "Provides PHP 8.3 HTTP module for PHP Extended HTTP Support- PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/php-8.3-pecl-mcrypt.yaml
+++ b/php-8.3-pecl-mcrypt.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.3-pecl-mcrypt
   version: 1.0.7
-  epoch: 2
-  description: "Provides PHP 8.3 bindings for the unmaintained libmcrypt - PECL"
+  epoch: 3
+  description: "Provides PHP ${{vars.phpMM}} bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.3-pecl-mongodb.yaml
+++ b/php-8.3-pecl-mongodb.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.3-pecl-mongodb
   version: 1.20.0
-  epoch: 2
-  description: "PHP 8.3 MongoDB driver - PECL"
+  epoch: 3
+  description: "PHP ${{vars.phpMM}} MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.3-pecl-pdosqlsrv.yaml
+++ b/php-8.3-pecl-pdosqlsrv.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.3-pecl-pdosqlsrv
   version: 5.12.0
-  epoch: 1
-  description: "Provides PHP 8.3 Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:

--- a/php-8.3-pecl-raphf.yaml
+++ b/php-8.3-pecl-raphf.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.3-pecl-raphf
   version: 2.0.1
-  epoch: 1
-  description: "Provides PHP 8.3 resource and persistent handles factory - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.3-pecl-sqlsrv.yaml
+++ b/php-8.3-pecl-sqlsrv.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.3-pecl-sqlsrv
   version: 5.12.0
-  epoch: 1
-  description: "Provides PHP 8.3 Microsoft Drivers for SQL Server (SQLSRV) - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:

--- a/php-8.3-redis.yaml
+++ b/php-8.3-redis.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-redis
   version: 6.1.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for Redis"
   copyright:
     - license: PHP-3.01
@@ -10,8 +10,6 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
       - php-${{vars.phpMM}}-igbinary
-    provides:
-      - php-redis=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -50,9 +48,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-redis-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
@@ -60,9 +55,6 @@ subpackages:
 
   - name: ${{package.name}}-dev
     description: PHP ${{vars.phpMM}} redis development headers
-    dependencies:
-      provides:
-        - php-redis-dev=${{package.full-version}}
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-swoole.yaml
+++ b/php-8.3-swoole.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-swoole
   version: 5.1.5
-  epoch: 1
+  epoch: 2
   description: "Coroutine-based concurrency library for PHP"
   copyright:
     - license: Apache-2.0
@@ -10,8 +10,6 @@ package:
       - ${{package.name}}-config
       - brotli
       - php-${{vars.phpMM}}
-    provides:
-      - php-swoole=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -53,9 +51,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-swoole-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"


### PR DESCRIPTION
We currently have 3 packages of each php module, one for each version of PHP.  For amqp, that is:

   php-8.1-amqp
   php-8.2-amqp
   php-8.3-amqp

Each of these has a dependency on the corresponding php-8.X.

Before this commit, the module for the newest php version was also providing 'php-amqp', such that if something just wanted 'php-amqp', it would get php-8.3-amqp.

That is somewhat fragile though and would require us to remove the provides from an 8.3 package when 8.4 is released. (see https://github.com/wolfi-dev/os/pull/16420)

We don't want to have to re-build php-8.3-* modules in order to add php-8.4 versions.

The other option here is to use provider-priority as we do in python. But in order to get there, we would probably have to remove all the previously published apks as they would 'provide' an explicit version.
