### PR TITLE
Use variable transform for fluent-bit-watcher subpackage version

### DIFF
--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-operator
   version: 3.2.0
-  epoch: 1
+  epoch: 3
   description: Operate Fluent Bit and Fluentd in the Kubernetes way - Previously known as FluentBit Operator
   copyright:
     - license: Apache-2.0

--- a/fluent-operator.yaml
+++ b/fluent-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: fluent-operator
   version: 3.2.0
-  epoch: 2
+  epoch: 1
   description: Operate Fluent Bit and Fluentd in the Kubernetes way - Previously known as FluentBit Operator
   copyright:
     - license: Apache-2.0
@@ -10,6 +10,16 @@ environment:
   contents:
     packages:
       - go
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d)\.(\d)\.(\d)$
+    replace: $1
+    to: fluent-major-version
+  - from: ${{package.version}}
+    match: ^(\d)\.(\d)\.(\d)$
+    replace: $2
+    to: fluent-minor-version
 
 pipeline:
   - uses: git-checkout
@@ -70,7 +80,7 @@ subpackages:
         # When this test fails, that likely means fluent-bit rolled forward to
         # a new version stream anad must be updated in the "replaces" block
         # below
-        - fluent-bit-3.2
+        - fluent-bit-${{vars.fluent-major-version}}.${{vars.fluent-minor-version}}
     pipeline:
       - runs: |
           mkdir -p "${{targets.contextdir}}"/fluent-bit/etc


### PR DESCRIPTION
Related: #35145 

Uses variable transform for fluent-bit-watcher subpackage to avoid manual updates on fluent-bit version bumps.