### PR TITLE
Rework some shell code for `supervisor` and `hwloc`

### DIFF
--- a/hwloc.yaml
+++ b/hwloc.yaml
@@ -87,7 +87,7 @@ test:
         hwloc-diff --help
         hwloc-distrib --version
         hwloc-distrib --help
-        if [[ uname -m == 'x86_64']]; then
+        if [[ "$(uname -m)" == 'x86_64' ]]; then
           hwloc-gather-cpuid --version
           hwloc-gather-cpuid --help
         fi;
@@ -105,7 +105,7 @@ test:
         lstopo --help
         lstopo-no-graphics --version
         lstopo-no-graphics --help
-        if [[ uname -m == 'x86_64']]; then
+        if [[ "$(uname -m)" == 'x86_64' ]]; then
           hwloc-dump-hwdata --version
           hwloc-dump-hwdata --help
         fi

--- a/hwloc.yaml
+++ b/hwloc.yaml
@@ -87,7 +87,8 @@ test:
         hwloc-diff --help
         hwloc-distrib --version
         hwloc-distrib --help
-        if [[ "$(uname -m)" == 'x86_64' ]]; then
+        if [[ "$(uname -m)" == 'x86_64' ]]
+        then
           hwloc-gather-cpuid --version
           hwloc-gather-cpuid --help
         fi;
@@ -105,7 +106,8 @@ test:
         lstopo --help
         lstopo-no-graphics --version
         lstopo-no-graphics --help
-        if [[ "$(uname -m)" == 'x86_64' ]]; then
+        if [[ "$(uname -m)" == 'x86_64' ]]
+        then
           hwloc-dump-hwdata --version
           hwloc-dump-hwdata --help
         fi

--- a/supervisor.yaml
+++ b/supervisor.yaml
@@ -66,6 +66,7 @@ pipeline:
         notifempty
         nocompress
       }
+      EOF
 
       chmod 600 ${{targets.destdir}}/etc/supervisord.conf
       chmod 644 ${{targets.destdir}}/etc/logrotate.d/supervisord


### PR DESCRIPTION
This attempts to fix our ability to parse shell code with `melange` by working around parsing bugs in https://github.com/mvdan/sh in a way that hopefully doesn't actually change build logic.

We first noticed this problem while seeing wolfictl's CI failing on the latest bump of melange: https://github.com/wolfi-dev/wolfictl/actions/runs/12088082103/job/33710862119?pr=1345

Related to https://github.com/chainguard-dev/melange/pull/1622

cc: @jonjohnsonjr @imjasonh 