### PR TITLE
Add a dep to datadog-agent-nvml to help it build more

### DIFF
--- a/datadog-agent-nvml.yaml
+++ b/datadog-agent-nvml.yaml
@@ -18,6 +18,7 @@ environment:
       - busybox
       - datadog-agent
       - datadog-agent-core-integrations
+      - python-${{vars.python_version}}-dev # strictly requires python3.11
       - rsync
 
 vars:

--- a/datadog-agent-nvml.yaml
+++ b/datadog-agent-nvml.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-agent-nvml
   version: 1.0.9
-  epoch: 2
+  epoch: 3
   description: "Checks NVIDIA Management Library (NVML) exposed metrics through the Datadog Agent and can correlate them with the exposed Kubernetes devices"
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
The package datadog-agent-nvml is failing to build with the following error:

```
2024-12-11T07:05:44Z INFO [git checkout] execute: git checkout --quiet origin/tags/nvml-1.0.9 uses=git-checkout
2024-12-11T07:05:46Z INFO [git checkout] tag nvml-1.0.9 is d38c5cdb4ab4d07f4432afb25e0ccd70341efb51 uses=git-checkout
2024-12-11T07:05:46Z WARN /bin/sh: python: not found
```

This change fixes that but locally building the package causes a segmentation violation which is detailed in https://github.com/chainguard-dev/melange/issues/1552. Maybe it'll pass in production?