### PR TITLE
dotnet-8: powershell: build separate package dotnet-sdk-8.0.404 to build powershell 7.4.6

### DIFF
--- a/dotnet-8.yaml
+++ b/dotnet-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotnet-8
   version: 8.0.11
-  epoch: 1
+  epoch: 2
   description: ".NET SDK"
   copyright:
     - license: MIT
@@ -23,6 +23,7 @@ environment:
       - clang-15-default
       - cmake
       - curl
+      - dotnet-bootstrap-8
       - glibc-locale-en
       - icu-dev
       - krb5-dev
@@ -53,8 +54,11 @@ pipeline:
       - runs: |
           sed -i -E 's|( /p:BuildDebPackage=false)|\1 /p:EnablePackageValidation=false|' src/runtime/eng/SourceBuild.props
           sed -i -E 's|( /p:BuildDebPackage=false)|\1 --cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE|' src/runtime/eng/SourceBuild.props
-          ./prep.sh --bootstrap
-      #             /p:PrebuiltPackagesPath=/home/build/src/packages \
+          ln -sf /usr/share/dotnet-bootstrap-8/dotnet .dotnet
+          mkdir -p prereqs/packages/archive/
+          ln -sf /usr/share/dotnet-bootstrap-8/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz
+          mkdir -p prereqs/packages/previously-source-built
+          tar -xzvf prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz -C prereqs/packages/previously-source-built/
       - runs: |
           ./build.sh --clean-while-building \
             -- \
@@ -62,7 +66,8 @@ pipeline:
             /p:ContinueOnPrebuiltBaselineError=true \
             /p:MinimalConsoleLogOutput=false \
             /p:SkipPortableRuntimeBuild=true \
-            /p:BuildWithOnlineSources=false
+            /p:BuildWithOnlineSources=false \
+            /p:CustomPrebuiltSourceBuiltPackagesPath=$(realpath prereqs/packages/previously-source-built)
       - runs: |
           mkdir -p "${{targets.destdir}}"/usr/share/dotnet
           mkdir -p "${{targets.destdir}}"/usr/bin

--- a/dotnet-bootstrap-8.yaml
+++ b/dotnet-bootstrap-8.yaml
@@ -1,0 +1,61 @@
+package:
+  name: dotnet-bootstrap-8
+  version: 8.0.11
+  epoch: 0
+  description: ".NET 8 SDK Bootstrap"
+  copyright:
+    - license: MIT
+  resources:
+    cpu: 2
+    memory: 32Gi
+  dependencies:
+    runtime:
+      - icu
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - glibc-locale-en
+      - icu-dev
+      - krb5-dev
+      - libunwind-dev
+      - lttng-ust-dev
+      - ncurses-dev
+      - openssl-dev
+      - wolfi-base
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/dotnet/dotnet
+      tag: v${{package.version}}
+      expected-commit: d5f3d652f9266d600777f626a9650a273419859b
+      destination: /home/build/src
+
+  - working-directory: /home/build/src
+    pipeline:
+      - runs: |
+          ./prep.sh
+      - runs: |
+          mkdir -p "${{targets.destdir}}"/usr/share/dotnet-bootstrap-8
+      - runs: |
+          # see https://github.com/jellyfin/jellyfin/pull/11063/
+          rm -f .dotnet/shared/Microsoft.NETCore.App/8.0.*/libcoreclrtraceptprovider.so
+          mv .dotnet "${{targets.destdir}}"/usr/share/dotnet-bootstrap-8/dotnet
+          mv prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz "${{targets.destdir}}"/usr/share/dotnet-bootstrap-8/
+
+  - uses: strip
+
+update:
+  enabled: false
+  github:
+    identifier: dotnet/dotnet
+    strip-prefix: v
+    use-tag: true
+    tag-filter: "v8"

