### PR TITLE
Add 'prevent-inclusion' and build/ cleaning in pip-build-install pipeline

### DIFF
--- a/pipelines/py/pip-build-install.yaml
+++ b/pipelines/py/pip-build-install.yaml
@@ -13,6 +13,11 @@ inputs:
   needs-exe-named-python:
     description: Does the build actually need 'python' in its PATH
     default: false
+  prevent-inclusion:
+    description: |
+      prevent the provided filesystem entries from being included in
+      the wheel by means of hiding them from build.
+    required: false
 
 pipeline:
   - name: "pip build"
@@ -87,6 +92,16 @@ pipeline:
         fi
       fi
 
+      prevents="${{inputs.prevent-inclusion}}"
+      if [ -n "$prevents" ]; then
+         # do not allow expansion of prevents
+         ( set -f; vr tar -cpf "$tmpd/prevent-inclusion.tar" $prevents &&
+           vr rm -rf $prevents ) ||
+           { echo "ERROR: failed creation of prevent-inclusion.tar with $prevents"; exit 1; }
+         echo "prevented-inclusion of $prevents"
+      fi
+
+      [ -d build ] && hadbuild=true || hadbuild=false
       # --find-links to an empty dir and --no-index makes pip fully "offline"
       distwheelsd="$tmpd/dist-wheels"
       mkdir -p "$distwheelsd"
@@ -97,3 +112,13 @@ pipeline:
           "--find-links=$distwheelsd" --no-index --no-build-isolation --no-deps \
           --force-reinstall --no-compile --prefix=/usr "--root=$root" "$wd"/*.whl
       vr $py -m compileall --invalidation-mode=unchecked-hash -r100 "$root/$sitepkgd"
+
+      if [ "$hadbuild" = "false" -a -d build ]; then
+        vr rm -Rf build
+      fi
+      if [ -n "$prevents" ]; then
+        vr tar -xpf "$tmpd/prevent-inclusion.tar" ||
+          { echo "ERROR: failed restoring 'prevent-inclusion' files"; exit 1; }
+        echo "restored $prevents"
+      fi
+      exit 0

--- a/py3-codespell.yaml
+++ b/py3-codespell.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-codespell
   version: 2.3.0
-  epoch: 1
+  epoch: 2
   description: 'checker for common misspellings '
   copyright:
     - license: GPL-2.0-or-later

--- a/py3-google-auth-oauthlib.yaml
+++ b/py3-google-auth-oauthlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-auth-oauthlib
   version: 1.2.1
-  epoch: 1
+  epoch: 2
   description: Google Authentication Library
   copyright:
     - license: Apache-2.0
@@ -45,6 +45,7 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+          prevent-inclusion: scripts docs
       - name: move usr/bin executables for -bin
         runs: |
           mkdir -p ./cleanup/${{range.key}}/

--- a/py3-google-auth.yaml
+++ b/py3-google-auth.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-auth
   version: 2.36.0
-  epoch: 0
+  epoch: 1
   description: Google Authentication Library
   copyright:
     - license: Apache-2.0

--- a/py3-google-resumable-media.yaml
+++ b/py3-google-resumable-media.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-resumable-media
   version: 2.7.2
-  epoch: 1
+  epoch: 2
   description: Utilities for Google Media Downloads and Resumable Uploads
   copyright:
     - license: Apache-2.0
@@ -47,6 +47,7 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+          prevent-inclusion: testing
       - uses: strip
     test:
       pipeline:

--- a/py3-googleapis-common-protos.yaml
+++ b/py3-googleapis-common-protos.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-googleapis-common-protos
   version: 1.65.0
-  epoch: 1
+  epoch: 2
   description: Common protobufs used in Google APIs
   copyright:
     - license: Apache-2.0

--- a/py3-pipenv.yaml
+++ b/py3-pipenv.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pipenv
   version: 2024.4.0
-  epoch: 0
+  epoch: 1
   description: Python Development Workflow for Humans.
   copyright:
     - license: MIT
@@ -54,6 +54,7 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+          prevent-inclusion: docs examples
       - runs: |
           mkdir -p ./cleanup/${{range.key}}/
           mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/

--- a/py3-proto-plus.yaml
+++ b/py3-proto-plus.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-proto-plus
   version: 1.25.0
-  epoch: 0
+  epoch: 1
   description: Beautiful, Pythonic protocol buffers.
   copyright:
     - license: Apache-2.0
@@ -46,6 +46,7 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+          prevent-inclusion: docs testing
       - uses: strip
     test:
       pipeline:

--- a/py3-python-gitlab.yaml
+++ b/py3-python-gitlab.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-gitlab
   version: 5.0.0
-  epoch: 0
+  epoch: 1
   description: A python wrapper for the GitLab API
   url: https://python-gitlab.readthedocs.io
   copyright:

--- a/py3-threadloop.yaml
+++ b/py3-threadloop.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-threadloop
   version: 1.0.2
-  epoch: 0
+  epoch: 1
   description: Tornado IOLoop Backed Concurrent Futures
   copyright:
     - license: MIT
@@ -41,6 +41,7 @@ subpackages:
         uses: py/pip-build-install
         with:
           python: python${{range.key}}
+          prevent-inclusion: tests
     dependencies:
       runtime:
         - py${{range.key}}-tornado

--- a/py3-tqdm.yaml
+++ b/py3-tqdm.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tqdm
   version: 4.67.0
-  epoch: 0
+  epoch: 1
   description: Fast, Extensible Progress Meter
   copyright:
     - license: MPL-2.0 AND MIT


### PR DESCRIPTION
Some packages were not co-installable because they included directories in their site-packages/ directory that were not intended.

The root of the problem seems to be around behavior changes of 'build' (called by 'pip wheel') when setuptools-scm is installed.

Fixes: https://github.com/wolfi-dev/os/issues/33397
