### PR TITLE
Make python 3.13 version of virtual packages the default. - batch 04

### DIFF
--- a/py3-meson-python.yaml
+++ b/py3-meson-python.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-meson-python
   version: 0.17.1
-  epoch: 0
+  epoch: 1
   description: Meson Python build backend (PEP 517)
   copyright:
     - license: MIT
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pathspec.yaml
+++ b/py3-pathspec.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pathspec
   version: 0.12.1
-  epoch: 4
+  epoch: 5
   description: Utility library for gitignore style pattern matching of file paths
   copyright:
     - license: MPL-2.0
@@ -17,7 +17,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-patiencediff.yaml
+++ b/py3-patiencediff.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-patiencediff
   version: 0.2.15
-  epoch: 1
+  epoch: 2
   description: Python implementation of the patiencediff algorithm
   copyright:
     - license: GPL-2.0-or-later
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pbr.yaml
+++ b/py3-pbr.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pbr
   version: 6.1.0
-  epoch: 2
+  epoch: 3
   description: Python Build Reasonableness
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-peewee.yaml
+++ b/py3-peewee.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-peewee
   version: 3.17.8
-  epoch: 0
+  epoch: 1
   description: a little orm
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pendulum.yaml
+++ b/py3-pendulum.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pendulum
   version: 3.0.0
-  epoch: 5
+  epoch: 6
   description: Python datetimes made easy
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pep517.yaml
+++ b/py3-pep517.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pep517
   version: 0.13.1
-  epoch: 2
+  epoch: 3
   description: wrappers to build python3 packages with PEP 517 hooks
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pexpect.yaml
+++ b/py3-pexpect.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pexpect
   version: 4.8.0
-  epoch: 6
+  epoch: 7
   description: Pexpect allows easy control of interactive console applications.
   copyright:
     - license: ISC
@@ -21,7 +21,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pickleshare.yaml
+++ b/py3-pickleshare.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pickleshare
   version: 0.7.5
-  epoch: 2
+  epoch: 3
   description: Tiny 'shelve'-like database with concurrency support
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pillow.yaml
+++ b/py3-pillow.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pillow
   version: 11.0.0
-  epoch: 0
+  epoch: 1
   description: Python Imaging Library (Fork)
   copyright:
     - license: HPND
@@ -41,7 +41,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 pipeline:
   - uses: git-checkout

--- a/py3-pip-tools.yaml
+++ b/py3-pip-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pip-tools
   version: 7.4.1
-  epoch: 1
+  epoch: 2
   description: A set of command line tools to help you keep your pip-based packages fresh, even when you've pinned them.
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pipenv.yaml
+++ b/py3-pipenv.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pipenv
   version: 2024.4.0
-  epoch: 1
+  epoch: 2
   description: Python Development Workflow for Humans.
   copyright:
     - license: MIT
@@ -30,7 +30,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 pipeline:
   - uses: git-checkout

--- a/py3-pkgconfig.yaml
+++ b/py3-pkgconfig.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pkgconfig
   version: 1.5.5
-  epoch: 5
+  epoch: 6
   description: Interface Python with pkg-config
   copyright:
     - license: MIT
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pkginfo.yaml
+++ b/py3-pkginfo.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pkginfo
   version: 1.12.0
-  epoch: 0
+  epoch: 1
   description: Query metadata from sdists / bdists / installed packages.
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-pkgutil_resolve_name.yaml
+++ b/py3-pkgutil_resolve_name.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pkgutil_resolve_name
   version: 1.3.10
-  epoch: 2
+  epoch: 3
   description: Resolve a name to an object.
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-platformdirs.yaml
+++ b/py3-platformdirs.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-platformdirs
   version: 4.3.6
-  epoch: 1
+  epoch: 2
   description: A small Python package for determining appropriate platform-specific dirs, e.g. a "user data dir".
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pluggy.yaml
+++ b/py3-pluggy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pluggy
   version: 1.5.0
