### PR TITLE
openssl: pin versions of libcrypto3 and libssl3 for CLI package

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -19,8 +19,8 @@ package:
       # However, the version of OpenSSL must match exactly or the CLI will crash due to missing symbols
       # Example: '/usr/lib/libcrypto.so.3: version `OPENSSL_3.4.0' not found (required by openssl)'
       # To avoid this, we explicitly pin the versions of libcrypto3 and libssl3 to match the CLI version
-      - libcrypto3=${{package.full-version}}
-      - libssl3=${{package.full-version}}
+      - libcrypto3>=${{package.version}}
+      - libssl3>=${{package.version}}
 
 environment:
   contents:

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -2,7 +2,7 @@
 package:
   name: openssl
   version: 3.4.0
-  epoch: 1
+  epoch: 2
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
@@ -15,6 +15,12 @@ package:
   dependencies:
     runtime:
       - openssl-provider-legacy
+      # Melange will automatically add a dependency on 'so:libcrypto.so.3' and 'so:libssl.so.3' via SCA
+      # However, the version of OpenSSL must match exactly or the CLI will crash due to missing symbols
+      # Example: '/usr/lib/libcrypto.so.3: version `OPENSSL_3.4.0' not found (required by openssl)'
+      # To avoid this, we explicitly pin the versions of libcrypto3 and libssl3 to match the CLI version
+      - libcrypto3=${{package.full-version}}
+      - libssl3=${{package.full-version}}
 
 environment:
   contents:

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -16,9 +16,11 @@ package:
     runtime:
       - openssl-provider-legacy
       # Melange will automatically add a dependency on 'so:libcrypto.so.3' and 'so:libssl.so.3' via SCA
-      # However, the version of OpenSSL must match exactly or the CLI will crash due to missing symbols
+      # However, this dependency is unversioned so it will be satisfied by an older version of either library
+      # The OpenSSL CLI expects this be at least the same <major>.<minor>.<patch> version or the CLI will crash
       # Example: '/usr/lib/libcrypto.so.3: version `OPENSSL_3.4.0' not found (required by openssl)'
-      # To avoid this, we explicitly pin the versions of libcrypto3 and libssl3 to match the CLI version
+      # To avoid this, we explicitly require the versions of libcrypto3 and libssl3 to be at least the CLI version
+      # A long-term fix is being tracked via: https://github.com/chainguard-dev/melange/issues/1621
       - libcrypto3>=${{package.version}}
       - libssl3>=${{package.version}}
 


### PR DESCRIPTION
If a Wolfi image already has an older version of the `libcrypto3` and/or `libssl3` package installed, and the `openssl` CLI is installed at runtime (or as say a `docker build` step), the `openssl` package will install correctly but will crash when used:
```
/ # apk list --installed | grep libcrypto
libcrypto3-3.3.2-r2 aarch64 {openssl} (Apache-2.0) [installed]
/ # apk add openssl
(1/2) Installing openssl-provider-legacy (3.4.0-r1)
(2/2) Installing openssl (3.4.0-r1)
OK: 15 MiB in 20 packages
/ # openssl
openssl: /usr/lib/libssl.so.3: version `OPENSSL_3.4.0' not found (required by openssl)
openssl: /usr/lib/libcrypto.so.3: version `OPENSSL_3.4.0' not found (required by openssl)
```
This is because the `openssl` CLI must use the exact same version (or at least the same `<major>.<minor>.<patch>`) of `libcrypto3` and `libssl3` that the `openssl` CLI was built with.

Currently, the relationship between `openssl` and `libcrypto3` and `libssl3` is picked up automatically by melange's SCA:
```
openssl-3.4.0-r1 depends on:
openssl-provider-legacy
so:ld-linux-aarch64.so.1
so:libc.so.6
so:libcrypto.so.3
so:libssl.so.3
```
However, this dependency will be satisfied by _any_ version of `libcrypto3` and `libssl3`.

This PR adds an explicit dependency on the matching versions which should prevent the installation (or force an upgrade) of the `openssl` CLI if the already installed `libcrypto3` and/or `libssl3` versions mismatch.