### PR TITLE
fix(repmgr-bitnami-compat): add required runtime deps

### DIFF
--- a/repmgr.yaml
+++ b/repmgr.yaml
@@ -1,7 +1,7 @@
 package:
   name: repmgr
   version: 5.5.0
-  epoch: 0
+  epoch: 1
   description: "A lightweight replication manager for PostgreSQL"
   copyright:
     - license: GPL-3.0-only
@@ -70,6 +70,9 @@ subpackages:
     description: "compat package with bitnami/repmgr image"
     dependencies:
       runtime:
+        - busybox
+        - posix-libc-utils
+        - glibc-locale-en
         - curl
         - coreutils
         - bash


### PR DESCRIPTION
Fixes the following errors:
* `initdb: error: invalid locale settings; check LANG and LC_* environment variables`
* `no usable system locales were found`
* `popen failure: No such file or directory`