-  epoch: 5
+  epoch: 6
   description: Plugin management and hook calling for Python
   copyright:
     - license: MIT
@@ -15,7 +15,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-ply.yaml
+++ b/py3-ply.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ply
   version: 3.11_git20180215
-  epoch: 5
+  epoch: 6
   description: Python Lex & Yacc
   copyright:
     - license: BSD-3-Clause
@@ -23,7 +23,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-poetry-core.yaml
+++ b/py3-poetry-core.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-poetry-core
   version: 1.9.1
-  epoch: 1
+  epoch: 2
   description: Poetry PEP 517 Build Backend
   copyright:
     - license: MIT
@@ -17,7 +17,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-poetry.yaml
+++ b/py3-poetry.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-poetry
   version: 1.8.5
-  epoch: 0
+  epoch: 1
   description: Python dependency management and packaging made easy.
   copyright:
     - license: MIT
@@ -20,7 +20,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-portalocker.yaml
+++ b/py3-portalocker.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-portalocker
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   description: An easy library for Python file locking. It works on Windows, Linux, BSD and Unix systems and can even perform distributed locking. Naturally it also supports the with statement
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-prometheus-client.yaml
+++ b/py3-prometheus-client.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-prometheus-client
   version: 0.21.1
-  epoch: 0
+  epoch: 1
   description: Python client for the Prometheus monitoring system.
   copyright:
     - license: Apache-2.0
@@ -19,7 +19,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-prompt-toolkit.yaml
+++ b/py3-prompt-toolkit.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-prompt-toolkit
   version: 3.0.48
-  epoch: 1
+  epoch: 2
   description: Library for building powerful interactive command lines in Python
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-propcache.yaml
+++ b/py3-propcache.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-propcache
   version: 0.2.1
-  epoch: 0
+  epoch: 1
   description: Fast property caching
   copyright:
     - license: Apache-2.0
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-proto-plus.yaml
+++ b/py3-proto-plus.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-proto-plus
   version: 1.25.0
-  epoch: 1
+  epoch: 2
   description: Beautiful, Pythonic protocol buffers.
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-protobuf.yaml
+++ b/py3-protobuf.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-protobuf
   version: 5.29.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-3-Clause
   dependencies:
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-psutil.yaml
+++ b/py3-psutil.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-psutil
   version: 6.1.0
-  epoch: 0
+  epoch: 1
   description: Cross-platform lib for process and system monitoring in Python.
   copyright:
     - license: BSD-3-Clause
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-psycopg2.yaml
+++ b/py3-psycopg2.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-psycopg2
   version: 2.9.10
-  epoch: 0
+  epoch: 1
   description: psycopg2 - Python-PostgreSQL Database Adapter
   copyright:
     - license: LGPL-3.0-or-later
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-ptyprocess.yaml
+++ b/py3-ptyprocess.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-ptyprocess
   version: 0.7.0
-  epoch: 5
+  epoch: 6
   description: Run a subprocess in a pseudo terminal
   copyright:
     - license: ISC
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pure-eval.yaml
+++ b/py3-pure-eval.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pure-eval
   version: 0.2.3
-  epoch: 1
+  epoch: 2
   description: Safely evaluate AST nodes without side effects
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-py4j.yaml
+++ b/py3-py4j.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-py4j
   version: 0.10.9.7
-  epoch: 3
+  epoch: 4
   description: Enables Python programs to dynamically access arbitrary Java objects
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   environment:

--- a/py3-pyaes.yaml
+++ b/py3-pyaes.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyaes
   version: 1.6.1
-  epoch: 4
+  epoch: 5
   description: Pure-Python Implementation of the AES block-cipher and common modes of operation
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pyasn1-modules.yaml
+++ b/py3-pyasn1-modules.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyasn1-modules
   version: 0.4.1
-  epoch: 2
+  epoch: 3
   description: A collection of ASN.1-based protocols modules
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pyasn1.yaml
+++ b/py3-pyasn1.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyasn1
   version: 0.6.1
