### PR TITLE
Drop pkg-config tests obsoleted by pkgconf tests

### DIFF
--- a/libspatialindex.yaml
+++ b/libspatialindex.yaml
@@ -36,6 +36,9 @@ subpackages:
   - name: libspatialindex-dev
     pipeline:
       - uses: split/dev
+    test:
+      pipeline:
+        - uses: test/pkgconf
 
 test:
   environment:
@@ -139,10 +142,6 @@ test:
 
         # Run the program to check if it can open the BPF object
         ./test_prog
-    - name: "Check pkg-config"
-      runs: |
-        pkg-config --exists libspatialindex
-        pkg-config --modversion libspatialindex
 
 update:
   enabled: true

--- a/userspace-rcu.yaml
+++ b/userspace-rcu.yaml
@@ -86,8 +86,3 @@ test:
         grep "RCU read lock acquired" output.log
         grep "RCU read lock released" output.log
         grep "RCU thread unregistered successfully" output.log
-    - name: "Check pkg-config information"
-      runs: |
-        pkg-config --exists liburcu
-        pkg-config --modversion liburcu | grep ${{package.version}}
-        pkg-config --libs liburcu | grep -- -lurcu

--- a/wayland-protocols.yaml
+++ b/wayland-protocols.yaml
@@ -49,10 +49,6 @@ test:
       runs: |
         test -d /usr/share/wayland-protocols
         test -d /usr/share/pkgconfig
-    - name: "Check pkg-config registration"
-      runs: |
-        pkg-config --exists wayland-protocols
-        pkg-config --variable=pkgdatadir wayland-protocols
     - name: "Verify presence of core protocol files"
       runs: |
         for proto in \


### PR DESCRIPTION
The pkg-config and pkgconf tests are the same so let's drop the pkg-config ones in favor of the pkgconf ones which use a pipeline.