### PR TITLE
grpc-1.67: Fix FTBFS issues and add python3.13 support

### DIFF
--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -53,6 +53,7 @@ environment:
       - protobuf-dev
       - py3-supported-build-base
       - py3-supported-python-dev
+      - python3
       - re2
       - re2-dev
       - samurai

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -43,7 +43,6 @@ environment:
       - chrpath
       - cmake
       - curl
-      - cython~0
       - icu-dev
       - libstdc++-dev
       - libsystemd
@@ -52,6 +51,7 @@ environment:
       - openssl-dev
       - protobuf-dev
       - py3-supported-build-base
+      - py3-supported-cython
       - py3-supported-python-dev
       - python3
       - re2

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -28,6 +28,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -140,6 +141,7 @@ subpackages:
         - py3.10-grpcio-${{vars.major-minor-version}}
         - py3.11-grpcio-${{vars.major-minor-version}}
         - py3.12-grpcio-${{vars.major-minor-version}}
+        - py3.13-grpcio-${{vars.major-minor-version}}
 
   - name: ${{package.name}}-dev
     pipeline:

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.67
   version: 1.67.1
-  epoch: 0
+  epoch: 1
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -63,6 +63,9 @@ environment:
       - xxhash-dev
       - yaml-dev
       - zlib-dev
+  environment:
+    # https://github.com/wolfi-dev/os/issues/34568
+    GCC_SPEC_FILE: /dev/null
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Related:
- https://github.com/chainguard-dev/internal-dev/issues/5334
- https://github.com/wolfi-dev/os/issues/34075 (abseil/openssf-related FTBFS)

See individual commit logs for details.