### PR TITLE
conda/py3-conda-libmamba-solver: python multiversioning

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -11,21 +11,7 @@ package:
     no-provides: true
     no-depends: true
   dependencies:
-    runtime:
-      - py3-archspec
-      - py3-boltons
-      - py3-conda-libmamba-solver
-      - py3-conda-package-handling
-      - py3-conda-package-streaming
-      - py3-libmambapy
-      - py3-packaging
-      - py3-platformdirs
-      - py3-pluggy
-      - py3-pycosat
-      - py3-requests
-      - py3-ruamel-yaml
-      - py3-tqdm
-      - python3
+    provider-priority: 0
 
 environment:
   contents:
@@ -57,11 +43,48 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 1e025e1ac47914e470e140253f0ec69849535ca6
 
-  - runs: |
-      hatch build
-      python3 -m installer -d "${{targets.destdir}}" dist/conda*.whl
-
 subpackages:
+  - name: py3-conda
+    description: python3 version of conda
+    dependencies:
+      runtime:
+        - py3-archspec
+        - py3-boltons
+        - py3-conda-libmamba-solver
+        - py3-conda-package-handling
+        - py3-conda-package-streaming
+        - py3-libmambapy
+        - py3-packaging
+        - py3-platformdirs
+        - py3-pluggy
+        - py3-pycosat
+        - py3-requests
+        - py3-ruamel-yaml
+        - py3-tqdm
+        - python3
+    pipeline:
+      - runs: |
+          hatch build
+          python3 -m installer -d "${{targets.contextdir}}" dist/conda*.whl
+      - name: "move usr/bin executables for -bin"
+        runs: |
+          mkdir -p ./cleanup/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/
+      - uses: strip
+
+  - name: py3-conda-bin
+    description: Executable binaries for conda installed for python3
+    dependencies:
+      runtime:
+        - py3-conda
+      provides:
+        - conda
+      provider-priority: "312"
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/bin ${{targets.contextdir}}/usr/
+
   - name: ${{package.name}}-init
     description: Initializes conda
     dependencies:

--- a/conda.yaml
+++ b/conda.yaml
@@ -20,9 +20,9 @@ vars:
     conda --version
     conda info
     conda init
-    conda create -n foo
-    conda install -n foo numpy
-    conda install -n foo --solver=classic requests
+    conda create --quiet -n foo
+    conda install --quiet -n foo numpy
+    conda install --quiet -n foo --solver=classic requests
     conda --help
 
 data:

--- a/conda.yaml
+++ b/conda.yaml
@@ -49,9 +49,6 @@ environment:
       - python3
       - wget
       - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
 
 pipeline:
   - uses: git-checkout

--- a/conda.yaml
+++ b/conda.yaml
@@ -15,6 +15,7 @@ package:
 
 vars:
   pypi-package: conda
+  import: conda
 
 data:
   - name: py-versions
@@ -83,6 +84,12 @@ subpackages:
           mkdir -p ./cleanup/${{range.key}}/
           mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
       - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
   - range: py-versions
     name: py${{range.key}}-${{vars.pypi-package}}-bin
@@ -107,6 +114,24 @@ subpackages:
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
         - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.12
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.13
+            import: ${{vars.import}}
 
   - name: ${{package.name}}-init
     description: Initializes conda

--- a/conda.yaml
+++ b/conda.yaml
@@ -24,6 +24,7 @@ environment:
       - py3-conda-package-handling
       - py3-conda-package-streaming
       - py3-hatch
+      - py3-hatch-vcs
       - py3-hatchling
       - py3-idna
       - py3-libmambapy
@@ -63,9 +64,7 @@ subpackages:
         - py3-tqdm
         - python3
     pipeline:
-      - runs: |
-          hatch build
-          python3 -m installer -d "${{targets.contextdir}}" dist/conda*.whl
+      - uses: py/pip-build-install
       - name: "move usr/bin executables for -bin"
         runs: |
           mkdir -p ./cleanup/

--- a/conda.yaml
+++ b/conda.yaml
@@ -28,10 +28,10 @@ vars:
 data:
   - name: py-versions
     items:
+      # As of 24.11.1, 3.13 fails tests: https://github.com/conda/conda/issues/14439
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
 
 environment:
   contents:
@@ -124,7 +124,6 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
-        - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: python/import
@@ -138,10 +137,6 @@ subpackages:
         - uses: python/import
           with:
             python: python3.12
-            import: ${{vars.import}}
-        - uses: python/import
-          with:
-            python: python3.13
             import: ${{vars.import}}
 
   - name: ${{package.name}}-init

