### PR TITLE
include helix runtime as part of helix package

### DIFF
--- a/helix.yaml
+++ b/helix.yaml
@@ -26,7 +26,7 @@ pipeline:
       tag: ${{package.version}}
 
   - uses: rust/cargobump
-  
+
   - name: Build
     uses: cargo/build
     with:

--- a/helix.yaml
+++ b/helix.yaml
@@ -1,7 +1,7 @@
 package:
   name: helix
   version: "24.07"
-  epoch: 1
+  epoch: 2
   description: "A post-modern modal text editor."
   copyright:
     - license: MPL-2.0
@@ -15,6 +15,8 @@ environment:
       - openssf-compiler-options
       - rust
       - wolfi-base
+  environment:
+    HELIX_DEFAULT_RUNTIME: "/usr/lib/helix/runtime"
 
 pipeline:
   - uses: git-checkout
@@ -23,11 +25,19 @@ pipeline:
       expected-commit: 079f544260f4f5eaff08104bf07abd57bfb7b611
       tag: ${{package.version}}
 
-  - name: Configure and build
+
+  - name: Build
+    uses: cargo/build
+    with:
+      opts: --locked --profile opt
+      output-dir: target/opt
+      output: hx
+
+  - name: Helix Runtime
     runs: |
-      cargo install --path helix-term --locked
-      mkdir -p ${{targets.destdir}}/usr/bin/
-      mv target/release/hx ${{targets.destdir}}/usr/bin/
+      rm -rf runtime/grammars/sources
+      mkdir -p ${{targets.destdir}}/usr/lib/helix/
+      cp -r runtime ${{targets.destdir}}/usr/lib/helix/
 
   - uses: strip
 

--- a/helix.yaml
+++ b/helix.yaml
@@ -25,7 +25,6 @@ pipeline:
       expected-commit: 079f544260f4f5eaff08104bf07abd57bfb7b611
       tag: ${{package.version}}
 
-
   - name: Build
     uses: cargo/build
     with:

--- a/helix.yaml
+++ b/helix.yaml
@@ -25,6 +25,8 @@ pipeline:
       expected-commit: 079f544260f4f5eaff08104bf07abd57bfb7b611
       tag: ${{package.version}}
 
+  - uses: rust/cargobump
+  
   - name: Build
     uses: cargo/build
     with:

--- a/helix/cargobump-deps.yaml
+++ b/helix/cargobump-deps.yaml
@@ -1,0 +1,5 @@
+packages:
+    - name: gix-attributes
+      version: 0.22.3
+    - name: gix-path
+      version: 0.10.11


### PR DESCRIPTION
this will power syntax highlighting for me and other helix users on workstations/containers once we including helix runtime as part of helix package. 

ref: https://docs.helix-editor.com/building-from-source.html#note-to-packagers