### PR TITLE
switch http git checkouts for github to https

### DIFF
--- a/ruby3.2-bindata.yaml
+++ b/ruby3.2-bindata.yaml
@@ -19,7 +19,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/dmendel/bindata
+      repository: https://github.com/dmendel/bindata
       tag: v${{package.version}}
       expected-commit: 8244a1c7e7b24617adcd7264e02370663bd03621
 

--- a/ruby3.2-mail.yaml
+++ b/ruby3.2-mail.yaml
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/mikel/mail
+      repository: https://github.com/mikel/mail
       tag: ${{package.version}}
       expected-commit: b6b6cb737d47a85ddc720fda0e6b991e99224848
 

--- a/ruby3.2-manticore.yaml
+++ b/ruby3.2-manticore.yaml
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/cheald/manticore
+      repository: https://github.com/cheald/manticore
       tag: v${{package.version}}
       expected-commit: acc25cac2999f4658a77a0f39f60ddbca8fe14a4
 

--- a/ruby3.2-openssl_pkcs8_pure.yaml
+++ b/ruby3.2-openssl_pkcs8_pure.yaml
@@ -20,7 +20,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/cielavenir/openssl_pkcs8_pure
+      repository: https://github.com/cielavenir/openssl_pkcs8_pure
       tag: v${{package.version}}
       expected-commit: 380967a0e48f3029b80874fd5a3d21e0b33ce7f8
 

--- a/ruby3.2-rack-oauth2.yaml
+++ b/ruby3.2-rack-oauth2.yaml
@@ -27,7 +27,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/nov/rack-oauth2
+      repository: https://github.com/nov/rack-oauth2
       tag: v${{package.version}}
       expected-commit: 70da234801c53a116c2d8e126bb09f237824af5a
 

--- a/ruby3.2-swd.yaml
+++ b/ruby3.2-swd.yaml
@@ -25,7 +25,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/nov/swd
+      repository: https://github.com/nov/swd
       tag: v${{package.version}}
       expected-commit: 80cb364d6c710477bc6e08d09da616532a741495
 

--- a/ruby3.2-validate_email.yaml
+++ b/ruby3.2-validate_email.yaml
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/perfectline/validates_email
+      repository: https://github.com/perfectline/validates_email
       tag: v${{package.version}}
       expected-commit: 25a5efcd7b4daa6445d3be9e8ba103b174ba9e4b
 

--- a/ruby3.2-webfinger.yaml
+++ b/ruby3.2-webfinger.yaml
@@ -24,7 +24,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/nov/webfinger
+      repository: https://github.com/nov/webfinger
       tag: v${{package.version}}
       expected-commit: a79f140bcd5a0ac2140eefed5316e572625a0563
 

--- a/ruby3.3-bindata.yaml
+++ b/ruby3.3-bindata.yaml
@@ -19,7 +19,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/dmendel/bindata
+      repository: https://github.com/dmendel/bindata
       tag: v${{package.version}}
       expected-commit: 8244a1c7e7b24617adcd7264e02370663bd03621
 

--- a/ruby3.3-mail.yaml
+++ b/ruby3.3-mail.yaml
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/mikel/mail
+      repository: https://github.com/mikel/mail
       tag: ${{package.version}}
       expected-commit: b6b6cb737d47a85ddc720fda0e6b991e99224848
 

--- a/ruby3.3-manticore.yaml
+++ b/ruby3.3-manticore.yaml
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/cheald/manticore
+      repository: https://github.com/cheald/manticore
       tag: v${{package.version}}
       expected-commit: acc25cac2999f4658a77a0f39f60ddbca8fe14a4
 

--- a/ruby3.3-openssl_pkcs8_pure.yaml
+++ b/ruby3.3-openssl_pkcs8_pure.yaml
@@ -20,7 +20,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/cielavenir/openssl_pkcs8_pure
+      repository: https://github.com/cielavenir/openssl_pkcs8_pure
       tag: v${{package.version}}
       expected-commit: 380967a0e48f3029b80874fd5a3d21e0b33ce7f8
 

--- a/ruby3.3-rack-oauth2.yaml
+++ b/ruby3.3-rack-oauth2.yaml
@@ -27,7 +27,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/nov/rack-oauth2
+      repository: https://github.com/nov/rack-oauth2
       tag: v${{package.version}}
       expected-commit: 70da234801c53a116c2d8e126bb09f237824af5a
 

--- a/ruby3.3-swd.yaml
+++ b/ruby3.3-swd.yaml
@@ -25,7 +25,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/nov/swd
+      repository: https://github.com/nov/swd
       tag: v${{package.version}}
       expected-commit: 80cb364d6c710477bc6e08d09da616532a741495
 

--- a/ruby3.3-validate_email.yaml
+++ b/ruby3.3-validate_email.yaml
@@ -23,7 +23,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/perfectline/validates_email
+      repository: https://github.com/perfectline/validates_email
       tag: v${{package.version}}
       expected-commit: 25a5efcd7b4daa6445d3be9e8ba103b174ba9e4b
 

--- a/ruby3.3-webfinger.yaml
+++ b/ruby3.3-webfinger.yaml
@@ -24,7 +24,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      repository: http://github.com/nov/webfinger
+      repository: https://github.com/nov/webfinger
       tag: v${{package.version}}
       expected-commit: a79f140bcd5a0ac2140eefed5316e572625a0563
 


### PR DESCRIPTION
This should probably be a lint check too.

Not bumping the epoch as no changes to the packages.