### PR TITLE
Drop virtual provides from php module packages

### DIFF
--- a/php-8.1-amqp.yaml
+++ b/php-8.1-amqp.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-amqp
   version: 2.1.2
-  epoch: 2
+  epoch: 3
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01
@@ -51,9 +51,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-amqp-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.1-igbinary.yaml
+++ b/php-8.1-igbinary.yaml
@@ -55,7 +55,7 @@ subpackages:
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
 
   - name: ${{package.name}}-dev
-    description: "PHP ${{vars.phpMM}} igbinary development headers"
+    description: PHP ${{vars.phpMM}} igbinary development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.1-igbinary.yaml
+++ b/php-8.1-igbinary.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-igbinary
   version: 3.2.16
-  epoch: 2
+  epoch: 3
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
@@ -49,19 +49,13 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-igbinary-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.phpMM}} igbinary development headers
-    dependencies:
-      provides:
-        - php-igbinary-dev=${{package.full-version}}
+    description: "PHP ${{vars.phpMM}} igbinary development headers"
     pipeline:
       - uses: split/dev
 

--- a/php-8.1-redis.yaml
+++ b/php-8.1-redis.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-redis
   version: 6.1.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for Redis"
   copyright:
     - license: PHP-3.01
@@ -49,19 +49,13 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-redis-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.phpMM}} redis development headers
-    dependencies:
-      provides:
-        - php-redis-dev=${{package.full-version}}
+    description: "PHP ${{vars.phpMM}} redis development headers"
     pipeline:
       - uses: split/dev
 

--- a/php-8.1-redis.yaml
+++ b/php-8.1-redis.yaml
@@ -55,7 +55,7 @@ subpackages:
           echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
 
   - name: ${{package.name}}-dev
-    description: "PHP ${{vars.phpMM}} redis development headers"
+    description: PHP ${{vars.phpMM}} redis development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.2-amqp.yaml
+++ b/php-8.2-amqp.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-amqp
   version: 2.1.2
-  epoch: 2
+  epoch: 3
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01
@@ -51,9 +51,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-amqp-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-amqp.yaml
+++ b/php-8.3-amqp.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-amqp
   version: 2.1.2
-  epoch: 2
+  epoch: 3
   description: "PHP extension to communicate with any AMQP compliant server"
   copyright:
     - license: PHP-3.01
@@ -10,8 +10,6 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
       - rabbitmq-c
-    provides:
-      - php-amqp=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -53,9 +51,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-amqp-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-apcu.yaml
+++ b/php-8.3-apcu.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-apcu
   version: 5.1.24
-  epoch: 1
+  epoch: 2
   description: "PHP extension for User Cache"
   copyright:
     - license: PHP-3.01
@@ -9,8 +9,6 @@ package:
     runtime:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
-    provides:
-      - php-apcu=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -48,9 +46,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-apcu-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-excimer.yaml
+++ b/php-8.3-excimer.yaml
@@ -29,7 +29,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/wikimedia/mediawiki-php-excimer
-      tag: ${{package.version}}
+      tag: "${{package.version}}"
       expected-commit: c52285d4e29be23dfbf54591ed23ad822ec02de0
 
   - name: Prepare build

--- a/php-8.3-excimer.yaml
+++ b/php-8.3-excimer.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-excimer
   version: 1.2.3
-  epoch: 0
+  epoch: 1
   description: "Excimer is a PHP extension that provides an interrupting timer and a low-overhead sampling profiler."
   copyright:
     - license: Apache-2.0
@@ -9,8 +9,6 @@ package:
     runtime:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
-    provides:
-      - php-excimer=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -31,7 +29,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/wikimedia/mediawiki-php-excimer
-      tag: "${{package.version}}"
+      tag: ${{package.version}}
       expected-commit: c52285d4e29be23dfbf54591ed23ad822ec02de0
 
   - name: Prepare build
@@ -51,9 +49,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-excimer-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-grpc.yaml
+++ b/php-8.3-grpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-grpc
   version: 1.68.0
