### PR TITLE
Bump supervisor to fix missing EOF

### DIFF
--- a/supervisor.yaml
+++ b/supervisor.yaml
@@ -1,7 +1,7 @@
 package:
   name: supervisor
   version: 4.2.5
-  epoch: 5
+  epoch: 6
   description: Supervisor process control system for Unix (supervisord)
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
This was fixed in https://github.com/wolfi-dev/os/pull/35579 but not bumped so we have a bad supervisor package:

```
$ curl -sL https://packages.wolfi.dev/os/aarch64/supervisor-4.2.5-r5.apk | tar -Oxz etc/logrotate.d/supervisord
/var/log/supervisor/*.log {
  missingok
  weekly
  notifempty
  nocompress
}

chmod 600 /home/build/melange-out/supervisor/etc/supervisord.conf
chmod 644 /home/build/melange-out/supervisor/etc/logrotate.d/supervisord

find "/home/build/melange-out/supervisor" -name "*.pyo" -exec rm -rf '{}' +
find "/home/build/melange-out/supervisor" -name "tests" -exec rm -rf '{}' +

exit 0
```