### PR TITLE
change license of eza from MIT to EUPL-1.2

### DIFF
--- a/eza.yaml
+++ b/eza.yaml
@@ -1,10 +1,10 @@
 package:
   name: eza
   version: 0.20.9
-  epoch: 0
+  epoch: 1
   description: "A modern, maintained replacement for ls"
   copyright:
-    - license: MIT
+    - license: EUPL-1.2
 
 environment:
   contents:


### PR DESCRIPTION
upstream project have migrated to new licenses in recent releases after https://github.com/eza-community/eza/releases/tag/v0.20.0

This is OSI approved license. 

ref: https://spdx.org/licenses/EUPL-1.2.html