### PR TITLE
Replace remaining occurences of php version with variable.

### DIFF
--- a/php-8.1-igbinary.yaml
+++ b/php-8.1-igbinary.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-igbinary
   version: 3.2.16
-  epoch: 1
+  epoch: 2
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
@@ -58,7 +58,7 @@ subpackages:
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.1 igbinary development headers
+    description: PHP ${{vars.phpMM}} igbinary development headers
     dependencies:
       provides:
         - php-igbinary-dev=${{package.full-version}}

--- a/php-8.1-memcached.yaml
+++ b/php-8.1-memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-memcached
   version: 3.3.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for Memcached"
   copyright:
     - license: PHP-3.01
@@ -55,7 +55,7 @@ subpackages:
           echo "extension=memcached.so" > "${{targets.subpkgdir}}/etc/php/conf.d/memcached.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.1 memcached development headers
+    description: PHP ${{vars.phpMM}} memcached development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.1-msgpack.yaml
+++ b/php-8.1-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-msgpack
   version: 3.0.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
@@ -53,7 +53,7 @@ subpackages:
           echo "extension=msgpack.so" > "${{targets.subpkgdir}}/etc/php/conf.d/msgpack.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.1 msgpack development headers
+    description: PHP ${{vars.phpMM}} msgpack development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.1-pdo_snowflake.yaml
+++ b/php-8.1-pdo_snowflake.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pdo_snowflake
   version: 3.0.3
-  epoch: 0
+  epoch: 1
   description: "Snowflake driver that uses the PHP Data Objects (PDO) extension"
   copyright:
     - license: Apache-2.0
@@ -76,8 +76,8 @@ test:
   environment:
     contents:
       packages:
-        - php-8.1
-        - php-8.1-pdo
+        - php-${{vars.phpMM}}
+        - php-${{vars.phpMM}}-pdo
   pipeline:
     - name: Verify Extension is Loaded
       runs: |

--- a/php-8.1-pecl-http.yaml
+++ b/php-8.1-pecl-http.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.1-pecl-http
   version: 4.2.4
-  epoch: 1
-  description: "Provides PHP 8.1 HTTP module for PHP Extended HTTP Support- PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/php-8.1-pecl-mcrypt.yaml
+++ b/php-8.1-pecl-mcrypt.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.1-pecl-mcrypt
   version: 1.0.7
-  epoch: 4
-  description: "Provides PHP 8.1 bindings for the unmaintained libmcrypt - PECL"
+  epoch: 5
+  description: "Provides PHP ${{vars.phpMM}} bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.1-pecl-mongodb.yaml
+++ b/php-8.1-pecl-mongodb.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.1-pecl-mongodb
   version: 1.20.0
-  epoch: 2
-  description: "PHP 8.1 MongoDB driver - PECL"
+  epoch: 3
+  description: "PHP ${{vars.phpMM}} MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.1-pecl-pdosqlsrv.yaml
+++ b/php-8.1-pecl-pdosqlsrv.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.1-pecl-pdosqlsrv
   version: 5.12.0
-  epoch: 1
-  description: "Provides PHP 8.1 Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:

--- a/php-8.1-pecl-raphf.yaml
+++ b/php-8.1-pecl-raphf.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.1-pecl-raphf
   version: 2.0.1
-  epoch: 5
-  description: "Provides PHP 8.1 resource and persistent handles factory - PECL"
+  epoch: 6
+  description: "Provides PHP ${{vars.phpMM}} resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.1-pecl-sqlsrv.yaml
+++ b/php-8.1-pecl-sqlsrv.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.1-pecl-sqlsrv
   version: 5.12.0
-  epoch: 1
-  description: "Provides PHP 8.1 Microsoft Drivers for SQL Server (SQLSRV) - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:

--- a/php-8.2-igbinary.yaml
+++ b/php-8.2-igbinary.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-igbinary
   version: 3.2.16
-  epoch: 1
+  epoch: 2
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
@@ -55,7 +55,7 @@ subpackages:
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.2 igbinary development headers
+    description: PHP ${{vars.phpMM}} igbinary development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.2-memcached.yaml
+++ b/php-8.2-memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-memcached
   version: 3.3.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for Memcached"
   copyright:
     - license: PHP-3.01
@@ -55,7 +55,7 @@ subpackages:
           echo "extension=memcached.so" > "${{targets.subpkgdir}}/etc/php/conf.d/memcached.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.2 memcached development headers
+    description: PHP ${{vars.phpMM}} memcached development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.2-msgpack.yaml
+++ b/php-8.2-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-msgpack
   version: 3.0.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
@@ -53,7 +53,7 @@ subpackages:
           echo "extension=msgpack.so" > "${{targets.subpkgdir}}/etc/php/conf.d/msgpack.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.2 msgpack development headers
+    description: PHP ${{vars.phpMM}} msgpack development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.2-pdo_snowflake.yaml
+++ b/php-8.2-pdo_snowflake.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pdo_snowflake
   version: 3.0.3
-  epoch: 0
+  epoch: 1
   description: "Snowflake driver that uses the PHP Data Objects (PDO) extension"
   copyright:
     - license: Apache-2.0
@@ -76,8 +76,8 @@ test:
   environment:
     contents:
       packages:
-        - php-8.2
-        - php-8.2-pdo
+        - php-${{vars.phpMM}}
+        - php-${{vars.phpMM}}-pdo
   pipeline:
     - name: Verify Extension is Loaded
       runs: |

--- a/php-8.2-pecl-http.yaml
+++ b/php-8.2-pecl-http.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.2-pecl-http
   version: 4.2.4
