### PR TITLE
use test/pkgconf as well

### DIFF
--- a/wayland-protocols.yaml
+++ b/wayland-protocols.yaml
@@ -45,6 +45,7 @@ test:
         - libxml2-utils # For xmllint
         - pkgconf
   pipeline:
+    - uses: test/pkgconf
     - name: "Verify installation directory structure"
       runs: |
         test -d /usr/share/wayland-protocols


### PR DESCRIPTION
this got lost in the shuffle, adding it back in.

keeping the 🤖 tests as well even they do arguably the same thing only worse because these are cheap