### PR TITLE
fix(repmgr): write to stdout

### DIFF
--- a/repmgr-17.yaml
+++ b/repmgr-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: repmgr-17
   version: 5.5.0
-  epoch: 0
+  epoch: 1
   description: "A lightweight replication manager for PostgreSQL"
   copyright:
     - license: GPL-3.0-only
@@ -162,6 +162,9 @@ subpackages:
           # Link binaries used by Bitnami config
           ln -sf /usr/libexec/postgresql${{vars.major-postgresql-version}} ${{targets.contextdir}}/opt/bitnami/postgresql/bin
           ln -sf /usr/lib/postgresql${{vars.major-postgresql-version}} ${{targets.contextdir}}/opt/bitnami/postgresql/lib
+
+          # Image is readonly, so we can't write anything to filesytem.
+          ln -sf /dev/stdout ${{targets.contextdir}}/opt/bitnami/postgresql/logs/postgresql.log
     test:
       environment:
         environment:


### PR DESCRIPTION
Image is readonly, so write to stdout as upsteam did.