### PR TITLE
add minio-operator-sidecar package

### DIFF
--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: minio-operator
   version: 6.0.4
-  epoch: 1
+  epoch: 2
   description: Minio Operator creates/configures/manages Minio on Kubernetes
   copyright:
     - license: AGPL-3.0-only
@@ -30,15 +30,38 @@ pipeline:
       modroot: ./cmd/operator
       packages: .
       output: minio-operator
-      ldflags: -s -w -X github.com/minio/operator/pkg.ReleaseTag=${{package.full-version}} -X github.com/minio/operator/pkg.Version=${{package.full-version}} -X github.com/minio/operator/pkg.ShortCommitID=$(git rev-parse HEAD)
-
-  - uses: strip
+      ldflags: -w -X github.com/minio/operator/pkg.ReleaseTag=${{package.full-version}} -X github.com/minio/operator/pkg.Version=${{package.full-version}} -X github.com/minio/operator/pkg.ShortCommitID=$(git rev-parse HEAD)
 
   - runs: |
       mkdir ${{targets.destdir}}/licenses
       cp CREDITS LICENSE ${{targets.destdir}}/licenses/
 
 subpackages:
+  - name: ${{package.name}}-sidecar
+    description: sidecar for minio-operator
+    pipeline:
+      - uses: go/bump
+        working-directory: ./sidecar
+        with:
+          deps: github.com/golang-jwt/jwt/v4@v4.5.1
+      - uses: go/build
+        working-directory: ./sidecar
+        with:
+          modroot: ./cmd/sidecar
+          packages: .
+          output: minio-operator-sidecar
+          ldflags: -w -X github.com/minio/operator/sidecar/pkg.ReleaseTag=${{package.full-version}} -X github.com/minio/operator/sidecar/pkg.Version=${{package.full-version}} -X github.com/minio/operator/sidecar/pkg.ShortCommitID=$(git rev-parse HEAD)
+      - runs: |
+          mkdir ${{targets.contextdir}}/licenses
+          cp CREDITS LICENSE ${{targets.contextdir}}/licenses/
+
+  - name: ${{package.name}}-sidecar-compat
+    description: compatibility symlinks package for minio-operator-sidecar Dockerfile
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          ln -sf /usr/bin/minio-operator-sidecar ${{targets.contextdir}}/minio-operator-sidecar
+
   - name: ${{package.name}}-compat
     description: compatibility symlinks package for minio-operator Dockerfile
     pipeline:

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -6,14 +6,6 @@ package:
   copyright:
     - license: AGPL-3.0-only
 
-environment:
-  contents:
-    packages:
-      - bash
-      - build-base
-      - ca-certificates-bundle
-      - go
-
 pipeline:
   - uses: git-checkout
     with:


### PR DESCRIPTION
### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
  - [X] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
