### PR TITLE
Workaround GCC issue to fix FTBFS with abseil-cpp and reverse deps

### DIFF
--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: abseil-cpp
   version: "20240722.0"
-  epoch: 0
+  epoch: 1
   description: Abseil Common Libraries (C++)
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,16 @@ pipeline:
       expected-commit: 4447c7562e3bc702ade25105912dce503f0c4010
 
   - runs: |
+      mkdir -p "${{targets.destdir}}"
+      # https://github.com/wolfi-dev/os/issues/34075
+      cp -r usr "${{targets.destdir}}"
+
+  - environment:
+      CMAKE_CXX_FLAGS: "-B ${{targets.destdir}}/usr/lib/gcc -specs abseil-cpp.spec"
+    runs: |
+      # https://github.com/wolfi-dev/os/issues/34075
       cmake -B build -G Ninja \
+      -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
       -DCMAKE_CXX_STANDARD=17 \
       -DCMAKE_BUILD_TYPE=MinSizeRel \
       -DCMAKE_INSTALL_PREFIX=/usr \
@@ -164,6 +173,10 @@ subpackages:
   - name: abseil-cpp-dev
     pipeline:
       - uses: split/dev
+      - name: "Install GCC spec files for https://github.com/wolfi-dev/os/issues/34075"
+        runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/gcc ${{targets.subpkgdir}}/usr/lib
     dependencies:
       runtime:
         - abseil-cpp

--- a/abseil-cpp/usr/lib/gcc/aarch64-unknown-linux-gnu/12/abseil-cpp.spec
+++ b/abseil-cpp/usr/lib/gcc/aarch64-unknown-linux-gnu/12/abseil-cpp.spec
@@ -1,0 +1,3 @@
+# https://github.com/wolfi-dev/os/issues/34075
+*self_spec:
+%<fno-delete-null-pointer-checks

--- a/abseil-cpp/usr/lib/gcc/aarch64-unknown-linux-gnu/13/abseil-cpp.spec
+++ b/abseil-cpp/usr/lib/gcc/aarch64-unknown-linux-gnu/13/abseil-cpp.spec
@@ -1,0 +1,3 @@
+# https://github.com/wolfi-dev/os/issues/34075
+*self_spec:
+%<fno-delete-null-pointer-checks

--- a/abseil-cpp/usr/lib/gcc/aarch64-unknown-linux-gnu/14/abseil-cpp.spec
+++ b/abseil-cpp/usr/lib/gcc/aarch64-unknown-linux-gnu/14/abseil-cpp.spec
@@ -1,0 +1,3 @@
+# https://github.com/wolfi-dev/os/issues/34075
+*self_spec:
+%<fno-delete-null-pointer-checks

--- a/abseil-cpp/usr/lib/gcc/x86_64-pc-linux-gnu/12/abseil-cpp.spec
+++ b/abseil-cpp/usr/lib/gcc/x86_64-pc-linux-gnu/12/abseil-cpp.spec
@@ -1,0 +1,3 @@
+# https://github.com/wolfi-dev/os/issues/34075
+*self_spec:
+%<fno-delete-null-pointer-checks

--- a/abseil-cpp/usr/lib/gcc/x86_64-pc-linux-gnu/13/abseil-cpp.spec
+++ b/abseil-cpp/usr/lib/gcc/x86_64-pc-linux-gnu/13/abseil-cpp.spec
@@ -1,0 +1,3 @@
+# https://github.com/wolfi-dev/os/issues/34075
+*self_spec:
+%<fno-delete-null-pointer-checks

--- a/abseil-cpp/usr/lib/gcc/x86_64-pc-linux-gnu/14/abseil-cpp.spec
+++ b/abseil-cpp/usr/lib/gcc/x86_64-pc-linux-gnu/14/abseil-cpp.spec
@@ -1,0 +1,3 @@
+# https://github.com/wolfi-dev/os/issues/34075
+*self_spec:
+%<fno-delete-null-pointer-checks

--- a/grpc-1.66.yaml
+++ b/grpc-1.66.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.66
   version: 1.66.2
-  epoch: 0
+  epoch: 1
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -63,11 +63,15 @@ pipeline:
       cd third_party
       git submodule update --init --recursive
 
