### PR TITLE
Add pkgconf test pipeline to apr-util

### DIFF
--- a/apr-util.yaml
+++ b/apr-util.yaml
@@ -1,7 +1,7 @@
 package:
   name: apr-util
   version: 1.6.3
-  epoch: 2
+  epoch: 3
   description: The Apache Portable Runtime Utility Library
   copyright:
     # Some files also contain RSA-MD.
@@ -56,6 +56,7 @@ subpackages:
         - apr-util
         - expat-dev
         - gdbm-dev
+        - libapr-dev
         - postgresql-16-dev
         - openldap-dev
         - openssl-dev
@@ -66,6 +67,7 @@ subpackages:
         - runs: |
             apu-1-config --version
             apu-1-config --help
+        - uses: test/pkgconf
 
   - name: apr-util-dbd_pgsql
     pipeline:


### PR DESCRIPTION
This also resolves the test failure reported in https://github.com/wolfi-dev/os/issues/34002 by adding `libapr-dev` as a dependency to apr-util-dev.