### PR TITLE
py3-fabric - multi-version

### DIFF
--- a/py3-deprecated.yaml
+++ b/py3-deprecated.yaml
@@ -1,8 +1,7 @@
-# Generated from https://pypi.org/project/Deprecated/
 package:
   name: py3-deprecated
   version: 1.2.15
-  epoch: 0
+  epoch: 1
   description: Python @deprecated decorator to deprecate old python classes, functions or methods.
   copyright:
     - license: MIT
@@ -10,8 +9,8 @@ package:
     provider-priority: "0"
 
 vars:
-  module_name: deprecated
   pypi-package: deprecated
+  import: deprecated
 
 data:
   - name: py-versions
@@ -50,15 +49,23 @@ subpackages:
         - py${{range.key}}-wrapt
       provides:
         - py3-${{vars.pypi-package}}
-        - py3-Deprecated=${{package.full-version}}
       provider-priority: ${{range.value}}
     test:
       pipeline:
         - name: Import Test
           uses: python/import
           with:
-            import: ${{vars.module_name}}
+            import: ${{vars.import}}
             python: python${{range.key}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true
@@ -71,4 +78,4 @@ test:
     - name: Import Test
       uses: python/import
       with:
-        import: ${{vars.module_name}}
+        import: ${{vars.import}}

--- a/py3-fabric.yaml
+++ b/py3-fabric.yaml
@@ -1,25 +1,29 @@
-# Generated from https://pypi.org/project/fabric/
 package:
   name: py3-fabric
   version: 3.2.2
-  epoch: 2
+  epoch: 3
   description: High level SSH command execution
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-invoke
-      - py3-paramiko
-      - py3-decorator
-      - py3-deprecated
+    provider-priority: 0
+
+vars:
+  pypi-package: fabric
+  import: fabric
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - wolfi-base
+      - py3-supported-build-base
 
 pipeline:
   - uses: git-checkout
@@ -28,21 +32,85 @@ pipeline:
       repository: https://github.com/fabric/fabric
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-invoke
+        - py${{range.key}}-paramiko
+        - py${{range.key}}-decorator
+        - py${{range.key}}-deprecated
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+      environment:
+        contents:
+          packages:
+            - openssl-provider-legacy
 
-  - uses: strip
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      environment:
+        contents:
+          packages:
+            - openssl-provider-legacy
+      pipeline:
+        - uses: test/populated-etc-passwd
+          with:
+            content: |
+              fab --version
+              fab --help
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
   environment:
     contents:
       packages:
-        - openssl-provider-legacy # needed for 'import fabric'
+        - openssl-provider-legacy
   pipeline:
     - uses: python/import
       with:
         imports: |
-          import fabric
+          import ${{vars.import}}
 
 update:
   ignore-regex-patterns:


### PR DESCRIPTION
use of openssl-legacy-provider is to avoid the:

>  RuntimeError: OpenSSL 3.0's legacy provider failed to load. This is
>  a fatal error by default, but cryptography supports running without
>  legacy algorithms by setting the environment variable
>  CRYPTOGRAPHY_OPENSSL_NO_LEGACY. If you did not expect this error, you
>  have likely made a mistake with your OpenSSL configuration.

The use of test/populated-etc-passwd is to cover python 3.13. os.getuid() requires. either USER set or user in /etc/passwd.

> ```
>  + fab --version
>  Traceback (most recent call last):
>    File "/usr/lib/python3.13/getpass.py", line 173, in getuser
>      return pwd.getpwuid(os.getuid())[0]
>             ~~~~~~~~~~~~^^^^^^^^^^^^^
>  KeyError: 'getpwuid(): uid not found: 1000'
> ```

py3-deprecated needed changing to not provide py3-Deprecated
at a specific version.