-  - runs: |
+  - environment:
+      # https://github.com/wolfi-dev/os/issues/34075
+      CMAKE_CXX_FLAGS: "-specs abseil-cpp.spec"
+    runs: |
       mkdir -p "${{targets.destdir}}"/usr/share/doc/grpc
       cmake -B _build -G Ninja \
       	-DCMAKE_BUILD_TYPE=None \
       	-DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
       	-DCMAKE_CXX_STANDARD=17 \
       	-DBUILD_SHARED_LIBS=True \
       	-DgRPC_INSTALL=ON \
@@ -82,7 +86,7 @@ pipeline:
       	-DgRPC_BUILD_TESTS=OFF
       cmake --build _build
 
-      GRPC_PYTHON_CFLAGS="-std=c++17" \
+      GRPC_PYTHON_CFLAGS="-std=c++17 -specs abseil-cpp.spec" \
       GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY=1 \
       GRPC_PYTHON_BUILD_SYSTEM_CARES=1 \
       GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -53,6 +53,7 @@ environment:
       - protobuf-dev
       - py3-supported-build-base
       - py3-supported-python-dev
+      - python3
       - re2
       - re2-dev
       - samurai

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -28,6 +28,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -144,6 +145,7 @@ subpackages:
         - py3.10-grpcio-${{vars.major-minor-version}}
         - py3.11-grpcio-${{vars.major-minor-version}}
         - py3.12-grpcio-${{vars.major-minor-version}}
+        - py3.13-grpcio-${{vars.major-minor-version}}
 
   - name: ${{package.name}}-dev
     pipeline:

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -73,11 +73,15 @@ pipeline:
       cd third_party
       git submodule update --init --recursive
 
-  - runs: |
+  - environment:
+      # https://github.com/wolfi-dev/os/issues/34075
+      CMAKE_CXX_FLAGS: "-specs abseil-cpp.spec"
+    runs: |
       mkdir -p "${{targets.destdir}}"/usr/share/doc/grpc
       cmake -B _build -G Ninja \
       	-DCMAKE_BUILD_TYPE=None \
       	-DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
       	-DCMAKE_CXX_STANDARD=17 \
       	-DBUILD_SHARED_LIBS=True \
       	-DgRPC_INSTALL=ON \
@@ -114,7 +118,7 @@ subpackages:
     pipeline:
       - uses: py/pip-build-install
         environment:
-          GRPC_PYTHON_CFLAGS: "-std=c++17"
+          GRPC_PYTHON_CFLAGS: "-std=c++17 -specs abseil-cpp.spec"
           GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY: "1"
           GRPC_PYTHON_BUILD_SYSTEM_CARES: "1"
           GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -43,7 +43,6 @@ environment:
       - chrpath
       - cmake
       - curl
-      - cython~0
       - icu-dev
       - libstdc++-dev
       - libsystemd
@@ -52,6 +51,7 @@ environment:
       - openssl-dev
       - protobuf-dev
       - py3-supported-build-base
+      - py3-supported-cython
       - py3-supported-python-dev
       - python3
       - re2

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.67
   version: 1.67.1
-  epoch: 0
+  epoch: 1
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/libreoffice-24.8.yaml
+++ b/libreoffice-24.8.yaml
@@ -1,6 +1,6 @@
 package:
   name: libreoffice-24.8
-  version: 24.8.3.1
+  version: 24.8.3.2
   epoch: 0
   description:
   # https://www.libreoffice.org/about-us/licenses
@@ -99,7 +99,7 @@ pipeline:
     with:
       repository: https://github.com/LibreOffice/core
       tag: libreoffice-${{package.version}}
-      expected-commit: 65412f067af443213e726c93f137ccc85c9a1e06
+      expected-commit: 48a6bac9e7e268aeb4c3483fcf825c94556d9f92
 
   # patch rather than cherry-pick. The git fetch of main takes multiple minutes.
   - uses: patch

--- a/libreoffice-24.8.yaml
+++ b/libreoffice-24.8.yaml
@@ -1,7 +1,7 @@
 package:
   name: libreoffice-24.8
   version: 24.8.3.1
-  epoch: 0
+  epoch: 1
   description:
   # https://www.libreoffice.org/about-us/licenses
   copyright:
@@ -92,6 +92,8 @@ environment:
       - python-${{vars.python-version}}-dev
       - zip
   environment:
