### PR TITLE
fix(datadog-agent): Include downloader in core integrations

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: 7.59.0
-  epoch: 2
+  epoch: 3
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -303,9 +303,10 @@ subpackages:
               excludes="datadog_checks_base datadog_checks_dev datadog_checks_tests_helper docker_daemon esxi teleport"
               checks=$(invoke -r /home/build agent.collect-integrations /home/integrations/ 3 linux --excluded "$excludes")
 
-              # Install core and dependencies
+              # Install core, downloader, and dependencies
               .venv/bin/pip install \
                 "./datadog_checks_base[deps, http]" \
+                "./datadog_checks_downloader" \
                 $(echo ${checks} | xargs -n1 echo | sed 's|^|./|')
 
               find .venv -name "*.pyc" -delete
@@ -570,6 +571,7 @@ test:
         PATH=$mypath:$PATH
         # this is left without path to be explicit which python is used.
         ${{vars.destd}}/embedded/bin/python3 -c "import datadog_checks.base"
+        ${{vars.destd}}/embedded/bin/python3 -c "import datadog_checks.downloader"
     - name: Execute bins
       runs: |
         PATH=$mypath:$PATH


### PR DESCRIPTION
Add the downloader to the core integrations subpackage and add an import test