### PR TITLE
Refactor docker.yaml

### DIFF
--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: 27.4.0
-  epoch: 1
+  epoch: 4
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -17,8 +17,10 @@ package:
       - dockerd
       - e2fsprogs
       - e2fsprogs-extra
+      - fuse-overlayfs
       - git
       - ip6tables
+      - iproute2
       # docker dind also needs a couple of runtime dependencies mentioned here (https://github.com/moby/moby/blob/0eecd59153c03ced5f5ddd79cc98f29e4d86daec/project/PACKAGERS.md#runtime-dependencies) below are those dependencies.
       - iptables
       - openssh-client

--- a/docker.yaml
+++ b/docker.yaml
@@ -68,7 +68,8 @@ pipeline:
       # pin to older dependencies when this package auto updates, we use sed with
       # the specific replacement version.
 
-      # CVE-2023-47108 GHSA-8pgv-569h-w5rw CVE-2023-45142 GHSA-rcjv-mgp8-qvmr
+      # CVE-2023-47108 GHSA-8pgv-569h-w5rw CVE-2023-45142 GHSA-rcjv-mgp8-qvmr CVE-2024-45337
+      sed -i 's|golang.org/x/crypto v0.27.0|golang.org/x/crypto v0.31.0|' vendor.mod
       sed -i 's|go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.45.0|go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0|' vendor.mod
       sed -i 's|go.opentelemetry.io/otel v1.19.0|go.opentelemetry.io/otel v1.21.0|' vendor.mod
       sed -i 's|go.opentelemetry.io/otel/sdk v1.19.0|go.opentelemetry.io/otel/sdk v1.21.0|' vendor.mod

--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: 27.4.0
-  epoch: 4
+  epoch: 1
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0

--- a/docker.yaml
+++ b/docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker
   version: 27.4.0
-  epoch: 0
+  epoch: 1
   description: A meta package for Docker Engine and Docker CLI
   copyright:
     - license: Apache-2.0
@@ -17,13 +17,13 @@ package:
       - dockerd
       - e2fsprogs
       - e2fsprogs-extra
-      - fuse-overlayfs
       - git
       - ip6tables
       # docker dind also needs a couple of runtime dependencies mentioned here (https://github.com/moby/moby/blob/0eecd59153c03ced5f5ddd79cc98f29e4d86daec/project/PACKAGERS.md#runtime-dependencies) below are those dependencies.
       - iptables
       - openssh-client
       - openssl
+      - openssl-config
       - pigz
       - procps
       - shadow-subids # equivalent of shadow-uidmap in wolfi


### PR DESCRIPTION
Add openssl-config, remove fuse-overlayfs

EDIT: we need fuse-overlayfs as a backup if overlay2 fails.

Added iproute2 as we get an unnecessary error in container logs otherwise