### PR TITLE
repmgr and bitnami-compat

### DIFF
--- a/repmgr.yaml
+++ b/repmgr.yaml
@@ -20,22 +20,30 @@ environment:
       - json-c-dev
       - krb5-dev
       - libedit-dev
-      - libpq
+      - libpq-16
       - libssl3
       - libxml2-dev
       - libxslt-dev
       - linux-pam-dev
+      - openssf-compiler-options
       - openssl-dev
-      - postgresql-dev
+      - postgresql-16-dev
       - readline-dev
       - wolfi-base
+
+vars:
+  # This needs to be 16 since bitnami does not support 17 yet:
+  # https://github.com/bitnami/containers/tree/main/bitnami/postgresql-repmgr
+  # When newer versions are supported, this should be updated to the latest version
+  # along with the postgresql-dev and libpq dependencies above.
+  PG_VERSION: 16
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/EnterpriseDB/repmgr
       tag: v${{package.version}}
-      expected-commit: 4e5246f210ed83c4897ce3200c7ae149e25257a4
+      expected-commit: c0d9dc6dac34c4cb60c3d8805842eed18cca4e85
 
   - uses: autoconf/configure
 
@@ -46,8 +54,8 @@ pipeline:
   - name: Symlink repmgr binaries
     runs: |
       mkdir -p "${{targets.destdir}}/usr/bin"
-      ln -sf /usr/libexec/postgresql17/repmgr ${{targets.destdir}}/usr/bin/repmgr
-      ln -sf /usr/libexec/postgresql17/repmgrd ${{targets.destdir}}/usr/bin/repmgrd
+      ln -sf /usr/libexec/postgresql${{vars.PG_VERSION}}/repmgr ${{targets.destdir}}/usr/bin/repmgr
+      ln -sf /usr/libexec/postgresql${{vars.PG_VERSION}}/repmgrd ${{targets.destdir}}/usr/bin/repmgrd
 
 subpackages:
   - name: "${{package.name}}-dev"
@@ -57,6 +65,136 @@ subpackages:
     test:
       pipeline:
         - uses: test/pkgconf
