### PR TITLE
Adding compat package to mirror upstream image

### DIFF
--- a/splunk-otel-collector.yaml
+++ b/splunk-otel-collector.yaml
@@ -1,7 +1,7 @@
 package:
   name: splunk-otel-collector
   version: 0.113.0
-  epoch: 1
+  epoch: 2
   description: Splunk OpenTelemetry Collector is a distribution of the OpenTelemetry Collector. It provides a unified way to receive, process, and export metric, trace, and log data for Splunk Observability Cloud
   copyright:
     - license: Apache-2.0
@@ -40,6 +40,12 @@ pipeline:
       cp cmd/otelcol/config/collector/ecs_ec2_config.yaml ${{targets.contextdir}}/etc/otel/collector/ecs_ec2_config.yaml
 
 subpackages:
+  - name: ${{package.name}}-compat
+    description: Symlink for the otel binary in the home folder
+    pipeline:
+      - runs: |
+          ln -sf /usr/bin/otelcol ${{targets.contextdir}}/
+
   - name: ${{package.name}}-doc
     description: Documentation for Splunk OTel Collector
     pipeline:

--- a/splunk-otel-collector.yaml
+++ b/splunk-otel-collector.yaml
@@ -41,7 +41,7 @@ pipeline:
 
 subpackages:
   - name: ${{package.name}}-compat
-    description: Symlink for the otel binary in the home folder
+    description: Symlink for the otel binary in the root folder
     pipeline:
       - runs: |
           ln -sf /usr/bin/otelcol ${{targets.contextdir}}/


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->
Compat package to allow calling the splunk otel binary from a different location
<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->
