### PR TITLE
Add a runtime dep to flac so the pkgconf test pipeline passes

### DIFF
--- a/flac.yaml
+++ b/flac.yaml
@@ -2,7 +2,7 @@
 package:
   name: flac
   version: 1.4.3
-  epoch: 2
+  epoch: 3
   description: Free Lossless Audio Codec
   copyright:
     - license: BSD-3-Clause AND GPL-2.0-or-later
@@ -51,6 +51,12 @@ subpackages:
     pipeline:
       - uses: split/dev
     description: flac dev
+    dependencies:
+      runtime:
+        - libogg-dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
   - name: libflac
     pipeline:


### PR DESCRIPTION
This will fix https://github.com/wolfi-dev/os/issues/34008.

Here's an excerpt from the test log after the changes:

```
2024/11/20 09:05:40 INFO uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 WARN + grep -q ^Name: usr/lib/pkgconfig/flac.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 WARN + basename usr/lib/pkgconfig/flac.pc .pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 WARN + lib_name=flac uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 WARN + echo usr/lib/pkgconfig/flac.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 WARN + grep -q '^usr/lib/pkgconfig/flac.pc$\|^usr/share/pkgconfig/flac.pc$' uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 WARN + pkgconf --exists flac uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 WARN + grep -q ^Version: usr/lib/pkgconfig/flac.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 WARN + pkgconf --modversion flac uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 INFO 1.4.3 uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 WARN + grep -q ^Libs: usr/lib/pkgconfig/flac.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 WARN + pkgconf --libs flac uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 INFO -lFLAC uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 WARN + grep -q ^Cflags: usr/lib/pkgconfig/flac.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 WARN + pkgconf --cflags flac uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 INFO uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 09:05:40 WARN + exit 0 uses=test/pkgconf name="pkgconf build dependency check"
```