### PR TITLE
bump jenkins to v2.481

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -155,7 +155,7 @@ test:
     - name: "Check .war timestamp is being set correctly (not zero)"
       runs: |
         WAR_TIME=$(stat -c %Y /usr/share/java/jenkins/jenkins.war)
-        if [ "$WAR_TIME" -ne 0 ]; then
+        if [ "$WAR_TIME" -eq 0 ]; then
           echo "WAR file timestamp is zero"
           exit 1
         fi

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -1,6 +1,6 @@
 package:
   name: jenkins
-  version: "2.480"
+  version: "2.481"
   epoch: 0
   description: Open-source CI/CD application.
   copyright:
@@ -44,7 +44,7 @@ pipeline:
     with:
       repository: https://github.com/jenkinsci/jenkins
       tag: jenkins-${{package.version}}
-      expected-commit: 42fae0104a507bb08e8bae56d884b5c92526e5be
+      expected-commit: b21f42837783a0a817b7fc4e355f2cb361c9a084
 
   - uses: patch
     with:


### PR DESCRIPTION
We were missing package updates, such as this one, which ended up closed by automation and superseeded:
 - https://github.com/wolfi-dev/os/pull/31584

This will build v2.481 once, then we'll move forward to v2.482, and resume normal service with v2.283