### PR TITLE
datadog-agent: refactor paths and stick to upstream

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -2,7 +2,7 @@ package:
   name: datadog-agent
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
-  version: 7.58.2
+  version: 7.58.1
   epoch: 1
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
@@ -245,11 +245,15 @@ subpackages:
             ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin
 
           # several startup scripts assume binaries are located in /opt/datadog-agent/...
-          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/agent
-          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin/system-probe
-          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin/security-agent
-          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin/process-agent
-          ln -s /usr/bin/agent ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin/trace-agent
+          cp ${{targets.destdir}}/usr/bin/agent ${{targets.contextdir}}/opt/datadog-agent/bin/agent/agent
+          ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/system-probe
+          ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/security-agent
+          ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/process-agent
+          ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/trace-agent
+
+          ln -s /usr/bin/python3.11 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python3.11
+          ln -s python3.11 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python3
+          ln -s python3 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python
 
           cp -r /opt/datadog-agent/embedded/share ${{targets.subpkgdir}}/opt/datadog-agent/embedded/share
 

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -182,37 +182,45 @@ pipeline:
         --embedded-path /usr/lib
 
   - runs: |
-      install -Dm755 bin/agent/agent ${{targets.destdir}}/usr/bin/agent
+      mkdir -p \
+        ${{targets.contextdir}}/opt/datadog-agent/bin/agent
+        ${{targets.contextdir}}/opt/datadog-agent/embedded/bin
+
+      install -Dm755 bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/bin/agent
       # *-agent is just a symlink to the "agent" multicall
-      ln -s agent ${{targets.destdir}}/usr/bin/process-agent
-      ln -s agent ${{targets.destdir}}/usr/bin/security-agent
-      ln -s agent ${{targets.destdir}}/usr/bin/trace-agent
-      ln -s agent ${{targets.destdir}}/usr/bin/system-probe
+      ln -s agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/process-agent
+      ln -s agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/security-agent
+      ln -s agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/trace-agent
+      ln -s agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/system-probe
 
-      mkdir -p ${{targets.destdir}}/etc/datadog-agent/
+      ln -s /usr/bin/python3.11 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python3.11
+      ln -s python3.11 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python3
+      ln -s python3 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python
 
-      cp -r Dockerfiles/agent/s6-services ${{targets.destdir}}/etc/services.d
-      cp -r Dockerfiles/agent/cont-init.d ${{targets.destdir}}/etc/cont-init.d
+      mkdir -p ${{targets.contextdir}}/etc/datadog-agent/
 
-      install -Dm644 Dockerfiles/agent/datadog-docker.yaml ${{targets.destdir}}/etc/datadog-agent/datadog-docker.yaml
-      install -Dm644 Dockerfiles/agent/datadog-ecs.yaml ${{targets.destdir}}/etc/datadog-agent/datadog-ecs.yaml
-      install -Dm644 bin/agent/dist/datadog.yaml ${{targets.destdir}}/etc/datadog-agent/datadog.yaml.example
-      install -Dm644 bin/agent/dist/system-probe.yaml ${{targets.destdir}}/etc/datadog-agent/system-probe.yaml.example
-      install -Dm644 bin/agent/dist/security-agent.yaml ${{targets.destdir}}/etc/datadog-agent/security-agent.yaml.example
+      cp -r Dockerfiles/agent/s6-services ${{targets.contextdir}}/etc/services.d
+      cp -r Dockerfiles/agent/cont-init.d ${{targets.contextdir}}/etc/cont-init.d
 
