### PR TITLE
Add melange test coverage to existing melange packages

### DIFF
--- a/ruby3.2-aws-sdk-kms.yaml
+++ b/ruby3.2-aws-sdk-kms.yaml
@@ -51,6 +51,44 @@ update:
   release-monitor:
     identifier: 174496
 
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+        - ruby${{vars.rubyMM}}-aws-sdk-core
+        - ruby${{vars.rubyMM}}-aws-sigv4
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'aws-sdk-kms'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        class TestAWSKMSSDK < Test::Unit::TestCase
+          def setup
+            # Mocking AWS KMS client
+            @kms = Aws::KMS::Client.new(stub_responses: true)
+          end
+
+          def test_encrypt_decrypt
+            # Mock encrypt and decrypt responses
+            @kms.stub_responses(:encrypt, { ciphertext_blob: "mocked_ciphertext" })
+            @kms.stub_responses(:decrypt, { plaintext: "decrypted_data" })
+
+            # Encrypt mock data
+            encrypt_resp = @kms.encrypt(key_id: "mocked-key-id", plaintext: "test_data")
+            assert_equal "mocked_ciphertext", encrypt_resp.ciphertext_blob, "Encryption failed"
+
+            # Decrypt mock data
+            decrypt_resp = @kms.decrypt(ciphertext_blob: encrypt_resp.ciphertext_blob)
+            assert_equal "decrypted_data", decrypt_resp.plaintext, "Decryption failed"
+
+            puts "KMS encrypt/decrypt test passed!"
+          end
+        end
+        EOF
+
 var-transforms:
   - from: ${{package.name}}
     match: ^ruby(\d\.\d+)-.*

--- a/ruby3.2-aws-sdk-s3.yaml
+++ b/ruby3.2-aws-sdk-s3.yaml
@@ -47,6 +47,37 @@ pipeline:
 vars:
   gem: aws-sdk-s3
 
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+        - ruby${{vars.rubyMM}}-rexml
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'aws-sdk-s3'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        class TestAWSS3SDK < Test::Unit::TestCase
+          def test_put_object
+            # Create a stubbed S3 client
+            s3 = Aws::S3::Client.new(stub_responses: true)
+
+            # Mock the put_object response
+            s3.stub_responses(:put_object, {})
+
+            # Perform the operation
+            response = s3.put_object(bucket: "test-bucket", key: "test-key", body: "test-content")
+
+            # Assert the response
+            assert response.successful?, "Put object operation failed"
+            puts "Basic put object test passed!"
+          end
+        end
+        EOF
+
 update:
   enabled: false
   manual: true # the library we fetch uses a different version then the package version

--- a/ruby3.2-aws-sdk-sqs.yaml
+++ b/ruby3.2-aws-sdk-sqs.yaml
@@ -45,6 +45,36 @@ pipeline:
 vars:
   gem: aws-sdk-sqs
 
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'aws-sdk-sqs'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        class TestAWSSQSSDK < Test::Unit::TestCase
+          def test_send_message
+            # Create a stubbed SQS client
+            sqs = Aws::SQS::Client.new(stub_responses: true)
+
+            # Mock the send_message response
+            sqs.stub_responses(:send_message, message_id: "12345")
+
+            # Perform the operation
+            response = sqs.send_message(queue_url: "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue", message_body: "Hello, SQS!")
+
+            # Assert the response
+            assert_equal "12345", response.message_id, "Message ID does not match"
+            puts "Basic send message test passed!"
+          end
+        end
+        EOF
+
 update:
   enabled: false
   manual: true # the library we fetch uses a different version then the package version

