### PR TITLE
Add libquadmath as runtime dep for gcc

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 14.2.0
-  epoch: 5
+  epoch: 6
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -11,6 +11,7 @@ package:
   dependencies:
     runtime:
       - binutils
+      - libquadmath # This is a temporary workaround for issues with single-arch packages.
       - libstdc++-dev
       - openssf-compiler-options
       - posix-cc-wrappers


### PR DESCRIPTION
This is silly, but the alternative to fix this will take a while, so I am proposing this in the meantime. We currently (incorrectly) assume that we will be able to solve for identical package sets across architectures, but that's not correct for per-arch things like libquadmath. I want to unwedge some things with this change, which I can revert once we fix these assumptions downstream.
