### PR TITLE
Updated subpackage names to match the most recent format

### DIFF
--- a/kyverno-1.12.yaml
+++ b/kyverno-1.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-1.12
   version: 1.12.6
-  epoch: 1
+  epoch: 0
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0
@@ -10,6 +10,12 @@ package:
       - ca-certificates-bundle
     provides:
       - kyverno=${{package.full-version}}
+
+var-transforms:
+  - from: ${{package.name}}
+    match: '.*-(\d+\.\d+).*'
+    replace: '$1'
+    to: major-minor-version
 
 environment:
   contents:
@@ -45,7 +51,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: ${{package.name}}-init-container
+  - name: kyverno-init-container-${{vars.major-minor-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -58,7 +64,7 @@ subpackages:
         - runs: |
             kyvernopre --help
 
-  - name: ${{package.name}}-reports-controller
+  - name: kyverno-reports-controller-${{vars.major-minor-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -71,7 +77,7 @@ subpackages:
         - runs: |
             reports-controller --help
 
-  - name: ${{package.name}}-background-controller
+  - name: kyverno-background-controller-${{vars.major-minor-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -84,7 +90,7 @@ subpackages:
         - runs: |
             background-controller --help
 
-  - name: ${{package.name}}-cleanup-controller
+  - name: kyverno-cleanup-controller-${{vars.major-minor-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -97,7 +103,7 @@ subpackages:
         - runs: |
             cleanup-controller --help
 
-  - name: ${{package.name}}-cli
+  - name: kyverno-cli-${{vars.major-minor-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin

--- a/kyverno-1.12.yaml
+++ b/kyverno-1.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-1.12
   version: 1.12.6
-  epoch: 0
+  epoch: 1
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0
@@ -45,7 +45,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: kyverno-init-container-1.12
+  - name: ${{package.name}}-init-container
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -58,7 +58,7 @@ subpackages:
         - runs: |
             kyvernopre --help
 
-  - name: kyverno-reports-controller-1.12
+  - name: ${{package.name}}-reports-controller
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -71,7 +71,7 @@ subpackages:
         - runs: |
             reports-controller --help
 
-  - name: kyverno-background-controller-1.12
+  - name: ${{package.name}}-background-controller
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -84,7 +84,7 @@ subpackages:
         - runs: |
             background-controller --help
 
-  - name: kyverno-cleanup-controller-1.12
+  - name: ${{package.name}}-cleanup-controller
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin
@@ -97,7 +97,7 @@ subpackages:
         - runs: |
             cleanup-controller --help
 
-  - name: kyverno-cli-1.12
+  - name: ${{package.name}}-cli
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/bin

--- a/kyverno-1.12.yaml
+++ b/kyverno-1.12.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-1.12
   version: 1.12.6
-  epoch: 0
+  epoch: 1
   description: Kubernetes Native Policy Management
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Updated the subpackage names to use the format `${{package.name}}-subpackagename`. 

Fixes: https://github.com/chainguard-dev/internal-dev/issues/5147

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [x] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [x] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))
