### PR TITLE
create a -compat subpackage for grafana-rollout-operator

### DIFF
--- a/grafana-rollout-operator.yaml
+++ b/grafana-rollout-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-rollout-operator
   version: 0.20.1
-  epoch: 0
+  epoch: 1
   description: Kubernetes Rollout Operator
   copyright:
     - license: Apache-2.0
@@ -18,10 +18,13 @@ pipeline:
       packages: ./cmd/rollout-operator
       output: rollout-operator
 
-  - name: hardlinks
-    runs: |
-      mkdir -p ${{targets.contextdir}}/bin
-      ln -sf /usr/bin/rollout-operator ${{targets.contextdir}}/bin/rollout-operator
+subpackages:
+  - name: ${{package.name}}-compat
+    description: "upstream image have executable placed at /bin"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/bin
+          ln -sf /usr/bin/rollout-operator ${{targets.contextdir}}/bin/rollout-operator
 
 test:
   pipeline:
@@ -33,4 +36,3 @@ update:
   github:
     identifier: grafana/rollout-operator
     strip-prefix: v
-    use-tag: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

