### PR TITLE
fix(ruby): Revert changes making Ruby co-installable

### DIFF
--- a/ruby-3.1.yaml
+++ b/ruby-3.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby-3.1
   version: 3.1.6
-  epoch: 9
+  epoch: 10
   description: "the Ruby programming language"
   copyright:
     - license: Ruby
@@ -9,8 +9,6 @@ package:
   dependencies:
     provides:
       - ruby=${{package.full-version}}
-    runtime:
-      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -36,15 +34,10 @@ environment:
       - xz-dev
       - zlib-dev
 
+vars:
+  prefix: /usr
+
 var-transforms:
-  - from: ${{package.version}}
-    match: ^(\d+\.\d+)\.\d+
-    replace: $1
-    to: major-minor-version
-  - from: ${{package.version}}
-    match: ^(\d+\.\d+)\.\d+
-    replace: $1.0
-    to: stdlib-version
   - from: ${{package.version}}
     match: \.
     replace: _
@@ -68,11 +61,7 @@ pipeline:
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
-         --prefix=/usr \
-         --bindir=/usr/libexec/ruby/${{vars.stdlib-version}} \
-         --datadir=/usr/share/ruby/${{vars.stdlib-version}} \
-         --docdir=/usr/share/ruby/${{vars.stdlib-version}}/doc \
-         --mandir=/usr/share/ruby/${{vars.stdlib-version}}/man \
+         --prefix=${{vars.prefix}} \
          --enable-ipv6 \
          --enable-loadable-sqlite-extensions \
          --enable-optimizations \
@@ -92,73 +81,38 @@ pipeline:
   - uses: strip
 
   - runs: |
-      rm ${{targets.destdir}}/usr/lib/libruby.so
+      # Ignore the patch version of ruby since ruby will install under the
+      # version of the latest standard library. Should produce the string 3.1.*
+      RUBYWILD="$(echo ${{package.version}} | cut -d. -f-2).*"
 
-      RUBYDIR=${{targets.destdir}}/usr/lib/ruby/${{vars.stdlib-version}}
-      rm -r ${RUBYDIR}/bundler
+      RUBYDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/$RUBYWILD
+      rm -rf ${RUBYDIR}/bundler
       rm ${RUBYDIR}/bundler.rb
 
-      GEMDIR=${{targets.destdir}}/usr/lib/ruby/gems/${{vars.stdlib-version}}
-      rm -r ${GEMDIR}/gems/bundler-*
+      GEMDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/gems/$RUBYWILD
+      rm -rf ${GEMDIR}/gems/bundler-*
       rm ${GEMDIR}/specifications/default/bundler-*.gemspec
 
