### PR TITLE
Fix a ftbfs with ldb due to a changed url

### DIFF
--- a/ldb.yaml
+++ b/ldb.yaml
@@ -1,7 +1,7 @@
 package:
   name: ldb
   version: 2.9.1
-  epoch: 2
+  epoch: 3
   description: schema-less, ldap like, API and database
   copyright:
     - license: LGPL-3.0-or-later

--- a/ldb.yaml
+++ b/ldb.yaml
@@ -32,7 +32,7 @@ pipeline:
   - uses: fetch
     with:
       expected-sha256: c95e4dc32dea8864b79899ee340c9fdf28b486f464bbc38ba99151a08b493f9b
-      uri: https://www.samba.org/ftp/pub/ldb/ldb-${{package.version}}.tar.gz
+      uri: https://www.samba.org/ftp/ldb/ldb-${{package.version}}.tar.gz
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
Before this change the package was failing to build from source:

```
2024-12-12T08:19:01Z WARN /sbin/ldconfig: /usr/lib/liblmdb.so.0 is not a symbolic link
2024-12-12T08:19:01Z WARN
2024-12-12T08:19:01Z INFO running step "fetch"
2024-12-12T08:19:14Z WARN --2024-12-12 08:19:14--  https://www.samba.org/ftp/pub/ldb/ldb-2.9.1.tar.gz
2024-12-12T08:19:14Z WARN Resolving www.samba.org... 144.76.82.148, 2a01:4f8:192:486::2:3
2024-12-12T08:19:14Z WARN Connecting to www.samba.org|144.76.82.148|:443... connected.
2024-12-12T08:19:15Z WARN HTTP request sent, awaiting response... 404 Not Found
2024-12-12T08:19:15Z WARN 2024-12-12 08:19:15 ERROR 404: Not Found.
2024-12-12T08:19:15Z WARN
2024-12-12T08:19:15Z INFO deleting guest dir /tmp/melange-guest-1384848019
2024-12-12T08:19:15Z INFO deleting workspace dir /tmp/melange-workspace-1279168773
2024-12-12T08:19:15Z INFO removing image path /tmp/melange-guest-241176385
2024-12-12T08:19:19Z ERRO failed to build package: unable to run package ldb pipeline: unable to run pipeline: unable to run pipeline: exit status 8
```

The url for the download changed.