### PR TITLE
add runtime dependency

### DIFF
--- a/gitlab-cng-17.5.yaml
+++ b/gitlab-cng-17.5.yaml
@@ -34,7 +34,7 @@ package:
   name: gitlab-cng-17.5
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
   version: "17.5.1"
-  epoch: 1
+  epoch: 2
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -140,6 +140,7 @@ subpackages:
         - xtail
         - tini
         - tini-compat
+        - tzdata
 
   - name: gitlab-webservice-config-${{vars.major-minor-version}}
     pipeline:

--- a/gitlab-cng-17.6.yaml
+++ b/gitlab-cng-17.6.yaml
@@ -34,7 +34,7 @@ package:
   name: gitlab-cng-17.6
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
   version: 17.6.0
-  epoch: 0
+  epoch: 1
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -140,6 +140,7 @@ subpackages:
         - xtail
         - tini
         - tini-compat
+        - tzdata
 
   - name: gitlab-webservice-config-${{vars.major-minor-version}}
     pipeline:


### PR DESCRIPTION
various components (ie: gitaly) appear to be relying on `/usr/share/zoneinfo`, so adding it to the base image as a precaution