-  epoch: 2
+  epoch: 3
   description: Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)
   copyright:
     - license: BSD-2-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pybind11.yaml
+++ b/py3-pybind11.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pybind11
   version: 2.13.6
-  epoch: 2
+  epoch: 3
   description: Seamless operability between C++11 and Python
   copyright:
     - license: BSD-3-Clause
@@ -19,7 +19,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pycosat.yaml
+++ b/py3-pycosat.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pycosat
   version: 0.6.6
-  epoch: 1
+  epoch: 2
   description: Python bindings to picosat (a SAT solver)
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pycparser.yaml
+++ b/py3-pycparser.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pycparser
   version: '2.22'
-  epoch: 3
+  epoch: 4
   description: C parser in Python
   copyright:
     - license: BSD-3-Clause
@@ -32,7 +32,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 pipeline:
   - uses: git-checkout

--- a/py3-pycryptodome.yaml
+++ b/py3-pycryptodome.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pycryptodome
   version: 3.21.0
-  epoch: 1
+  epoch: 2
   description: Cryptographic library for Python
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pycurl.yaml
+++ b/py3-pycurl.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pycurl
   version: 7.45.3
-  epoch: 1
+  epoch: 2
   description: PycURL -- A Python Interface To The cURL library
   copyright:
     - license: LGPL-2.1-or-later AND MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pydantic-core.yaml
+++ b/py3-pydantic-core.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pydantic-core
   version: 2.27.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:
@@ -37,7 +37,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 pipeline:
   - uses: git-checkout

--- a/py3-pydantic.yaml
+++ b/py3-pydantic.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pydantic
   version: 2.10.3
-  epoch: 0
+  epoch: 1
   description: Data validation using Python type hints
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pydot.yaml
+++ b/py3-pydot.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pydot
   version: 3.0.3
-  epoch: 0
+  epoch: 1
   description: Python interface to Graphviz's Dot
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pyelftools.yaml
+++ b/py3-pyelftools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyelftools
   version: 0.31
-  epoch: 1
+  epoch: 2
   description: Python Library for analyzing ELF files and DWARF debugging information
   copyright:
     - license: LicenseRef-pyelftools-public-domain
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pyfarmhash.yaml
+++ b/py3-pyfarmhash.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyfarmhash
   version: 0.3.2
-  epoch: 5
+  epoch: 6
   description: Google FarmHash Bindings for Python
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pygithub.yaml
+++ b/py3-pygithub.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pygithub
   version: 2.5.0
-  epoch: 0
+  epoch: 1
   description: Use the full Github API v3
   copyright:
     - license: LGPL-3.0-or-later OR GPL-3.0-or-later
@@ -19,7 +19,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 environment:
   contents:

--- a/py3-pygments.yaml
+++ b/py3-pygments.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pygments
   version: 2.18.0
-  epoch: 2
+  epoch: 3
   description: Syntax highlighting package written in Python
   copyright:
     - license: BSD-2-Clause
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pyjwt.yaml
+++ b/py3-pyjwt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyjwt
   version: 2.10.1
-  epoch: 0
+  epoch: 1
   description: JSON Web Token implementation in Python
   copyright:
     - license: MIT
@@ -14,7 +14,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 vars:
   module_name: jwt

--- a/py3-pykube-ng.yaml
+++ b/py3-pykube-ng.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pykube-ng
   version: 23.6.0
-  epoch: 2
+  epoch: 3
   description: Pykube (pykube-ng) is a lightweight Python 3.6+ client library for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pymongo.yaml
+++ b/py3-pymongo.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pymongo
   version: 4.10.1
-  epoch: 1
+  epoch: 2
   description: Python driver for MongoDB <http://www.mongodb.org>
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pymysql.yaml
+++ b/py3-pymysql.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pymysql
   version: 1.1.1