--- a/dotnet-sdk-8.yaml
+++ b/dotnet-sdk-8.yaml
@@ -1,0 +1,148 @@
+package:
+  name: dotnet-sdk-8-only
+  version: 8.0.404
+  epoch: 1
+  description: ".NET SDK"
+  copyright:
+    - license: MIT
+  resources:
+    cpu: 2
+    memory: 32Gi
+  dependencies:
+    runtime:
+      - icu
+
+environment:
+  environment:
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    DISABLE_CROSSGEN: true
+    DisableArcade: 1
+  contents:
+    packages:
+      - bash
+      - brotli-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang-15
+      - clang-15-default
+      - cmake
+      - curl
+      - glibc-locale-en
+      - icu-dev
+      - krb5-dev
+      - libunwind
+      - libunwind-dev
+      - llvm15
+      - llvm15-cmake-default
+      - llvm15-dev
+      - llvm15-tools
+      - lttng-ust-dev
+      - ncurses-dev
+      - nodejs-22
+      - openssl-dev
+      - python3
+      - rapidjson-dev
+      - samurai
+      - wolfi-base
+      - zlib-dev
+      - dotnet-bootstrap-8
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/dotnet/sdk
+      branch: v8.0.404
+      depth: -1
+      destination: /home/build/src
+
+  - working-directory: /home/build/src
+    pipeline:
+      - runs: |
+          ln -sf /usr/share/dotnet-bootstrap-8/dotnet .dotnet
+          mkdir -p prereqs/packages/archive/
+          ln -sf /usr/share/dotnet-bootstrap-8/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz
+          mkdir -p prereqs/packages/previously-source-built
+          tar -xzvf prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz -C prereqs/packages/previously-source-built/
+      - runs: |
+          ./build.sh --configuration Release --build /p:CustomPrebuiltSourceBuiltPackagesPath=$(realpath prereqs/packages/previously-source-built) -- \
+            /v:n \
+            /p:ContinueOnPrebuiltBaselineError=true \
+            /p:MinimalConsoleLogOutput=false \
+            /p:SkipPortableRuntimeBuild=true \
+            /p:BuildWithOnlineSources=false \
+            /p:CustomPrebuiltSourceBuiltPackagesPath=$(realpath prereqs/packages/previously-source-built)
+
+      - runs: |
+          mkdir -p "${{targets.destdir}}"/usr/share
+
+          cp -R artifacts/bin/redist/Release/dotnet "${{targets.destdir}}"/usr/share/dotnet
+
+  - uses: strip
+
+subpackages:
+  - name: dotnet-sdk-8.0.404
+    description: "The .NET Core SDK, version 8"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/share/dotnet/sdk
+          mkdir -p "${{targets.contextdir}}"/usr/share/dotnet/sdk-manifests
+          mkdir -p "${{targets.contextdir}}"/usr/share/dotnet/templates/8.0.10
+
+          cp -R "${{targets.destdir}}"/usr/share/dotnet/sdk/8.0.404-dev "${{targets.contextdir}}"/usr/share/dotnet/sdk/
+          cp -R "${{targets.destdir}}"/usr/share/dotnet/sdk-manifests/8.0.400 "${{targets.contextdir}}"/usr/share/dotnet/sdk-manifests/
+          cp -R "${{targets.destdir}}"/usr/share/dotnet/templates/8.0.10/*8.0.404* "${{targets.contextdir}}"/usr/share/dotnet/templates/8.0.10/
+
+    dependencies:
+      runtime:
+        - dotnet-8-sdk-default
+
+update:
+  enabled: true
+  github:
+    identifier: dotnet/dotnet
+    strip-prefix: v
+    use-tag: true
+    tag-filter: "v8"
+
+test:
+  environment:
+    contents:
+      packages:
+        - dotnet-8-sdk
+  pipeline:
+    - name: Basic .NET command test
+      runs: |
+        dotnet --info
+    - name: Compile and run a simple .NET application
+      runs: |
+        cat <<'EOF' > HelloWorld.cs
+        using System;
+
+        class Program
+        {
+            static void Main()
+            {
+                Console.WriteLine("Hello, World!");
+            }
+        }
+        EOF
+        dotnet new console -o HelloWorldApp --force
+        mv HelloWorld.cs HelloWorldApp/Program.cs
+        dotnet run --project HelloWorldApp
+    - name: Compile and run a .NET application with arguments
+      runs: |
+        cat <<'EOF' > ArgumentEcho.cs
+        using System;
+
+        class Program
+        {
+            static void Main(string[] args)
+            {
+                Console.WriteLine("Arguments: " + String.Join(", ", args));
+            }
+        }
+        EOF
+        dotnet new console -o ArgumentEchoApp --force
+        mv ArgumentEcho.cs ArgumentEchoApp/Program.cs
+        dotnet run --project ArgumentEchoApp -- arg1 arg2 arg3

--- a/powershell.yaml
+++ b/powershell.yaml
@@ -1,6 +1,6 @@
 package:
   name: powershell
-  version: 7.4.1
+  version: 7.4.6
   epoch: 2
   description: 'cross-platform automation and configuration tool/framework'
   copyright:
@@ -18,7 +18,7 @@ environment:
       - aspnet-8-runtime
       - aspnet-8-targeting-pack
       - build-base
-      - dotnet-8-sdk
+      - dotnet-sdk-8.0.404
       - icu-dev
       - krb5-dev
       - libpsl-native
@@ -32,7 +32,7 @@ pipeline:
     with:
       repository: https://github.com/powershell/powershell
       tag: v${{package.version}}
-      expected-commit: 5668713d3c906d63cd68e37d415206a95ac061d0
+      expected-commit: 81930547a20205e5bfed32c66ab6fed50d6e2008
       destination: powershell
 
   - working-directory: /home/build/powershell
@@ -70,7 +70,7 @@ pipeline:
           install -dm 755 "${{targets.destdir}}"/usr/lib "${{targets.destdir}}"/usr/bin
 
           # library copy
-          cp -ar /home/build/powershell/src/powershell-unix/bin/Linux/*/wolfi* "${{targets.destdir}}"/usr/lib/${{package.name}}
+          cp -ar /home/build/powershell/src/powershell-unix/bin/Linux/*/linux-x64* "${{targets.destdir}}"/usr/lib/${{package.name}}
 
           # already provided by 'libpsl-native' aport
           rm -f "${{targets.destdir}}"/usr/lib/$pkgname/libpsl-native.so


### PR DESCRIPTION
Add dotnet-sdk only package 8.0.404 that is installed alongside 8.0.110.
The SDK  8.0.404 is required to build PowerShell 7.4.6