### PR TITLE
adding new ruby package: ruby-io-stream

### DIFF
--- a/ruby3.2-io-stream.yaml
+++ b/ruby3.2-io-stream.yaml
@@ -1,0 +1,92 @@
+package:
+  name: ruby3.2-io-stream
+  version: 0.6.1
+  epoch: 0
+  description: A Ruby gem providing stream abstractions for input and output.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby-${{vars.rubyMM}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 8b0080a120e085e8f22afcd08b51b06cf5cab78c
+      repository: https://github.com/socketry/io-stream
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: io-stream
+
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'io/stream'
+        require 'stringio'
+        require 'test/unit'
+        include Test::Unit::Assertions
+        class TestIOStream < Test::Unit::TestCase
+          def test_write_and_read
+            # Create a StringIO object and wrap it in IO::Stream
+            buffer = StringIO.new
+            stream = IO::Stream::Buffered.new(buffer)
+            # Write to the stream
+            stream.write("Hello, Stream!")
+            stream.flush  # Ensure data is written to the buffer
+            # Reset buffer for reading and read back the data
+            buffer.rewind
+            message = buffer.read
+            # Assert that the message matches what was written
+            assert_equal "Hello, Stream!", message, "Expected written message to be read back from stream"
+            puts "Basic write and read test passed."
+          end
+          def test_close
+            buffer = StringIO.new
+            stream = IO::Stream::Buffered.new(buffer)
+            # Close the stream and assert it's closed
+            stream.close
+            assert stream.closed?, "Expected stream to be closed"
+            puts "Stream close test passed."
+          end
+        end
+        EOF
+
+update:
+  enabled: true
+  github:
+    identifier: socketry/io-stream
+    strip-prefix: v
+    use-tag: true
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM

--- a/ruby3.3-io-stream.yaml
+++ b/ruby3.3-io-stream.yaml
@@ -1,0 +1,92 @@
+package:
+  name: ruby3.3-io-stream
+  version: 0.6.1
+  epoch: 0
+  description: A Ruby gem providing stream abstractions for input and output.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby-${{vars.rubyMM}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 8b0080a120e085e8f22afcd08b51b06cf5cab78c
+      repository: https://github.com/socketry/io-stream
+      tag: v${{package.version}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+vars:
+  gem: io-stream
+
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'io/stream'
+        require 'stringio'
+        require 'test/unit'
+        include Test::Unit::Assertions
+        class TestIOStream < Test::Unit::TestCase
+          def test_write_and_read
+            # Create a StringIO object and wrap it in IO::Stream
+            buffer = StringIO.new
+            stream = IO::Stream::Buffered.new(buffer)
+            # Write to the stream
+            stream.write("Hello, Stream!")
+            stream.flush  # Ensure data is written to the buffer
+            # Reset buffer for reading and read back the data
+            buffer.rewind
+            message = buffer.read
+            # Assert that the message matches what was written
+            assert_equal "Hello, Stream!", message, "Expected written message to be read back from stream"
+            puts "Basic write and read test passed."
+          end
+          def test_close
+            buffer = StringIO.new
+            stream = IO::Stream::Buffered.new(buffer)
+            # Close the stream and assert it's closed
+            stream.close
+            assert stream.closed?, "Expected stream to be closed"
+            puts "Stream close test passed."
+          end
+        end
+        EOF
+
+update:
+  enabled: true
+  github:
+    identifier: socketry/io-stream
+    strip-prefix: v
+    use-tag: true
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM


### PR DESCRIPTION
There are a number of existing ruby packages which rely on this package at runtime. Adding this allows us to create and expand melange test coverage for other packages.