### PR TITLE
WIP jupyterhub-docker-stacks

### DIFF
--- a/jupyterlab-docker-stacks.yaml
+++ b/jupyterlab-docker-stacks.yaml
@@ -8,24 +8,52 @@ package:
   dependencies:
     runtime:
     #TODO for testing
-      - bash
-      - busybox
-      - coreutils
+      - python3
 
 environment:
   contents:
     packages:
-      - build-base
+      - busybox
+      - python3
+      - py3-jupyter-core
 
 pipeline:
   - uses: fetch
     with:
-      expected-sha256: 6c704b7b3f13e828d87de8b971b99721e46586fd3a8a547cf4e7b748cbe3d493
+      expected-sha256: d8a57048e535547b39a0fe5968c2086dc1ca4ff20107bba817ab9de80e0970f6
       uri: https://github.com/jupyter/docker-stacks/archive/ac8453913cafb6e4f23b9f2288c484620f97e999.tar.gz
 
 subpackages:
   - name: ${{package.name}}-base-notebook
+    dependencies:
+      runtime:
+        - font-liberation
+        # - jupyterhub-singleuser 
+        # - jupyterlab
+        - nbclassic
+        # - pandoc TODO MAKE PACKAGE
+        - run-one
+    pipeline:
+      - working-directory: images/base-notebook
+        pipeline:
+          - runs: |
+              echo TODO
+
   - name: ${{package.name}}-minimal-notebook
+    dependencies:
+      runtime:
+        # - bzip2
+        # - ca-certificates-bundle
+        # - glibc-locales
+        # - tini
+        # - wget
+        # - glibc-locale-gen
+    pipeline:
+      - working-directory: images/minimal-notebook
+        pipeline:
+          - runs: |
+              echo TODO
+      
   - name: ${{package.name}}-docker-stacks-foundation
     dependencies:
       runtime:
@@ -37,7 +65,18 @@ subpackages:
         - glibc-locale-gen
     pipeline:
       - working-directory: images/docker-stacks-foundation
-        runs: |
-          mkdir -p ${{targets.contextdir}}/usr/bin/fix/
-          chmod a+rx fix-permissions
-          cp fix-permissions ${{targets.contextdir}}/usr/bin/fix/
+        pipeline:
+          - runs: |
+              mkdir -p ${{targets.contextdir}}/usr/bin/fix/
+              chmod a+rx fix-permissions
+              cp fix-permissions ${{targets.contextdir}}/usr/bin/fix/
+
+              # sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc && \
+              # echo 'eval "$(conda shell.bash hook)"' >> /etc/skel/.bashrc
+
+              mkdir -p ${{targets.contextdir}}/usr/local/bin
+              cp run-hooks.sh start.sh ${{targets.contextdir}}/usr/local/bin/
+
+              mkdir ${{targets.contextdir}}/usr/local/bin/start-notebook.d && \
+              mkdir ${{targets.contextdir}}/usr/local/bin/before-notebook.d
+              cp 10activate-conda-env.sh ${{targets.contextdir}}/usr/local/bin/before-notebook.d/

--- a/jupyterlab-docker-stacks.yaml
+++ b/jupyterlab-docker-stacks.yaml
@@ -1,0 +1,39 @@
+package:
+  name: jupyterlab-docker-stacks
+  version: 4.26.0.20241101
+  epoch: 0
+  description: Ready-to-run images containing Jupyter applications
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    runtime:
+    #TODO for testing
+      - bash
+      - busybox
+      - coreutils
+
+environment:
+  contents:
+    packages:
+      - build-base
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: 6c704b7b3f13e828d87de8b971b99721e46586fd3a8a547cf4e7b748cbe3d493
+      uri: https://github.com/jupyter/docker-stacks/archive/ac8453913cafb6e4f23b9f2288c484620f97e999.tar.gz
+
+subpackages:
+  - name: ${{package.name}}-base-notebook
+  - name: ${{package.name}}-minimal-notebook
+  - name: ${{package.name}}-docker-stacks-foundation
+    dependencies:
+      runtime:
+        - bzip2
+        - ca-certificates-bundle
+        - glibc-locales
+        - tini
+        - wget
+        - glibc-locale-gen
+    pipeline:
+      - working-directory: images/docker-stacks-foundation

--- a/jupyterlab-docker-stacks.yaml
+++ b/jupyterlab-docker-stacks.yaml
@@ -37,3 +37,7 @@ subpackages:
         - glibc-locale-gen
     pipeline:
       - working-directory: images/docker-stacks-foundation
+        runs: |
+          mkdir -p ${{targets.contextdir}}/usr/bin/fix/
+          chmod a+rx fix-permissions
+          cp fix-permissions ${{targets.contextdir}}/usr/bin/fix/


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
