### PR TITLE
fix(open-liberty): Use correct paths in scripts and cleanup

### DIFF
--- a/open-liberty.yaml
+++ b/open-liberty.yaml
@@ -2,7 +2,7 @@
 package:
   name: open-liberty
   version: 24.0.0.11
-  epoch: 0
+  epoch: 1
   description: "Open Liberty is a highly composable, fast to start, dynamic application server runtime environment"
   resources:
     cpu: 32
@@ -13,15 +13,23 @@ package:
 vars:
   open-liberty-home: "/usr/share/java/open-liberty"
 
+data:
+  - name: variants
+    items:
+      full: "full"
+      slim: "kernel-slim"
+
 environment:
   contents:
     packages:
       - busybox
       - ca-certificates-bundle
       - curl
+      - findutils
       - libarchive-tools
       - openjdk-21
       - openjdk-21-default-jvm
+      - sed
   environment:
     LANG: en_US.UTF-8
     JAVA_HOME: /usr/lib/jvm/java-21-openjdk
@@ -42,6 +50,10 @@ pipeline:
       mkdir -p ${{targets.contextdir}}/${{vars.open-liberty-home}}
       bsdtar xvf cnf/release/dev/openliberty/${{package.version}}*/openliberty-${{package.version}}*.zip --strip-components=1 -C ${{targets.contextdir}}/${{vars.open-liberty-home}}
 
+      # Remove Windows batch scripts and executables
+      find ${{targets.contextdir}} -name "*.bat" -exec rm -rf '{}' +
+      find ${{targets.contextdir}} -name "*.exe" -exec rm -rf '{}' +
+
   - uses: strip
 
   # Tags aren't cut, a branch specific to the version of Open Liberty is created before release
@@ -52,21 +64,30 @@ pipeline:
       branch: ${{package.version}}-release
 
 subpackages:
-  - name: ${{package.name}}-docker-full
-    description: Configuration and scripts for running Open Liberty in Docker - full
+  - range: variants
+    name: ${{package.name}}-docker-${{range.key}}
+    description: Configuration and scripts for running Open Liberty in Docker - ${{range.key}}
+    dependencies:
+      runtime:
+        - ${{package.name}}
+        - bash
+        - busybox
+        - dumb-init
+        - glibc-locale-en
+        - openssl
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/${{vars.open-liberty-home}}
-          mv releases/${{package.version}}/full/helpers \
+          mv releases/${{package.version}}/${{range.value}}/helpers \
             ${{targets.contextdir}}/${{vars.open-liberty-home}}/helpers
 
-  - name: ${{package.name}}-docker-slim
-    description: Configuration and scripts for running Open Liberty in Docker - slim
-    pipeline:
-      - runs: |
-          mkdir -p ${{targets.contextdir}}/${{vars.open-liberty-home}}
-          mv releases/${{package.version}}/kernel-slim/helpers \
-            ${{targets.contextdir}}/${{vars.open-liberty-home}}/helpers
+          # Create server config directories
+          mkdir -p ${{targets.contextdir}}/config/configDropins/defaults
+          mkdir -p ${{targets.contextdir}}/config/configDropins/overrides
+
+          # Use correct paths
+          find ${{targets.contextdir}} -type f -exec sed -i 's|/opt/ol/wlp|${{vars.open-liberty-home}}|g' {} +
+          find ${{targets.contextdir}} -type f -exec sed -i 's|/opt/ol|${{vars.open-liberty-home}}|g' {} +
 
 update:
   enabled: true


### PR DESCRIPTION
- Actually use the correct path to Open Liberty in Docker scripts
- Create missing server config paths
- Consolidate scripts using a range for full/slim Open Liberty variants
- Remove Windows batch scripts and executables