### PR TITLE
add docker cli completion subpackages

### DIFF
--- a/docker-cli.yaml
+++ b/docker-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-cli
   version: 27.3.1
-  epoch: 1
+  epoch: 2
   description: The Docker CLI
   copyright:
     - license: Apache-2.0
@@ -54,6 +54,27 @@ subpackages:
     description: "docker-cli documentation"
     pipeline:
       - uses: split/manpages
+
+  - name: docker-cli-bash-completion
+    description: bash completion for docker-cli
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}/usr/share/bash-completion/completions"
+          cp contrib/completion/bash/docker ${{targets.contextdir}}/usr/share/bash-completion/completions/docker
+
+  - name: docker-cli-zsh-completion
+    description: zsh completion for docker-cli
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}/usr/share/zsh/site-functions"
+          cp contrib/completion/zsh/_docker ${{targets.contextdir}}/usr/share/zsh/site-functions/_docker
+
+  - name: docker-cli-fish-completion
+    description: fish completion for docker-cli
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}/usr/share/fish/vendor_completions.d"
+          cp contrib/completion/fish/docker.fish ${{targets.contextdir}}/usr/share/fish/vendor_completions.d/docker.fish
 
 update:
   enabled: true


### PR DESCRIPTION
add docker cli completion subpackages

this is going to be really useful for workstations, the default
completion generated by cobra is not very useful in different contexts.
docker have stores and maintained this completions for different shells
and these completions provide much better user experience over the
default cobra completions.

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>