### PR TITLE
Update grafana-image-renderer to work with grafana helm chart

### DIFF
--- a/grafana-image-renderer.yaml
+++ b/grafana-image-renderer.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-image-renderer
   version: 3.11.6
-  epoch: 0
+  epoch: 1
   description: A Grafana backend plugin that handles rendering of panels & dashboards to PNGs using headless browser (Chromium/Chrome)
   copyright:
     - license: Apache-2.0
@@ -9,6 +9,7 @@ package:
     - x86_64
   dependencies:
     runtime:
+      - busybox
       - chromium
       - dumb-init
       - nodejs
@@ -22,7 +23,6 @@ environment:
       - nodejs
       - scanelf
       - ttf-dejavu
-      - vim
       - yarn
 
 pipeline:
@@ -47,7 +47,7 @@ pipeline:
       cp -r ./proto ${{targets.destdir}}/usr/src/app/
       cp -r ./build ${{targets.destdir}}/usr/src/app/
       cp -r ./node_modules ${{targets.destdir}}/usr/src/app/
-      cp ./devenv/docker/custom-config/config.json ${{targets.destdir}}/usr/src/app/
+      cp ./default.json ${{targets.destdir}}/usr/src/app/config.json
       cp ./plugin.json ${{targets.destdir}}/usr/src/app/
 
 update:
@@ -62,7 +62,7 @@ test:
       working-directory: /usr/src/app
       uses: test/daemon-check-output
       with:
-        start: "env CHROME_BIN=/usr/bin/chromium-browser dumb-init -- node build/app.js server --config=config.json"
+        start: "dumb-init -- node build/app.js server --config=config.json"
         timeout: 5
         expected_output: |
           {"level":"info","message":"HTTP Server started, listening at http://localhost:8081"}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
