### PR TITLE
Check for .pc files in usr/local/lib too

### DIFF
--- a/pipelines/test/pkgconf.yaml
+++ b/pipelines/test/pkgconf.yaml
@@ -17,7 +17,7 @@ pipeline:
           lib_name=$(basename "$pc_file" ".pc")
           # Ensure .pc file is installed in usr/lib/pkgconfig/*.pc or
           # in usr/share/pkgconfig/*.pc
-          echo "$pc_file" | grep -q "^usr/lib/pkgconfig/${lib_name}.pc$\|^usr/share/pkgconfig/${lib_name}.pc$"
+          echo "$pc_file" | grep -q "^usr/lib\|share/pkgconfig/${lib_name}.pc$\|^usr/local/lib/pkgconfig/${lib_name}.pc$"
           # Try to get the library name from the pc filename
           # Run some package config tests, which will likely be used by
           # other packages that have build dependencies on this dev package


### PR DESCRIPTION
Also check in usr/local/lib which is where audit puts it's .pc files:

```
2024/11/01 16:07:21 WARN + echo usr/local/lib/pkgconfig/audit.pc uses=test/pkgconf name="pkgconf build dependency check"
```