### PR TITLE
datadog-agent: add missing directory for system probe sockets

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: 7.59.0
-  epoch: 1
+  epoch: 2
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -228,6 +228,11 @@ pipeline:
       mkdir -p ${{targets.contextdir}}/etc/s6/init
       cp -r Dockerfiles/agent/init-stage3 ${{targets.contextdir}}/etc/s6/init/init-stage3
       cp Dockerfiles/agent/init-stage3-host-pid ${{targets.contextdir}}/etc/s6/init/init-stage3-host-pid
+
+      # Needed by the system-probe and runtime security agent sockets.
+      # The default system-probe socket path is /opt/datadog-agent/run/sysprobe.sock
+      # The default runtime security agent socket path is /opt/datadog-agent/run/runtime-security.sock
+      mkdir ${{targets.contextdir}}${{vars.destd}}/run
 
   - uses: strip
 


### PR DESCRIPTION
This PR adds the required directory for the system probe agents' IPC socket files.
In particular:
* system probe (default: /opt/datadog-agent/run/sysprobe.sock)
* security runtime agent (default: /opt/datadog-agent/run/runtime-security.sock)

The /opt/datadog-agent/run directory was missing leading to the impossibility to create the IPC socket files for the system probes, for which the following error log is printed:
```
error while starting api server, exiting: error creating IPC socket:
can't listen unix /opt/datadog-agent/run/sysprobe.sock: bind: no such file or directory.
```