### PR TITLE
python-3.12: cherry-pick CVE-2024-9287  mitigation

### DIFF
--- a/python-3.12.yaml
+++ b/python-3.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.12
   version: 3.12.7
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -52,6 +52,8 @@ pipeline:
       expected-commit: 0b05ead877f909b7efe712db758012d9dbece7ce
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
+      cherry-picks: |
+        3.12/8450b2482586857d689b6658f08de9c8179af7db: CVE-2024-9287
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
Cherry pick fixes for https://nvd.nist.gov/vuln/detail/CVE-2024-9287  from commits listed here  https://github.com/python/cpython/issues/124651