### PR TITLE
py3-google-api-core - needs grpcio as a dep.

### DIFF
--- a/py3-gcsfs.yaml
+++ b/py3-gcsfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-gcsfs
   version: 2024.10.0
-  epoch: 1
+  epoch: 2
   description: Convenient Filesystem interface over GCS
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,6 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
 
 environment:
   contents:
@@ -68,7 +67,6 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
-        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:

--- a/py3-google-api-core.yaml
+++ b/py3-google-api-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-api-core
   version: 2.22.0
-  epoch: 0
+  epoch: 1
   description: Google API client core library
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,6 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
 
 environment:
   contents:
@@ -41,9 +40,10 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}-googleapis-common-protos
-        - py${{range.key}}-protobuf
         - py${{range.key}}-google-auth
+        - py${{range.key}}-googleapis-common-protos
+        - py${{range.key}}-grpcio
+        - py${{range.key}}-protobuf
         - py${{range.key}}-requests
     pipeline:
       - uses: py/pip-build-install
@@ -65,7 +65,6 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
-        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:

--- a/py3-google-cloud-core.yaml
+++ b/py3-google-cloud-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-cloud-core
   version: 2.4.1
-  epoch: 2
+  epoch: 3
   description: Google Cloud API client core library
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,6 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
 
 environment:
   contents:
@@ -63,7 +62,6 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
-        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:

--- a/py3-google-cloud-storage.yaml
+++ b/py3-google-cloud-storage.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-cloud-storage
   version: 2.18.2
-  epoch: 1
+  epoch: 2
   description: Google Cloud Storage API client library
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,6 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
 
 environment:
   contents:
@@ -66,7 +65,6 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
-        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:


### PR DESCRIPTION
Also here, as a result you have to drop the 3.13 packages 
until grpcio gets 3.13 support.

As a result of the change to add grpcio here
we have to drop 3.13 from google-cloud-storage as it
becomes non-installable.
