### PR TITLE
kubeflow-pipelines/GHSA-27wf-5967-98gx fix

### DIFF
--- a/kubeflow-pipelines.yaml
+++ b/kubeflow-pipelines.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines
   version: 2.3.0
-  epoch: 2
+  epoch: 3
   description: Machine Learning Pipelines for Kubeflow
   checks:
     disabled:
@@ -57,8 +57,8 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4 golang.org/x/net@v0.23.0 sigs.k8s.io/controller-runtime@v0.15.3 k8s.io/kubernetes@v1.27.16
-      replaces: k8s.io/api=k8s.io/api@v0.27.13 k8s.io/apimachinery=k8s.io/apimachinery@v0.27.13 k8s.io/client-go=k8s.io/client-go@v0.27.13 k8s.io/code-generator=k8s.io/code-generator@v0.27.13
+      deps: google.golang.org/protobuf@v1.33.0 github.com/golang/protobuf@v1.5.4 golang.org/x/net@v0.23.0 sigs.k8s.io/controller-runtime@v0.15.3 k8s.io/kubernetes@v1.28.12
+      replaces: k8s.io/api=k8s.io/api@v0.28.12 k8s.io/apimachinery=k8s.io/apimachinery@v0.28.12 k8s.io/client-go=k8s.io/client-go@v0.28.12 k8s.io/code-generator=k8s.io/code-generator@v0.28.12
 
   - uses: patch
     with:


### PR DESCRIPTION
Updated the versions of k8s dependencies to fix versions, luckily kubeflow uses the updated API endpoints so we were able to do this. Will not be the case in the PRs to follow which will require advisories.
