### PR TITLE
openjdk-24: enable linkable runtime

### DIFF
--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -138,6 +138,8 @@ subpackages:
         - libxrender
         - libxtst
         - ttf-dejavu
+      provides:
+        - ${{package.name}}-jmods
     pipeline:
       - runs: |
           _java_home="usr/lib/jvm/java-24-openjdk"
@@ -191,14 +193,6 @@ subpackages:
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
-
-  - name: "${{package.name}}-jmods"
-    description: "OpenJDK 24 jmods"
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-24-openjdk
-          mv "${{targets.destdir}}"/usr/lib/jvm/java-24-openjdk/jmods \
-             "${{targets.subpkgdir}}"/usr/lib/jvm/java-24-openjdk
 
   - name: "${{package.name}}-doc"
     description: "OpenJDK 24 Documentation"

--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -194,14 +194,6 @@ subpackages:
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
           ln -sf . "${{targets.subpkgdir}}/$_java_home/jre"
 
-  - name: "${{package.name}}-doc"
-    description: "OpenJDK 24 Documentation"
-    pipeline:
-      - runs: |
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm/java-24-openjdk
-          mv "${{targets.destdir}}"/usr/lib/jvm/java-24-openjdk/man \
-             "${{targets.subpkgdir}}"/usr/lib/jvm/java-24-openjdk
-
   - name: "${{package.name}}-demos"
     description: "OpenJDK 24 Demos"
     pipeline:

--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: 24
-  epoch: 2
+  epoch: 3
   description: OpenJDK 24 Early Access Package
   copyright:
     - license: GPL-2.0-or-later
@@ -88,6 +88,7 @@ pipeline:
         --with-libjpeg=system \
         --with-giflib=system \
         --with-lcms=system \
+        --enable-linkable-runtime \
         --with-gtest="/home/build/googletest" \
         --with-version-pre="no" \
         --with-version-string=""

--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: 24
-  epoch: 3
+  epoch: 4
   description: OpenJDK 24 Early Access Package
   copyright:
     - license: GPL-2.0-or-later
@@ -48,8 +48,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/openjdk/jdk
-      tag: jdk-${{package.version}}+16
-      expected-commit: c58fbef05eace85a2e429da1ac8ff1ae09a0b736
+      tag: jdk-${{package.version}}+27
+      expected-commit: 85fedbf668023fd00d70ec649504c2f80e4c84bb
 
   - working-directory: /home/build/googletest
     pipeline:


### PR DESCRIPTION
Enable support for [JEP-493](https://openjdk.org/jeps/493)

Once this lands, can figure out image tests & package tests & dependencies to assert and validate this works.

Note, needs pandoc to build manpages now, which we don't have as we don't have haskell.