-  epoch: 1
+  epoch: 2
   description: Pure Python MySQL Driver
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pynacl.yaml
+++ b/py3-pynacl.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pynacl
   version: 1.5.0
-  epoch: 2
+  epoch: 3
   description: Python binding to the Networking and Cryptography (NaCl) library
   copyright:
     - license: Apache-2.0
@@ -15,7 +15,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 vars:
   module_name: nacl

--- a/py3-pyopenssl.yaml
+++ b/py3-pyopenssl.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyopenssl
   version: 24.3.0
-  epoch: 0
+  epoch: 1
   description: Python wrapper module around the OpenSSL library
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pyparsing.yaml
+++ b/py3-pyparsing.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pyparsing
   version: 3.2.0
-  epoch: 1
+  epoch: 2
   description: pyparsing module - Classes and methods to define and execute parsing grammars
   copyright:
     - license: MIT
@@ -19,7 +19,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-pyperclip.yaml
+++ b/py3-pyperclip.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyperclip
   version: 1.9.0
-  epoch: 2
+  epoch: 3
   description: A cross-platform clipboard module for Python. (Only handles plain text for now.)
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pyproject-hooks.yaml
+++ b/py3-pyproject-hooks.yaml
@@ -9,8 +9,8 @@ package:
     provider-priority: 0
 
 vars:
+  import: pyproject_hooks
   pypi-package: pyproject-hooks
-  module-name: pyproject_hooks
 
 data:
   - name: py-versions
@@ -50,6 +50,12 @@ subpackages:
         with:
           python: python${{range.key}}
       - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -62,7 +68,9 @@ subpackages:
 
 test:
   pipeline:
-    - runs: python3.12 -c "import ${{vars.module-name}}"
+    - uses: python/import
+      with:
+        import: ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-pyproject-hooks.yaml
+++ b/py3-pyproject-hooks.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyproject-hooks
   version: 1.2.0
-  epoch: 0
+  epoch: 1
   description: A low-level library for calling build-backends in `pyproject.toml`-based project
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-pyproject-metadata.yaml
+++ b/py3-pyproject-metadata.yaml
@@ -47,7 +47,7 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py${{range.key}}
+        - py${{range.key}}-packaging
     pipeline:
       - uses: py/pip-build-install
         with:

--- a/py3-pyproject-metadata.yaml
+++ b/py3-pyproject-metadata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyproject-metadata
   version: 0.9.0
-  epoch: 0
+  epoch: 1
   description: PEP 621 metadata parsing
   copyright:
     - license: MIT
@@ -9,8 +9,8 @@ package:
     provider-priority: 0
 
 vars:
+  import: pyproject_metadata
   pypi-package: pyproject-metadata
-  module-name: pyproject_metadata
 
 data:
   - name: py-versions
@@ -18,7 +18,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:
@@ -47,12 +47,18 @@ subpackages:
       provides:
         - py3-${{vars.pypi-package}}
       runtime:
-        - py3-packaging
+        - py${{range.key}}
     pipeline:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
       - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -65,7 +71,9 @@ subpackages:
 
 test:
   pipeline:
-    - runs: python3.12 -c "import ${{vars.module-name}}"
+    - uses: python/import
+      with:
+        import: ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-pyrfc3339.yaml
+++ b/py3-pyrfc3339.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyrfc3339
   version: 2.0.1
-  epoch: 0
+  epoch: 1
   description: Generate and parse RFC 3339 timestamps
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pyrsistent.yaml
+++ b/py3-pyrsistent.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyrsistent
   version: 0.20.0
-  epoch: 1
+  epoch: 2
   description: Persistent/Functional/Immutable data structures
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pytest-timeout.yaml
+++ b/py3-pytest-timeout.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pytest-timeout
   version: 2.3.1
-  epoch: 3
+  epoch: 4
   description: pytest plugin to abort hanging tests
   copyright:
     - license: MIT
@@ -19,7 +19,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pytest.yaml
+++ b/py3-pytest.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pytest
   version: 8.3.4
