### PR TITLE
new pkg: nushell

### DIFF
--- a/nushell.yaml
+++ b/nushell.yaml
@@ -1,0 +1,75 @@
+package:
+  name: nushell
+  version: 0.99.1
+  epoch: 0
+  description: A new type of shell
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cargo-auditable
+      - libgit2-dev
+      - libssh2-dev
+      - openssf-compiler-options
+      - openssl-dev
+      - rust
+      - sqlite-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 2d7c779b90e6382516db74d2a4b902764ae4e739c4b1b0d615521c7d8082c0d5
+      uri: https://github.com/nushell/nushell/archive/${{package.version}}.tar.gz
+
+  # TODO: figure out why I cant link against mimalloc
+  # error: gnu/bin/ld: cannot find -lmimalloc: No such file or directory
+  - runs: |
+      #!/bin/bash
+      set -x
+
+      export LIBSSH2_SYS_USE_PKG_CONFIG=1  # use system libssh2
+      export TARGET=$(rustc -vV | sed -n 's/host: //p')
+      mkdir -p ~/.cargo
+      cat >> ~/.cargo/config.toml <<-EOF
+
+        [target.$TARGET]
+        git2 = { rustc-link-lib = ["git2"] }
+        rusqlite = { rustc-link-lib = ["sqlite3"] }
+      EOF
+
+  - runs: |
+      cargo auditable build --workspace --locked --release
+
+      find target/release \
+        -maxdepth 1 \
+        -executable \
+        -type f \
+        -name "nu*" \
+        -exec install -vDm755 -t "${{targets.destdir}}/usr/bin" "{}" +
+
+  - uses: strip
+
+subpackages:
+  - name: nushell-plugins
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/bin/
+          mv ${{targets.destdir}}/usr/bin/nu_plugin_* ${{targets.contextdir}}/usr/bin/
+    description: nushell plugins
+
+test:
+  pipeline:
+    - name: version and command test
+      runs: |
+        nu --version || exit 1
+        nu -c 'echo "hello"'
+
+update:
+  enabled: true
+  github:
+    identifier: nushell/nushell


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/33708

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
