### PR TITLE
ruby3.X: faraday-net_http: fix runtimedeps

### DIFF
--- a/ruby3.2-faraday-net_http.yaml
+++ b/ruby3.2-faraday-net_http.yaml
@@ -1,10 +1,13 @@
 package:
   name: ruby3.2-faraday-net_http
   version: 3.4.0
-  epoch: 0
+  epoch: 1
   description: Faraday adapter for Net::HTTP
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      - ruby3.2-net-http
 
 environment:
   contents:
@@ -42,7 +45,6 @@ test:
     contents:
       packages:
         - ruby3.2-faraday
-        - ruby3.2-net-http
   pipeline:
     # Users do not import this package directly, see the following for a deeper
     # explanation: https://github.com/lostisland/faraday-net_http/issues/25

--- a/ruby3.3-faraday-net_http.yaml
+++ b/ruby3.3-faraday-net_http.yaml
@@ -1,10 +1,13 @@
 package:
   name: ruby3.3-faraday-net_http
   version: 3.4.0
-  epoch: 0
+  epoch: 1
   description: Faraday adapter for Net::HTTP
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      - ruby3.3-net-http
 
 environment:
   contents:
@@ -42,7 +45,6 @@ test:
     contents:
       packages:
         - ruby3.3-faraday
-        - ruby3.3-net-http
   pipeline:
     # Users do not import this package directly, see the following for a deeper
     # explanation: https://github.com/lostisland/faraday-net_http/issues/25


### PR DESCRIPTION
A runtime dep were mistakenly added as a test deps.

Faraday-net_http is the default faraday net provider and will be
automatically pulled in by faraday.  This packages is mostly uesless without
faraday so does not need to depend on it. This also avoids a dep cycle