### PR TITLE
add openssl-config to docker runtime deps

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: 27.3.1
-  epoch: 6
+  epoch: 7
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -24,6 +24,7 @@ package:
       - iptables
       - openssh-client
       - openssl
+      - openssl-config
       - pigz
       - procps
       - shadow-subids # equivalent of shadow-uidmap in wolfi


### PR DESCRIPTION
else we run into following: 
```bash
Can't open "/etc/ssl/openssl.cnf" for reading, No such file or directory
803B09B2977B0000:error:80000002:system library:BIO_new_file:No such file or directory:crypto/bio/bss_file.c:67:calling fopen(/etc/ssl/openssl.cnf, r)
803B09B2977B0000:error:10000080:BIO routines:BIO_new_file:no such file:crypto/bio/bss_file.c:75:
```