### PR TITLE
py3-grpcio-gcp: Add python multiversion support

### DIFF
--- a/pipelines/py/pip-build-install.yaml
+++ b/pipelines/py/pip-build-install.yaml
@@ -7,6 +7,9 @@ inputs:
   dest:
     description: the destination
     default: ${{targets.contextdir}}
+  source:
+    description: directory containing the python package source
+    default: .
   needs-exe-named-python3:
     description: Does the build actually need 'python3' in its PATH
     default: false
@@ -107,7 +110,7 @@ pipeline:
       mkdir -p "$distwheelsd"
       echo "$py is $pyver with site_packages dir '$sitepkgd'"
       vr $py -m pip wheel --verbose "--wheel-dir=$wd" \
-          "--find-links=$distwheelsd" --no-index --no-build-isolation --no-deps .
+          "--find-links=$distwheelsd" --no-index --no-build-isolation --no-deps "${{inputs.source}}"
       vr $py -m pip install --verbose \
           "--find-links=$distwheelsd" --no-index --no-build-isolation --no-deps \
           --force-reinstall --no-compile --prefix=/usr "--root=$root" "$wd"/*.whl

--- a/py3-grpcio-gcp.yaml
+++ b/py3-grpcio-gcp.yaml
@@ -17,22 +17,34 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - py3-build-base
+      - py3-grpcio-tools
       - py3-setuptools
       - python-3
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: e292605effc7da39b7a8734c719afb12ec4b5362add3528d8afad3aa3aa9057c
-      uri: https://files.pythonhosted.org/packages/source/g/grpcio-gcp/grpcio-gcp-${{package.version}}.tar.gz
+      repository: https://github.com/GoogleCloudPlatform/grpc-gcp-python
+      tag: v${{package.version}}
+      expected-commit: 8ef890243664ebd95ae0225cdf87e7442b570f9e
+
+  - runs: |
+      cd src
+      # From src/setup.sh
+      cp -f ../template/version.py version.py
+      python3 -m grpc_tools.protoc -I. --python_out=grpc_gcp/proto grpc_gcp.proto
 
   - name: Python Build
-    uses: python/build-wheel
+    uses: py/pip-build-install
+    with:
+      source: ./src
 
   - uses: strip
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 100779
+  github:
+    identifier: GoogleCloudPlatform/grpc-gcp-python
+    strip-prefix: v

--- a/py3-grpcio-gcp.yaml
+++ b/py3-grpcio-gcp.yaml
@@ -1,27 +1,31 @@
-# Generated from https://pypi.org/project/grpcio-gcp/
 package:
   name: py3-grpcio-gcp
   version: 0.2.2
-  epoch: 2
+  epoch: 3
   description: gRPC extensions for Google Cloud Platform
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - py3-grpcio
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: grpcio-gcp
+  import: grpc_gcp
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-build-base
       - py3-grpcio-tools
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-setuptools
 
 pipeline:
   - uses: git-checkout
@@ -36,12 +40,48 @@ pipeline:
       cp -f ../template/version.py version.py
       python3 -m grpc_tools.protoc -I. --python_out=grpc_gcp/proto grpc_gcp.proto
 
-  - name: Python Build
-    uses: py/pip-build-install
-    with:
-      source: ./src
-
   - uses: strip
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-grpcio
+        - py${{range.key}}-protobuf
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+          source: ./src
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true


### PR DESCRIPTION
Related: https://github.com/chainguard-dev/internal-dev/issues/5334

From the individual commits:

-  pip-build-install pipeline: Introduce "source" input variable
    -  Python modules may be provided in subdirectories of the upstream source.
-  py3-grpcio-gcp: Build from github repository using py/pip-build-install
    -  Building from the tarball results in an unusable package because  the included grpc_gcp_pb2.py is generated from an old protobuf. The tarball includes the .proto file we need to generate a new one.
-  py3-grpcio-gcp: Add python multiversion support