-  epoch: 0
+  epoch: 1
   description: 'pytest: simple powerful testing with Python'
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-python-crfsuite.yaml
+++ b/py3-python-crfsuite.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-crfsuite
   version: 0.9.10
-  epoch: 1
+  epoch: 2
   description: Python binding for CRFsuite
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-python-daemon.yaml
+++ b/py3-python-daemon.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-daemon
   version: 3.1.2
-  epoch: 0
+  epoch: 1
   description: Library to implement a well-behaved Unix daemon process.
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-python-dateutil.yaml
+++ b/py3-python-dateutil.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-python-dateutil
   version: 2.9.0
-  epoch: 6
+  epoch: 7
   description: Extensions to the standard Python datetime module
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 pipeline:
   - uses: git-checkout

--- a/py3-python-editor.yaml
+++ b/py3-python-editor.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-editor
   version: 1.0.4
-  epoch: 4
+  epoch: 5
   description: Programmatically open an editor, capture the result.
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-python-gitlab.yaml
+++ b/py3-python-gitlab.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-gitlab
   version: 5.1.0
-  epoch: 0
+  epoch: 1
   description: A python wrapper for the GitLab API
   url: https://python-gitlab.readthedocs.io
   copyright:
@@ -19,7 +19,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-python-json-logger.yaml
+++ b/py3-python-json-logger.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-json-logger
   version: 2.0.7
-  epoch: 4
+  epoch: 5
   description: A python library adding a json log formatter
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-python-lsp-jsonrpc.yaml
+++ b/py3-python-lsp-jsonrpc.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-lsp-jsonrpc
   version: 1.1.2
-  epoch: 3
+  epoch: 4
   description: JSON RPC 2.0 server library
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-python-pypi-mirror.yaml
+++ b/py3-python-pypi-mirror.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-pypi-mirror
   version: 5.2.1
-  epoch: 0
+  epoch: 1
   description: A script to create a partial PyPI mirror
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 environment:
   contents:

--- a/py3-python-slugify.yaml
+++ b/py3-python-slugify.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-slugify
   version: 8.0.4
-  epoch: 1
+  epoch: 2
   description: A Python slugify application that also handles Unicode
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pythran.yaml
+++ b/py3-pythran.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pythran
   version: 0.17.0
-  epoch: 0
+  epoch: 1
   description: Ahead of Time compiler for numeric kernels
   copyright:
     - license: BSD-3-Clause
@@ -17,7 +17,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-pytimeparse.yaml
+++ b/py3-pytimeparse.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pytimeparse
   version: 1.1.8
-  epoch: 2
+  epoch: 3
   description: Time expression parser
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pytz.yaml
+++ b/py3-pytz.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pytz
   version: 2024.1
-  epoch: 3
+  epoch: 4
   description: World timezone definitions, modern and historical
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pywin32-ctypes.yaml
+++ b/py3-pywin32-ctypes.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pywin32-ctypes
   version: 0.2.3
-  epoch: 1
+  epoch: 2
   description: A (partial) reimplementation of pywin32 using ctypes/cffi
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pywinpty.yaml
+++ b/py3-pywinpty.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-pywinpty
   version: 2.0.13
-  epoch: 3
+  epoch: 4
   description: Pseudo terminal support for Windows from Python.
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-pyyaml.yaml
+++ b/py3-pyyaml.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyyaml
   version: 6.0.2
-  epoch: 1
+  epoch: 2
   description: Python3 bindings for YAML
   copyright:
     - license: MIT
@@ -17,7 +17,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-pyzmq.yaml
+++ b/py3-pyzmq.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pyzmq
   version: 26.2.0
-  epoch: 1
+  epoch: 2
   description: Python bindings for 0MQ
   copyright:
     # Upstream completed relicensing: https://github.com/zeromq/pyzmq/tree/main/RELICENSE
