### PR TITLE
bump kubernetes-latest to default to k8s 1.32

### DIFF
--- a/kubernetes-latest.yaml
+++ b/kubernetes-latest.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-latest
   version: 0
-  epoch: 5
+  epoch: 6
   description: "Compatibility infrastructure for Kubernetes components"
   copyright:
     - license: GPL-2.0-or-later
@@ -13,7 +13,7 @@ environment:
 
 vars:
   components: "kubectl kubeadm kubelet kube-scheduler kube-proxy kube-controller-manager kube-apiserver"
-  kubernetes-version: 1.31
+  kubernetes-version: 1.32
 
 pipeline:
   - runs: |


### PR DESCRIPTION
-   bump kubernetes-latest to default to k8s 1.32

slack thread https://chainguard-dev.slack.com/archives/C02SD39C6BW/p1734091822059719