### PR TITLE
Revert "Revert "pull build deps from apk.cgr.dev/chainguard""

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,8 @@ PKGLISTCMD ?= $(WOLFICTL) text --dir . --type name --pipeline-dir=./pipelines/
 
 BOOTSTRAP_REPO ?= https://packages.wolfi.dev/bootstrap/stage3
 BOOTSTRAP_KEY ?= https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
-WOLFI_REPO ?= https://packages.wolfi.dev/os
-WOLFI_KEY ?= https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
 BOOTSTRAP ?= no
+WOLFI_REPO ?= https://apk.cgr.dev/chainguard
 
 ifeq (${BOOTSTRAP}, yes)
 	MELANGE_OPTS += -k ${BOOTSTRAP_KEY}
@@ -69,10 +68,10 @@ ifeq (${BOOTSTRAP}, yes)
 	PKGLISTCMD += -k ${BOOTSTRAP_KEY}
 	PKGLISTCMD += -r ${BOOTSTRAP_REPO}
 else
-	MELANGE_OPTS += -k ${WOLFI_KEY}
 	MELANGE_OPTS += -r ${WOLFI_REPO}
-	PKGLISTCMD += -k ${WOLFI_KEY}
-	PKGLISTCMD += -r ${WOLFI_REPO}
+	PKGLISTCMD += -k https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+	PKGLISTCMD += -r https://packages.wolfi.dev/os
+
 endif
 
 all: ${KEY} .build-packages


### PR DESCRIPTION
Reverts wolfi-dev/os#32343

The build cluster doesn't NAT anymore so we can try this again.