### PR TITLE
pin containerd-shim to <2 and remove k3s-images subpackage

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.31.2.1
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: Apache-2.0
@@ -9,7 +9,12 @@ package:
     runtime:
       - busybox
       - conntrack-tools
-      - containerd-shim-runc-v2
+      # containerd-shim-runc-v2 is now pulling in versions > 2.0.0 by default. (https://github.com/containerd/containerd/issues/10984)
+      # pinning is required because any version >2.0.0 is not compatible with daemon < 2.0.0
+      # daemon in this case is coming from k3s itself and they've not migrated yet to version > 2.0.0
+      # there's is an issue tracking k3s update to containerd > 2.0.0 (https://github.com/k3s-io/k3s/issues/11375)
+      # remove pin once upstream migrates to containerd > 2.0.0
+      - containerd-shim-runc-v2=~1.7.22
       - ip6tables # this pulls in iptables as well
       - kmod
       - libseccomp

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -14,7 +14,7 @@ package:
       # daemon in this case is coming from k3s itself and they've not migrated yet to version > 2.0.0
       # there's is an issue tracking k3s update to containerd > 2.0.0 (https://github.com/k3s-io/k3s/issues/11375)
       # remove pin once upstream migrates to containerd > 2.0.0
-      - containerd-shim-runc-v2=~1.7.22
+      - containerd-shim-runc-v2=~1
       - ip6tables # this pulls in iptables as well
       - kmod
       - libseccomp
@@ -228,55 +228,6 @@ subpackages:
             loopback --help
             portmap --version
             portmap --help
-
-  - name: k3s-images
-    description: "pre-packaged k3s core runtime images"
-    pipeline:
-      - runs: |
-          set -e -u -x
-
-          _arch=$(go env GOARCH)
-
-          images=""
-          while read -r line
-          do
-            repo=$(echo $line | cut -d ':' -f 1)
-            tag=$(echo $line | cut -d ':' -f 2)
-
-            # Replace upstream images with cgr.dev equivalents only if they exist
-            case $repo in
-              docker.io/rancher/klipper-helm|docker.io/rancher/klipper-lb|docker.io/rancher/local-path-provisioner|docker.io/rancher/mirrored-pause)
-                # TODO: Replace these known gaps with cgr variants
-                image="$repo:$tag@$(crane digest $repo:$tag)"
-                ;;
-              docker.io/rancher/mirrored-metrics-server)
-                image=$(crane digest --full-ref cgr.dev/chainguard/metrics-server:latest)
-                ;;
-              docker.io/rancher/mirrored-coredns-coredns)
-                image=$(crane digest --full-ref cgr.dev/chainguard/coredns:latest)
-                ;;
-              docker.io/rancher/mirrored-library-busybox)
-                image=$(crane digest --full-ref cgr.dev/chainguard/busybox:latest)
-                ;;
-              docker.io/rancher/mirrored-library-traefik)
-                image=$(crane digest --full-ref cgr.dev/chainguard/traefik:latest)
-                ;;
-              *)
-                echo "unaccounted for image: $repo:$tag"
-                exit 1
-                ;;
-            esac
-
-            images="$images $image"
-          done < ./scripts/airgap/image-list.txt
-
-          echo "Pulling images locally..."
-          echo $images
-
-          _images_path="${{targets.subpkgdir}}"/var/lib/rancher/k3s/agent/images
-          mkdir -p $_images_path
-
-          crane pull $images $_images_path/k3s-airgap-images-$_arch.tar
 
 update:
   enabled: true

--- a/k3s.yaml
+++ b/k3s.yaml
@@ -70,10 +70,8 @@ pipeline:
       ./scripts/download
   - uses: go/bump
     with:
-      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.54.0 google.golang.org/grpc@v1.67.0 github.com/golang-jwt/jwt/v4@v4.5.1
+      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.54.0 google.golang.org/grpc@v1.67.0 github.com/golang-jwt/jwt/v4@v4.5.1 github.com/opencontainers/runc@v1.1.14
   - runs: |
-      sed -i '/VERSION_RUNC=$(get-module-version github.com\/opencontainers\/runc)/a VERSION_RUNC="v1.1.14"' ./scripts/version.sh
-
       # Override the go version check at runtime to always match the go version at build time
       # Ref: https://github.com/k3s-io/k3s/pull/9054
       GOVERSION=$(go env GOVERSION)


### PR DESCRIPTION
notes:

containerd-shim-runc-v2 is now pulling in versions > 2.0.0 by default. (https://github.com/containerd/containerd/issues/10984)
pinning is required because any version >2.0.0 is not compatible with daemon < 2.0.0
daemon in this case is coming from k3s itself and upstream k3s project have not migrated yet to version > 2.0.0
there's is an issue tracking k3s update to containerd > 2.0.0 (https://github.com/k3s-io/k3s/issues/11375)
remove pin once upstream migrates to containerd > 2.0.0

this also removes k3s-images subpackage because we no longer have those images available.