### PR TITLE
[DNM] test build cilium 1.16.4

### DIFF
--- a/cilium-1.16.yaml
+++ b/cilium-1.16.yaml
@@ -1,8 +1,8 @@
 #nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: cilium-1.16
-  version: 1.16.3
-  epoch: 1
+  version: 1.16.4
+  epoch: 0
   description: Cilium is a networking, observability, and security solution with an eBPF-based dataplane
   copyright:
     - license: Apache-2.0
@@ -36,72 +36,63 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - clang-17
+      - clang~17
       - clang-17-dev
       - cmake
-      - coreutils # for GNU install
-      # We need to stick to gcc 12 for now, envoy doesn't build with gcc >= 13
-      - gcc-12-default
+      - coreutils
       - git
-      - go
-      - grep
-      - ip6tables
-      - iptables # for cilium-iptables
-      - isl-dev
       - libtool
+      - llvm-libcxx-17
+      - llvm-libcxx-17-dev
+      - llvm-libcxxabi-17
       - llvm-lld-17
       - llvm17
       - llvm17-dev
-      - mpc-dev
       - openjdk-11
-      - openssf-compiler-options
       - patch
       - python3-dev
       - samurai
       - wolfi-baselayout
+  environment:
+    # https://github.com/wolfi-dev/os/issues/34568
+    GCC_SPEC_FILE: /dev/null
 
 vars:
   # https://github.com/cilium/cilium/blob/v1.15.6/images/cilium/Dockerfile
-  CILIUM_PROXY_COMMIT: "0d05e48bfbb8c4737ec40d5781d970a550ed2bbd"
+  # CILIUM_PROXY_COMMIT: "0d05e48bfbb8c4737ec40d5781d970a550ed2bbd"
+  CILIUM_PROXY_COMMIT: "97edc2815e2c6a174d3d12e71731d54f5d32ea16"
 
 pipeline:
-  - uses: git-checkout
-    with:
-      repository: https://github.com/cilium/cilium
-      tag: v${{package.version}}
-      expected-commit: f221719170636b0e0da2c7b8227c18967a1201c8
+  # - uses: git-checkout
+  #   with:
+  #     repository: https://github.com/cilium/cilium
+  #     tag: v${{package.version}}
+  #     # expected-commit: "f221719170636b0e0da2c7b8227c18967a1201c8"
+  #     expected-commit: "0380724290f01576aa053c2c2ad35532063c695e"
 
-  - uses: go/bump
-    with:
-      deps: google.golang.org/grpc@v1.64.1
+  # - uses: go/bump
+  #   with:
+  #     deps: google.golang.org/grpc@v1.64.1
 
-  - uses: patch
-    with:
-      patches: loopback-location.patch
+  # - uses: patch
+  #   with:
+  #     patches: loopback-location.patch
 
-  - runs: |
-      # Bazel errors out on toolchain stanza
-      sed -i '/$toolchain /d' go.mod
-      # Bazel errors out on go point release
-      sed -i 's|^\(go 1\.[0-9]*\)\.[0-9]*|\1|' go.mod
+  # - runs: |
+  #     # Bazel errors out on toolchain stanza
+  #     sed -i '/$toolchain /d' go.mod
+  #     # Bazel errors out on go point release
+  #     sed -i 's|^\(go 1\.[0-9]*\)\.[0-9]*|\1|' go.mod
 
-  - runs: |
-      # Remove groupadd from Makefile: it's not doing anything useful in
-      # a package build anyway, and it's not available in busybox.
-      find . -name Makefile -exec sed -i '/groupadd/d' {} \;
+  # - runs: |
+  #     # Check the Dockerfile for a SHA and match against the proxy SHA
+  #     ENVOY_SHA=$(grep 'ARG.*cilium-envoy' ./images/cilium/Dockerfile \
+  #       | sed "s/^ARG.*:v[0-9.]\+-[0-9]\+-//g" | cut -d@ -f1)
 
-      DESTDIR=${{targets.destdir}} DISABLE_ENVOY_INSTALLATION=1 make build-container
-      DESTDIR=${{targets.destdir}} DISABLE_ENVOY_INSTALLATION=1 make install-container
-
-  - runs: |
-      # Check the Dockerfile for a SHA and match against the proxy SHA
-      ENVOY_SHA=$(grep 'ARG.*cilium-envoy' ./images/cilium/Dockerfile \
-        | sed "s/^ARG.*:v[0-9.]\+-[0-9]\+-//g" | cut -d@ -f1)
-
-      if [ "$ENVOY_SHA" != "${{vars.CILIUM_PROXY_COMMIT}}" ]; then
-        echo "Expected vars.CILIUM_PROXY_COMMIT to be $ENVOY_SHA. Please update" 1>&2
-        exit 1
-      fi
+  #     if [ "$ENVOY_SHA" != "${{vars.CILIUM_PROXY_COMMIT}}" ]; then
+  #       echo "Expected vars.CILIUM_PROXY_COMMIT to be $ENVOY_SHA. Please update" 1>&2
+  #       exit 1
+  #     fi
 
   - uses: git-checkout
     with:
