### PR TITLE
openssl: do not install obsolete cryptography by default

### DIFF
--- a/kubeflow-centraldashboard.yaml
+++ b/kubeflow-centraldashboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-centraldashboard
   version: 1.9.2
-  epoch: 1
+  epoch: 2
   description: Landing page and central dashboard for Kubeflow deployments
   copyright:
     - license: MIT
@@ -20,6 +20,7 @@ environment:
       - nodejs-18
       - npm
       - openssl
+      - openssl-provider-legacy
       - wolfi-base
 
 pipeline:

--- a/kubeflow-jupyter-web-app.yaml
+++ b/kubeflow-jupyter-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-jupyter-web-app
   version: 1.9.2
-  epoch: 1
+  epoch: 2
   description: Kubeflow jupyter web app component
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,7 @@ environment:
       - npm
       - openssf-compiler-options
       - openssl
+      - openssl-provider-legacy
       - py3-pip
       - py3-setuptools
       - py3-urllib3

--- a/kubeflow-volumes-web-app.yaml
+++ b/kubeflow-volumes-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-volumes-web-app
   version: 1.9.2
-  epoch: 1
+  epoch: 2
   description: Kubeflow volumes web app component
   copyright:
     - license: Apache-2.0
@@ -22,6 +22,7 @@ environment:
       - npm
       - openssf-compiler-options
       - openssl
+      - openssl-provider-legacy
       - py3-pip
       - py3-setuptools
       - py3-wheel

--- a/kyverno-policy-reporter-ui.yaml
+++ b/kyverno-policy-reporter-ui.yaml
@@ -1,7 +1,7 @@
 package:
   name: kyverno-policy-reporter-ui
   version: 1.9.2
-  epoch: 9
+  epoch: 10
   description: Policy Reporter UI
   copyright:
     - license: Apache-2.0
@@ -20,6 +20,7 @@ environment:
       - nodejs-18
       - npm
       - openssl
+      - openssl-provider-legacy
       - python-3.11
       - wolfi-baselayout
 

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -2,19 +2,13 @@
 package:
   name: openssl
   version: 3.4.0
-  epoch: 2
+  epoch: 3
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
   resources:
     cpu: 16
     memory: 16Gi
-  # For now, continue to install the legacy openssl provider if the parent openssl
-  # package is installed.  This is done because users may be installing the openssl
-  # package to gain that provider.
-  dependencies:
-    runtime:
-      - openssl-provider-legacy
 
 environment:
   contents:

--- a/py3-cryptography.yaml
+++ b/py3-cryptography.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cryptography
   version: 44.0.0
-  epoch: 0
+  epoch: 1
   description: cryptography is a package which provides cryptographic recipes and primitives to Python developers.
   copyright:
     - license: Apache-2.0 OR BSD-3-Clause
@@ -29,6 +29,7 @@ environment:
       - maturin
       - openssf-compiler-options
       - openssl-dev
+      - openssl-provider-legacy
       - py3-supported-cffi
       - py3-supported-maturin
       - py3-supported-pip
@@ -54,6 +55,7 @@ subpackages:
         - py3-${{vars.pypi-package}}
       runtime:
         - py${{range.key}}-cffi
+        - openssl-provider-legacy
     pipeline:
       - uses: py/pip-build-install
         with:


### PR DESCRIPTION
Make it opt-in. Known users are py3-cryptography and webpack v4 (uses md4 as a oneway compression function).

This means algorithms provided by legacy provider will not be available, unless one explicitely installs or depends on openssl-provider-legacy.

The algorithms in question are all broken, obsolete and no longer in active use. For a full list please see:

https://docs.openssl.org/3.4/man7/OSSL_PROVIDER-legacy/

Note that many other security focused distributions have already stopped shipping legacy provider altogether (i.e. OpenBSD).