### PR TITLE
Remove php provides with a version, replace with providerPriority

### DIFF
--- a/php-8.1-amqp.yaml
+++ b/php-8.1-amqp.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-amqp
   version: 2.1.2
-  epoch: 2
+  epoch: 3
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01
@@ -11,11 +11,9 @@ package:
       - php-${{vars.phpMM}}
       - rabbitmq-c
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
+  phpPriority: 801
 
 environment:
   contents:
@@ -53,7 +51,8 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-amqp-config=${{package.full-version}}
+        - php-amqp-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.1-apcu.yaml
+++ b/php-8.1-apcu.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-apcu
   version: 5.1.24
-  epoch: 1
+  epoch: 2
   description: "PHP extension for User Cache"
   copyright:
     - license: PHP-3.01
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-ddtrace.yaml
+++ b/php-8.1-ddtrace.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-ddtrace
   version: 1.5.1
-  epoch: 0
+  epoch: 1
   description: "Datadog PHP Clients"
   copyright:
     - license: Apache-2.0 OR BSD-3-Clause
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-decimal.yaml
+++ b/php-8.1-decimal.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-decimal
   version: 1.5.0
-  epoch: 1
+  epoch: 2
   description: Correctly-rounded, arbitrary-precision decimal arithmetic for PHP
   copyright:
     - license: MIT
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-ds.yaml
+++ b/php-8.1-ds.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-ds
   version: 1.5.0
-  epoch: 1
+  epoch: 2
   description: "An extension providing efficient data structures for PHP"
   copyright:
     - license: MIT
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-excimer.yaml
+++ b/php-8.1-excimer.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-excimer
   version: 1.2.3
-  epoch: 0
+  epoch: 1
   description: "Excimer is a PHP extension that provides an interrupting timer and a low-overhead sampling profiler."
   copyright:
     - license: Apache-2.0
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-grpc.yaml
+++ b/php-8.1-grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-grpc
   version: 1.68.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for gRPC"
   copyright:
     - license: Apache-2.0
@@ -11,11 +11,8 @@ package:
       - grpc
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-igbinary.yaml
+++ b/php-8.1-igbinary.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-igbinary
   version: 3.2.16
-  epoch: 2
+  epoch: 3
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
@@ -10,11 +10,9 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
+  phpPriority: 801
 
 environment:
   contents:
@@ -51,17 +49,19 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-igbinary-config=${{package.full-version}}
+        - php-igbinary-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.phpMM}} igbinary development headers
+    description: "PHP ${{vars.phpMM}} igbinary development headers"
     dependencies:
       provides:
-        - php-igbinary-dev=${{package.full-version}}
+        - php-igbinary-dev
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - uses: split/dev
 

--- a/php-8.1-imagick.yaml
+++ b/php-8.1-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-imagick
   version: 3.7.0
-  epoch: 3
+  epoch: 4
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01
@@ -11,11 +11,8 @@ package:
       - imagemagick
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-memcached.yaml
+++ b/php-8.1-memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-memcached
   version: 3.3.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for Memcached"
   copyright:
     - license: PHP-3.01
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-msgpack.yaml
+++ b/php-8.1-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-msgpack
   version: 3.0.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-opentelemetry.yaml
+++ b/php-8.1-opentelemetry.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-opentelemetry
   version: 1.1.0
-  epoch: 1
+  epoch: 2
   description: "OpenTelemetry PHP auto-instrumentation extension"
   copyright:
     - license: Apache-2.0
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-pdo_snowflake.yaml
+++ b/php-8.1-pdo_snowflake.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pdo_snowflake
   version: 3.0.3
-  epoch: 1
+  epoch: 2
   description: "Snowflake driver that uses the PHP Data Objects (PDO) extension"
   copyright:
     - license: Apache-2.0
@@ -13,11 +13,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-pecl-http.yaml
+++ b/php-8.1-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-http
   version: 4.2.6
-  epoch: 0
+  epoch: 1
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-pecl-mcrypt.yaml
+++ b/php-8.1-pecl-mcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-mcrypt
   version: 1.0.7
-  epoch: 5
+  epoch: 6
   description: "Provides PHP ${{vars.phpMM}} bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-pecl-mongodb.yaml
