### PR TITLE
feat(pgbouncer.yaml): Bump pgbouncer to newest version 1.23.1

### DIFF
--- a/pgbouncer.yaml
+++ b/pgbouncer.yaml
@@ -1,7 +1,7 @@
 package:
   name: pgbouncer
-  version: 1.22.1
-  epoch: 1
+  version: 1.23.1
+  epoch: 0
   description: lightweight connection pooler for PostgreSQL
   copyright:
     - license: ISC
@@ -31,8 +31,8 @@ pipeline:
   # and the docs require pandoc which requires haskell
   - uses: fetch
     with:
-      uri: https://github.com/pgbouncer/pgbouncer/releases/download/pgbouncer_${{vars.mangled-package-version}}/pgbouncer-${{package.version}}.tar.gz
-      expected-sha256: 2b018aa6ce7f592c9892bb9e0fd90262484eb73937fd2af929770a45373ba215
+      uri: https://github.com/pgbouncer/pgbouncer/releases/download/pgbouncer_${{vars.mangled-package-version}}-fixed/pgbouncer-${{package.version}}.tar.gz
+      expected-sha256: 1963b497231d9a560a62d266e4a2eae6881ab401853d93e5d292c3740eec5084
 
   - uses: autoconf/configure
 


### PR DESCRIPTION
This involves updating the download path to include `-fixed` which I assume is a temporary update by upstream due to a failed release of 1.23.1.

Signed-off-by: philroche <phil.roche@chainguard.dev>
