### PR TITLE
New package rust-audit-info

### DIFF
--- a/rust-audit-info.yaml
+++ b/rust-audit-info.yaml
@@ -1,0 +1,45 @@
+package:
+  name: rust-audit-info
+  version: 0.5.4
+  epoch: 0
+  description: Read audit information from rust binaries
+  copyright:
+    - license: MIT OR Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - cargo-auditable
+      - openssf-compiler-options
+      - rust
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/rust-secure-code/cargo-auditable
+      tag: rust-audit-info/v${{package.version}}
+      expected-commit: a0ed9cb5b98a0c927fa8d78aed04065144b136e7
+
+  - name: Configure and build
+    runs: |
+      cd rust-audit-info/
+      cargo auditable build --release
+      mkdir -p ${{targets.destdir}}/usr/bin/
+      mv target/release/rust-audit-info ${{targets.destdir}}/usr/bin/
+
+  - uses: strip
+
+test:
+  pipeline:
+    - runs: |
+        rust-audit-info /usr/bin/rust-audit-info
+
+update:
+  enabled: true
+  github:
+    identifier: rust-secure-code/cargo-auditable
+    use-tag: true
+    tag-filter: rust-audit-info/v
+    strip-prefix: rust-audit-info/v


### PR DESCRIPTION
Small binary from cargo-auditable collection of tools that helps to
parse & read cargo audit json information from a binary. Helps with
inspecting SBOM of a given binary.