+++ b/php-8.1-pecl-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-mongodb
   version: 1.20.0
-  epoch: 3
+  epoch: 4
   description: "PHP ${{vars.phpMM}} MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-pecl-pdosqlsrv.yaml
+++ b/php-8.1-pecl-pdosqlsrv.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-pdosqlsrv
   version: 5.12.0
-  epoch: 2
+  epoch: 3
   description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-pecl-raphf.yaml
+++ b/php-8.1-pecl-raphf.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-raphf
   version: 2.0.1
-  epoch: 6
+  epoch: 7
   description: "Provides PHP ${{vars.phpMM}} resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-pecl-sqlsrv.yaml
+++ b/php-8.1-pecl-sqlsrv.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-sqlsrv
   version: 5.12.0
-  epoch: 2
+  epoch: 3
   description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
     - license: MIT
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-protobuf.yaml
+++ b/php-8.1-protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-protobuf
   version: 4.28.3
-  epoch: 1
+  epoch: 2
   description: "Protocol Buffers - Google's data interchange format"
   copyright:
     - license: BSD-3-Clause
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-redis.yaml
+++ b/php-8.1-redis.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-redis
   version: 6.1.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for Redis"
   copyright:
     - license: PHP-3.01
@@ -11,11 +11,9 @@ package:
       - php-${{vars.phpMM}}
       - php-${{vars.phpMM}}-igbinary
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
+  phpPriority: 801
 
 environment:
   contents:
@@ -51,17 +49,19 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-redis-config=${{package.full-version}}
+        - php-redis-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.phpMM}} redis development headers
+    description: "PHP ${{vars.phpMM}} redis development headers"
     dependencies:
       provides:
-        - php-redis-dev=${{package.full-version}}
+        - php-redis-dev
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - uses: split/dev
 

--- a/php-8.1-ssh2.yaml
+++ b/php-8.1-ssh2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-ssh2
   version: 1.4.1
-  epoch: 1
+  epoch: 2
   description: "Bindings for the libssh2 library"
   copyright:
     - license: PHP-3.01
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-swoole.yaml
+++ b/php-8.1-swoole.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-swoole
   version: 5.1.5
-  epoch: 1
+  epoch: 2
   description: "Coroutine-based concurrency library for PHP"
   copyright:
     - license: Apache-2.0
@@ -11,11 +11,8 @@ package:
       - brotli
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-xdebug.yaml
+++ b/php-8.1-xdebug.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-xdebug
   version: 3.3.2
-  epoch: 1
+  epoch: 2
   description: "Step Debugger for PHP"
   copyright:
     - license: PHP-3.01
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.1-zstd.yaml
+++ b/php-8.1-zstd.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-zstd
   version: 0.14.0
-  epoch: 0
+  epoch: 1
   description: Zstd Extension for PHP
   copyright:
     - license: MIT
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.1"
 
 environment:
   contents:

--- a/php-8.2-amqp.yaml
+++ b/php-8.2-amqp.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-amqp
   version: 2.1.2
-  epoch: 2
+  epoch: 3
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01
@@ -11,11 +11,9 @@ package:
       - php-${{vars.phpMM}}
       - rabbitmq-c
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
+  phpPriority: 802
 
 environment:
   contents:
@@ -53,7 +51,8 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-amqp-config=${{package.full-version}}
+        - php-amqp-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.2-apcu.yaml
+++ b/php-8.2-apcu.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-apcu
   version: 5.1.24
-  epoch: 1
+  epoch: 2
   description: "PHP extension for User Cache"
   copyright:
     - license: PHP-3.01
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-ddtrace.yaml
+++ b/php-8.2-ddtrace.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-ddtrace
   version: 1.5.1
-  epoch: 0
+  epoch: 1
   description: "Datadog PHP Clients"
   copyright:
     - license: Apache-2.0 OR BSD-3-Clause
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-decimal.yaml
+++ b/php-8.2-decimal.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-decimal
   version: 1.5.0
-  epoch: 1
+  epoch: 2
   description: Correctly-rounded, arbitrary-precision decimal arithmetic for PHP
   copyright:
     - license: MIT
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-ds.yaml
+++ b/php-8.2-ds.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-ds
   version: 1.5.0
