### PR TITLE
Fix: CVE GHSA-rcjc-c4pj-xxrp in druid

### DIFF
--- a/druid.yaml
+++ b/druid.yaml
@@ -1,7 +1,7 @@
 package:
   name: druid
   version: 31.0.0
-  epoch: 2
+  epoch: 3
   description: Apache Druid is a high performance real-time analytics database.
   copyright:
     - license: Apache-2.0
@@ -9,7 +9,7 @@ package:
     runtime:
       - bash
       - busybox
-      - openjdk-17-default-jvm
+      - openjdk-21-default-jvm
 
 environment:
   contents:
@@ -17,8 +17,8 @@ environment:
       - bash
       - busybox
       - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-21
+      - openjdk-21-default-jvm
       - py3-pyyaml
       - python3
 

--- a/druid/pombump-deps.yaml
+++ b/druid/pombump-deps.yaml
@@ -5,3 +5,6 @@ patches:
     - groupId: io.netty
       artifactId: netty-common
       version: 4.1.115.Final
+    - groupId: org.apache.derby
+      artifactId: derby
+      version: 10.17.1.0


### PR DESCRIPTION
This fix needs java version upgrade to 21 which is not what upstream mentioned https://github.com/apache/druid/blob/master/docs/operations/java.md\#selecting-a-java-runtime
