### PR TITLE
Fix a ftbfs with asciidoc due to an incorrect dep

### DIFF
--- a/asciidoc.yaml
+++ b/asciidoc.yaml
@@ -17,7 +17,7 @@ environment:
       - git
       - libxml2-utils
       - libxslt
-      - py3-pip
+      - py3-supported-pip
       - python3
       - wolfi-base
 

--- a/asciidoc.yaml
+++ b/asciidoc.yaml
@@ -6,6 +6,9 @@ package:
   copyright:
     - license: GPL-2.0-or-later
 
+vars:
+  py-version: 3.13
+
 environment:
   contents:
     packages:
@@ -17,8 +20,8 @@ environment:
       - git
       - libxml2-utils
       - libxslt
-      - py3-supported-pip
-      - python3
+      - py${{vars.py-version}}-pip
+      - python-${{vars.py-version}}
       - wolfi-base
 
 pipeline:
@@ -27,6 +30,10 @@ pipeline:
       repository: https://github.com/asciidoc-py/asciidoc-py
       tag: ${{package.version}}
       expected-commit: 21e33efe96ba9a51d99d1150691dae750afd6ed1
+
+  - uses: patch
+    with:
+      patches: allow-specify-python.yaml
 
   - runs: |
       autoreconf -fi
@@ -40,8 +47,12 @@ pipeline:
         --infodir=/usr/share/info
 
   - uses: autoconf/make
+    with:
+      opts: PYTHON=python${{vars.py-version}}
 
   - uses: autoconf/make-install
+    with:
+      opts: PYTHON=python${{vars.py-version}}
 
 update:
   enabled: true

--- a/asciidoc.yaml
+++ b/asciidoc.yaml
@@ -1,7 +1,7 @@
 package:
   name: asciidoc
   version: 10.2.1
-  epoch: 0
+  epoch: 1
   description: "Text based documentation"
   copyright:
     - license: GPL-2.0-or-later

--- a/asciidoc/allow-specify-python.yaml
+++ b/asciidoc/allow-specify-python.yaml
@@ -1,0 +1,77 @@
+From af56a5e8290c3a6fbcfd9ef32be90fef147fdb91 Mon Sep 17 00:00:00 2001
+From: Scott Moser <scott.moser@chainguard.dev>
+Date: Thu, 12 Dec 2024 14:04:32 -0500
+Subject: [PATCH] Allow python to be provided in Makefile
+
+When 'python3' is used to do the install (through `make install`)
+then the shbang on the installed program will be /usr/bin/python3.
+For systems with more than one python, it is better to invoke
+with python3.X so that the shbang has the proper value
+(/usr/bin/python3.X rather than /usr/bin/python3).
+
+https://github.com/asciidoc-py/asciidoc-py/pull/276
+---
+ Makefile.in | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 35861db..934928e 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -29,6 +29,7 @@ doc = $(wildcard README*) $(wildcard BUGS*) $(wildcard INSTALL*) $(wildcard CHAN
+ 
+ TARGETS = doc
+ 
++PYTHON ?= python3
+ DESTDIR ?= /
+ 
+ INSTDIRS = $(TARGETS:%=%dir)
+@@ -53,7 +54,7 @@ $(INSTDIRS):
+ 	$(INSTALL) -d $(DESTDIR)$($@)
+ 
+ $(manp): %.1 : %.1.txt
+-	python3 -m asciidoc.a2x -f manpage $<
++	$(PYTHON) -m asciidoc.a2x -f manpage $<
+ 
+ ##.
+ 
+@@ -78,7 +79,7 @@ doc_spell: spell
+ 
+ .PHONY: pip
+ pip:
+-	python3 -m pip install --root $(DESTDIR) .
++	$(PYTHON) -m pip install --root $(DESTDIR) .
+ 
+ ##   install: install asciidoc to target directory
+ .PHONY: install
+@@ -109,7 +110,7 @@ docs:
+ ##   uninstall: uninstall asciidoc
+ .PHONY: uninstall
+ uninstall:
+-	python3 -m pip uninstall asciidoc
++	$(PYTHON) -m pip uninstall asciidoc
+ 	rm -f $(DESTDIR)$(manpdir)/asciidoc.1
+ 	rm -f $(DESTDIR)$(manpdir)/testasciidoc.1
+ 	rm -f $(DESTDIR)$(manpdir)/a2x.1
+@@ -121,7 +122,7 @@ clean:
+ 	rm -f $(manp)
+ 
+ MANIFEST: build_manifest.py
+-	python3 build_manifest.py
++	$(PYTHON) build_manifest.py
+ 
+ ##.
+ ##   dist: creates the zip and tarball for release
+@@ -140,6 +141,6 @@ dist: manpages MANIFEST
+ ##   test: run the asciidoc test suite
+ .PHONY: test
+ test:
+-	python3 -m asciidoc.asciidoc --doctest
+-	python3 -m pytest
+-	python3 tests/testasciidoc.py run
++	$(PYTHON) -m asciidoc.asciidoc --doctest
++	$(PYTHON) -m pytest
++	$(PYTHON) tests/testasciidoc.py run
+-- 
+2.47.1
+


### PR DESCRIPTION
Before changing the dependency the build was failing like this:

```
2024-12-12T07:55:38Z INFO make: Entering directory '/home/build'
2024-12-12T07:55:38Z INFO python3 -m pip install --root /home/build/melange-out/asciidoc .
2024-12-12T07:55:38Z WARN /usr/bin/python3: No module named pip
2024-12-12T07:55:38Z INFO make: Leaving directory '/home/build'
2024-12-12T07:55:38Z WARN make: *** [Makefile:81: pip] Error 1
2024-12-12T07:55:39Z INFO deleting guest dir /tmp/melange-guest-1045945340
2024-12-12T07:55:39Z INFO deleting workspace dir /tmp/melange-workspace-2190194630
2024-12-12T07:55:40Z INFO removing image path /tmp/melange-guest-231127100
2024-12-12T07:55:41Z ERRO failed to build package: unable to run package asciidoc pipeline: unable to run pipeline: unable to run pipeline: exit status 2
```