### PR TITLE
Add a runtime dep to libtracefs so the pkgconf test pipeline passes

### DIFF
--- a/libtracefs.yaml
+++ b/libtracefs.yaml
@@ -1,7 +1,7 @@
 package:
   name: libtracefs
   version: 1.8.1
-  epoch: 0
+  epoch: 1
   description: "Linux kernel trace file system library"
   copyright:
     - license: "LGPL-2.1-or-later"
@@ -33,7 +33,13 @@ subpackages:
   - name: libtracefs-dev
     pipeline:
       - uses: split/dev
+    dependencies:
+      runtime:
+        - libtraceevent-dev
     description: libtracefs dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
 update:
   enabled: true


### PR DESCRIPTION
This will fix https://github.com/wolfi-dev/os/issues/34338

Evidence of the test passing:

```
2024/11/20 21:01:44 INFO running step "test/pkgconf"
2024/11/20 21:01:44 WARN + '[' -d /home/build ] uses=test/pkgconf
2024/11/20 21:01:44 WARN + cd /home/build uses=test/pkgconf
2024/11/20 21:01:44 WARN + exit 0 uses=test/pkgconf
2024/11/20 21:01:44 INFO running step "pkgconf build dependency check" uses=test/pkgconf
2024/11/20 21:01:44 WARN + '[' -d /home/build ] uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + cd /home/build uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + basename /home/build/melange-out/libtracefs-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + dev_pkg=libtracefs-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + cd / uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + apk info -L libtracefs-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + grep '\.pc$' uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN WARNING: opening /home/user/src/wolfi-os/packages: No such file or directory uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN WARNING: opening from cache https://packages.wolfi.dev/os: No such file or directory uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + grep -q ^Name: usr/lib/pkgconfig/libtracefs.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + basename usr/lib/pkgconfig/libtracefs.pc .pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + lib_name=libtracefs uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + echo usr/lib/pkgconfig/libtracefs.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + grep -q '^usr/lib/pkgconfig/libtracefs.pc$\|^usr/share/pkgconfig/libtracefs.pc$' uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + pkgconf --exists libtracefs uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + grep -q ^Version: usr/lib/pkgconfig/libtracefs.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + pkgconf --modversion libtracefs uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 INFO 1.8.1 uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + grep -q ^Libs: usr/lib/pkgconfig/libtracefs.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + pkgconf --libs libtracefs uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 INFO -ltracefs -ltraceevent uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + grep -q ^Cflags: usr/lib/pkgconfig/libtracefs.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + pkgconf --cflags libtracefs uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 INFO -I/usr/include/tracefs -I/usr/include/traceevent uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:01:44 WARN + exit 0 uses=test/pkgconf name="pkgconf build dependency check"
```