### PR TITLE
fix(py3-conda-libmamba-solver): Cherrypick upstream commits to add support for libmamba 2.0

### DIFF
--- a/py3-conda-libmamba-solver.yaml
+++ b/py3-conda-libmamba-solver.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-conda-libmamba-solver
   version: 24.9.0
-  epoch: 0
+  epoch: 1
   description: The libmamba based solver for conda.
   copyright:
     - license: BSD-3-Clause
@@ -32,6 +32,10 @@ pipeline:
       repository: https://github.com/conda/conda-libmamba-solver
       tag: ${{package.version}}
       expected-commit: bbaab52122674e0991e1bd14bdfc114a33f70975
+      cherry-picks: |
+        24.11.0rc/1b491d911e97bfb5ef7695b2b1376e1bebe08974: mamba version 2 support refactor prerequisite
+        24.11.0rc/fa9f2ccb3cbc4d50b0d7db4eeb10946549c291d4: mamba version 2 support refactor prerequisite
+        24.11.0rc/cbc9f1f80400e6fe68ae08937ae949191b9cd2d5: mamba version 2 support refactor
 
   - name: Python Build
     runs: python -m build


### PR DESCRIPTION
We have already released packages updates to libmamba and subpackages which is a major version jump from 1.5 to 2.0.

This caused failures in the conda packages and images due to py3-conda-libmamba-solver not yet supporting libmamba 2.0.

There is not yet an upstream release of conda-libmamba-solver with mamba 2.0 support but there is a release candidate
branch @ https://github.com/conda/conda-libmamba-solver/tree/24.11.0rc awaiting release.

We have broken dependent packages so we cannot wait for upstream to release.

As such I have cherrypicked the relevant 2.0 support commits from the 24.11.0rc branch.

This resolves the issues seen with conda and libmamba.

Full diff for conda-libmamba-solver @  https://github.com/conda/conda-libmamba-solver/compare/24.9.0...24.11.0rc

https://github.com/mamba-org/mamba/issues/3506 was the most helpful in finding the work to support libmamba 2.0
Signed-off-by: philroche <phil.roche@chainguard.dev>

