### PR TITLE
fix(repmgr): provide missing conf.d dir

### DIFF
--- a/repmgr-17.yaml
+++ b/repmgr-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: repmgr-17
   version: 5.5.0
-  epoch: 1
+  epoch: 2
   description: "A lightweight replication manager for PostgreSQL"
   copyright:
     - license: GPL-3.0-only
@@ -142,6 +142,7 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/conf
           mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/conf/conf.d
           mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/conf.default
+          mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/conf.default/conf.d
           mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/share
           mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/tmp
           mkdir -p ${{targets.contextdir}}/opt/bitnami/postgresql/logs


### PR DESCRIPTION
The upstream image was also respecting the `/opt/bitnami/postgresql/conf.default/conf.d` path, so it must be exist. (All `conf.d`s are empty.)