### PR TITLE
revert: icu 76.1 package update as contains ABI breakage, bumps dependants that have already been built with new ABI

### DIFF
--- a/icu.yaml
+++ b/icu.yaml
@@ -1,7 +1,7 @@
 package:
   name: icu
-  version: "76.1"
-  epoch: 0
+  version: "75.1"
+  epoch: 4
   description: "International Components for Unicode library"
   copyright:
     - license: MIT
@@ -37,7 +37,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/unicode-org/icu/releases/download/release-${{vars.dash-package-version}}/icu4c-${{vars.underscore-package-version}}-src.tgz
-      expected-sha256: dfacb46bfe4747410472ce3e1144bf28a102feeaa4e3875bac9b4c6cf30f4f3e
+      expected-sha256: cb968df3e4d2e87e8b11c49a5d01c787bd13b9545280fc6642f826527618caef
       strip-components: 0
 
   - runs: |

--- a/ruby3.4-charlock_holmes.yaml
+++ b/ruby3.4-charlock_holmes.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.4-charlock_holmes
   version: 0.7.9
-  epoch: 0
+  epoch: 1
   description: charlock_holmes provides binary and text detection as well as text transcoding using libicu
   copyright:
     - license: MIT

--- a/tensorflow-core.yaml
+++ b/tensorflow-core.yaml
@@ -100,7 +100,10 @@ pipeline:
       expected-commit: 6550e4bd80223cdb8be6c3afd1f81e86a4d433c3
       tag: v${{package.version}}
 
-  - runs: |
+  - environment:
+      # It otherwise defaults to the latest while the upstream does not provide lockfiles for > 3.12.
+      HERMETIC_PYTHON_VERSION: "3.12"
+    runs: |
       ./configure
 
       bazel ${{vars.bazel-common-opts}} //tensorflow:libtensorflow.so //tensorflow:libtensorflow_cc.so //tensorflow:install_headers //tensorflow:libtensorflow_framework.so

--- a/tensorflow-core.yaml
+++ b/tensorflow-core.yaml
@@ -2,7 +2,7 @@ package:
   name: tensorflow-core
   description: Framework for data-graph oriented computing (core libraries, oneDNN build)
   version: 2.18.0
-  epoch: 2
+  epoch: 3
   copyright:
     - license: Apache-2.0
   resources:

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -12,3 +12,7 @@ repmgr-dev-5.5.0-r3.apk
 repmgr-5.5.0-r3.apk
 repmgr-bitnami-compat-5.5.0-r3.apk
 py3-pywinpty-2.0.13-r3.apk
+icu-76.1-r0.apk
+icu-data-full-76.1-r0.apk
+icu-dev-76.1-r0.apk
+icu-libs-76.1-r0.apk


### PR DESCRIPTION
see https://github.com/wolfi-dev/os/pull/35274

package update check is expected to fail as we are rolling back an update.