### PR TITLE
fix(linux-pam): Restore configuration for PAM

### DIFF
--- a/linux-pam.yaml
+++ b/linux-pam.yaml
@@ -1,7 +1,7 @@
 package:
   name: linux-pam
   version: 1.7.0
-  epoch: 1
+  epoch: 2
   description: Linux PAM (Pluggable Authentication Modules for Linux)
   copyright:
     - license: BSD-3-Clause
@@ -42,6 +42,9 @@ pipeline:
   - runs: |
       # install our pam.d files
       mkdir -p ${{targets.destdir}}/etc/pam.d
+      for pam_conf in *.pamd; do
+        mv "${pam_conf}" ${{targets.destdir}}/etc/pam.d/"${pam_conf%.pamd}"
+      done
 
       # make "unix_chkpwd" shadow group and enable g+s
       chgrp shadow ${{targets.destdir}}/sbin/unix_chkpwd \


### PR DESCRIPTION
The update to 1.7.0 led to a regression: https://github.com/wolfi-dev/os/commit/43142c69945903be6b859f52c39c0568f5a2c398

We are no longer shipping configuration for PAM in linux-pam, leaving it in a broken state. Fix that.