### PR TITLE
abseil-cpp: Add GCC spec file to workaround GCC bug

### DIFF
--- a/abseil-cpp.yaml
+++ b/abseil-cpp.yaml
@@ -1,7 +1,7 @@
 package:
   name: abseil-cpp
   version: "20240722.0"
-  epoch: 0
+  epoch: 1
   description: Abseil Common Libraries (C++)
   copyright:
     - license: Apache-2.0
@@ -26,7 +26,15 @@ pipeline:
       expected-commit: 4447c7562e3bc702ade25105912dce503f0c4010
 
   - runs: |
+      mkdir -p "${{targets.destdir}}"
+      # https://github.com/wolfi-dev/os/issues/34075
+      cp -r usr "${{targets.destdir}}"
+
+  - runs: |
+      # https://github.com/wolfi-dev/os/issues/34075
+      CMAKE_CXX_FLAGS="-B ${{targets.destdir}}/usr/lib/gcc -specs abseil-cpp.spec"
       cmake -B build -G Ninja \
+      -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
       -DCMAKE_CXX_STANDARD=17 \
       -DCMAKE_BUILD_TYPE=MinSizeRel \
       -DCMAKE_INSTALL_PREFIX=/usr \
@@ -164,6 +172,10 @@ subpackages:
   - name: abseil-cpp-dev
     pipeline:
       - uses: split/dev
+      - name: "Install GCC spec files for https://github.com/wolfi-dev/os/issues/34075"
+        runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/gcc ${{targets.subpkgdir}}/usr/lib
     dependencies:
       runtime:
         - abseil-cpp

--- a/abseil-cpp/usr/lib/gcc/aarch64-unknown-linux-gnu/12/abseil-cpp.spec
+++ b/abseil-cpp/usr/lib/gcc/aarch64-unknown-linux-gnu/12/abseil-cpp.spec
@@ -1,0 +1,3 @@
+# https://github.com/wolfi-dev/os/issues/34075
+*self_spec:
+%<fno-delete-null-pointer-checks

--- a/abseil-cpp/usr/lib/gcc/aarch64-unknown-linux-gnu/13/abseil-cpp.spec
+++ b/abseil-cpp/usr/lib/gcc/aarch64-unknown-linux-gnu/13/abseil-cpp.spec
@@ -1,0 +1,3 @@
+# https://github.com/wolfi-dev/os/issues/34075
+*self_spec:
+%<fno-delete-null-pointer-checks

--- a/abseil-cpp/usr/lib/gcc/aarch64-unknown-linux-gnu/14/abseil-cpp.spec
+++ b/abseil-cpp/usr/lib/gcc/aarch64-unknown-linux-gnu/14/abseil-cpp.spec
@@ -1,0 +1,3 @@
+# https://github.com/wolfi-dev/os/issues/34075
+*self_spec:
+%<fno-delete-null-pointer-checks

--- a/abseil-cpp/usr/lib/gcc/x86_64-pc-linux-gnu/12/abseil-cpp.spec
+++ b/abseil-cpp/usr/lib/gcc/x86_64-pc-linux-gnu/12/abseil-cpp.spec
@@ -1,0 +1,3 @@
+# https://github.com/wolfi-dev/os/issues/34075
+*self_spec:
+%<fno-delete-null-pointer-checks

--- a/abseil-cpp/usr/lib/gcc/x86_64-pc-linux-gnu/13/abseil-cpp.spec
+++ b/abseil-cpp/usr/lib/gcc/x86_64-pc-linux-gnu/13/abseil-cpp.spec
@@ -1,0 +1,3 @@
+# https://github.com/wolfi-dev/os/issues/34075
+*self_spec:
+%<fno-delete-null-pointer-checks

--- a/abseil-cpp/usr/lib/gcc/x86_64-pc-linux-gnu/14/abseil-cpp.spec
+++ b/abseil-cpp/usr/lib/gcc/x86_64-pc-linux-gnu/14/abseil-cpp.spec
@@ -1,0 +1,3 @@
+# https://github.com/wolfi-dev/os/issues/34075
+*self_spec:
+%<fno-delete-null-pointer-checks


### PR DESCRIPTION
Cherry-picked just the `abseil-cpp` bit of https://github.com/wolfi-dev/os/pull/34201 into this PR to debug the hanging CI.