### PR TITLE
fluent-plugin-label-router: bump to latest

### DIFF
--- a/fluent-plugin-label-router.yaml
+++ b/fluent-plugin-label-router.yaml
@@ -1,7 +1,8 @@
+#nolint:valid-pipeline-git-checkout-tag
 package:
   name: fluent-plugin-label-router
-  version: "0.2.10_git20230928"
-  epoch: 6
+  version: "0.4.0_git20241202"
+  epoch: 0
   description: Label-Router helps routing log messages based on their labels and namespace tag in a Kubernetes environment.
   copyright:
     - license: Apache-2.0
@@ -23,26 +24,34 @@ environment:
       - ruby-3.2-dev
 
 pipeline:
-  # Hack until they cut a release
-  - runs: |
-      git clone https://github.com/kube-logging/fluent-plugin-label-router
-      cd fluent-plugin-label-router
-      git checkout 695d289f3b170d4739e79b21ce062700b10acf16
+  - uses: git-checkout
+    with:
+      expected-commit: 9ed269cc6e7eced5d91737ff5cb5e4519f50ba22
+      repository: https://github.com/kube-logging/fluent-plugin-label-router
+      branch: master
 
-  - working-directory: fluent-plugin-label-router
-    pipeline:
-      - uses: ruby/build
-        with:
-          gem: ${{vars.gem}}
-      - uses: ruby/install
-        with:
-          gem: ${{vars.gem}}
-          # Hard-coding the version here to match with gemspec till they come with a release/tag
-          version: 0.2.10
-      - uses: ruby/clean
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: 0.4.0
+
+  - uses: ruby/clean
 
 vars:
   gem: fluent-plugin-label-router
 
 update:
-  enabled: false
+  enabled: true
+  schedule:
+    period: daily
+    reason: Upstream does not maintain tags or releases
+  git: {}
+
+test:
+  pipeline:
+    - runs: |
+        ruby -e "require 'fluent/plugin/out_label_router.rb'"


### PR DESCRIPTION
Upstream fixed the issue related with the latest Kubernetes api client, so it works as expected now.