### PR TITLE
Add a runtime dep to py3-cairo so the pkgconf test pipeline passes

### DIFF
--- a/py3-cairo.yaml
+++ b/py3-cairo.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cairo
   version: 1.27.0
-  epoch: 1
+  epoch: 2
   description: Python3 bindings for the cairo graphics library
   copyright:
     - license: LGPL-2.0-or-later
@@ -118,11 +118,13 @@ subpackages:
     description: py3-cairo dev
     dependencies:
       runtime:
+        - cairo-dev
         - py3-cairo
     pipeline:
       - uses: split/dev
     test:
       pipeline:
+        - uses: test/pkgconf
         - uses: py/one-python
           with:
             content: |


### PR DESCRIPTION
Fixes https://github.com/wolfi-dev/os/issues/34368