### PR TITLE
pin to v1 containerd shim

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.31.2.1
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: Apache-2.0
@@ -65,10 +65,8 @@ pipeline:
       ./scripts/download
   - uses: go/bump
     with:
-      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.54.0 google.golang.org/grpc@v1.67.0 github.com/golang-jwt/jwt/v4@v4.5.1
+      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.54.0 google.golang.org/grpc@v1.67.0
   - runs: |
-      sed -i '/VERSION_RUNC=$(get-module-version github.com\/opencontainers\/runc)/a VERSION_RUNC="v1.1.14"' ./scripts/version.sh
-
       # Override the go version check at runtime to always match the go version at build time
       # Ref: https://github.com/k3s-io/k3s/pull/9054
       GOVERSION=$(go env GOVERSION)

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -9,7 +9,8 @@ package:
     runtime:
       - busybox
       - conntrack-tools
-      - containerd-shim-runc-v2
+      # TODO(joshrwolf): Bump to v2 when upstream bumps containerd
+      - containerd-shim-runc-v2~1
       - ip6tables # this pulls in iptables as well
       - kmod
       - libseccomp
@@ -65,7 +66,7 @@ pipeline:
       ./scripts/download
   - uses: go/bump
     with:
-      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.54.0 google.golang.org/grpc@v1.67.0
+      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.54.0 google.golang.org/grpc@v1.67.0 github.com/opencontainers/runc@v1.1.14
   - runs: |
       # Override the go version check at runtime to always match the go version at build time
       # Ref: https://github.com/k3s-io/k3s/pull/9054
@@ -221,55 +222,6 @@ subpackages:
             loopback --help
             portmap --version
             portmap --help
-
-  - name: k3s-images
-    description: "pre-packaged k3s core runtime images"
-    pipeline:
-      - runs: |
-          set -e -u -x
-
-          _arch=$(go env GOARCH)
-
-          images=""
-          while read -r line
-          do
-            repo=$(echo $line | cut -d ':' -f 1)
-            tag=$(echo $line | cut -d ':' -f 2)
-
-            # Replace upstream images with cgr.dev equivalents only if they exist
-            case $repo in
-              docker.io/rancher/klipper-helm|docker.io/rancher/klipper-lb|docker.io/rancher/local-path-provisioner|docker.io/rancher/mirrored-pause)
-                # TODO: Replace these known gaps with cgr variants
-                image="$repo:$tag@$(crane digest $repo:$tag)"
-                ;;
-              docker.io/rancher/mirrored-metrics-server)
-                image=$(crane digest --full-ref cgr.dev/chainguard/metrics-server:latest)
-                ;;
-              docker.io/rancher/mirrored-coredns-coredns)
-                image=$(crane digest --full-ref cgr.dev/chainguard/coredns:latest)
-                ;;
-              docker.io/rancher/mirrored-library-busybox)
-                image=$(crane digest --full-ref cgr.dev/chainguard/busybox:latest)
-                ;;
-              docker.io/rancher/mirrored-library-traefik)
-                image=$(crane digest --full-ref cgr.dev/chainguard/traefik:latest)
-                ;;
-              *)
-                echo "unaccounted for image: $repo:$tag"
-                exit 1
-                ;;
-            esac
-
-            images="$images $image"
-          done < ./scripts/airgap/image-list.txt
-
-          echo "Pulling images locally..."
-          echo $images
-
-          _images_path="${{targets.subpkgdir}}"/var/lib/rancher/k3s/agent/images
-          mkdir -p $_images_path
-
-          crane pull $images $_images_path/k3s-airgap-images-$_arch.tar
 
 update:
   enabled: true


### PR DESCRIPTION
pinning to v1 stream of the containerd-runc-shim-v2 (weird naming, I know :D).

this materialized in tests as:

```
CreatePodSandboxError: \"Failed to create sandbox for pod \\\"coredns-56f6fc8fd7-fqpm5_kube-system(8339db2a-922c-4d54-8443-15be77093dba)\\\": rpc error: code = Unimplemented desc = failed to create containerd task: failed to start shim: start failed: unsupported shim version (3): not implemented\"" 
```

also removing the images subpackage, as this will no longer work, the corresponding image will be removed after this lands