### PR TITLE
bluez: workaround permission issue to enable test runs.

### DIFF
--- a/bluez.yaml
+++ b/bluez.yaml
@@ -2,7 +2,7 @@
 package:
   name: bluez
   version: "5.79"
-  epoch: 1
+  epoch: 2
   description: Tools for the Bluetooth protocol stack
   copyright:
     - license: GPL-2.0-or-later AND BSD-2-Clause AND MIT
@@ -58,6 +58,12 @@ pipeline:
 
       install -Dm644 obexd/src/org.bluez.obex.service \
         "${{targets.destdir}}"/usr/share/dbus-1/services/org.bluez.obex.service
+
+      # Workaround permission issue. Fixed upstream, but pulling in patch requires
+      # running autoreconf which seems to generate issues.
+      # https://github.com/bluez/bluez/commit/b1fd409960001a77cda2a09ecc00147ebd9c3667
+      # Fixes: https://github.com/wolfi-dev/os/issues/31026
+      chmod 0755 "${{targets.destdir}}"/etc/bluetooth
 
   - uses: strip
 


### PR DESCRIPTION
Workaround via melange the permission issue that makes tests not work for bluez.
As per inline comment, this is fixed upstream by https://github.com/bluez/bluez/commit/b1fd409960001a77cda2a09ecc00147ebd9c3667 . Originally I tried to just switch bluez to use git-checkout, but the git-based releases of bluez do not have a generated `./configure`, and running autoreconf results in build that is not working. This would require a bit more digging to know what's wrong. But I don't know if it's worth the time as bluez seems to release rather frequently, so we'll get a new version with the fix pretty soon. And the workaround is very non-invasive.

But if people prefer me to get to the bottom of bluez+autoreconf runs, I can do that too.

Fixes: https://github.com/wolfi-dev/os/issues/31026

Related:

