### PR TITLE
Add a runtime dep to libassuan so the pkgconf test pipeline passes

### DIFF
--- a/libassuan.yaml
+++ b/libassuan.yaml
@@ -1,7 +1,7 @@
 package:
   name: libassuan
   version: 3.0.1
-  epoch: 0
+  epoch: 1
   description: IPC library used by some GnuPG related software
   copyright:
     - license: LGPL-2.1-or-later
@@ -38,7 +38,11 @@ subpackages:
     dependencies:
       runtime:
         - libassuan
+        - libgpg-error-dev
     description: libassuan dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
   - name: libassuan-doc
     pipeline:


### PR DESCRIPTION
This fixes https://github.com/wolfi-dev/os/issues/34321.

Here's an excerpt from the pass:

```
2024/11/20 10:49:01 INFO running step "pkgconf build dependency check" uses=test/pkgconf
2024/11/20 10:49:01 WARN + '[' -d /home/build ] uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + cd /home/build uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + basename /home/build/melange-out/libassuan-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + dev_pkg=libassuan-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + cd / uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + apk info -L libassuan-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + grep '\.pc$' uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN WARNING: opening /home/brian-murray/Working/wolfi-os/packages: No such file or directory uses=test/pkgconf name="pkgconf build dependency chec
k" 
2024/11/20 10:49:01 WARN WARNING: opening from cache https://packages.wolfi.dev/os: No such file or directory uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + grep -q ^Name: usr/lib/pkgconfig/libassuan.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + basename usr/lib/pkgconfig/libassuan.pc .pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + lib_name=libassuan uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + echo usr/lib/pkgconfig/libassuan.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + grep -q '^usr/lib/pkgconfig/libassuan.pc$\|^usr/share/pkgconfig/libassuan.pc$' uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + pkgconf --exists libassuan uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + grep -q ^Version: usr/lib/pkgconfig/libassuan.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + pkgconf --modversion libassuan uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 INFO 3.0.1 uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + grep -q ^Libs: usr/lib/pkgconfig/libassuan.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + pkgconf --libs libassuan uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 INFO -lassuan uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + grep -q ^Cflags: usr/lib/pkgconfig/libassuan.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + pkgconf --cflags libassuan uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 INFO uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 10:49:01 WARN + exit 0 uses=test/pkgconf name="pkgconf build dependency check"
```