--- a/conda.yaml
+++ b/conda.yaml
@@ -33,15 +33,14 @@ environment:
       - bash
       - busybox
       - ca-certificates-bundle
+      - py3-build-base
       - py3-charset-normalizer
       - py3-conda-package-handling
       - py3-conda-package-streaming
       - py3-hatch
       - py3-hatchling
       - py3-idna
-      - py3-installer
       - py3-libmambapy
-      - py3-pip
       - py3-pycosat
       - py3-requests
       - py3-urllib3

--- a/conda.yaml
+++ b/conda.yaml
@@ -13,26 +13,37 @@ package:
   dependencies:
     provider-priority: 0
 
+vars:
+  pypi-package: conda
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "300"
+
 environment:
   contents:
     packages:
       - bash
       - busybox
       - ca-certificates-bundle
-      - py3-build-base
-      - py3-charset-normalizer
-      - py3-conda-package-handling
-      - py3-conda-package-streaming
-      - py3-hatch
-      - py3-hatch-vcs
-      - py3-hatchling
-      - py3-idna
-      - py3-libmambapy
-      - py3-pycosat
-      - py3-requests
-      - py3-urllib3
-      - py3-wheel
-      - py3-zstandard
+      - py3-supported-build-base
+      - py3-supported-charset-normalizer
+      - py3-supported-conda-package-handling
+      - py3-supported-conda-package-streaming
+      - py3-supported-hatch
+      - py3-supported-hatch-vcs
+      - py3-supported-hatchling
+      - py3-supported-idna
+      - py3-supported-libmambapy
+      - py3-supported-pycosat
+      - py3-supported-requests
+      - py3-supported-urllib3
+      - py3-supported-wheel
+      - py3-supported-zstandard
       - python3
       - wget
       - wolfi-base
@@ -45,44 +56,57 @@ pipeline:
       expected-commit: 1e025e1ac47914e470e140253f0ec69849535ca6
 
 subpackages:
-  - name: py3-conda
-    description: python3 version of conda
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
     dependencies:
       runtime:
-        - py3-archspec
-        - py3-boltons
-        - py3-conda-libmamba-solver
-        - py3-conda-package-handling
-        - py3-conda-package-streaming
-        - py3-libmambapy
-        - py3-packaging
-        - py3-platformdirs
-        - py3-pluggy
-        - py3-pycosat
-        - py3-requests
-        - py3-ruamel-yaml
-        - py3-tqdm
-        - python3
+        - py${{range.key}}-archspec
+        - py${{range.key}}-boltons
+        - py${{range.key}}-conda-libmamba-solver
+        - py${{range.key}}-conda-package-handling
+        - py${{range.key}}-conda-package-streaming
+        - py${{range.key}}-libmambapy
+        - py${{range.key}}-packaging
+        - py${{range.key}}-platformdirs
+        - py${{range.key}}-pluggy
+        - py${{range.key}}-pycosat
+        - py${{range.key}}-requests
+        - py${{range.key}}-ruamel-yaml
+        - py${{range.key}}-tqdm
     pipeline:
       - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
       - name: "move usr/bin executables for -bin"
         runs: |
-          mkdir -p ./cleanup/
-          mv ${{targets.contextdir}}/usr/bin ./cleanup/
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
       - uses: strip
 
-  - name: py3-conda-bin
-    description: Executable binaries for conda installed for python3
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
     dependencies:
       runtime:
-        - py3-conda
+        - py${{range.key}}-${{vars.pypi-package}}
+        - python-${{range.key}}
       provides:
         - conda
