### PR TITLE
remove default tags from go/build for x509-certificate-exporter

### DIFF
--- a/x509-certificate-exporter.yaml
+++ b/x509-certificate-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: x509-certificate-exporter
   version: 3.17.0
-  epoch: 0
+  epoch: 1
   description: A Prometheus exporter to monitor x509 certificates expiration in Kubernetes clusters or standalone.
   copyright:
     - license: MIT
@@ -17,7 +17,6 @@ pipeline:
     with:
       packages: ./cmd/x509-certificate-exporter
       output: x509-certificate-exporter
-      tags: netgo,osusergo
       ldflags: |
         -X github.com/enix/x509-certificate-exporter/v3/internal.Version=${{package.version}}
         -X github.com/enix/x509-certificate-exporter/v3/internal.Revision=$(git rev-parse HEAD)


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

