### PR TITLE
python-3.11: cherry pick CVE-2024-9287 fixes

### DIFF
--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: 3.11.10
-  epoch: 3
+  epoch: 4
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -49,6 +49,8 @@ pipeline:
       expected-commit: 0c47759eee3e170e04a5dae82f12f6b375ae78f7
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
+      cherry-picks: |
+        3.11/ae961ae94bf19c8f8c7fbea3d1c25cc55ce8ae97: CVE-2024-9287
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
Cherry pick fixes for https://nvd.nist.gov/vuln/detail/CVE-2024-9287 from commits listed here https://github.com/python/cpython/issues/124651