### PR TITLE
feat: Add kubernetes daemonsets for fluentd 1.17

### DIFF
--- a/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
@@ -110,7 +110,7 @@ subpackages:
               sh -c "
               export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
               export GEM_HOME="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
-              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --dry-run
               "
             timeout: 10
             expected_output: parsing config file is succeeded

--- a/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
@@ -110,10 +110,11 @@ subpackages:
               sh -c "
               export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
               export GEM_HOME="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
-              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --dry-run
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --help
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --version
               "
             timeout: 10
-            expected_output: parsing config file is succeeded
+            expected_output: "Usage: fluentd"
 
 update:
   enabled: true

--- a/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
@@ -109,7 +109,7 @@ subpackages:
             start: |
               sh -c "
               export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
-              export GEM_HOME="$GEM_PATH"
+              export GEM_HOME="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
               /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile
               "
             timeout: 10

--- a/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
@@ -70,7 +70,10 @@ subpackages:
           bundle config set path ${{targets.contextdir}}/fluentd/vendor/bundle
           bundle config set clean 'true'
           bundle config set deployment 'true'
-          bundle install --gemfile ./Gemfile --jobs $(nproc)
+          # --retry doesn't seem to help with network issues, completely rerun the command
+          if ! bundle install --gemfile ./Gemfile --jobs $(nproc); then
+            bundle install --gemfile ./Gemfile --jobs $(nproc)
+          fi
           bundle config unset path
 
           # Copy gemfile

