### PR TITLE
add libyang2.1 package

### DIFF
--- a/libyang-2.1.yaml
+++ b/libyang-2.1.yaml
@@ -66,6 +66,7 @@ update:
   github:
     identifier: CESNET/libyang
     strip-prefix: v
+    tag-filter: v2.1.
 
 test:
   environment:

--- a/libyang-2.1.yaml
+++ b/libyang-2.1.yaml
@@ -1,0 +1,85 @@
+package:
+  name: libyang-2.1
+  version: 2.1.148
+  epoch: 0
+  description: YANG data modeling language library
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - cmake
+      - cmocka-dev
+      - doxygen
+      - graphviz
+      - openssf-compiler-options
+      - pcre2-dev
+      - tcl
+      - valgrind
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: fc4dbd923e044006c93df020590a1e5a8656c09e
+      repository: https://github.com/CESNET/libyang
+      tag: v${{package.version}}
+
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=True \
+        -DCMAKE_C_FLAGS="$CFLAGS"
+
+  - uses: cmake/build
+
+  - uses: cmake/install
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-dev
+    description: dev library for libyang-2.1
+    dependencies:
+      runtime:
+        - libyang-2.1
+    pipeline:
+      - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
+
+  - name: ${{package.name}}-doc
+    pipeline:
+      - uses: split/manpages
+    description: libyang-2.1 manpages
+
+  - name: ${{package.name}}-debug
+    pipeline:
+      - uses: split/debug
+    description: libyang-2.1 debug
+
+update:
+  enabled: true
+  github:
+    identifier: CESNET/libyang
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - pkgconf
+        - libyang-2.1
+        - libyang-2.1-dev
+  pipeline:
+    - name: pkg-config tests
+      runs: |
+        pkg-config --exists libyang
+        pkg-config --libs libyang
+    - name: libyang-2.1-dev headers file
+      runs: |
+        stat /usr/include/libyang/*.h
+        stat /usr/lib/libyang.so


### PR DESCRIPTION
this is a follow-up of https://github.com/wolfi-dev/os/pull/32784 

the reason to package this old non-supported version is because https://github.com/CESNET/libyang/releases/tag/v2.2.8 which is a breaking change was introduced here. 

this library is required for frr and then seem to be pinning this version and without building this we cannot build frr. 