+
+  - name: ${{package.name}}-bitnami-compat
+    description: "compat package with bitnami/repmgr image"
+    dependencies:
+      runtime:
+        - curl
+        - coreutils
+        - bash
+        - brotli
+        - libcom_err
+        - libcurl-openssl4
+        - libedit
+        - libffi
+        - libgcc
+        - gnutls
+        - nettle
+        - net-tools
+        - icu-libs
+        - libidn
+        - krb5
+        - keyutils-libs
+        - libldap
+        - liblz4-1
+        - xz
+        - libmd
+        - libnghttp2-14
+        - p11-kit-trust
+        - pcre2
+        - libpsl
+        - readline
+        - librtmp
+        - sqlite-libs
+        - sed
+        - grep
+        - libssh
+        - libssl3
+        - libstdc++-6
+        - libtasn1
+        - ncurses
+        - libunistring
+        - libuuid
+        - libxml2
+        - libxslt
+        - libzstd1
+        - glibc-locales
+        - procps
+        - zlib
+        - samba-libs
+        - krb5-libs
+        - cyrus-sasl
+        - gmp
+        - postgresql-16
+        - postgresql-16-client
+    pipeline:
+      - uses: bitnami/compat
+        with:
+          image: postgresql-repmgr
+          version-path: ${{vars.PG_VERSION}}/debian-12
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/repmgr/bin
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/repmgr/conf
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/repmgr/tmp
+          mv ${{targets.contextdir}}/events ${{targets.contextdir}}/opt/bitnami/repmgr/events
+          ln -sf /usr/libexec/postgresql${{vars.PG_VERSION}}/repmgr ${{targets.contextdir}}/opt/bitnami/repmgr/bin/repmgr
+          ln -sf /usr/libexec/postgresql${{vars.PG_VERSION}}/repmgrd ${{targets.contextdir}}/opt/bitnami/repmgr/bin/repmgrd
+          chmod -R u+rwX,g+rwX,o+rw ${{targets.contextdir}}/opt/bitnami/
+          find / -perm /6000 -type f -exec chmod a-s {} \; || true
+      - name: PostgreSQL 16 Bitnami compat
+        runs: |
+          # Copy-paste from postgresql-17-bitnami-compat package with some modifications included.
+          # Having the postgresql-16-bitnami-compat package would be ideal, but it was retulting
+          # conflicts with the bitnami dirs that owned by this package.
+          mkdir -p ${{targets.contextdir}}/bitnami/postgresql
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/conf
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/conf.default
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/bin
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/share
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/tmp
+
+          chmod -R u+rwX,g+rwX,o+rw ${{targets.contextdir}}/bitnami/postgresql
+          chmod -R u+rwX,g+rwX,o+rw ${{targets.contextdir}}/opt/bitnami/postgresql
+
+          # Copy sample configs used to generate Bitnami config
+          cp /usr/share/postgresql${{vars.PG_VERSION}}/pg_hba.conf.sample ${{targets.contextdir}}/opt/bitnami/postgresql/share/pg_hba.conf.sample
+          cp /usr/share/postgresql${{vars.PG_VERSION}}/postgresql.conf.sample ${{targets.contextdir}}/opt/bitnami/postgresql/share/postgresql.conf.sample
+
+          # Use package path while unpacking
+          find . -iname "*.sh" -exec sed 's#/opt/bitnami#${{targets.contextdir}}/opt/bitnami#g' -i {} \;
+            ${{targets.contextdir}}/opt/bitnami/scripts/postgresql/postunpack.sh || true
+          # Restore path
+          find ${{targets.contextdir}}/opt/bitnami -type f -exec sed 's#${{targets.contextdir}}##g' -i {} \;
+
+          # Link binaries used by Bitnami config
+          ln -sf /usr/libexec/postgresql${{vars.PG_VERSION}}/initdb ${{targets.contextdir}}/opt/bitnami/postgresql/bin/initdb
+          ln -sf /usr/libexec/postgresql${{vars.PG_VERSION}}/pg_ctl ${{targets.contextdir}}/opt/bitnami/postgresql/bin/pg_ctl
+          ln -sf /usr/libexec/postgresql${{vars.PG_VERSION}}/pg_rewind ${{targets.contextdir}}/opt/bitnami/postgresql/bin/pg_rewind
+          ln -sf /usr/libexec/postgresql${{vars.PG_VERSION}}/pg_isready /${{targets.contextdir}}/opt/bitnami/postgresql/bin/pg_isready
+    test:
+      environment:
+        environment:
+          PATH: "/opt/bitnami/postgresql/bin:/opt/bitnami/repmgr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          BITNAMI_APP_NAME: "postgresql-repmgr"
+          NSS_WRAPPER_LIB: "/opt/bitnami/common/lib/libnss_wrapper.so"
+        accounts:
+          groups:
+            - groupname: postgres
+              gid: 1001
+          users:
+            - username: postgres
+              gid: 1001
+              uid: 1001
+          run-as: 1001
+      pipeline:
+        - working-directory: /tmp # Workaround for "can't cd to /home/build: Permission denied" error
+          pipeline:
+            - name: "Launch the postgresql-repmgr"
+              uses: test/daemon-check-output
+              with:
+                start: |
+                  env REPMGR_PASSWORD=repmgrpass \
+                      REPMGR_NODE_NETWORK_NAME=pg-0 \
+                      REPMGR_NODE_NAME=pg-0 \
+                      REPMGR_PARTNER_NODES=pg-0 \
+                      REPMGR_PRIMARY_HOST=pg-0 \
+                      POSTGRESQL_PASSWORD=secretpass \
+                      /opt/bitnami/scripts/postgresql-repmgr/entrypoint.sh /opt/bitnami/scripts/postgresql-repmgr/run.sh
+                timeout: 60
+                expected_output: |
+                  Initializing Repmgr
+                  Starting PostgreSQL in background
 
 update:
   enabled: true
@@ -72,12 +210,12 @@ test:
   environment:
     contents:
       packages:
-        - postgresql
+        - postgresql-16
         - repmgr
         - shadow
         - sudo-rs
         - glibc-locales
-        - postgresql-client
+        - postgresql-16-client
     environment:
       PGDATA: /tmp/test_db
       PGUSER: repmgruser

