### PR TITLE
python-3.10, python-3.11 - build tkinter with python

### DIFF
--- a/python-3.10.yaml
+++ b/python-3.10.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.10
   version: 3.10.16
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -22,6 +22,7 @@ environment:
       - expat-dev
       - gdbm-dev
       - libffi-dev
+      - libx11-dev
       - linux-headers
       - mpdecimal-dev
       - ncurses-dev
@@ -29,8 +30,18 @@ environment:
       - openssl-dev
       - readline-dev
       - sqlite-dev
+      - tcl-dev~${{vars.tcltk-major}}
+      - tcl~${{vars.tcltk-major}}
+      - tk-dev~${{vars.tcltk-major}}
+      - tk~${{vars.tcltk-major}}
       - xz-dev
       - zlib-dev
+
+vars:
+  # python 3.10 does not support tcl/tk version 9
+  # So here we build and runtime depend on tcl and tk at ~8.
+  # Doing this properly would require versioned tcl/tk stream.
+  tcltk-major: 8
 
 # creates helpfull python3.M and 3.M variables
 var-transforms:
@@ -102,6 +113,10 @@ pipeline:
       cd ${{targets.destdir}}/usr/lib/${{vars.python}}
       rm site-packages/README.txt
       rmdir site-packages
+
+  - name: "remove idle (python IDE)"
+    runs: |
+      rm -R "${{targets.destdir}}/usr/lib/${{vars.python}}/idlelib"
 
   - runs: |
       rm -R ${{targets.destdir}}/usr/lib/${{vars.python}}/ensurepip/_bundled/
@@ -183,6 +198,31 @@ subpackages:
             done
 
             rm -Rf "$d"
+
+  - name: "${{package.name}}-tk"
+    dependencies:
+      provides:
+        - py3-tkinter=${{package.full-version}}
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
+        - tcl~${{vars.tcltk-major}}
+        - tk~${{vars.tcltk-major}}
+    pipeline:
+      - runs: |
+          # these got moved by python-3.xx-base from ${{targets.destdir}}
+          fromd="${{targets.destdir}}-base"
+          tod=${{targets.contextdir}}
+          d=usr/lib/${{vars.python}}
+
+          mkdir -p "$tod/$d/lib-dynload"
+          mv "$fromd/$d/lib-dynload"/_tkinter.*.so "$tod/$d/lib-dynload/"
+          mv "$fromd/$d/tkinter" "$tod/$d/"
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{vars.pyversion}}
+            import: tkinter
 
   - name: "${{package.name}}-doc"
     description: "python3 documentation"

--- a/python-3.11.yaml
+++ b/python-3.11.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.11
   version: 3.11.11
-  epoch: 0
+  epoch: 1
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -22,6 +22,7 @@ environment:
       - expat-dev
       - gdbm-dev
       - libffi-dev
+      - libx11-dev
       - linux-headers
       - mpdecimal-dev
       - ncurses-dev
@@ -29,8 +30,18 @@ environment:
       - openssl-dev
       - readline-dev
       - sqlite-dev
+      - tcl-dev~${{vars.tcltk-major}}
+      - tcl~${{vars.tcltk-major}}
+      - tk-dev~${{vars.tcltk-major}}
+      - tk~${{vars.tcltk-major}}
       - xz-dev
       - zlib-dev
+
+vars:
+  # python 3.11 does not support tcl/tk version 9
+  # So here we build and runtime depend on tcl and tk at ~8.
+  # Doing this properly would require versioned tcl/tk stream.
+  tcltk-major: 8
 
 # creates helpfull python3.M and 3.M variables
 var-transforms:
@@ -102,6 +113,10 @@ pipeline:
       cd ${{targets.destdir}}/usr/lib/${{vars.python}}
       rm site-packages/README.txt
       rmdir site-packages
+
+  - name: "remove idle (python IDE)"
+    runs: |
+      rm -R "${{targets.destdir}}/usr/lib/${{vars.python}}/idlelib"
 
   - runs: |
       rm -R ${{targets.destdir}}/usr/lib/${{vars.python}}/ensurepip/_bundled/
@@ -183,6 +198,31 @@ subpackages:
             done
 
             rm -Rf "$d"
+
+  - name: "${{package.name}}-tk"
+    dependencies:
+      provides:
+        - py3-tkinter=${{package.full-version}}
+      runtime:
+        - ${{package.name}}-base=${{package.full-version}}
+        - tcl~${{vars.tcltk-major}}
+        - tk~${{vars.tcltk-major}}
+    pipeline:
+      - runs: |
+          # these got moved by python-3.xx-base from ${{targets.destdir}}
+          fromd="${{targets.destdir}}-base"
+          tod=${{targets.contextdir}}
+          d=usr/lib/${{vars.python}}
+
+          mkdir -p "$tod/$d/lib-dynload"
+          mv "$fromd/$d/lib-dynload"/_tkinter.*.so "$tod/$d/lib-dynload/"
+          mv "$fromd/$d/tkinter" "$tod/$d/"
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{vars.pyversion}}
+            import: tkinter
 
   - name: "${{package.name}}-doc"
     description: "python3 documentation"


### PR DESCRIPTION
This is similar to the python-3.12 and python-3.12 change to build tkinter inside python 
at https://github.com/wolfi-dev/os/pull/29194.

The big difference is that we have to use tcl and tk at major version 8 because
python-3.10 and python-3.11 do not support tcl/tk at version 9.

The proper way to do this would be to version tcl and tk (tcl-8.yaml, tk-8.yaml).

In order to correctly use tkinter (and pass the provided test), we have to add explicit runtime tcl and tk dependencies because melange does not identify the dependency that