--- a/ruby3.2-aws-sigv4.yaml
+++ b/ruby3.2-aws-sigv4.yaml
@@ -45,6 +45,47 @@ pipeline:
 vars:
   gem: aws-sigv4
 
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'aws-sigv4'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        # Test basic signer creation
+        signer = Aws::Sigv4::Signer.new(
+          service: 'service',
+          region: 'us-east-1',
+          access_key_id: 'akid',
+          secret_access_key: 'secret'
+        )
+        assert_kind_of Aws::Sigv4::Signer, signer
+        puts "Signer creation test passed"
+
+        # Test basic signature generation
+        signature = signer.sign_request(
+          http_method: 'GET',
+          url: 'https://service.us-east-1.amazonaws.com',
+          headers: {
+            'host' => 'service.us-east-1.amazonaws.com'
+          }
+        )
+        assert_kind_of String, signature.string_to_sign
+        puts "Signature string generation test passed"
+
+        # Test canonical request generation
+        assert signature.canonical_request.include?('GET')
+        assert signature.canonical_request.include?('host:service.us-east-1.amazonaws.com')
+        puts "Canonical request test passed"
+
+        puts "All tests passed!"
+        EOF
+
 update:
   enabled: false
   manual: true # the library we fetch uses a different version then the package version

--- a/ruby3.2-base64.yaml
+++ b/ruby3.2-base64.yaml
@@ -38,6 +38,31 @@ pipeline:
 vars:
   gem: base64
 
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'base64'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        class TestBase64 < Test::Unit::TestCase
+          def test_base64_encode_decode
+            original = "Hello, Base64!"
+            encoded = Base64.encode64(original)
+            decoded = Base64.decode64(encoded)
+
+            # Verify encoding and decoding
+            assert_equal "Hello, Base64!", decoded, "Decoded value did not match original."
+            puts "Base64 encode/decode test passed!"
+          end
+        end
+        EOF
+
 update:
   enabled: true
   github:

--- a/ruby3.2-benchmark.yaml
+++ b/ruby3.2-benchmark.yaml
@@ -13,8 +13,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - git
-      - ruby-3.2
-      - ruby-3.2-dev
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
 
 pipeline:
   - uses: git-checkout
@@ -38,13 +38,38 @@ vars:
   gem: benchmark
 
 test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
   pipeline:
-    - runs: ruby -e "require 'benchmark'"
     - runs: |
-        ruby -e 'require "benchmark"; Benchmark.measure { 1 + 1 }; puts "OK"'
+        ruby <<-EOF
+        require 'benchmark'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        class TestBenchmark < Test::Unit::TestCase
+          def test_measure
+            result = Benchmark.measure { (1..1000).each { |i| i * 2 } }
+
+            # Verify that the result is a Benchmark::Tms object
+            assert_instance_of Benchmark::Tms, result, "Result should be a Benchmark::Tms object"
+
+            # Print a success message
+            puts "Benchmark measure test passed!"
+          end
+        end
+        EOF
 
 update:
   enabled: true
   github:
     identifier: ruby/benchmark
     strip-prefix: v
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM

--- a/ruby3.2-bindata.yaml
+++ b/ruby3.2-bindata.yaml
@@ -37,6 +37,45 @@ pipeline:
 vars:
   gem: bindata
 
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'bindata'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        class TestBinData < Test::Unit::TestCase
+          def test_uint16_read
+            # Create a binary string
+            data = "\x01\x02".b
+
+            # Read the binary data as an unsigned 16-bit integer
+            uint16 = BinData::Uint16be.read(data)
+
+            # Verify the value
+            assert_equal 258, uint16, "Expected the value to be 258 for binary \\x01\\x02"
+            puts "BinData Uint16 read test passed!"
+          end
+
+          def test_uint16_write
+            # Create a BinData Uint16 object
+            uint16 = BinData::Uint16be.new(258)
+
+            # Write it to a binary string
+            binary = uint16.to_binary_s
+
+            # Verify the binary output
+            assert_equal "\x01\x02".b, binary, "Expected binary output to match \\x01\\x02"
+            puts "BinData Uint16 write test passed!"
+          end
+        end
+        EOF
+
 update:
   enabled: true
   github:

--- a/ruby3.2-bundler.yaml
+++ b/ruby3.2-bundler.yaml
@@ -74,6 +74,12 @@ test:
         bundler --version
         bundle --help
         bundler --help
+    - runs: |
+        echo "source 'https://rubygems.org'" > Gemfile
+        echo "gem 'rake'" >> Gemfile
+        bundle install --path vendor/bundle
+        bundle list
+        echo "Bundler test passed!"
 
 var-transforms:
   - from: ${{package.name}}

