### PR TITLE
dotnet-7: add source build stages

### DIFF
--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -64,13 +64,18 @@ pipeline:
           sed -i -E 's|( /p:BuildDebPackage=false)|\1 --cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE|' src/runtime/eng/SourceBuild.props
           ./prep.sh --bootstrap
       - runs: |
-          ./build.sh --online --clean-while-building \
+          mkdir source-artifacts
+          tar -xzvf packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz -C source-artifacts
+          ./build.sh --clean-while-building \
+            --with-sdk /home/build/src/.dotnet/ \
+            --with-packages /home/build/src/source-artifacts \
             -- \
             /v:n \
             /p:ContinueOnPrebuiltBaselineError=true \
             /p:MinimalConsoleLogOutput=false \
             /p:PrebuiltPackagesPath=/home/build/src/packages \
-            /p:SkipPortableRuntimeBuild=true
+            /p:SkipPortableRuntimeBuild=true \
+            /p:BuildWithOnlineSources=false
       - runs: |
           mkdir -p "${{targets.destdir}}"/usr/share/dotnet
           mkdir -p "${{targets.destdir}}"/usr/bin

--- a/dotnet-7.yaml
+++ b/dotnet-7.yaml
@@ -2,7 +2,7 @@ package:
   name: dotnet-7
   # Remove `-sb` from the git-checkout tag at the next release
   version: 7.0.120
-  epoch: 0
+  epoch: 1
   description: ".NET SDK"
   copyright:
     - license: MIT


### PR DESCRIPTION
Decouple the stages in two: bootstrap and source build.
