### PR TITLE
fix(ruby-dev): Depend on ruby-base-dev

### DIFF
--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.6
-  epoch: 7
+  epoch: 8
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -158,7 +158,7 @@ subpackages:
       provides:
         - ruby-dev=${{package.full-version}}
       runtime:
-        - ${{package.name}}-base=${{package.full-version}}
+        - ${{package.name}}-base-dev=${{package.full-version}}
 
 update:
   enabled: true

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: 3.2.6
-  epoch: 2
+  epoch: 3
   description: "The Ruby ${{vars.major-minor-version}} programming language"
   copyright:
     - license: Ruby
@@ -167,7 +167,7 @@ subpackages:
       provides:
         - ruby-dev=${{package.full-version}}
       runtime:
-        - ${{package.name}}-base=${{package.full-version}}
+        - ${{package.name}}-base-dev=${{package.full-version}}
 
 update:
   enabled: true

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.3
   version: 3.3.6
-  epoch: 1
+  epoch: 2
   description: "The Ruby ${{vars.major-minor-version}} programming language"
   copyright:
     - license: Ruby
@@ -165,7 +165,7 @@ subpackages:
       provides:
         - ruby-dev=${{package.full-version}}
       runtime:
-        - ${{package.name}}-base=${{package.full-version}}
+        - ${{package.name}}-base-dev=${{package.full-version}}
 
 update:
   enabled: true


### PR DESCRIPTION
Previously, ruby-dev was pulling in -base but not -base-dev