### PR TITLE
feat(ruby): Make coinstallable

### DIFF
--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.6
-  epoch: 6
+  epoch: 7
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -9,6 +9,8 @@ package:
   dependencies:
     provides:
       - ruby=${{package.full-version}}
+    runtime:
+      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -34,10 +36,15 @@ environment:
       - xz-dev
       - zlib-dev
 
-vars:
-  prefix: /usr
-
 var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+
+    replace: $1
+    to: major-minor-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+
+    replace: $1.0
+    to: stdlib-version
   - from: ${{package.version}}
     match: \.
     replace: _
@@ -61,7 +68,11 @@ pipeline:
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
-         --prefix=${{vars.prefix}} \
+         --prefix=/usr \
+         --bindir=/usr/libexec/ruby/${{vars.stdlib-version}} \
+         --datadir=/usr/share/ruby/${{vars.stdlib-version}} \
+         --docdir=/usr/share/ruby/${{vars.stdlib-version}}/doc \
+         --mandir=/usr/share/ruby/${{vars.stdlib-version}}/man \
          --enable-ipv6 \
          --enable-loadable-sqlite-extensions \
          --enable-optimizations \
@@ -81,38 +92,73 @@ pipeline:
   - uses: strip
 
   - runs: |
-      # Ignore the patch version of ruby since ruby will install under the
-      # version of the latest standard library. Should produce the string 3.1.*
-      RUBYWILD="$(echo ${{package.version}} | cut -d. -f-2).*"
+      rm ${{targets.destdir}}/usr/lib/libruby.so
 
-      RUBYDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/$RUBYWILD
-      rm -rf ${RUBYDIR}/bundler
+      RUBYDIR=${{targets.destdir}}/usr/lib/ruby/${{vars.stdlib-version}}
+      rm -r ${RUBYDIR}/bundler
       rm ${RUBYDIR}/bundler.rb
 
-      GEMDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/gems/$RUBYWILD
-      rm -rf ${GEMDIR}/gems/bundler-*
+      GEMDIR=${{targets.destdir}}/usr/lib/ruby/gems/${{vars.stdlib-version}}
+      rm -r ${GEMDIR}/gems/bundler-*
       rm ${GEMDIR}/specifications/default/bundler-*.gemspec
 
