### PR TITLE
multi-version py3-nullauthenticator, add openssl-provider-legacy to test

### DIFF
--- a/py3-nullauthenticator.yaml
+++ b/py3-nullauthenticator.yaml
@@ -1,25 +1,29 @@
-# Generated from https://pypi.org/project/nullauthenticator/
 package:
   name: py3-nullauthenticator
   version: 1.0.0
-  epoch: 0
+  epoch: 1
   description: 'JupyterHub: A multi-user server for Jupyter notebooks'
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-jupyterhub
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: nullauthenticator
+  import: nullauthenticator
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -28,15 +32,52 @@ pipeline:
       repository: https://github.com/jupyterhub/nullauthenticator
       tag: ${{package.version}}
 
-  - name: Python Build
-    runs: |
-      python setup.py build
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-jupyterhub
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - openssl-provider-legacy
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - name: Python Install
-    runs: |
-      python setup.py install --prefix=/usr --root="${{targets.destdir}}"
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
-  - uses: strip
+test:
+  environment:
+    contents:
+      packages:
+        - openssl-provider-legacy
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true


### PR DESCRIPTION
Adding openssl-provider-legacy to the test environment is a fix employed by many things that depend (directly or indirectly) on py3-cryptography.

The message you see that indicates it is needed is a Traceback for a RuntimeError that ends like:

>     Traceback (most recent call last):
>       File "<string>", line 1, in <module>
>       ...
>       File "/usr/lib/python3.12/site-packages/cryptography/fernet.py", line 14, in <module>
>         from cryptography.exceptions import InvalidSignature
>       File "/usr/lib/python3.12/site-packages/cryptography/exceptions.py", line 9, in <module>
>         from cryptography.hazmat.bindings._rust import exceptions as rust_exceptions
>     RuntimeError: OpenSSL 3.0's legacy provider failed to load.
>       This is a fatal error by default, but cryptography supports running without
>       legacy algorithms by setting the environment variable CRYPTOGRAPHY_OPENSSL_NO_LEGACY.
>       If you did not expect this error, you have likely made a mistake
>       with your OpenSSL configuration.
