### PR TITLE
openssf-compiler-options: add bypass

### DIFF
--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
   version: 20240627
-  epoch: 4
+  epoch: 5
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:

--- a/openssf-compiler-options/usr/local/bin/gcc-wrapper
+++ b/openssf-compiler-options/usr/local/bin/gcc-wrapper
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /usr/bin/${0##*/} -specs openssf.spec "$@"
+exec /usr/bin/${0##*/} -specs "${GCC_SPEC_FILE:-openssf.spec}" "$@"

--- a/pipelines/test/compiler-hardening-check.yaml
+++ b/pipelines/test/compiler-hardening-check.yaml
@@ -32,8 +32,17 @@ pipeline:
           return buffer[argc] + dynbuffer[argc];
       }
       EOF
-      ${{inputs.cc}} -v -o hello hello.c
-      out=$(./hello 1 || true)
+      ${{inputs.cc}} -v -o hello-default hello.c
+      out=$(./hello-default 1 || true)
+      [ "$out" = "hello-c" ]
+
+      case ${{inputs.cc}} in
+          clang*)
+              disablearg=--config-system-dir=/var/empty
+              ;;
+      esac
+      GCC_SPEC_FILE=/dev/null ${{inputs.cc}} $disablearg -v -o hello-disabled hello.c
+      out=$(./hello-disabled 1 || true)
       [ "$out" = "hello-c" ]
 
       arch_skip=
@@ -42,4 +51,8 @@ pipeline:
           arch_skip=--nocfprotection
       fi
 
-      hardening-check $arch_skip ${{inputs.args}} --color hello
+      # Test disabling hardening flags
+      hardening-check --nostackprotector $arch_skip ${{inputs.args}} --color hello-disabled && exit 1
+
+      # Test default build
+      hardening-check --nostackprotector $arch_skip ${{inputs.args}} --color hello-default


### PR DESCRIPTION
If for any reason a bypass is desired add environment variable support
in the gcc wrapper to use any other spec file for example /dev/null.

We don't have wrappers for clang, and it doesn't have env variable to
change config directly, but it does have command-line option to
override configs location at runtime, which will be documented.

Implement test cases in test/compiler-hardening-check that checks that
both bypass methods work.
