### PR TITLE
withdraw icu 76.1 packages (again)

### DIFF
--- a/icu.yaml
+++ b/icu.yaml
@@ -1,7 +1,7 @@
 package:
   name: icu
-  version: "76.1"
-  epoch: 0
+  version: "75.1"
+  epoch: 5
   description: "International Components for Unicode library"
   copyright:
     - license: MIT
@@ -37,7 +37,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/unicode-org/icu/releases/download/release-${{vars.dash-package-version}}/icu4c-${{vars.underscore-package-version}}-src.tgz
-      expected-sha256: dfacb46bfe4747410472ce3e1144bf28a102feeaa4e3875bac9b4c6cf30f4f3e
+      expected-sha256: cb968df3e4d2e87e8b11c49a5d01c787bd13b9545280fc6642f826527618caef
       strip-components: 0
 
   - runs: |
@@ -104,6 +104,7 @@ subpackages:
 #   strip-prefix: release-
 update:
   enabled: true
+  manual: true # ICU updates contain ABI breaking changes which require manual intervention
   version-transform:
     - match: \-
       replace: .


### PR DESCRIPTION
`manual:true` will create an issue to crack the update manually and prevent automated PRs

package update check failure is expected as this is rolling back a version

The withdraw.txt doesn't need to be updated as they are already listed in there, but we will need to run the withdraw action again once this merges.