-  epoch: 1
+  epoch: 2
   description: "An extension providing efficient data structures for PHP"
   copyright:
     - license: MIT
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-excimer.yaml
+++ b/php-8.2-excimer.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-excimer
   version: 1.2.3
-  epoch: 0
+  epoch: 1
   description: "Excimer is a PHP extension that provides an interrupting timer and a low-overhead sampling profiler."
   copyright:
     - license: Apache-2.0
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-grpc.yaml
+++ b/php-8.2-grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-grpc
   version: 1.68.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for gRPC"
   copyright:
     - license: Apache-2.0
@@ -11,11 +11,8 @@ package:
       - grpc
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-igbinary.yaml
+++ b/php-8.2-igbinary.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-igbinary
   version: 3.2.16
-  epoch: 2
+  epoch: 3
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-imagick.yaml
+++ b/php-8.2-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-imagick
   version: 3.7.0
-  epoch: 3
+  epoch: 4
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01
@@ -11,11 +11,8 @@ package:
       - imagemagick
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-memcached.yaml
+++ b/php-8.2-memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-memcached
   version: 3.3.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for Memcached"
   copyright:
     - license: PHP-3.01
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-msgpack.yaml
+++ b/php-8.2-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-msgpack
   version: 3.0.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-opentelemetry.yaml
+++ b/php-8.2-opentelemetry.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-opentelemetry
   version: 1.1.0
-  epoch: 1
+  epoch: 2
   description: "OpenTelemetry PHP auto-instrumentation extension"
   copyright:
     - license: Apache-2.0
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-pdo_snowflake.yaml
+++ b/php-8.2-pdo_snowflake.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pdo_snowflake
   version: 3.0.3
-  epoch: 1
+  epoch: 2
   description: "Snowflake driver that uses the PHP Data Objects (PDO) extension"
   copyright:
     - license: Apache-2.0
@@ -13,11 +13,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-pecl-http.yaml
+++ b/php-8.2-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-http
   version: 4.2.6
-  epoch: 0
+  epoch: 1
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-pecl-mcrypt.yaml
+++ b/php-8.2-pecl-mcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-mcrypt
   version: 1.0.7
-  epoch: 5
+  epoch: 6
   description: "Provides PHP ${{vars.phpMM}} bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-pecl-mongodb.yaml
+++ b/php-8.2-pecl-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-mongodb
   version: 1.20.0
-  epoch: 3
+  epoch: 4
   description: "PHP ${{vars.phpMM}} MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-pecl-pdosqlsrv.yaml
+++ b/php-8.2-pecl-pdosqlsrv.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-pdosqlsrv
   version: 5.12.0
-  epoch: 2
+  epoch: 3
   description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-pecl-raphf.yaml
+++ b/php-8.2-pecl-raphf.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-raphf
   version: 2.0.1
-  epoch: 5
+  epoch: 6
   description: "Provides PHP ${{vars.phpMM}} resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-pecl-sqlsrv.yaml
+++ b/php-8.2-pecl-sqlsrv.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-sqlsrv
   version: 5.12.0
-  epoch: 2
+  epoch: 3
   description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
     - license: MIT
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-protobuf.yaml
+++ b/php-8.2-protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-protobuf
   version: 4.28.3
-  epoch: 1
+  epoch: 2
   description: "Protocol Buffers - Google's data interchange format"
   copyright:
     - license: BSD-3-Clause
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-redis.yaml
+++ b/php-8.2-redis.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-redis
   version: 6.1.0
-  epoch: 1
+  epoch: 2
   description: "A PHP extension for Redis"
   copyright:
     - license: PHP-3.01
@@ -11,11 +11,8 @@ package:
       - php-${{vars.phpMM}}
       - php-${{vars.phpMM}}-igbinary
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-ssh2.yaml
+++ b/php-8.2-ssh2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-ssh2
   version: 1.4.1
-  epoch: 1
+  epoch: 2
   description: "Bindings for the libssh2 library"
   copyright:
     - license: PHP-3.01
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-swoole.yaml
+++ b/php-8.2-swoole.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-swoole
   version: 5.1.5
