### PR TITLE
py3-ansible-runner: add integration tests with ansible-core

### DIFF
--- a/py3-ansible-runner.yaml
+++ b/py3-ansible-runner.yaml
@@ -64,7 +64,19 @@ update:
     identifier: ansible/ansible-runner
 
 test:
+  environment:
+    contents:
+      packages:
+        - py3-ansible-core
   pipeline:
     - name: version tests
       runs: |
         ansible-runner --version | grep ${{package.version}}
+    - name: Test with ansible
+      runs: |
+        cat <<EOF >playbook.yml
+        - hosts: localhost
+          tasks:
+            - shell: id
+        EOF
+        ansible-runner run . -p playbook.yml


### PR DESCRIPTION
This PR adds integration tests with ansible-core by running an Ansible playbook.