### PR TITLE
sqlpad/GHSA-3xgq-45jj-v275-fix-cross-spawn

### DIFF
--- a/sqlpad.yaml
+++ b/sqlpad.yaml
@@ -1,7 +1,7 @@
 package:
   name: sqlpad
   version: 7.5.1 # when updating check the patch below as it contains dependency version updates which may downgrade if upstream upgrades them
-  epoch: 0
+  epoch: 1
   description: Web-based SQL editor. Legacy project in maintenance mode.
   copyright:
     - license: MIT
@@ -26,6 +26,10 @@ pipeline:
       repository: https://github.com/sqlpad/sqlpad
       expected-commit: fe788bf1cd50072148e5a7e9db729bd62ee97dc2
       tag: v${{package.version}}
+
+  - uses: patch
+    with:
+      patches: GHSA-3xgq-45jj-v275-fix-cross-spawn.patch
 
   - working-directory: /home/build/server
     runs: |

--- a/sqlpad/GHSA-3xgq-45jj-v275-fix-cross-spawn.patch
+++ b/sqlpad/GHSA-3xgq-45jj-v275-fix-cross-spawn.patch
@@ -1,0 +1,51 @@
+diff --git a/client/yarn.lock b/client/yarn.lock
+index 5ac7fb27d..1b73bdcc4 100644
+--- a/client/yarn.lock
++++ b/client/yarn.lock
+@@ -910,9 +910,9 @@ convert-source-map@^2.0.0:
+   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+ 
+ cross-spawn@^7.0.2:
+-  version "7.0.3"
+-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
++  version "7.0.6"
++  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
++  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+   dependencies:
+     path-key "^3.1.0"
+     shebang-command "^2.0.0"
+diff --git a/server/yarn.lock b/server/yarn.lock
+index 2f8350496..2189dacf1 100644
+--- a/server/yarn.lock
++++ b/server/yarn.lock
+@@ -1345,9 +1345,9 @@ core-util-is@~1.0.0:
+   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+ 
+ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+-  version "7.0.3"
+-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
++  version "7.0.6"
++  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
++  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+   dependencies:
+     path-key "^3.1.0"
+     shebang-command "^2.0.0"
+diff --git a/yarn.lock b/yarn.lock
+index 84ea979f1..7c4ac1e55 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -57,9 +57,9 @@ commander@~12.1.0:
+   integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
+ 
+ cross-spawn@^7.0.3:
+-  version "7.0.3"
+-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
++  version "7.0.6"
++  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
++  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+   dependencies:
+     path-key "^3.1.0"
+     shebang-command "^2.0.0"


### PR DESCRIPTION
This fix originated from a [merged commit upstream](https://github.com/sqlpad/sqlpad/pull/1259/commits/8fdd7d0496e6c404117c21698f4b86adf7fd6822) which bumps the version of cross-spawn to the fix version. This was required to be a patch as cherry-picking introduced merge conflicts. 