### PR TITLE
py3-sphinx-7: Provide py3.*-sphinx

### DIFF
--- a/py3-sphinx-7.yaml
+++ b/py3-sphinx-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinx-7
   version: 7.4.7
-  epoch: 2
+  epoch: 3
   description: Python Documentation Generator
   copyright:
     - license: MIT
@@ -40,6 +40,8 @@ subpackages:
     description: python${{range.key}} version of ${{vars.pypi-package}}
     dependencies:
       provider-priority: ${{range.value}}
+      provides:
+        - py${{range.key}}-sphinx
       runtime:
         - py${{range.key}}-alabaster
         - py${{range.key}}-babel


### PR DESCRIPTION
Allow sphinx-7 to satisfy generic sphinx deps. Fixes an issue where apk may try to install conflicting py3-sphinx-7 and py3-sphinx (8.x) deps, which can be observed by running:

  apk add py3-sphinx-7 py3-sphinx-rtd-theme
