### PR TITLE
datadog-agent-nvml: add missing requirements for the check

### DIFF
--- a/datadog-agent-nvml.yaml
+++ b/datadog-agent-nvml.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent-nvml
   version: 1.0.9
-  epoch: 1
+  epoch: 2
   description: "Checks NVIDIA Management Library (NVML) exposed metrics through the Datadog Agent and can correlate them with the exposed Kubernetes devices"
   copyright:
     - license: Apache-2.0
@@ -66,6 +66,7 @@ pipeline:
       #
       # This project uses hatchling as build backend, instead of setuptools, as defaulted in pip.
       pip install --no-deps --no-cache-dir --constraint /opt/datadog-agent/final_constraints-py3.txt ./nvml
+      pip install -r ./nvml/requirements.in
 
       # Cleanup before preparing the package content.
       find ${{vars.dd_shared}} -name "*.pyc" -delete


### PR DESCRIPTION
This PR adds missing requirements that are needed by the check to work.