### PR TITLE
update fluent-operator replaces to 3.2

### DIFF
--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-operator
   version: 3.2.0
-  epoch: 1
+  epoch: 2
   description: Operate Fluent Bit and Fluentd in the Kubernetes way - Previously known as FluentBit Operator
   copyright:
     - license: Apache-2.0
@@ -70,7 +70,7 @@ subpackages:
         # When this test fails, that likely means fluent-bit rolled forward to
         # a new version stream anad must be updated in the "replaces" block
         # below
-        - fluent-bit-3.1
+        - fluent-bit-3.2
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/fluent-bit/etc


### PR DESCRIPTION
The `fluent-watcher-config` subpackage notes that the `fluent-bit` version in the replaces block needs to be updated with version-stream updates. So this PR bumps the version from 3.1 -> 3.2.