@@ -19,7 +19,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-rapidfuzz.yaml
+++ b/py3-rapidfuzz.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-rapidfuzz
   version: 3.10.1
-  epoch: 0
+  epoch: 1
   description: rapid fuzzy string matching
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-rdflib.yaml
+++ b/py3-rdflib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rdflib
   version: 7.1.1
-  epoch: 0
+  epoch: 1
   description: RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information.
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-reactivex.yaml
+++ b/py3-reactivex.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-reactivex
   version: 4.0.4
-  epoch: 0
+  epoch: 1
   description: ReactiveX (Rx) for Python
   copyright:
     - license: MIT
@@ -20,7 +20,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 vars:
   module_name: reactivex

--- a/py3-recommonmark.yaml
+++ b/py3-recommonmark.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-recommonmark
   version: 0.7.1
-  epoch: 1
+  epoch: 2
   description: A docutils-compatibility bridge to CommonMark, enabling you to write CommonMark inside of Docutils & Sphinx projects.
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-referencing.yaml
+++ b/py3-referencing.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-referencing
   version: 0.35.1
-  epoch: 3
+  epoch: 4
   description: Cross-specification JSON referencing (JSON Schema, OpenAPI, and the one you just made up!).
   copyright:
     - license: MIT
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-regex.yaml
+++ b/py3-regex.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-regex
   version: 2024.11.7
-  epoch: 0
+  epoch: 1
   description: Alternative regular expression module, to replace re.
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-reno.yaml
+++ b/py3-reno.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-reno
   version: 4.1.0
-  epoch: 2
+  epoch: 3
   description: RElease NOtes manager
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-requests-oauthlib.yaml
+++ b/py3-requests-oauthlib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-requests-oauthlib
   version: 2.0.0
-  epoch: 1
+  epoch: 2
   description: OAuthlib authentication support for Requests.
   copyright:
     - license: ISC
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-requests-toolbelt.yaml
+++ b/py3-requests-toolbelt.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-requests-toolbelt
   version: 1.0.0
-  epoch: 4
+  epoch: 5
   description: A utility belt for advanced users of python-requests
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-requests-unixsocket.yaml
+++ b/py3-requests-unixsocket.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-requests-unixsocket
   version: 0.3.0
-  epoch: 0
+  epoch: 1
   description: Use requests to talk HTTP via a UNIX domain socket
   copyright:
     - license: Apache-2.0
@@ -28,7 +28,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 pipeline:
   - uses: fetch

--- a/py3-requests.yaml
+++ b/py3-requests.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-requests
   version: 2.32.3
-  epoch: 3
+  epoch: 4
   description: Python HTTP for Humans.
   copyright:
     - license: Apache-2.0
@@ -29,7 +29,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 pipeline:
   - uses: git-checkout

--- a/py3-resolvelib.yaml
+++ b/py3-resolvelib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-resolvelib
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: Resolve abstract dependencies into concrete ones
   copyright:
     - license: ISC
@@ -18,7 +18,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 environment:
   contents:

--- a/py3-retrying.yaml
+++ b/py3-retrying.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-retrying
   version: 1.3.4
-  epoch: 5
+  epoch: 6
   description: python 2 and 3 compatibility library
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-rfc3339-validator.yaml
+++ b/py3-rfc3339-validator.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rfc3339-validator
   version: 0.1.4
-  epoch: 4
+  epoch: 5
   description: A pure python RFC3339 validator
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-rfc3986-validator.yaml
+++ b/py3-rfc3986-validator.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rfc3986-validator
   version: 0.1.1
-  epoch: 4
+  epoch: 5
   description: Pure python rfc3986 validator
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-rich.yaml
+++ b/py3-rich.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rich
   version: 13.9.4
-  epoch: 0
+  epoch: 1
   description: "Rich is a Python library for rich text and beautiful formatting in the terminal."
   copyright:
     - license: LGPL-2.1-or-later
@@ -17,7 +17,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-robotframework.yaml
+++ b/py3-robotframework.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-robotframework
   version: 7.1.1
