### PR TITLE
debezium: symlink for apicurio

### DIFF
--- a/debezium-3.0.yaml
+++ b/debezium-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-3.0
   version: 3.0.4
-  epoch: 0
+  epoch: 1
   description: Debezium is a change data capture (CDC) platform that achieves its durability, reliability, and fault tolerance qualities by reusing Kafka and Kafka Connect.
   copyright:
     - license: Apache-2.0
@@ -207,6 +207,16 @@ subpackages:
           for lib in debezium-connect-rest-extension debezium-scripting; do
             ln -sf /usr/share/java/debezium/${lib} "${{targets.contextdir}}"/kafka/external_libs/${lib}
           done
+          ln -sf /usr/share/java/apicurio-registry "${{targets.contextdir}}"/kafka/external_libs/apicurio
+    test:
+      pipeline:
+        - name: Check some symlinks
+          runs: |
+            stat /kafka/connect
+            stat /kafka/connect/debezium-connector-spanner
+            stat /kafka/external_libs
+            stat /kafka/external_libs/debezium-scripting
+            stat /kafka/external_libs/apicurio
 
 update:
   enabled: true


### PR DESCRIPTION
Symlink the apicurio add-on that expected at path `/kafka/external_libs/apicurio`.