### PR TITLE
bluez: switch to fetching from git and cherry-pick dir permission fix…

### DIFF
--- a/bluez.yaml
+++ b/bluez.yaml
@@ -122,8 +122,8 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 10029
+  github:
+    identifier: bluez/bluez
 
 test:
   pipeline:

--- a/bluez.yaml
+++ b/bluez.yaml
@@ -2,7 +2,7 @@
 package:
   name: bluez
   version: "5.79"
-  epoch: 1
+  epoch: 2
   description: Tools for the Bluetooth protocol stack
   copyright:
     - license: GPL-2.0-or-later AND BSD-2-Clause AND MIT

--- a/bluez.yaml
+++ b/bluez.yaml
@@ -32,10 +32,14 @@ environment:
       - systemd-dev
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 4164a5303a9f71c70f48c03ff60be34231b568d93a9ad5e79928d34e6aa0ea8a
-      uri: https://www.kernel.org/pub/linux/bluetooth/bluez-${{package.version}}.tar.xz
+      expected-commit: 0845b8f6ef2ac004b1c953cf4fe4ca3458cd8e36
+      repository: https://github.com/bluez/bluez.git
+      tag: ${{package.version}}
+      cherry-picks: |
+        # https://github.com/wolfi-dev/os/issues/31026
+        master/b1fd409960001a77cda2a09ecc00147ebd9c3667: build: Leave config files writable for owner
 
   - uses: autoconf/configure
     with:


### PR DESCRIPTION
… to make testing possible.

Previously we were using fetch instead of using git, and I wonder if there was any reason for that. Switched to `git-checkout` to be able to cleanly cherry-pick the required fix, without being worried that at some point in time the patch will no longer apply cleanly and will require manual dropping.
The tests didn't couldn't run because the permissions on `/etc/bluetooth/` were too restrictive.

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: #31026

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->
