### PR TITLE
harbor-scanner-trivy: move to goharbor/harbor-scanner-trivy

### DIFF
--- a/harbor-scanner-trivy.yaml
+++ b/harbor-scanner-trivy.yaml
@@ -1,7 +1,7 @@
 package:
   name: harbor-scanner-trivy
-  version: 0.31.4
-  epoch: 1
+  version: 0.32.0
+  epoch: 0
   description: Use Trivy as a plug-in vulnerability scanner in the Harbor registry
   copyright:
     - license: Apache-2.0
@@ -13,8 +13,8 @@ package:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: d42c6b1f91f9ec87c789035f7583f684bcde0103
-      repository: https://github.com/aquasecurity/harbor-scanner-trivy
+      expected-commit: 1087bb66fb81116f972ae7a10a8a87f1e0267c86
+      repository: https://github.com/goharbor/harbor-scanner-trivy
       tag: v${{package.version}}
 
   - uses: go/build
@@ -32,6 +32,8 @@ test:
 
 update:
   enabled: true
+  ignore-regex-patterns:
+    - rc
   github:
-    identifier: aquasecurity/harbor-scanner-trivy
+    identifier: goharbor/harbor-scanner-trivy
     strip-prefix: v


### PR DESCRIPTION
upstream repo has stopped further development here https://github.com/aquasecurity/harbor-scanner-trivy
  and  refers  https://github.com/goharbor/harbor-scanner-trivy as the new destination   