### PR TITLE
Add a runtime dep to liblangtag so the pkgconf test pipeline passes

### DIFF
--- a/liblangtag.yaml
+++ b/liblangtag.yaml
@@ -2,7 +2,7 @@
 package:
   name: liblangtag
   version: 0.6.7
-  epoch: 0
+  epoch: 1
   description: Interface library to access/deal with tags for identifying languages
   copyright:
     - license: LGPL-3.0-or-later OR MPL-2.0
@@ -41,8 +41,12 @@ subpackages:
     dependencies:
       runtime:
         - liblangtag
+        - libxml2-dev
         - glib-dev
     description: liblangtag dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
   - name: liblangtag-doc
     pipeline:


### PR DESCRIPTION
This will fix https://github.com/wolfi-dev/os/issues/34331

An excerpt from the test passing follows:

```
2024/11/20 20:49:13 INFO running step "test/pkgconf"
2024/11/20 20:49:13 WARN + '[' -d /home/build ] uses=test/pkgconf
2024/11/20 20:49:13 WARN + cd /home/build uses=test/pkgconf
2024/11/20 20:49:13 WARN + exit 0 uses=test/pkgconf
2024/11/20 20:49:13 INFO running step "pkgconf build dependency check" uses=test/pkgconf
2024/11/20 20:49:13 WARN + '[' -d /home/build ] uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + cd /home/build uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + basename /home/build/melange-out/liblangtag-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + dev_pkg=liblangtag-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + cd / uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + apk info -L liblangtag-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + grep '\.pc$' uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN WARNING: opening /home/user/src/wolfi-os/packages: No such file or directory uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN WARNING: opening from cache https://packages.wolfi.dev/os: No such file or directory uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + grep -q ^Name: usr/lib/pkgconfig/liblangtag.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + basename usr/lib/pkgconfig/liblangtag.pc .pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + lib_name=liblangtag uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + echo usr/lib/pkgconfig/liblangtag.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + grep -q '^usr/lib/pkgconfig/liblangtag.pc$\|^usr/share/pkgconfig/liblangtag.pc$' uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + pkgconf --exists liblangtag uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + grep -q ^Version: usr/lib/pkgconfig/liblangtag.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + pkgconf --modversion liblangtag uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 INFO 0.6.7 uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + grep -q ^Libs: usr/lib/pkgconfig/liblangtag.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + pkgconf --libs liblangtag uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 INFO -llangtag -lxml2 uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + grep -q ^Cflags: usr/lib/pkgconfig/liblangtag.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 20:49:13 WARN + exit 0 uses=test/pkgconf name="pkgconf build dependency check"
```