### PR TITLE
php-8.3 - make changes for version-stream.

### DIFF
--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: 8.3.13
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01
@@ -11,6 +11,12 @@ package:
     runtime:
       - ${{package.name}}-config
       - libxml2
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^php-(\d\.\d+)
+    replace: $1
+    to: phpMM
 
 environment:
   contents:
@@ -230,7 +236,7 @@ subpackages:
           echo "${prefix}extension=${{range.key}}.so" > $CONF_DIR/"$((order+order*deps))-${{range.key}}.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP 8.3 development headers
+    description: PHP ${{vars.phpMM}} development headers
     dependencies:
       provides:
         - php-dev=${{package.full-version}}
@@ -242,7 +248,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/lib ${{targets.subpkgdir}}/usr
 
   - name: ${{package.name}}-doc
-    description: PHP 8.3 documentation
+    description: PHP ${{vars.phpMM}} documentation
     dependencies:
       provides:
         - php-doc=${{package.full-version}}
@@ -250,7 +256,7 @@ subpackages:
       - uses: split/manpages
 
   - name: "${{package.name}}-cgi"
-    description: PHP 8.3 CGI
+    description: PHP ${{vars.phpMM}} CGI
     dependencies:
       provides:
         - php-cgi=${{package.full-version}}
@@ -270,7 +276,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/bin/phpdbg ${{targets.subpkgdir}}/usr/bin/
 
   - name: "${{package.name}}-fpm"
-    description: PHP 8.3 FastCGI Process Manager (FPM)
+    description: PHP ${{vars.phpMM}} FastCGI Process Manager (FPM)
     dependencies:
       runtime:
         - "${{package.name}}-fpm-config"
@@ -282,7 +288,7 @@ subpackages:
           mv ${{targets.destdir}}/usr/sbin/php-fpm ${{targets.subpkgdir}}/usr/sbin/
 
   - name: ${{package.name}}-fpm-config
-    description: PHP 8.3 FastCGI Process Manager (FPM) configuration
+    description: PHP ${{vars.phpMM}} FastCGI Process Manager (FPM) configuration
     dependencies:
       provides:
         - php-fpm-config=${{package.full-version}}


### PR DESCRIPTION
8.4 should be released next week.  This replaces 8.3 in this file with a variable based on package name.

The descriptions are the only places where this change is necessary the prefix on the tag-filter would be updated by version-stream.
