### PR TITLE
Change default value for go telemetry from 'local' to 'off'

### DIFF
--- a/go-1.23.yaml
+++ b/go-1.23.yaml
@@ -1,7 +1,7 @@
 package:
   name: go-1.23
   version: 1.23.3
-  epoch: 0
+  epoch: 1
   description: "the Go programming language"
   copyright:
     - license: BSD-3-Clause
@@ -38,7 +38,9 @@ pipeline:
 
   - uses: patch
     with:
-      patches: cmd-go-always-emit-ldflags-version-information.patch
+      patches: |
+        cmd-go-always-emit-ldflags-version-information.patch
+        change-default-telemetry-from-local-to-off.patch
 
   - runs: |
       cd src
@@ -146,3 +148,41 @@ test:
 
         # Run the Go program with cgo and check the output
         go run hello_cgo.go | grep "Hello from cgo!"
+    - name: Test telemetry settings
+      runs: |
+        fail() { echo "FAIL:" "$@" 1>&2; exit 1; }
+
+        tmpd=$(mktemp -d)
+        trap "rm -R '$tmpd'" EXIT
+        export HOME="$tmpd/home"
+        mkdir "$HOME"
+
+        out=$(go telemetry) || fail "'go telemetry' exited $?"
+        [ "$out" = "off" ] ||
+          fail "go telemetry output '$out'. expected 'off'"
+
+        cfgdir="$HOME/.config/go/telemetry"
+        if [ -d "$cfgdir" ]; then
+          fail "$cfgdir was created by running 'go telemetry'"
+        fi
+
+        go telemetry on ||
+          fail "'go telemetry on' exited $?"
+        out=$(go telemetry) || fail "'go telemetry' after 'on' exited $?"
+        [ "$out" = "on" ] ||
+          fail "go telemetry after 'on' output '$out'. expected 'on'"
+
+        [ -f "$cfgdir/mode" ] ||
+          fail "ERROR: 'go telemetry on' did not write ~/${cfgdir#$HOME/}"
+
+        go telemetry local ||
+          fail "'go telemetry local' exited $?"
+        out=$(go telemetry) || fail "'go telemetry' after 'local' exited $?"
+        [ "$out" = "local" ] ||
+          fail "go telemetry after 'local' output '$out'. expected 'on'"
+
+        go telemetry off ||
+          fail "explicit 'go telemetry off' exited $?"
+        out=$(go telemetry) || fail "'go telemetry' after explicit off exited $?"
+        [ "$out" = "off" ] ||
+          fail "go telemetry after explicit off output '$out'. expected 'off'"

--- a/go-1.23/change-default-telemetry-from-local-to-off.patch
+++ b/go-1.23/change-default-telemetry-from-local-to-off.patch
@@ -1,0 +1,48 @@
+From bccdae45d85882dc2fb2fafa80b8b2997f561fe3 Mon Sep 17 00:00:00 2001
+From: Scott Moser <smoser@brickies.net>
+Date: Wed, 13 Nov 2024 14:01:30 -0500
+Subject: [PATCH] Change default telemetry setting from 'local' to 'off'
+
+Go 1.23 introduced a telemetry feature that collects local audit data
+about the Go toolchain, storing it by default in
+$HOME/.config/go/telemetry. While this data is not sent externally by
+default, the local storage path can trigger security alerts in tools
+like Falco, as it writes to a sensitive location under /root.
+
+The behavior can be disabled with 'go telemetry off', which writes
+to the config file above, but that means the user needs to do so
+before calling 'go' in any other manner.  Doing so for a container
+is non-obvious.  We could build /root/.config/go/telemetry into
+a 'go' image, but that would still provide a problem for any user
+other than uid 0.
+
+There is no mechanism to change the behavior "system wide" or an
+environment variable that can set the value.
+
+See https://github.com/golang/go/issues/68960 and
+https://github.com/golang/go/issues/69113. The second one requests that
+env GOTELEMETRY=off would disable telemetry. That would be easy for us
+to utilize but it was rejected upstream.
+
+Instead, we just change the default value returned if there is no
+.config/go/telemetry/mode file present.
+---
+ src/cmd/vendor/golang.org/x/telemetry/internal/telemetry/dir.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cmd/vendor/golang.org/x/telemetry/internal/telemetry/dir.go b/src/cmd/vendor/golang.org/x/telemetry/internal/telemetry/dir.go
+index dd7a63c816..cc4d08f651 100644
+--- a/src/cmd/vendor/golang.org/x/telemetry/internal/telemetry/dir.go
++++ b/src/cmd/vendor/golang.org/x/telemetry/internal/telemetry/dir.go
+@@ -127,7 +127,7 @@ func (d Dir) Mode() (string, time.Time) {
+ 	}
+ 	data, err := os.ReadFile(d.modefile)
+ 	if err != nil {
+-		return "local", time.Time{} // default
++		return "off", time.Time{} // default
+ 	}
+ 	mode := string(data)
+ 	mode = strings.TrimSpace(mode)
+-- 
+2.43.0
+


### PR DESCRIPTION
This will set the default value for go telemetry to 'off' rather than 'local'.

Go 1.23 introduced a telemetry feature that collects local audit data about the Go toolchain, storing it by default in
$HOME/.config/go/telemetry. While this data is not sent externally by default, the local storage path can trigger security alerts in tools like Falco, as it writes to a sensitive location under /root.

The behavior can be disabled with 'go telemetry off', which writes to the config file above, but that means the user needs to do so before calling 'go' in any other manner.  Doing so for a container is non-obvious.  We could build /root/.config/go/telemetry into a 'go' image, but that would still provide a problem for any user other than uid 0.

There is no mechanism to change the behavior "system wide" or an environment variable that can set the value.

See https://github.com/golang/go/issues/68960 and
https://github.com/golang/go/issues/69113. The second one requests that env GOTELEMETRY=off would disable telemetry. That would be easy for us to utilize but it was rejected upstream.

Instead, we just change the default value returned if there is no .config/go/telemetry file present.