### PR TITLE
Make python 3.13 version of virtual packages the default. - batch 05

### DIFF
--- a/py3-scikit-learn.yaml
+++ b/py3-scikit-learn.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scikit-learn
   version: 1.6.0
-  epoch: 0
+  epoch: 1
   description: A set of python modules for machine learning and data mining
   copyright:
     - license: BSD-3-Clause
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-scikit-optimize.yaml
+++ b/py3-scikit-optimize.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scikit-optimize
   version: 0.9.0
-  epoch: 3
+  epoch: 4
   description: Sequential model-based optimization toolbox.
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-scipy.yaml
+++ b/py3-scipy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scipy
   version: 1.14.1
-  epoch: 3
+  epoch: 4
   description: Fundamental algorithms for scientific computing in Python
   copyright:
     - license: BSD-3-Clause
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-scipy.yaml
+++ b/py3-scipy.yaml
@@ -9,6 +9,7 @@ package:
     provider-priority: 0
 
 vars:
+  import: scipy
   pypi-package: scipy
 
 data:
@@ -75,7 +76,7 @@ subpackages:
         - uses: python/import
           with:
             python: python${{range.key}}
-            import: ${{vars.pypi-package}}
+            import: ${{vars.import}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -90,7 +91,7 @@ subpackages:
         - uses: python/import
           with:
             python: python3.10
-            import: ${{vars.pypi-package}}
+            import: ${{vars.import}}
 
 update:
   enabled: true
@@ -99,10 +100,7 @@ update:
     strip-prefix: v
 
 test:
-  environment:
-    contents:
-      packages:
-        - python3
   pipeline:
-    - runs: |
-        python3 -c "import scipy"
+    - uses: python/import
+      with:
+        import: ${{vars.import}}

--- a/py3-scp.yaml
+++ b/py3-scp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-scp
   version: 0.15.0
-  epoch: 2
+  epoch: 3
   description: scp module for paramiko
   copyright:
     - license: LGPL-2.1-or-later
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-seaborn.yaml
+++ b/py3-seaborn.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-seaborn
   version: 0.13.2
-  epoch: 2
+  epoch: 3
   description: Statistical data visualization
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-secretstorage.yaml
+++ b/py3-secretstorage.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-secretstorage
   version: 3.3.3
-  epoch: 6
+  epoch: 7
   description: Python bindings to FreeDesktop.org Secret Service API
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-semantic-version.yaml
+++ b/py3-semantic-version.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-semantic-version
   version: 2.10.0
-  epoch: 6
+  epoch: 7
   description: A library implementing the 'SemVer' scheme.
   copyright:
     - license: BSD-3-Clause
@@ -19,7 +19,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-semver.yaml
+++ b/py3-semver.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-semver
   version: 3.0.2
-  epoch: 4
+  epoch: 5
   description: Python helper for Semantic Versioning (https://semver.org)
   copyright:
     - license: BSD-3-Clause
@@ -15,7 +15,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-send2trash.yaml
+++ b/py3-send2trash.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-send2trash
   version: 1.8.3
-  epoch: 1
+  epoch: 2
   description: Send file to trash natively under Mac OS X, Windows and Linux
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sentencepiece.yaml
+++ b/py3-sentencepiece.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sentencepiece
   version: 0.2.0
-  epoch: 3
+  epoch: 4
   description: SentencePiece is an unsupervised text tokenizer and detokenizer
   copyright:
     - license: Apache-2.0
@@ -15,7 +15,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-setproctitle.yaml
+++ b/py3-setproctitle.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-setproctitle
   version: 1.3.4
-  epoch: 0
+  epoch: 1
   description: A Python module to customize the process title
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-setuptools-gettext.yaml
+++ b/py3-setuptools-gettext.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-setuptools-gettext
   version: 0.1.14
-  epoch: 1
+  epoch: 2
   description: Setuptools gettext extension plugin
   copyright:
     - license: "GPL-2.0-or-later"
@@ -19,7 +19,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 environment:
   contents:

--- a/py3-setuptools-git-versioning.yaml
+++ b/py3-setuptools-git-versioning.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-setuptools-git-versioning
   version: 2.0.0
-  epoch: 0
+  epoch: 1
   description: Use git repo data for building a version number according PEP-440
   copyright:
     - license: MIT
@@ -26,7 +26,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-setuptools-rust.yaml
+++ b/py3-setuptools-rust.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-setuptools-rust
   version: 1.10.2
-  epoch: 0
+  epoch: 1
   description: Setuptools Rust extension plugin
   copyright:
     - license: MIT
@@ -33,7 +33,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 pipeline:
   - uses: git-checkout

--- a/py3-setuptools-scm.yaml
+++ b/py3-setuptools-scm.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-setuptools-scm
   version: 8.1.0
-  epoch: 3
+  epoch: 4
   description: the blessed package to manage your versions by scm tags
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-setuptools.yaml
+++ b/py3-setuptools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-setuptools
   version: 75.6.0
-  epoch: 0
+  epoch: 1
   description: Easily download, build, install, upgrade, and uninstall Python packages
   copyright:
     - license: "MIT"
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-setuptools.yaml
+++ b/py3-setuptools.yaml
@@ -9,6 +9,7 @@ package:
     provider-priority: 0
 
 vars:
+  import: setuptools
   pypi-package: setuptools
 
 data:
@@ -49,6 +50,12 @@ subpackages:
         with:
           python: python${{range.key}}
       - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -66,13 +73,7 @@ update:
     strip-prefix: v
 
 test:
-  environment:
-    contents:
-      packages:
-        - python3
-        - py3-pip
   pipeline:
-    - name: Verify setuptools installation
-      runs: |
-        python -m pip install setuptools
-        python -c "import setuptools"
+    - uses: python/import
+      with:
+        import: ${{vars.import}}

--- a/py3-shellingham.yaml
+++ b/py3-shellingham.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-shellingham
   version: 1.5.4
-  epoch: 4
+  epoch: 5
   description: Tool to Detect Surrounding Shell
   copyright:
     - license: ISC
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-simplejson.yaml
+++ b/py3-simplejson.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-simplejson
   version: 3.19.3
-  epoch: 2
+  epoch: 3
   description: Simple, fast, extensible JSON encoder/decoder for Python
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-six.yaml
+++ b/py3-six.yaml
@@ -9,6 +9,7 @@ package:
     provider-priority: 0
 
 vars:
+  import: six
   pypi-package: six
 
 data:
@@ -47,6 +48,12 @@ subpackages:
         with:
           python: python${{range.key}}
       - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
   - name: py3-wheels-${{vars.pypi-package}}
     pipeline:
@@ -68,6 +75,13 @@ update:
 
 test:
   pipeline:
-    - name: Verify py3-six installation
-      runs: |
-        python3.12 -c "import six; assert not six.PY2; assert six.PY3" || exit 1
+    - uses: python/import
+      with:
+        import: ${{vars.import}}
+    - uses: py/one-python
+      with:
+        content: |
+          #!/usr/bin/env python3
+          import six
+          assert not six.PY2
+          assert six.PY3

--- a/py3-six.yaml
+++ b/py3-six.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-six
   version: 1.17.0
-  epoch: 0
+  epoch: 1
   description: python 2 and 3 compatibility library
   copyright:
     - license: MIT
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sniffio.yaml
+++ b/py3-sniffio.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-sniffio
   version: 1.3.1
-  epoch: 2
+  epoch: 3
   description: Sniff out which async library your code is running under
   copyright:
     - license: MIT OR Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-snowballstemmer.yaml
+++ b/py3-snowballstemmer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-snowballstemmer
   version: 2.2.0
-  epoch: 2
+  epoch: 3
   description: This package provides 29 stemmers for 28 languages generated from Snowball algorithms.
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sortedcontainers.yaml
+++ b/py3-sortedcontainers.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sortedcontainers
   version: 2.4.0
-  epoch: 3
+  epoch: 4
   description: Sorted Containers -- Sorted List, Sorted Dict, Sorted Set
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-soupsieve.yaml
+++ b/py3-soupsieve.yaml
@@ -4,7 +4,7 @@
 package:
   name: py3-soupsieve
   version: '2.6'
-  epoch: 1
+  epoch: 2
   description: A modern CSS selector implementation for Beautiful Soup.
   copyright:
     - license: MIT
@@ -21,7 +21,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-spdx-tools.yaml
+++ b/py3-spdx-tools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-spdx-tools
   version: 0.8.3
-  epoch: 1
+  epoch: 2
   description: SPDX parser and tools.
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sphinx-7.yaml
+++ b/py3-sphinx-7.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinx-7
   version: 7.4.7
-  epoch: 3
+  epoch: 4
   description: Python Documentation Generator
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sphinx-rtd-theme.yaml
+++ b/py3-sphinx-rtd-theme.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinx-rtd-theme
   version: 3.0.2
-  epoch: 0
+  epoch: 1
   description: Read the Docs theme for Sphinx
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sphinx.yaml
+++ b/py3-sphinx.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinx
   version: 8.1.3
-  epoch: 2
+  epoch: 3
   description: Python Documentation Generator
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sphinxcontrib-applehelp.yaml
+++ b/py3-sphinxcontrib-applehelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-applehelp
   version: 2.0.0
-  epoch: 2
+  epoch: 3
   description: sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books
   copyright:
     - license: BSD-2-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sphinxcontrib-devhelp.yaml
+++ b/py3-sphinxcontrib-devhelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-devhelp
   version: 2.0.0
-  epoch: 2
+  epoch: 3
   description: sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp documents
   copyright:
     - license: BSD-2-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sphinxcontrib-htmlhelp.yaml
+++ b/py3-sphinxcontrib-htmlhelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-htmlhelp
   version: 2.1.0
-  epoch: 2
+  epoch: 3
   description: sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files
   copyright:
     - license: BSD-2-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sphinxcontrib-jquery.yaml
+++ b/py3-sphinxcontrib-jquery.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-jquery
   version: '4.1'
-  epoch: 1
+  epoch: 2
   description: Extension to include jQuery on newer Sphinx releases
   copyright:
     - license: 0BSD
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sphinxcontrib-jsmath.yaml
+++ b/py3-sphinxcontrib-jsmath.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-jsmath
   version: 1.0.1
-  epoch: 6
+  epoch: 7
   description: A sphinx extension which renders display math in HTML via JavaScript
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sphinxcontrib-packages.yaml
+++ b/py3-sphinxcontrib-packages.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-packages
   version: 1.1.2
-  epoch: 6
+  epoch: 7
   description: This packages contains the Packages sphinx extension, which provides directives to display packages installed on the host machine
   copyright:
     - license: AGPL-3.0-or-later
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sphinxcontrib-qthelp.yaml
+++ b/py3-sphinxcontrib-qthelp.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-qthelp
   version: 2.0.0
-  epoch: 2
+  epoch: 3
   description: sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp documents
   copyright:
     - license: BSD-2-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sphinxcontrib-serializinghtml.yaml
+++ b/py3-sphinxcontrib-serializinghtml.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sphinxcontrib-serializinghtml
   version: 2.0.0
-  epoch: 2
+  epoch: 3
   description: sphinxcontrib-serializinghtml is a sphinx extension which outputs "serialized" HTML files (json and pickle)
   copyright:
     - license: BSD-2-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sqlalchemy-cockroachdb.yaml
+++ b/py3-sqlalchemy-cockroachdb.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sqlalchemy-cockroachdb
   version: 2.0.2
-  epoch: 1
+  epoch: 2
   description: CockroachDB dialect for SQLAlchemy
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sqlalchemy.yaml
+++ b/py3-sqlalchemy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sqlalchemy
   version: 2.0.36
-  epoch: 0
+  epoch: 1
   description: Database Abstraction Library
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sqlglot.yaml
+++ b/py3-sqlglot.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sqlglot
   version: 26.0.0
-  epoch: 0
+  epoch: 1
   description: An easily customizable SQL parser and transpiler
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sqlparse.yaml
+++ b/py3-sqlparse.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sqlparse
   version: 0.5.3
-  epoch: 0
+  epoch: 1
   description: A non-validating SQL parser.
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-sshtunnel.yaml
+++ b/py3-sshtunnel.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sshtunnel
   version: 0.4.0
-  epoch: 2
+  epoch: 3
   description: Pure python SSH tunnels
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-stack-data.yaml
+++ b/py3-stack-data.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-stack-data
   version: 0.6.3
-  epoch: 2
+  epoch: 3
   description: Extract data from python stack frames and tracebacks for informative displays
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-statsd.yaml
+++ b/py3-statsd.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-statsd
   version: 4.0.1
-  epoch: 1
+  epoch: 2
   description: A simple statsd client.
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-stevedore.yaml
+++ b/py3-stevedore.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-stevedore
   version: 5.4.0
-  epoch: 0
+  epoch: 1
   description: Manage dynamic plugins for Python applications
   copyright:
     - license: Apache-2.0
@@ -19,7 +19,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 environment:
   contents:

--- a/py3-sympy.yaml
+++ b/py3-sympy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-sympy
   version: 1.13.3
-  epoch: 2
+  epoch: 3
   description: Computer algebra system (CAS) in Python
   copyright:
     - license: BSD-3-Clause
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-tabulate.yaml
+++ b/py3-tabulate.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tabulate
   version: 0.9.0
-  epoch: 4
+  epoch: 5
   description: Pretty-print tabular data
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-tenacity.yaml
+++ b/py3-tenacity.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tenacity
   version: 9.0.0
-  epoch: 1
+  epoch: 2
   description: General-purpose retrying library, written in Python, to simplify the task of adding retry behavior to just about anything
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-tensorflow-metadata.yaml
+++ b/py3-tensorflow-metadata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tensorflow-metadata
   version: 1.16.1
-  epoch: 1
+  epoch: 2
   description: Utilities for passing TensorFlow-related metadata between tools
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-tensorflow-metadata.yaml
+++ b/py3-tensorflow-metadata.yaml
@@ -111,23 +111,18 @@ update:
     strip-prefix: v
 
 test:
-  environment:
-    contents:
-      packages:
-        - python3
   pipeline:
     - name: Import Test
       uses: python/import
       with:
-        python: python3
         import: ${{vars.import}}
     - name: Basic Functionality Test
-      runs: |
-        echo "Testing tensorflow-metadata basic functionality..."
-        python3 <<EOF-
-        from tensorflow_metadata.proto.v0 import schema_pb2
-        schema = schema_pb2.Schema()
-        schema.feature.add(name='example_feature')
-        assert schema.feature[0].name == 'example_feature', 'Basic feature addition failed'
-        print('tensorflow-metadata basic functionality success')
-        EOF-
+      uses: py/one-python
+      with:
+        content: |
+          #!/usr/bin/env python3
+          from tensorflow_metadata.proto.v0 import schema_pb2
+          schema = schema_pb2.Schema()
+          schema.feature.add(name='example_feature')
+          assert schema.feature[0].name == 'example_feature', 'Basic feature addition failed'
+          print('tensorflow-metadata basic functionality success')

--- a/py3-termcolor.yaml
+++ b/py3-termcolor.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-termcolor
   version: 2.5.0
-  epoch: 1
+  epoch: 2
   description: ANSI color formatting for output in terminal
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-terminado.yaml
+++ b/py3-terminado.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-terminado
   version: 0.18.1
-  epoch: 1
+  epoch: 2
   description: Tornado websocket backend for the Xterm.js Javascript terminal emulator library.
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-testpath.yaml
+++ b/py3-testpath.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-testpath
   version: 0.6.0
-  epoch: 3
+  epoch: 4
   description: Test utilities for code working with files and commands
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-testtools.yaml
+++ b/py3-testtools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-testtools
   version: 2.7.2
-  epoch: 1
+  epoch: 2
   description: Extensions to the Python standard library unit testing framework
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-text-unidecode.yaml
+++ b/py3-text-unidecode.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-text-unidecode
   version: '1.3'
-  epoch: 2
+  epoch: 3
   description: The most basic Text::Unidecode port
   copyright:
     - license: GPL-2.0-or-later
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-threadloop.yaml
+++ b/py3-threadloop.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-threadloop
   version: 1.0.2
-  epoch: 1
+  epoch: 2
   description: Tornado IOLoop Backed Concurrent Futures
   copyright:
     - license: MIT
@@ -24,7 +24,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 pipeline:
   - uses: git-checkout

--- a/py3-threadpoolctl.yaml
+++ b/py3-threadpoolctl.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-threadpoolctl
   version: 3.5.0
-  epoch: 2
+  epoch: 3
   description: Python helpers to limit the number of threads used in native libraries
   copyright:
     - license: BSD-3-Clause
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-tinycss2.yaml
+++ b/py3-tinycss2.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tinycss2
   version: 1.4.0
-  epoch: 0
+  epoch: 1
   description: A tiny CSS parser
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-tinydb.yaml
+++ b/py3-tinydb.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tinydb
   version: 4.8.2
-  epoch: 1
+  epoch: 2
   description: A tiny, document-oriented database
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-toml.yaml
+++ b/py3-toml.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-toml
   version: 0.10.2
-  epoch: 2
+  epoch: 3
   description: Python Library for Tom's Obvious, Minimal Language
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-tomli-w.yaml
+++ b/py3-tomli-w.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tomli-w
   version: 1.1.0
-  epoch: 1
+  epoch: 2
   description: A lil' TOML writer
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-tomli.yaml
+++ b/py3-tomli.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tomli
   version: 2.2.1
-  epoch: 0
+  epoch: 1
   description: TOML parser
   copyright:
     - license: MIT
@@ -17,7 +17,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-tomlkit.yaml
+++ b/py3-tomlkit.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-tomlkit
   version: 0.13.2
-  epoch: 2
+  epoch: 3
   description: Style preserving TOML library
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-tornado.yaml
+++ b/py3-tornado.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tornado
   version: 6.4.2
-  epoch: 0
+  epoch: 1
   description: Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed.
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-tqdm.yaml
+++ b/py3-tqdm.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tqdm
   version: 4.67.1
-  epoch: 0
+  epoch: 1
   description: Fast, Extensible Progress Meter
   copyright:
     - license: MPL-2.0 AND MIT
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-traitlets.yaml
+++ b/py3-traitlets.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-traitlets
   version: 5.14.3
-  epoch: 1
+  epoch: 2
   description: Traitlets Python configuration system
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-trio.yaml
+++ b/py3-trio.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-trio
   version: 0.27.0
-  epoch: 0
+  epoch: 1
   description: A friendly Python library for async concurrency and I/O
   copyright:
     - license: MIT
@@ -19,7 +19,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-trove-classifiers.yaml
+++ b/py3-trove-classifiers.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-trove-classifiers
   version: 2024.10.21.16
-  epoch: 0
+  epoch: 1
   description: Canonical source for classifiers on PyPI (pypi.org).
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-twython.yaml
+++ b/py3-twython.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-twython
   version: 3.9.1
-  epoch: 1
+  epoch: 2
   description: Actively maintained, pure Python wrapper for the Twitter API. Supports both normal and streaming Twitter APIs
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-typing-extensions.yaml
+++ b/py3-typing-extensions.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-typing-extensions
   version: 4.12.2
-  epoch: 7
+  epoch: 8
   description: Backported and Experimental Type Hints for Python 3.7+
   copyright:
     - license: PSF-2.0
@@ -19,7 +19,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-typing-inspect.yaml
+++ b/py3-typing-inspect.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-typing-inspect
   version: 0.9.0
-  epoch: 3
+  epoch: 4
   description: Runtime inspection utilities for typing module.
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-typogrify.yaml
+++ b/py3-typogrify.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-typogrify
   version: 2.0.7
-  epoch: 2
+  epoch: 3
   description: Filters to enhance web typography, including support for Django & Jinja templates
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-tz.yaml
+++ b/py3-tz.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tz
   version: '2024.2'
-  epoch: 1
+  epoch: 2
   description: Python3 definitions of world timezone
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-tzdata.yaml
+++ b/py3-tzdata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tzdata
   version: '2024.2'
-  epoch: 1
+  epoch: 2
   description: Provider of IANA time zone data
   copyright:
     - license: Apache-2.0
@@ -17,7 +17,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/py3-tzlocal.yaml
+++ b/py3-tzlocal.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-tzlocal
   version: '5.2'
-  epoch: 1
+  epoch: 2
   description: tzinfo object for the local timezone
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-udev.yaml
+++ b/py3-udev.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-udev
   version: 0.24.3
-  epoch: 3
+  epoch: 4
   description: Python bindings to libudev
   copyright:
     - license: LGPL-2.1-or-later
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-ujson.yaml
+++ b/py3-ujson.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ujson
   version: 5.10.0
-  epoch: 2
+  epoch: 3
   description: Ultra fast JSON decoder and encoder written in C with Python bindings.
   copyright:
     - license: BSD-3-Clause
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-uritemplate.yaml
+++ b/py3-uritemplate.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-uritemplate
   version: 4.1.1
-  epoch: 2
+  epoch: 3
   description: Implementation of RFC 6570 URI Templates
   copyright:
     - license: BSD-3-Clause OR Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-uritools.yaml
+++ b/py3-uritools.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-uritools
   version: 4.0.3
-  epoch: 1
+  epoch: 2
   description: URI parsing, classification and composition
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-urllib3.yaml
+++ b/py3-urllib3.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-urllib3
   version: 2.2.3
-  epoch: 1
+  epoch: 2
   description: HTTP library with thread-safe connection pooling, file post, and more
   copyright:
     - license: MIT
@@ -28,7 +28,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 pipeline:
   - uses: git-checkout

--- a/py3-userpath.yaml
+++ b/py3-userpath.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-userpath
   version: 1.9.2
-  epoch: 1
+  epoch: 2
   description: Cross-platform tool for adding locations to the user PATH
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-vcrpy.yaml
+++ b/py3-vcrpy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-vcrpy
   version: 6.0.2
-  epoch: 1
+  epoch: 2
   description: Automatically mock your HTTP interactions to simplify and speed up testing
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-versioneer.yaml
+++ b/py3-versioneer.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-versioneer
   version: '0.29'
-  epoch: 4
+  epoch: 5
   description: Easy VCS-based management of project version strings
   copyright:
     - license: Unlicense
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-virtualenv.yaml
+++ b/py3-virtualenv.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-virtualenv
   version: 20.28.0
-  epoch: 0
+  epoch: 1
   description: Virtual Python Environment builder
   copyright:
     - license: MIT
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-wcmatch.yaml
+++ b/py3-wcmatch.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wcmatch
   version: '10.0'
-  epoch: 1
+  epoch: 2
   description: Wilcard File Name matching library.
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-wcwidth.yaml
+++ b/py3-wcwidth.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-wcwidth
   version: 0.2.13
-  epoch: 3
+  epoch: 4
   description: Measures the displayed width of unicode strings in a terminal
   copyright:
     - license: MIT
@@ -30,7 +30,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 pipeline:
   - uses: git-checkout

--- a/py3-webencodings.yaml
+++ b/py3-webencodings.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-webencodings
   version: 0.5.1
-  epoch: 4
+  epoch: 5
   description: Character encoding aliases for legacy web content
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 environment:
   contents:

--- a/py3-websocket-client.yaml
+++ b/py3-websocket-client.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-websocket-client
   version: 1.8.0
-  epoch: 1
+  epoch: 2
   description: WebSocket client for Python with low level API options
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-werkzeug.yaml
+++ b/py3-werkzeug.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-werkzeug
   version: 3.1.3
-  epoch: 0
+  epoch: 1
   description: The comprehensive WSGI web application library.
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-widgetsnbextension.yaml
+++ b/py3-widgetsnbextension.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-widgetsnbextension
   version: 4.0.13
-  epoch: 1
+  epoch: 2
   description: Jupyter interactive widgets for Jupyter Notebook
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-wrapt.yaml
+++ b/py3-wrapt.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-wrapt
   version: 1.17.0
-  epoch: 0
+  epoch: 1
   description: Module for decorators, wrappers and monkey patching.
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       "3.10": "310"
       "3.11": "311"
       "3.12": "312"
-      "3.13": "300"
+      "3.13": "313"
 
 environment:
   contents:

--- a/py3-wrapt.yaml
+++ b/py3-wrapt.yaml
@@ -64,41 +64,41 @@ update:
     strip-prefix: wrapt-
 
 test:
-  environment:
-    contents:
-      packages:
-        - python-3
   pipeline:
     - name: Import Test
       uses: python/import
       with:
         import: ${{vars.module_name}}
     - name: Test decorator functionality
-      runs: |
-        # Create a simple decorator using wrapt
-        echo '
-        import wrapt
+      uses: py/one-python
+      with:
+        content: |
+          #!/usr/bin/env python3
+          import wrapt
+          before_hit = False
+          body_hit = False
+          after_hit = False
 
-        # Define a decorator that prints messages before and after the function execution
-        @wrapt.decorator
-        def my_decorator(wrapped, instance, args, kwargs):
-            print(f"Before function")
-            result = wrapped(*args, **kwargs)  # Call the decorated function
-            print(f"After function")
-            return result
+          # Define a decorator that prints messages before and after the function
+          @wrapt.decorator
+          def my_decorator(wrapped, instance, args, kwargs):
+              global before_hit, after_hit
+              before_hit = True
+              print("Before function")
+              result = wrapped(*args, **kwargs)  # Call the decorated function
+              after_hit = True
+              return result
 
-        # Apply the decorator to a sample function
-        @my_decorator
-        def sample_function():
-            print("Function body")  # This is the body of the function
+          # Apply the decorator to a sample function
+          @my_decorator
+          def sample_function():
+              global body_hit
+              body_hit = True
+              print("Function body")  # This is the body of the function
 
-        # Call the decorated function
-        sample_function()
-        ' > test_wrapt.py
+          # Call the decorated function
+          sample_function()
 
-        # Check that the decorator correctly prints "Before function"
-        python3 test_wrapt.py | grep "Before function" || exit 1
-        # Check that the function body prints correctly
-        python3 test_wrapt.py | grep "Function body" || exit 1
-        # Check that the decorator correctly prints "After function"
-        python3 test_wrapt.py | grep "After function" || exit 1
+          assert before_hit is True, "Before code not hit"
+          assert after_hit is True, "After code not hit"
+          assert body_hit is True, "Body was not hit"

--- a/py3-xattr.yaml
+++ b/py3-xattr.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-xattr
   version: 1.1.0
-  epoch: 3
+  epoch: 4
   description: Python wrapper for extended filesystem attributes
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-xmlsec.yaml
+++ b/py3-xmlsec.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-xmlsec
   version: 1.3.14
-  epoch: 2
+  epoch: 3
   description: About Python bindings for the XML Security Library
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-xmltodict.yaml
+++ b/py3-xmltodict.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-xmltodict
   version: 0.14.2
-  epoch: 0
+  epoch: 1
   description: Makes working with XML feel like you are working with JSON
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-xyzservices.yaml
+++ b/py3-xyzservices.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-xyzservices
   version: 2024.9.0
-  epoch: 1
+  epoch: 2
   description: Source of XYZ tiles providers
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-yarl.yaml
+++ b/py3-yarl.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-yarl
   version: 1.18.3
-  epoch: 0
+  epoch: 1
   description: Yet another URL library
   copyright:
     - license: Apache-2.0
@@ -17,7 +17,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-zaproxy.yaml
+++ b/py3-zaproxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-zaproxy
   version: 0.3.2
-  epoch: 2
+  epoch: 3
   description: ZAP Python API
   copyright:
     - license: Apache-2.0
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-zipp.yaml
+++ b/py3-zipp.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-zipp
   version: 3.21.0
-  epoch: 0
+  epoch: 1
   description: Backport of pathlib-compatible object wrapper for zip files
   copyright:
     - license: MIT
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-zope.event.yaml
+++ b/py3-zope.event.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-zope.event
   version: '5.0'
-  epoch: 1
+  epoch: 2
   description: Very basic event publishing system
   copyright:
     - license: ZPL-2.1
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-zope.interface.yaml
+++ b/py3-zope.interface.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-zope.interface
   version: "7.2"
-  epoch: 0
+  epoch: 1
   description: Interfaces for Python
   copyright:
     - license: ZPL-2.1
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/py3-zstandard.yaml
+++ b/py3-zstandard.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-zstandard
   version: 0.23.0
-  epoch: 1
+  epoch: 2
   description: Zstandard bindings for Python
   copyright:
     - license: BSD-3-Clause
@@ -18,7 +18,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/s3cmd.yaml
+++ b/s3cmd.yaml
@@ -1,7 +1,7 @@
 package:
   name: s3cmd
   version: 2.4.0
-  epoch: 4
+  epoch: 5
   description: Command-line tool for managing Amazon S3 and CloudFront services
   copyright:
     - license: GPL-2.0-or-later
@@ -17,7 +17,7 @@ data:
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
+      3.13: "313"
 
 environment:
   contents:

--- a/strongswan.yaml
+++ b/strongswan.yaml
@@ -1,7 +1,7 @@
 package:
   name: strongswan
   version: 5.9.14
-  epoch: 0
+  epoch: 1
   description: IPsec-based VPN solution focused on security and ease of use, supporting IKEv1/IKEv2 and MOBIKE
   copyright:
     # GPL-2.0-or-later WITH OpenSSL-Exception
@@ -29,7 +29,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/thrift.yaml
+++ b/thrift.yaml
@@ -1,7 +1,7 @@
 package:
   name: thrift
   version: 0.21.0
-  epoch: 1
+  epoch: 2
   description: "Language-independent software stack for RPC implementation"
   copyright:
     - license: "Apache-2.0"
@@ -34,7 +34,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Make python-3.13 version of PYPI_PKG provide virtual py3-PYPI_PKG

This just makes the python v3.13 version of a package the highest
version.  So now, if you do `apk add py3-appnope`, you'll get
`py3.13-appnope` where before you would get py3.12-appnope.

The 'set-313.sh' script used to do this looks like:

    #!/bin/sh -e
    r=' \(["'\'']*3[.]13["'\'']*\): \(["'\'']*\)[0-9]\+\(["'\'']*\)'
    n=313

    files=$(git grep -l "$r")
    set -- $files
    echo "$# files"
    sed -i -e "s,$r, \1: \2${n}\3," "$@"
    wolfictl bump "$@"