-      install -Dm755 Dockerfiles/agent/entrypoint.sh ${{targets.destdir}}/bin/entrypoint.sh
-      install -Dm755 Dockerfiles/agent/probe.sh ${{targets.destdir}}/probe.sh
-      install -Dm755 Dockerfiles/agent/initlog.sh ${{targets.destdir}}/initlog.sh
-      install -Dm755 Dockerfiles/agent/secrets-helper/readsecret.py ${{targets.destdir}}/readsecret.py
-      install -Dm755 Dockerfiles/agent/secrets-helper/readsecret.sh ${{targets.destdir}}/readsecret.sh
-      install -Dm755 Dockerfiles/agent/secrets-helper/readsecret_multiple_providers.sh ${{targets.destdir}}/readsecret_multiple_providers.sh
+      install -Dm644 Dockerfiles/agent/datadog-docker.yaml ${{targets.contextdir}}/etc/datadog-agent/datadog-docker.yaml
+      install -Dm644 Dockerfiles/agent/datadog-ecs.yaml ${{targets.contextdir}}/etc/datadog-agent/datadog-ecs.yaml
+      install -Dm644 bin/agent/dist/datadog.yaml ${{targets.contextdir}}/etc/datadog-agent/datadog.yaml.example
+      install -Dm644 bin/agent/dist/system-probe.yaml ${{targets.contextdir}}/etc/datadog-agent/system-probe.yaml.example
+      install -Dm644 bin/agent/dist/security-agent.yaml ${{targets.contextdir}}/etc/datadog-agent/security-agent.yaml.example
 
-      cp -r bin/agent/dist/conf.d ${{targets.destdir}}/etc/datadog-agent/conf.d
+      install -Dm755 Dockerfiles/agent/entrypoint.sh ${{targets.contexdir}}/bin/entrypoint.sh
+      install -Dm755 Dockerfiles/agent/probe.sh ${{targets.contexdir}}/probe.sh
+      install -Dm755 Dockerfiles/agent/initlog.sh ${{targets.contextdir}}/initlog.sh
+      install -Dm755 Dockerfiles/agent/secrets-helper/readsecret.py ${{targets.contextdir}}/readsecret.py
+      install -Dm755 Dockerfiles/agent/secrets-helper/readsecret.sh ${{targets.contextdir}}/readsecret.sh
+      install -Dm755 Dockerfiles/agent/secrets-helper/readsecret_multiple_providers.sh ${{targets.contextdir}}/readsecret_multiple_providers.sh
+
+      cp -r bin/agent/dist/conf.d ${{targets.contextdir}}/etc/datadog-agent/conf.d
 
       # Setup s3-overlay overrides
-      mkdir -p ${{targets.destdir}}/etc/s6/init
-      cp -r Dockerfiles/agent/init-stage3 ${{targets.destdir}}/etc/s6/init/init-stage3
-      cp Dockerfiles/agent/init-stage3-host-pid ${{targets.destdir}}/etc/s6/init/init-stage3-host-pid
+      mkdir -p ${{targets.contextdir}}/etc/s6/init
+      cp -r Dockerfiles/agent/init-stage3 ${{targets.contextdir}}/etc/s6/init/init-stage3
+      cp Dockerfiles/agent/init-stage3-host-pid ${{targets.contextdir}}/etc/s6/init/init-stage3-host-pid
 
   - uses: strip
 
@@ -239,30 +247,18 @@ subpackages:
     pipeline:
       - runs: |
           mkdir -p \
-            ${{targets.subpkgdir}}/conf.d \
-            ${{targets.subpkgdir}}/checks.d \
-            ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/dist \
-            ${{targets.subpkgdir}}/opt/datadog-agent/embedded/bin
+            ${{targets.contextdir}}/conf.d \
+            ${{targets.contextdir}}/checks.d \
+            ${{targets.contextdir}}/opt/datadog-agent/bin/agent/dist
 
-          # several startup scripts assume binaries are located in /opt/datadog-agent/...
-          cp ${{targets.destdir}}/usr/bin/agent ${{targets.contextdir}}/opt/datadog-agent/bin/agent/agent
-          ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/system-probe
-          ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/security-agent
-          ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/process-agent
-          ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/trace-agent
+          cp -r /opt/datadog-agent/embedded/share ${{targets.contextdir}}/opt/datadog-agent/embedded/share
 
-          ln -s /usr/bin/python3.11 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python3.11
-          ln -s python3.11 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python3
-          ln -s python3 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python
+          cp -r bin/agent/dist/checks ${{targets.contextdir}}/opt/datadog-agent/bin/agent/dist/
+          install -Dm644 bin/agent/dist/config.py ${{targets.contextdir}}/opt/datadog-agent/bin/agent/dist/config.py
+          cp -r bin/agent/dist/utils ${{targets.contextdir}}/opt/datadog-agent/bin/agent/dist/
+          cp -r bin/agent/dist/views ${{targets.contextdir}}/opt/datadog-agent/bin/agent/dist/
 
