### PR TITLE
Switch some pkgs to the pkgconf test pipeline; remove old style tests

### DIFF
--- a/libestr.yaml
+++ b/libestr.yaml
@@ -40,6 +40,9 @@ subpackages:
       runtime:
         - libestr
     description: libestr dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
 update:
   enabled: true
@@ -48,13 +51,3 @@ update:
     strip-prefix: v
     tag-filter: v
     use-tag: true
-
-test:
-  environment:
-    contents:
-      packages:
-        - pkgconf
-        - libestr-dev
-  pipeline:
-    - runs: |
-        pkg-config --libs libestr | grep /usr/lib

--- a/libfastjson.yaml
+++ b/libfastjson.yaml
@@ -40,6 +40,9 @@ subpackages:
       runtime:
         - libfastjson
     description: libfastjson dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
 update:
   enabled: true
@@ -48,13 +51,3 @@ update:
     strip-prefix: v
     tag-filter: v
     use-tag: true
-
-test:
-  environment:
-    contents:
-      packages:
-        - pkgconf
-        - libfastjson-dev
-  pipeline:
-    - runs: |
-        pkg-config --libs libfastjson | grep /usr/lib

--- a/libnvme.yaml
+++ b/libnvme.yaml
@@ -57,14 +57,9 @@ test:
   environment:
     contents:
       packages:
-        - pkgconf
         - libnvme
         - libnvme-dev
   pipeline:
-    - name: pkg-config testse
-      runs: |
-        pkg-config --exists libnvme
-        pkg-config --libs libnvme
     - name: libnvme-dev headers file
       runs: |
         stat /usr/include/libnvme.h

--- a/librelp.yaml
+++ b/librelp.yaml
@@ -50,6 +50,9 @@ subpackages:
       runtime:
         - librelp
     description: librelp dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
 update:
   enabled: true
@@ -58,13 +61,3 @@ update:
     strip-prefix: v
     tag-filter: v
     use-tag: true
-
-test:
-  environment:
-    contents:
-      packages:
-        - pkgconf
-        - librelp-dev
-  pipeline:
-    - runs: |
-        pkg-config --libs relp | grep /usr/lib

--- a/libyang.yaml
+++ b/libyang.yaml
@@ -79,10 +79,6 @@ test:
   pipeline:
     - name: version test
       runs: /usr/bin/yanglint --version | grep ${{package.version}}
-    - name: pkg-config tests
-      runs: |
-        pkg-config --exists libyang
-        pkg-config --libs libyang
     - name: libyang-dev headers file
       runs: |
         stat /usr/include/libyang/*.h

--- a/rtrlib.yaml
+++ b/rtrlib.yaml
@@ -70,14 +70,9 @@ test:
   environment:
     contents:
       packages:
-        - pkgconf
         - rtrlib
         - rtrlib-dev
   pipeline:
-    - name: pkg-config tests
-      runs: |
-        pkg-config --exists rtrlib
-        pkg-config --libs rtrlib
     - name: rtrlib-dev headers and shared objects file
       runs: |
         stat /usr/include/rtrlib/rtrlib.h


### PR DESCRIPTION
This modifies libestr and libfastjson such that they use the pkgconf test pipeline instead of their old failing and  less comprehensive tests.

It also removes some unnecessary pkg-config testing from packages which were modified to use the pkgconf test pipeline.