### PR TITLE
Adjust amazon-cloudwatch-agent and -operator to use tags.

### DIFF
--- a/amazon-cloudwatch-agent-operator.yaml
+++ b/amazon-cloudwatch-agent-operator.yaml
@@ -1,6 +1,6 @@
 package:
   name: amazon-cloudwatch-agent-operator
-  version: 1.6.0
+  version: 1.9.0
   epoch: 0
   description: Software developed to manage the CloudWatch Agent on kubernetes.
   copyright:
@@ -9,13 +9,13 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: e4fd9a62a095b26e58fdc09cc59a0e9f10b0e333
+      expected-commit: 8e78c016b614b62c0d5770e0f95f2012526f51cd
       repository: https://github.com/aws/amazon-cloudwatch-agent-operator
       tag: v${{package.version}}
 
   - uses: go/bump
     with:
-      deps: golang.org/x/net@v0.23.0 github.com/hashicorp/go-retryablehttp@v0.7.7 github.com/Azure/azure-sdk-for-go/sdk/azidentity@v1.6.0 github.com/docker/docker@v25.0.6
+      deps: github.com/hashicorp/go-retryablehttp@v0.7.7 github.com/Azure/azure-sdk-for-go/sdk/azidentity@v1.6.0 github.com/docker/docker@v25.0.6
 
   - uses: go/build
     with:
@@ -47,6 +47,8 @@ update:
   github:
     identifier: aws/amazon-cloudwatch-agent-operator
     strip-prefix: v
+    tag-filter: v
+    use-tag: true
 
 test:
   environment:

--- a/amazon-cloudwatch-agent.yaml
+++ b/amazon-cloudwatch-agent.yaml
@@ -1,6 +1,6 @@
 package:
   name: amazon-cloudwatch-agent
-  version: 1.300048.1
+  version: 1.300049.1
   epoch: 0
   description: CloudWatch Agent enables you to collect and export host-level metrics and logs on instances running Linux or Windows server.
   copyright:
@@ -19,7 +19,7 @@ pipeline:
     with:
       repository: https://github.com/aws/amazon-cloudwatch-agent
       tag: v${{package.version}}
-      expected-commit: bde3bd9775ae1d4e4f8a2fdb92d7b6fdd5186fba
+      expected-commit: 8ac5454dd18dc136bfa0238a394abf12bf4649d5
 
   - uses: go/bump
     with:
@@ -64,6 +64,7 @@ update:
     identifier: aws/amazon-cloudwatch-agent
     strip-prefix: v
     tag-filter: v
+    use-tag: true
 
 test:
   pipeline:


### PR DESCRIPTION
amazon-cloudwatch-agent and amazon-cloudwatch-agent-operator both are creating tags without creating releases in github.

 https://github.com/aws/amazon-cloudwatch-agent/tags
 https://github.com/aws/amazon-cloudwatch-agent-operator/tags

The agent is making releases more consistently from tags. The operator has not made a release newer than v1.6.0 (Jul 30, 2024) but has tags for 1.7.0, 1.8.0, 1.9.0 (yesterday).

This was noticed when the --auto-instrumentation-nodejs-image flag was found to be missing from the manager binary (built by -operator).
