### PR TITLE
kubernetes-latest: bump to kubernetes 1.32

### DIFF
--- a/kubernetes-latest.yaml
+++ b/kubernetes-latest.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-latest
   version: 0
-  epoch: 5
+  epoch: 6
   description: "Compatibility infrastructure for Kubernetes components"
   copyright:
     - license: GPL-2.0-or-later
@@ -13,7 +13,7 @@ environment:
 
 vars:
   components: "kubectl kubeadm kubelet kube-scheduler kube-proxy kube-controller-manager kube-apiserver"
-  kubernetes-version: 1.31
+  kubernetes-version: 1.32
 
 pipeline:
   - runs: |


### PR DESCRIPTION
Latest Kubernetes is v1.32:
 - https://github.com/wolfi-dev/os/pull/36719

As per internal runbook, bumping version here to match. Example of previous upgrade: https://github.com/wolfi-dev/os/pull/26288