### PR TITLE
upgrade grafana-rollout-operator to latest

### DIFF
--- a/grafana-rollout-operator.yaml
+++ b/grafana-rollout-operator.yaml
@@ -1,47 +1,27 @@
 package:
-  name: grafana-rollout-operator-0.14
-  version: 0.14.0
-  epoch: 4
+  name: grafana-rollout-operator
+  version: 0.20.1
+  epoch: 0
   description: Kubernetes Rollout Operator
   copyright:
     - license: Apache-2.0
-  dependencies:
-    provides:
-      - grafana-rollout-operator=${{package.full-version}}
-
-environment:
-  contents:
-    packages:
-      - build-base
-      - go
-  environment:
-    CGO_ENABLED: 0
 
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/grafana/rollout-operator
       tag: v${{package.version}}
-      expected-commit: 4dfc90339440982d07065cad294b32d9ba77e8ae
-
-  - uses: go/bump
-    with:
-      deps: golang.org/x/net@v0.23.0 google.golang.org/protobuf@v1.33.0
+      expected-commit: e74c10fade60ae17d522dbaf7d152f5c894d1849
 
   - uses: go/build
     with:
-      modroot: .
       packages: ./cmd/rollout-operator
       output: rollout-operator
-      ldflags: '-extldflags "-static"'
-      go-package: go
 
   - name: hardlinks
     runs: |
       mkdir -p ${{targets.contextdir}}/bin
       ln -sf /usr/bin/rollout-operator ${{targets.contextdir}}/bin/rollout-operator
-
-  - uses: strip
 
 test:
   pipeline:
@@ -54,4 +34,3 @@ update:
     identifier: grafana/rollout-operator
     strip-prefix: v
     use-tag: true
-    tag-filter: v0.14.


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)


