### PR TITLE
rsyslog: Use relative symlink

### DIFF
--- a/rsyslog.yaml
+++ b/rsyslog.yaml
@@ -1,7 +1,7 @@
 package:
   name: rsyslog
   version: 8.2412.0
-  epoch: 0
+  epoch: 1
   description: a Rocket-fast SYStem for LOG processing
   copyright:
     - license: Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later
@@ -59,7 +59,7 @@ pipeline:
       make check
       # rsyslogd will default to pid files in /var/run
       mkdir -p ${{targets.destdir}}/var
-      ln -sf /run ${{targets.destdir}}/var/run
+      ln -sf ../run ${{targets.destdir}}/var/run # We probably want to move this to wolfi-baselayout
 
   - uses: strip
 


### PR DESCRIPTION
This works around what seems to be a bug in apko when installing a directory in a parent directory that happens to be a symlink. The relative syntax appears to work but this absolute syntax doesn't.

Rather than trying to fix this in apko (which, I'm not sure if it's a bug or not, because the error is really coming from os stdlib), let's just make this relative.

Other distros seem to do this by default, so we may want to do this in wolfi-baselayout instead, but I'm not confident enough in my distro skills to propose that.