### PR TITLE
Drop pkgconf tests that fail because the package provides no .pc files

### DIFF
--- a/frr-10.2.yaml
+++ b/frr-10.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: frr-10.2
   version: "10.2"
-  epoch: 0
+  epoch: 1
   description: The FRRouting Protocol Suite
   copyright:
     - license: GPL-2.0-only
@@ -91,9 +91,6 @@ subpackages:
         - frr=${{package.full-version}}
     pipeline:
       - uses: split/dev
-    test:
-      pipeline:
-        - uses: test/pkgconf
 
   - name: ${{package.name}}-debug
     dependencies:

--- a/libva.yaml
+++ b/libva.yaml
@@ -2,7 +2,7 @@
 package:
   name: libva
   version: 2.22.0
-  epoch: 1
+  epoch: 2
   description: Video Acceleration (VA) API for Linux
   copyright:
     - license: MIT
@@ -54,7 +54,3 @@ update:
   enabled: true
   github:
     identifier: intel/libva
-
-test:
-  pipeline:
-    - uses: test/pkgconf

--- a/lsof.yaml
+++ b/lsof.yaml
@@ -1,7 +1,7 @@
 package:
   name: lsof
   version: 4.99.4
-  epoch: 0
+  epoch: 1
   description: List Open Files
   copyright:
     - license: lsof
@@ -61,9 +61,6 @@ subpackages:
         - lsof
     pipeline:
       - uses: split/dev
-    test:
-      pipeline:
-        - uses: test/pkgconf
 
   - name: lsof-doc
     pipeline:

--- a/mimalloc.yaml
+++ b/mimalloc.yaml
@@ -1,7 +1,7 @@
 package:
   name: mimalloc
   version: 1.8.7
-  epoch: 2
+  epoch: 3
   description: "A compact general purpose allocator with excellent performance"
   copyright:
     - license: MIT
@@ -36,9 +36,6 @@ subpackages:
     dependencies:
       runtime:
         - mimalloc
-    test:
-      pipeline:
-        - uses: test/pkgconf
 
 test:
   environment:

--- a/qpdf.yaml
+++ b/qpdf.yaml
@@ -1,7 +1,7 @@
 package:
   name: qpdf
   version: 11.9.1
-  epoch: 2
+  epoch: 3
   description: Command-line tools and library for transforming PDF files
   copyright:
     - license: Apache-2.0
@@ -53,9 +53,6 @@ subpackages:
       runtime:
         - qpdf
     description: qpdf dev
-    test:
-      pipeline:
-        - uses: test/pkgconf
 
   - name: qpdf-doc
     pipeline:

--- a/tk.yaml
+++ b/tk.yaml
@@ -1,7 +1,7 @@
 package:
   name: tk
   version: 9.0.0
-  epoch: 3
+  epoch: 4
   description: GUI toolkit for the Tcl scripting language
   copyright:
     - license: TCL
@@ -87,9 +87,6 @@ subpackages:
     dependencies:
       runtime:
         - tk
-    test:
-      pipeline:
-        - uses: test/pkgconf
 
 update:
   enabled: true


### PR DESCRIPTION
Determined by grep'ing the YAML for 'test/pkgconf', running the tests for matching packages, and then grep'ing those logs for the string "please remove the pkgconf test".
