### PR TITLE
disable presubmit elastic build

### DIFF
--- a/.github/chainguard/elastic-build.sts.yaml
+++ b/.github/chainguard/elastic-build.sts.yaml
@@ -1,14 +1,14 @@
 issuer: https://accounts.google.com
 
 # staging:
-#  presubmit: 116478844699827634314: ebuild-tho0c6rsknlo655tnyjlifi@staging-enforce-cd1e.iam.gserviceaccount.com
+# DISABLED presubmit: 116478844699827634314: ebuild-tho0c6rsknlo655tnyjlifi@staging-enforce-cd1e.iam.gserviceaccount.com
 #  postsubmit: 115457633213442188328: ebuild-m2wshgog0q6xjkbz7j8swed@staging-enforce-cd1e.iam.gserviceaccount.com
 #  world: 118305965159726888964: ebuild-i74lfrzfboxqsa518b5p3qi@staging-enforce-cd1e.iam.gserviceaccount.com
 # prod:
-#  presubmit: 114870839879105817572: ebuild-zasv64d5x1oc4m3epw39yod@prod-enforce-fabc.iam.gserviceaccount.com
+# DISABLED presubmit: 114870839879105817572: ebuild-zasv64d5x1oc4m3epw39yod@prod-enforce-fabc.iam.gserviceaccount.com
 #  postsubmit: 118124811908286464886: ebuild-ckhudf69he6dfl1xy83uuke@prod-enforce-fabc.iam.gserviceaccount.com
 #  world: 100027593799559093519: ebuild-n0ppcbm8uzc6ew2wy4gesfg@prod-enforce-fabc.iam.gserviceaccount.com
-subject_pattern: "(116478844699827634314|115457633213442188328|118305965159726888964|114870839879105817572|118124811908286464886|100027593799559093519)"
+subject_pattern: "(115457633213442188328|118305965159726888964|118124811908286464886|100027593799559093519)"
 
 permissions:
   contents: read


### PR DESCRIPTION
This prevents us from being able to pull source code from this repo, which should cause jobs to fail before running any builds.