### PR TITLE
Don't test for .pc files in /usr/local

### DIFF
--- a/audit.yaml
+++ b/audit.yaml
@@ -96,9 +96,6 @@ subpackages:
         - audit
         - linux-headers
     description: audit dev
-    test:
-      pipeline:
-        - uses: test/pkgconf
 
   - name: audit-doc
     pipeline:

--- a/libeconf.yaml
+++ b/libeconf.yaml
@@ -39,9 +39,6 @@ subpackages:
       runtime:
         - libeconf
     description: libeconf dev
-    test:
-      pipeline:
-        - uses: test/pkgconf
 
 update:
   enabled: true

--- a/libvterm.yaml
+++ b/libvterm.yaml
@@ -32,9 +32,6 @@ subpackages:
     pipeline:
       - uses: split/dev
     description: ${{package.name}} dev
-    test:
-      pipeline:
-        - uses: test/pkgconf
 
   - name: ${{package.name}}-static
     pipeline:

--- a/pipelines/test/pkgconf.yaml
+++ b/pipelines/test/pkgconf.yaml
@@ -17,7 +17,7 @@ pipeline:
           lib_name=$(basename "$pc_file" ".pc")
           # Ensure .pc file is installed in usr/lib/pkgconfig/*.pc or
           # in usr/share/pkgconfig/*.pc
-          echo "$pc_file" | grep -q "^usr/lib\|share/pkgconfig/${lib_name}.pc$\|^usr/local/lib/pkgconfig/${lib_name}.pc$"
+          echo "$pc_file" | grep -q "^usr/lib/pkgconfig/${lib_name}.pc$\|^usr/share/pkgconfig/${lib_name}.pc$"
           # Try to get the library name from the pc filename
           # Run some package config tests, which will likely be used by
           # other packages that have build dependencies on this dev package

--- a/rtmpdump.yaml
+++ b/rtmpdump.yaml
@@ -46,9 +46,6 @@ subpackages:
         - gnutls-dev
         - nettle-dev
         - zlib-dev
-    test:
-      pipeline:
-        - uses: test/pkgconf
 
   - name: ${{package.name}}-doc
     description: ${{package.name}} documentation


### PR DESCRIPTION
After some discussion with @xnox I realize that we don't actually want to be testing for .pc files in /usr/local as that is a way for the user to override the operating system's .pc files. Subsequently, we should drop the change to check for them in /usr/local and also remove the tests that will fail because they use /usr/local and consider those a bug in the package.