### PR TITLE
chore: Rebuild Ruby 3.1-3.3

### DIFF
--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.6
-  epoch: 8
+  epoch: 9
   description: "the Ruby programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.2
   version: 3.2.6
-  epoch: 3
+  epoch: 4
   description: "The Ruby ${{vars.major-minor-version}} programming language"
   copyright:
     - license: Ruby

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.3
   version: 3.3.6
-  epoch: 2
+  epoch: 3
   description: "The Ruby ${{vars.major-minor-version}} programming language"
   copyright:
     - license: Ruby


### PR DESCRIPTION
ruby-3.x-base currently depends on ruby-3.x, rebuild to pickup changes made to SCA