### PR TITLE
argo-cd-2.13/GHSA-m5vv-6r4h-3vj9 fix

### DIFF
--- a/argo-cd-2.13.yaml
+++ b/argo-cd-2.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-cd-2.13
   version: 2.13.0
-  epoch: 0
+  epoch: 1
   description: Declarative continuous deployment for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -26,9 +26,13 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 347f221adba5599ef4d5f12ee572b2c17d01db4d
 
+  - uses: patch
+    with:
+      patches: GHSA-m5vv-6r4h-3vj9.patch
+
   - uses: go/bump
     with:
-      deps: github.com/golang-jwt/jwt/v4@v4.5.1
+      deps: github.com/golang-jwt/jwt/v4@v4.5.1 github.com/Azure/azure-sdk-for-go/sdk/azcore@v1.12.0 github.com/Azure/azure-sdk-for-go/sdk/azidentity@v1.6.0 github.com/Azure/azure-sdk-for-go/sdk/internal@v1.9.0 github.com/AzureAD/microsoft-authentication-library-for-go@v1.2.2 github.com/pkg/browser@v0.0.0-20240102092130-5ac0b6a4141c
 
   - runs: |
       cd ui

--- a/argo-cd-2.13/GHSA-m5vv-6r4h-3vj9.patch
+++ b/argo-cd-2.13/GHSA-m5vv-6r4h-3vj9.patch
@@ -1,0 +1,113 @@
+From 4776e486a39dfa075f7f0d2d22ebea461b731d17 Mon Sep 17 00:00:00 2001
+From: Jason Hall <jason@chainguard.dev>
+Date: Fri, 8 Nov 2024 10:34:52 -0500
+Subject: [PATCH] chore: update azure/kubelogin to address CVE (#20578)
+
+* update azure/kubelogin to address CVE
+
+Signed-off-by: Jason Hall <jason@chainguard.dev>
+
+* actually emit token
+
+Signed-off-by: Jason Hall <jason@chainguard.dev>
+
+* update deps, go mod tidy
+
+Signed-off-by: Jason Hall <jason@chainguard.dev>
+
+* fix go.sum
+
+Signed-off-by: Jason Hall <jason@chainguard.dev>
+
+* bcho's suggestion
+
+Signed-off-by: Jason Hall <jason@chainguard.dev>
+
+---------
+
+Signed-off-by: Jason Hall <jason@chainguard.dev>
+---
+ cmd/argocd-k8s-auth/commands/azure.go | 17 +++++-----
+ go.mod                                | 17 +++++-----
+ go.sum                                | 45 ++++++++++++---------------
+ 3 files changed, 38 insertions(+), 41 deletions(-)
+
+diff --git a/cmd/argocd-k8s-auth/commands/azure.go b/cmd/argocd-k8s-auth/commands/azure.go
+index f4c3b9d3c96b9..287b8d457aee1 100644
+--- a/cmd/argocd-k8s-auth/commands/azure.go
++++ b/cmd/argocd-k8s-auth/commands/azure.go
+@@ -1,6 +1,7 @@
+ package commands
+ 
+ import (
++	"fmt"
+ 	"os"
+ 
+ 	"github.com/Azure/kubelogin/pkg/token"
+@@ -19,24 +20,26 @@ const (
+ )
+ 
+ func newAzureCommand() *cobra.Command {
+-	o := token.NewOptions()
+-	// we'll use default of WorkloadIdentityLogin for the login flow
+-	o.LoginMethod = token.WorkloadIdentityLogin
+-	o.ServerID = DEFAULT_AAD_SERVER_APPLICATION_ID
+ 	command := &cobra.Command{
+ 		Use: "azure",
+ 		Run: func(c *cobra.Command, args []string) {
+-			o.UpdateFromEnv()
++			o := token.OptionsWithEnv()
++			if o.LoginMethod == "" { // no environment variable overrides
++				// we'll use default of WorkloadIdentityLogin for the login flow
++				o.LoginMethod = token.WorkloadIdentityLogin
++			}
++			o.ServerID = DEFAULT_AAD_SERVER_APPLICATION_ID
+ 			if v, ok := os.LookupEnv(envServerApplicationID); ok {
+ 				o.ServerID = v
+ 			}
+ 			if v, ok := os.LookupEnv(envEnvironmentName); ok {
+ 				o.Environment = v
+ 			}
+-			plugin, err := token.New(&o)
++			tp, err := token.GetTokenProvider(o)
+ 			errors.CheckError(err)
+-			err = plugin.Do()
++			tok, err := tp.GetAccessToken(c.Context())
+ 			errors.CheckError(err)
++			_, _ = fmt.Fprint(os.Stdout, formatJSON(tok.Token, tok.ExpiresOn))
+ 		},
+ 	}
+ 	return command
+diff --git a/go.mod b/go.mod
+index 03e84a0080893..ca79f348a404d 100644
+--- a/go.mod
++++ b/go.mod
+@@ -4,7 +4,7 @@ go 1.22.0
+ 
+ require (
+ 	code.gitea.io/sdk/gitea v0.19.0
+-	github.com/Azure/kubelogin v0.0.20
++	github.com/Azure/kubelogin v0.1.4
+ 	github.com/Masterminds/semver/v3 v3.3.0
+ 	github.com/Masterminds/sprig/v3 v3.3.0
+ 	github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d
+
+@@ -137,7 +137,7 @@ require (
+ 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
+ 	github.com/go-fed/httpsig v1.1.0 // indirect
+ 	github.com/go-jose/go-jose/v4 v4.0.2 // indirect
+-	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
++	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
+ 	github.com/google/gnostic-models v0.6.8 // indirect
+ 	github.com/google/go-github/v62 v62.0.0 // indirect
+ 	github.com/google/s2a-go v0.1.7 // indirect
+
+@@ -308,7 +307,7 @@ replace (
+ 
+ 	k8s.io/api => k8s.io/api v0.31.0
+ 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.31.0
+-	k8s.io/apimachinery => k8s.io/apimachinery v0.31.0
++	k8s.io/apimachinery => k8s.io/apimachinery v0.31.2
+ 	k8s.io/apiserver => k8s.io/apiserver v0.31.0
+ 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.31.0
+ 	k8s.io/client-go => k8s.io/client-go v0.31.0


### PR DESCRIPTION
Unfortunately we were not able to use a cherry-pick as there were unresolvable merge issues so I brought what I could in via a patch and go-bumped the remaining dependencies.
