### PR TITLE
logstash-8/GHSA-2x2g-32r7-p4x8

### DIFF
--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-8
   version: 8.16.1
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0
@@ -81,7 +81,7 @@ pipeline:
       echo "gem 'rexml', '3.3.9'" >> Gemfile.template
       echo "gem 'puma', '6.4.3'" >> Gemfile.template
       echo "gem 'sinatra', '4.1.0'" >> Gemfile.template
-      echo "gem 'logstash-integration-kafka', '11.5.2'" >> Gemfile.template
+      echo "gem 'logstash-integration-kafka', '11.5.3'" >> Gemfile.template
       # Disable the logstash-integration-jdbc plugin download as we build and
       # package it separately
       jq 'del(.["logstash-integration-jdbc"])' rakelib/plugins-metadata.json > /tmp/plugins-metadata.json


### PR DESCRIPTION
version bump for affected dependency logstash-integration-kafka from version 11.5.2 to 11.5.3
