### PR TITLE
test nvidia device plugin

### DIFF
--- a/k8s-device-plugin.yaml
+++ b/k8s-device-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8s-device-plugin
   version: 0.17.0
-  epoch: 1
+  epoch: 2
   description: meta package providing all NVIDIA device plugins for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -21,6 +21,7 @@ environment:
   environment:
     # See https://github.com/wolfi-dev/os/issues/34568
     GCC_SPEC_FILE: "/dev/null"
+    CGO_CFLAGS: "-O2 -Wno-hardened -fstack-protector-strong -fhardened -Wl,-z,lazy"
 
 pipeline:
   - uses: git-checkout

--- a/k8s-device-plugin.yaml
+++ b/k8s-device-plugin.yaml
@@ -13,6 +13,8 @@ package:
 
 environment:
   contents:
+    build_repositories:
+      - https://apk.cgr.dev/wolfi-presubmit/8c8f1f952c892b4bc56df38f9b7db2e2d74250d7
     packages:
       - build-base
       - busybox


### PR DESCRIPTION
- **Ensure k8s-device-plugin is built with hardening, and yet lazy binding**
  

- **Temporary build against presubmit gcc with lazy fix**
  