### PR TITLE
openjdk-8: update to jdk8u432-ga

### DIFF
--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
-  version: 8.422.05 # this corresponds to same release as jdk8u422-ga / jdk8u422-b05
-  epoch: 3
+  version: 8.432.06 # this corresponds to same release as jdk8u432-ga / jdk8u432-b06
+  epoch: 0
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later
@@ -72,15 +72,15 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://icedtea.classpath.org/download/source/icedtea-3.32.0.tar.xz
-      expected-sha512: 151a1edb7fc459ee2bf43b44d90561513b2fdce39429bf1deca6ef004692fb946a58ad113f02876926df3ec7bcbf639484b903cd0c8840fc9457cab5bc2fa44a
+      uri: https://icedtea.classpath.org/download/source/icedtea-3.33.0.tar.xz
+      expected-sha512: ff2803f4be50ac11b6fa8b758c934357423a9cb9d7f41922486e062e1cfe565441af830a8698d67319e61ec0ee7e7de692749ccd18bd5b4c1bf078852c3d3862
 
   - working-directory: /home/build/icedtea-drops
     pipeline:
       - uses: fetch
         with:
-          uri: https://icedtea.classpath.org/download/drops/icedtea8/3.32.0/openjdk-git.tar.xz
-          expected-sha512: 502f2d84bf430468464247f9a67d68a18b5d57b09fd47150da05e6da4f848ce48ab368702b347d0b3df1773657ea452491841f4aa5257a8fefd947a0b1e9ec5c
+          uri: https://icedtea.classpath.org/download/drops/icedtea8/3.33.0/openjdk-git.tar.xz
+          expected-sha512: bb2946bbea3e63cd9f4aea88e498403317d0c07b3e283a4789d142ecd2bc35547518ec6b2f3ea97a37b7aa469311ac0217dcca9ffa65cbbacd316dd1306e82fa
           extract: false
       - uses: fetch
         with:


### PR DESCRIPTION
https://mail.openjdk.org/pipermail/distro-pkg-dev/2024-November/042654.html

What's New?
===========
New in release 3.33.0 (2024-11-04):

* CVEs
  - CVE-2024-21208
  - CVE-2024-21210
  - CVE-2024-21217
  - CVE-2024-21235
* Security fixes
  - JDK-8290367, JDK-8332643: Update default value and extend the scope of com.sun.jndi.ldap.object.trustSerialData system property
  - JDK-8313626, JDK-8307769: C2 crash due to unexpected exception control flow
  - JDK-8328286: Enhance HTTP client
  - JDK-8328544: Improve handling of vectorization
  - JDK-8328726: Better Kerberos support
  - JDK-8331446: Improve deserialization support
  - JDK-8332644: Improve graph optimizations
  - JDK-8335713: Enhance vectorization analysis
* Import of OpenJDK 8 u432 build 06
  - JDK-4660158: TTY: NumberFormatException while trying to set values by 'set' command
  - JDK-6544871: java/awt/event/KeyEvent/KeyTyped/CtrlASCII.html fails from jdk b09 on windows.
  - JDK-7188098: TEST_BUG: closed/javax/sound/midi/Synthesizer/Receiver/bug6186488.java fails
  - JDK-8021775: compiler/8009761/Test8009761.java  "Failed: init recursive calls: 51. After deopt 50"
  - JDK-8030204: com/sun/jdi/JdbExprTest.sh: Required output "Can\\'t convert 2147483648 to int" not found
  - JDK-8030795: java/nio/file/Files/probeContentType/ForceLoad.java failing with ServiceConfigurationError without jtreg -agentvm option
  - JDK-8035395: sun/management/jmxremote/startstop/JMXStartStopTest.java fails intermittently: Port already in use
  - JDK-8075511: Enable -Woverloaded-virtual C++ warning for HotSpot build
  - JDK-8137329: [windows] Build broken on VS2010 after  "8046148: JEP 158: Unified JVM Logging"
  - JDK-8145919: sun/management/jmxremote/bootstrap/RmiSslBootstrapTest failed with Connection failed for no credentials
  - JDK-8152207: Perform array bound checks while getting a length of bytecode instructions
  - JDK-8193682: Infinite loop in ZipOutputStream.close()
  - JDK-8196770: Add JNDI test com/sun/jndi/ldap/blits/AddTests/AddNewEntry.java
  - JDK-8221903: PIT: javax/swing/RepaintManager/IconifyTest/IconifyTest.java fails on ubuntu18.04
  - JDK-8233364: Fix undefined behavior in Canonicalizer::do_ShiftOp
  - JDK-8238274: (sctp) JDK-7118373 is not fixed for SctpChannel
  - JDK-8251188: Update LDAP tests not to use wildcard addresses
  ...

