### PR TITLE
drawio(24.7.17):  new package

### DIFF
--- a/drawio.yaml
+++ b/drawio.yaml
@@ -49,8 +49,8 @@ pipeline:
       
       cp -a ./dist/linux-unpacked/. "${{targets.destdir}}"/usr/local/bin/
       cp -a ./dist/linux-unpacked/*.so "${{targets.destdir}}"/usr/local/lib/
-
-      chmod -R 4755 "${{targets.destdir}}"/usr/local/bin/
+      
+      chmod -R 4755 "${{targets.destdir}}"/usr/local/bin/chrome-sandbox
       
       mv "${{targets.destdir}}"/usr/local/bin/draw.io "${{targets.destdir}}"/usr/local/bin/drawio
 

--- a/drawio.yaml
+++ b/drawio.yaml
@@ -13,6 +13,10 @@ package:
       - ffmpeg-dev
       - libnss
       - mesa-libgallium
+      - Xvfb
+      - xvfb-run
+      - xkeyboard-config
+      - xkbcomp
 
 environment:
   contents:

--- a/drawio.yaml
+++ b/drawio.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: "Draw.io Desktop Headless"
   target-architecture:
-    - x86_64
+    - x86_64  # due to so:ld-linux-x86-64.so.2 for arm64 not being available
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/drawio.yaml
+++ b/drawio.yaml
@@ -1,0 +1,69 @@
+package:
+  name: drawio
+  version: 24.7.17
+  epoch: 0
+  description: "Draw.io Desktop Headless"
+  target-architecture:
+    - x86_64
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ffmpeg
+      - ffmpeg-dev
+      - libnss
+      - mesa-libgallium
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - nodejs
+      - npm
+      - glib
+      - glibc
+      - ld-linux
+      - ffmpeg
+      - ffmpeg-dev
+      - mesa-libgallium
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/jgraph/drawio-desktop
+      tag: v${{package.version}}
+      expected-commit: d1bb63c97f4b5e33a3adc200687a0c2a7265e290
+
+  - runs: |
+      npm install
+      node_modules/.bin/electron-builder build --dir -l --x64
+      
+      mkdir -p \
+        "${{targets.destdir}}"/usr/local/bin \
+        "${{targets.destdir}}"/usr/local/lib
+      
+      cp -a ./dist/linux-unpacked/. "${{targets.destdir}}"/usr/local/bin/
+      cp -a ./dist/linux-unpacked/*.so "${{targets.destdir}}"/usr/local/lib/
+
+      chmod -R 4755 "${{targets.destdir}}"/usr/local/bin/
+      
+      mv "${{targets.destdir}}"/usr/local/bin/draw.io "${{targets.destdir}}"/usr/local/bin/drawio
+
+update:
+  enabled: true
+  github:
+    identifier: jgraph/drawio-desktop
+    strip-prefix: v
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - build-base
+        - busybox
+  pipeline:
+    - runs: |
+        version=$(/bin/local/usr/drawio --version)
+        echo "$version" | grep "${{package.version}}"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/31977

Seeking help. **Work in progress**

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
