### PR TITLE
new pkg: dotnet-9

### DIFF
--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -30,6 +30,7 @@ environment:
       - glibc-locale-en
       - icu-dev
       - krb5-dev
+      - libunwind
       - libunwind-dev
       - llvm15
       - llvm15-cmake-default
@@ -37,6 +38,7 @@ environment:
       - llvm15-tools
       - lttng-ust-dev
       - ncurses-dev
+      - nodejs-22
       - openssl-dev
       - python3
       - rapidjson-dev
@@ -64,7 +66,7 @@ pipeline:
             /p:ContinueOnPrebuiltBaselineError=true \
             /p:MinimalConsoleLogOutput=true \
             /p:SkipPortableRuntimeBuild=true \
-            /p:UseSystemLibs=brotli+rapidjson+zlib
+            /p:UseSystemLibs=brotli+rapidjson+zlib+libunwind
       - runs: |
           mkdir -p "${{targets.destdir}}"/usr/share/dotnet
           mkdir -p "${{targets.destdir}}"/usr/bin

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-9
   version: 9.0.0
-  epoch: 1
+  epoch: 0
   description: ".NET SDK"
   copyright:
     - license: MIT

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -19,6 +19,7 @@ environment:
     packages:
       - bash
       - brotli-dev
+      - brotli-dev
       - build-base
       - busybox
       - ca-certificates-bundle
@@ -38,6 +39,7 @@ environment:
       - ncurses-dev
       - openssl-dev
       - python3
+      - rapidjson-dev
       - samurai
       - wolfi-base
       - zlib-dev
@@ -61,7 +63,8 @@ pipeline:
             /p:LogVerbosity=minimal \
             /p:ContinueOnPrebuiltBaselineError=true \
             /p:MinimalConsoleLogOutput=true \
-            /p:SkipPortableRuntimeBuild=true
+            /p:SkipPortableRuntimeBuild=true \
+            /p:UseSystemLibs=brotli+rapidjson+zlib
       - runs: |
           mkdir -p "${{targets.destdir}}"/usr/share/dotnet
           mkdir -p "${{targets.destdir}}"/usr/bin
@@ -149,6 +152,16 @@ subpackages:
         - aspnet-9-runtime-default
       provides:
         - dotnet-sdk=9
