### PR TITLE
oxipng: new package

### DIFF
--- a/oxipng.yaml
+++ b/oxipng.yaml
@@ -1,0 +1,47 @@
+package:
+  name: oxipng
+  version: 9.1.3
+  epoch: 0
+  description: Multithreaded PNG optimizer written in Rust
+  copyright:
+    - license: MIT
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/shssoichiro/oxipng
+      tag: v${{package.version}}
+      expected-commit: e8e8309c2da99676d2be0859df66314fa4fd42c3
+
+  - uses: cargo/build
+    with:
+      output: ${{package.name}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: shssoichiro/oxipng
+    strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - imagemagick
+  pipeline:
+    - name: Verify oxipng version
+      runs: |
+        oxipng --version | grep "${{package.version}}"
+    - name: Create a dummy PNG file
+      runs: |
+        magick -size 100x100 xc:blue test.png || echo "ImageMagick needed for testing"
+    - name: Optimize the PNG file
+      runs: |
+        oxipng --filters 6 test.png --out optimized.png
+    - name: Check the optimized file size
+      runs: |
+        { test -s optimized.png && \
+          test $(stat -c%s optimized.png) -lt $(stat -c%s test.png); } || \
+          exit 1

--- a/oxipng.yaml
+++ b/oxipng.yaml
@@ -7,9 +7,8 @@ package:
     - license: MIT
 
 environment:
-  contents:
-    packages:
-      - openssf-compiler-options
+  environment:
+    RUSTFLAGS: "-C linker=/usr/local/bin/gcc"
 
 pipeline:
   - uses: git-checkout

--- a/oxipng.yaml
+++ b/oxipng.yaml
@@ -6,6 +6,11 @@ package:
   copyright:
     - license: MIT
 
+environment:
+  contents:
+    packages:
+      - openssf-compiler-options
+
 pipeline:
   - uses: git-checkout
     with:


### PR DESCRIPTION
#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates

