### PR TITLE
Add test/ldd-check pipeline, replace ldd 'tests' with it.

### DIFF
--- a/aws-c-auth.yaml
+++ b/aws-c-auth.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-auth
   version: 0.8.0
-  epoch: 0
+  epoch: 1
   description: "C99 library implementation of AWS client-side authentication: standard credentials providers and signing"
   copyright:
     - license: Apache-2.0
@@ -64,14 +64,10 @@ subpackages:
     description: aws-c-auth dev
 
 test:
-  environment:
-    contents:
-      packages:
-        - posix-libc-utils
   pipeline:
-    - name: "Verify shared library dependencies"
-      runs: |
-        ldd /usr/lib/libaws-c-auth.so.1.0.0
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/libaws-c-auth.so.1.0.0
 
 update:
   enabled: true

--- a/aws-c-cal.yaml
+++ b/aws-c-cal.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-cal
   version: 0.8.1
-  epoch: 0
+  epoch: 1
   description: "AWS Crypto Abstraction Layer: Cross-Platform, C99 wrapper for cryptography primitives"
   copyright:
     - license: Apache-2.0
@@ -58,14 +58,10 @@ subpackages:
     description: aws-c-cal dev
 
 test:
-  environment:
-    contents:
-      packages:
-        - posix-libc-utils
   pipeline:
-    - name: "Verify shared library dependencies"
-      runs: |
-        ldd /usr/lib/libaws-c-cal.so.1.0.0
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/libaws-c-cal.so.1.0.0
 
 update:
   enabled: true

--- a/aws-c-common.yaml
+++ b/aws-c-common.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-common
   version: 0.10.6
-  epoch: 0
+  epoch: 1
   description: Core c99 package for AWS SDK for C including cross-platform primitives, configuration, data structures, and error handling
   copyright:
     - license: Apache-2.0
@@ -57,14 +57,10 @@ subpackages:
     description: aws-c-common dev
 
 test:
-  environment:
-    contents:
-      packages:
-        - posix-libc-utils
   pipeline:
-    - name: "Verify shared library dependencies"
-      runs: |
-        ldd /usr/lib/libaws-c-common.so.1.0.0
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/libaws-c-common.so.1.0.0
 
 update:
   enabled: true

--- a/aws-c-compression.yaml
+++ b/aws-c-compression.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-compression
   version: 0.3.0
-  epoch: 0
+  epoch: 1
   description: C99 implementation of huffman encoding/decoding
   copyright:
     - license: Apache-2.0
@@ -54,14 +54,10 @@ subpackages:
     description: aws-c-compression dev
 
 test:
-  environment:
-    contents:
-      packages:
-        - posix-libc-utils
   pipeline:
-    - name: "Verify shared library dependencies"
-      runs: |
-        ldd /usr/lib/libaws-c-compression.so.1.0.0
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/libaws-c-compression.so.1.0.0
 
 update:
   enabled: true

--- a/aws-c-event-stream.yaml
+++ b/aws-c-event-stream.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-event-stream
   version: 0.5.0
-  epoch: 0
+  epoch: 1
   description: "AWS C99 implementation of the vnd.amazon.eventstream content-type"
   copyright:
     - license: Apache-2.0
@@ -62,14 +62,10 @@ subpackages:
     description: aws-c-event-stream dev
 
 test:
-  environment:
-    contents:
-      packages:
-        - posix-libc-utils
   pipeline:
-    - name: "Verify shared library dependencies"
-      runs: |
-        ldd /usr/lib/libaws-c-event-stream.so.1.0.0
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/libaws-c-event-stream.so.1.0.0
 
 update:
   enabled: true

--- a/aws-c-http.yaml
+++ b/aws-c-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-http
   version: 0.9.2
-  epoch: 0
+  epoch: 1
   description: AWS C99 implementation of the HTTP/1.1 and HTTP/2 specifications
   copyright:
     - license: Apache-2.0
@@ -61,14 +61,10 @@ subpackages:
     description: aws-c-http dev
 
 test:
-  environment:
-    contents:
-      packages:
-        - posix-libc-utils
   pipeline:
-    - name: "Verify shared library dependencies"
-      runs: |
-        ldd /usr/lib/libaws-c-http.so.1.0.0
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/libaws-c-http.so.1.0.0
 
 update:
   enabled: true

--- a/aws-c-mqtt.yaml
+++ b/aws-c-mqtt.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-c-mqtt
   version: 0.11.0
-  epoch: 0
+  epoch: 1
   description: AWS C99 implementation of the MQTT 3.1.1 specification
   copyright:
     - license: Apache-2.0
@@ -79,12 +79,11 @@ test:
         - aws-c-io-dev
         - build-base
         - gcc
-        - posix-libc-utils
         - aws-c-mqtt-dev
   pipeline:
-    - name: "Verify shared library dependencies"
-      runs: |
-        ldd /usr/lib/libaws-c-mqtt.so.1.0.0
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/libaws-c-mqtt.so.1.0.0
     - name: "Compile simple MQTT test program"
       runs: |
         cat << 'EOF' > test.c

--- a/aws-c-s3.yaml
+++ b/aws-c-s3.yaml
@@ -74,14 +74,10 @@ subpackages:
     description: aws-c-s3 dev
 
 test:
-  environment:
-    contents:
-      packages:
-        - posix-libc-utils
   pipeline:
-    - name: "Verify shared library dependencies"
-      runs: |
-        ldd /usr/lib/libaws-c-s3.so.1.0.0
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/libaws-c-s3.so.1.0.0
 
 update:
   enabled: true

