### PR TITLE
py3-google-cloud-spanner: Add python multiversion and 3.13 support

### DIFF
--- a/py3-google-api-core.yaml
+++ b/py3-google-api-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-api-core
   version: 2.23.0
-  epoch: 0
+  epoch: 1
   description: Google API client core library
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -65,6 +66,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:

--- a/py3-google-cloud-core.yaml
+++ b/py3-google-cloud-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-cloud-core
   version: 2.4.1
-  epoch: 3
+  epoch: 4
   description: Google Cloud API client core library
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -62,6 +63,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:

--- a/py3-google-cloud-spanner.yaml
+++ b/py3-google-cloud-spanner.yaml
@@ -1,7 +1,7 @@
 # Generated from https://pypi.org/project/google-cloud-spanner/
 package:
   name: py3-google-cloud-spanner
-  version: 3.50.0
+  version: 3.50.1
   epoch: 0
   description: Google Cloud Spanner API client library
   copyright:
@@ -29,7 +29,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 1f4c9c8c4ee1509c37852f62c2589172bdd7f112
+      expected-commit: 3079bdd59cc87f01b20d90c15cbdaf42285a41f8
       repository: https://github.com/googleapis/python-spanner
       tag: v${{package.version}}
 

--- a/py3-google-cloud-spanner.yaml
+++ b/py3-google-cloud-spanner.yaml
@@ -1,4 +1,3 @@
-# Generated from https://pypi.org/project/google-cloud-spanner/
 package:
   name: py3-google-cloud-spanner
   version: 3.50.1
@@ -7,24 +6,24 @@ package:
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - py3-google-api-core
-      - py3-google-cloud-core
-      - py3-grpc-google-iam-v1
-      - py3-proto-plus
-      - py3-sqlparse
-      - py3-protobuf
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: google-cloud-spanner
+  import: google.cloud.spanner
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -33,10 +32,52 @@ pipeline:
       repository: https://github.com/googleapis/python-spanner
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
-
   - uses: strip
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-google-api-core
+        - py${{range.key}}-google-cloud-core
+        - py${{range.key}}-grpc-google-iam-v1
+        - py${{range.key}}-grpc-interceptor
+        - py${{range.key}}-proto-plus
+        - py${{range.key}}-sqlparse
+        - py${{range.key}}-protobuf
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-grpc-google-iam-v1.yaml
+++ b/py3-grpc-google-iam-v1.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-grpc-google-iam-v1
   version: 0.13.1
-  epoch: 2
+  epoch: 3
   description: IAM API client library
   copyright:
     - license: Apache-2.0
@@ -18,6 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -63,6 +64,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:

--- a/py3-grpc-interceptor.yaml
+++ b/py3-grpc-interceptor.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-grpc-interceptor
   version: 0.15.4
-  epoch: 0
+  epoch: 1
   description: Simplifies gRPC interceptors
   copyright:
     - license: MIT
@@ -15,6 +15,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
+      "3.13": "300"
 
 vars:
   import: grpc_interceptor
@@ -62,6 +63,7 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   pipeline:


### PR DESCRIPTION
Related: https://github.com/chainguard-dev/internal-dev/issues/5334