-  epoch: 0
+  epoch: 1
   description: Generic automation framework for acceptance testing and robotic process automation (RPA)
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-rouge-score.yaml
+++ b/py3-rouge-score.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rouge-score
   version: 0.1.2
-  epoch: 3
+  epoch: 4
   description: Pure python implementation of ROUGE-1.5.5
   copyright:
     - license: Apache-2.0
@@ -23,7 +23,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-rpds-py.yaml
+++ b/py3-rpds-py.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rpds-py
   version: 0.22.3
-  epoch: 0
+  epoch: 1
   description: Python bindings to Rust's persistent data structures (rpds).
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-rsa.yaml
+++ b/py3-rsa.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-rsa
   version: 4.9
-  epoch: 6
+  epoch: 7
   description: Pure-Python3 RSA implementation
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-ruamel-yaml-clib.yaml
+++ b/py3-ruamel-yaml-clib.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ruamel-yaml-clib
   version: 0.2.12
-  epoch: 1
+  epoch: 2
   description: C version of reader, parser and emitter for ruamel.yaml derived from libyaml.
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-ruamel-yaml.yaml
+++ b/py3-ruamel-yaml.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ruamel-yaml
   version: 0.18.6
-  epoch: 1
+  epoch: 2
   description: ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-s3transfer.yaml
+++ b/py3-s3transfer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-s3transfer
   version: 0.10.4
-  epoch: 0
+  epoch: 1
   description: Amazon S3 Transfer Manager for Python
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sacrebleu.yaml
+++ b/py3-sacrebleu.yaml
@@ -39,9 +39,9 @@ subpackages:
     dependencies:
       provider-priority: ${{range.value}}
       runtime:
-        - numpy
         - py${{range.key}}-colorama
         - py${{range.key}}-lxml
+        - py${{range.key}}-numpy
         - py${{range.key}}-portalocker
         - py${{range.key}}-regex
         - py${{range.key}}-tabulate

--- a/py3-sacrebleu.yaml
+++ b/py3-sacrebleu.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sacrebleu
   version: 2.4.3
-  epoch: 0
+  epoch: 1
   description: Reference BLEU implementation that auto-downloads test sets and reports a version string to facilitate cross-lab comparisons
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-scandir.yaml
+++ b/py3-scandir.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scandir
   version: 1.10.0
-  epoch: 4
+  epoch: 5
   description: scandir, a better directory iterator and faster os.walk()
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-scikit-build-core.yaml
+++ b/py3-scikit-build-core.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-scikit-build-core
   version: 0.10.7
-  epoch: 1
+  epoch: 2
   description: Build backend for CMake based projects
   copyright:
     - license: APACHE-2.0
@@ -76,7 +76,7 @@ data:
       '3.10': '310'
       '3.11': '311'
       '3.12': '312'
-      '3.13': '300'
+      '3.13': '313'
 
 update:
   enabled: true

--- a/py3-scikit-build.yaml
+++ b/py3-scikit-build.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scikit-build
   version: 0.18.1
-  epoch: 1
+  epoch: 2
   description: Improved build system generator for Python C/C++/Fortran/Cython extensions
   copyright:
     - license: BSD-3-Clause
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:


### PR DESCRIPTION
Make python-3.13 version of PYPI_PKG provide virtual py3-PYPI_PKG

This just makes the python v3.13 version of a package the highest
version.  So now, if you do `apk add py3-appnope`, you'll get
`py3.13-appnope` where before you would get py3.12-appnope.

The 'set-313.sh' script used to do this looks like:

    #!/bin/sh -e
    r=' \(["'\'']*3[.]13["'\'']*\): \(["'\'']*\)[0-9]\+\(["'\'']*\)'
    n=313

    files=$(git grep -l "$r")
    set -- $files
    echo "$# files"
    sed -i -e "s,$r, \1: \2${n}\3," "$@"
    wolfictl bump "$@"
