### PR TITLE
add py3-minidb pkg

### DIFF
--- a/py3-minidb.yaml
+++ b/py3-minidb.yaml
@@ -33,7 +33,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: d0f136fe64f9374f18a04562305b178fb380d1ec
+      expected-commit: b18571efe558491f692d9a8413a91772c920435e
       repository: https://github.com/thp/minidb
       tag: ${{package.version}}
 

--- a/py3-minidb.yaml
+++ b/py3-minidb.yaml
@@ -1,0 +1,69 @@
+# Generated from https://pypi.org/project/minidb/
+package:
+  name: py3-minidb
+  version: 2.0.8
+  epoch: 1
+  description: "Simple SQLite3 store for Python objects"
+  copyright:
+    - license: ISC
+  dependencies:
+    provider-priority: 0
+    runtime:
+      - python3
+  source:
+    url: https://files.pythonhosted.org/packages/source/m/minidb/minidb-2.0.8.tar.gz
+    sha512: 04cdf6ae3a537aa421cd9ca9c283ac3c721ce35a6e23bf71f56ff70ee94dfad4672feb9cea7490e6747f9c2cfaabc7d163559cce3a40cf643df0287cbea6f994
+
+vars:
+  pypi-package: minidb
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - py3-supported-python
+      - py3-supported-setuptools
+      - py3-supported-gpep517
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: d0f136fe64f9374f18a04562305b178fb380d1ec
+      repository: https://github.com/thp/minidb
+      tag: ${{package.version}}
+
+subpackages:
+  - name: py3-${{vars.pypi-package}}-pyc
+    description: Compiled Python files for ${{vars.pypi-package}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-sqlite3
+        - py${{range.key}}-setuptools
+        - py${{range.key}}-gpep517
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.pypi-package}}
+        - runs: |
+            python${{range.key}} -m pytest ./test_minidb.py
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: thp/minidb

--- a/py3-minidb.yaml
+++ b/py3-minidb.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-minidb
   version: 2.0.8
-  epoch: 1
+  epoch: 0
   description: "Simple SQLite3 store for Python objects"
   copyright:
     - license: ISC
@@ -74,5 +74,6 @@ subpackages:
 update:
   enabled: true
   manual: false
+  use-tag: true
   github:
     identifier: thp/minidb

--- a/py3-minidb.yaml
+++ b/py3-minidb.yaml
@@ -28,7 +28,6 @@ environment:
       - busybox
       - py3-supported-python
       - py3-supported-setuptools
-      - py3-supported-gpep517
 
 pipeline:
   - uses: git-checkout
@@ -41,11 +40,6 @@ subpackages:
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}
     description: ${{vars.pypi-package}} installed for python${{range.key}}
-    dependencies:
-      runtime:
-        - py${{range.key}}-sqlite3
-        - py${{range.key}}-setuptools
-        - py${{range.key}}-gpep517
       provides:
         - py3-${{vars.pypi-package}}
       provider-priority: ${{range.value}}

--- a/py3-minidb.yaml
+++ b/py3-minidb.yaml
@@ -8,14 +8,18 @@ package:
     - license: ISC
   dependencies:
     provider-priority: 0
-    runtime:
-      - python3
-  source:
-    url: https://files.pythonhosted.org/packages/source/m/minidb/minidb-2.0.8.tar.gz
-    sha512: 04cdf6ae3a537aa421cd9ca9c283ac3c721ce35a6e23bf71f56ff70ee94dfad4672feb9cea7490e6747f9c2cfaabc7d163559cce3a40cf643df0287cbea6f994
 
 vars:
   pypi-package: minidb
+  import: minidb
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -34,9 +38,6 @@ pipeline:
       tag: ${{package.version}}
 
 subpackages:
-  - name: py3-${{vars.pypi-package}}-pyc
-    description: Compiled Python files for ${{vars.pypi-package}}
-
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}
     description: ${{vars.pypi-package}} installed for python${{range.key}}
@@ -58,9 +59,17 @@ subpackages:
         - uses: python/import
           with:
             python: python${{range.key}}
-            import: ${{vars.pypi-package}}
-        - runs: |
-            python${{range.key}} -m pytest ./test_minidb.py
+            imports: |
+              import ${{vars.import}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

https://pkgs.alpinelinux.org/package/edge/testing/x86_64/py3-minidb

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [x] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
