### PR TITLE
python-3.10: cherry pick CVE-2024-9287 fixes

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: 3.10.15
-  epoch: 2
+  epoch: 3
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -49,6 +49,8 @@ pipeline:
       expected-commit: ffee63f34445412322a7afc2535731be221cabba
       repository: https://github.com/python/cpython.git
       tag: v${{package.version}}
+      cherry-picks: |
+        3.10/9286ab3a107ea41bd3f3c3682ce2512692bdded8: CVE-2024-9287
 
   - name: Force use of system libraries
     runs: |


### PR DESCRIPTION
Cherry pick fixes for https://nvd.nist.gov/vuln/detail/CVE-2024-9287 from commits listed here https://github.com/python/cpython/issues/124651

Advisory for the package is here https://github.com/wolfi-dev/advisories/pull/8825