+    # https://github.com/wolfi-dev/os/issues/34075
+    CXXFLAGS: -specs abseil-cpp.spec
     JAVA_HOME: ${{vars.java-home}}
 
 pipeline:

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-22
   version: 22.11.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -43,6 +43,8 @@ pipeline:
     runs: |
       # Add defines recommended in libuv readme.
       common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+      # https://github.com/wolfi-dev/os/issues/34075
+      common_flags="-specs abseil-cpp.spec $common_flags"
 
       # Compiling with O2 instead of Os increases binary size by ~10%
       # (53.1 MiB -> 58.6 MiB), but also increases performance by ~20%

--- a/nodejs-23.yaml
+++ b/nodejs-23.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-23
   version: 23.1.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -43,6 +43,8 @@ pipeline:
     runs: |
       # Add defines recommended in libuv readme.
       common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+      # https://github.com/wolfi-dev/os/issues/34075
+      common_flags="-specs abseil-cpp.spec $common_flags"
 
       # Compiling with O2 instead of Os increases binary size by ~10%
       # (53.1 MiB -> 58.6 MiB), but also increases performance by ~20%

--- a/nodejs-23.yaml
+++ b/nodejs-23.yaml
@@ -1,6 +1,6 @@
 package:
   name: nodejs-23
-  version: 23.1.0
+  version: 23.2.0
   epoch: 0
   description: "JavaScript runtime built on V8 engine"
   dependencies:
@@ -37,7 +37,7 @@ pipeline:
     with:
       repository: https://github.com/nodejs/node.git
       tag: v${{package.version}}
-      expected-commit: 17fae65c72321659390c4cbcd9ddaf248accb953
+      expected-commit: a83fbdbde16b7decf5ec41277917abe267746661
 
   - name: Configure and build
     runs: |

--- a/protobuf-c.yaml
+++ b/protobuf-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf-c
   version: 1.5.0
-  epoch: 9
+  epoch: 10
   description: Protocol Buffers implementation in C
   copyright:
     - license: BSD-2-Clause
@@ -17,6 +17,9 @@ environment:
       - ca-certificates-bundle
       - libtool
       - protobuf-dev
+  environment:
+    # https://github.com/wolfi-dev/os/issues/34075
+    CXXFLAGS: "-specs abseil-cpp.spec"
 
 pipeline:
   - uses: git-checkout

--- a/protobuf.yaml
+++ b/protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf
-  version: 3.27.4
-  epoch: 1
+  version: 3.28.3
+  epoch: 0
   description: Library for extensible, efficient structure packing
   copyright:
     - license: BSD-3-Clause
@@ -34,7 +34,7 @@ pipeline:
     with:
       repository: https://github.com/protocolbuffers/protobuf
       tag: v${{package.version}}
-      expected-commit: 80d48ae92d3007caac5eab0a8f8ee4e57f3a921e
+      expected-commit: 5fda5abda3dee5f7a102c85860594bff8d8610bd
 
   - runs: |
       cd third_party

--- a/protobuf.yaml
+++ b/protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf
   version: 3.27.4
-  epoch: 1
+  epoch: 2
   description: Library for extensible, efficient structure packing
   copyright:
     - license: BSD-3-Clause
@@ -40,8 +40,13 @@ pipeline:
       cd third_party
       git submodule update --init --recursive
 
-  - runs: |
+  - environment:
+      # https://github.com/wolfi-dev/os/issues/34075
+      CMAKE_CXX_FLAGS: "-specs abseil-cpp.spec"
+
+    runs: |
       cmake -B build -G Ninja \
+        -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DBUILD_SHARED_LIBS=True \

--- a/re2.yaml
+++ b/re2.yaml
@@ -1,7 +1,7 @@
 package:
   name: re2
   version: "2024.02.01"
-  epoch: 2
+  epoch: 3
   description: Efficient, principled regular expression library
   copyright:
     - license: BSD-3-Clause
@@ -22,6 +22,9 @@ environment:
       - busybox
       - ca-certificates-bundle
       - icu-dev
+  environment:
+    # https://github.com/wolfi-dev/os/issues/34075
+    CXXFLAGS: "-specs abseil-cpp.spec"
 
 pipeline:
   - uses: fetch


### PR DESCRIPTION
Related: #34075 https://github.com/chainguard-dev/internal-dev/issues/5334

This is part of the `py3.13-google-cloud-spanner` dependency chain.