--- a/ruby3.2-charlock_holmes.yaml
+++ b/ruby3.2-charlock_holmes.yaml
@@ -44,6 +44,35 @@ pipeline:
 vars:
   gem: charlock_holmes
 
+test:
+  pipeline:
+    - runs: |
+        ruby -e "require 'charlock_holmes'; puts 'Charlock Holmes library loaded successfully!'"
+    - runs: |
+        ruby <<-EOF
+        # encoding: utf-8
+        require 'charlock_holmes'
+
+        # Test basic detection capabilities
+        detector = CharlockHolmes::EncodingDetector.new
+
+        # Test single detection
+        result = detector.detect("Hello, World!")
+        raise "Detection failed" unless result.is_a?(Hash) &&
+                                     result[:type] == :text &&
+                                     result[:encoding] &&
+                                     result[:confidence]
+        puts "Single detection test passed"
+
+        # Test multiple detection
+        results = detector.detect_all("testing")
+        raise "Multiple detection failed" unless results.is_a?(Array) &&
+                                               results.all? { |r| r[:encoding] && r[:confidence] }
+        puts "Multiple detection test passed"
+
+        puts "All tests passed!"
+        EOF
+
 update:
   enabled: true
   github:

--- a/ruby3.2-chronic_duration.yaml
+++ b/ruby3.2-chronic_duration.yaml
@@ -27,6 +27,16 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 55f992d6715a0920fefb5c4051e9eff40f948a21
 
+  # Upstream pin to an eol version of numerizer as a runtime dependency. This
+  # results in runtime failures when we attempt to use our (newer) version.
+  # This patch removes upstream pinning to a particular version at runtime.
+  #
+  # There hasn't been any updates for quite some time upstream, so there doesn't
+  # look to be any other reason for the pinning.
+  - uses: patch
+    with:
+      patches: numerizer-dependency.patch
+
   - uses: ruby/build
     with:
       gem: ${{vars.gem}}
@@ -40,6 +50,38 @@ pipeline:
 
 vars:
   gem: chronic_duration
+
+test:
+  pipeline:
+    - runs: |
+        ruby -e "require 'chronic_duration'; puts 'ChronicDuration loaded successfully!'"
+    - runs: |
+        ruby <<-EOF
+        require 'chronic_duration'
+
+        # Test case 1: Parsing a simple duration
+        result = ChronicDuration.parse('4 hours and 30 minutes')
+        if result != 16200
+          raise 'Assertion failed: Expected 16200, got ' + result.to_s
+        end
+        puts 'Test case 1 passed: Simple duration parsing'
+
+        # Test case 2: Parsing a duration with seconds
+        result = ChronicDuration.parse('3 minutes and 20 seconds')
+        if result != 200
+          raise 'Assertion failed: Expected 200, got ' + result.to_s
+        end
+        puts 'Test case 2 passed: Duration with seconds parsing'
+
+        # Test case 3: Invalid input
+        result = ChronicDuration.parse('invalid input')
+        if result != nil
+          raise 'Assertion failed: Expected nil for invalid input, got ' + result.to_s
+        end
+        puts 'Test case 3 passed: Handling invalid input'
+
+        puts 'All test cases passed!'
+        EOF
 
 update:
   enabled: true

--- a/ruby3.2-chronic_duration/numerizer-dependency.patch
+++ b/ruby3.2-chronic_duration/numerizer-dependency.patch
@@ -1,0 +1,13 @@
+diff --git a/chronic_duration.gemspec b/chronic_duration.gemspec
+index c94711a..abd5fcc 100644
+--- a/chronic_duration.gemspec
++++ b/chronic_duration.gemspec
+@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
+   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+   gem.require_paths = ["lib"]
+ 
+-  gem.add_runtime_dependency "numerizer", "~> 0.1.1"
++  gem.add_runtime_dependency "numerizer"
+ 
+   gem.add_development_dependency "rake", "~> 10.0.3"
+   gem.add_development_dependency "rspec", "~> 2.12.0"