-      rm ${{targets.destdir}}/usr/bin/bundle \
-         ${{targets.destdir}}/usr/bin/bundler
+      rm ${{targets.destdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/bundle \
+         ${{targets.destdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/bundler
+
+  - runs: |
+      find ${{targets.destdir}} -name 'mkmf.log' -exec rm {} \;
 
 subpackages:
-  - name: "ruby-3.1-doc"
-    description: "ruby documentation"
+  - name: "${{package.name}}-base"
+    description: "Ruby ${{vars.major-minor-version}} base"
     pipeline:
-      - uses: split/manpages
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/share
-          mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
-          mv "${{targets.destdir}}"/usr/share/ri "${{targets.subpkgdir}}"/usr/share/
+          mkdir -p ${{targets.contextdir}}
 
-  - name: "ruby-3.1-dev"
-    description: "ruby development headers"
+          mv ${{targets.destdir}}/* ${{targets.contextdir}}
+
+          mkdir -p ${{targets.destdir}}/usr/bin
+          mkdir -p ${{targets.contextdir}}/usr/bin
+
+          for bin in ${{targets.contextdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/*; do
+            bn="$(basename $bin)"
+            ln -s /usr/libexec/ruby/${{vars.stdlib-version}}/$bn ${{targets.destdir}}/usr/bin/
+            ln -s /usr/libexec/ruby/${{vars.stdlib-version}}/$bn ${{targets.contextdir}}/usr/bin/$bn\${{vars.major-minor-version}}
+          done
+
+  - name: "${{package.name}}-doc"
+    description: "Ruby ${{vars.major-minor-version}} documentation"
+    pipeline:
+      - runs: |
+          datadir="/usr/share/ruby/${{vars.stdlib-version}}"
+
+          mkdir -p "${{targets.contextdir}}/$datadir"
+
+          mv "${{targets.outdir}}/${{package.name}}-base/$datadir/doc" "${{targets.contextdir}}/$datadir/"
+          mv "${{targets.outdir}}/${{package.name}}-base/$datadir/man" "${{targets.contextdir}}/$datadir/"
+          mv "${{targets.outdir}}/${{package.name}}-base/usr/share/ri" "${{targets.contextdir}}/usr/share/"
+
+  - name: "${{package.name}}-base-dev"
+    description: "Ruby ${{vars.major-minor-version}} development headers"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
     pipeline:
       - uses: split/dev
+        with:
+          package: "${{package.name}}-base"
     test:
       pipeline:
         - uses: test/pkgconf
+
+  # Empty package, ensures ruby-dev always installs development files for latest ruby version
+  - name: "${{package.name}}-dev"
+    description: "Ruby ${{vars.major-minor-version}} development headers"
+    dependencies:
+      provides:
+        - ruby-dev=${{package.full-version}}
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
 
 update:
   enabled: true

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,14 +1,16 @@
 package:
   name: ruby-3.2
   version: 3.2.6
-  epoch: 1
-  description: "the Ruby programming language"
+  epoch: 2
+  description: "The Ruby ${{vars.major-minor-version}} programming language"
   copyright:
     - license: Ruby
     - license: BSD-2-Clause
   dependencies:
     provides:
       - ruby=${{package.full-version}}
+    runtime:
+      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -41,10 +43,15 @@ environment:
       - yaml-dev
       - zlib-dev
 
-vars:
-  prefix: /usr
-
 var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+
+    replace: $1
+    to: major-minor-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+
+    replace: $1.0
+    to: stdlib-version
   - from: ${{package.version}}
     match: \.
     replace: _
@@ -68,7 +75,11 @@ pipeline:
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
-         --prefix=${{vars.prefix}} \
+         --prefix=/usr \
+         --bindir=/usr/libexec/ruby/${{vars.stdlib-version}} \
+         --datadir=/usr/share/ruby/${{vars.stdlib-version}} \
+         --docdir=/usr/share/ruby/${{vars.stdlib-version}}/doc \
+         --mandir=/usr/share/ruby/${{vars.stdlib-version}}/man \
          --enable-shared \
          --disable-rpath \
          --sysconfdir=/etc \
@@ -90,41 +101,73 @@ pipeline:
   - uses: autoconf/make-install
 
   - runs: |
-      # Ignore the patch version of ruby since ruby will install under the
-      # version of the latest standard library. Should produce the string 3.2.*
-      RUBYWILD="$(echo ${{package.version}} | cut -d. -f-2).*"
+      rm ${{targets.destdir}}/usr/lib/libruby.so
 
-      RUBYDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/$RUBYWILD
-      rm -rf ${RUBYDIR}/bundler
-      rm -f ${RUBYDIR}/bundler.rb
+      RUBYDIR=${{targets.destdir}}/usr/lib/ruby/${{vars.stdlib-version}}
+      rm -r ${RUBYDIR}/bundler
+      rm ${RUBYDIR}/bundler.rb
 
-      GEMDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/gems/$RUBYWILD
-      rm -rf ${GEMDIR}/gems/bundler-*
-      rm -f ${GEMDIR}/specifications/default/bundler-*.gemspec
+      GEMDIR=${{targets.destdir}}/usr/lib/ruby/gems/${{vars.stdlib-version}}
+      rm -r ${GEMDIR}/gems/bundler-*
+      rm ${GEMDIR}/specifications/default/bundler-*.gemspec
 
-      rm -f ${{targets.destdir}}/usr/bin/bundle \
-         ${{targets.destdir}}/usr/bin/bundler
+      rm ${{targets.destdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/bundle \
+         ${{targets.destdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/bundler
 
   - runs: |
       find ${{targets.destdir}} -name 'mkmf.log' -exec rm {} \;
 
 subpackages:
-  - name: "ruby-3.2-doc"
-    description: "ruby documentation"
+  - name: "${{package.name}}-base"
+    description: "Ruby ${{vars.major-minor-version}} base"
     pipeline:
-      - uses: split/manpages
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/share
-          mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
-          mv "${{targets.destdir}}"/usr/share/ri "${{targets.subpkgdir}}"/usr/share/
+          mkdir -p ${{targets.contextdir}}
 
-  - name: "ruby-3.2-dev"
-    description: "ruby development headers"
+          mv ${{targets.destdir}}/* ${{targets.contextdir}}
+
+          mkdir -p ${{targets.destdir}}/usr/bin
+          mkdir -p ${{targets.contextdir}}/usr/bin
+
+          for bin in ${{targets.contextdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/*; do
+            bn="$(basename $bin)"
+            ln -s /usr/libexec/ruby/${{vars.stdlib-version}}/$bn ${{targets.destdir}}/usr/bin/
+            ln -s /usr/libexec/ruby/${{vars.stdlib-version}}/$bn ${{targets.contextdir}}/usr/bin/$bn\${{vars.major-minor-version}}
+          done
+
+  - name: "${{package.name}}-doc"
+    description: "Ruby ${{vars.major-minor-version}} documentation"
+    pipeline:
+      - runs: |
+          datadir="/usr/share/ruby/${{vars.stdlib-version}}"
+
+          mkdir -p "${{targets.contextdir}}/$datadir"
+
+          mv "${{targets.outdir}}/${{package.name}}-base/$datadir/doc" "${{targets.contextdir}}/$datadir/"
+          mv "${{targets.outdir}}/${{package.name}}-base/$datadir/man" "${{targets.contextdir}}/$datadir/"
+          mv "${{targets.outdir}}/${{package.name}}-base/usr/share/ri" "${{targets.contextdir}}/usr/share/"
+
+  - name: "${{package.name}}-base-dev"
+    description: "Ruby ${{vars.major-minor-version}} development headers"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
     pipeline:
       - uses: split/dev
+        with:
+          package: "${{package.name}}-base"
     test:
       pipeline:
         - uses: test/pkgconf
+
+  # Empty package, ensures ruby-dev always installs development files for latest ruby version
+  - name: "${{package.name}}-dev"
+    description: "Ruby ${{vars.major-minor-version}} development headers"
+    dependencies:
+      provides:
+        - ruby-dev=${{package.full-version}}
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
 
 update:
   enabled: true

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,14 +1,16 @@
 package:
   name: ruby-3.3
   version: 3.3.6
-  epoch: 0
-  description: "the Ruby programming language"
+  epoch: 1
+  description: "The Ruby ${{vars.major-minor-version}} programming language"
   copyright:
     - license: Ruby
     - license: BSD-2-Clause
   dependencies:
     provides:
       - ruby=${{package.full-version}}
+    runtime:
+      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -39,10 +41,15 @@ environment:
       - yaml-dev
       - zlib-dev
 
-vars:
-  prefix: /usr
-
 var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+
+    replace: $1
+    to: major-minor-version
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+
+    replace: $1.0
+    to: stdlib-version
   - from: ${{package.version}}
     match: \.
     replace: _
@@ -66,7 +73,11 @@ pipeline:
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
-         --prefix=${{vars.prefix}} \
+         --prefix=/usr \
+         --bindir=/usr/libexec/ruby/${{vars.stdlib-version}} \
+         --datadir=/usr/share/ruby/${{vars.stdlib-version}} \
+         --docdir=/usr/share/ruby/${{vars.stdlib-version}}/doc \
+         --mandir=/usr/share/ruby/${{vars.stdlib-version}}/man \
          --enable-shared \
          --disable-rpath \
          --sysconfdir=/etc \
@@ -88,41 +99,73 @@ pipeline:
   - uses: autoconf/make-install
 
   - runs: |
-      # Ignore the patch version of ruby since ruby will install under the
-      # version of the latest standard library. Should produce the string 3.3.*
-      RUBYWILD="$(echo ${{package.version}} | cut -d. -f-2).*"
+      rm ${{targets.destdir}}/usr/lib/libruby.so
 
-      RUBYDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/$RUBYWILD
-      rm -rf ${RUBYDIR}/bundler
-      rm -f ${RUBYDIR}/bundler.rb
+      RUBYDIR=${{targets.destdir}}/usr/lib/ruby/${{vars.stdlib-version}}
+      rm -r ${RUBYDIR}/bundler
+      rm ${RUBYDIR}/bundler.rb
 
-      GEMDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/gems/$RUBYWILD
-      rm -rf ${GEMDIR}/gems/bundler-*
-      rm -f ${GEMDIR}/specifications/default/bundler-*.gemspec
+      GEMDIR=${{targets.destdir}}/usr/lib/ruby/gems/${{vars.stdlib-version}}
+      rm -r ${GEMDIR}/gems/bundler-*
+      rm ${GEMDIR}/specifications/default/bundler-*.gemspec
 
-      rm -f ${{targets.destdir}}/usr/bin/bundle \
-         ${{targets.destdir}}/usr/bin/bundler
+      rm ${{targets.destdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/bundle \
+         ${{targets.destdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/bundler
 
   - runs: |
       find ${{targets.destdir}} -name 'mkmf.log' -exec rm {} \;
 
 subpackages:
-  - name: "ruby-3.3-doc"
-    description: "ruby documentation"
+  - name: "${{package.name}}-base"
+    description: "Ruby ${{vars.major-minor-version}} base"
     pipeline:
-      - uses: split/manpages
       - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/share
-          mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
-          mv "${{targets.destdir}}"/usr/share/ri "${{targets.subpkgdir}}"/usr/share/
+          mkdir -p ${{targets.contextdir}}
 
-  - name: "ruby-3.3-dev"
-    description: "ruby development headers"
+          mv ${{targets.destdir}}/* ${{targets.contextdir}}
+
+          mkdir -p ${{targets.destdir}}/usr/bin
+          mkdir -p ${{targets.contextdir}}/usr/bin
+
+          for bin in ${{targets.contextdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/*; do
+            bn="$(basename $bin)"
+            ln -s /usr/libexec/ruby/${{vars.stdlib-version}}/$bn ${{targets.destdir}}/usr/bin/
+            ln -s /usr/libexec/ruby/${{vars.stdlib-version}}/$bn ${{targets.contextdir}}/usr/bin/$bn\${{vars.major-minor-version}}
+          done
+
+  - name: "${{package.name}}-doc"
+    description: "Ruby ${{vars.major-minor-version}} documentation"
+    pipeline:
+      - runs: |
+          datadir="/usr/share/ruby/${{vars.stdlib-version}}"
+
+          mkdir -p "${{targets.contextdir}}/$datadir"
+
+          mv "${{targets.outdir}}/${{package.name}}-base/$datadir/doc" "${{targets.contextdir}}/$datadir/"
+          mv "${{targets.outdir}}/${{package.name}}-base/$datadir/man" "${{targets.contextdir}}/$datadir/"
+          mv "${{targets.outdir}}/${{package.name}}-base/usr/share/ri" "${{targets.contextdir}}/usr/share/"
+
+  - name: "${{package.name}}-base-dev"
+    description: "Ruby ${{vars.major-minor-version}} base development headers"
+    dependencies:
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
     pipeline:
       - uses: split/dev
+        with:
+          package: "${{package.name}}-base"
     test:
       pipeline:
         - uses: test/pkgconf
+
+  # Empty package, ensures ruby-dev always installs development files for latest ruby version
+  - name: "${{package.name}}-dev"
+    description: "Ruby ${{vars.major-minor-version}} development headers"
+    dependencies:
+      provides:
+        - ruby-dev=${{package.full-version}}
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
 
 update:
   enabled: true


### PR DESCRIPTION
This makes Ruby 3.1-3.3 coinstallable, allowing for multiple versions of Ruby to be installed at the same time. This will help us simplifiy a lot of package manifests we have for Ruby as we'll be able to build gems for multiple Ruby versions within the same definition, without creating an entirely separate manifest

To full leverage this, we'll need to make SCA changes: chainguard-dev/melange#1676

And then rebuild the world for Ruby (purging the cmd:ruby dependency that all packages have right now, causing the resolver to fail unless you explicitly request a version of Ruby that aligns with the gem)