### PR TITLE
ruby-3.2: Build modules

### DIFF
--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: 3.2.6
-  epoch: 0
+  epoch: 1
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -21,13 +21,18 @@ environment:
       - ca-certificates-bundle
       - expat-dev
       - gdbm-dev
+      - glibc-dev
+      - gmp-dev
+      - gperf
       - libffi-dev
+      - libxcrypt-dev
       - linux-headers
       - mpdecimal-dev
       - ncurses-dev
       - oniguruma-dev
       - openssf-compiler-options
       - openssl-dev
+      - pkgconf
       - readline-dev
       - ruby-3.1
       - rust
@@ -52,6 +57,10 @@ pipeline:
       tag: v${{vars.underscore-package-version}}
       expected-commit: 63aeb018eb1cc0f7b00f955980711fd1bd94af7f
 
+  - uses: patch
+    with:
+      patches: 0001-change-bundled-gems.patch
+
   - name: Generate and Configure
     runs: |
       ./autogen.sh
@@ -60,24 +69,25 @@ pipeline:
          --build=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
          --prefix=${{vars.prefix}} \
-         --enable-ipv6 \
-         --enable-loadable-sqlite-extensions \
-         --enable-optimizations \
          --enable-shared \
-         --without-lto \
-         --with-computed-gotos \
-         --with-dbmliborder=gdbm:ndbm \
-         --with-system-expat \
-         --with-system-ffi \
-         --with-system-libmpdec \
-         --without-ensurepip \
+         --disable-rpath \
+         --sysconfdir=/etc \
+         --enable-mkmf-verbose \
          --enable-yjit
 
   - uses: autoconf/make
 
-  - uses: autoconf/make-install
+  # Update and Extract bundled gems
+  - uses: autoconf/make
+    with:
+      opts: update-gems extract-gems
 
-  - uses: strip
+  # Build documentation
+  - uses: autoconf/make
+    with:
+      opts: rdoc capi
+
+  - uses: autoconf/make-install
 
   - runs: |
       # Ignore the patch version of ruby since ruby will install under the
@@ -86,14 +96,17 @@ pipeline:
 
       RUBYDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/$RUBYWILD
       rm -rf ${RUBYDIR}/bundler
-      rm ${RUBYDIR}/bundler.rb
+      rm -f ${RUBYDIR}/bundler.rb
 
       GEMDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/gems/$RUBYWILD
       rm -rf ${GEMDIR}/gems/bundler-*
-      rm ${GEMDIR}/specifications/default/bundler-*.gemspec
+      rm -f ${GEMDIR}/specifications/default/bundler-*.gemspec
 
-      rm ${{targets.destdir}}/usr/bin/bundle \
+      rm -f ${{targets.destdir}}/usr/bin/bundle \
          ${{targets.destdir}}/usr/bin/bundler
+
+  - runs: |
+      find ${{targets.destdir}} -name 'mkmf.log' -exec rm {} \;
 
 subpackages:
   - name: "ruby-3.2-doc"

--- a/ruby-3.2/0001-change-bundled-gems.patch
+++ b/ruby-3.2/0001-change-bundled-gems.patch
@@ -1,0 +1,15 @@
+diff --git a/gems/bundled_gems b/gems/bundled_gems
+index c48acb50d8..c667b4ca14 100644
+--- a/gems/bundled_gems
++++ b/gems/bundled_gems
+@@ -3,10 +3,8 @@ minitest        5.16.3  https://github.com/seattlerb/minitest
+ power_assert    2.0.3   https://github.com/ruby/power_assert
+ rake            13.0.6  https://github.com/ruby/rake
+ test-unit       3.5.7   https://github.com/test-unit/test-unit
+-rexml           3.3.9   https://github.com/ruby/rexml
+ rss             0.3.1   https://github.com/ruby/rss
+ net-ftp         0.2.1   https://github.com/ruby/net-ftp
+-net-imap        0.3.4.1   https://github.com/ruby/net-imap
+ net-pop         0.1.2   https://github.com/ruby/net-pop
+ net-smtp        0.3.4   https://github.com/ruby/net-smtp
+ matrix          0.4.2   https://github.com/ruby/matrix


### PR DESCRIPTION
Just like ruby-3.3 we didn't actually build the ruby extensions. Now we do. We also removed the modules we already have separate packages for.