-  epoch: 0
+  epoch: 1
   description: "A PHP extension for gRPC"
   copyright:
     - license: Apache-2.0
@@ -10,8 +10,6 @@ package:
       - ${{package.name}}-config
       - grpc
       - php-${{vars.phpMM}}
-    provides:
-      - php-grpc=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -49,9 +47,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-grpc-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-igbinary.yaml
+++ b/php-8.3-igbinary.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-igbinary
   version: 3.2.16
-  epoch: 2
+  epoch: 3
   description: "Igbinary is a drop in replacement for the standard php serializer."
   copyright:
     - license: BSD-3-Clause
@@ -9,8 +9,6 @@ package:
     runtime:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
-    provides:
-      - php-igbinary=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -51,19 +49,13 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-igbinary-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.phpMM}} igbinary development headers
-    dependencies:
-      provides:
-        - php-igbinary-dev=${{package.full-version}}
+    description: "PHP ${{vars.phpMM}} igbinary development headers"
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-igbinary.yaml
+++ b/php-8.3-igbinary.yaml
@@ -55,7 +55,7 @@ subpackages:
           echo "extension=igbinary.so" > "${{targets.subpkgdir}}/etc/php/conf.d/igbinary.ini"
 
   - name: ${{package.name}}-dev
-    description: "PHP ${{vars.phpMM}} igbinary development headers"
+    description: PHP ${{vars.phpMM}} igbinary development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-imagick.yaml
+++ b/php-8.3-imagick.yaml
@@ -31,7 +31,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/Imagick/imagick
-      tag: ${{package.version}}
+      tag: "${{package.version}}"
       expected-commit: 52ec37ff633de0e5cca159a6437b8c340afe7831
 
   - name: Prepare build

--- a/php-8.3-imagick.yaml
+++ b/php-8.3-imagick.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-imagick
   version: 3.7.0
-  epoch: 3
+  epoch: 4
   description: "PHP extension for ImageMagick"
   copyright:
     - license: PHP-3.01
@@ -10,8 +10,6 @@ package:
       - ${{package.name}}-config
       - imagemagick
       - php-${{vars.phpMM}}
-    provides:
-      - php-imagick=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -33,7 +31,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/Imagick/imagick
-      tag: "${{package.version}}"
+      tag: ${{package.version}}
       expected-commit: 52ec37ff633de0e5cca159a6437b8c340afe7831
 
   - name: Prepare build
@@ -50,9 +48,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-imagick-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-memcached.yaml
+++ b/php-8.3-memcached.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-memcached
   version: 3.3.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for Memcached"
   copyright:
     - license: PHP-3.01
@@ -9,8 +9,6 @@ package:
     runtime:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
-    provides:
-      - php-memcached=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -34,7 +32,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/php-memcached-dev/php-memcached
-      tag: v${{package.version}}
+      tag: "v${{package.version}}"
       expected-commit: b0b82692d789a2a5fd95b3910e87f73615c0f918
 
   - name: Prepare build
@@ -51,19 +49,13 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-memcached-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=memcached.so" > "${{targets.subpkgdir}}/etc/php/conf.d/memcached.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.phpMM}} memcached development headers
-    dependencies:
-      provides:
-        - php-memcached-dev=${{package.full-version}}
+    description: "PHP ${{vars.phpMM}} memcached development headers"
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-memcached.yaml
+++ b/php-8.3-memcached.yaml
@@ -32,7 +32,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/php-memcached-dev/php-memcached
-      tag: "v${{package.version}}"
+      tag: v${{package.version}}
       expected-commit: b0b82692d789a2a5fd95b3910e87f73615c0f918
 
   - name: Prepare build
@@ -55,7 +55,7 @@ subpackages:
           echo "extension=memcached.so" > "${{targets.subpkgdir}}/etc/php/conf.d/memcached.ini"
 
   - name: ${{package.name}}-dev
-    description: "PHP ${{vars.phpMM}} memcached development headers"
+    description: PHP ${{vars.phpMM}} memcached development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-msgpack.yaml
+++ b/php-8.3-msgpack.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-msgpack
   version: 3.0.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for msgpack"
   copyright:
     - license: BSD-3-Clause
