### PR TITLE
New packages: ruby-uri and ruby-benchmark

### DIFF
--- a/ruby3.2-benchmark.yaml
+++ b/ruby3.2-benchmark.yaml
@@ -1,0 +1,50 @@
+package:
+  name: ruby3.2-benchmark
+  version: 0.4.0
+  epoch: 0
+  description: "A performance benchmarking library for Ruby"
+  copyright:
+    - license: BSD-2-Clause OR Ruby
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ruby/benchmark
+      tag: v${{package.version}}
+      expected-commit: a5d77ceae06d69a8b1b06d45760c9590a466707d
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: benchmark
+
+test:
+  pipeline:
+    - runs: ruby -e "require 'benchmark'"
+    - runs: |
+        ruby -e 'require "benchmark"; Benchmark.measure { 1 + 1 }; puts "OK"'
+
+update:
+  enabled: true
+  github:
+    identifier: ruby/benchmark
+    strip-prefix: v

--- a/ruby3.2-benchmark.yaml
+++ b/ruby3.2-benchmark.yaml
@@ -2,7 +2,7 @@ package:
   name: ruby3.2-benchmark
   version: 0.4.0
   epoch: 0
-  description: "A performance benchmarking library for Ruby"
+  description: "A performance benchmarking library for Ruby."
   copyright:
     - license: BSD-2-Clause OR Ruby
 

--- a/ruby3.2-uri.yaml
+++ b/ruby3.2-uri.yaml
@@ -1,0 +1,50 @@
+package:
+  name: ruby3.2-uri
+  version: 1.0.1
+  epoch: 0
+  description: "URI is a module providing classes to handle Uniform Resource Identifiers"
+  copyright:
+    - license: BSD-2-Clause OR Ruby
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ruby/uri
+      tag: v${{package.version}}
+      expected-commit: 3011eb6f6e53c7870f91404d4a789cb854c893ad
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: uri
+
+test:
+  pipeline:
+    - runs: ruby -e "require 'uri'"
+    - runs: |
+        ruby -e 'require "uri"; uri = URI("https://wolfi.dev"); raise "Failed to parse URI" unless uri.host == "wolfi.dev" && uri.scheme == "https"'
+
+update:
+  enabled: true
+  github:
+    identifier: ruby/uri
+    strip-prefix: v

--- a/ruby3.3-benchmark.yaml
+++ b/ruby3.3-benchmark.yaml
@@ -1,0 +1,50 @@
+package:
+  name: ruby3.3-benchmark
+  version: 0.4.0
+  epoch: 0
+  description: "A performance benchmarking library for Ruby"
+  copyright:
+    - license: BSD-2-Clause OR Ruby
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.3
+      - ruby-3.3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ruby/benchmark
+      tag: v${{package.version}}
+      expected-commit: a5d77ceae06d69a8b1b06d45760c9590a466707d
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: benchmark
+
+test:
+  pipeline:
+    - runs: ruby -e "require 'benchmark'"
+    - runs: |
+        ruby -e 'require "benchmark"; Benchmark.measure { 1 + 1 }; puts "OK"'
+
+update:
+  enabled: true
+  github:
+    identifier: ruby/benchmark
+    strip-prefix: v

--- a/ruby3.3-uri.yaml
+++ b/ruby3.3-uri.yaml
@@ -1,0 +1,50 @@
+package:
+  name: ruby3.3-uri
+  version: 1.0.1
+  epoch: 0
+  description: "URI is a module providing classes to handle Uniform Resource Identifiers"
+  copyright:
+    - license: BSD-2-Clause OR Ruby
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.3
+      - ruby-3.3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ruby/uri
+      tag: v${{package.version}}
+      expected-commit: 3011eb6f6e53c7870f91404d4a789cb854c893ad
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: uri
+
+test:
+  pipeline:
+    - runs: ruby -e "require 'uri'"
+    - runs: |
+        ruby -e 'require "uri"; uri = URI("https://wolfi.dev"); raise "Failed to parse URI" unless uri.host == "wolfi.dev" && uri.scheme == "https"'
+
+update:
+  enabled: true
+  github:
+    identifier: ruby/uri
+    strip-prefix: v


### PR DESCRIPTION
These packages are now needed to be able to test the following package:
 - https://github.com/wolfi-dev/os/pull/33613
