### PR TITLE
[GenAI] Java OpenJDK Version 18, 19, 20 Package Tests

### DIFF
--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -236,3 +236,36 @@ subpackages:
 update:
   enabled: false
   exclude-reason: This version is EOL and only built to enable bootstrapping
+
+test:
+  environment:
+    contents:
+      packages:
+        - openjdk-18-default-jdk
+        - openjdk-18-jmods
+    environment:
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+  pipeline:
+    # Test a basic Hello World
+    - name: Display Java version
+      runs: |
+        java -version
+    - name: Check JDK version
+      runs: |
+        version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+        if [[ "$version" != "18"* ]]; then
+          echo "Expected Java version 18, but got $version"
+          exit 1
+        fi
+    - working-directory: basic
+      runs: |
+        echo 'public class HelloWorld { public static void main(String[] args) { System.out.println("Hello, World!"); } }' > HelloWorld.java
+        javac HelloWorld.java
+        java HelloWorld
+    # Test a basic HTTP connection
+    - working-directory: basic
+      runs: |
+        # echo 'import java.net.HttpURLConnection; import java.net.URL; public class HttpTest { public static void main(String[] args) { try { URL url = new URL("http://example.com"); HttpURLConnection con = (HttpURLConnection) url.openConnection(); con.setRequestMethod("GET"); int status = con.getResponseCode(); if (status != 200) { System.out.println("Failed to connect, status code: " + status); System.exit(1); } System.out.println("HTTP connection successful"); } catch (Exception e) { System.out.println("Exception: " + e.getMessage()); System.exit(1); } } }' > RequestTest.java
+        echo 'import java.net.http.*; import java.net.URI; public class RequestTest { public static void main(String[] args) throws Exception { HttpClient client = HttpClient.newHttpClient(); HttpRequest request = HttpRequest.newBuilder().uri(URI.create("http://example.com")).build(); HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString()); if (response.statusCode() != 200) { System.out.println("Failed to perform HTTP request, status code: " + response.statusCode()); System.exit(1); } System.out.println("HTTP request successful"); } }' > RequestTest.java
+        javac RequestTest.java
+        java RequestTest

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -233,3 +233,36 @@ subpackages:
 update:
   enabled: false
   exclude-reason: This version is EOL and only built to enable bootstrapping
+
+test:
+  environment:
+    contents:
+      packages:
+        - openjdk-19-default-jdk
+        - openjdk-19-jmods
+    environment:
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+  pipeline:
+    # Test a basic Hello World
+    - name: Display Java version
+      runs: |
+        java -version
+    - name: Check JDK version
+      runs: |
+        version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+        if [[ "$version" != "19"* ]]; then
+          echo "Expected Java version 19, but got $version"
+          exit 1
+        fi
+    - working-directory: basic
+      runs: |
+        echo 'public class HelloWorld { public static void main(String[] args) { System.out.println("Hello, World!"); } }' > HelloWorld.java
+        javac HelloWorld.java
+        java HelloWorld
+    # Test a basic HTTP connection
+    - working-directory: basic
+      runs: |
+        # echo 'import java.net.HttpURLConnection; import java.net.URL; public class HttpTest { public static void main(String[] args) { try { URL url = new URL("http://example.com"); HttpURLConnection con = (HttpURLConnection) url.openConnection(); con.setRequestMethod("GET"); int status = con.getResponseCode(); if (status != 200) { System.out.println("Failed to connect, status code: " + status); System.exit(1); } System.out.println("HTTP connection successful"); } catch (Exception e) { System.out.println("Exception: " + e.getMessage()); System.exit(1); } } }' > RequestTest.java
+        echo 'import java.net.http.*; import java.net.URI; public class RequestTest { public static void main(String[] args) throws Exception { HttpClient client = HttpClient.newHttpClient(); HttpRequest request = HttpRequest.newBuilder().uri(URI.create("http://example.com")).build(); HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString()); if (response.statusCode() != 200) { System.out.println("Failed to perform HTTP request, status code: " + response.statusCode()); System.exit(1); } System.out.println("HTTP request successful"); } }' > RequestTest.java
+        javac RequestTest.java
+        java RequestTest

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -239,3 +239,36 @@ subpackages:
 update:
   enabled: false
   exclude-reason: This version is EOL and only built to enable bootstrapping
+
+test:
+  environment:
+    contents:
+      packages:
+        - openjdk-20-default-jdk
+        - openjdk-20-jmods
+    environment:
+      JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+  pipeline:
+    # Test a basic Hello World
+    - name: Display Java version
+      runs: |
+        java -version
+    - name: Check JDK version
+      runs: |
+        version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+        if [[ "$version" != "20"* ]]; then
+          echo "Expected Java version 20, but got $version"
+          exit 1
+        fi
+    - working-directory: basic
+      runs: |
+        echo 'public class HelloWorld { public static void main(String[] args) { System.out.println("Hello, World!"); } }' > HelloWorld.java
+        javac HelloWorld.java
+        java HelloWorld
+    # Test a basic HTTP connection
+    - working-directory: basic
+      runs: |
+        # echo 'import java.net.HttpURLConnection; import java.net.URL; public class HttpTest { public static void main(String[] args) { try { URL url = new URL("http://example.com"); HttpURLConnection con = (HttpURLConnection) url.openConnection(); con.setRequestMethod("GET"); int status = con.getResponseCode(); if (status != 200) { System.out.println("Failed to connect, status code: " + status); System.exit(1); } System.out.println("HTTP connection successful"); } catch (Exception e) { System.out.println("Exception: " + e.getMessage()); System.exit(1); } } }' > RequestTest.java
+        echo 'import java.net.http.*; import java.net.URI; public class RequestTest { public static void main(String[] args) throws Exception { HttpClient client = HttpClient.newHttpClient(); HttpRequest request = HttpRequest.newBuilder().uri(URI.create("http://example.com")).build(); HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString()); if (response.statusCode() != 200) { System.out.println("Failed to perform HTTP request, status code: " + response.statusCode()); System.exit(1); } System.out.println("HTTP request successful"); } }' > RequestTest.java
+        javac RequestTest.java
+        java RequestTest


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
