### PR TITLE
py3-pybind11: Fix priorities of provides

### DIFF
--- a/py3-pybind11.yaml
+++ b/py3-pybind11.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pybind11
   version: 2.13.6
-  epoch: 1
+  epoch: 2
   description: Seamless operability between C++11 and Python
   copyright:
     - license: BSD-3-Clause
@@ -16,9 +16,9 @@ vars:
 data:
   - name: py-versions
     items:
+      3.10: '310'
+      3.11: '311'
       3.12: '312'
-      3.11: '312'
-      3.10: '312'
       3.13: '300'
 
 environment:


### PR DESCRIPTION
When py3-bind11 was python multi-versioned, all provides for py3-pybind11 and py3-pybind11-dev were assigned the same priority. This looks like just a cut & paste error - fix it.

Fixes: commit d76de48b0 ("pybind11: py versioned (#26482)")
