### PR TITLE
unixodbc: remove empty config files that cause file conflicts

### DIFF
--- a/unixodbc.yaml
+++ b/unixodbc.yaml
@@ -2,7 +2,7 @@
 package:
   name: unixodbc
   version: 2.3.12
-  epoch: 4
+  epoch: 5
   description: ODBC is an open specification to access Data Sources
   copyright:
     - license: LGPL-2.0-or-later
@@ -40,6 +40,11 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - name: Remove empty config fils
+    runs: |
+      rm ${{targets.destdir}}/etc/odbc.ini
+      rm ${{targets.destdir}}/etc/odbcinst.ini
 
   - uses: strip
 


### PR DESCRIPTION
It is left as an exercise for the user to configure odbc.ini or have
other packages to install that (like ms one does). Empty config file
is not helping anything, but causes APK file conflicts.
