### PR TITLE
chore(gitsign,guac): fix ghsa-v778-237x-gjrc

### DIFF
--- a/gitsign.yaml
+++ b/gitsign.yaml
@@ -1,7 +1,7 @@
 package:
   name: gitsign
   version: 0.11.0
-  epoch: 1
+  epoch: 2
   description: Keyless Git signing with Sigstore!
   copyright:
     - license: Apache-2.0
@@ -37,9 +37,6 @@ subpackages:
   - name: gitsign-credential-cache
     description: "helper binary that allows users to cache signing credentials"
     pipeline:
-      - uses: go/bump
-        with:
-          deps: golang.org/x/crypto@v0.31.0
       - uses: go/build
         with:
           packages: ./cmd/gitsign-credential-cache

--- a/gitsign.yaml
+++ b/gitsign.yaml
@@ -19,7 +19,7 @@ pipeline:
 
   - uses: go/bump
     with:
-      deps: github.com/golang-jwt/jwt/v4@v4.5.1
+      deps: "github.com/golang-jwt/jwt/v4@v4.5.1 golang.org/x/crypto@v0.31.0"
 
   - uses: go/build
     with:
@@ -37,6 +37,9 @@ subpackages:
   - name: gitsign-credential-cache
     description: "helper binary that allows users to cache signing credentials"
     pipeline:
+      - uses: go/bump
+        with:
+          deps: golang.org/x/crypto@v0.31.0
       - uses: go/build
         with:
           packages: ./cmd/gitsign-credential-cache

--- a/guac.yaml
+++ b/guac.yaml
@@ -1,7 +1,7 @@
 package:
   name: guac
   version: 0.12.0
-  epoch: 1
+  epoch: 2
   description: GUAC aggregates software security metadata into a high fidelity graph database.
   copyright:
     - license: Apache-2.0

--- a/guac.yaml
+++ b/guac.yaml
@@ -21,6 +21,10 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: a944fc47d917c1f591e24fc2fa68abe0ccb90782
 
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.31.0
+
   - uses: go/build
     with:
       packages: ./cmd/guaccollect


### PR DESCRIPTION
This commit bumps golang.org/x/crypto to 0.31.0

#### For security-related PRs
<!-- remove if unrelated -->
- [x] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo