### PR TITLE
openssh: support config snippets includes

### DIFF
--- a/openssh.yaml
+++ b/openssh.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssh
   version: 9.9_p1
-  epoch: 2
+  epoch: 3
   description: "the OpenBSD SSH implementation"
   copyright:
     - license: ISC
@@ -122,6 +122,8 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/etc/ssh
           mv "${{targets.destdir}}"/etc/ssh/moduli "${{targets.subpkgdir}}"/etc/ssh/
           mv "${{targets.destdir}}"/etc/ssh/ssh_config "${{targets.subpkgdir}}"/etc/ssh/
+          mkdir -p "${{targets.subpkgdir}}"/etc/ssh/ssh_config.d
+          sed -i 's|\(^# Host\)|Include /etc/ssh/ssh_config.d/*.conf\n\n\1|' "${{targets.subpkgdir}}"/etc/ssh/ssh_config
 
   - name: "openssh-server"
     description: "OpenSSH server"


### PR DESCRIPTION
This allows to ship config snippets for hardened configurations.

This also creates config parity with Debian & Ubuntu.