### PR TITLE
dotnet-8: use a bootstrap package to decouple the requirement artifacts

### DIFF
--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: 8.0.11
-  epoch: 1
+  epoch: 2
   description: ".NET SDK"
   copyright:
     - license: MIT
@@ -23,6 +23,7 @@ environment:
       - clang-15-default
       - cmake
       - curl
+      - dotnet-bootstrap-8
       - glibc-locale-en
       - icu-dev
       - krb5-dev
@@ -53,8 +54,11 @@ pipeline:
       - runs: |
           sed -i -E 's|( /p:BuildDebPackage=false)|\1 /p:EnablePackageValidation=false|' src/runtime/eng/SourceBuild.props
           sed -i -E 's|( /p:BuildDebPackage=false)|\1 --cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE|' src/runtime/eng/SourceBuild.props
-          ./prep.sh --bootstrap
-      #             /p:PrebuiltPackagesPath=/home/build/src/packages \
+          ln -sf /usr/share/dotnet-bootstrap-8/dotnet .dotnet
+          mkdir -p prereqs/packages/archive/
+          ln -sf /usr/share/dotnet-bootstrap-8/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz
+          mkdir -p prereqs/packages/previously-source-built
+          tar -xzvf prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz -C prereqs/packages/previously-source-built/
       - runs: |
           ./build.sh --clean-while-building \
             -- \
@@ -62,7 +66,8 @@ pipeline:
             /p:ContinueOnPrebuiltBaselineError=true \
             /p:MinimalConsoleLogOutput=false \
             /p:SkipPortableRuntimeBuild=true \
-            /p:BuildWithOnlineSources=false
+            /p:BuildWithOnlineSources=false \
+            /p:CustomPrebuiltSourceBuiltPackagesPath=$(realpath prereqs/packages/previously-source-built)
       - runs: |
           mkdir -p "${{targets.destdir}}"/usr/share/dotnet
           mkdir -p "${{targets.destdir}}"/usr/bin

--- a/dotnet-bootstrap-8.yaml
+++ b/dotnet-bootstrap-8.yaml
@@ -1,0 +1,61 @@
+package:
+  name: dotnet-bootstrap-8
+  version: 8.0.11
+  epoch: 0
+  description: ".NET 8 SDK Bootstrap"
+  copyright:
+    - license: MIT
+  resources:
+    cpu: 2
+    memory: 32Gi
+  dependencies:
+    runtime:
+      - icu
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - glibc-locale-en
+      - icu-dev
+      - krb5-dev
+      - libunwind-dev
+      - lttng-ust-dev
+      - ncurses-dev
+      - openssl-dev
+      - wolfi-base
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/dotnet/dotnet
+      tag: v${{package.version}}
+      expected-commit: d5f3d652f9266d600777f626a9650a273419859b
+      destination: /home/build/src
+
+  - working-directory: /home/build/src
+    pipeline:
+      - runs: |
+          ./prep.sh
+      - runs: |
+          mkdir -p "${{targets.destdir}}"/usr/share/dotnet-bootstrap-8
+      - runs: |
+          # see https://github.com/jellyfin/jellyfin/pull/11063/
+          rm -f .dotnet/shared/Microsoft.NETCore.App/8.0.*/libcoreclrtraceptprovider.so
+          mv .dotnet "${{targets.destdir}}"/usr/share/dotnet-bootstrap-8/dotnet
+          mv prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz "${{targets.destdir}}"/usr/share/dotnet-bootstrap-8/
+
+  - uses: strip
+
+update:
+  enabled: false
+  github:
+    identifier: dotnet/dotnet
+    strip-prefix: v
+    use-tag: true
+    tag-filter: "v8"


### PR DESCRIPTION
To build dotnet in a more controlled way, I propose to have a bootstrap package and a main package that uses the bootstrap one.

The workflow:

  * build dotnet-bootstrap-8
  * build dotnet-source-8

The `dotnet-bootstrap-8` package bundles the artifacts from the `prep.sh` run. Those files consist of:

  * .dotnet folder - the `prep.sh` downloads and extracts the following https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.110/dotnet-sdk-8.0.110-linux-x64.tar.gz. The size is ~564MB, License is MIT.
  * prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz. This files is a bootstrap resulted from the download and extraction of https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.8.0.110-servicing.24474.1.centos.9-x64.tar.gz (size ~705MB). The bootstrap result is prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz (~1.4GB). License - this is a very big list of .nupkg, need to check in-depth.

The `dotnet-source-8` package uses the bootstrap package and does not need the `prep.sh` anymore, as the `.dotnet` folder is symlinked to the bootstrapped `/usr/share`. Also the `prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz` is symlinked.

The outcome is that the build of `dotnet-source-8` is done offline (excluding the actual git clone of the dotnet/dotnet repository).

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
