### PR TITLE
bump sqlite and use var-transforms

### DIFF
--- a/sqlite.yaml
+++ b/sqlite.yaml
@@ -1,6 +1,6 @@
 package:
   name: sqlite
-  version: 3.47.0
+  version: 3.47.2
   epoch: 0
   description: "C library which implements an SQL database engine"
   copyright:
@@ -16,14 +16,22 @@ environment:
       - readline
 
 # ref: https://www.sqlite.org/download.html
-# For version 3.X.Y the filename encoding is 3XXYY00. For branch version 3.X.Y.Z, the encoding is 3XXYYZZ.
+# For version 3.X.Y the filename encoding is 3XX0Y00.
 # 3.40.1 => 3400100 => https://www.sqlite.org/2022/sqlite-autoconf-3400100.tar.gz
-# TODO: use vars-transform maybe but 0 padding with regex is a bit complicated.
+var-transforms:
+  - from: ${{package.version}}
+    # transform 3.47.0 to 3470000 and 3.47.2 to 3470200 and similarly
+    match: ^(\d+)\.(\d+)\.(\d+)$
+    # replace here is appending 0 minor version and then appending two more zeros after patch version.
+    replace: ${1}${2}0${3}00
+    to: sqlite-download-version
+
 pipeline:
   - uses: fetch
     with:
-      uri: https://www.sqlite.org/2024/sqlite-autoconf-3470000.tar.gz
-      expected-sha256: 83eb21a6f6a649f506df8bd3aab85a08f7556ceed5dbd8dea743ea003fc3a957
+      uri: https://www.sqlite.org/2024/sqlite-autoconf-${{vars.sqlite-download-version}}.tar.gz
+      expected-sha256: f1b2ee412c28d7472bc95ba996368d6f0cdcf00362affdadb27ed286c179540b
+
   - name: Configure
     runs: |
       _amalgamation="-DSQLITE_ENABLE_FTS4 \
@@ -54,7 +62,9 @@ pipeline:
       sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 
       make -j$(nproc) V=1
+
   - uses: autoconf/make-install
+
   - uses: strip
 
 subpackages:
@@ -83,7 +93,6 @@ subpackages:
 
 update:
   enabled: true
-  manual: true # fetch URL contains non version string
   release-monitor:
     identifier: 4877
 


### PR DESCRIPTION
bumps sqlite to 3.47.2 and uses var-transforms to get the download URL.
also removes `manual: true` (this way we'll get it automated from here on)