@@ -109,7 +100,8 @@ pipeline:
       # Branch from https://github.com/cilium/cilium/blob/v1.15.5/images/cilium/Dockerfile
       # Note often the branch is updated with dependencies updates, no tags
       # See CILIUM_PROXY_COMMIT for anchor point
-      branch: v1.29
+      branch: v1.30
+      # branch: v1.29
       depth: 1000
       destination: envoy
 
@@ -120,41 +112,55 @@ pipeline:
     with:
       patches: toolchains-paths.patch
 
-  - uses: patch
-    with:
-      patches: envoy-55b0fc45cfdc2c0df002690606853540cf794fab.patch
+  # - uses: patch
+  #   with:
+  #     patches: envoy-55b0fc45cfdc2c0df002690606853540cf794fab.patch
+  # - runs: |
+  #     # Bazel errors out on toolchain stanza
+  #     sed -i '/$toolchain /d' go.mod
+  #     # Bazel errors out on go point release
+  #     sed -i 's|^\(go 1\.[0-9]*\)\.[0-9]*|\1|' go.mod
 
   - runs: |
-      # Bazel errors out on toolchain stanza
-      sed -i '/$toolchain /d' go.mod
-      # Bazel errors out on go point release
-      sed -i 's|^\(go 1\.[0-9]*\)\.[0-9]*|\1|' go.mod
-
-  - runs: |
-      cd /home/build/envoy/proxylib
-      make
-      mkdir -p ${{targets.destdir}}/usr/lib
-      cp -v libcilium.so ${{targets.destdir}}/usr/lib/libcilium.so
-
       cd /home/build/envoy
-      # The Python interpreter complains about being run as root, there's a flag to pass to disable that warning.
+      # Delete all "cxx_flags = ["-std=c++0x"]," lines
+      sed 's/std=c++0x/std=c++17/g' -i bazel/toolchains/BUILD
+      sed 's/register_toolchains/#register_toolchains/g' -i WORKSPACE
+
+      # # The Python interpreter complains about being run as root, there's a flag to pass to disable that warning.
       sed -i 's/envoy_dependencies_extra()/envoy_dependencies_extra(ignore_root_user_error=True)/g' WORKSPACE
       export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
       mkdir -p .cache/bazel/_bazel_root
-
       ./bazel/setup_clang.sh /usr
+      echo "build --config=libc++" >> user.bazelrc
 
-      mkdir -p ${{targets.destdir}}/usr/bin
+         # --discard_analysis_cache --nokeep_state_after_build --notrack_incremental_state --fission=no \
+      bazel build --config=release \
+         --discard_analysis_cache --nokeep_state_after_build \
+         --notrack_incremental_state \
+         --fission=no \
+         --cxxopt='-Wno-thread-safety' \
+         --subcommands \
+         --verbose_failures -c opt //:cilium-envoy
 
-      for target in cilium-envoy-starter cilium-envoy; do
-        bazel build --fission=no --config=clang \
-          --discard_analysis_cache \
-          --nokeep_state_after_build \
-          --notrack_incremental_state \
-          --conlyopt="-Wno-strict-prototypes" \
-          --verbose_failures -c opt //:${target}
-        cp -v bazel-bin/${target} ${{targets.destdir}}/usr/bin/${target}
-      done
+      # for target in cilium-envoy cilium-envoy-starter; do
+      #   bazel build --fission=no --config=clang --config=release \
+      #     --discard_analysis_cache \
+      #     --nokeep_state_after_build \
+      #     --notrack_incremental_state \
+      #     --conlyopt="-Wno-strict-prototypes" \
+      #     --verbose_failures -c opt //:${target}
+      #   cp -v bazel-bin/${target} ${{targets.destdir}}/usr/bin/${target}
+      # done
+
+  # - runs: |
+  #     # Remove groupadd from Makefile: it's not doing anything useful in
+  #     # a package build anyway, and it's not available in busybox.
+  #     find . -name Makefile -exec sed -i '/groupadd/d' {} \;
+
+  #     DESTDIR=${{targets.destdir}} DISABLE_ENVOY_INSTALLATION=1 make build-container
+  #     DESTDIR=${{targets.destdir}} DISABLE_ENVOY_INSTALLATION=1 make install-container
+
 
   - uses: strip
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
