### PR TITLE
Add a runtime dep to libksba so the pkgconf test pipeline passes

### DIFF
--- a/libksba.yaml
+++ b/libksba.yaml
@@ -1,7 +1,7 @@
 package:
   name: libksba
   version: 1.6.7
-  epoch: 0
+  epoch: 1
   description: Libksba is a CMS and X.509 access library
   copyright:
     - license: GPL-2.0-or-later OR GPL-3.0-or-later
@@ -47,8 +47,12 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
+        - libgpg-error-dev
         - libksba
     description: libksba dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
   - name: libksba-doc
     pipeline:


### PR DESCRIPTION
This will fix https://github.com/wolfi-dev/os/issues/34330

Here is an excerpt from a passing test:

```
2024/11/20 12:39:07 INFO running step "test/pkgconf"
2024/11/20 12:39:07 WARN + '[' -d /home/build ] uses=test/pkgconf
2024/11/20 12:39:07 WARN + cd /home/build uses=test/pkgconf
2024/11/20 12:39:07 WARN + exit 0 uses=test/pkgconf
2024/11/20 12:39:07 INFO running step "pkgconf build dependency check" uses=test/pkgconf
2024/11/20 12:39:07 WARN + '[' -d /home/build ] uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + cd /home/build uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + basename /home/build/melange-out/libksba-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + dev_pkg=libksba-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + cd / uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + apk info -L libksba-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + grep '\.pc$' uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN WARNING: opening /home/brian-murray/Working/wolfi-os/packages: No such file or directory uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN WARNING: opening from cache https://packages.wolfi.dev/os: No such file or directory uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + grep -q ^Name: usr/lib/pkgconfig/ksba.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + basename usr/lib/pkgconfig/ksba.pc .pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + lib_name=ksba uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + echo usr/lib/pkgconfig/ksba.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + grep -q '^usr/lib/pkgconfig/ksba.pc$\|^usr/share/pkgconfig/ksba.pc$' uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + pkgconf --exists ksba uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + grep -q ^Version: usr/lib/pkgconfig/ksba.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + pkgconf --modversion ksba uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 INFO 1.6.7 uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + grep -q ^Libs: usr/lib/pkgconfig/ksba.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + pkgconf --libs ksba uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 INFO -lksba -lgpg-error uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + grep -q ^Cflags: usr/lib/pkgconfig/ksba.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + pkgconf --cflags ksba uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 INFO uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 12:39:07 WARN + exit 0 uses=test/pkgconf name="pkgconf build dependency check"
```