### PR TITLE
Check for .pc files in usr/lib and usr/share

### DIFF
--- a/glew.yaml
+++ b/glew.yaml
@@ -58,9 +58,6 @@ subpackages:
       - uses: split/dev
       - runs: |
           rm -rf "${{targets.subpkgdir}}"/usr/lib/cmake
-    test:
-      pipeline:
-        - uses: test/pkgconf
 
 update:
   enabled: true

--- a/glew.yaml
+++ b/glew.yaml
@@ -58,6 +58,9 @@ subpackages:
       - uses: split/dev
       - runs: |
           rm -rf "${{targets.subpkgdir}}"/usr/lib/cmake
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
 update:
   enabled: true

--- a/pipelines/test/pkgconf.yaml
+++ b/pipelines/test/pkgconf.yaml
@@ -17,7 +17,7 @@ pipeline:
           lib_name=$(basename "$pc_file" ".pc")
           # Ensure .pc file is installed in usr/lib/pkgconfig/*.pc or
           # in usr/share/pkgconfig/*.pc
-          echo "$pc_file" | grep -q "^usr/lib/pkgconfig/${lib_name}.pc$|^usr/share/pkgconfig/${lib_name}.pc$"
+          echo "$pc_file" | grep -q "^usr/lib/pkgconfig/${lib_name}.pc$\|^usr/share/pkgconfig/${lib_name}.pc$"
           # Try to get the library name from the pc filename
           # Run some package config tests, which will likely be used by
           # other packages that have build dependencies on this dev package

--- a/pipelines/test/pkgconf.yaml
+++ b/pipelines/test/pkgconf.yaml
@@ -15,8 +15,9 @@ pipeline:
         # Ensure this is a pkgconf .pc file
         if grep -q "^Name:" $pc_file; then
           lib_name=$(basename "$pc_file" ".pc")
-          # Ensure .pc file is installed in usr/lib/pkgconfig/*.pc
-          echo "$pc_file" | grep -q "^usr/lib/pkgconfig/${lib_name}.pc$"
+          # Ensure .pc file is installed in usr/lib/pkgconfig/*.pc or
+          # in usr/share/pkgconfig/*.pc
+          echo "$pc_file" | grep -q "^usr/lib\|share/pkgconfig/${lib_name}.pc$"
           # Try to get the library name from the pc filename
           # Run some package config tests, which will likely be used by
           # other packages that have build dependencies on this dev package

--- a/pipelines/test/pkgconf.yaml
+++ b/pipelines/test/pkgconf.yaml
@@ -17,7 +17,7 @@ pipeline:
           lib_name=$(basename "$pc_file" ".pc")
           # Ensure .pc file is installed in usr/lib/pkgconfig/*.pc or
           # in usr/share/pkgconfig/*.pc
-          echo "$pc_file" | grep -q "^usr/lib\|share/pkgconfig/${lib_name}.pc$"
+          echo "$pc_file" | grep -q "^usr/lib/pkgconfig/${lib_name}.pc$|^usr/share/pkgconfig/${lib_name}.pc$"
           # Try to get the library name from the pc filename
           # Run some package config tests, which will likely be used by
           # other packages that have build dependencies on this dev package


### PR DESCRIPTION
This fixes the following test failure with pkgconf:

```
   2024/10/31 12:56:35 WARN + echo usr/share/pkgconfig/catch2-with-main.pc uses=test/pkgconf name="pkgconf build dependency check"
   2024/10/31 12:56:35 WARN + grep -q '^usr/lib/pkgconfig/catch2-with-main.pc$' uses=test/pkgconf name="pkgconf build dependency check"
   2024/10/31 12:56:35 INFO ERROR: failed to test package. the test environment has been preserved:

```