-  epoch: 1
+  epoch: 2
   description: "Coroutine-based concurrency library for PHP"
   copyright:
     - license: Apache-2.0
@@ -11,11 +11,8 @@ package:
       - brotli
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-xdebug.yaml
+++ b/php-8.2-xdebug.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-xdebug
   version: 3.3.2
-  epoch: 1
+  epoch: 2
   description: "Step Debugger for PHP"
   copyright:
     - license: PHP-3.01
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.2-zstd.yaml
+++ b/php-8.2-zstd.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-zstd
   version: 0.14.0
-  epoch: 0
+  epoch: 1
   description: Zstd Extension for PHP
   copyright:
     - license: MIT
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.2"
 
 environment:
   contents:

--- a/php-8.3-amqp.yaml
+++ b/php-8.3-amqp.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-amqp
   version: 2.1.2
-  epoch: 2
+  epoch: 3
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01
@@ -11,13 +11,12 @@ package:
       - php-${{vars.phpMM}}
       - rabbitmq-c
     provides:
-      - php-amqp=${{package.full-version}}
+      - php-amqp
+    provider-priority: ${{vars.phpPriority}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
+  phpPriority: 803
 
 environment:
   contents:
@@ -55,7 +54,8 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-amqp-config=${{package.full-version}}
+        - php-amqp-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-apcu.yaml
+++ b/php-8.3-apcu.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-apcu
   version: 5.1.24
-  epoch: 1
+  epoch: 2
   description: "PHP extension for User Cache"
   copyright:
     - license: PHP-3.01
@@ -10,13 +10,12 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
     provides:
-      - php-apcu=${{package.full-version}}
+      - php-apcu
+    provider-priority: ${{vars.phpPriority}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
+  phpPriority: 803
 
 environment:
   contents:
@@ -50,7 +49,8 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-apcu-config=${{package.full-version}}
+        - php-apcu-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
@@ -66,13 +66,13 @@ update:
 
 test:
   pipeline:
-    - name: "Check if extension is loaded"
+    - name: Check if extension is loaded
       runs: |
         php -m | grep -i "apcu"
-    - name: "Verify extension version"
+    - name: Verify extension version
       runs: |
         php -r 'echo phpversion("apcu");'
-    - name: "Test basic cache storage and retrieval"
+    - name: Test basic cache storage and retrieval
       runs: |
         php -d apc.enable_cli=1 -r '
           if (!apcu_store("test_key", "test_value")) exit(1);
@@ -80,7 +80,7 @@ test:
           if ($value !== "test_value") exit(1);
           echo "Success";
         '
-    - name: "Test cache exists functionality"
+    - name: Test cache exists functionality
       runs: |
         php -d apc.enable_cli=1 -r '
           if (!apcu_store("check_key", "check_value")) exit(1);
@@ -88,7 +88,7 @@ test:
           if (apcu_exists("nonexistent_key")) exit(1);
           echo "Success";
         '
-    - name: "Test cache deletion"
+    - name: Test cache deletion
       runs: |
         php -d apc.enable_cli=1 -r '
           if (!apcu_store("delete_key", "delete_value")) exit(1);
@@ -96,7 +96,7 @@ test:
           if (apcu_exists("delete_key")) exit(1);
           echo "Success";
         '
-    - name: "Test cache clearing"
+    - name: Test cache clearing
       runs: |
         php -d apc.enable_cli=1 -r '
           if (!apcu_store("clear_key", "clear_value")) exit(1);
@@ -104,7 +104,7 @@ test:
           if (apcu_exists("clear_key")) exit(1);
           echo "Success";
         '
-    - name: "Test increment/decrement operations"
+    - name: Test increment/decrement operations
       runs: |
         php -d apc.enable_cli=1 -r '
           if (!apcu_store("counter", 5)) exit(1);
@@ -112,10 +112,10 @@ test:
           if (apcu_dec("counter") !== 5) exit(1);
           echo "Success";
         '
-    - name: "Verify configuration file"
+    - name: Verify configuration file
       runs: |
         grep -q "^extension=apcu.so" /etc/php/conf.d/apcu.ini
-    - name: "Verify APCu is enabled in CLI"
+    - name: Verify APCu is enabled in CLI
       runs: |
         php -d apc.enable_cli=1 -r '
           if (!ini_get("apc.enable_cli")) exit(1);

--- a/php-8.3-ddtrace.yaml
+++ b/php-8.3-ddtrace.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-ddtrace
   version: 1.5.1
-  epoch: 0
+  epoch: 1
   description: "Datadog PHP Clients"
   copyright:
     - license: Apache-2.0 OR BSD-3-Clause
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:

--- a/php-8.3-decimal.yaml
+++ b/php-8.3-decimal.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-decimal
   version: 1.5.0
-  epoch: 1
+  epoch: 2
   description: Correctly-rounded, arbitrary-precision decimal arithmetic for PHP
   copyright:
     - license: MIT
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:

--- a/php-8.3-ds.yaml
+++ b/php-8.3-ds.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-ds
   version: 1.5.0
-  epoch: 1
+  epoch: 2
   description: "An extension providing efficient data structures for PHP"
   copyright:
     - license: MIT
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:

--- a/php-8.3-excimer.yaml
+++ b/php-8.3-excimer.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-excimer
   version: 1.2.3
-  epoch: 0
+  epoch: 1
   description: "Excimer is a PHP extension that provides an interrupting timer and a low-overhead sampling profiler."
   copyright:
     - license: Apache-2.0
@@ -10,13 +10,12 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
     provides:
-      - php-excimer=${{package.full-version}}
+      - php-excimer
+    provider-priority: ${{vars.phpPriority}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
+  phpPriority: 803
 
 environment:
   contents:
@@ -31,7 +30,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/wikimedia/mediawiki-php-excimer
-      tag: "${{package.version}}"
+      tag: ${{package.version}}
       expected-commit: c52285d4e29be23dfbf54591ed23ad822ec02de0
 
   - name: Prepare build
@@ -53,7 +52,8 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-excimer-config=${{package.full-version}}
+        - php-excimer-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-grpc.yaml
+++ b/php-8.3-grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-grpc
   version: 1.68.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for gRPC"
   copyright:
     - license: Apache-2.0
@@ -11,13 +11,12 @@ package:
       - grpc
       - php-${{vars.phpMM}}
     provides:
-      - php-grpc=${{package.full-version}}
+      - php-grpc
+    provider-priority: ${{vars.phpPriority}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
+  phpPriority: 803
 
 environment:
   contents:
@@ -51,7 +50,8 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-grpc-config=${{package.full-version}}
+        - php-grpc-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-igbinary.yaml
+++ b/php-8.3-igbinary.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-igbinary
   version: 3.2.16
-  epoch: 2
+  epoch: 3
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
@@ -10,13 +10,12 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
     provides:
-      - php-igbinary=${{package.full-version}}
+      - php-igbinary
+    provider-priority: ${{vars.phpPriority}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
+  phpPriority: 803
 
 environment:
   contents:
@@ -53,17 +52,19 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-igbinary-config=${{package.full-version}}
+        - php-igbinary-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.phpMM}} igbinary development headers
+    description: "PHP ${{vars.phpMM}} igbinary development headers"
     dependencies:
       provides:
-        - php-igbinary-dev=${{package.full-version}}
+        - php-igbinary-dev
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-imagick.yaml
+++ b/php-8.3-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-imagick
   version: 3.7.0
-  epoch: 3
+  epoch: 4
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01
@@ -11,13 +11,12 @@ package:
       - imagemagick
       - php-${{vars.phpMM}}
     provides:
-      - php-imagick=${{package.full-version}}
+      - php-imagick
+    provider-priority: ${{vars.phpPriority}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
+  phpPriority: 803
 
 environment:
   contents:
@@ -33,7 +32,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/Imagick/imagick
-      tag: "${{package.version}}"
+      tag: ${{package.version}}
       expected-commit: 52ec37ff633de0e5cca159a6437b8c340afe7831
 
   - name: Prepare build
@@ -52,7 +51,8 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-imagick-config=${{package.full-version}}
+        - php-imagick-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-memcached.yaml
+++ b/php-8.3-memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-memcached
   version: 3.3.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for Memcached"
   copyright:
     - license: PHP-3.01
@@ -10,13 +10,12 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
     provides:
-      - php-memcached=${{package.full-version}}
+      - php-memcached
+    provider-priority: ${{vars.phpPriority}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
+  phpPriority: 803
 
 environment:
   contents:
@@ -34,7 +33,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/php-memcached-dev/php-memcached
-      tag: v${{package.version}}
+      tag: "v${{package.version}}"
       expected-commit: b0b82692d789a2a5fd95b3910e87f73615c0f918
 
   - name: Prepare build
@@ -53,17 +52,19 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-memcached-config=${{package.full-version}}
+        - php-memcached-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=memcached.so" > "${{targets.subpkgdir}}/etc/php/conf.d/memcached.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.phpMM}} memcached development headers
+    description: "PHP ${{vars.phpMM}} memcached development headers"
     dependencies:
       provides:
-        - php-memcached-dev=${{package.full-version}}
+        - php-memcached-dev
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-msgpack.yaml
+++ b/php-8.3-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-msgpack
   version: 3.0.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
@@ -10,13 +10,12 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
     provides:
-      - php-msgpack=${{package.full-version}}
+      - php-msgpack
+    provider-priority: ${{vars.phpPriority}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
+  phpPriority: 803
 
 environment:
   contents:
@@ -51,17 +50,19 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-msgpack-config=${{package.full-version}}
+        - php-msgpack-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=msgpack.so" > "${{targets.subpkgdir}}/etc/php/conf.d/msgpack.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.phpMM}} msgpack development headers
+    description: "PHP ${{vars.phpMM}} msgpack development headers"
     dependencies:
       provides:
-        - php-msgpack-dev=${{package.full-version}}
+        - php-msgpack-dev
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-opentelemetry.yaml
+++ b/php-8.3-opentelemetry.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-opentelemetry
   version: 1.1.0
-  epoch: 1
+  epoch: 2
   description: "OpenTelemetry PHP auto-instrumentation extension"
   copyright:
     - license: Apache-2.0
@@ -10,13 +10,12 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
     provides:
-      - php-opentelemetry=${{package.full-version}}
+      - php-opentelemetry
+    provider-priority: ${{vars.phpPriority}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
+  phpPriority: 803
 
 environment:
   contents:
@@ -53,7 +52,8 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-opentelemetry-config=${{package.full-version}}
+        - php-opentelemetry-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-pdo_snowflake.yaml
+++ b/php-8.3-pdo_snowflake.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pdo_snowflake
   version: 3.0.3
-  epoch: 1
+  epoch: 2
   description: "Snowflake driver that uses the PHP Data Objects (PDO) extension"
   copyright:
     - license: Apache-2.0
@@ -13,11 +13,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:

--- a/php-8.3-pecl-http.yaml
+++ b/php-8.3-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pecl-http
   version: 4.2.4
-  epoch: 2
+  epoch: 3
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:

--- a/php-8.3-pecl-mcrypt.yaml
+++ b/php-8.3-pecl-mcrypt.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pecl-mcrypt
   version: 1.0.7
-  epoch: 3
+  epoch: 4
   description: "Provides PHP ${{vars.phpMM}} bindings for the unmaintained libmcrypt - PECL"
   copyright:
     - license: PHP-3.01
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:

--- a/php-8.3-pecl-mongodb.yaml
+++ b/php-8.3-pecl-mongodb.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pecl-mongodb
   version: 1.20.0
-  epoch: 3
+  epoch: 4
   description: "PHP ${{vars.phpMM}} MongoDB driver - PECL"
   copyright:
     - license: PHP-3.01
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:

--- a/php-8.3-pecl-pdosqlsrv.yaml
+++ b/php-8.3-pecl-pdosqlsrv.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pecl-pdosqlsrv
   version: 5.12.0
-  epoch: 2
+  epoch: 3
   description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (PDO_SQLSRV) - PECL"
   copyright:
     - license: MIT
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:

--- a/php-8.3-pecl-raphf.yaml
+++ b/php-8.3-pecl-raphf.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pecl-raphf
   version: 2.0.1
-  epoch: 2
+  epoch: 3
   description: "Provides PHP ${{vars.phpMM}} resource and persistent handles factory - PECL"
   copyright:
     - license: PHP-3.01
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:

--- a/php-8.3-pecl-sqlsrv.yaml
+++ b/php-8.3-pecl-sqlsrv.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pecl-sqlsrv
   version: 5.12.0
-  epoch: 2
+  epoch: 3
   description: "Provides PHP ${{vars.phpMM}} Microsoft Drivers for SQL Server (SQLSRV) - PECL"
   copyright:
     - license: MIT
@@ -9,11 +9,8 @@ package:
     runtime:
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:

--- a/php-8.3-protobuf.yaml
+++ b/php-8.3-protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-protobuf
   version: 4.28.3
-  epoch: 1
+  epoch: 2
   description: "Protocol Buffers - Google's data interchange format"
   copyright:
     - license: BSD-3-Clause
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:

--- a/php-8.3-redis.yaml
+++ b/php-8.3-redis.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-redis
   version: 6.1.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for Redis"
   copyright:
     - license: PHP-3.01
@@ -11,13 +11,12 @@ package:
       - php-${{vars.phpMM}}
       - php-${{vars.phpMM}}-igbinary
     provides:
-      - php-redis=${{package.full-version}}
+      - php-redis
+    provider-priority: ${{vars.phpPriority}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
+  phpPriority: 803
 
 environment:
   contents:
@@ -52,17 +51,19 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-redis-config=${{package.full-version}}
+        - php-redis-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.phpMM}} redis development headers
+    description: "PHP ${{vars.phpMM}} redis development headers"
     dependencies:
       provides:
-        - php-redis-dev=${{package.full-version}}
+        - php-redis-dev
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-ssh2.yaml
+++ b/php-8.3-ssh2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-ssh2
   version: 1.4.1
-  epoch: 1
+  epoch: 2
   description: "Bindings for the libssh2 library"
   copyright:
     - license: PHP-3.01
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:

--- a/php-8.3-swoole.yaml
+++ b/php-8.3-swoole.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-swoole
   version: 5.1.5
-  epoch: 1
+  epoch: 2
   description: "Coroutine-based concurrency library for PHP"
   copyright:
     - license: Apache-2.0
@@ -11,13 +11,12 @@ package:
       - brotli
       - php-${{vars.phpMM}}
     provides:
-      - php-swoole=${{package.full-version}}
+      - php-swoole
+    provider-priority: ${{vars.phpPriority}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
+  phpPriority: 803
 
 environment:
   contents:
@@ -55,7 +54,8 @@ subpackages:
   - name: ${{package.name}}-config
     dependencies:
       provides:
-        - php-swoole-config=${{package.full-version}}
+        - php-swoole-config
+      provider-priority: ${{vars.phpPriority}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-xdebug.yaml
+++ b/php-8.3-xdebug.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-xdebug
   version: 3.3.2
-  epoch: 1
+  epoch: 2
   description: "Step Debugger for PHP"
   copyright:
     - license: PHP-3.01
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:

--- a/php-8.3-zstd.yaml
+++ b/php-8.3-zstd.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-zstd
   version: 0.14.0
-  epoch: 0
+  epoch: 1
   description: Zstd Extension for PHP
   copyright:
     - license: MIT
@@ -10,11 +10,8 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
 
-var-transforms:
-  - from: ${{package.name}}
-    match: ^php-(\d+\.\d+)-.*$
-    replace: "$1"
-    to: phpMM
+vars:
+  phpMM: "8.3"
 
 environment:
   contents:


### PR DESCRIPTION
In all the php-8.*-*.yaml files:
1. replace all of the 'phpMM' definitions with simple var rather than transform based name.
2. replace any virtual provides with a version with an empty version and set providerPriority to a value based on the PHP version (instead of package version).

   This takes care to handle PHP versions 8.10 by using major*100 + minor (803 for 8.3 , which would mean 810 for 8.10).

The first item isn't a huge win, but the second is needed if we're going to have virtual provides.

Fixes: https://github.com/wolfi-dev/os/issues/32874
