### PR TITLE
build-*.env: drop environment variables in favor of openssf-compiler-options

### DIFF
--- a/build-aarch64.env
+++ b/build-aarch64.env
@@ -1,8 +1,3 @@
-# Ampere Altra, the CPU used by most cloud providers, is Neoverse N1.
-export CFLAGS="-O2 -Wall -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -march=armv8-a+crc+crypto -mtune=neoverse-n1"
-export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
-export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack"
 export GOFLAGS=""
 export GOTOOLCHAIN=local
 # Build jemalloc with 64k page support

--- a/build-x86_64.env
+++ b/build-x86_64.env
@@ -1,6 +1,2 @@
-export CFLAGS="-O2 -Wall -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -march=x86-64-v2 -mtune=broadwell"
-export CPPFLAGS="-O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS"
-export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack"
 export GOFLAGS=""
 export GOTOOLCHAIN=local


### PR DESCRIPTION
Note this can only be merged after the below got published in post
submit:
- https://github.com/wolfi-dev/os/pull/33213
- https://github.com/wolfi-dev/os/pull/33215
- https://github.com/wolfi-dev/os/pull/33216

As compilers now implement OpenSSF recommended compiler options, by
default, up to the 2024-06-27 recommendation, there is no need to
specify environment variables. Note that envrionment variables often
were ignored.

Some of the optimisations (march/mtune) are now compiler version
specific. See build configuration of individual compilers.

For more information, please see https://github.com/orgs/wolfi-dev/discussions/33052
