### PR TITLE
datadog: switch from python 3.11 to 3.12

### DIFF
--- a/datadog-agent-nvml.yaml
+++ b/datadog-agent-nvml.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent-nvml
   version: 1.0.9
-  epoch: 2
+  epoch: 3
   description: "Checks NVIDIA Management Library (NVML) exposed metrics through the Datadog Agent and can correlate them with the exposed Kubernetes devices"
   copyright:
     - license: Apache-2.0
@@ -24,7 +24,7 @@ vars:
   dd_conf: /etc/datadog-agent/conf.d
   dd_home: / # agent being run by root expects /.
   dd_shared: /opt/datadog-agent/embedded
-  python_version: "3.11"
+  python_version: "3.12"
 
 pipeline:
   # This integration wheel comes from the integrations-extras repository

--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: 7.59.0
-  epoch: 2
+  epoch: 3
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -17,7 +17,7 @@ package:
       - shadow
 
 vars:
-  py-version: "3.11"
+  py-version: "3.12"
   destd: /opt/datadog-agent
 
 var-transforms:
@@ -68,7 +68,7 @@ environment:
       - procps-dev
       - py${{vars.py-version}}-pip
       - py${{vars.py-version}}-semver
-      - python-${{vars.py-version}}-dev # strictly requires python3.11
+      - python-${{vars.py-version}}-dev
       - systemd-dev
       - util-linux-misc # unshare
       - wget # Required for downloading clang-12 and kernel headers from debian


### PR DESCRIPTION
Upstream image has upgraded to python 3.12

```
Agent 7.59.0 - Commit: b97c90616b - Serialization version: v5.0.132 - Go version: go1.22.8

/opt/datadog-agent/embedded/lib/python3.12/site-packages
```
