### PR TITLE
add promitor (aka promitor-agent-scraper)

### DIFF
--- a/promitor.yaml
+++ b/promitor.yaml
@@ -1,0 +1,94 @@
+package:
+  name: promitor
+  version: 2.11.2
+  epoch: 0
+  description: Bringing Azure Monitor metrics where you need them.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - aspnet-8-runtime-default
+      - dotnet-8-runtime-default
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - dotnet-8-sdk
+      - openssf-compiler-options
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tomkerkhove/promitor
+      tag: Scraper-v${{package.version}}
+      expected-commit: a457a98b6e2920ea2751f4d07d0d8e085946eeec
+
+  - working-directory: src
+    pipeline:
+      - name: "Build Promitor Scraper"
+        runs: |
+          # Set runtime arch
+          if [[ "${{build.arch}}" == "aarch64" ]]; then
+            runtime_arch="arm64"
+          elif [[ "${{build.arch}}" == "x86_64" ]]; then
+            runtime_arch="x64"
+          fi
+
+          dotnet publish \
+            Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj \
+            --configuration release \
+            --output app \
+            --runtime linux-$runtime_arch \
+            --no-self-contained \
+            /p:Version=${{package.version}} \
+            -p:DebugSymbols=false \
+            -p:DebugType=none
+
+          mkdir -p "${{targets.contextdir}}"/usr/lib
+          cp -dr app "${{targets.contextdir}}"/usr/lib/promitor
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream image"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}/app"
+          ln -sf /usr/lib/promitor/Promitor.Agents.Scraper.dll "${{targets.contextdir}}/app/Promitor.Agents.Scraper.dll"
+
+update:
+  enabled: true
+  github:
+    identifier: tomkerkhove/promitor
+    use-tag: true
+    strip-prefix: Scraper-v
+    tag-filter: Scraper-v
+
+test:
+  environment:
+    contents:
+      packages:
+        - curl
+        - promitor-compat
+    environment:
+      PROMITOR_CONFIG_FOLDER: "/config"
+      DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: "false"
+  pipeline:
+    - name: "start daemon"
+      uses: test/daemon-check-output
+      with:
+        setup: |
+          # Config will be mounted on deployment time already so we can just download it for testing
+          # There is two "Validation failed" errors in the logs, its because upstream configs seems to be outdated a bit
+          # Azure related options also requires real Azure credentials to be set, that we cant provide in here
+          mkdir -p /config
+          curl -sL https://raw.githubusercontent.com/tomkerkhove/promitor/refs/heads/master/config/promitor/scraper/runtime.yaml -o /config/runtime.yaml
+          curl -sL https://raw.githubusercontent.com/tomkerkhove/promitor/refs/heads/master/config/promitor/scraper/metrics.yaml -o /config/metrics-declaration.yaml
+        start: "dotnet /app/Promitor.Agents.Scraper.dll"
+        timeout: 60
+        expected_output: |
+          Booting up Promitor
+          OpenTelemetry Collector Metric   │ Success │ Everything is well-configured.
+          Prometheus Scraping Endpoint     │ Success │ Everything is well-configured.

--- a/promitor.yaml
+++ b/promitor.yaml
@@ -24,6 +24,10 @@ pipeline:
       tag: Scraper-v${{package.version}}
       expected-commit: a457a98b6e2920ea2751f4d07d0d8e085946eeec
 
+  - uses: patch
+    with:
+      patches: mitigate-CVE-2024-35255.patch
+
   - working-directory: src
     pipeline:
       - name: "Build Promitor Scraper"

--- a/promitor/mitigate-CVE-2024-35255.patch
+++ b/promitor/mitigate-CVE-2024-35255.patch
@@ -1,0 +1,25 @@
+From 423e03c47eeee866da82e6945f32f76f151e938e Mon Sep 17 00:00:00 2001
+From: Dentrax <furkan.turkal@chainguard.dev>
+Date: Thu, 7 Nov 2024 17:02:46 +0300
+Subject: [PATCH] mitigate CVE-2024-35255
+
+Signed-off-by: Dentrax <furkan.turkal@chainguard.dev>
+---
+ src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj b/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
+index b244403..dc95a26 100644
+--- a/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
++++ b/src/Promitor.Agents.Scraper/Promitor.Agents.Scraper.csproj
+@@ -47,6 +47,7 @@
+     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
+     <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.1" />
+     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
++    <PackageReference Include="Microsoft.Identity.Client" Version="4.60.4" />
+   </ItemGroup>
+ 
+   <ItemGroup>
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
