### PR TITLE
Add a runtime dep to libxtst so the pkgconf test pipeline passes

### DIFF
--- a/libxtst.yaml
+++ b/libxtst.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxtst
   version: 1.2.5
-  epoch: 0
+  epoch: 1
   description: X11 Testing -- Resource extension library
   copyright:
     - license: XFree86-1.1
@@ -49,7 +49,11 @@ subpackages:
       runtime:
         - libxtst
         - libxi-dev
+        - xorgproto
     description: libxtst dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
   - name: libxtst-doc
     pipeline:


### PR DESCRIPTION
Fixes https://github.com/wolfi-dev/os/issues/34354

Passing log:

```
2024/11/20 22:35:29 INFO running step "test/pkgconf"
2024/11/20 22:35:29 WARN + '[' -d /home/build ] uses=test/pkgconf
2024/11/20 22:35:29 WARN + cd /home/build uses=test/pkgconf
2024/11/20 22:35:29 WARN + exit 0 uses=test/pkgconf
2024/11/20 22:35:29 INFO running step "pkgconf build dependency check" uses=test/pkgconf
2024/11/20 22:35:29 WARN + '[' -d /home/build ] uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + cd /home/build uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + basename /home/build/melange-out/libxtst-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + dev_pkg=libxtst-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + cd / uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + apk info -L libxtst-dev uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + grep '\.pc$' uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN WARNING: opening /home/user/src/wolfi-os/packages: No such file or directory uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN WARNING: opening from cache https://packages.wolfi.dev/os: No such file or directory uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + grep -q ^Name: usr/lib/pkgconfig/xtst.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + basename usr/lib/pkgconfig/xtst.pc .pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + lib_name=xtst uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + echo usr/lib/pkgconfig/xtst.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + grep -q '^usr/lib/pkgconfig/xtst.pc$\|^usr/share/pkgconfig/xtst.pc$' uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + pkgconf --exists xtst uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + grep -q ^Version: usr/lib/pkgconfig/xtst.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + pkgconf --modversion xtst uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 INFO 1.2.5 uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + grep -q ^Libs: usr/lib/pkgconfig/xtst.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + pkgconf --libs xtst uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 INFO -lXtst uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + grep -q ^Cflags: usr/lib/pkgconfig/xtst.pc uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + pkgconf --cflags xtst uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 INFO uses=test/pkgconf name="pkgconf build dependency check"
2024/11/20 22:35:29 WARN + exit 0 uses=test/pkgconf name="pkgconf build dependency check"
```