-          cp -r /opt/datadog-agent/embedded/share ${{targets.subpkgdir}}/opt/datadog-agent/embedded/share
-
-          cp -r bin/agent/dist/checks ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/dist/
-          install -Dm644 bin/agent/dist/config.py ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/dist/config.py
-          cp -r bin/agent/dist/utils ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/dist/
-          cp -r bin/agent/dist/views ${{targets.subpkgdir}}/opt/datadog-agent/bin/agent/dist/
-
-          cp -r Dockerfiles/agent/entrypoint.d ${{targets.subpkgdir}}/opt/entrypoints
+          cp -r Dockerfiles/agent/entrypoint.d ${{targets.contextdir}}/opt/entrypoints
 
   - name: datadog-agent-core-integrations
     dependencies:

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: 7.58.2
-  epoch: 1
+  epoch: 2
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -2,8 +2,8 @@ package:
   name: datadog-agent
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
-  version: 7.58.1
-  epoch: 1
+  version: 7.58.2
+  epoch: 0
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -183,15 +183,15 @@ pipeline:
 
   - runs: |
       mkdir -p \
-        ${{targets.contextdir}}/opt/datadog-agent/bin/agent
+        ${{targets.contextdir}}/opt/datadog-agent/bin/agent \
         ${{targets.contextdir}}/opt/datadog-agent/embedded/bin
 
       install -Dm755 bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/bin/agent
       # *-agent is just a symlink to the "agent" multicall
-      ln -s agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/process-agent
-      ln -s agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/security-agent
-      ln -s agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/trace-agent
-      ln -s agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/system-probe
+      ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/process-agent
+      ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/security-agent
+      ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/trace-agent
+      ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/system-probe
 
       ln -s /usr/bin/python3.11 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python3.11
       ln -s python3.11 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python3
@@ -208,8 +208,8 @@ pipeline:
       install -Dm644 bin/agent/dist/system-probe.yaml ${{targets.contextdir}}/etc/datadog-agent/system-probe.yaml.example
       install -Dm644 bin/agent/dist/security-agent.yaml ${{targets.contextdir}}/etc/datadog-agent/security-agent.yaml.example
 
-      install -Dm755 Dockerfiles/agent/entrypoint.sh ${{targets.contexdir}}/bin/entrypoint.sh
-      install -Dm755 Dockerfiles/agent/probe.sh ${{targets.contexdir}}/probe.sh
+      install -Dm755 Dockerfiles/agent/entrypoint.sh ${{targets.contextdir}}/bin/entrypoint.sh
+      install -Dm755 Dockerfiles/agent/probe.sh ${{targets.contextdir}}/probe.sh
       install -Dm755 Dockerfiles/agent/initlog.sh ${{targets.contextdir}}/initlog.sh
       install -Dm755 Dockerfiles/agent/secrets-helper/readsecret.py ${{targets.contextdir}}/readsecret.py
       install -Dm755 Dockerfiles/agent/secrets-helper/readsecret.sh ${{targets.contextdir}}/readsecret.sh
@@ -249,6 +249,7 @@ subpackages:
           mkdir -p \
             ${{targets.contextdir}}/conf.d \
             ${{targets.contextdir}}/checks.d \
+            ${{targets.contextdir}}/opt/datadog-agent/embedded/bin \
             ${{targets.contextdir}}/opt/datadog-agent/bin/agent/dist
 
           cp -r /opt/datadog-agent/embedded/share ${{targets.contextdir}}/opt/datadog-agent/embedded/share

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -545,6 +545,9 @@ test:
     - name: Ensure the agent's requirements.txt for integrations is included
       runs: |
         ls /opt/datadog-agent/requirements-agent-release.txt
+    - name: Ensure the agent integration subcommand works
+      runs: |
+        agent integration freeze >/dev/null
     - name: Ensure checks can be loaded
       runs: |
         python -c "import datadog_checks.base"

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -193,10 +193,6 @@ pipeline:
       ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/trace-agent
       ln -s /opt/datadog-agent/bin/agent/agent ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/system-probe
 
