### PR TITLE
ensure the -1 package depends on the -1 subpackage runtimes

### DIFF
--- a/containerd-1.yaml
+++ b/containerd-1.yaml
@@ -1,7 +1,7 @@
 package:
   name: containerd-1
   version: 1.7.24
-  epoch: 1
+  epoch: 2
   description: An open and reliable container runtime
   copyright:
     - license: Apache-2.0
@@ -14,12 +14,6 @@ package:
       - containerd-stress-1
       - ctr-1
       - runc
-
-var-transforms:
-  - from: ${{package.version}}
-    match: ^(\d+\.\d+)\.\d+$
-    replace: "$1"
-    to: major-minor-version
 
 environment:
   contents:
@@ -58,7 +52,7 @@ data:
 
 subpackages:
   - range: bins
-    name: ${{range.key}}-${{vars.major-minor-version}}
+    name: ${{range.key}}-1
     description: ${{range.value}}
     dependencies:
       provides:
@@ -69,7 +63,7 @@ subpackages:
       - runs: |
           install -Dm755 "./bin/${{range.key}}" "${{targets.subpkgdir}}"/usr/bin/${{range.key}}
 
-  - name: containerd-service-${{vars.major-minor-version}}
+  - name: containerd-service-1
     description: "Systemd services for containerd"
     dependencies:
       provides:

--- a/containerd-1.yaml
+++ b/containerd-1.yaml
@@ -1,7 +1,7 @@
 package:
   name: containerd-1
   version: 1.7.24
-  epoch: 0
+  epoch: 1
   description: An open and reliable container runtime
   copyright:
     - license: Apache-2.0
@@ -10,9 +10,9 @@ package:
       - containerd=${{package.full-version}}
     # Aggregate all the subpackages into this meta-package.
     runtime:
-      - containerd-shim-runc-v2
-      - containerd-stress
-      - ctr
+      - containerd-shim-runc-v2-1
+      - containerd-stress-1
+      - ctr-1
       - runc
 
 var-transforms:
@@ -75,7 +75,7 @@ subpackages:
       provides:
         - containerd-service=${{package.full-version}}
       runtime:
-        - containerd
+        - containerd-1
         - systemd
     pipeline:
       - runs: |

--- a/containerd-2.yaml
+++ b/containerd-2.yaml
@@ -10,16 +10,10 @@ package:
       - containerd=${{package.full-version}}
     # Aggregate all the subpackages into this meta-package.
     runtime:
-      - containerd-shim-runc-v2
-      - containerd-stress
+      - containerd-shim-runc-v2-2
+      - containerd-stress-2
       - ctr
       - runc
-
-var-transforms:
-  - from: ${{package.version}}
-    match: ^(\d+\.\d+)\.\d+$
-    replace: "$1"
-    to: major-minor-version
 
 environment:
   contents:
@@ -58,7 +52,7 @@ data:
 
 subpackages:
   - range: bins
-    name: ${{range.key}}-${{vars.major-minor-version}}
+    name: ${{range.key}}-2
     description: ${{range.value}}
     dependencies:
       provides:
@@ -69,13 +63,13 @@ subpackages:
       - runs: |
           install -Dm755 "./bin/${{range.key}}" "${{targets.subpkgdir}}"/usr/bin/${{range.key}}
 
-  - name: containerd-service-${{vars.major-minor-version}}
+  - name: containerd-service-2
     description: "Systemd services for containerd"
     dependencies:
       provides:
         - containerd-service=${{package.full-version}}
       runtime:
-        - containerd
+        - containerd-2
         - systemd
     pipeline:
       - runs: |


### PR DESCRIPTION
follow up from #35346.

I thought the solver would favor versions from the same origin but I must have dreamed that.

this properly names the subpackages according to their major version (`-1`) instead of the previous incorrect major-minor (`1.7`)

this means the following works as expected:

```
apk add containerd-1
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
(1/6) Installing containerd-shim-runc-v2-1 (1.7.24-r2)
(2/6) Installing containerd-stress-1 (1.7.24-r2)
(3/6) Installing ctr-1 (1.7.24-r2)
(4/6) Installing libseccomp (2.5.5-r5)
(5/6) Installing runc (1.2.3-r0)
(6/6) Installing containerd-1 (1.7.24-r2)
Executing glibc-2.40-r3.trigger
Executing busybox-1.37.0-r0.trigger
OK: 114 MiB in 21 packages
```