### PR TITLE
py3-sphinx-7 - multi-version

### DIFF
--- a/py3-sphinx-7.yaml
+++ b/py3-sphinx-7.yaml
@@ -1,41 +1,31 @@
 package:
   name: py3-sphinx-7
   version: 7.4.7
-  epoch: 1
-  description: "Python Documentation Generator"
+  epoch: 2
+  description: Python Documentation Generator
   copyright:
     - license: MIT
   dependencies:
-    provides:
-      - py3-sphinx=${{package.full-version}}
-    runtime:
-      - py3-alabaster
-      - py3-babel
-      - py3-docutils
-      - py3-imagesize
-      - py3-jinja2
-      - py3-packaging
-      - py3-pygments
-      - py3-requests
-      - py3-snowballstemmer
-      - py3-sphinxcontrib-applehelp
-      - py3-sphinxcontrib-devhelp
-      - py3-sphinxcontrib-htmlhelp
-      - py3-sphinxcontrib-jsmath
-      - py3-sphinxcontrib-qthelp
-      - py3-sphinxcontrib-serializinghtml
+    provider-priority: 0
+
+vars:
+  pypi-package: sphinx-7
+  import: sphinx
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-flit-core
-      - py3-gpep517
-      - py3-installer
-      - python3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-flit-core
+      - py3-supported-gpep517
 
 pipeline:
   - uses: git-checkout
@@ -44,15 +34,86 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 0d912c85fd3ec385432fe707f6a0678425d1e841
 
-  - runs: |
-      mkdir -p dist
-      backend="$(python3 -m gpep517 get-backend)"
-      python3 -m gpep517 build-wheel --wheel-dir dist --backend "$backend" --output-fd 1
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      runtime:
+        - py${{range.key}}-alabaster
+        - py${{range.key}}-babel
+        - py${{range.key}}-docutils
+        - py${{range.key}}-imagesize
+        - py${{range.key}}-jinja2
+        - py${{range.key}}-packaging
+        - py${{range.key}}-pygments
+        - py${{range.key}}-requests
+        - py${{range.key}}-snowballstemmer
+        - py${{range.key}}-sphinxcontrib-applehelp
+        - py${{range.key}}-sphinxcontrib-devhelp
+        - py${{range.key}}-sphinxcontrib-htmlhelp
+        - py${{range.key}}-sphinxcontrib-jsmath
+        - py${{range.key}}-sphinxcontrib-qthelp
+        - py${{range.key}}-sphinxcontrib-serializinghtml
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - runs: |
-      python3 -m installer -d "${{targets.destdir}}" dist/sphinx-*.whl
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      pipeline:
+        - runs: |
+            sphinx-build --version
+            sphinx-build --help
+            sphinx-apidoc --version
+            sphinx-apidoc --help
+            sphinx-autogen --version
+            sphinx-autogen --help
+            sphinx-quickstart --version
+            sphinx-quickstart --help
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true
@@ -61,18 +122,3 @@ update:
     use-tag: true
     strip-prefix: v
     tag-filter: v7.4.
-
-test:
-  pipeline:
-    - uses: python/import
-      with:
-        import: sphinx
-      runs: |
-        sphinx-build --version
-        sphinx-build --help
-        sphinx-apidoc --version
-        sphinx-apidoc --help
-        sphinx-autogen --version
-        sphinx-autogen --help
-        sphinx-quickstart --version
-        sphinx-quickstart --help


### PR DESCRIPTION
This isn't really needed anywhere now, but multi-versioned for consistency.  We should look to drop it.
