### PR TITLE
clang-15..18: enable openssf-compiler-options by default

### DIFF
--- a/clang-15.yaml
+++ b/clang-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-15
   version: 15.0.7
-  epoch: 3
+  epoch: 4
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -11,6 +11,7 @@ package:
   dependencies:
     runtime:
       - libLLVM-15
+      - openssf-compiler-options
 
 environment:
   contents:

--- a/clang-16.yaml
+++ b/clang-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-16
   version: 16.0.6
-  epoch: 5
+  epoch: 6
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -11,6 +11,7 @@ package:
   dependencies:
     runtime:
       - libLLVM-16
+      - openssf-compiler-options
     provides:
       - clang=${{package.full-version}}
 

--- a/clang-17.yaml
+++ b/clang-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-17
   version: 17.0.6
-  epoch: 2
+  epoch: 3
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -11,6 +11,7 @@ package:
   dependencies:
     runtime:
       - libLLVM-17
+      - openssf-compiler-options
     provides:
       - clang=${{package.full-version}}
 

--- a/clang-18.yaml
+++ b/clang-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: clang-18
   version: 18.1.8
-  epoch: 5
+  epoch: 6
   description: "C language family frontend for LLVM"
   copyright:
     - license: Apache-2.0
@@ -15,6 +15,7 @@ package:
       - libLLVM-18
       - libclang-cpp-18
       - llvm-18
+      - openssf-compiler-options
     provides:
       - clang=${{package.full-version}}
 


### PR DESCRIPTION
This implements OpenSSF recommended compiler options, by default, up
to the 2024-06-27 recommendation.

For more information, please see https://github.com/orgs/wolfi-dev/discussions/33052
