### PR TITLE
Fix a ftbfs with meson due to an incorrect dep

### DIFF
--- a/meson.yaml
+++ b/meson.yaml
@@ -15,8 +15,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - openssf-compiler-options
-      - py3-supported-pip
       - py3-setuptools
+      - py3-supported-pip
       - python3
       - samurai
 

--- a/meson.yaml
+++ b/meson.yaml
@@ -1,7 +1,7 @@
 package:
   name: meson
   version: 1.6.0
-  epoch: 1
+  epoch: 2
   description: Fast and user friendly build system
   copyright:
     - license: Apache-2.0

--- a/meson.yaml
+++ b/meson.yaml
@@ -15,7 +15,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - openssf-compiler-options
-      - py3-pip
+      - py3-supported-pip
       - py3-setuptools
       - python3
       - samurai


### PR DESCRIPTION
Before this change the package build would fail in the following way:

```
2024-12-12T07:22:17Z INFO running step "py/pip-build-install"
2024-12-12T07:22:17Z INFO running step "pip build"
2024-12-12T07:22:17Z INFO /usr/bin/python3.12 is 3.12 with site_packages dir 'usr/lib/python3.12/site-packages'
2024-12-12T07:22:17Z INFO execute: /usr/bin/python3.12 -m pip wheel --verbose --wheel-dir=./.wheels/3.12 --find-links=/tmp/tmp.GprFUG/dist-wheels --no-index --no-build-isolation --no-deps .
2024-12-12T07:22:17Z WARN /usr/bin/python3.12: No module named pip
2024-12-12T07:22:17Z INFO deleting guest dir /tmp/melange-guest-130102806
2024-12-12T07:22:17Z INFO deleting workspace dir /tmp/melange-workspace-226502872
2024-12-12T07:22:17Z INFO removing image path /tmp/melange-guest-1547025742
2024-12-12T07:22:18Z ERRO failed to build package: unable to run package meson pipeline: unable to run pipeline: unable to run pipeline: exit status 1
```