### PR TITLE
crac-criu: enable openssf hardening flags

### DIFF
--- a/crac-criu.yaml
+++ b/crac-criu.yaml
@@ -1,7 +1,7 @@
 package:
   name: crac-criu
   version: 1.4.3
-  epoch: 0
+  epoch: 1
   description: A project to implement checkpoint/restore functionality for Linux
   copyright:
     - license: GPL-2.0-only
@@ -30,11 +30,14 @@ environment:
       - nftables
       - nftables-dev
       - nftables-static
+      - openssf-compiler-options
       - perl
       - pkgconf
       - protobuf-c-dev
       - protobuf-dev
       - protoc
+  environment:
+    CFLAGS: "-Wno-error=format-truncation -Wno-error=maybe-uninitialized"
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Hardening flags cause compiler to manage to find additional bugs,
which upstream fails to spot, despite always building with Wall Werror
for those things.

Add additional Wno-error flags to skip those net-new warnings, to
ensure they are not treated as errors.
