### PR TITLE
gcc-12 & gcc-13: enable openssf-compiler-options by default

### DIFF
--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.4.0
-  epoch: 6
+  epoch: 7
   description: "the GNU compiler collection - version 12"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -12,6 +12,7 @@ package:
     runtime:
       - binutils
       - libstdc++-12-dev
+      - openssf-compiler-options
       - posix-cc-wrappers
 
 environment:

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-13
   version: 13.3.0
-  epoch: 5
+  epoch: 6
   description: "the GNU compiler collection - version 13"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -12,6 +12,7 @@ package:
     runtime:
       - binutils
       - libstdc++-13-dev
+      - openssf-compiler-options
       - posix-cc-wrappers
 
 environment:


### PR DESCRIPTION
This implements OpenSSF recommended compiler options, by default, up
to the 2024-06-27 recommendation.

For more information, please see https://github.com/orgs/wolfi-dev/discussions/33052
