### PR TITLE
Refactor docker package to reuse in fips image

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -114,6 +114,10 @@ subpackages:
     pipeline:
       - runs: |
           install -Dm755 /home/docker-library/docker-entrypoint.sh "${{targets.subpkgdir}}"/usr/bin/docker-entrypoint.sh
+    test:
+      pipeline:
+        - runs: |
+            stat /usr/bin/docker-entrypoint.sh
 
   - name: dockerd-oci-entrypoint
     description: "dockerd OCI entrypoint"
@@ -126,6 +130,10 @@ subpackages:
     pipeline:
       - runs: |
           install -Dm755 /home/docker-library/dockerd-entrypoint.sh "${{targets.subpkgdir}}"/usr/bin/dockerd-entrypoint.sh
+    test:
+      pipeline:
+        - runs: |
+            stat /usr/bin/dockerd-entrypoint.sh
 
   - name: docker-rootless
     description: "dockerd rootless"

--- a/docker.yaml
+++ b/docker.yaml
@@ -111,23 +111,14 @@ subpackages:
 
   - name: docker-oci-entrypoint
     description: "docker OCI entrypoint"
-    dependencies:
-      runtime:
-        - docker
     pipeline:
       - runs: |
           install -Dm755 /home/docker-library/docker-entrypoint.sh "${{targets.subpkgdir}}"/usr/bin/docker-entrypoint.sh
-    test:
-      pipeline:
-        - runs: |
-            docker-entrypoint.sh --version
-            docker-entrypoint.sh --help
 
   - name: dockerd-oci-entrypoint
     description: "dockerd OCI entrypoint"
     dependencies:
       runtime:
-        - docker
         # Used as a fallback in the dockerd-entrypoint.sh script
         - docker-oci-entrypoint
         # Used as a fallback in the dockerd-entrypoint.sh script
@@ -135,11 +126,6 @@ subpackages:
     pipeline:
       - runs: |
           install -Dm755 /home/docker-library/dockerd-entrypoint.sh "${{targets.subpkgdir}}"/usr/bin/dockerd-entrypoint.sh
-    test:
-      pipeline:
-        - runs: |
-            dockerd-entrypoint.sh --version
-            dockerd-entrypoint.sh --help
 
   - name: docker-rootless
     description: "dockerd rootless"
@@ -158,9 +144,6 @@ subpackages:
   # Ref: https://github.com/docker-library/docker/blob/master/Dockerfile-dind.template
   - name: docker-dind
     description: "Docker in Docker"
-    dependencies:
-      runtime:
-        - docker
     pipeline:
       - runs: |
           install -Dm755 /home/build/hack/dind "${{targets.subpkgdir}}"/usr/bin/dind
@@ -169,7 +152,6 @@ subpackages:
     description: "Systemd services for docker"
     dependencies:
       runtime:
-        - docker
         - containerd-service
         - systemd
     pipeline:

--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: 27.3.1
-  epoch: 3
+  epoch: 4
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Refacored docker package- removed docker dependency to reuse in fips image. 

Note: Some tests were removed as well, checking for version/help. I have verified no image used these subpackages so we will just have to be careful with our docker and docker fips image module