-      ln -s /usr/bin/python3.11 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python3.11
-      ln -s python3.11 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python3
-      ln -s python3 ${{targets.contextdir}}/opt/datadog-agent/embedded/bin/python
-
       mkdir -p ${{targets.contextdir}}/etc/datadog-agent/
 
       cp -r Dockerfiles/agent/s6-services ${{targets.contextdir}}/etc/services.d
@@ -249,7 +245,7 @@ subpackages:
           mkdir -p \
             ${{targets.contextdir}}/conf.d \
             ${{targets.contextdir}}/checks.d \
-            ${{targets.contextdir}}/opt/datadog-agent/embedded/bin \
+            ${{targets.contextdir}}/opt/datadog-agent/embedded \
             ${{targets.contextdir}}/opt/datadog-agent/bin/agent/dist
 
           cp -r /opt/datadog-agent/embedded/share ${{targets.contextdir}}/opt/datadog-agent/embedded/share
@@ -548,18 +544,18 @@ test:
         ls /opt/datadog-agent/requirements-agent-release.txt
     - name: Ensure the agent integration subcommand works
       runs: |
-        agent integration freeze >/dev/null
+        /opt/datadog-agent/bin/agent/agent integration freeze >/dev/null
     - name: Ensure checks can be loaded
       runs: |
         python -c "import datadog_checks.base"
-        agent version
-        agent --help
-        process-agent --version
-        process-agent --help
-        security-agent --help
-        system-probe --help
-        trace-agent --version
-        trace-agent --help
+        /opt/datadog-agent/bin/agent/agent version
+        /opt/datadog-agent/bin/agent/agent --help
+        /opt/datadog-agent/embedded/bin/process-agent --version
+        /opt/datadog-agent/embedded/bin/process-agent --help
+        /opt/datadog-agent/embedded/bin/security-agent --help
+        /opt/datadog-agent/embedded/bin/system-probe --help
+        /opt/datadog-agent/embedded/bin/trace-agent --version
+        /opt/datadog-agent/embedded/bin/trace-agent --help
     - name: Ensure agent can be started
       runs: |
         cat > /etc/datadog-agent/datadog.yaml <<EOF
@@ -570,11 +566,11 @@ test:
 
         export DD_LOG_LEVEL=debug
         export DD_HOSTNAME_FILE=/etc/hostname
-        agent check uptime
-        agent check disk
+        /opt/datadog-agent/bin/agent/agent check uptime
+        /opt/datadog-agent/bin/agent/agent check disk
     - name: Validate multicall components are correctly linked
       runs: |
-        trace-agent version | grep trace-agent
-        security-agent version | grep "Security agent"
-        process-agent version | grep Agent
-        system-probe version | grep "System Probe"
+        /opt/datadog-agent/embedded/bin/trace-agent version | grep trace-agent
+        /opt/datadog-agent/embedded/bin/security-agent version | grep "Security agent"
+        /opt/datadog-agent/embedded/bin/process-agent version | grep Agent
+        /opt/datadog-agent/embedded/bin/system-probe version | grep "System Probe"

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: 7.58.2
-  epoch: 0
+  epoch: 1
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -305,12 +305,12 @@ subpackages:
               cp requirements-agent-release.txt ${{targets.contextdir}}/opt/datadog-agent/
 
               # Use Python in virtual environment
