### PR TITLE
Make default gcc & clang compilers use openssf-compiler-options

### DIFF
--- a/clang-19.yaml
+++ b/clang-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-19
   version: 19.1.2
-  epoch: 2
+  epoch: 3
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -15,6 +15,7 @@ package:
       - libLLVM-19
       - libclang-cpp-19
       - llvm-19
+      - openssf-compiler-options
     provides:
       - clang=${{package.full-version}}
 

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 14.2.0
-  epoch: 4
+  epoch: 5
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -12,6 +12,7 @@ package:
     runtime:
       - binutils
       - libstdc++-dev
+      - openssf-compiler-options
       - posix-cc-wrappers
 
 environment:


### PR DESCRIPTION
This implements OpenSSF recommended compiler options, by default, up
to the 2024-06-27 recommendation.

For more information, please see https://github.com/orgs/wolfi-dev/discussions/33052
