### PR TITLE
Bumping selenium server to use jdk-17

### DIFF
--- a/selenium.yaml
+++ b/selenium.yaml
@@ -1,13 +1,13 @@
 package:
   name: selenium
   version: 4.26.0
-  epoch: 0
+  epoch: 1
   description: A browser automation framework and ecosystem.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - openjdk-11-default-jvm
+      - openjdk-17-default-jvm
 
 environment:
   contents:
@@ -26,14 +26,14 @@ environment:
       - libbz2-1
       - liblz4-1
       - libzstd1
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-17
+      - openjdk-17-default-jvm
       - python3
       - ruby-3.3
       - tzdata
       - wolfi-baselayout
   environment:
-    JAVA_HOME: /usr/lib/jvm/java-11-openjdk
+    JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
 pipeline:
   - uses: git-checkout
@@ -62,7 +62,7 @@ subpackages:
     description: The Selenium Server is needed in order to run Remote Selenium WebDriver (Grid).
     dependencies:
       runtime:
-        - openjdk-11-default-jvm
+        - openjdk-17-default-jvm
     pipeline:
       - runs: |
           bazel build //java/src/org/openqa/selenium/grid:executable-grid
@@ -76,7 +76,7 @@ subpackages:
         contents:
           packages:
             - wolfi-base
-            - openjdk-11-default-jvm
+            - openjdk-17-default-jvm
       pipeline:
         - runs: |
             selenium-server-standalone info
@@ -87,7 +87,7 @@ subpackages:
     description: The Selenium Server is needed in order to run Remote Selenium WebDriver (Grid).
     dependencies:
       runtime:
-        - openjdk-11-default-jvm
+        - openjdk-17-default-jvm
     pipeline:
       - runs: |
           bazel build //java/src/org/openqa/selenium/grid:selenium_server_deploy.jar
@@ -101,7 +101,7 @@ subpackages:
         contents:
           packages:
             - wolfi-base
-            - openjdk-11-default-jvm
+            - openjdk-17-default-jvm
       pipeline:
         - runs: |
             java -jar /usr/bin/selenium-server
@@ -121,7 +121,7 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-11-default-jvm
+        - openjdk-17-default-jvm
   pipeline:
     - runs: |
         selenium info


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
The selenium server in https://github.com/SeleniumHQ/selenium/blob/cde43bcc398813a36142f01e026a34e0d71d1cbd/MODULE.bazel#L151 uses jdk-17. This PR is to bump the current version of jdk from 11 to 17. This allows the building of docker-selenium images
<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->