--- a/repmgr.yaml
+++ b/repmgr.yaml
@@ -1,0 +1,150 @@
+package:
+  name: repmgr
+  version: 5.5.0
+  epoch: 0
+  description: "A lightweight replication manager for PostgreSQL"
+  copyright:
+    - license: GPL-3.0-only
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - build-base
+      - ca-certificates-bundle
+      - curl-dev
+      - docbook-xml
+      - flex
+      - git
+      - json-c-dev
+      - krb5-dev
+      - libedit-dev
+      - libpq
+      - libssl3
+      - libxml2-dev
+      - libxslt-dev
+      - linux-pam-dev
+      - openssl-dev
+      - postgresql-dev
+      - readline-dev
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/EnterpriseDB/repmgr
+      tag: v${{package.version}}
+      expected-commit: 4e5246f210ed83c4897ce3200c7ae149e25257a4
+
+  - uses: autoconf/configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+  - name: Symlink repmgr binaries
+    runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      ln -sf /usr/libexec/postgresql17/repmgr ${{targets.destdir}}/usr/bin/repmgr
+      ln -sf /usr/libexec/postgresql17/repmgrd ${{targets.destdir}}/usr/bin/repmgrd
+
+subpackages:
+  - name: "${{package.name}}-dev"
+    description: "${{package.name}} development headers"
+    pipeline:
+      - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - rc*
+  github:
+    identifier: EnterpriseDB/repmgr
+    use-tag: true
+    strip-prefix: v
+    tag-filter: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - postgresql
+        - repmgr
+        - shadow
+        - sudo-rs
+        - glibc-locales
+        - postgresql-client
+    environment:
+      PGDATA: /tmp/test_db
+      PGUSER: repmgruser
+      PGPASS: repmgrpassword
+      PGDB: repmgr_test
+  pipeline:
+    - name: Create a non-root PostgreSQL user
+      runs: |
+        useradd repmgruser
+        echo "${PGUSER}:${PGPASS}" | chpasswd
+    - name: Initialize PostgreSQL as non-root user
+      runs: |
+        sudo -u ${PGUSER} initdb -D ${PGDATA}
+        sudo -u ${PGUSER} pg_ctl -D ${PGDATA} -l /tmp/logfile start
+        sudo -u ${PGUSER} createdb ${PGDB}
+        sudo -u ${PGUSER} psql -d ${PGDB} -c "GRANT ALL PRIVILEGES ON SCHEMA public TO ${PGUSER};"
+    - name: Configure primary for replication
+      runs: |
+        echo "host replication ${PGUSER} 127.0.0.1/32 md5" | sudo tee -a ${PGDATA}/pg_hba.conf
+        echo "host replication ${PGUSER} ::1/128 md5" | sudo tee -a ${PGDATA}/pg_hba.conf
+        echo "wal_level = replica" | sudo tee -a ${PGDATA}/postgresql.conf
+        echo "archive_mode = on" | sudo tee -a ${PGDATA}/postgresql.conf
+        echo "max_wal_senders = 5" | sudo tee -a ${PGDATA}/postgresql.conf
+        echo "hot_standby = on" | sudo tee -a ${PGDATA}/postgresql.conf
+        sudo -u ${PGUSER} pg_ctl -D ${PGDATA} restart
+    - name: Create repmgr configuration for primary
+      runs: |
+        cat <<EOF | sudo tee /etc/repmgr.conf
+        node_id=1
+        node_name=primary_node
+        conninfo='host=localhost port=5432 user=${PGUSER} dbname=${PGDB} password=${PGPASS}'
+        data_directory='${PGDATA}'
+        log_file='/tmp/repmgr_primary.log'
+        EOF
+        sudo chown ${PGUSER}:${PGUSER} /etc/repmgr.conf
+    - name: Register primary node
+      runs: |
+        sudo -u ${PGUSER} repmgr -f /etc/repmgr.conf primary register
+    - name: Initialize standby PostgreSQL node
+      runs: |
+        sudo -u ${PGUSER} pg_basebackup -D /tmp/test_db_standby -R -X stream -c fast -U ${PGUSER} -h localhost
+        echo "primary_conninfo = 'host=localhost port=5432 user=${PGUSER} password=${PGPASS} application_name=standby_node'" \
+        | sudo tee -a /tmp/test_db_standby/postgresql.auto.conf
+        echo "port = 5433" | sudo tee -a /tmp/test_db_standby/postgresql.auto.conf
+        sudo chown -R ${PGUSER}:${PGUSER} /tmp/test_db_standby
+    - name: Start standby PostgreSQL server
+      runs: |
+        sudo -u ${PGUSER} pg_ctl -D /tmp/test_db_standby -l /tmp/logfile_standby start
+    - name: Wait for standby to be ready
+      runs: |
+        until PGPASSWORD=${PGPASS} psql -p 5433 -U ${PGUSER} -d ${PGDB} -c "SELECT 1" >/dev/null 2>&1; do
+          echo "Waiting for standby to be ready..."
+          sleep 2
+        done
+    - name: Create repmgr configuration for standby
+      runs: |
+        cat <<EOF | sudo tee /etc/repmgr_standby.conf
+        node_id=2
+        node_name=standby_node
+        conninfo='host=localhost port=5433 user=${PGUSER} dbname=${PGDB} password=${PGPASS}'
+        data_directory='/tmp/test_db_standby'
+        log_file='/tmp/repmgr_standby.log'
+        EOF
+        sudo chown ${PGUSER}:${PGUSER} /etc/repmgr_standby.conf
+    - name: Start and register standby node
+      runs: |
+        sudo -u ${PGUSER} repmgr -f /etc/repmgr_standby.conf standby register --upstream-node-id=1
+    - name: Verify cluster configuration
+      runs: |
+        sudo -u ${PGUSER} repmgr cluster show


### PR DESCRIPTION
* https://github.com/bitnami/containers/tree/main/bitnami/postgresql-repmgr

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
