### PR TITLE
fix(datadog-agent): Use 7.58.x branch for datadog-agent sub package datadog-agent-core-integrations

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -16,6 +16,19 @@ package:
       - libseccomp
       - shadow
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    # this is used in the datadog-agent-core-integrations sub package git checkout as there will not always be a
+    # corresponding tag of the same name as the origin package version. There does however appear to be a pattern of
+    # maintaining the same major.minor.x branch for the integrations-core repo. This was first observed with the
+    # 7.58.1 tag/release of the datadog-agent package.
+    # Upstream bug https://github.com/DataDog/integrations-core/issues/18955 created seeking clarification on why there
+    # appears to be a missing tag in DataDog/integrations-core. Until that is resolved
+    # or until the next release we can use the 7.58.x branch of the DataDog/integrations-core repo
+    replace: "$1.x"
+    to: datadog-major-minor-x
+
 environment:
   contents:
     packages:
@@ -257,7 +270,7 @@ subpackages:
           - uses: git-checkout
             with:
               repository: https://github.com/DataDog/integrations-core
-              tag: ${{package.version}}
+              branch: ${{vars.datadog-major-minor-x}} # 7.58.x
               expected-commit: 32f78c0c8aae400ecc1c14a5369e7f702be7b572 # needs to be updated with each new release
           - uses: patch
             with:


### PR DESCRIPTION
There will not always be a corresponding tag of the same name as the origin package version.

There does however appear to be a pattern of maintaining the same major.minor.x branch for the integrations-core repo.

This was first observed with the 7.58.1 tag/release of the datadog-agent package in
package update PR https://github.com/wolfi-dev/os/pull/32059.

Upstream bug https://github.com/DataDog/integrations-core/issues/18955 created seeking clarification on why there
appears to be a missing tag in DataDog/integrations-core. Until that is resolved
or until the next release we can use the 7.58.x branch of the DataDog/integrations-core repo

One benefit of this approach over hardcoding a tag name is that when the branch moves the build will fail due to mismatched sha which will prompt us to check the current tags to see if the missing tag has been created. If so - we can revert this change. 

Signed-off-by: philroche <phil.roche@chainguard.dev>
