### PR TITLE
withdraw repmgr old packages

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,1 +1,13 @@
 vim-9.0.2100-r0.apk
+repmgr-dev-5.5.0-r0.apk
+repmgr-5.5.0-r0.apk
+repmgr-bitnami-compat-5.5.0-r0.apk
+repmgr-dev-5.5.0-r1.apk
+repmgr-bitnami-compat-5.5.0-r1.apk
+repmgr-5.5.0-r1.apk
+repmgr-dev-5.5.0-r2.apk
+repmgr-bitnami-compat-5.5.0-r2.apk
+repmgr-5.5.0-r2.apk
+repmgr-dev-5.5.0-r3.apk
+repmgr-5.5.0-r3.apk
+repmgr-bitnami-compat-5.5.0-r3.apk


### PR DESCRIPTION
because we changed name from repmgr to repmgr-17 

see PR: https://github.com/wolfi-dev/os/pull/35770