### PR TITLE
py3-wheel - Update virtual to prefer python-3.13 package.

### DIFF
--- a/py3-wheel.yaml
+++ b/py3-wheel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wheel
   version: 0.45.1
-  epoch: 0
+  epoch: 1
   description: "built-package format for Python"
   copyright:
     - license: MIT
@@ -17,7 +17,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:


### PR DESCRIPTION
see similar changes https://github.com/wolfi-dev/os/pull/36330. This package is part of 3 that have a dependency loop if all updated together (py3-pip, py3-supported-python, py3-wheel).