+
+  - name: dotnet-9-aot
+    description: "Ahead-of-Time (AOT) support for the .NET SDK version 9"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/share/dotnet/packs
+          mv "${{targets.destdir}}"/usr/share/dotnet/packs/runtime.*.Microsoft.DotNet.ILCompiler "${{targets.contextdir}}"/usr/share/dotnet/packs/
+    dependencies:
+      runtime:
+        - dotnet-9-targeting-pack
 
 update:
   enabled: true

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -1,0 +1,201 @@
+package:
+  name: dotnet-9
+  version: 9.0.0
+  epoch: 1
+  description: ".NET SDK"
+  copyright:
+    - license: MIT
+  resources:
+    cpu: 2
+    memory: 32Gi
+  dependencies:
+    runtime:
+      - icu
+
+environment:
+  environment:
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  contents:
+    packages:
+      - bash
+      - brotli-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang-15
+      - clang-15-default
+      - cmake
+      - curl
+      - glibc-locale-en
+      - icu-dev
+      - krb5-dev
+      - libunwind-dev
+      - llvm15
+      - llvm15-cmake-default
+      - llvm15-dev
+      - llvm15-tools
+      - lttng-ust-dev
+      - ncurses-dev
+      - openssl-dev
+      - python3
+      - samurai
+      - wolfi-base
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/dotnet/dotnet
+      tag: v${{package.version}}
+      expected-commit: a2bc464e40415d625118f38fbb0556d1803783ff
+      destination: /home/build/src
+
+  - working-directory: /home/build/src
+    pipeline:
+      - runs: |
+          ./prep-source-build.sh
+      - runs: |
+          ./build.sh -sb --clean-while-building \
+            -- \
+            /v:minimal \
+            /p:LogVerbosity=minimal \
+            /p:ContinueOnPrebuiltBaselineError=true \
+            /p:MinimalConsoleLogOutput=true \
+            /p:SkipPortableRuntimeBuild=true
+      - runs: |
+          mkdir -p "${{targets.destdir}}"/usr/share/dotnet
+          mkdir -p "${{targets.destdir}}"/usr/bin
+
+          cp -R /home/build/src/artifacts/obj/extracted-dotnet-sdk/* "${{targets.destdir}}"/usr/share/dotnet
+      - runs: |
+          ln -s /usr/share/dotnet/dotnet "${{targets.destdir}}"/usr/bin/dotnet
+
+  - uses: strip
+
+subpackages:
+  - name: dotnet-9-runtime
+    description: "The .NET Core Runtime, version 9"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/share/dotnet/shared
+          mv "${{targets.destdir}}"/usr/share/dotnet/shared/Microsoft.NETCore.App "${{targets.contextdir}}"/usr/share/dotnet/shared/
+    dependencies:
+      runtime:
+        - dotnet-9
+
+  - name: dotnet-9-runtime-default
+    dependencies:
+      runtime:
+        - dotnet-9-runtime
+      provides:
+        - dotnet-runtime=9
+
+  - name: aspnet-9-runtime
+    description: "The ASP.NET Core Runtime, version 9"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/share/dotnet/shared
+          mv "${{targets.destdir}}"/usr/share/dotnet/shared/Microsoft.AspNetCore.App "${{targets.contextdir}}"/usr/share/dotnet/shared/
+    dependencies:
+      runtime:
+        - dotnet-9-runtime
+
+  - name: aspnet-9-runtime-default
+    dependencies:
+      runtime:
+        - aspnet-9-runtime
+      provides:
+        - aspnet-runtime=9
+
+  - name: dotnet-9-targeting-pack
+    description: "The .NET Core targeting pack, version 9"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/share/dotnet/packs
+          mv "${{targets.destdir}}"/usr/share/dotnet/packs/NETStandard.Library.* "${{targets.contextdir}}"/usr/share/dotnet/packs/
+          mv "${{targets.destdir}}"/usr/share/dotnet/packs/Microsoft.NETCore.App.* "${{targets.contextdir}}"/usr/share/dotnet/packs/
+
+  - name: aspnet-9-targeting-pack
+    description: "The ASP.NET targeting pack, version 9"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/share/dotnet/packs
+          mv "${{targets.destdir}}"/usr/share/dotnet/packs/Microsoft.AspNetCore.App.* "${{targets.contextdir}}"/usr/share/dotnet/packs/
+    dependencies:
+      runtime:
+        - dotnet-9-targeting-pack
+
+  - name: dotnet-9-sdk
+    description: "The .NET Core SDK, version 9"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/share/dotnet
+
+          for i in sdk sdk-manifests templates; do
+            mv "${{targets.destdir}}"/usr/share/dotnet/$i "${{targets.contextdir}}"/usr/share/dotnet/
+          done
+    dependencies:
+      runtime:
+        - dotnet-9-runtime
+        - aspnet-9-runtime
+        - dotnet-9-targeting-pack
+        - aspnet-9-targeting-pack
+
+  - name: dotnet-9-sdk-default
+    dependencies:
+      runtime:
+        - dotnet-9-sdk
+        - dotnet-9-runtime-default
+        - aspnet-9-runtime-default
+      provides:
+        - dotnet-sdk=9
+
+update:
+  enabled: true
+  github:
+    identifier: dotnet/dotnet
+    strip-prefix: v
+    use-tag: true
+    tag-filter: "v9"
+
+test:
+  environment:
+    contents:
+      packages:
+        - dotnet-9-sdk
+  pipeline:
+    - name: Basic .NET command test
+      runs: |
+        dotnet --info
+    - name: Compile and run a simple .NET application
+      runs: |
+        cat <<'EOF' > HelloWorld.cs
+        using System;
+
+        class Program
+        {
+            static void Main()
+            {
+                Console.WriteLine("Hello, World!");
+            }
+        }
+        EOF
+        dotnet new console -o HelloWorldApp --force
+        mv HelloWorld.cs HelloWorldApp/Program.cs
+        dotnet run --project HelloWorldApp
+    - name: Compile and run a .NET application with arguments
+      runs: |
+        cat <<'EOF' > ArgumentEcho.cs
+        using System;
+
+        class Program
+        {
+            static void Main(string[] args)
+            {
+                Console.WriteLine("Arguments: " + String.Join(", ", args));
+            }
+        }
+        EOF
+        dotnet new console -o ArgumentEchoApp --force
+        mv ArgumentEcho.cs ArgumentEchoApp/Program.cs
+        dotnet run --project ArgumentEchoApp -- arg1 arg2 arg3

--- a/dotnet-9.yaml
+++ b/dotnet-9.yaml
@@ -19,7 +19,6 @@ environment:
     packages:
       - bash
       - brotli-dev
-      - brotli-dev
       - build-base
       - busybox
       - ca-certificates-bundle


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: https://github.com/wolfi-dev/os/issues/33999

![image](https://github.com/user-attachments/assets/aeb66f54-77ae-46e6-aa82-81d451e74245)


Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
