### PR TITLE
fix(microvm-init): fix modprobe when missing modalias

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -1,7 +1,7 @@
 package:
   name: melange
   version: 0.17.7
-  epoch: 0
+  epoch: 1
   description: build APKs from source code
   copyright:
     - license: Apache-2.0

--- a/melange/init
+++ b/melange/init
@@ -34,11 +34,25 @@ fi
 # If this fails and we won't have network, the ifconfig command will fail anyway.
 # Also we load cpu accelleration drivers in case those are needed.
 depmod -a || :
-sort -u \
-	/sys/devices/system/cpu/modalias  \
-	/sys/devices/pci*/*/virtio*/modalias | xargs -n1 modprobe 2>/dev/null || :
+sort -u /sys/devices/system/cpu/modalias | xargs -n1 modprobe 2>/dev/null || :
+sort -u /sys/devices/pci*/*/virtio*/modalias | xargs -n1 modprobe 2>/dev/null || :
 # modprobe 9p if absent
-grep -q 9p /proc/filesystems || modprobe 9p
+if ! grep -q 9p /proc/filesystems; then
+	modprobe virtio
+	modprobe virtio_blk
+	modprobe virtio_gpu
+	modprobe virtio_net
+	modprobe virtio_pci
+	modprobe virtio_pci_legacy_dev
+	modprobe virtio_pci_modern_dev
+	modprobe virtio_pmem
+	modprobe virtio_ring
+	modprobe virtio_rng
+	modprobe virtio_scsi
+	modprobe 9pnet_virtio
+	modprobe 9pnet
+	modprobe 9p
+fi
 
 # Setup default mountpoint for 9p shared dir
 mount -t 9p -otrans=virtio -oversion=9p2000.L  defaultshare /mnt/


### PR DESCRIPTION
On some kernels and systems (especially if cross compiled) the `modalias` method of bulk loading modules may not work (see Alpine's arm64 linux-virt kernel)

This fixes by falling back to perform single modprobes in order, to ensure functionality.
