### PR TITLE
pkgconf test pipeline - be more informative on a failure

### DIFF
--- a/pipelines/test/pkgconf.yaml
+++ b/pipelines/test/pkgconf.yaml
@@ -21,7 +21,7 @@ pipeline:
           # Try to get the library name from the pc filename
           # Run some package config tests, which will likely be used by
           # other packages that have build dependencies on this dev package
-          pkgconf --exists $lib_name
+          pkgconf --exists $lib_name || pkgconf --print-errors --exists $lib_name
           # If we have a module version in our .pc file, ensure pkgconf can get it
           if grep -q "^Version:" $pc_file; then
             pkgconf --modversion $lib_name


### PR DESCRIPTION
Instead of just failing if the library doesn't exist let's print some errors e.g.:

```
2024/10/31 14:56:35 WARN + pkgconf --exists glew uses=test/pkgconf name="pkgconf build dependency check"
2024/10/31 14:56:35 WARN + pkgconf --print-errors --exists glew uses=test/pkgconf name="pkgconf build dependency check"
2024/10/31 14:56:35 WARN Package osmesa was not found in the pkg-config search path. uses=test/pkgconf name="pkgconf build dependency check"
2024/10/31 14:56:35 WARN Perhaps you should add the directory containing `osmesa.pc' uses=test/pkgconf name="pkgconf build dependency check"
2024/10/31 14:56:35 WARN to the PKG_CONFIG_PATH environment variable uses=test/pkgconf name="pkgconf build dependency check"
2024/10/31 14:56:35 WARN Package 'osmesa', required by 'glu', not found uses=test/pkgconf name="pkgconf build dependency check"
2024/10/31 14:56:45 INFO pod 2886d2d106818576696201d58be1f7a9e4307c36d18fea30ca3953075be33752 terminated
```