### PR TITLE
ruby3.X-activesupport: move uri to runtime dep

### DIFF
--- a/ruby3.2-activesupport.yaml
+++ b/ruby3.2-activesupport.yaml
@@ -1,17 +1,19 @@
 package:
   name: ruby3.2-activesupport
   version: 8.0.0
-  epoch: 0
+  epoch: 1
   description: A toolkit of support libraries and Ruby core extensions extracted from the Rails framework. Rich support for multibyte strings, internationalization, time zones, and testing.
   copyright:
     - license: MIT
   dependencies:
     runtime:
+      - ruby${{vars.rubyMM}}-benchmark
       - ruby${{vars.rubyMM}}-concurrent-ruby
       - ruby${{vars.rubyMM}}-connection_pool
       - ruby${{vars.rubyMM}}-i18n
       - ruby${{vars.rubyMM}}-securerandom
       - ruby${{vars.rubyMM}}-tzinfo
+      - ruby${{vars.rubyMM}}-uri
 
 environment:
   contents:
@@ -53,11 +55,6 @@ update:
     strip-prefix: v
 
 test:
-  environment:
-    contents:
-      packages:
-        - ruby${{vars.rubyMM}}-uri
-        - ruby${{vars.rubyMM}}-benchmark
   pipeline:
     - name: Basic require test
       runs: |

--- a/ruby3.3-activesupport.yaml
+++ b/ruby3.3-activesupport.yaml
@@ -1,17 +1,19 @@
 package:
   name: ruby3.3-activesupport
   version: 8.0.0
-  epoch: 0
+  epoch: 1
   description: A toolkit of support libraries and Ruby core extensions extracted from the Rails framework. Rich support for multibyte strings, internationalization, time zones, and testing.
   copyright:
     - license: MIT
   dependencies:
     runtime:
+      - ruby${{vars.rubyMM}}-benchmark
       - ruby${{vars.rubyMM}}-concurrent-ruby
       - ruby${{vars.rubyMM}}-connection_pool
       - ruby${{vars.rubyMM}}-i18n
       - ruby${{vars.rubyMM}}-securerandom
       - ruby${{vars.rubyMM}}-tzinfo
+      - ruby${{vars.rubyMM}}-uri
 
 environment:
   contents:
@@ -53,11 +55,6 @@ update:
     strip-prefix: v
 
 test:
-  environment:
-    contents:
-      packages:
-        - ruby${{vars.rubyMM}}-uri
-        - ruby${{vars.rubyMM}}-benchmark
   pipeline:
     - name: Basic require test
       runs: |


### PR DESCRIPTION
These deps were incorrectly added to the test instead of runtime when the test failures were noticed.

