### PR TITLE
Fail the pkgconf test if the package does not contain any .pc files

### DIFF
--- a/pipelines/test/pkgconf.yaml
+++ b/pipelines/test/pkgconf.yaml
@@ -11,7 +11,9 @@ pipeline:
       dev_pkg=$(basename ${{targets.contextdir}})
       # Find all pc files installed by this dev_pkg
       cd /
+      pc_files=false
       for pc_file in $(apk info -L "$dev_pkg" | grep "\.pc$"); do
+        pc_files=true
         # Ensure this is a pkgconf .pc file
         if grep -q "^Name:" $pc_file; then
           lib_name=$(basename "$pc_file" ".pc")
@@ -36,3 +38,6 @@ pipeline:
           fi
         fi
       done
+      if [ $pc_files = "false" ]; then
+        echo "No .pc files found in $dev_pkg please remove the pkgconf test" && exit 1
+      fi


### PR DESCRIPTION
There are some packages which have included the pkgconf test pipeline but the test doesn't actually do anything because the package does not provide any .pc files. So running the test doesn't accomplish anything and could actually skew stats leading us to believe there are more tests than there really are.