### PR TITLE
fix/apache nifi 2.0 support

### DIFF
--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -156,6 +156,16 @@ update:
 test:
   pipeline:
     - runs: |
+        # ensure the same environment variables are set as the container image
         export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+        export NIFI_BASE_DIR="/usr/share/nifi"
+        export NIFI_HOME="/usr/share/nifi/nifi-current"
+        export NIFI_TOOLKIT_HOME="/usr/share/nifi/nifi-toolkit-current"
+        export NIFI_PID_DIR="/usr/share/nifi/nifi-current/run"
+        export NIFI_LOG_DIR="/usr/share/nifi/nifi-current/logs"
         # Use the same start script as the container image uses as its entrypoint
-        /usr/share/nifi/scripts/start.sh
+        /usr/share/nifi/scripts/start.sh &
+        # wait until we know the server has started. In my testing 25 seconds is more than enough time
+        sleep 25
+        # ensure that a known running server log message is present
+        grep "org.apache.nifi.web.server.JettyServer Started Server on" /usr/share/nifi/nifi-current/logs/nifi-app.log

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -16,6 +16,7 @@ package:
       - glibc-locale-en
       - openjdk-21-default-jvm
       - openjdk-21-jre
+      - python3
       - xmlstarlet
 
 environment:

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-nifi
   version: 2.0.0
-  epoch: 2
+  epoch: 3
   description: Apache NiFi is an easy to use, powerful, and reliable system to process and distribute data.
   copyright:
     - license: Apache-2.0

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -57,12 +57,8 @@ pipeline:
       patches: upgrade-netty.4.version.patch
 
   - runs: |
-      # Use single thread on x86_64
-      if [[ "${{build.arch}}" == "x86_64" ]]; then
-        MAVEN_THREADS=1
-      else
-        MAVEN_THREADS=$(nproc)
-      fi
+      # Use single thread to avoid `java.lang.IllegalStateException: Could not acquire lock(s)` build error
+      MAVEN_THREADS=1
 
       # Build NiFi
       ./mvnw -T${MAVEN_THREADS}C -q package \

--- a/apache-nifi.yaml
+++ b/apache-nifi.yaml
@@ -157,4 +157,5 @@ test:
   pipeline:
     - runs: |
         export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
-        /usr/share/nifi/nifi-current/bin/nifi.sh start
+        # Use the same start script as the container image uses as its entrypoint
+        /usr/share/nifi/scripts/start.sh


### PR DESCRIPTION
**fix(apache-nifi.yaml): Use single thread in both architectures**

Use single thread to avoid `java.lang.IllegalStateException: Could not acquire lock(s)` build error

**fix(apache-nifi.yaml): Catch error when testing apache-nifi server start script**

More accurately represent a correct apache-nifi server start - just as our container images do.

The start script will not exit non zero even if it fails. Previous test would always pass as long
as the script existed and was executable.

As such we need to ensure we start the same we to with the apache-nifi container image entrypoint
by setting the expected environment variables and by ensuring the expected log message is present.


**fix(apache-nifi.yaml): Use the same start script as the container image uses as its entrypoint**

This ensures we are being consistent in testing and ensuring that we block on the correct failure which would block image build/test.

**fix(apache-nifi.yaml): Add python3 as a runtime dependency**

With Apachae nifi 2.0+ - python3 is now a runtime dependency.

Without this error below will occur when attempting start

```
Caused by: java.lang.IllegalStateException: Failed to communicate with Python Controller
Caused by: java.io.IOException: Cannot run program "python3": error=2, No such file or directory
```


