### PR TITLE
fix(git-lfs): avoid data loss on deinstall

### DIFF
--- a/git-lfs.yaml
+++ b/git-lfs.yaml
@@ -1,7 +1,7 @@
 package:
   name: git-lfs
   version: 3.6.0
-  epoch: 1
+  epoch: 2
   description: "large file support for git"
   copyright:
     - license: MIT
@@ -12,9 +12,9 @@ package:
     post-install: |
       #!/bin/sh
       git-lfs install --skip-repo --system
-    post-deinstall: |
+    pre-deinstall: |
       #!/bin/sh
-      rm -f /etc/gitconfig
+      git lfs uninstall --skip-repo --system
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Use pre-deinstall hook instead of post and avoid data loss