--- a/ruby3.3-aws-sdk-kms.yaml
+++ b/ruby3.3-aws-sdk-kms.yaml
@@ -45,6 +45,44 @@ pipeline:
 vars:
   gem: aws-sdk-kms
 
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+        - ruby${{vars.rubyMM}}-aws-sdk-core
+        - ruby${{vars.rubyMM}}-aws-sigv4
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'aws-sdk-kms'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        class TestAWSKMSSDK < Test::Unit::TestCase
+          def setup
+            # Mocking AWS KMS client
+            @kms = Aws::KMS::Client.new(stub_responses: true)
+          end
+
+          def test_encrypt_decrypt
+            # Mock encrypt and decrypt responses
+            @kms.stub_responses(:encrypt, { ciphertext_blob: "mocked_ciphertext" })
+            @kms.stub_responses(:decrypt, { plaintext: "decrypted_data" })
+
+            # Encrypt mock data
+            encrypt_resp = @kms.encrypt(key_id: "mocked-key-id", plaintext: "test_data")
+            assert_equal "mocked_ciphertext", encrypt_resp.ciphertext_blob, "Encryption failed"
+
+            # Decrypt mock data
+            decrypt_resp = @kms.decrypt(ciphertext_blob: encrypt_resp.ciphertext_blob)
+            assert_equal "decrypted_data", decrypt_resp.plaintext, "Decryption failed"
+
+            puts "KMS encrypt/decrypt test passed!"
+          end
+        end
+        EOF
+
 update:
   enabled: false
   manual: true # the library we fetch uses a different version then the package version

--- a/ruby3.3-aws-sdk-s3.yaml
+++ b/ruby3.3-aws-sdk-s3.yaml
@@ -47,6 +47,37 @@ pipeline:
 vars:
   gem: aws-sdk-s3
 
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+        - ruby${{vars.rubyMM}}-rexml
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'aws-sdk-s3'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        class TestAWSS3SDK < Test::Unit::TestCase
+          def test_put_object
+            # Create a stubbed S3 client
+            s3 = Aws::S3::Client.new(stub_responses: true)
+
+            # Mock the put_object response
+            s3.stub_responses(:put_object, {})
+
+            # Perform the operation
+            response = s3.put_object(bucket: "test-bucket", key: "test-key", body: "test-content")
+
+            # Assert the response
+            assert response.successful?, "Put object operation failed"
+            puts "Basic put object test passed!"
+          end
+        end
+        EOF
+
 update:
   enabled: false
   manual: true # the library we fetch uses a different version then the package version

--- a/ruby3.3-aws-sdk-sqs.yaml
+++ b/ruby3.3-aws-sdk-sqs.yaml
@@ -45,6 +45,36 @@ pipeline:
 vars:
   gem: aws-sdk-sqs
 
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'aws-sdk-sqs'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        class TestAWSSQSSDK < Test::Unit::TestCase
+          def test_send_message
+            # Create a stubbed SQS client
+            sqs = Aws::SQS::Client.new(stub_responses: true)
+
+            # Mock the send_message response
+            sqs.stub_responses(:send_message, message_id: "12345")
+
+            # Perform the operation
+            response = sqs.send_message(queue_url: "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue", message_body: "Hello, SQS!")
+
+            # Assert the response
+            assert_equal "12345", response.message_id, "Message ID does not match"
+            puts "Basic send message test passed!"
+          end
+        end
+        EOF
+
 update:
   enabled: false
   manual: true # the library we fetch uses a different version then the package version

--- a/ruby3.3-aws-sigv4.yaml
+++ b/ruby3.3-aws-sigv4.yaml
@@ -45,6 +45,47 @@ pipeline:
 vars:
   gem: aws-sigv4
 
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'aws-sigv4'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        # Test basic signer creation
+        signer = Aws::Sigv4::Signer.new(
+          service: 'service',
+          region: 'us-east-1',
+          access_key_id: 'akid',
+          secret_access_key: 'secret'
+        )
+        assert_kind_of Aws::Sigv4::Signer, signer
+        puts "Signer creation test passed"
+
+        # Test basic signature generation
+        signature = signer.sign_request(
+          http_method: 'GET',
+          url: 'https://service.us-east-1.amazonaws.com',
+          headers: {
+            'host' => 'service.us-east-1.amazonaws.com'
+          }
+        )
+        assert_kind_of String, signature.string_to_sign
+        puts "Signature string generation test passed"
+
+        # Test canonical request generation
+        assert signature.canonical_request.include?('GET')
+        assert signature.canonical_request.include?('host:service.us-east-1.amazonaws.com')
+        puts "Canonical request test passed"
+
+        puts "All tests passed!"
+        EOF
+
 update:
   enabled: false
   manual: true # the library we fetch uses a different version then the package version