--- a/aws-c-sdkutils.yaml
+++ b/aws-c-sdkutils.yaml
@@ -57,14 +57,10 @@ subpackages:
     description: aws-c-sdkutils dev
 
 test:
-  environment:
-    contents:
-      packages:
-        - posix-libc-utils
   pipeline:
-    - name: "Verify shared library dependencies"
-      runs: |
-        ldd /usr/lib/libaws-c-sdkutils.so.1.0.0
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/libaws-c-sdkutils.so.1.0.0
 
 update:
   enabled: true

--- a/aws-checksums.yaml
+++ b/aws-checksums.yaml
@@ -57,14 +57,10 @@ subpackages:
     description: aws-checksums dev
 
 test:
-  environment:
-    contents:
-      packages:
-        - posix-libc-utils
   pipeline:
-    - name: "Verify shared library dependencies"
-      runs: |
-        ldd /usr/lib/libaws-checksums.so.1.0.0
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/libaws-checksums.so.1.0.0
 
 update:
   enabled: true

--- a/chromium.yaml
+++ b/chromium.yaml
@@ -330,14 +330,15 @@ test:
         #- py3-pip
         #- python3
   pipeline:
+    - uses: test/ldd-check
+      with:
+        verbose: true
+        files: /usr/lib/chromium/chrome
     - runs: |
         # Make sure Chrome and ChromeDriver are at the correct path
         test -x /usr/lib/chromium/chrome
         test -x /usr/lib/chromium/chromedriver
         test -f /usr/lib/chromium/locales/en-US.pak
-
-        # Ensure all libraries are linked
-        ldd /usr/lib/chromium/chrome
 
         # Check status with new headless mode
         chromium --no-sandbox --headless --disable-gpu --dump-dom https://www.chromestatus.com

--- a/expat.yaml
+++ b/expat.yaml
@@ -97,9 +97,9 @@ test:
 
         gcc -o test test.c -lexpat
         ./test
-    - name: "Check shared library"
-      runs: |
-        ldd /usr/lib/libexpat.so.1
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/libexpat.so.1
     - name: "Verify XML parsing functionality"
       runs: |
         cat > test.xml << EOF

--- a/pipelines/test/ldd-check.yaml
+++ b/pipelines/test/ldd-check.yaml
@@ -1,0 +1,59 @@
+name: ldd-check
+
+needs:
+  packages:
+    - busybox
+    - posix-libc-utils
+
+inputs:
+  files:
+    description: |
+      The files to run `ldd` on and check for missing deps.
+    required: true
+  verbose:
+    description: |
+      Should the full ldd output be shown
+    required: false
+    default: false
+
+pipeline:
+  - name: "run ldd on provided files"
+    runs: |
+      set +x
+      set -f
+      error() { echo "ERROR[ldd-check]:" "$@"; exit 1; }
+      fail() { echo "FAIL[ldd-check]:" "$@"; fails=$((fails+1)); }
+      pass() { echo "PASS[ldd-check]:" "$@"; passes=$((passes+1)); }
+      cleanup() { [ -n "$tmpd" -o -z "$tmpd" ] && return 0; rm -Rf "$tmpd"; }
+
+      tmpd=$(mktemp -d) || fail "ERROR: failed to create tmpdir"
+      trap cleanup EXIT
+
+      fails=0
+      passes=0
+      files="${{inputs.files}}"
+      verbose="${{inputs.verbose}}"
+      case "$verbose" in
+        true|false) :;;
+        *) error "verbose must be 'true' or 'false'. found '$verbose'";;
+      esac
+
+      export LANG=C
+      set -- $files
+      outf="$tmpd/out"
+      for f in "$@"; do
+        [ -e "$f" ] || { fail "$f: does not exist"; continue; }
+        [ -f "$f" ] || { fail "$f: not a file"; continue; }
+        ldd "$f" > "$outf" || { fail "$f: ldd exited $?"; continue; }
+        missing=$(awk \
+          '$0 ~ /=> not found/ { miss = miss " " $1; }; END { printf("%s\n", miss); }' \
+          "$outf") || error "$f: parsing with awk failed $?";
+        if [ "$verbose" = "true" ]; then
+          echo "> $ ldd $f"
+          sed 's,^,> ,' "$outf"
+        fi
+        [ -z "$missing" ] && { pass "$f"; continue; }
+        fail "$f: missing ${missing# }"
+      done
+      echo "tested $((passes+fails)) files with ldd. $passes passes. $fails fails."
+      exit $fails

--- a/rtmpdump.yaml
+++ b/rtmpdump.yaml
@@ -79,8 +79,9 @@ test:
   pipeline:
     - name: Smoke test for rtmpdump binary
       runs: rtmpdump --help
-    - name: "Check shared library"
-      runs: ldd /usr/lib/librtmp.so.1
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/librtmp.so.1
     - name: Compile and link a simple C program
       runs: |
         cat <<EOF > test_rtmp.c

--- a/s2n-tls.yaml
+++ b/s2n-tls.yaml
@@ -64,9 +64,9 @@ test:
       packages:
         - posix-libc-utils
   pipeline:
-    - name: "Verify shared library dependencies"
-      runs: |
-        ldd /usr/lib/libs2n.so.1.0.0
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/libs2n.so.1.0.0
 
 update:
   enabled: true


### PR DESCRIPTION
I happened to see the test that aws-c-s3 had in place
and realized that it does not actually notice failure.
Running `ldd` on a program or library with missing dependencies
will exit zero unless ldd itself fails.
    
The added 'test/ldd-check' pipeline will check and list missing
dependencies.
