### PR TITLE
local-static-provisioner-GHSA-27wf-5967-98gx-fix

### DIFF
--- a/local-static-provisioner.yaml
+++ b/local-static-provisioner.yaml
@@ -1,7 +1,7 @@
 package:
   name: local-static-provisioner
   version: 2.7.0
-  epoch: 7
+  epoch: 8
   description: Static provisioner of local volumes
   copyright:
     - license: Apache-2.0
@@ -26,10 +26,12 @@ pipeline:
       repository: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
       tag: v${{package.version}}
       expected-commit: 4f81db77908ff67d8cac223c31413a293cd65d73
-
+  - uses: patch
+    with:
+      patches: k8s-GHSA-27wf-5967-98gx-fix.patch
   - uses: go/bump
     with:
-      deps: google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0 k8s.io/apiserver@v0.27.13 k8s.io/kubernetes@v1.27.16
+      deps: google.golang.org/protobuf@v1.35.2 golang.org/x/net@v0.32.0 golang.org/x/crypto@v0.31.0
 
   - uses: go/build
     with:

--- a/local-static-provisioner.yaml
+++ b/local-static-provisioner.yaml
@@ -26,9 +26,11 @@ pipeline:
       repository: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner
       tag: v${{package.version}}
       expected-commit: 4f81db77908ff67d8cac223c31413a293cd65d73
+
   - uses: patch
     with:
       patches: k8s-GHSA-27wf-5967-98gx-fix.patch
+
   - uses: go/bump
     with:
       deps: google.golang.org/protobuf@v1.35.2 golang.org/x/net@v0.32.0 golang.org/x/crypto@v0.31.0

