### PR TITLE
rustls-ffi: enable cargo auditable capi

### DIFF
--- a/rustls-ffi.yaml
+++ b/rustls-ffi.yaml
@@ -1,7 +1,7 @@
 package:
   name: rustls-ffi
   version: 0.14.1
-  epoch: 0
+  epoch: 1
   description: "C-to-rustls bindings"
   copyright:
     - license: MIT
@@ -13,6 +13,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - cargo-auditable
       - cargo-c
       - openssf-compiler-options
       - rust
@@ -26,8 +27,8 @@ pipeline:
       expected-commit: 2014e6154074ba66c0023a683b27fdae93fbeabb
 
   - runs: |
-      cargo capi build --release
-      cargo capi install --prefix=/usr --destdir "${{targets.contextdir}}"
+      cargo auditable capi build --release
+      cargo auditable capi install --prefix=/usr --destdir "${{targets.contextdir}}"
 
   - uses: strip
 
@@ -39,6 +40,15 @@ subpackages:
     dependencies:
       runtime:
         - ${{package.name}}
+
+test:
+  environment:
+    contents:
+      packages:
+        - rust-audit-info
+  pipeline:
+    - runs: |
+        rust-audit-info /usr/lib/librustls.so.0.*
 
 update:
   enabled: true


### PR DESCRIPTION
cargo-audtiable in latest upstream release fixed ability to have
auditable capi builds. Start using these.