@@ -9,8 +9,6 @@ package:
     runtime:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
-    provides:
-      - php-msgpack=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -49,19 +47,13 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-msgpack-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=msgpack.so" > "${{targets.subpkgdir}}/etc/php/conf.d/msgpack.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.phpMM}} msgpack development headers
-    dependencies:
-      provides:
-        - php-msgpack-dev=${{package.full-version}}
+    description: "PHP ${{vars.phpMM}} msgpack development headers"
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-msgpack.yaml
+++ b/php-8.3-msgpack.yaml
@@ -53,7 +53,7 @@ subpackages:
           echo "extension=msgpack.so" > "${{targets.subpkgdir}}/etc/php/conf.d/msgpack.ini"
 
   - name: ${{package.name}}-dev
-    description: "PHP ${{vars.phpMM}} msgpack development headers"
+    description: PHP ${{vars.phpMM}} msgpack development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-opentelemetry.yaml
+++ b/php-8.3-opentelemetry.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-opentelemetry
   version: 1.1.0
-  epoch: 1
+  epoch: 2
   description: "OpenTelemetry PHP auto-instrumentation extension"
   copyright:
     - license: Apache-2.0
@@ -9,8 +9,6 @@ package:
     runtime:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
-    provides:
-      - php-opentelemetry=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -51,9 +49,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-opentelemetry-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"

--- a/php-8.3-redis.yaml
+++ b/php-8.3-redis.yaml
@@ -54,7 +54,7 @@ subpackages:
           echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
 
   - name: ${{package.name}}-dev
-    description: "PHP ${{vars.phpMM}} redis development headers"
+    description: PHP ${{vars.phpMM}} redis development headers
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-redis.yaml
+++ b/php-8.3-redis.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-redis
   version: 6.1.0
-  epoch: 2
+  epoch: 3
   description: "A PHP extension for Redis"
   copyright:
     - license: PHP-3.01
@@ -10,8 +10,6 @@ package:
       - ${{package.name}}-config
       - php-${{vars.phpMM}}
       - php-${{vars.phpMM}}-igbinary
-    provides:
-      - php-redis=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -50,19 +48,13 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-redis-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"
           echo "extension=redis.so" > "${{targets.subpkgdir}}/etc/php/conf.d/redis.ini"
 
   - name: ${{package.name}}-dev
-    description: PHP ${{vars.phpMM}} redis development headers
-    dependencies:
-      provides:
-        - php-redis-dev=${{package.full-version}}
+    description: "PHP ${{vars.phpMM}} redis development headers"
     pipeline:
       - uses: split/dev
 

--- a/php-8.3-swoole.yaml
+++ b/php-8.3-swoole.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-swoole
   version: 5.1.5
-  epoch: 1
+  epoch: 2
   description: "Coroutine-based concurrency library for PHP"
   copyright:
     - license: Apache-2.0
@@ -10,8 +10,6 @@ package:
       - ${{package.name}}-config
       - brotli
       - php-${{vars.phpMM}}
-    provides:
-      - php-swoole=${{package.full-version}}
 
 var-transforms:
   - from: ${{package.name}}
@@ -53,9 +51,6 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-config
-    dependencies:
-      provides:
-        - php-swoole-config=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/etc/php/conf.d"


### PR DESCRIPTION
Some of the php modules had virtual provides. The intent of such a thing would be so that a process could 'apk add php-amqp' and get a sane result.

The implementation had a problem where by doing so would choose whichever php-8.X-amqp version had the newest package version. That is almost certainly _not_ what the process wanted (one day to get php-8.2-ampq and the next to get php-8.1-ampq).

https://github.com/wolfi-dev/os/issues/32874 describes the problem and a solution. https://github.com/wolfi-dev/os/pull/34680 implemented that solution.  In the PR we realized that the provides were so inconsistent that it would be had to use the. So then, given the option of making them consistent or dropping them, we chose to drop them.
