### PR TITLE
Make python-3.13 the answer if you request 'python3' or 'python3-dev'

### DIFF
--- a/python-3.13.yaml
+++ b/python-3.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: python-3.13
   version: 3.13.1
-  epoch: 3
+  epoch: 4
   description: "the Python programming language"
   copyright:
     - license: PSF-2.0
@@ -10,8 +10,8 @@ package:
     memory: 8Gi
   dependencies:
     provides:
-      - python3=0
-      - python-3=0
+      - python3=${{package.full-version}}
+      - python-3=${{package.full-version}}
     runtime:
       - ${{package.name}}-base=${{package.full-version}}
 
@@ -45,7 +45,7 @@ var-transforms:
     replace: ''
     to: python
   - from: ${{package.version}}
-    match: (\d).(\d+).(\d+).*
+    match: (\d).(\d+).(\d+)
     replace: '$1.$2'
     to: pyversion
 
@@ -230,8 +230,8 @@ subpackages:
     description: "python3 development headers"
     dependencies:
       provides:
-        - python3-dev=0
-        - python-3-dev=0
+        - python3-dev=${{package.full-version}}
+        - python-3-dev=${{package.full-version}}
       runtime:
         - ${{package.name}}=${{package.full-version}}
         - ${{package.name}}-base-dev=${{package.full-version}}
@@ -268,6 +268,12 @@ test:
         # main package should provide 'python' and 'python3'.
         python version-check.py ${{package.version}}
         python3 version-check.py ${{package.version}}
+        pydoc3 --version
+        pydoc3 --help
+        python --version
+        python --help
+        python3 --version
+        python3 --help
     - name: Verify working python3 -m venv
       runs: |
         d=$(mktemp -d)


### PR DESCRIPTION
Python 3.13 is now intended to provide the answer if a request is made for the virtual 'python-3', 'python3', 'python3-dev' or 'python-3-dev'

The other changes here are just to keep python-3.13 and python-3.12 in sync so a 'diff' of the two will only show intentional differences.
