### PR TITLE
Add a runtime dep to portaudio so the pkgconf test pipeline passes

### DIFF
--- a/portaudio.yaml
+++ b/portaudio.yaml
@@ -1,7 +1,7 @@
 package:
   name: portaudio
   version: 19.7.0
-  epoch: 0
+  epoch: 1
   description: "A cross-platform, open-source C language library for real-time audio input and output"
   copyright:
     - license: MIT
@@ -62,7 +62,11 @@ subpackages:
       - uses: split/dev
     dependencies:
       runtime:
+        - alsa-lib-dev
         - portaudio
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
 update:
   enabled: true


### PR DESCRIPTION
This fixes https://github.com/wolfi-dev/os/issues/34363

Here's evidence of the test passing:

```
2024/11/20 21:12:04 INFO -pthread uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 WARN + grep -q ^Name: usr/lib/pkgconfig/portaudiocpp.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 WARN + basename usr/lib/pkgconfig/portaudiocpp.pc .pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 WARN + lib_name=portaudiocpp uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 WARN + echo usr/lib/pkgconfig/portaudiocpp.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 WARN + grep -q '^usr/lib/pkgconfig/portaudiocpp.pc$\|^usr/share/pkgconfig/portaudiocpp.pc$' uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 WARN + pkgconf --exists portaudiocpp uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 WARN + grep -q ^Version: usr/lib/pkgconfig/portaudiocpp.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 WARN + pkgconf --modversion portaudiocpp uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 INFO 12 uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 WARN + grep -q ^Libs: usr/lib/pkgconfig/portaudiocpp.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 WARN + pkgconf --libs portaudiocpp uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 INFO -lportaudiocpp -lportaudio -lm -lpthread -lasound uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 WARN + grep -q ^Cflags: usr/lib/pkgconfig/portaudiocpp.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 WARN + pkgconf --cflags portaudiocpp uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 INFO -pthread uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 21:12:04 WARN + exit 0 uses=test/pkgconf name="pkgconf build dependency check"
```