### PR TITLE
Jasper

### DIFF
--- a/jasper.yaml
+++ b/jasper.yaml
@@ -31,11 +31,10 @@ pipeline:
         -DINSTALL_PREFIX=/usr \
         -DSOURCE_DIR=. \
         -B$BUILD_DIR=/output
-
   - working-directory: /
-
     uses: cmake/build
-
+  - working-directory: /
+    uses: cmake/install
   - uses: strip
 
 
@@ -48,5 +47,5 @@ update:
 test:
   pipeline:
     - runs: |
-        jasper --help
+        jasper --help &
         jasper --version

--- a/jasper.yaml
+++ b/jasper.yaml
@@ -1,0 +1,52 @@
+package:
+  name: jasper
+  version: "4.2.4"
+  epoch: 0
+  description: JasPer is a collection of software (i.e., a library and application programs) for the coding and manipulation of images
+  copyright:
+    - license: Apache
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - gcc
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/jasper-software/jasper
+      tag: version-${{package.version}}
+      expected-commit: 8766848706a727f61c1c76a5a7cf1078433fad02
+  - runs: 
+      mkdir -p {{targets.contextdir}}/output
+  - uses: cmake/configure
+    with:
+      opts: |
+        -DINSTALL_PREFIX=/usr \
+        -DSOURCE_DIR=. \
+        -B$BUILD_DIR=/output
+
+  - working-directory: /
+
+    uses: cmake/build
+
+  - uses: strip
+
+
+update:
+  enabled: true
+  github:
+    identifier: jasper-software/jasper
+    strip-prefix: version_
+
+test:
+  pipeline:
+    - runs: |
+        jasper --help
+        jasper --version

--- a/jasper.yaml
+++ b/jasper.yaml
@@ -43,7 +43,7 @@ update:
   enabled: true
   github:
     identifier: jasper-software/jasper
-    strip-prefix: version_
+    strip-prefix: version-
 
 test:
   pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
