### PR TITLE
datadog-agent - build without requiring root.

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: 7.58.2
-  epoch: 0
+  epoch: 1
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -66,6 +66,7 @@ environment:
       - py3.11-semver
       - python3-dev~3.11 # strictly requires python3.11
       - systemd-dev
+      - util-linux-misc # unshare
       - wget # Required for downloading clang-12 and kernel headers from debian
   environment:
     # CGo allows Go programs to call C code
@@ -143,7 +144,8 @@ pipeline:
 
       # Build once to correctly setup links/generates. The system-probe we end
       # up using will be part of the multicall below.
-      invoke -e system-probe.build \
+      unshare --user --map-root-user \
+        invoke -e system-probe.build \
         --strip-object-files \
         --no-bundle \
         --bundle-ebpf


### PR DESCRIPTION
datadog-agent would fail to build unless you were root.
