### PR TITLE
tileserver-gl/GHSA-3xgq-45jj-v275 fix. Bumps cross-spawn to fix version

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -55,7 +55,7 @@ pipeline:
       expected-commit: 6cda7a0b384940b781838be7415b2ae448edcd29
       destination: app
       cherry-picks: |
-        master/93f72c1fe7671429f234c853e81f202e635522e9: GHSA-3xgq-45jj-v275 fix. Bumps cross-spawn to fix version. 
+        master/93f72c1fe7671429f234c853e81f202e635522e9: GHSA-3xgq-45jj-v275 fix. Bumps cross-spawn to fix version.
 
   # patch and install npm dependencies
   - uses: patch

--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: 5.0.0
-  epoch: 3
+  epoch: 4
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause
@@ -54,6 +54,8 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 6cda7a0b384940b781838be7415b2ae448edcd29
       destination: app
+      cherry-picks: |
+        master/93f72c1fe7671429f234c853e81f202e635522e9: GHSA-3xgq-45jj-v275 fix. Bumps cross-spawn to fix version. 
 
   # patch and install npm dependencies
   - uses: patch


### PR DESCRIPTION
As can be seen here in this [upstream commit that has been merged](https://github.com/maptiler/tileserver-gl/commit/93f72c1fe7671429f234c853e81f202e635522e9) and is just waiting release, this is a simple version bump in the package-lock.json 