-      provider-priority: "312"
+      provider-priority: ${{range.value}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/
-          mv ./cleanup/bin ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
   - name: ${{package.name}}-init
     description: Initializes conda

--- a/conda.yaml
+++ b/conda.yaml
@@ -3,7 +3,7 @@
 package:
   name: conda
   version: 24.11.1
-  epoch: 0
+  epoch: 1
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause

--- a/conda.yaml
+++ b/conda.yaml
@@ -16,6 +16,14 @@ package:
 vars:
   pypi-package: conda
   import: conda
+  test-commands: |
+    conda --version
+    conda info
+    conda init
+    conda create -n foo
+    conda install -n foo numpy
+    conda install -n foo --solver=classic requests
+    conda --help
 
 data:
   - name: py-versions
@@ -105,6 +113,9 @@ subpackages:
       - runs: |
           mkdir -p ${{targets.contextdir}}/usr/
           mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      pipeline:
+        - runs: ${{vars.test-commands}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -178,11 +189,4 @@ update:
 
 test:
   pipeline:
-    - runs: |
-        conda --version
-        conda info
-        conda init
-        conda create -n foo
-        conda install -n foo numpy
-        conda install -n foo --solver=classic requests
-        conda --help
+    - runs: ${{vars.test-commands}}

--- a/py3-conda-libmamba-solver.yaml
+++ b/py3-conda-libmamba-solver.yaml
@@ -22,9 +22,6 @@ environment:
       - py3-setuptools
       - python3
       - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
 
 pipeline:
   - uses: git-checkout

--- a/py3-conda-libmamba-solver.yaml
+++ b/py3-conda-libmamba-solver.yaml
@@ -11,6 +11,45 @@ package:
 vars:
   pypi-package: conda-libmamba-solver
   import: conda_libmamba_solver
+  test-comprehensive: |
+    python3 <<-EOF
+    from conda.models.match_spec import MatchSpec
+    from conda.models.channel import Channel
+    from conda_libmamba_solver.solver import LibMambaSolver
+
+    # Test a simple solve scenario
+    channel = Channel('defaults')
+    solver = LibMambaSolver(
+      prefix='/tmp/test-env',
+        channels=[channel],
+        specs_to_add=[MatchSpec('python=3.10'), MatchSpec('numpy')]
+    )
+
+    try:
+        solution = solver.solve_final_state()
+        if not solution:
+            raise Exception("No solution returned.")
+
+        # Check that expected packages are present
+        solved_names = {pkg.name for pkg in solution}
+        for expected in ['python', 'numpy']:
+            if expected not in solved_names:
+                raise Exception(f"Expected {expected} in solution, got {solved_names}")
+
+        print("Solver returned a valid solution containing python and numpy.")
+
+    except Exception as e:
+        print(f"Error during solver test: {e}")
+        exit(1)
+
+    # Test a conflicting scenario
+    solver.specs_to_add = [MatchSpec('python=3.10'), MatchSpec('python=3.9')]
+    try:
+        conflict_solution = solver.solve_final_state()
+        raise Exception("Expected a conflict, but solver returned a solution.")
+    except Exception as conflict_exception:
+        print("As expected, no solution could be found for conflicting specs.")
+    EOF
 
 data:
   - name: py-versions
@@ -53,11 +92,21 @@ subpackages:
           python: python${{range.key}}
       - uses: strip
     test:
+      environment:
+        contents:
+          packages:
+            # The comprehensive solver test will use `python3`, so let's
+            # make sure it points to the python3.x we want to test by
+            # installing python-3.x.
+            - py${{range.key}}-conda
+            - python-${{range.key}}
       pipeline:
         - uses: python/import
           with:
             python: python${{range.key}}
             import: ${{vars.import}}
+        - name: "Run comprehensive solver test for python${{range.key}}"
+          runs: ${{vars.test-comprehensive}}
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions
@@ -95,50 +144,12 @@ test:
   environment:
     contents:
       packages:
-        - python3
         - conda
+        - python3
   pipeline:
     - uses: python/import
       with:
         python: python3
         import: ${{vars.import}}
-    - name: "Run comprehensive solver test"
-      runs: |
-        python3 <<-EOF
-        from conda.models.match_spec import MatchSpec
-        from conda.models.channel import Channel
-        from conda_libmamba_solver.solver import LibMambaSolver
-
-        # Test a simple solve scenario
-        channel = Channel('defaults')
-        solver = LibMambaSolver(
-            prefix='/tmp/test-env',
-            channels=[channel],
-            specs_to_add=[MatchSpec('python=3.10'), MatchSpec('numpy')]
-        )
-
-        try:
-            solution = solver.solve_final_state()
-            if not solution:
-                raise Exception("No solution returned.")
-
-            # Check that expected packages are present
-            solved_names = {pkg.name for pkg in solution}
-            for expected in ['python', 'numpy']:
-                if expected not in solved_names:
-                    raise Exception(f"Expected {expected} in solution, got {solved_names}")
-
-            print("Solver returned a valid solution containing python and numpy.")
-
-        except Exception as e:
-            print(f"Error during solver test: {e}")
-            exit(1)
-
-        # Test a conflicting scenario
-        solver.specs_to_add = [MatchSpec('python=3.10'), MatchSpec('python=3.9')]
-        try:
-            conflict_solution = solver.solve_final_state()
-            raise Exception("Expected a conflict, but solver returned a solution.")
-        except Exception as conflict_exception:
-            print("As expected, no solution could be found for conflicting specs.")
-        EOF
+    - name: "Run comprehensive solver test w/ python3"
+      runs: ${{vars.test-comprehensive}}

--- a/py3-conda-libmamba-solver.yaml
+++ b/py3-conda-libmamba-solver.yaml
@@ -17,12 +17,8 @@ vars:
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
       - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-setuptools
+      - py3-build-base
       - python3
       - wolfi-base
 

--- a/py3-conda-libmamba-solver.yaml
+++ b/py3-conda-libmamba-solver.yaml
@@ -19,7 +19,8 @@ environment:
     packages:
       - ca-certificates-bundle
       - py3-build-base
-      - python3
+      - py3-hatch-vcs
+      - py3-hatchling
       - wolfi-base
 
 pipeline:
@@ -29,11 +30,7 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: e09df1271eac29b62c0c773a24c5b05a9dd5b8ae
 
-  - name: Python Build
-    runs: python -m build
-
-  - name: Python Install
-    runs: python -m installer -d "${{targets.destdir}}/" dist/*.whl
+  - uses: py/pip-build-install
 
   - uses: strip
 

--- a/py3-conda-libmamba-solver.yaml
+++ b/py3-conda-libmamba-solver.yaml
@@ -6,21 +6,27 @@ package:
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-boltons
-      - py3-libmambapy
-      - python3
+    provider-priority: 0
 
 vars:
+  pypi-package: conda-libmamba-solver
   import: conda_libmamba_solver
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "300"
 
 environment:
   contents:
     packages:
       - ca-certificates-bundle
-      - py3-build-base
-      - py3-hatch-vcs
-      - py3-hatchling
+      - py3-supported-build-base
+      - py3-supported-hatch-vcs
+      - py3-supported-hatchling
       - wolfi-base
 
 pipeline:
@@ -30,9 +36,55 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: e09df1271eac29b62c0c773a24c5b05a9dd5b8ae
 
-  - uses: py/pip-build-install
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+      runtime:
+        - py${{range.key}}-boltons
+        - py${{range.key}}-libmambapy
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.12
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.13
+            import: ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-conda-libmamba-solver.yaml
+++ b/py3-conda-libmamba-solver.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-conda-libmamba-solver
   version: 24.11.1
-  epoch: 0
+  epoch: 1
   description: The libmamba based solver for conda.
   copyright:
     - license: BSD-3-Clause

--- a/py3-conda-libmamba-solver.yaml
+++ b/py3-conda-libmamba-solver.yaml
@@ -11,6 +11,9 @@ package:
       - py3-libmambapy
       - python3
 
+vars:
+  import: conda_libmamba_solver
+
 environment:
   contents:
     packages:
@@ -50,8 +53,10 @@ test:
         - python3
         - conda
   pipeline:
-    - runs: |
-        python3 -c "import conda_libmamba_solver"
+    - uses: python/import
+      with:
+        python: python3
+        import: ${{vars.import}}
     - name: "Run comprehensive solver test"
       runs: |
         python3 <<-EOF

--- a/py3-conda-libmamba-solver.yaml
+++ b/py3-conda-libmamba-solver.yaml
@@ -54,10 +54,10 @@ vars:
 data:
   - name: py-versions
     items:
+      # 3.13 is disabled until conda is available
       3.10: "310"
       3.11: "311"
       3.12: "312"
-      3.13: "300"
 
 environment:
   contents:
@@ -115,7 +115,6 @@ subpackages:
         - py3.10-${{vars.pypi-package}}
         - py3.11-${{vars.pypi-package}}
         - py3.12-${{vars.pypi-package}}
-        - py3.13-${{vars.pypi-package}}
     test:
       pipeline:
         - uses: python/import
@@ -129,10 +128,6 @@ subpackages:
         - uses: python/import
           with:
             python: python3.12
-            import: ${{vars.import}}
-        - uses: python/import
-          with:
-            python: python3.13
             import: ${{vars.import}}
 
 update:


### PR DESCRIPTION
Now that [libmambapy is multiversioned](https://github.com/wolfi-dev/os/pull/36030), we can move up the stack. 

I started with `py3-conda-libmamba-solver`, but found that it had dependencies on `conda`, which is really a python package in disguise, so I give it  the `py3-` treatment here.

The other significant thing worth noting is that I abuse variables here to hold test code so I can share it between the main package and subpackages. I generally want to make sure tests work with each `py3.x-foo`, but also want to make sure we didn't regress that test for users who are pulling in the legacy provides, and hate cut & pasting code. Another option we could consider is to put the tests in scripts outside of the YAML, similar to how we include local patches.

Note: there's a pseudo-circular dependency here. `py3-conda-libmamba-solver` uses `py3-conda` from `conda` in its test cases, and `conda` uses `py3-conda-libmamba-solver` at runtime.

Also note that Python 3.13 support is currently blocked - upstream doesn't support it yet. I've filed and referenced the upstream issue.

See individual commit logs for details.