--- a/ruby3.3-base64.yaml
+++ b/ruby3.3-base64.yaml
@@ -38,6 +38,31 @@ pipeline:
 vars:
   gem: base64
 
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'base64'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        class TestBase64 < Test::Unit::TestCase
+          def test_base64_encode_decode
+            original = "Hello, Base64!"
+            encoded = Base64.encode64(original)
+            decoded = Base64.decode64(encoded)
+
+            # Verify encoding and decoding
+            assert_equal "Hello, Base64!", decoded, "Decoded value did not match original."
+            puts "Base64 encode/decode test passed!"
+          end
+        end
+        EOF
+
 update:
   enabled: true
   github:

--- a/ruby3.3-benchmark.yaml
+++ b/ruby3.3-benchmark.yaml
@@ -13,8 +13,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - git
-      - ruby-3.3
-      - ruby-3.3-dev
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
 
 pipeline:
   - uses: git-checkout
@@ -38,13 +38,38 @@ vars:
   gem: benchmark
 
 test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
   pipeline:
-    - runs: ruby -e "require 'benchmark'"
     - runs: |
-        ruby -e 'require "benchmark"; Benchmark.measure { 1 + 1 }; puts "OK"'
+        ruby <<-EOF
+        require 'benchmark'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        class TestBenchmark < Test::Unit::TestCase
+          def test_measure
+            result = Benchmark.measure { (1..1000).each { |i| i * 2 } }
+
+            # Verify that the result is a Benchmark::Tms object
+            assert_instance_of Benchmark::Tms, result, "Result should be a Benchmark::Tms object"
+
+            # Print a success message
+            puts "Benchmark measure test passed!"
+          end
+        end
+        EOF
 
 update:
   enabled: true
   github:
     identifier: ruby/benchmark
     strip-prefix: v
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM

--- a/ruby3.3-bindata.yaml
+++ b/ruby3.3-bindata.yaml
@@ -37,6 +37,45 @@ pipeline:
 vars:
   gem: bindata
 
+test:
+  environment:
+    contents:
+      packages:
+        - ruby-${{vars.rubyMM}}
+  pipeline:
+    - runs: |
+        ruby <<-EOF
+        require 'bindata'
+        require 'test/unit'
+        include Test::Unit::Assertions
+
+        class TestBinData < Test::Unit::TestCase
+          def test_uint16_read
+            # Create a binary string
+            data = "\x01\x02".b
+
+            # Read the binary data as an unsigned 16-bit integer
+            uint16 = BinData::Uint16be.read(data)
+
+            # Verify the value
+            assert_equal 258, uint16, "Expected the value to be 258 for binary \\x01\\x02"
+            puts "BinData Uint16 read test passed!"
+          end
+
+          def test_uint16_write
+            # Create a BinData Uint16 object
+            uint16 = BinData::Uint16be.new(258)
+
+            # Write it to a binary string
+            binary = uint16.to_binary_s
+
+            # Verify the binary output
+            assert_equal "\x01\x02".b, binary, "Expected binary output to match \\x01\\x02"
+            puts "BinData Uint16 write test passed!"
+          end
+        end
+        EOF
+
 update:
   enabled: true
   github:

--- a/ruby3.3-bundler.yaml
+++ b/ruby3.3-bundler.yaml
@@ -74,3 +74,9 @@ test:
         bundler --version
         bundle --help
         bundler --help
+    - runs: |
+        echo "source 'https://rubygems.org'" > Gemfile
+        echo "gem 'rake'" >> Gemfile
+        bundle install --path vendor/bundle
+        bundle list
+        echo "Bundler test passed!"

