### PR TITLE
New package: ruby-net-http

### DIFF
--- a/ruby3.2-net-http.yaml
+++ b/ruby3.2-net-http.yaml
@@ -23,13 +23,16 @@ pipeline:
       repository: https://github.com/ruby/net-http
       tag: v${{package.version}}
       expected-commit: 28a4bf9295f65eeea693419c2640ddf22c116732
+
   - uses: ruby/build
     with:
       gem: ${{vars.gem}}
+
   - uses: ruby/install
     with:
       gem: ${{vars.gem}}
       version: ${{package.version}}
+
   - uses: ruby/clean
 
 vars:

--- a/ruby3.2-net-http.yaml
+++ b/ruby3.2-net-http.yaml
@@ -1,4 +1,3 @@
-
 package:
   name: ruby3.2-net-http
   version: 0.5.0

--- a/ruby3.2-net-http.yaml
+++ b/ruby3.2-net-http.yaml
@@ -1,0 +1,56 @@
+
+package:
+  name: ruby3.2-net-http
+  version: 0.5.0
+  epoch: 0
+  description: "A rich library which can be used to build HTTP user-agents for Ruby"
+  copyright:
+    - license: BSD-2-Clause OR Ruby
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.2
+      - ruby-3.2-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ruby/net-http
+      tag: v${{package.version}}
+      expected-commit: 28a4bf9295f65eeea693419c2640ddf22c116732
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+  - uses: ruby/clean
+
+vars:
+  gem: net-http
+
+test:
+  pipeline:
+    - name: Verify library import
+      runs: ruby -e "require 'net/http'"
+    - name: Basic usage
+      runs: |
+        cat <<EOF > /tmp/test.rb
+        require "net/http"
+        uri = URI("https://edu.chainguard.dev/open-source/wolfi/overview/")
+        Net::HTTP.get(uri)
+        puts "OK"
+        EOF
+        ruby /tmp/test.rb
+
+update:
+  enabled: true
+  github:
+    identifier: ruby/net-http
+    strip-prefix: v

--- a/ruby3.3-net-http.yaml
+++ b/ruby3.3-net-http.yaml
@@ -23,13 +23,16 @@ pipeline:
       repository: https://github.com/ruby/net-http
       tag: v${{package.version}}
       expected-commit: 28a4bf9295f65eeea693419c2640ddf22c116732
+
   - uses: ruby/build
     with:
       gem: ${{vars.gem}}
+
   - uses: ruby/install
     with:
       gem: ${{vars.gem}}
       version: ${{package.version}}
+
   - uses: ruby/clean
 
 vars:

--- a/ruby3.3-net-http.yaml
+++ b/ruby3.3-net-http.yaml
@@ -1,0 +1,56 @@
+
+package:
+  name: ruby3.3-net-http
+  version: 0.5.0
+  epoch: 0
+  description: "A rich library which can be used to build HTTP user-agents for Ruby"
+  copyright:
+    - license: BSD-2-Clause OR Ruby
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - ruby-3.3
+      - ruby-3.3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/ruby/net-http
+      tag: v${{package.version}}
+      expected-commit: 28a4bf9295f65eeea693419c2640ddf22c116732
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+  - uses: ruby/clean
+
+vars:
+  gem: net-http
+
+test:
+  pipeline:
+    - name: Verify library import
+      runs: ruby -e "require 'net/http'"
+    - name: Basic usage
+      runs: |
+        cat <<EOF > /tmp/test.rb
+        require "net/http"
+        uri = URI("https://edu.chainguard.dev/open-source/wolfi/overview/")
+        Net::HTTP.get(uri)
+        puts "OK"
+        EOF
+        ruby /tmp/test.rb
+
+update:
+  enabled: true
+  github:
+    identifier: ruby/net-http
+    strip-prefix: v

--- a/ruby3.3-net-http.yaml
+++ b/ruby3.3-net-http.yaml
@@ -1,4 +1,3 @@
-
 package:
   name: ruby3.3-net-http
   version: 0.5.0


### PR DESCRIPTION
Newer versions of the net-http gem are required for testing of other packages. This introduces it for both ruby3.2 and ruby3.3.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Related: https://github.com/wolfi-dev/os/pull/34039
Related: https://github.com/wolfi-dev/os/pull/34044

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)