### PR TITLE
feat: Add rust bindgen

### DIFF
--- a/rust-bindgen.yaml
+++ b/rust-bindgen.yaml
@@ -1,0 +1,36 @@
+package:
+  name: rust-bindgen
+  version: 0.70.1
+  epoch: 0
+  description: Automatically generates Rust FFI bindings to C (and some C++) libraries
+  copyright:
+    - license: BSD-3-Clause
+
+pipeline:
+  - name: Checkout bindgen
+    uses: git-checkout
+    with:
+      expected-commit: 21c60f473f4e824d4aa9b2b508056320d474b110
+      repository: https://github.com/rust-lang/rust-bindgen
+      tag: v${{package.version}}
+
+  - name: Build bindgen
+    uses: cargo/build
+    with:
+      output: bindgen
+
+  - name: Strip bindgen
+    uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: rust-lang/rust-bindgen
+    strip-prefix: v
+
+test:
+  pipeline:
+    - name: Test bindgen
+      runs: |
+        bindgen --help
+        bindgen --version

--- a/rust-bindgen.yaml
+++ b/rust-bindgen.yaml
@@ -14,6 +14,9 @@ pipeline:
       repository: https://github.com/rust-lang/rust-bindgen
       tag: v${{package.version}}
 
+  - name: Bump bindgen deps
+    runs: cargo update --package rustix --precise 0.37.25
+
   - name: Build bindgen
     uses: cargo/build
     with:


### PR DESCRIPTION
Automatically generates Rust FFI bindings to C (and some C++) libraries.