### PR TITLE
Add pkgconf test pipeline to at-spi-2.0

### DIFF
--- a/at-spi2-core.yaml
+++ b/at-spi2-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: at-spi2-core
   version: 2.54.0
-  epoch: 1
+  epoch: 2
   description: Protocol definitions and daemon for D-Bus at-spi
   copyright:
     - license: LGPL-2.0-or-later
@@ -60,7 +60,11 @@ subpackages:
     dependencies:
       runtime:
         - at-spi2-core
+        - libxext-dev
     description: at-spi2-core dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
   - name: at-spi2-core-lang
     pipeline:


### PR DESCRIPTION
This also resolves the test failure reported in https://github.com/wolfi-dev/os/issues/34005 by adding `libxext-dev` as a dependency.