### PR TITLE
refactor(kubernetes): remove setcap

### DIFF
--- a/kubernetes-1.31.yaml
+++ b/kubernetes-1.31.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-1.31
   version: 1.31.2
-  epoch: 1
+  epoch: 2
   description: Production-Grade Container Scheduling and Management
   copyright:
     - license: Apache-2.0
@@ -61,11 +61,6 @@ pipeline:
       done
 
       make WHAT="$WHAT"
-
-  - runs: |
-      # We apply cap_net_bind_service so that kube-apiserver can be run as
-      # non-root and still listen on port less than 1024
-      setcap cap_net_bind_service=+ep _output/bin/kube-apiserver
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin/


### PR DESCRIPTION
Removing setcap as this prevents the build from working in bubblewrap as non-root.

The `kube-apiserver` is running as uid 0 and setcap should not be needed.