### PR TITLE
fix(datadog-agent): Also add apm to core integrations

### DIFF
--- a/datadog-agent.yaml
+++ b/datadog-agent.yaml
@@ -3,7 +3,7 @@ package:
   # This package has two git checkouts. For each new release, the commit SHA for
   # DataDog/integrations-core must also be updated.
   version: 7.59.0
-  epoch: 3
+  epoch: 4
   description: "Collect events and metrics from your hosts that send data to Datadog."
   copyright:
     - license: Apache-2.0
@@ -305,6 +305,7 @@ subpackages:
 
               # Install core, downloader, and dependencies
               .venv/bin/pip install \
+                "./datadog_checks_apm" \
                 "./datadog_checks_base[deps, http]" \
                 "./datadog_checks_downloader" \
                 $(echo ${checks} | xargs -n1 echo | sed 's|^|./|')
@@ -570,6 +571,7 @@ test:
       runs: |
         PATH=$mypath:$PATH
         # this is left without path to be explicit which python is used.
+        ${{vars.destd}}/embedded/bin/python3 -c "import datadog_checks.apm"
         ${{vars.destd}}/embedded/bin/python3 -c "import datadog_checks.base"
         ${{vars.destd}}/embedded/bin/python3 -c "import datadog_checks.downloader"
     - name: Execute bins


### PR DESCRIPTION
Missed this one. Add apm with an import test