### PR TITLE
datadog-agent-nvml: update binary and packages paths

### DIFF
--- a/datadog-agent-nvml.yaml
+++ b/datadog-agent-nvml.yaml
@@ -116,3 +116,4 @@ update:
     identifier: DataDog/integrations-extras
     strip-prefix: nvml-
     tag-filter: nvml-
+    use-tag: true

--- a/datadog-agent-nvml.yaml
+++ b/datadog-agent-nvml.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent-nvml
   version: 1.0.9
-  epoch: 0
+  epoch: 1
   description: "Checks NVIDIA Management Library (NVML) exposed metrics through the Datadog Agent and can correlate them with the exposed Kubernetes devices"
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ environment:
 vars:
   dd_conf: /etc/datadog-agent/conf.d
   dd_home: / # agent being run by root expects /.
-  dd_shared: /usr/share/datadog-agent
+  dd_shared: /opt/datadog-agent/embedded
   python_version: "3.11"
 
 pipeline:
@@ -96,19 +96,18 @@ test:
         - datadog-agent-core-integrations
         - datadog-agent-nvml=${{package.full-version}}
     environment:
-      PYTHONPATH: /usr/share/datadog-agent/lib/python${{vars.python_version}}/site-packages
-      PATH: /opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      PYTHONPATH: ${{vars.dd_shared}}/lib/python${{vars.python_version}}/site-packages
   pipeline:
     - runs: |
         stat /etc/datadog-agent/conf.d/nvml.d/conf.yaml.example
-        stat /usr/share/datadog-agent/lib/python${{vars.python_version}}/site-packages/datadog_checks/nvml/__init__.py
-        stat /usr/share/datadog-agent/lib/python${{vars.python_version}}/site-packages/datadog_nvml-${{package.version}}.dist-info/WHEEL
+        stat ${{vars.dd_shared}}/lib/python${{vars.python_version}}/site-packages/datadog_checks/nvml/__init__.py
+        stat ${{vars.dd_shared}}/lib/python${{vars.python_version}}/site-packages/datadog_nvml-${{package.version}}.dist-info/WHEEL
     - name: Verify the integration is installed # https://docs.datadoghq.com/agent/guide/integration-management/?tab=linux#install
       runs: |
-        cp /opt/datadog-agent/requirements-agent-release.txt ${{vars.dd_home}}/
-        cp /opt/datadog-agent/final_constraints-py3.txt ${{vars.dd_home}}/
-        mkdir -p /embedded/bin && ln -s $(which python3) ${{vars.dd_home}}/embedded/bin/python3
-        VERSION="$(agent integration show datadog-nvml | cut -d ':' -f2 | tr -d ' ')"
+        /opt/datadog-agent/bin/agent/agent integration show datadog-nvml
+    - name: Verify the integration version
+      runs: |
+        VERSION="$(/opt/datadog-agent/bin/agent/agent integration show datadog-nvml | cut -d ':' -f2 | tr -d ' ')"
         test $VERSION = ${{package.version}}
 
 update:


### PR DESCRIPTION
This follows the refactoring introduced with https://github.com/wolfi-dev/os/pull/33186.