### PR TITLE
gow: new package

### DIFF
--- a/gow.yaml
+++ b/gow.yaml
@@ -1,0 +1,31 @@
+package:
+  name: gow
+  version: '20231006'
+  epoch: 0
+  description: Missing watch mode for Go commands. Watch Go files and execute a command like "go run" or "go test".
+  copyright:
+    - license: Unlicense
+
+environment:
+  contents:
+    packages:
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/mitranim/gow.git
+      branch: master
+      expected-commit: af11a6e1e9ebccdcdace2a6df619355b85494d74
+
+  - uses: go/build
+    with:
+      packages: .
+      output: gow
+
+  - uses: strip
+
+test:
+  pipeline:
+    - runs: |
+        gow -h

--- a/gow.yaml
+++ b/gow.yaml
@@ -25,6 +25,12 @@ pipeline:
 
   - uses: strip
 
+update:
+  enabled: false
+  github:
+    identifier: mitranim/gow
+    use-tag: false
+
 test:
   pipeline:
     - runs: |


### PR DESCRIPTION
This adds the [gow](https://github.com/mitranim/gow) command line tool as a package to the repository. We use this tool to run our Go servers in our development containers and it currently needs to be installed separately. Adding it to the wolfi repository would reduce our custom container configuration.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)