### PR TITLE
WIP: Spark 3.5 with Scala 2.12 and 2.13

### DIFF
--- a/spark-3.5-scala-2.12.yaml
+++ b/spark-3.5-scala-2.12.yaml
@@ -1,0 +1,242 @@
+package:
+  name: spark-3.5-scala-2.12
+  version: 3.5.3
+  epoch: 0
+  description: Unified engine for large-scale data analytics
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    provides:
+      - spark=${{package.full-version}}
+      - spark-3.5=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - R
+      - R-dev
+      - bash
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - glibc-iconv
+      - glibc-locale-en
+      - grep
+      - maven
+      - openjdk-11
+      - openjdk-17
+      # Only 8 is used during the build process
+      - openjdk-8
+      - perl-utils
+      - procps
+      - py3.11-pip
+      - python-3.11
+      - wolfi-base
+      - wolfi-baselayout
+      - yaml-dev
+  environment:
+    LANG: en_US.UTF-8
+    SCALA_VERSION: 2.12
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/apache/spark
+      tag: v${{package.version}}
+      expected-commit: 32232e9ed33bb16b93ad58cfde8b82e0f07c0970
+
+  - uses: patch
+    with:
+      patches: make-distribution.patch internal-access.patch
+
+  - uses: maven/pombump
+
+data:
+  - name: openjdk-versions
+    items:
+      8: "java-1.8-openjdk"
+      11: "java-11-openjdk"
+      17: "java-17-openjdk"
+
+subpackages:
+  - range: openjdk-versions
+    name: ${{package.name}}-openjdk-${{range.key}}
+    dependencies:
+      # Both `python` and `openjdk-{11,17}-default-jvm` are required for running Spark,
+      # but will be added in the image, since upstream supports different Python versions
+      # and Java versions. So we don't need to specify them here to avoid conflicts.
+      runtime:
+        - openjdk-${{range.key}}-default-jvm
+        - bash
+        - busybox
+        - procps
+        - posix-libc-utils
+        - tini
+        - tini-compat
+        - net-tools
+        - logrotate
+        - linux-pam
+        - procps
+        - libnss
+      provides:
+        - spark=${{package.full-version}}
+        - ${{package.name}}=${{package.full-version}}
+    pipeline:
+      - runs: |
+          export JAVA_HOME="/usr/lib/jvm/${{range.value}}"
+          export PATH=$PATH:$JAVA_HOME/bin
+
+          ./dev/change-scala-version.sh $SCALA_VERSION
+
+          ./dev/make-distribution.sh --name custom-spark --pip -Psparkr -Phive -Phive-thriftserver -Pmesos -Pyarn -Pkubernetes -Pscala-$SCALA_VERSION
+
+          patch dist/bin/load-spark-env.sh load-spark-env.sh.diff
+          patch dist/sbin/spark-daemon.sh spark-daemon.sh.diff
+
+          mkdir -p ${{targets.contextdir}}/usr/lib/spark
+          mkdir -p ${{targets.contextdir}}/usr/lib/spark/work-dir
+          mv dist/* ${{targets.contextdir}}/usr/lib/spark/
+    test:
+      environment:
+        contents:
+          packages:
+            - python3
+            - openjdk-${{range.key}}-default-jvm
+            - R
+        environment:
+          LANG: en_US.UTF-8
+          JAVA_HOME: /usr/lib/jvm/${{range.value}}
+      pipeline:
+        - name: Test ${{package.name}} with OpenJDK ${{range.key}}
+          pipeline:
+            - name: Test if the Scala versions are correct
+              runs: ls /usr/lib/spark/jars/scala-* | grep -q $SCALA_VERSION
+            - name: Check spark-shell --version
+            - runs: /usr/lib/spark/bin/spark-shell --version
+            - name: Check spark-submit --version
+            - runs: /usr/lib/spark/bin/spark-submit --version
+            - name: Check pyspark --version
+            - runs: /usr/lib/spark/bin/pyspark --version
+            - name: Check spark-sql --version
+            - runs: /usr/lib/spark/bin/spark-sql --version
+            - name: Test entrypoint
+              runs: timeout 10 /opt/entrypoint.sh /opt/spark/bin/spark-shell > spark_log.txt 2>&1 || [ $? -eq 143 ] && grep "Spark session available" spark_log.txt && exit_code=0 || exit_code=$? && echo $exit_code
+            - name: Run a simple Scala test script
+              runs: |
+                cat <<EOF > SimpleJob.scala
+                val data = Seq(1, 2, 3, 4, 5)
+                val rdd = spark.sparkContext.parallelize(data)
+                val sum = rdd.reduce(_ + _)
+                assert(sum == 15)
+                EOF
+                cat SimpleJob.scala | /usr/lib/spark/bin/spark-shell
+            - name: Run a simple Spark job in Python
+              runs: |
+                cat <<EOF > simple_job.py
+                from pyspark.sql import SparkSession
+                spark = SparkSession.builder.appName("SimpleJob").getOrCreate()
+                data = [1, 2, 3, 4, 5]
+                rdd = spark.sparkContext.parallelize(data)
+                sum = rdd.reduce(lambda x, y: x + y)
+                assert sum == 15
+                EOF
+                /usr/lib/spark/bin/spark-submit simple_job.py --jars /usr/lib/spark/jars/guava-32.0.1-jre.jar
+            - name: Perform SQL query on DataFrame in Scala
+              runs: |
+                cat <<EOF > SQLTest.scala
+                import org.apache.spark.sql.SparkSession
+                val spark = SparkSession.builder.appName("SQLTest").getOrCreate()
+                import spark.implicits._
+                val df = Seq((1, "Alice"), (2, "Bob")).toDF("id", "name")
+                df.createOrReplaceTempView("people")
+                val result = spark.sql("SELECT name FROM people WHERE id = 2")
+                assert(result.count() == 1 && result.first().getString(0) == "Bob")
+                EOF
+                cat SQLTest.scala | /usr/lib/spark/bin/spark-shell
+            - name: Run basic SQL query with spark-sql
+              runs: |
+                echo 'CREATE OR REPLACE TEMP VIEW test AS SELECT 1 AS id;' > test.sql
+                echo 'SELECT * FROM test;' >> test.sql
+                /usr/lib/spark/bin/spark-sql -f test.sql
+            - name: Run SparkR script
+              runs: |
+                cat <<EOF > sparkr_test.R
+                library(SparkR)
+                sparkR.session()
+                df <- as.DataFrame(data.frame(id = c(1, 2), name = c("Alice", "Bob")))
+                createOrReplaceTempView(df, "people")
+                df2 <- sql("SELECT * FROM people WHERE id > 1")
+                stopifnot(count(df2) == 1)
+                EOF
+                /usr/lib/spark/bin/spark-submit sparkr_test.R
+
+  - name: ${{package.name}}-compat
+    description: "Compatibility package to place binaries in the location expected by upstream image"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/bin
+          mkdir -p "${{targets.subpkgdir}}"/opt/
+          ln -s /usr/lib/spark/ ${{targets.subpkgdir}}/opt/spark
+          ln -sf /usr/lib/spark/kubernetes/dockerfiles/spark/entrypoint.sh ${{targets.subpkgdir}}/opt/entrypoint.sh
+          ln -sf /usr/lib/spark/kubernetes/dockerfiles/spark/decom.sh ${{targets.subpkgdir}}/opt/decom.sh
+          ln -sf /usr/lib/spark/bin/spark-submit ${{targets.subpkgdir}}/usr/bin/spark-submit
+          ln -sf /usr/lib/spark/bin/spark-shell ${{targets.subpkgdir}}/usr/bin/spark-shell
+          ln -sf /usr/lib/spark/bin/pyspark ${{targets.subpkgdir}}/usr/bin/pyspark
+          ln -sf /usr/lib/spark/bin/spark-class ${{targets.subpkgdir}}/usr/bin/spark-class
+          ln -sf /usr/lib/spark/bin/spark-sql ${{targets.subpkgdir}}/usr/bin/spark-sql
+          ln -sf /usr/lib/spark/bin/sparkR ${{targets.subpkgdir}}/usr/bin/spark
+      - uses: strip
+
+  - range: openjdk-versions
+    name: ${{package.name}}-minimal-openjdk-${{range.key}}
+    dependencies:
+      runtime:
+        - openjdk-${{range.key}}-default-jvm
+      provides:
+        - spark-minimal=${{package.full-version}}
+        - ${{package.name}}-minimal=${{package.full-version}}
+    pipeline:
+      - runs: |
+          export JAVA_HOME="/usr/lib/jvm/${{range.value}}"
+          export PATH=$PATH:$JAVA_HOME/bin
+
+          ./dev/make-distribution.sh --name minimal-spark --pip -Psparkr -Phive
+
+          mkdir -p ${{targets.contextdir}}/usr/lib/spark
+          mv dist/* ${{targets.contextdir}}/usr/lib/spark/
+
+  - name: ${{package.name}}-bitnami-compat
+    description: Bitnami compat for spark 3.5
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: spark
+          version-path: 3.5/debian-12
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/spark/
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/spark/logs
+          mkdir -p "${{targets.subpkgdir}}"/opt/bitnami/spark/tmp
+
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/spark/conf.default/
+          mkdir -p ${{targets.subpkgdir}}/opt/bitnami/spark/conf/
+
+          cp -r /home/build/melange-out/${{package.name}}-openjdk-17/usr/lib/spark/conf/* ${{targets.subpkgdir}}/opt/bitnami/spark/conf.default/
+          # We copy conf instead of symlinking to avoid issues with the bitnami volume mount.
+          cp -r /home/build/melange-out/${{package.name}}-openjdk-17/usr/lib/spark/conf/* ${{targets.subpkgdir}}/opt/bitnami/spark/conf/
+
+          ln -s /usr/lib/spark/jars ${{targets.subpkgdir}}/opt/bitnami/spark/jars
+          ln -s /usr/lib/spark/bin ${{targets.subpkgdir}}/opt/bitnami/spark/bin
+          ln -s /usr/lib/spark/data ${{targets.subpkgdir}}/opt/bitnami/spark/data
+          ln -s /usr/lib/spark/python ${{targets.subpkgdir}}/opt/bitnami/spark/python
+          ln -s /usr/lib/spark/licenses ${{targets.subpkgdir}}/opt/bitnami/spark/licenses
+          ln -s /usr/lib/spark/kubernetes ${{targets.subpkgdir}}/opt/bitnami/spark/kubernetes
+          ln -s /usr/lib/spark/sbin ${{targets.subpkgdir}}/opt/bitnami/spark/sbin
+          ln -s /usr/lib/spark/yarn ${{targets.subpkgdir}}/opt/bitnami/spark/yarn
+
+update:
+  enabled: true
+  github:
+    identifier: apache/spark
+    use-tag: true
+    strip-prefix: v
+    tag-filter: v3.5

--- a/spark-3.5.yaml
+++ b/spark-3.5.yaml
@@ -1,10 +1,15 @@
 package:
   name: spark-3.5
   version: 3.5.3
-  epoch: 4
+  epoch: 5
   description: Unified engine for large-scale data analytics
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - spark=${{package.full-version}}
+      - spark-3.5=${{package.full-version}}
+      - spark-3.5-scala-2.13=${{package.full-version}}
 
 environment:
   contents:
@@ -32,6 +37,7 @@ environment:
       - yaml-dev
   environment:
     LANG: en_US.UTF-8
+    SCALA_VERSION: 2.13
 
 pipeline:
   - uses: git-checkout
@@ -81,6 +87,8 @@ subpackages:
           export JAVA_HOME="/usr/lib/jvm/${{range.value}}"
           export PATH=$PATH:$JAVA_HOME/bin
 
+          ./dev/change-scala-version.sh $SCALA_VERSION
+
           ./dev/make-distribution.sh --name custom-spark --pip -Psparkr -Phive -Phive-thriftserver -Pmesos -Pyarn -Pkubernetes
 
           patch dist/bin/load-spark-env.sh load-spark-env.sh.diff
@@ -102,6 +110,8 @@ subpackages:
       pipeline:
         - name: Test ${{package.name}} with OpenJDK ${{range.key}}
           pipeline:
+            - name: Test if the Scala versions are correct
+              runs: ls /usr/lib/spark/jars/scala-* | grep -q $SCALA_VERSION
             - name: Check spark-shell --version
             - runs: /usr/lib/spark/bin/spark-shell --version
             - name: Check spark-submit --version


### PR DESCRIPTION
See: https://www.apache.org/dyn/closer.lua/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3-scala2.13.tgz

Upstream provides Spark-3.5.x with Scala-2.13, but the current `scala-3.5` package was providing `scala-2.12`. So let's bump that to `2.13` and create a separate package to provide the `scala-2.12` version as-is.