### PR TITLE
Converted mercurial package to build with each supported python version

### DIFF
--- a/mercurial.yaml
+++ b/mercurial.yaml
@@ -50,7 +50,7 @@ subpackages:
         - py3-${{vars.pypi-package}}
         - mercurial
       runtime:
-        - py${{range.key}}
+        - python-${{range.key}}
     pipeline:
       - runs: |
           # Build the wheel for this python version

--- a/mercurial.yaml
+++ b/mercurial.yaml
@@ -59,13 +59,13 @@ subpackages:
             --output-fd 3 3>&1 >&2
 
           # Install the built wheel
-          python${{range.key}} -m installer -d "${{targets.subpkgdir}}" dist/mercurial-6.9-cp*.whl
+          python${{range.key}} -m installer -d "${{targets.subpkgdir}}" dist/mercurial-${{package.version}}-cp*.whl
 
           # Copy the hg bins to the right location
           install -Dm755 contrib/hg-ssh hgeditor -t "${{targets.subpkgdir}}/usr/bin"
 
           # Cleanup the wheel so the other subpackages don't try to install it too
-          rm -f dist/mercurial-6.9-cp*.whl
+          rm -f dist/mercurial-${{package.version}}-cp*.whl
       - uses: strip
     test:
       pipeline:

--- a/mercurial.yaml
+++ b/mercurial.yaml
@@ -1,13 +1,23 @@
 package:
   name: mercurial
   version: "6.9"
-  epoch: 0
+  epoch: 1
   description: "Scalable distributed SCM tool"
   copyright:
     - license: GPL-2.0-or-later
   dependencies:
-    runtime:
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: mercurial
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '300'
 
 environment:
   contents:
@@ -16,12 +26,11 @@ environment:
       - busybox
       - ca-certificates-bundle
       - gettext-dev
-      - py3-flit-core
-      - py3-gpep517
-      - py3-setuptools
-      - py3-wheel
-      - python3
-      - python3-dev
+      - py3-supported-flit-core
+      - py3-supported-gpep517
+      - py3-supported-python-dev
+      - py3-supported-setuptools
+      - py3-supported-wheel
       - wolfi-base
       - zlib-dev
 
@@ -31,28 +40,58 @@ pipeline:
       uri: https://www.mercurial-scm.org/release/mercurial-${{package.version}}.tar.gz
       expected-sha256: 629604293df2be8171ec856bf4f8b4faa8e4305af13607dce0f89f74132836d6
 
-  - runs: |
-      python3 -m gpep517 build-wheel \
-        --wheel-dir dist \
-        --output-fd 3 3>&1 >&2
-
-      python3 -m installer -d "${{targets.destdir}}" \
-        dist/*.whl
-
-      install -Dm755 contrib/hg-ssh hgeditor -t "${{targets.destdir}}"/usr/bin
-
-      for man in doc/*.?; do
-        install -Dm644 "$man" \
-          "${{targets.destdir}}"/usr/share/man/man${man##*.}/${man##*/}
-      done
-
-  - uses: strip
-
 subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+        - mercurial
+      runtime:
+        - py${{range.key}}
+    pipeline:
+      - runs: |
+          # Build the wheel for this python version
+          python${{range.key}} -m gpep517 build-wheel \
+            --wheel-dir dist \
+            --output-fd 3 3>&1 >&2
+
+          # Install the built wheel
+          python${{range.key}} -m installer -d "${{targets.subpkgdir}}" dist/mercurial-6.9-cp*.whl
+
+          # Copy the hg bins to the right location
+          install -Dm755 contrib/hg-ssh hgeditor -t "${{targets.subpkgdir}}/usr/bin"
+
+          # Cleanup the wheel so the other subpackages don't try to install it too
+          rm -f dist/mercurial-6.9-cp*.whl
+      - uses: strip
+    test:
+      pipeline:
+        - runs: |
+            hg --version
+            hg --help
+
   - name: "mercurial-doc"
     description: "mercurial documentation"
     pipeline:
+      - runs: |
+          for man in doc/*.?; do
+            install -Dm644 "$man" \
+              "${{targets.destdir}}"/usr/share/man/man${man##*.}/${man##*/}
+          done
+      - uses: strip
       - uses: split/manpages
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/mercurial.yaml
+++ b/mercurial.yaml
@@ -84,15 +84,6 @@ subpackages:
       - uses: strip
       - uses: split/manpages
 
-  - name: py3-supported-${{vars.pypi-package}}
-    description: meta package providing ${{vars.pypi-package}} for supported python versions.
-    dependencies:
-      runtime:
-        - py3.10-${{vars.pypi-package}}
-        - py3.11-${{vars.pypi-package}}
-        - py3.12-${{vars.pypi-package}}
-        - py3.13-${{vars.pypi-package}}
-
 update:
   enabled: true
   release-monitor:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Firefox needs an older Python version to resolve a build issue, but it also relies on Mercurial being built with that same older Python version. This provides those older python version builds without any impact on other packages using Mercurial. 

Related: https://github.com/wolfi-dev/os/pull/36188

I definitely learned a lot during this conversion, so please fact check everything I did to make sure I haven't missed anything. Thanks! 