### PR TITLE
sync epoches for debezium and the entrypoint package

### DIFF
--- a/debezium-3.0.yaml
+++ b/debezium-3.0.yaml
@@ -1,6 +1,8 @@
 package:
   name: debezium-3.0
   version: 3.0.2
+  # Ensure that debezium-3.0 and debezium-connect-entrypoint-3.0 have their epochs kept in sync,
+  # to install properly at the same time: https://github.com/chainguard-dev/terraform-provider-apko/issues/377
   epoch: 1
   description: Debezium is a change data capture (CDC) platform that achieves its durability, reliability, and fault tolerance qualities by reusing Kafka and Kafka Connect.
   copyright:

--- a/debezium-connect-entrypoint-3.0.yaml
+++ b/debezium-connect-entrypoint-3.0.yaml
@@ -1,7 +1,9 @@
 package:
   name: debezium-connect-entrypoint-3.0
   version: 3.0.3
-  epoch: 0
+  # Ensure that debezium-3.0 and debezium-connect-entrypoint-3.0 have their epochs kept in sync,
+  # to install properly at the same time: https://github.com/chainguard-dev/terraform-provider-apko/issues/377
+  epoch: 1
   description: Helper package to provide necessary files for the Debezium images
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
To install the `debezium` and `debezium-connect-entrypoint` at the same time, epoches must match. Otherwise it leads to:

```
Multiple packages match with different versions: debezium-connect-entrypoint-3.0 (3.0.2-r2) and debezium-3.0-connector-mysql (3.0.2-r1)
```

https://github.com/chainguard-dev/terraform-provider-apko/issues/377