--- a/ruby3.3-charlock_holmes.yaml
+++ b/ruby3.3-charlock_holmes.yaml
@@ -44,6 +44,35 @@ pipeline:
 vars:
   gem: charlock_holmes
 
+test:
+  pipeline:
+    - runs: |
+        ruby -e "require 'charlock_holmes'; puts 'Charlock Holmes library loaded successfully!'"
+    - runs: |
+        ruby <<-EOF
+        # encoding: utf-8
+        require 'charlock_holmes'
+
+        # Test basic detection capabilities
+        detector = CharlockHolmes::EncodingDetector.new
+
+        # Test single detection
+        result = detector.detect("Hello, World!")
+        raise "Detection failed" unless result.is_a?(Hash) &&
+                                     result[:type] == :text &&
+                                     result[:encoding] &&
+                                     result[:confidence]
+        puts "Single detection test passed"
+
+        # Test multiple detection
+        results = detector.detect_all("testing")
+        raise "Multiple detection failed" unless results.is_a?(Array) &&
+                                               results.all? { |r| r[:encoding] && r[:confidence] }
+        puts "Multiple detection test passed"
+
+        puts "All tests passed!"
+        EOF
+
 update:
   enabled: true
   github:

--- a/ruby3.3-chronic_duration.yaml
+++ b/ruby3.3-chronic_duration.yaml
@@ -27,6 +27,16 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 55f992d6715a0920fefb5c4051e9eff40f948a21
 
+  # Upstream pin to an eol version of `numerizer` as a runtime dependency. This
+  # results in runtime failures when we attempt to use our (newer) version.
+  # This patch removes upstream pinning to a particular version at runtime.
+  #
+  # There hasn't been any updates for quite some time upstream, so there doesn't
+  # look to be any other reason for the pinning.
+  - uses: patch
+    with:
+      patches: numerizer-dependency.patch
+
   - uses: ruby/build
     with:
       gem: ${{vars.gem}}
@@ -40,6 +50,38 @@ pipeline:
 
 vars:
   gem: chronic_duration
+
+test:
+  pipeline:
+    - runs: |
+        ruby -e "require 'chronic_duration'; puts 'ChronicDuration loaded successfully!'"
+    - runs: |
+        ruby <<-EOF
+        require 'chronic_duration'
+
+        # Test case 1: Parsing a simple duration
+        result = ChronicDuration.parse('4 hours and 30 minutes')
+        if result != 16200
+          raise 'Assertion failed: Expected 16200, got ' + result.to_s
+        end
+        puts 'Test case 1 passed: Simple duration parsing'
+
+        # Test case 2: Parsing a duration with seconds
+        result = ChronicDuration.parse('3 minutes and 20 seconds')
+        if result != 200
+          raise 'Assertion failed: Expected 200, got ' + result.to_s
+        end
+        puts 'Test case 2 passed: Duration with seconds parsing'
+
+        # Test case 3: Invalid input
+        result = ChronicDuration.parse('invalid input')
+        if result != nil
+          raise 'Assertion failed: Expected nil for invalid input, got ' + result.to_s
+        end
+        puts 'Test case 3 passed: Handling invalid input'
+
+        puts 'All test cases passed!'
+        EOF
 
 update:
   enabled: true

--- a/ruby3.3-chronic_duration/numerizer-dependency.patch
+++ b/ruby3.3-chronic_duration/numerizer-dependency.patch
@@ -1,0 +1,13 @@
+diff --git a/chronic_duration.gemspec b/chronic_duration.gemspec
+index c94711a..abd5fcc 100644
+--- a/chronic_duration.gemspec
++++ b/chronic_duration.gemspec
+@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
+   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+   gem.require_paths = ["lib"]
+ 
+-  gem.add_runtime_dependency "numerizer", "~> 0.1.1"
++  gem.add_runtime_dependency "numerizer"
+ 
+   gem.add_development_dependency "rake", "~> 10.0.3"
+   gem.add_development_dependency "rspec", "~> 2.12.0"


### PR DESCRIPTION
Adds melange test coverage to ruby packages which previously lacked tests.

Adding tests also uncovered an undetected runtime issue with the ruby-chronic_duration! I introduced a patch to remediate this and tests to validate the changes.