### PR TITLE
ca-certificates: add one more compat symlink

### DIFF
--- a/ca-certificates.yaml
+++ b/ca-certificates.yaml
@@ -2,7 +2,7 @@ package:
   name: ca-certificates
   # manual: update java-cacerts
   version: "20241010"
-  epoch: 1
+  epoch: 2
   description: "CA certificates from the Mozilla trusted root program"
   copyright:
     - license: MPL-2.0 AND MIT
@@ -66,6 +66,9 @@ subpackages:
           # Provide Fedora compatible location for the bundle (fixes compat with Dart lang)
           mkdir -p ${{targets.subpkgdir}}/etc/pki/tls/certs/
           ln -s ../../../ssl/certs/ca-certificates.crt ${{targets.subpkgdir}}/etc/pki/tls/certs/ca-bundle.crt
+          # Provide RHEL compatible location for the bundle (fixes compat with fluent-bit)
+          mkdir -p ${{targets.subpkgdir}}/etc/ssl/certs/
+          ln -s ca-certificates.crt ${{targets.subpkgdir}}/etc/ssl/certs/ca-bundle.crt
 
 test:
   environment:
@@ -80,6 +83,8 @@ test:
         SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt curl --ipv4 -v https://packages.wolfi.dev
         # Test Fedora-like compat path
         SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt curl --ipv4 -v https://packages.wolfi.dev
+        # Test Rhel-like compat path
+        SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt curl --ipv4 -v https://packages.wolfi.dev
         c_rehash -v
         update-ca-certificates --version
         update-ca-certificates --help


### PR DESCRIPTION
Add one more compat symlink pointing at RHEL compatible bundle
location as used by fluent-bit by default.

At
https://github.com/fluent/fluent-bit/blob/58cc2d5944a00b0844e58b91b950ecf595e05063/include/fluent-bit/tls/flb_tls_info.h.in#L42
bundle location is defined which is used unconditionally ignoring the
environment variable set one.
