### PR TITLE
new pkg: google-authenticator

### DIFF
--- a/google-authenticator.yaml
+++ b/google-authenticator.yaml
@@ -15,6 +15,7 @@ environment:
       - libtool
       - linux-pam-dev
       - m4
+      - openssf-compiler-options
       - openssl-dev
 
 pipeline:

--- a/google-authenticator.yaml
+++ b/google-authenticator.yaml
@@ -1,0 +1,62 @@
+package:
+  name: google-authenticator
+  version: 1.10
+  epoch: 0
+  description: Google Authenticator PAM module
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - automake
+      - build-base
+      - busybox
+      - libtool
+      - linux-pam-dev
+      - m4
+      - openssl-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/google/google-authenticator-libpam
+      tag: ${{package.version}}
+      expected-commit: 5c8f2a7a719c8ab7baa89795f3aea36260ee8d27
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}/etc/pam.d"
+      echo -e "auth\trequired\tpam_google_authenticator.so" > "${{targets.destdir}}/etc/pam.d/google-authenticator"
+
+  - uses: strip
+
+subpackages:
+  - name: google-authenticator-doc
+    pipeline:
+      - uses: split/manpages
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/share
+          mv "${{targets.destdir}}"/usr/share/doc/google-authenticator "${{targets.contextdir}}"/usr/share
+    description: google authenticator manpages
+
+update:
+  enabled: true
+  github:
+    identifier: google/google-authenticator-libpam
+    use-tag: true
+
+test:
+  pipeline:
+    - name: Verify google-authenticator installation
+      runs: |
+        google-authenticator --version || exit 1
+        google-authenticator --help
+    - name: Init new key test
+      runs: |
+        yes -1 | google-authenticator --time-based --disallow-reuse --force --rate-limit=3 --rate-time=30 --window-size=3


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/33189

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
