### PR TITLE
Add TLS support to memcached and test it

### DIFF
--- a/memcached.yaml
+++ b/memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: memcached
   version: 1.6.32
-  epoch: 1
+  epoch: 2
   description: "Distributed memory object caching system"
   copyright:
     - license: BSD-3-Clause
@@ -15,11 +15,9 @@ environment:
       - cyrus-sasl-dev
       - libevent-dev
       - libseccomp-dev
-      - linux-headers
       - openssf-compiler-options
+      - openssl-dev
       - pkgconf-dev
-      # - bsd-compat-headers
-      - wolfi-base
 
 pipeline:
   - uses: git-checkout
@@ -38,7 +36,8 @@ pipeline:
         --prefix=/usr \
         --enable-sasl \
         --enable-sasl-pwdb \
-        --enable-seccomp
+        --enable-seccomp \
+        --enable-tls
 
   - uses: autoconf/make
 
@@ -88,6 +87,9 @@ test:
     contents:
       packages:
         - memcached-bitnami-compat
+        - openssl
+        - stunnel
+        - libmemcached
     accounts:
       groups:
         - groupname: nonroot
@@ -124,6 +126,30 @@ test:
         - name: Check folder exists
           runs: |
             stat /opt/bitnami/memcached/conf.default
-      runs: |
-        memcached --version
-        memcached --help
+
+        - name: test TLS
+          runs: |
+            cat <<EOF > openssl.cnf
+            [ req ]
+            prompt = no
+            EOF
+
+            openssl genpkey -algorithm RSA -out example.key
+            openssl req -new -key example.key -out example.csr -subj "/CN=example.com" -config openssl.cnf
+            openssl x509 -req -days 2 -in example.csr -signkey example.key -out example.crt
+           
+            memcached -Z -o ssl_chain_cert=example.crt,ssl_key=example.key&
+
+            cat <<EOF > stunnel.cnf
+            [memcached]
+            client = yes
+            accept = 127.0.0.1:11212
+            connect = 127.0.0.1:11211
+            cert = example.crt
+            key = example.key
+            EOF
+            stunnel stunnel.cnf
+
+            echo "hello memcached" > test
+            memcp -s 127.0.0.1:11212 test
+            memcat -s 127.0.0.1:11212 test |grep "hello memcached"

--- a/memcached.yaml
+++ b/memcached.yaml
@@ -126,7 +126,6 @@ test:
         - name: Check folder exists
           runs: |
             stat /opt/bitnami/memcached/conf.default
-
         - name: test TLS
           runs: |
             cat <<EOF > openssl.cnf
@@ -137,7 +136,7 @@ test:
             openssl genpkey -algorithm RSA -out example.key
             openssl req -new -key example.key -out example.csr -subj "/CN=example.com" -config openssl.cnf
             openssl x509 -req -days 2 -in example.csr -signkey example.key -out example.crt
-           
+
             memcached -Z -o ssl_chain_cert=example.crt,ssl_key=example.key&
 
             cat <<EOF > stunnel.cnf


### PR DESCRIPTION
Enables memcached's TLS support.  The [`awesomeized/libmemcached`](https://github.com/wolfi-dev/os/blob/main/libmemcached.yaml#L29) that ships in Wolfi doesn't support TLS, so the test uses stunnel instead.