-              sed -i "s|$(pwd)/.venv|/usr/share/datadog-agent|g" .venv/pyvenv.cfg
-              sed -i "s|$(pwd)/.venv|/usr/share/datadog-agent|g" .venv/bin/*
+              sed -i "s|$(pwd)/.venv|/opt/datadog-agent/embedded|g" .venv/pyvenv.cfg
+              sed -i "s|$(pwd)/.venv|/opt/datadog-agent/embedded|g" .venv/bin/*
 
               # Install virtual environment
-              mkdir -p ${{targets.contextdir}}/usr/share/datadog-agent
-              cp -r .venv/* ${{targets.contextdir}}/usr/share/datadog-agent/
+              mkdir -p ${{targets.contextdir}}/opt/datadog-agent/embedded
+              cp -r .venv/* ${{targets.contextdir}}/opt/datadog-agent/embedded/
 
               # this is intentionally referencing the main package, since we only "install" if a config doesn't already exist
               conf_dir="${{targets.destdir}}/etc/datadog-agent/conf.d"
@@ -540,7 +540,7 @@ test:
         - datadog-agent-fakeintake=${{package.full-version}}
         - datadog-agent-core-integrations=${{package.full-version}}
     environment:
-      PYTHONPATH: "/usr/share/datadog-agent/lib/python3.11/site-packages"
+      PYTHONPATH: "/opt/datadog-agent/embedded/lib/python3.11/site-packages"
   pipeline:
     - name: Ensure the agent's requirements.txt for integrations is included
       runs: |

--- a/datadog-agent/cve-fixes.patch
+++ b/datadog-agent/cve-fixes.patch
@@ -37,3 +37,16 @@ index 3a56775cbf..e706f41b58 100644
  ]
 
  [[envs.default.matrix]]
+diff --git a/snowflake/pyproject.toml b/snowflake/pyproject.toml
+index d39f8e1e1a..69e70a4a60 100644
+--- a/snowflake/pyproject.toml
++++ b/snowflake/pyproject.toml
+@@ -37,7 +37,7 @@ license = "BSD-3-Clause"
+
+ [project.optional-dependencies]
+ deps = [
+-    "snowflake-connector-python==3.12.1; python_version > '3.0'",
++    "snowflake-connector-python==3.12.3; python_version > '3.0'",
+ ]
+
+ [project.urls]

--- a/datadog-agent/cve-fixes.patch
+++ b/datadog-agent/cve-fixes.patch
@@ -37,16 +37,29 @@ index 3a56775cbf..e706f41b58 100644
  ]
 
  [[envs.default.matrix]]
+diff --git a/agent_requirements.in b/agent_requirements.in
+index a99a9e938b..3876c00f1b 100644
+--- a/agent_requirements.in
++++ b/agent_requirements.in
+@@ -105,7 +105,7 @@ service-identity[idna]==21.1.0; python_version < '3.0'
+ service-identity[idna]==24.1.0; python_version > '3.0'
+ simplejson==3.19.3
+ six==1.16.0
+-snowflake-connector-python==3.12.1; python_version > '3.0'
++snowflake-connector-python==3.12.3; python_version > '3.0'
+ supervisor==4.2.5
+ tuf==4.0.0; python_version > '3.0'
+ typing==3.10.0.0; python_version < '3.0'
 diff --git a/snowflake/pyproject.toml b/snowflake/pyproject.toml
 index d39f8e1e1a..69e70a4a60 100644
 --- a/snowflake/pyproject.toml
 +++ b/snowflake/pyproject.toml
 @@ -37,7 +37,7 @@ license = "BSD-3-Clause"
-
+ 
  [project.optional-dependencies]
  deps = [
 -    "snowflake-connector-python==3.12.1; python_version > '3.0'",
 +    "snowflake-connector-python==3.12.3; python_version > '3.0'",
  ]
-
+ 
  [project.urls]


### PR DESCRIPTION
The `agent integration` subcommand, and possibly other subcommands, expect the `agent` binary to be written to the datadog home directory, which in OCI upstream image is `/opt/datadog-agent`.
Symlinks are resolved to calculate the agent home directory, so they are not supported.

The home directory is used by the `integration` subcommand to locate:
* agent integrations [requirements file](https://github.com/wolfi-dev/os/blob/335cc68c9bffa5300eb3369fe9c3cedf20b0f76d/datadog-agent.yaml#L303)
* agent integrations [constraint file](https://github.com/wolfi-dev/os/blob/335cc68c9bffa5300eb3369fe9c3cedf20b0f76d/datadog-agent.yaml#L300)

files.

In example, the `agent` binary path should be placed in `$DATADOG_HOME/bin/agent/`.
Python binaries are also expected to be placed in `$DATADOG_HOME/embedded/bin`. Symbolic links are supported here instead.

Fixes #33190