### PR TITLE
nodetaint/GHSA-27wf-5967-98gx fix

### DIFF
--- a/nodetaint.yaml
+++ b/nodetaint.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodetaint
   version: 0.0.4
-  epoch: 22
+  epoch: 23
   description: Controller to manage taints for nodes in a k8s cluster.
   copyright:
     - license: Apache-2.0
@@ -23,36 +23,35 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: k8s.io/api@v0.27.13 k8s.io/client-go@v0.27.13 google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0 k8s.io/apimachinery@v0.27.13 k8s.io/kubernetes@v1.27.16
+      deps: k8s.io/api@v0.28.15 k8s.io/client-go@v0.28.15 google.golang.org/protobuf@v1.33.0 golang.org/x/net@v0.23.0 k8s.io/apimachinery@v0.28.15 k8s.io/kubernetes@v1.28.15
 
   - runs: |
-      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487
+      # Mitigate CVE-2023-39325, CVE-2023-3978, CVE-2023-44487, GHSA-27wf-5967-98gx
 
       # CVE-2021-25736, CVE-2023-3676, CVE-2023-3955, GHSA-8cfg-vx93-jvxw
-      go mod edit -replace=k8s.io/api=k8s.io/api@v0.27.8
-      go mod edit -replace=k8s.io/apiextensions-apiserver=k8s.io/apiextensions-apiserver@v0.27.8
-      go mod edit -replace=k8s.io/apimachinery=k8s.io/apimachinery@v0.27.8
-      go mod edit -replace=k8s.io/apiserver=k8s.io/apiserver@v0.27.8
-      go mod edit -replace=k8s.io/cli-runtime=k8s.io/cli-runtime@v0.27.8
-      go mod edit -replace=k8s.io/client-go=k8s.io/client-go@v0.27.8
-      go mod edit -replace=k8s.io/cloud-provider=k8s.io/cloud-provider@v0.27.8
-      go mod edit -replace=k8s.io/cluster-bootstrap=k8s.io/cluster-bootstrap@v0.27.8
-      go mod edit -replace=k8s.io/code-generator=k8s.io/code-generator@v0.27.8
-      go mod edit -replace=k8s.io/component-base=k8s.io/component-base@v0.27.8
-      go mod edit -replace=k8s.io/cri-api=k8s.io/cri-api@v0.27.8
-      go mod edit -replace=k8s.io/csi-translation-lib=k8s.io/csi-translation-lib@v0.27.8
-      go mod edit -replace=k8s.io/kube-aggregator=k8s.io/kube-aggregator@v0.27.8
-      go mod edit -replace=k8s.io/kube-controller-manager=k8s.io/kube-controller-manager@v0.27.8
-      go mod edit -replace=k8s.io/kube-proxy=k8s.io/kube-proxy@v0.27.8
-      go mod edit -replace=k8s.io/kube-scheduler=k8s.io/kube-scheduler@v0.27.8
-      go mod edit -replace=k8s.io/kubectl=k8s.io/kubectl@v0.27.8
-      go mod edit -replace=k8s.io/kubelet=k8s.io/kubelet@v0.27.8
-      go mod edit -replace=k8s.io/legacy-cloud-providers=k8s.io/legacy-cloud-providers@v0.27.8
-      go mod edit -replace=k8s.io/metrics=k8s.io/metrics@v0.27.8
-      go mod edit -replace=k8s.io/sample-apiserver=k8s.io/sample-apiserver@v0.27.8
-      go mod edit -replace=k8s.io/sample-cli-plugin=k8s.io/sample-cli-plugin@v0.27.8
-      go mod edit -replace=k8s.io/sample-controller=k8s.io/sample-controller@v0.27.8
-
+      go mod edit -replace=k8s.io/api=k8s.io/api@v0.28.15
+      go mod edit -replace=k8s.io/apiextensions-apiserver=k8s.io/apiextensions-apiserver@v0.28.15
+      go mod edit -replace=k8s.io/apimachinery=k8s.io/apimachinery@v0.28.15
+      go mod edit -replace=k8s.io/apiserver=k8s.io/apiserver@v0.28.15
+      go mod edit -replace=k8s.io/cli-runtime=k8s.io/cli-runtime@v0.28.15
+      go mod edit -replace=k8s.io/client-go=k8s.io/client-go@v0.28.15
+      go mod edit -replace=k8s.io/cloud-provider=k8s.io/cloud-provider@v0.28.15
+      go mod edit -replace=k8s.io/cluster-bootstrap=k8s.io/cluster-bootstrap@v0.28.15
+      go mod edit -replace=k8s.io/code-generator=k8s.io/code-generator@v0.28.15
+      go mod edit -replace=k8s.io/component-base=k8s.io/component-base@v0.28.15
+      go mod edit -replace=k8s.io/cri-api=k8s.io/cri-api@v0.28.15
+      go mod edit -replace=k8s.io/csi-translation-lib=k8s.io/csi-translation-lib@v0.28.15
+      go mod edit -replace=k8s.io/kube-aggregator=k8s.io/kube-aggregator@v0.28.15
+      go mod edit -replace=k8s.io/kube-controller-manager=k8s.io/kube-controller-manager@v0.28.15
+      go mod edit -replace=k8s.io/kube-proxy=k8s.io/kube-proxy@v0.28.15
+      go mod edit -replace=k8s.io/kube-scheduler=k8s.io/kube-scheduler@v0.28.15
+      go mod edit -replace=k8s.io/kubectl=k8s.io/kubectl@v0.28.15
+      go mod edit -replace=k8s.io/kubelet=k8s.io/kubelet@v0.28.15
+      go mod edit -replace=k8s.io/legacy-cloud-providers=k8s.io/legacy-cloud-providers@v0.28.15
+      go mod edit -replace=k8s.io/metrics=k8s.io/metrics@v0.28.15
+      go mod edit -replace=k8s.io/sample-apiserver=k8s.io/sample-apiserver@v0.28.15
+      go mod edit -replace=k8s.io/sample-cli-plugin=k8s.io/sample-cli-plugin@v0.28.15
+      go mod edit -replace=k8s.io/sample-controller=k8s.io/sample-controller@v0.28.15
       go mod tidy -compat=1.17
 
       CGO_ENABLED=0 GOARCH=$(go env GOARCH) GOOS=$(go env GOOS) go build -o . -a -installsuffix cgo .


### PR DESCRIPTION
This is a good example as to how cluttered a package can get when attempting to remediate k8s dependencies with go mod / go/bump. It is a simple version bump but the dependencies are so tightly coupled and with no recursive dependency updating there can be trail and error in finding everything needing to be updated. Anyway, version bumped, epoch bumped. 