### PR TITLE
cyrus-sasl: disable des and ntlm

### DIFF
--- a/cyrus-sasl.yaml
+++ b/cyrus-sasl.yaml
@@ -1,7 +1,7 @@
 package:
   name: cyrus-sasl
   version: 2.1.28
-  epoch: 6
+  epoch: 7
   description: "Cyrus Simple Authentication Service Layer (SASL)"
   copyright:
     - license: BSD-3-Clause
@@ -64,7 +64,8 @@ pipeline:
         --enable-cram \
         --enable-digest \
         --enable-httpform \
-        --enable-ntlm \
+        --disable-ntlm \
+        --without-des \
         --enable-plain \
         --enable-login \
         --enable-auth-sasldb \


### PR DESCRIPTION
ntlm & des are both broken and absolete.

Previously we already managed to turn these off in wget & curl without
any fallout:
- https://github.com/wolfi-dev/os/pull/16713

This PR helps to achieve removal of DES support in OpenSSL itself in
the future.
