### PR TITLE
fix(trino.yaml): Ensure build time and runtime use the same version of JVM and JDK

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
   version: "464"
-  epoch: 2
+  epoch: 3
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0
@@ -10,7 +10,7 @@ package:
     memory: 64Gi
   dependencies:
     runtime:
-      - openjdk-22-default-jvm
+      - openjdk-23-default-jvm
       - python3 # required by trino launcher script
       - trino-config
 


### PR DESCRIPTION
fix(trino.yaml): Ensure build time and runtime use the same version of JVM and JDK

Without this there will be runtime errors during image test like:

```
Exception in thread "main" java.lang.UnsupportedClassVersionError: io/trino/server/Server has been compiled by a more recent version of the Java Runtime (class file version 67.0), this version of the Java Runtime only recognizes class file versions up to 66.0
```

This fix addresses trino container image test failures blocking publication.

Signed-off-by: philroche <phil.roche@chainguard.dev>

