### PR TITLE
Update python 3.13 priority in 4 packages.

### DIFF
--- a/libmamba.yaml
+++ b/libmamba.yaml
@@ -1,7 +1,7 @@
 package:
   name: libmamba
   version: 2024.10.02
-  epoch: 1
+  epoch: 2
   description: Cross-Platform Package Manager
   copyright:
     - license: BSD-3-Clause
@@ -16,7 +16,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:
@@ -173,13 +173,9 @@ test:
   environment:
     contents:
       packages:
-        - py3-libmambapy
-        - python3
         - micromamba
         - mamba-package
   pipeline:
-    - runs: |
-        python3 -c "import libmambapy; print(libmambapy.Context)"
     - runs: |
         micromamba --help
         bash -c "micromamba shell init -s bash -p ~/micromamba; source ~/.bashrc; micromamba activate; micromamba install python=3.11 requests -c conda-forge"

--- a/py3-build.yaml
+++ b/py3-build.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-build
   version: 1.2.2
-  epoch: 1
+  epoch: 2
   description: A simple, correct Python build frontend
   copyright:
     - license: MIT
@@ -9,6 +9,7 @@ package:
     provider-priority: 0
 
 vars:
+  import: build
   pypi-package: build
 
 data:
@@ -17,7 +18,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:
@@ -42,8 +43,6 @@ subpackages:
     description: ${{vars.pypi-package}} installed for python${{range.key}}
     dependencies:
       provider-priority: ${{range.value}}
-      provides:
-        - py3-${{vars.pypi-package}}
       runtime:
         - py${{range.key}}-packaging
         - py${{range.key}}-pyproject-hooks
@@ -52,6 +51,12 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}-bin
@@ -66,6 +71,18 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr
           mv ${{targets.contextdir}}/../py${{range.key}}-${{vars.pypi-package}}/usr/bin ${{targets.contextdir}}/usr
+    test:
+      pipeline:
+        - runs: |
+            set +x
+            fail() { echo "FAIL:" "$@"; exit 1; }
+
+            set -- pyproject-build --version
+            ver=${{package.version}}
+            out=$("$@") || fail "$* exited $?"
+            echo "$out" | grep -q -wF "$ver" ||
+                fail "FAIL: '$*' did not contain '$ver': $out"
+            echo "PASS: '$*' contained '$ver'"
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -78,7 +95,10 @@ subpackages:
 
 test:
   pipeline:
-    - runs: python3.12 -c "import ${{vars.pypi-package}}"
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-cairo.yaml
+++ b/py3-cairo.yaml
@@ -87,19 +87,6 @@ subpackages:
           packages:
             - py3-supported-${{vars.pypi-package}}
 
-  - range: py-versions
-    name: py${{range.key}}-${{vars.pypi-package}}-dev
-    description: py${{range.key}} dev files for ${{vars.pypi-package}}
-    dependencies:
-      runtime:
-        - cairo-dev
-        - py${{range.key}}-${{vars.pypi-package}}
-      provides:
-        - py3-${{vars.pypi-package}}-dev
-      provider-priority: ${{range.value}}
-    pipeline:
-      - uses: split/dev
-
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
     dependencies:

--- a/py3-cairo.yaml
+++ b/py3-cairo.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-cairo
   version: 1.27.0
-  epoch: 2
+  epoch: 3
   description: Python3 bindings for the cairo graphics library
   copyright:
     - license: LGPL-2.0-or-later
@@ -18,7 +18,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:
@@ -80,12 +80,25 @@ subpackages:
             python: python${{range.key}}
             import: ${{vars.import}}
         - runs: |
-            include="$(python${{range.key}} -c 'import ${{vars.import}}; print(${{vars.import}}.get_include())')"
+            include="$(python${{range.key}} -c 'import cairo; print(cairo.get_include())')"
             test -f "$include/py3cairo.h"
       environment:
         contents:
           packages:
             - py3-supported-${{vars.pypi-package}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-dev
+    description: py${{range.key}} dev files for ${{vars.pypi-package}}
+    dependencies:
+      runtime:
+        - cairo-dev
+        - py${{range.key}}-${{vars.pypi-package}}
+      provides:
+        - py3-${{vars.pypi-package}}-dev
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: split/dev
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -113,23 +126,6 @@ subpackages:
           with:
             python: python3.13
             import: ${{vars.import}}
-
-  - name: py3-cairo-dev
-    description: py3-cairo dev
-    dependencies:
-      runtime:
-        - cairo-dev
-        - py3-cairo
-    pipeline:
-      - uses: split/dev
-    test:
-      pipeline:
-        - uses: test/pkgconf
-        - uses: py/one-python
-          with:
-            content: |
-              include="$(python3 -c 'import ${{vars.import}}; print(${{vars.import}}.get_include())')"
-              test -f "$include/py3cairo.h"
 
 update:
   enabled: true

--- a/py3-google-apitools.yaml
+++ b/py3-google-apitools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-google-apitools
   version: 0.5.33
-  epoch: 3
+  epoch: 4
   description: client libraries for humans
   copyright:
     - license: Apache-2.0
@@ -14,11 +14,12 @@ vars:
 
 data:
   - name: py-versions
+    ## 3.13 does not work in 0.5.33.
+    ## https://github.com/google/apitools/issues/327
     items:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
 
 environment:
   contents:
@@ -75,21 +76,9 @@ subpackages:
           mkdir -p ${{targets.contextdir}}/usr/
           mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
     test:
-      environment:
-        contents:
-          packages:
-            - apk-tools
       pipeline:
         - runs: |
-            apk info -L py${{range.key}}-${{vars.pypi-package}}-bin > "pkg.list"
-            echo "Please write a test for these:"
-            grep usr/bin/ pkg.list > bins.list
-            sed 's,^,> ,' bins.list
-
-            while read line; do
-              echo == /$line ==
-              /$line --help && echo exited 0 || echo "exited $?"
-            done < bins.list
+            gen_client --help
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.


### PR DESCRIPTION
These packages did not "just work" with some sed changes to move 3.13 as the highest priority python packages.

py3-build - update python 3.13 version, fix test, improve test 
py3-cairo -  need multiple versions of the py3-cairo-dev 
libmamba - drop python test from base package
py3-google-apitools - do not build 3.13, does not work 

See similar changes #36330 
