### PR TITLE
fix: typo on the groupID and artifactID fields

### DIFF
--- a/tez/patches.yaml
+++ b/tez/patches.yaml
@@ -1,5 +1,5 @@
 patches:
 # CVE-2024-7254
-- groupID: com.google.protobuf
-  artifactID: protobuf-java
+- groupId: com.google.protobuf
+  artifactId: protobuf-java
   version: 3.25.5

--- a/thingsboard/pombump-deps.yaml
+++ b/thingsboard/pombump-deps.yaml
@@ -14,8 +14,8 @@ patches:
     - groupId: com.squareup.wire
       artifactId: wire-schema-jvm
       version: 4.9.9
-    - groupId: ""
-      artifactId: ""
+    - groupId: com.google.protobuf
+      artifactId: protobuf-java
       version: 3.25.5
     - groupId: org.springframework
       artifactId: spring-web


### PR DESCRIPTION
Fix typos on the pombump property names.