### PR TITLE
jenkins: require sequential auto update PRs to merge, not auto close un-merged ones

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins
   version: "2.488"
-  epoch: 0
+  epoch: 1
   description: Open-source CI/CD application.
   copyright:
     - license: MIT

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -134,6 +134,7 @@ subpackages:
 
 update:
   enabled: true
+  require-sequential: true
   github:
     identifier: jenkinsci/jenkins
     strip-prefix: jenkins-


### PR DESCRIPTION
This uses the new malange update config `update.require-sequential: true` see https://github.com/chainguard-dev/melange/blob/main/docs/UPDATE.md#github

```
require-sequential: true # Default: false - indicates that automated pull requests should be merged in order rather than superseding and closing previous unmerged PRs
```

Epoch was only bumped to validate elastic builds can parse the new update config.

Example of what a PR will look like that requires previous auto update PRs be merged...

<img width="1568" alt="Screenshot 2024-12-09 at 23 58 19" src="https://github.com/user-attachments/assets/2132c2fe-19b1-44d3-93b2-07835e825d80">
