### PR TITLE
powershell: build latest 7.5 rc

### DIFF
--- a/powershell.yaml
+++ b/powershell.yaml
@@ -1,24 +1,24 @@
 package:
   name: powershell
-  version: 7.4.1
-  epoch: 2
+  version: 7.5.0_rc1
+  epoch: 0
   description: 'cross-platform automation and configuration tool/framework'
   copyright:
     - license: MIT
   dependencies:
     runtime:
-      - aspnet-8-runtime
-      - dotnet-8-runtime
+      - aspnet-9-runtime
+      - dotnet-9-runtime
       - libpsl-native
       - ncurses-terminfo-base
 
 environment:
   contents:
     packages:
-      - aspnet-8-runtime
-      - aspnet-8-targeting-pack
+      - aspnet-9-runtime
+      - aspnet-9-targeting-pack
       - build-base
-      - dotnet-8-sdk
+      - dotnet-9-sdk
       - icu-dev
       - krb5-dev
       - libpsl-native
@@ -31,8 +31,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/powershell/powershell
-      tag: v${{package.version}}
-      expected-commit: 5668713d3c906d63cd68e37d415206a95ac061d0
+      tag: v7.5.0-rc.1
+      expected-commit: 2800f895f59272e97583fddec9285cd773142f5b
       destination: powershell
 
   - working-directory: /home/build/powershell
@@ -50,7 +50,7 @@ pipeline:
                 /t:_GetDependencies \
                 "/property:DesignTimeBuild=true;_DependencyFile=$PWD/src/TypeCatalogGen/powershell.inc" \
                 /nologo
-          echo v${{package.version}} > powershell.version
+          echo v7.5.0-rc.1 > powershell.version
       - working-directory: /home/build/powershell/src/ResGen
         runs: |
           dotnet run


### PR DESCRIPTION
This is a PoC PR that builds the latest rc version of PowerShell 7.5 with dotnet-9.