--- a/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
@@ -1,0 +1,140 @@
+package:
+  # fluentd supported versions: https://github.com/fluent/fluentd/blob/master/SECURITY.md
+  # The kubernetes daemonset trails fluentd releases by a bit
+  name: ruby3.1-fluentd-kubernetes-daemonset-1.17
+  version: 1.17.1.1.2
+  epoch: 0
+  description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libtool
+      - m4
+      - ruby${{vars.rubyMM}}-bundler
+      - ruby-${{vars.rubyMM}}-dev
+      - snappy-dev
+
+var-transforms:
+  - from: ${{package.name}}
+    match: .*-(\d+\.\d+)
+    replace: $1
+    to: fluentdMM
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+\.\d+)\.(\d+\.\d+)
+    replace: $1-$2
+    to: mangled-package-version
+
+data:
+  - name: plugins
+    items:
+      azureblob:
+      cloudwatch:
+      elasticsearch7:
+      elasticsearch8:
+      forward:
+      gcs:
+      graylog:
+      kafka:
+      kafka2:
+      kinesis:
+      logentries:
+      loggly:
+      logzio:
+      opensearch:
+      papertrail:
+      s3:
+      syslog:
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 6183f108748bc4ed980437d6f93cf5f990e33b36
+      repository: https://github.com/fluent/fluentd-kubernetes-daemonset.git
+      tag: v${{vars.mangled-package-version}}
+
+subpackages:
+  - range: plugins
+    name: ${{package.name}}-${{range.key}}
+    description: Fluentd kubernetes daemonset for ${{range.key}}
+    options:
+      no-depends: true
+      no-provides: true
+    dependencies:
+      runtime:
+        - ca-certificates
+        - ruby-${{vars.rubyMM}}
+        - tini
+    pipeline:
+      - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
+        runs: |
+          # Install bundle
+          mkdir -p ${{targets.contextdir}}/fluentd/vendor/bundle
+          bundle config silence_root_warning true
+          bundle config set path ${{targets.contextdir}}/fluentd/vendor/bundle
+          bundle config set clean 'true'
+          bundle config set deployment 'true'
+          bundle install --gemfile ./Gemfile --jobs $(nproc)
+          bundle config unset path
+
+          # Copy gemfile
+          mkdir -p ${{targets.contextdir}}/fluentd
+          cp ./Gemfile ${{targets.contextdir}}/fluentd/Gemfile
+
+          # Copy configuration
+          mkdir -p ${{targets.contextdir}}/fluentd/etc
+          cp -r ./conf/* ${{targets.contextdir}}/fluentd/etc
+          touch ${{targets.contextdir}}/fluentd/etc/disable.conf
+
+          # Create log directory
+          mkdir -p ${{targets.contextdir}}/fluentd/log
+
+          # Copy plugins
+          mkdir -p ${{targets.contextdir}}/fluentd/plugins
+          cp -r ./plugins/* ${{targets.contextdir}}/fluentd/plugins
+
+          # Copy entrypoint
+          cp entrypoint.sh ${{targets.contextdir}}/fluentd/entrypoint.sh
+    test:
+      environment:
+        environment:
+          FLUENTD_CONF: "fluent.conf"
+          FLUENTD_DISABLE_BUNDLER_INJECTION: 1
+          KUBERNETES_SERVICE_HOST: "127.0.0.1"
+          KUBERNETES_SERVICE_PORT: 32764
+      pipeline:
+        - uses: test/kwok/cluster
+        # Just make sure the config is okay, kwok doesn't get us very far
+        - uses: test/daemon-check-output
+          with:
+            start: |
+              sh -c "
+              export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
+              export GEM_HOME="$GEM_PATH"
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile
+              "
+            timeout: 10
+            expected_output: parsing config file is succeeded
+
+update:
+  enabled: true
+  version-transform:
+    - match: '_'
+      replace: '.'
+  github:
+    identifier: fluent/fluentd-kubernetes-daemonset
+    strip-prefix: v
+    tag-filter: v1.17.
+    use-tag: true

--- a/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
@@ -40,23 +40,7 @@ var-transforms:
 data:
   - name: plugins
     items:
-      azureblob:
-      cloudwatch:
-      elasticsearch7:
-      elasticsearch8:
-      forward:
-      gcs:
-      graylog:
-      kafka:
-      kafka2:
       kinesis:
-      logentries:
-      loggly:
-      logzio:
-      opensearch:
-      papertrail:
-      s3:
-      syslog:
 
 pipeline:
   - uses: git-checkout

--- a/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
@@ -110,7 +110,7 @@ subpackages:
               sh -c "
               export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
               export GEM_HOME="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
-              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --dry-run
               "
             timeout: 10
             expected_output: parsing config file is succeeded

--- a/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
@@ -110,10 +110,11 @@ subpackages:
               sh -c "
               export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
               export GEM_HOME="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
-              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --dry-run
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --help
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --version
               "
             timeout: 10
-            expected_output: parsing config file is succeeded
+            expected_output: "Usage: fluentd"
 
 update:
   enabled: true

--- a/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
@@ -109,7 +109,7 @@ subpackages:
             start: |
               sh -c "
               export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
-              export GEM_HOME="$GEM_PATH"
+              export GEM_HOME="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
               /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile
               "
             timeout: 10

--- a/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
@@ -70,7 +70,10 @@ subpackages:
           bundle config set path ${{targets.contextdir}}/fluentd/vendor/bundle
           bundle config set clean 'true'
           bundle config set deployment 'true'
-          bundle install --gemfile ./Gemfile --jobs $(nproc)
+          # --retry doesn't seem to help with network issues, completely rerun the command
+          if ! bundle install --gemfile ./Gemfile --jobs $(nproc); then
+            bundle install --gemfile ./Gemfile --jobs $(nproc)
+          fi
           bundle config unset path
 
           # Copy gemfile

--- a/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
@@ -40,23 +40,7 @@ var-transforms:
 data:
   - name: plugins
     items:
-      azureblob:
-      cloudwatch:
-      elasticsearch7:
-      elasticsearch8:
-      forward:
-      gcs:
-      graylog:
-      kafka:
-      kafka2:
       kinesis:
-      logentries:
-      loggly:
-      logzio:
-      opensearch:
-      papertrail:
-      s3:
-      syslog:
 
 pipeline:
   - uses: git-checkout

--- a/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
@@ -1,0 +1,140 @@
+package:
+  # fluentd supported versions: https://github.com/fluent/fluentd/blob/master/SECURITY.md
+  # The kubernetes daemonset trails fluentd releases by a bit
+  name: ruby3.2-fluentd-kubernetes-daemonset-1.17
+  version: 1.17.1.1.2
+  epoch: 0
+  description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libtool
+      - m4
+      - ruby${{vars.rubyMM}}-bundler
+      - ruby-${{vars.rubyMM}}-dev
+      - snappy-dev
+
+var-transforms:
+  - from: ${{package.name}}
+    match: .*-(\d+\.\d+)
+    replace: $1
+    to: fluentdMM
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+\.\d+)\.(\d+\.\d+)
+    replace: $1-$2
+    to: mangled-package-version
+
+data:
+  - name: plugins
+    items:
+      azureblob:
+      cloudwatch:
+      elasticsearch7:
+      elasticsearch8:
+      forward:
+      gcs:
+      graylog:
+      kafka:
+      kafka2:
+      kinesis:
+      logentries:
+      loggly:
+      logzio:
+      opensearch:
+      papertrail:
+      s3:
+      syslog:
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 6183f108748bc4ed980437d6f93cf5f990e33b36
+      repository: https://github.com/fluent/fluentd-kubernetes-daemonset.git
+      tag: v${{vars.mangled-package-version}}
+
+subpackages:
+  - range: plugins
+    name: ${{package.name}}-${{range.key}}
+    description: Fluentd kubernetes daemonset for ${{range.key}}
+    options:
+      no-depends: true
+      no-provides: true
+    dependencies:
+      runtime:
+        - ca-certificates
+        - ruby-${{vars.rubyMM}}
+        - tini
+    pipeline:
+      - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
+        runs: |
+          # Install bundle
+          mkdir -p ${{targets.contextdir}}/fluentd/vendor/bundle
+          bundle config silence_root_warning true
+          bundle config set path ${{targets.contextdir}}/fluentd/vendor/bundle
+          bundle config set clean 'true'
+          bundle config set deployment 'true'
+          bundle install --gemfile ./Gemfile --jobs $(nproc)
+          bundle config unset path
+
+          # Copy gemfile
+          mkdir -p ${{targets.contextdir}}/fluentd
+          cp ./Gemfile ${{targets.contextdir}}/fluentd/Gemfile
+
+          # Copy configuration
+          mkdir -p ${{targets.contextdir}}/fluentd/etc
+          cp -r ./conf/* ${{targets.contextdir}}/fluentd/etc
+          touch ${{targets.contextdir}}/fluentd/etc/disable.conf
+
+          # Create log directory
+          mkdir -p ${{targets.contextdir}}/fluentd/log
+
+          # Copy plugins
+          mkdir -p ${{targets.contextdir}}/fluentd/plugins
+          cp -r ./plugins/* ${{targets.contextdir}}/fluentd/plugins
+
+          # Copy entrypoint
+          cp entrypoint.sh ${{targets.contextdir}}/fluentd/entrypoint.sh
+    test:
+      environment:
+        environment:
+          FLUENTD_CONF: "fluent.conf"
+          FLUENTD_DISABLE_BUNDLER_INJECTION: 1
+          KUBERNETES_SERVICE_HOST: "127.0.0.1"
+          KUBERNETES_SERVICE_PORT: 32764
+      pipeline:
+        - uses: test/kwok/cluster
+        # Just make sure the config is okay, kwok doesn't get us very far
+        - uses: test/daemon-check-output
+          with:
+            start: |
+              sh -c "
+              export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
+              export GEM_HOME="$GEM_PATH"
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile
+              "
+            timeout: 10
+            expected_output: parsing config file is succeeded
+
+update:
+  enabled: true
+  version-transform:
+    - match: '_'
+      replace: '.'
+  github:
+    identifier: fluent/fluentd-kubernetes-daemonset
+    strip-prefix: v
+    tag-filter: v1.17.
+    use-tag: true

--- a/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
@@ -110,7 +110,7 @@ subpackages:
               sh -c "
               export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
               export GEM_HOME="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
-              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --dry-run
               "
             timeout: 10
             expected_output: parsing config file is succeeded

--- a/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
@@ -110,10 +110,11 @@ subpackages:
               sh -c "
               export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
               export GEM_HOME="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
-              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --dry-run
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --help
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --version
               "
             timeout: 10
-            expected_output: parsing config file is succeeded
+            expected_output: "Usage: fluentd"
 
 update:
   enabled: true

--- a/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
@@ -109,7 +109,7 @@ subpackages:
             start: |
               sh -c "
               export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
-              export GEM_HOME="$GEM_PATH"
+              export GEM_HOME="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
               /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile
               "
             timeout: 10

--- a/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
@@ -70,7 +70,10 @@ subpackages:
           bundle config set path ${{targets.contextdir}}/fluentd/vendor/bundle
           bundle config set clean 'true'
           bundle config set deployment 'true'
-          bundle install --gemfile ./Gemfile --jobs $(nproc)
+          # --retry doesn't seem to help with network issues, completely rerun the command
+          if ! bundle install --gemfile ./Gemfile --jobs $(nproc); then
+            bundle install --gemfile ./Gemfile --jobs $(nproc)
+          fi
           bundle config unset path
 
           # Copy gemfile

--- a/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
@@ -1,0 +1,140 @@
+package:
+  # fluentd supported versions: https://github.com/fluent/fluentd/blob/master/SECURITY.md
+  # The kubernetes daemonset trails fluentd releases by a bit
+  name: ruby3.3-fluentd-kubernetes-daemonset-1.17
+  version: 1.17.1.1.2
+  epoch: 0
+  description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libtool
+      - m4
+      - ruby${{vars.rubyMM}}-bundler
+      - ruby-${{vars.rubyMM}}-dev
+      - snappy-dev
+
+var-transforms:
+  - from: ${{package.name}}
+    match: .*-(\d+\.\d+)
+    replace: $1
+    to: fluentdMM
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+\.\d+)\.(\d+\.\d+)
+    replace: $1-$2
+    to: mangled-package-version
+
+data:
+  - name: plugins
+    items:
+      azureblob:
+      cloudwatch:
+      elasticsearch7:
+      elasticsearch8:
+      forward:
+      gcs:
+      graylog:
+      kafka:
+      kafka2:
+      kinesis:
+      logentries:
+      loggly:
+      logzio:
+      opensearch:
+      papertrail:
+      s3:
+      syslog:
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 6183f108748bc4ed980437d6f93cf5f990e33b36
+      repository: https://github.com/fluent/fluentd-kubernetes-daemonset.git
+      tag: v${{vars.mangled-package-version}}
+
+subpackages:
+  - range: plugins
+    name: ${{package.name}}-${{range.key}}
+    description: Fluentd kubernetes daemonset for ${{range.key}}
+    options:
+      no-depends: true
+      no-provides: true
+    dependencies:
+      runtime:
+        - ca-certificates
+        - ruby-${{vars.rubyMM}}
+        - tini
+    pipeline:
+      - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
+        runs: |
+          # Install bundle
+          mkdir -p ${{targets.contextdir}}/fluentd/vendor/bundle
+          bundle config silence_root_warning true
+          bundle config set path ${{targets.contextdir}}/fluentd/vendor/bundle
+          bundle config set clean 'true'
+          bundle config set deployment 'true'
+          bundle install --gemfile ./Gemfile --jobs $(nproc)
+          bundle config unset path
+
+          # Copy gemfile
+          mkdir -p ${{targets.contextdir}}/fluentd
+          cp ./Gemfile ${{targets.contextdir}}/fluentd/Gemfile
+
+          # Copy configuration
+          mkdir -p ${{targets.contextdir}}/fluentd/etc
+          cp -r ./conf/* ${{targets.contextdir}}/fluentd/etc
+          touch ${{targets.contextdir}}/fluentd/etc/disable.conf
+
+          # Create log directory
+          mkdir -p ${{targets.contextdir}}/fluentd/log
+
+          # Copy plugins
+          mkdir -p ${{targets.contextdir}}/fluentd/plugins
+          cp -r ./plugins/* ${{targets.contextdir}}/fluentd/plugins
+
+          # Copy entrypoint
+          cp entrypoint.sh ${{targets.contextdir}}/fluentd/entrypoint.sh
+    test:
+      environment:
+        environment:
+          FLUENTD_CONF: "fluent.conf"
+          FLUENTD_DISABLE_BUNDLER_INJECTION: 1
+          KUBERNETES_SERVICE_HOST: "127.0.0.1"
+          KUBERNETES_SERVICE_PORT: 32764
+      pipeline:
+        - uses: test/kwok/cluster
+        # Just make sure the config is okay, kwok doesn't get us very far
+        - uses: test/daemon-check-output
+          with:
+            start: |
+              sh -c "
+              export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
+              export GEM_HOME="$GEM_PATH"
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile
+              "
+            timeout: 10
+            expected_output: parsing config file is succeeded
+
+update:
+  enabled: true
+  version-transform:
+    - match: '_'
+      replace: '.'
+  github:
+    identifier: fluent/fluentd-kubernetes-daemonset
+    strip-prefix: v
+    tag-filter: v1.17.
+    use-tag: true

--- a/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
@@ -40,23 +40,7 @@ var-transforms:
 data:
   - name: plugins
     items:
-      azureblob:
-      cloudwatch:
-      elasticsearch7:
-      elasticsearch8:
-      forward:
-      gcs:
-      graylog:
-      kafka:
-      kafka2:
       kinesis:
-      logentries:
-      loggly:
-      logzio:
-      opensearch:
-      papertrail:
-      s3:
-      syslog:
 
 pipeline:
   - uses: git-checkout

--- a/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
@@ -110,7 +110,7 @@ subpackages:
               sh -c "
               export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
               export GEM_HOME="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
-              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --dry-run
               "
             timeout: 10
             expected_output: parsing config file is succeeded

--- a/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
@@ -110,10 +110,11 @@ subpackages:
               sh -c "
               export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
               export GEM_HOME="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
-              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --dry-run
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --help
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile --version
               "
             timeout: 10
-            expected_output: parsing config file is succeeded
+            expected_output: "Usage: fluentd"
 
 update:
   enabled: true

--- a/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
@@ -109,7 +109,7 @@ subpackages:
             start: |
               sh -c "
               export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
-              export GEM_HOME="$GEM_PATH"
+              export GEM_HOME="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
               /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile
               "
             timeout: 10

--- a/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
@@ -70,7 +70,10 @@ subpackages:
           bundle config set path ${{targets.contextdir}}/fluentd/vendor/bundle
           bundle config set clean 'true'
           bundle config set deployment 'true'
-          bundle install --gemfile ./Gemfile --jobs $(nproc)
+          # --retry doesn't seem to help with network issues, completely rerun the command
+          if ! bundle install --gemfile ./Gemfile --jobs $(nproc); then
+            bundle install --gemfile ./Gemfile --jobs $(nproc)
+          fi
           bundle config unset path
 
           # Copy gemfile

--- a/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
@@ -1,0 +1,140 @@
+package:
+  # fluentd supported versions: https://github.com/fluent/fluentd/blob/master/SECURITY.md
+  # The kubernetes daemonset trails fluentd releases by a bit
+  name: ruby3.4-fluentd-kubernetes-daemonset-1.17
+  version: 1.17.1.1.2
+  epoch: 0
+  description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - automake
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libtool
+      - m4
+      - ruby${{vars.rubyMM}}-bundler
+      - ruby-${{vars.rubyMM}}-dev
+      - snappy-dev
+
+var-transforms:
+  - from: ${{package.name}}
+    match: .*-(\d+\.\d+)
+    replace: $1
+    to: fluentdMM
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+\.\d+)\.(\d+\.\d+)
+    replace: $1-$2
+    to: mangled-package-version
+
+data:
+  - name: plugins
+    items:
+      azureblob:
+      cloudwatch:
+      elasticsearch7:
+      elasticsearch8:
+      forward:
+      gcs:
+      graylog:
+      kafka:
+      kafka2:
+      kinesis:
+      logentries:
+      loggly:
+      logzio:
+      opensearch:
+      papertrail:
+      s3:
+      syslog:
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 6183f108748bc4ed980437d6f93cf5f990e33b36
+      repository: https://github.com/fluent/fluentd-kubernetes-daemonset.git
+      tag: v${{vars.mangled-package-version}}
+
+subpackages:
+  - range: plugins
+    name: ${{package.name}}-${{range.key}}
+    description: Fluentd kubernetes daemonset for ${{range.key}}
+    options:
+      no-depends: true
+      no-provides: true
+    dependencies:
+      runtime:
+        - ca-certificates
+        - ruby-${{vars.rubyMM}}
+        - tini
+    pipeline:
+      - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
+        runs: |
+          # Install bundle
+          mkdir -p ${{targets.contextdir}}/fluentd/vendor/bundle
+          bundle config silence_root_warning true
+          bundle config set path ${{targets.contextdir}}/fluentd/vendor/bundle
+          bundle config set clean 'true'
+          bundle config set deployment 'true'
+          bundle install --gemfile ./Gemfile --jobs $(nproc)
+          bundle config unset path
+
+          # Copy gemfile
+          mkdir -p ${{targets.contextdir}}/fluentd
+          cp ./Gemfile ${{targets.contextdir}}/fluentd/Gemfile
+
+          # Copy configuration
+          mkdir -p ${{targets.contextdir}}/fluentd/etc
+          cp -r ./conf/* ${{targets.contextdir}}/fluentd/etc
+          touch ${{targets.contextdir}}/fluentd/etc/disable.conf
+
+          # Create log directory
+          mkdir -p ${{targets.contextdir}}/fluentd/log
+
+          # Copy plugins
+          mkdir -p ${{targets.contextdir}}/fluentd/plugins
+          cp -r ./plugins/* ${{targets.contextdir}}/fluentd/plugins
+
+          # Copy entrypoint
+          cp entrypoint.sh ${{targets.contextdir}}/fluentd/entrypoint.sh
+    test:
+      environment:
+        environment:
+          FLUENTD_CONF: "fluent.conf"
+          FLUENTD_DISABLE_BUNDLER_INJECTION: 1
+          KUBERNETES_SERVICE_HOST: "127.0.0.1"
+          KUBERNETES_SERVICE_PORT: 32764
+      pipeline:
+        - uses: test/kwok/cluster
+        # Just make sure the config is okay, kwok doesn't get us very far
+        - uses: test/daemon-check-output
+          with:
+            start: |
+              sh -c "
+              export GEM_PATH="/fluentd/vendor/bundle/ruby/$(basename $(gem env home))"
+              export GEM_HOME="$GEM_PATH"
+              /fluentd/vendor/bundle/ruby/$(basename $(gem env home))/bin/fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile
+              "
+            timeout: 10
+            expected_output: parsing config file is succeeded
+
+update:
+  enabled: true
+  version-transform:
+    - match: '_'
+      replace: '.'
+  github:
+    identifier: fluent/fluentd-kubernetes-daemonset
+    strip-prefix: v
+    tag-filter: v1.17.
+    use-tag: true

--- a/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
@@ -40,23 +40,7 @@ var-transforms:
 data:
   - name: plugins
     items:
-      azureblob:
-      cloudwatch:
-      elasticsearch7:
-      elasticsearch8:
-      forward:
-      gcs:
-      graylog:
-      kafka:
-      kafka2:
       kinesis:
-      logentries:
-      loggly:
-      logzio:
-      opensearch:
-      papertrail:
-      s3:
-      syslog:
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Adds Kubernetes DaemonSets for fluentd. Note that fluentd is vendored in the bundle so is not included as a package dependency. Upstream includes two separate installations of fluentd which is not necessary. Add for all supported Ruby versions (3.1-3.3) and 3.4 (in preview)

There isn't value in splitting away the entrypoint scripts or configuration for each so those have been bundled together