### PR TITLE
hdf5: Upstream has changed their tagging scheme

### DIFF
--- a/hdf5.yaml
+++ b/hdf5.yaml
@@ -138,7 +138,7 @@ subpackages:
           mv "${{targets.destdir}}"/usr/lib/${{range.value}}.so.* ${{targets.contextdir}}/usr/lib/
 
 update:
-  enabled: false
+  enabled: true
   github:
     identifier: HDFGroup/hdf5
     strip-prefix: hdf5_

--- a/hdf5.yaml
+++ b/hdf5.yaml
@@ -1,8 +1,8 @@
 package:
   name: hdf5
   description: Library for accessing Hierarchical Data Format version 5 files
-  version: 1.14.2
-  epoch: 2
+  version: 1.14.5
+  epoch: 0
   url: https://www.hdfgroup.org/solutions/hdf5/
   copyright:
     - license: BSD-3-Clause
@@ -21,18 +21,12 @@ environment:
   environment:
     GCC_SPEC_FILE: "/dev/null"
 
-var-transforms:
-  - from: ${{package.version}}
-    match: \.
-    replace: _
-    to: mangled-package-version
-
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/HDFGroup/hdf5
-      expected-commit: 2d926cf0426d2ed9403946071d9b05ac8b4dd778
-      tag: hdf5-${{vars.mangled-package-version}}
+      expected-commit: 0fe0459fc24d71be13d5f266513c2832b525671b
+      tag: hdf5_${{package.version}}
 
   # Remove -Werror from compile flags.
   - runs: |
@@ -147,7 +141,4 @@ update:
   enabled: false
   github:
     identifier: HDFGroup/hdf5
-    strip-prefix: hdf5-
-  version-transform:
-    - match: (\d*)_(\d*)_(\d*)
-      replace: $1.$2.$3
+    strip-prefix: hdf5_


### PR DESCRIPTION
Upstream has altered their tagging scheme for recent releases:

```
$ git tag | grep 1.14
1.14.1
hdf5-1_14_0
hdf5-1_14_1
hdf5-1_14_1-2
hdf5-1_14_2
hdf5-1_14_3
hdf5-1_14_3-rc1
hdf5_1.14.4
hdf5_1.14.4.1
hdf5_1.14.4.2
hdf5_1.14.4.3
hdf5_1.14.5
snapshot-1.14
```
Adjust to that, move to the latest release, and re-enable updates.