--- a/local-static-provisioner/k8s-GHSA-27wf-5967-98gx-fix.patch
+++ b/local-static-provisioner/k8s-GHSA-27wf-5967-98gx-fix.patch
@@ -1,0 +1,108 @@
+diff --git a/go.mod b/go.mod
+index d19a005d..166c689b 100644
+--- a/go.mod
++++ b/go.mod
+@@ -11,13 +11,13 @@ require (
+ 	github.com/spf13/pflag v1.0.5
+ 	golang.org/x/sys v0.17.0
+ 	gopkg.in/yaml.v2 v2.4.0
+-	k8s.io/api v0.27.8
+-	k8s.io/apimachinery v0.27.8
+-	k8s.io/apiserver v0.27.8
+-	k8s.io/client-go v0.27.8
+-	k8s.io/component-base v0.27.8
++	k8s.io/api v0.28.15
++	k8s.io/apimachinery v0.28.15
++	k8s.io/apiserver v0.28.15
++	k8s.io/client-go v0.28.15
++	k8s.io/component-base v0.28.15
+ 	k8s.io/klog/v2 v2.90.1
+-	k8s.io/kubernetes v1.27.8
++	k8s.io/kubernetes v1.28.15
+ 	k8s.io/pod-security-admission v0.0.0
+ 	k8s.io/utils v0.0.0-20230209194617-a36077c30491
+ 	sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0
+@@ -123,15 +123,15 @@ require (
+ 	gopkg.in/warnings.v0 v0.1.1 // indirect
+ 	gopkg.in/yaml.v3 v3.0.1 // indirect
+ 	k8s.io/apiextensions-apiserver v0.0.0 // indirect
+-	k8s.io/cloud-provider v0.27.8 // indirect
+-	k8s.io/component-helpers v0.27.8 // indirect
+-	k8s.io/controller-manager v0.27.8 // indirect
+-	k8s.io/kms v0.27.8 // indirect
++	k8s.io/cloud-provider v0.28.15 // indirect
++	k8s.io/component-helpers v0.28.15 // indirect
++	k8s.io/controller-manager v0.28.15 // indirect
++	k8s.io/kms v0.28.15 // indirect
+ 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
+ 	k8s.io/kubectl v0.0.0 // indirect
+ 	k8s.io/kubelet v0.0.0 // indirect
+ 	k8s.io/legacy-cloud-providers v0.0.0 // indirect
+-	k8s.io/mount-utils v0.27.8 // indirect
++	k8s.io/mount-utils v0.28.15 // indirect
+ 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.1.2 // indirect
+ 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
+ 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
+@@ -139,33 +139,33 @@ require (
+ 
+ replace (
+ 	github.com/emicklei/go-restful => github.com/emicklei/go-restful/v3 v3.8.0
+-	k8s.io/api => k8s.io/api v0.27.8
+-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.27.8
+-	k8s.io/apimachinery => k8s.io/apimachinery v0.27.8
+-	k8s.io/apiserver => k8s.io/apiserver v0.27.8
+-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.27.8
+-	k8s.io/client-go => k8s.io/client-go v0.27.8
+-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.27.8
+-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.27.8
+-	k8s.io/code-generator => k8s.io/code-generator v0.27.8
+-	k8s.io/component-base => k8s.io/component-base v0.27.8
+-	k8s.io/component-helpers => k8s.io/component-helpers v0.27.8
+-	k8s.io/controller-manager => k8s.io/controller-manager v0.27.8
+-	k8s.io/cri-api => k8s.io/cri-api v0.27.8
+-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.27.8
+-	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.27.8
+-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.27.8
+-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.27.8
+-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.27.8
+-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.27.8
+-	k8s.io/kubectl => k8s.io/kubectl v0.27.8
+-	k8s.io/kubelet => k8s.io/kubelet v0.27.8
+-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.27.8
+-	k8s.io/metrics => k8s.io/metrics v0.27.8
+-	k8s.io/mount-utils => k8s.io/mount-utils v0.27.8
+-	k8s.io/node-api => k8s.io/node-api v0.27.8
+-	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.27.8
+-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.27.8
+-	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.27.8
+-	k8s.io/sample-controller => k8s.io/sample-controller v0.27.8
++	k8s.io/api => k8s.io/api v0.28.15
++	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.28.15
++	k8s.io/apimachinery => k8s.io/apimachinery v0.28.15
++	k8s.io/apiserver => k8s.io/apiserver v0.28.15
++	k8s.io/cli-runtime => k8s.io/cli-runtime v0.28.15
++	k8s.io/client-go => k8s.io/client-go v0.28.15
++	k8s.io/cloud-provider => k8s.io/cloud-provider v0.28.15
++	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.28.15
++	k8s.io/code-generator => k8s.io/code-generator v0.28.15
++	k8s.io/component-base => k8s.io/component-base v0.28.15
++	k8s.io/component-helpers => k8s.io/component-helpers v0.28.15
++	k8s.io/controller-manager => k8s.io/controller-manager v0.28.15
++	k8s.io/cri-api => k8s.io/cri-api v0.28.15
++	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.28.15
++	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.28.15
++	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.28.15
++	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.28.15
++	k8s.io/kube-proxy => k8s.io/kube-proxy v0.28.15
++	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.28.15
++	k8s.io/kubectl => k8s.io/kubectl v0.28.15
++	k8s.io/kubelet => k8s.io/kubelet v0.28.15
++	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.28.15
++	k8s.io/metrics => k8s.io/metrics v0.28.15
++	k8s.io/mount-utils => k8s.io/mount-utils v0.28.15
++	k8s.io/node-api => k8s.io/node-api v0.28.15
++	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.28.15
++	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.28.15
++	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.28.15
++	k8s.io/sample-controller => k8s.io/sample-controller v0.28.15
+ )


### PR DESCRIPTION
Manually created a patch that updates the affected version of k8s to the unaffected version. k8s are a mess to try and update via the go/bump method so a patch is much more effective, also remediated [CVE-2024-45337](https://www.cve.org/CVERecord?id=CVE-2024-45337) by bumping golang.org/x/crypto version