### PR TITLE
don't provide for embedded components

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.31.2.1
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: Apache-2.0
@@ -154,6 +154,9 @@ subpackages:
         - runc
         - umount
         - kmod
+    options:
+      # Do not provide copies of the statically linked embedded components (like containerd)
+      no-provides: true
     pipeline:
       - runs: |
           sed -i '/VERSION_RUNC=$(get-module-version github.com\/opencontainers\/runc)/a VERSION_RUNC="v1.1.14"' ./scripts/version.sh


### PR DESCRIPTION
melange's sca rightfully picks up provides for the embedded components (like containerd), so avoid providing these via k3s-static.