### PR TITLE
xsimd - fix apache-arrow FTBFS by putting cmake files in -dev package, update python 3.13

### DIFF
--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-arrow
   version: 18.1.0
-  epoch: 0
+  epoch: 1
   description: "multi-language toolbox for accelerated data interchange and in-memory processing"
   copyright:
     - license: Apache-2.0
@@ -15,7 +15,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/xsimd.yaml
+++ b/xsimd.yaml
@@ -1,7 +1,7 @@
 package:
   name: xsimd
   version: 13.1.0
-  epoch: 0
+  epoch: 1
   description: "C++ wrappers for SIMD intrinsics and parallelized, optimized mathematical functions (SSE, AVX, NEON, AVX512)"
   copyright:
     - license: "BSD-3-Clause"
@@ -41,6 +41,14 @@ subpackages:
     description: "C++ wrappers for SIMD intrinsics and parallelized, optimized mathematical functions (SSE, AVX, NEON, AVX512) (development files)"
     pipeline:
       - uses: split/dev
+      - runs: |
+          # split/dev does not currently grab cmake files in /usr/share/cmake
+          # https://github.com/chainguard-dev/melange/pull/1693
+          if [ -d "${{targets.destdir}}/usr/share/cmake/xsimd" ]; then
+            mkdir -p "${{targets.contextdir}}/usr/share/cmake"
+            mv "${{targets.destdir}}/usr/share/cmake/xsimd" \
+               "${{targets.contextdir}}/usr/share/cmake/"
+          fi
     test:
       pipeline:
         - uses: test/pkgconf


### PR DESCRIPTION
xsimd changed where it put its cmake files in version 13.1.0 (from /usr/lib/cmake to /usr/share/cmake). The new location meant that cmake files were left in xsimd rather than xsimd-dev.

apache-arrow only lists xsimd-dev and thus it's cmake build did not find xsimd.

The fix here is to get the files into xsimd-dev.

See https://github.com/chainguard-dev/melange/pull/1693 for a pipeline fix.  After that lands, the change here could be backed out.

Last, we update the priority of the python3.13 package for arrow so it gets chosen "by default" now.