### PR TITLE
thingsboard/GHSA-wm9w-rjj3-j356 fix

### DIFF
--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: thingsboard
   version: 3.8.1
-  epoch: 1
+  epoch: 2
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0
@@ -68,7 +68,8 @@ subpackages:
             "moment": "^2.29.4",
             "tough-cookie": "^4.1.3",
             "xml2js": "^0.5.0",
-            "cookie": "^0.7.0"
+            "cookie": "^0.7.0",
+            "tomcat-embed-core.version": "10.1.25"
           }'
           jq --argjson resolutions "$resolutions" '.resolutions += $resolutions' package.json > temp.json && mv temp.json package.json
           jq '.dependencies.express = "^4.19.2"' package.json > temp.json && mv temp.json package.json
@@ -169,7 +170,8 @@ subpackages:
             "json5": "^2.2.2",
             "moment": "^2.29.4",
             "tinymce": "^7.0.0",
-            "cookie": "^0.7.0"
+            "cookie": "^0.7.0",
+            "tomcat-embed-core": "10.1.25"
           }'
           jq --argjson resolutions "$resolutions" '.resolutions += $resolutions' package.json > temp.json && mv temp.json package.json
           jq '.dependencies.express = "^4.19.2"' package.json > temp.json && mv temp.json package.json

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -23,3 +23,6 @@ patches:
   - groupId: org.springframework
     artifactId: spring-context
     version: 6.1.14
+  - groupId: org.apache.tomcat.embed
+    artifactId: tomcat-embed-core
+    version: 10.1.25

--- a/thingsboard/pombump-properties.yaml
+++ b/thingsboard/pombump-properties.yaml
@@ -1,0 +1,4 @@
+properties:
+  - property: tomcat-embed-core.version
+    value: "10.1.25"
+


### PR DESCRIPTION
Attempting to reintroduce the version bump for tomcat-embed-core after it was removed due to incompatibility issues [found in this PR](https://github.com/wolfi-dev/os/pull/33688)