### PR TITLE
ffmpeg: Enable VAAPI

### DIFF
--- a/ffmpeg-7.1.yaml
+++ b/ffmpeg-7.1.yaml
@@ -36,6 +36,7 @@ environment:
       - fontconfig-dev
       - harfbuzz-dev
       - lame-dev
+      - libdrm-dev
       - libogg-dev
       - libsdl2-dev
       - libsodium-dev
@@ -43,6 +44,7 @@ environment:
       - libssh-dev
       - libtheora
       - libtheora-dev
+      - libva-dev
       - libvorbis-dev
       - libwebp-dev
       - libxml2-dev
@@ -83,6 +85,7 @@ pipeline:
         --enable-libmp3lame \
         --enable-ffplay \
         --enable-libdav1d \
+        --enable-libdrm \
         --enable-libharfbuzz \
         --enable-libopus \
         --enable-libsnappy \
@@ -98,7 +101,8 @@ pipeline:
         --enable-libopenjpeg \
         --enable-libspeex \
         --enable-libsoxr \
-        --enable-libzmq
+        --enable-libzmq \
+        --enable-vaapi
 
   - uses: autoconf/make
 

--- a/ffmpeg-7.yaml
+++ b/ffmpeg-7.yaml
@@ -37,6 +37,7 @@ environment:
       - fontconfig-dev
       - harfbuzz-dev
       - lame-dev
+      - libdrm-dev
       - libogg-dev
       - libsdl2-dev
       - libsodium-dev
@@ -44,6 +45,7 @@ environment:
       - libssh-dev
       - libtheora
       - libtheora-dev
+      - libva-dev
       - libvorbis-dev
       - libwebp-dev
       - libxml2-dev
@@ -84,6 +86,7 @@ pipeline:
         --enable-libmp3lame \
         --enable-ffplay \
         --enable-libdav1d \
+        --enable-libdrm \
         --enable-libharfbuzz \
         --enable-libopus \
         --enable-libsnappy \
@@ -99,7 +102,8 @@ pipeline:
         --enable-libopenjpeg \
         --enable-libspeex \
         --enable-libsoxr \
-        --enable-libzmq
+        --enable-libzmq \
+        --enable-vaapi
 
   - uses: autoconf/make
 


### PR DESCRIPTION
Enables VAAPI and libdrm in ffmpeg for hardware acceleration support.

Actually using it requires appropriate drivers. I have personally built packages for Intel drivers based on the alpine packages that I can PR as well if that is desired and within scope.