### PR TITLE
add py3-requests-unixsocket package

### DIFF
--- a/py3-requests-unixsocket.yaml
+++ b/py3-requests-unixsocket.yaml
@@ -6,16 +6,30 @@ package:
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - py3-requests
+    provider-priority: 0
 
 environment:
   contents:
     packages:
+      - build-base
       - busybox
-      - py3-pip
-      - py3-setuptools
-      - python3
+      - py3-supported-pip
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-wheel
+
+vars:
+  pypi-package: requests-unixsocket
+  module-name: requests_unixsocket
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
+
 
 pipeline:
   - uses: fetch
@@ -23,26 +37,28 @@ pipeline:
       expected-sha256: 28304283ea9357d45fff58ad5b11e47708cfbf5806817aa59b2a363228ee971e
       uri: https://files.pythonhosted.org/packages/source/r/requests-unixsocket/requests-unixsocket-${{package.version}}.tar.gz
 
-  - runs: |
-      python3 setup.py bdist_wheel
-
-  - runs: |
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
-
-  - uses: strip
-
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-requests
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.module-name}}
 update:
   enabled: true
   release-monitor:
     identifier: 375444
-
-test:
-  environment:
-    contents:
-      packages:
-        - python3
-  pipeline:
-    - uses: python/import
-      with:
-        python: python3
-        import: requests_unixsocket

--- a/py3-requests-unixsocket.yaml
+++ b/py3-requests-unixsocket.yaml
@@ -30,7 +30,6 @@ data:
       3.12: '312'
       3.13: '300'
 
-
 pipeline:
   - uses: fetch
     with:
@@ -58,6 +57,7 @@ subpackages:
           with:
             python: python${{range.key}}
             import: ${{vars.module-name}}
+
 update:
   enabled: true
   release-monitor:

--- a/py3-requests-unixsocket.yaml
+++ b/py3-requests-unixsocket.yaml
@@ -1,6 +1,6 @@
 package:
   name: py3-requests-unixsocket
-  version: 0.2.0
+  version: 0.3.0
   epoch: 0
   description: Use requests to talk HTTP via a UNIX domain socket
   copyright:
@@ -18,11 +18,10 @@ environment:
       - python3
 
 pipeline:
-  - uses: git-checkout
+  - uses: fetch
     with:
-      repository: https://github.com/msabramo/requests-unixsocket
-      tag: ${{package.version}}
-      expected-commit: f4703e02e0c894ece5b2c5d69f647c9b8c3716db
+      expected-sha256: 28304283ea9357d45fff58ad5b11e47708cfbf5806817aa59b2a363228ee971e
+      uri: https://files.pythonhosted.org/packages/source/r/requests-unixsocket/requests-unixsocket-${{package.version}}.tar.gz
 
   - runs: |
       python3 setup.py bdist_wheel
@@ -34,9 +33,8 @@ pipeline:
 
 update:
   enabled: true
-  github:
-    identifier: msabramo/requests-unixsocket
-    use-tag: true
+  release-monitor:
+    identifier: 375444
 
 test:
   environment:

--- a/py3-requests-unixsocket.yaml
+++ b/py3-requests-unixsocket.yaml
@@ -1,0 +1,50 @@
+package:
+  name: py3-requests-unixsocket
+  version: 0.2.0
+  epoch: 0
+  description: Use requests to talk HTTP via a UNIX domain socket
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - py3-requests
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - py3-pip
+      - py3-setuptools
+      - python3
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/msabramo/requests-unixsocket
+      tag: ${{package.version}}
+      expected-commit: f4703e02e0c894ece5b2c5d69f647c9b8c3716db
+
+  - runs: |
+      python3 setup.py build
+
+  - runs: |
+      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: msabramo/requests-unixsocket
+    use-tag: true
+
+test:
+  environment:
+    contents:
+      packages:
+        - python3
+  pipeline:
+    - uses: python/import
+      with:
+        python: python3
+        import: requests_unixsocket

--- a/py3-requests-unixsocket.yaml
+++ b/py3-requests-unixsocket.yaml
@@ -25,7 +25,7 @@ pipeline:
       expected-commit: f4703e02e0c894ece5b2c5d69f647c9b8c3716db
 
   - runs: |
-      python3 setup.py build
+      python3 setup.py bdist_wheel
 
   - runs: |
       python3 setup.py install --prefix=/usr --root="${{targets.destdir}}" --skip-build


### PR DESCRIPTION
dependency for ansible-runner-http package. 

using `py/pip-build-install` pipeline was not possible given the project is still using setup.py and haven't made the transition to using pyproject.toml as of now. 