### PR TITLE
prism/GHSA-pppg-cpfq-h7wr: CVE Remediation

### DIFF
--- a/prism.yaml
+++ b/prism.yaml
@@ -1,7 +1,7 @@
 package:
   name: prism
   version: 5.11.2
-  epoch: 1
+  epoch: 2
   description: "A set of packages for API mocking and contract testing with OpenAPI v2 and OpenAPI v3.x"
   url: https://github.com/stoplightio/prism
   copyright:


### PR DESCRIPTION
Bumping the epoch forces a new build and fetches a fixed version of the critical dependency jsonpath-plus