-      rm ${{targets.destdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/bundle \
-         ${{targets.destdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/bundler
-
-  - runs: |
-      find ${{targets.destdir}} -name 'mkmf.log' -exec rm {} \;
+      rm ${{targets.destdir}}/usr/bin/bundle \
+         ${{targets.destdir}}/usr/bin/bundler
 
 subpackages:
-  - name: "${{package.name}}-base"
-    description: "Ruby ${{vars.major-minor-version}} base"
+  - name: "ruby-3.1-doc"
+    description: "ruby documentation"
     pipeline:
+      - uses: split/manpages
       - runs: |
-          mkdir -p ${{targets.contextdir}}
+          mkdir -p "${{targets.subpkgdir}}"/usr/share
+          mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
+          mv "${{targets.destdir}}"/usr/share/ri "${{targets.subpkgdir}}"/usr/share/
 
-          mv ${{targets.destdir}}/* ${{targets.contextdir}}
-
-          mkdir -p ${{targets.destdir}}/usr/bin
-          mkdir -p ${{targets.contextdir}}/usr/bin
-
-          for bin in ${{targets.contextdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/*; do
-            bn="$(basename $bin)"
-            ln -s /usr/libexec/ruby/${{vars.stdlib-version}}/$bn ${{targets.destdir}}/usr/bin/
-            ln -s /usr/libexec/ruby/${{vars.stdlib-version}}/$bn ${{targets.contextdir}}/usr/bin/$bn\${{vars.major-minor-version}}
-          done
-
-  - name: "${{package.name}}-doc"
-    description: "Ruby ${{vars.major-minor-version}} documentation"
-    pipeline:
-      - runs: |
-          datadir="/usr/share/ruby/${{vars.stdlib-version}}"
-
-          mkdir -p "${{targets.contextdir}}/$datadir"
-
-          mv "${{targets.outdir}}/${{package.name}}-base/$datadir/doc" "${{targets.contextdir}}/$datadir/"
-          mv "${{targets.outdir}}/${{package.name}}-base/$datadir/man" "${{targets.contextdir}}/$datadir/"
-          mv "${{targets.outdir}}/${{package.name}}-base/usr/share/ri" "${{targets.contextdir}}/usr/share/"
-
-  - name: "${{package.name}}-base-dev"
-    description: "Ruby ${{vars.major-minor-version}} development headers"
-    dependencies:
-      runtime:
-        - ${{package.name}}-base=${{package.full-version}}
+  - name: "ruby-3.1-dev"
+    description: "ruby development headers"
     pipeline:
       - uses: split/dev
-        with:
-          package: "${{package.name}}-base"
     test:
       pipeline:
         - uses: test/pkgconf
-
-  # Empty package, ensures ruby-dev always installs development files for latest ruby version
-  - name: "${{package.name}}-dev"
-    description: "Ruby ${{vars.major-minor-version}} development headers"
-    dependencies:
-      provides:
-        - ruby-dev=${{package.full-version}}
-      runtime:
-        - ${{package.name}}-base-dev=${{package.full-version}}
 
 update:
   enabled: true

--- a/ruby-3.2.yaml
+++ b/ruby-3.2.yaml
@@ -1,16 +1,14 @@
 package:
   name: ruby-3.2
   version: 3.2.6
-  epoch: 4
-  description: "The Ruby ${{vars.major-minor-version}} programming language"
+  epoch: 5
+  description: "the Ruby programming language"
   copyright:
     - license: Ruby
     - license: BSD-2-Clause
   dependencies:
     provides:
       - ruby=${{package.full-version}}
-    runtime:
-      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -43,15 +41,10 @@ environment:
       - yaml-dev
       - zlib-dev
 
+vars:
+  prefix: /usr
+
 var-transforms:
-  - from: ${{package.version}}
-    match: ^(\d+\.\d+)\.\d+
-    replace: $1
-    to: major-minor-version
-  - from: ${{package.version}}
-    match: ^(\d+\.\d+)\.\d+
-    replace: $1.0
-    to: stdlib-version
   - from: ${{package.version}}
     match: \.
     replace: _
@@ -75,11 +68,7 @@ pipeline:
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
-         --prefix=/usr \
-         --bindir=/usr/libexec/ruby/${{vars.stdlib-version}} \
-         --datadir=/usr/share/ruby/${{vars.stdlib-version}} \
-         --docdir=/usr/share/ruby/${{vars.stdlib-version}}/doc \
-         --mandir=/usr/share/ruby/${{vars.stdlib-version}}/man \
+         --prefix=${{vars.prefix}} \
          --enable-shared \
          --disable-rpath \
          --sysconfdir=/etc \
@@ -101,73 +90,41 @@ pipeline:
   - uses: autoconf/make-install
 
   - runs: |
-      rm ${{targets.destdir}}/usr/lib/libruby.so
+      # Ignore the patch version of ruby since ruby will install under the
+      # version of the latest standard library. Should produce the string 3.2.*
+      RUBYWILD="$(echo ${{package.version}} | cut -d. -f-2).*"
 
-      RUBYDIR=${{targets.destdir}}/usr/lib/ruby/${{vars.stdlib-version}}
-      rm -r ${RUBYDIR}/bundler
-      rm ${RUBYDIR}/bundler.rb
+      RUBYDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/$RUBYWILD
+      rm -rf ${RUBYDIR}/bundler
+      rm -f ${RUBYDIR}/bundler.rb
 
-      GEMDIR=${{targets.destdir}}/usr/lib/ruby/gems/${{vars.stdlib-version}}
-      rm -r ${GEMDIR}/gems/bundler-*
-      rm ${GEMDIR}/specifications/default/bundler-*.gemspec
+      GEMDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/gems/$RUBYWILD
+      rm -rf ${GEMDIR}/gems/bundler-*
+      rm -f ${GEMDIR}/specifications/default/bundler-*.gemspec
 
-      rm ${{targets.destdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/bundle \
-         ${{targets.destdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/bundler
+      rm -f ${{targets.destdir}}/usr/bin/bundle \
+         ${{targets.destdir}}/usr/bin/bundler
 
   - runs: |
       find ${{targets.destdir}} -name 'mkmf.log' -exec rm {} \;
 
 subpackages:
-  - name: "${{package.name}}-base"
-    description: "Ruby ${{vars.major-minor-version}} base"
+  - name: "ruby-3.2-doc"
+    description: "ruby documentation"
     pipeline:
+      - uses: split/manpages
       - runs: |
-          mkdir -p ${{targets.contextdir}}
+          mkdir -p "${{targets.subpkgdir}}"/usr/share
+          mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
+          mv "${{targets.destdir}}"/usr/share/ri "${{targets.subpkgdir}}"/usr/share/
 
-          mv ${{targets.destdir}}/* ${{targets.contextdir}}
-
-          mkdir -p ${{targets.destdir}}/usr/bin
-          mkdir -p ${{targets.contextdir}}/usr/bin
-
-          for bin in ${{targets.contextdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/*; do
-            bn="$(basename $bin)"
-            ln -s /usr/libexec/ruby/${{vars.stdlib-version}}/$bn ${{targets.destdir}}/usr/bin/
-            ln -s /usr/libexec/ruby/${{vars.stdlib-version}}/$bn ${{targets.contextdir}}/usr/bin/$bn\${{vars.major-minor-version}}
-          done
-
-  - name: "${{package.name}}-doc"
-    description: "Ruby ${{vars.major-minor-version}} documentation"
-    pipeline:
-      - runs: |
-          datadir="/usr/share/ruby/${{vars.stdlib-version}}"
-
-          mkdir -p "${{targets.contextdir}}/$datadir"
-
-          mv "${{targets.outdir}}/${{package.name}}-base/$datadir/doc" "${{targets.contextdir}}/$datadir/"
-          mv "${{targets.outdir}}/${{package.name}}-base/$datadir/man" "${{targets.contextdir}}/$datadir/"
-          mv "${{targets.outdir}}/${{package.name}}-base/usr/share/ri" "${{targets.contextdir}}/usr/share/"
-
-  - name: "${{package.name}}-base-dev"
-    description: "Ruby ${{vars.major-minor-version}} development headers"
-    dependencies:
-      runtime:
-        - ${{package.name}}-base=${{package.full-version}}
+  - name: "ruby-3.2-dev"
+    description: "ruby development headers"
     pipeline:
       - uses: split/dev
-        with:
-          package: "${{package.name}}-base"
     test:
       pipeline:
         - uses: test/pkgconf
-
-  # Empty package, ensures ruby-dev always installs development files for latest ruby version
-  - name: "${{package.name}}-dev"
-    description: "Ruby ${{vars.major-minor-version}} development headers"
-    dependencies:
-      provides:
-        - ruby-dev=${{package.full-version}}
-      runtime:
-        - ${{package.name}}-base-dev=${{package.full-version}}
 
 update:
   enabled: true

--- a/ruby-3.3.yaml
+++ b/ruby-3.3.yaml
@@ -1,16 +1,14 @@
 package:
   name: ruby-3.3
   version: 3.3.6
-  epoch: 3
-  description: "The Ruby ${{vars.major-minor-version}} programming language"
+  epoch: 4
+  description: "the Ruby programming language"
   copyright:
     - license: Ruby
     - license: BSD-2-Clause
   dependencies:
     provides:
       - ruby=${{package.full-version}}
-    runtime:
-      - ${{package.name}}-base=${{package.full-version}}
 
 environment:
   contents:
@@ -41,15 +39,10 @@ environment:
       - yaml-dev
       - zlib-dev
 
+vars:
+  prefix: /usr
+
 var-transforms:
-  - from: ${{package.version}}
-    match: ^(\d+\.\d+)\.\d+
-    replace: $1
-    to: major-minor-version
-  - from: ${{package.version}}
-    match: ^(\d+\.\d+)\.\d+
-    replace: $1.0
-    to: stdlib-version
   - from: ${{package.version}}
     match: \.
     replace: _
@@ -73,11 +66,7 @@ pipeline:
          --host=${{host.triplet.gnu}} \
          --build=${{host.triplet.gnu}} \
          --target=${{host.triplet.gnu}} \
-         --prefix=/usr \
-         --bindir=/usr/libexec/ruby/${{vars.stdlib-version}} \
-         --datadir=/usr/share/ruby/${{vars.stdlib-version}} \
-         --docdir=/usr/share/ruby/${{vars.stdlib-version}}/doc \
-         --mandir=/usr/share/ruby/${{vars.stdlib-version}}/man \
+         --prefix=${{vars.prefix}} \
          --enable-shared \
          --disable-rpath \
          --sysconfdir=/etc \
@@ -99,73 +88,41 @@ pipeline:
   - uses: autoconf/make-install
 
   - runs: |
-      rm ${{targets.destdir}}/usr/lib/libruby.so
+      # Ignore the patch version of ruby since ruby will install under the
+      # version of the latest standard library. Should produce the string 3.3.*
+      RUBYWILD="$(echo ${{package.version}} | cut -d. -f-2).*"
 
-      RUBYDIR=${{targets.destdir}}/usr/lib/ruby/${{vars.stdlib-version}}
-      rm -r ${RUBYDIR}/bundler
-      rm ${RUBYDIR}/bundler.rb
+      RUBYDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/$RUBYWILD
+      rm -rf ${RUBYDIR}/bundler
+      rm -f ${RUBYDIR}/bundler.rb
 
-      GEMDIR=${{targets.destdir}}/usr/lib/ruby/gems/${{vars.stdlib-version}}
-      rm -r ${GEMDIR}/gems/bundler-*
-      rm ${GEMDIR}/specifications/default/bundler-*.gemspec
+      GEMDIR=${{targets.destdir}}${{vars.prefix}}/lib/ruby/gems/$RUBYWILD
+      rm -rf ${GEMDIR}/gems/bundler-*
+      rm -f ${GEMDIR}/specifications/default/bundler-*.gemspec
 
-      rm ${{targets.destdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/bundle \
-         ${{targets.destdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/bundler
+      rm -f ${{targets.destdir}}/usr/bin/bundle \
+         ${{targets.destdir}}/usr/bin/bundler
 
   - runs: |
       find ${{targets.destdir}} -name 'mkmf.log' -exec rm {} \;
 
 subpackages:
-  - name: "${{package.name}}-base"
-    description: "Ruby ${{vars.major-minor-version}} base"
+  - name: "ruby-3.3-doc"
+    description: "ruby documentation"
     pipeline:
+      - uses: split/manpages
       - runs: |
-          mkdir -p ${{targets.contextdir}}
+          mkdir -p "${{targets.subpkgdir}}"/usr/share
+          mv "${{targets.destdir}}"/usr/share/doc "${{targets.subpkgdir}}"/usr/share/
+          mv "${{targets.destdir}}"/usr/share/ri "${{targets.subpkgdir}}"/usr/share/
 
-          mv ${{targets.destdir}}/* ${{targets.contextdir}}
-
-          mkdir -p ${{targets.destdir}}/usr/bin
-          mkdir -p ${{targets.contextdir}}/usr/bin
-
-          for bin in ${{targets.contextdir}}/usr/libexec/ruby/${{vars.stdlib-version}}/*; do
-            bn="$(basename $bin)"
-            ln -s /usr/libexec/ruby/${{vars.stdlib-version}}/$bn ${{targets.destdir}}/usr/bin/
-            ln -s /usr/libexec/ruby/${{vars.stdlib-version}}/$bn ${{targets.contextdir}}/usr/bin/$bn\${{vars.major-minor-version}}
-          done
-
-  - name: "${{package.name}}-doc"
-    description: "Ruby ${{vars.major-minor-version}} documentation"
-    pipeline:
-      - runs: |
-          datadir="/usr/share/ruby/${{vars.stdlib-version}}"
-
-          mkdir -p "${{targets.contextdir}}/$datadir"
-
-          mv "${{targets.outdir}}/${{package.name}}-base/$datadir/doc" "${{targets.contextdir}}/$datadir/"
-          mv "${{targets.outdir}}/${{package.name}}-base/$datadir/man" "${{targets.contextdir}}/$datadir/"
-          mv "${{targets.outdir}}/${{package.name}}-base/usr/share/ri" "${{targets.contextdir}}/usr/share/"
-
-  - name: "${{package.name}}-base-dev"
-    description: "Ruby ${{vars.major-minor-version}} base development headers"
-    dependencies:
-      runtime:
-        - ${{package.name}}-base=${{package.full-version}}
+  - name: "ruby-3.3-dev"
+    description: "ruby development headers"
     pipeline:
       - uses: split/dev
-        with:
-          package: "${{package.name}}-base"
     test:
       pipeline:
         - uses: test/pkgconf
-
-  # Empty package, ensures ruby-dev always installs development files for latest ruby version
-  - name: "${{package.name}}-dev"
-    description: "Ruby ${{vars.major-minor-version}} development headers"
-    dependencies:
-      provides:
-        - ruby-dev=${{package.full-version}}
-      runtime:
-        - ${{package.name}}-base-dev=${{package.full-version}}
 
 update:
   enabled: true


### PR DESCRIPTION
Everything that depends on cmd:ruby currently fails to resolve to the correct version of Ruby