### PR TITLE
simplify lint.sh, don't rely on build order

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,3 +29,4 @@ jobs:
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4.2.2
     - run: ./lint.sh
+    - run: git diff --exit-code

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,9 +3,6 @@ name: Lint
 on:
   pull_request:
     branches: ['main']
-  push:
-    branches:
-      - gh-readonly-queue/main/**
 
 permissions:
   contents: read
@@ -24,16 +21,6 @@ jobs:
       with:
         egress-policy: audit
 
-    # Install wolfictl
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4.2.2
-      with:
-        repository: wolfi-dev/wolfictl
-        path: wolfictl
-    - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
-      with:
-        go-version-file: 'wolfictl/go.mod'
-    - working-directory: wolfictl
-      run: go install
     # Install yam
     - run: go install github.com/chainguard-dev/yam@latest
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,6 +22,9 @@ jobs:
         egress-policy: audit
 
     # Install yam
+    - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      with:
+        go-version: 1.23
     - run: go install github.com/chainguard-dev/yam@latest
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4.2.2

--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,6 @@ ifeq (${LINT}, yes)
 	MELANGE_OPTS += --fail-on-lint-warning
 endif
 
-# The list of packages to be built. The order matters.
-# wolfictl determines the list and order
-# set only to be called when needed, so make can be instant to run
-# when it is not
-PKGLISTCMD ?= $(WOLFICTL) text --dir . --type name --pipeline-dir=./pipelines/
-
 BOOTSTRAP_REPO ?= https://packages.wolfi.dev/bootstrap/stage3
 BOOTSTRAP_KEY ?= https://packages.wolfi.dev/bootstrap/stage3/wolfi-signing.rsa.pub
 WOLFI_REPO ?= https://packages.wolfi.dev/os
@@ -66,37 +60,16 @@ BOOTSTRAP ?= no
 ifeq (${BOOTSTRAP}, yes)
 	MELANGE_OPTS += -k ${BOOTSTRAP_KEY}
 	MELANGE_OPTS += -r ${BOOTSTRAP_REPO}
-	PKGLISTCMD += -k ${BOOTSTRAP_KEY}
-	PKGLISTCMD += -r ${BOOTSTRAP_REPO}
 else
 	MELANGE_OPTS += -k ${WOLFI_KEY}
 	MELANGE_OPTS += -r ${WOLFI_REPO}
-	PKGLISTCMD += -k ${WOLFI_KEY}
-	PKGLISTCMD += -r ${WOLFI_REPO}
 endif
-
-all: ${KEY} .build-packages
-ifeq ($(MAKECMDGOALS),all)
-  PKGLIST := $(addprefix package/,$(shell $(PKGLISTCMD)))
-else
-  PKGLIST :=
-endif
-.build-packages: $(PKGLIST)
 
 ${KEY}:
 	${MELANGE} keygen ${KEY}
 
 clean:
 	rm -rf packages/${ARCH}
-
-.PHONY: list list-yaml
-list:
-	$(info $(shell $(PKGLISTCMD)))
-	@printf ''
-
-list-yaml:
-	$(info $(addsuffix .yaml,$(shell $(PKGLISTCMD))))
-	@printf ''
 
 fetch-kernel:
 	$(eval KERNEL_PKG := $(shell curl -sL https://dl-cdn.alpinelinux.org/alpine/edge/main/$(ARCH)/APKINDEX.tar.gz | tar -Oxz APKINDEX | awk -F':' '$$1 == "P" {printf "%s-", $$2} $$1 == "V" {printf "%s.apk\n", $$2}' | grep "linux-virt" | grep -v dev))
@@ -238,3 +211,9 @@ dev-container-wolfi:
 		ghcr.io/wolfi-dev/sdk:latest@sha256:8b4a75a1e5c423c3182c25a27dd5c2e5d655f0fe360fd5dab90b1c1ec322b7b1
 	@rm "$(TMP_REPOS_FILE)"
 	@rmdir "$(TMP_REPOS_DIR)"
+
+# Checks that the repo can be built in order from bootstrap packages.
+check-bootstrap:
+	$(WOLFICTL) text --dir . --type name --pipeline-dir=./pipelines/ \
+		-k ${BOOTSTRAP_KEY} \
+		-r ${BOOTSTRAP_REPO}

--- a/lint.sh
+++ b/lint.sh
@@ -2,22 +2,9 @@
 
 set -euo pipefail
 
-for p in $(make list); do
+for fn in *.yaml; do
+  p=$(yq -r '.package.name' ${fn})
   echo "--- package" $p
-
-  if [ -f ${p}.yaml ]; then
-    if [ -f **/${p}/${p}.melange.yaml ]; then
-      echo "ERROR: ${p}.yaml and **/${p}/${p}.melange.yaml both exist"
-      exit 1
-    fi
-
-    fn=${p}.yaml
-  elif [ -f **/${p}/${p}.melange.yaml ]; then
-    fn=$(ls **/${p}/${p}.melange.yaml | head -n 1)
-  else
-    echo "ERROR: ${p}.yaml or **/${p}/${p}.melange.yaml does not exist, or multiple matches found"
-    exit 1
-  fi
 
   # Don't specify repositories or keyring for os packages
   if grep -q packages.wolfi.dev/os ${fn}; then

--- a/lint.sh
+++ b/lint.sh
@@ -25,9 +25,6 @@ for fn in *.yaml; do
   yam ${fn}
 done
 
-git --no-pager diff # Show any diff.
-git diff --quiet    # Fail any diff.
-
 # New section to check for .sts.yaml files under ./.github/chainguard/
 echo "Checking for .sts.yaml files in ./.github/chainguard/..."
 for file in $(find .github/chainguard -type f); do


### PR DESCRIPTION
This also removes some logic that we put in a ~year ago to supported nested package dirs, but then never actually took advantage of. If we want that we can add it back.

This removes `make list` which was only used in linting, and replaces it with `make check-bootstrap` which makes it clear it's only there to determine a bootstrap order, and nothing else.