### PR TITLE
add missing provides to versioned streamed package

### DIFF
--- a/cloud-provider-aws-1.31.yaml
+++ b/cloud-provider-aws-1.31.yaml
@@ -1,10 +1,13 @@
 package:
   name: cloud-provider-aws-1.31
   version: 1.31.1
-  epoch: 0
+  epoch: 1
   description: The AWS cloud provider provides the interface between a Kubernetes cluster and AWS service APIs.
   copyright:
     - license: Apache-2.0
+  dependencies:
+    provides:
+      - cloud-provider-aws=${{package.full-version}}
 
 pipeline:
   - uses: git-checkout
@@ -16,6 +19,9 @@ pipeline:
 subpackages:
   - name: ${{package.name}}-cloud-controller-manager
     description: The AWS Cloud Controller Manager is the controller that is primarily responsible for creating and updating AWS loadbalancers (classic and NLB) and node lifecycle management.
+    dependencies:
+      provides:
+        - cloud-provider-aws-cloud-controller-manager=${{package.full-version}}
     pipeline:
       - uses: go/build
         with:
@@ -32,6 +38,9 @@ subpackages:
 
   - name: ${{package.name}}-ecr-credential-provider
     description: The credential provider is a binary that is executed by kubelet to provide credentials for images in ECR.
+    dependencies:
+      provides:
+        - cloud-provider-aws-ecr-credential-provider=${{package.full-version}}
     pipeline:
       - uses: go/build
         with:
@@ -48,6 +57,9 @@ subpackages:
 
   - name: "${{package.name}}-cloud-controller-manager-compat"
     description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    dependencies:
+      provides:
+        - cloud-provider-aws-cloud-controller-manager-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}/bin"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [x] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [x] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [x] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions
