### PR TITLE
don't require build maintainers approval

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,3 @@
-# Require review by build system owners for workflow and Makefile changes.
-Makefile @wolfi-dev/wolfi-build-maintainers
-/.github/workflows/ @wolfi-dev/wolfi-build-maintainers
-
 # Require review by repo owners of changes to CODEOWNERS
 CODEOWNERS @wolfi-dev/wolfi-owners
 


### PR DESCRIPTION
Historically, we imposed a limit on who could approve changes in `Makefile` and `.github/workflows/` to prevent PRs from breaking CI.

Now that builds happen in elastic-build, it's a lot harder for randos to break the build (not impossible; _this does not constitute a challenge_), and we should let others contribute to the Makefile and GHA workflows. The blast radius of changes to those are a lot smaller now.