### PR TITLE
use go/build pipeline and more runtime deps for rclone

### DIFF
--- a/rclone.yaml
+++ b/rclone.yaml
@@ -23,7 +23,9 @@ pipeline:
       packages: .
       output: rclone
 
-  - runs: echo "user_allow_other" >> ${{targets.destdir}}/etc/fuse.conf
+  - runs: |
+      mkdir -p ${{targets.destdir}}/etc
+      echo "user_allow_other" >> ${{targets.destdir}}/etc/fuse.conf
 
 update:
   enabled: true

--- a/rclone.yaml
+++ b/rclone.yaml
@@ -1,21 +1,15 @@
 package:
   name: rclone
   version: 1.68.2
-  epoch: 0
+  epoch: 1
   description: rsync for cloud storage - Google Drive, S3, Dropbox, Backblaze B2, One Drive, Swift, Hubic, Wasabi, Google Cloud Storage, Yandex Files
   copyright:
     - license: MIT
   dependencies:
     runtime:
+      - ca-certificates
       - fuse3
-
-environment:
-  contents:
-    packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - go
+      - tzdata
 
 pipeline:
   - uses: git-checkout
@@ -24,19 +18,18 @@ pipeline:
       repository: https://github.com/rclone/rclone
       tag: v${{package.version}}
 
-  - runs: |
-      CGO_ENABLED=0 make
-      mkdir -p ${{targets.destdir}}/usr/bin
-      mv rclone ${{targets.destdir}}/usr/bin/rclone
+  - uses: go/build
+    with:
+      packages: .
+      output: rclone
 
-  - uses: strip
+  - runs: echo "user_allow_other" >> ${{targets.destdir}}/etc/fuse.conf
 
 update:
   enabled: true
   github:
     identifier: rclone/rclone
     strip-prefix: v
-    use-tag: true
 
 test:
   pipeline:


### PR DESCRIPTION
uses go/build pipeline now
rely on releases for updates

making it closer to https://github.com/rclone/rclone/blob/master/Dockerfile