### PR TITLE
linux-headers: upgrade

### DIFF
--- a/linux-headers.yaml
+++ b/linux-headers.yaml
@@ -1,7 +1,7 @@
 package:
   name: linux-headers
-  version: 6.6.29
-  epoch: 1
+  version: 6.6.62
+  epoch: 0
   description: "the Linux kernel headers (cross compilation)"
   copyright:
     - license: GPL-2.0-only WITH Linux-syscall-note
@@ -20,7 +20,7 @@ pipeline:
     with:
       repository: https://github.com/gregkh/linux
       tag: v${{package.version}}
-      expected-commit: a3463f08104612fc979c41fa54733e925205d3d7
+      expected-commit: c1036e4f14d03aba549cdd9b186148d331013056
 
   - runs: |
       make mrproper
@@ -36,7 +36,6 @@ pipeline:
 
 update:
   enabled: true
-  manual: true # be careful upgrading this package
   github:
     identifier: gregkh/linux
     strip-prefix: v


### PR DESCRIPTION
linux-headers guarantees backwards compatibility, and has very strong
forwards compatibility too. Because that is the UAPI ABI/API guarantee
by the kernel.

And especially in point releases, changes are very minor. Upgrade to
latest point release, and remove manual update stanza. Still point to
longterm version stream.
