### PR TITLE
postgresql-bitnami: provide missing dirs

### DIFF
--- a/postgresql-17-bitnami-compat.yaml
+++ b/postgresql-17-bitnami-compat.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-17-bitnami-compat
   version: "17.0"
-  epoch: 0
+  epoch: 1
   description: "compat package with postgresql image"
   copyright:
     - license: BSD-3-Clause
@@ -29,10 +29,16 @@ pipeline:
       version-path: 17/debian-12
 
   - runs: |
-      mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/conf
-      mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/conf.default
-      mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/bin
+      mkdir -p ${{targets.contextdir}}/bitnami/postgresql
+      mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/conf/conf.d
+      mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/conf.default/conf.d
       mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/share
+      mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/tmp
+      mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/logs
+
+      # Provide necessary permissions as per Bitnami image
+      chmod -R u+rwX,g+rwX,o+rw ${{targets.contextdir}}/bitnami/postgresql
+      chmod -R u+rwX,g+rwX,o+rw ${{targets.contextdir}}/opt/bitnami/postgresql
 
       # Copy sample configs used to generate Bitnami config
       cp /usr/share/postgresql17/pg_hba.conf.sample ${{targets.contextdir}}/opt/bitnami/postgresql/share/pg_hba.conf.sample
@@ -48,10 +54,8 @@ pipeline:
       rm ${{targets.contextdir}}/opt/bitnami/postgresql/share/*.sample
 
       # Link binaries used by Bitnami config
-      ln -sf /usr/libexec/postgresql17/initdb ${{targets.contextdir}}/opt/bitnami/postgresql/bin/initdb
-      ln -sf /usr/libexec/postgresql17/pg_ctl ${{targets.contextdir}}/opt/bitnami/postgresql/bin/pg_ctl
-      ln -sf /usr/libexec/postgresql17/pg_rewind ${{targets.contextdir}}/opt/bitnami/postgresql/bin/pg_rewind
-      ln -sf /usr/libexec/postgresql17/pg_isready /${{targets.contextdir}}/opt/bitnami/postgresql/bin/pg_isready
+      ln -sf /usr/libexec/postgresql17 ${{targets.contextdir}}/opt/bitnami/postgresql/bin
+      ln -sf /usr/lib/postgresql17 ${{targets.contextdir}}/opt/bitnami/postgresql/lib
 
 test:
   pipeline:


### PR DESCRIPTION
On the upstream postgres-ha image, there is conf.d dirs maintained. And also those packages were missing lots of other binaries, so let's symlink the entire bin and lib dirs for .so files.

This is not a breaking change.