-  epoch: 1
-  description: "Provides PHP 8.2 HTTP module for PHP Extended HTTP Support- PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/php-8.2-pecl-mcrypt.yaml
+++ b/php-8.2-pecl-mcrypt.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.2-pecl-mcrypt
   version: 1.0.7
-  epoch: 4
-  description: "Provides PHP 8.2 bindings for the unmaintained libmcrypt - PECL"
+  epoch: 5
+  description: "Provides PHP ${{vars.phpMM}} bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.2-pecl-mongodb.yaml
+++ b/php-8.2-pecl-mongodb.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.2-pecl-mongodb
   version: 1.20.0
-  epoch: 2
-  description: "PHP 8.2 MongoDB driver - PECL"
+  epoch: 3
+  description: "PHP ${{vars.phpMM}} MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.2-pecl-pdosqlsrv.yaml
+++ b/php-8.2-pecl-pdosqlsrv.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.2-pecl-pdosqlsrv
   version: 5.12.0
-  epoch: 1
-  description: "Provides PHP 8.2 Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:

--- a/php-8.2-pecl-raphf.yaml
+++ b/php-8.2-pecl-raphf.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.2-pecl-raphf
   version: 2.0.1
-  epoch: 4
-  description: "Provides PHP 8.2 resource and persistent handles factory - PECL"
+  epoch: 5
+  description: "Provides PHP ${{vars.phpMM}} resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.2-pecl-sqlsrv.yaml
+++ b/php-8.2-pecl-sqlsrv.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.2-pecl-sqlsrv
   version: 5.12.0
-  epoch: 1
-  description: "Provides PHP 8.2 Microsoft Drivers for SQL Server (SQLSRV) - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:

--- a/php-8.3-igbinary.yaml
+++ b/php-8.3-igbinary.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-igbinary
   version: 3.2.16
-  epoch: 1
+  epoch: 2
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
@@ -60,7 +60,7 @@ subpackages:
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.3 igbinary development headers
+    description: PHP ${{vars.phpMM}} igbinary development headers
     dependencies:
       provides:
         - php-igbinary-dev=${{package.full-version}}

--- a/php-8.3-memcached.yaml
+++ b/php-8.3-memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-memcached
   version: 3.3.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for Memcached"
   copyright:
     - license: PHP-3.01
@@ -60,7 +60,7 @@ subpackages:
           echo "extension=memcached.so" > "${{targets.subpkgdir}}/etc/php/conf.d/memcached.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.3 memcached development headers
+    description: PHP ${{vars.phpMM}} memcached development headers
     dependencies:
       provides:
         - php-memcached-dev=${{package.full-version}}

--- a/php-8.3-msgpack.yaml
+++ b/php-8.3-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-msgpack
   version: 3.0.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
@@ -58,7 +58,7 @@ subpackages:
           echo "extension=msgpack.so" > "${{targets.subpkgdir}}/etc/php/conf.d/msgpack.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.3 msgpack development headers
+    description: PHP ${{vars.phpMM}} msgpack development headers
     dependencies:
       provides:
         - php-msgpack-dev=${{package.full-version}}

--- a/php-8.3-pdo_snowflake.yaml
+++ b/php-8.3-pdo_snowflake.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pdo_snowflake
   version: 3.0.3
-  epoch: 0
+  epoch: 1
   description: "Snowflake driver that uses the PHP Data Objects (PDO) extension"
   copyright:
     - license: Apache-2.0
@@ -76,8 +76,8 @@ test:
   environment:
     contents:
       packages:
-        - php-8.3
-        - php-8.3-pdo
+        - php-${{vars.phpMM}}
+        - php-${{vars.phpMM}}-pdo
   pipeline:
     - name: Verify Extension is Loaded
       runs: |

--- a/php-8.3-pecl-http.yaml
+++ b/php-8.3-pecl-http.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.3-pecl-http
   version: 4.2.4
-  epoch: 1
-  description: "Provides PHP 8.3 HTTP module for PHP Extended HTTP Support- PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/php-8.3-pecl-mcrypt.yaml
+++ b/php-8.3-pecl-mcrypt.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.3-pecl-mcrypt
   version: 1.0.7
-  epoch: 2
-  description: "Provides PHP 8.3 bindings for the unmaintained libmcrypt - PECL"
+  epoch: 3
+  description: "Provides PHP ${{vars.phpMM}} bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.3-pecl-mongodb.yaml
+++ b/php-8.3-pecl-mongodb.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.3-pecl-mongodb
   version: 1.20.0
-  epoch: 2
-  description: "PHP 8.3 MongoDB driver - PECL"
+  epoch: 3
+  description: "PHP ${{vars.phpMM}} MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.3-pecl-pdosqlsrv.yaml
+++ b/php-8.3-pecl-pdosqlsrv.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.3-pecl-pdosqlsrv
   version: 5.12.0
-  epoch: 1
-  description: "Provides PHP 8.3 Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:

--- a/php-8.3-pecl-raphf.yaml
+++ b/php-8.3-pecl-raphf.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.3-pecl-raphf
   version: 2.0.1
-  epoch: 1
-  description: "Provides PHP 8.3 resource and persistent handles factory - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
   dependencies:

--- a/php-8.3-pecl-sqlsrv.yaml
+++ b/php-8.3-pecl-sqlsrv.yaml
@@ -1,8 +1,8 @@
 package:
   name: php-8.3-pecl-sqlsrv
   version: 5.12.0
-  epoch: 1
-  description: "Provides PHP 8.3 Microsoft Drivers for SQL Server (SQLSRV) - PECL"
+  epoch: 2
+  description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
     - license: MIT
   dependencies:


### PR DESCRIPTION
This just replaces any 8.X with vars.phpMM .  Some places were missed, now the only ones are in name: fields.