### PR TITLE
Add the ldd-check test pipeline to more packages

### DIFF
--- a/xz.yaml
+++ b/xz.yaml
@@ -113,6 +113,9 @@ test:
         xz -t data.txt.xz
         xz -d data.txt.xz
         cmp data.txt data.bak
+    - uses: test/ldd-check
+      with:
+        files: /usr/lib/liblzma.so.5
 
 update:
   enabled: true

--- a/zlib.yaml
+++ b/zlib.yaml
@@ -113,6 +113,9 @@ test:
     - uses: test/hardening-check
       with:
         package-match: "zlib\\|minizip"
+    - uses: test/ldd-check
+      with:
+        files: /lib/libz.so.1
 
 update:
   enabled: true

--- a/zstd.yaml
+++ b/zstd.yaml
@@ -65,6 +65,12 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libzstd.so.* "${{targets.subpkgdir}}"/usr/lib/
+    test:
+      pipeline:
+        - uses: test/ldd-check
+          with:
+            files: /usr/lib/libzstd.so.1
+
 
 update:
   enabled: true

--- a/zstd.yaml
+++ b/zstd.yaml
@@ -71,7 +71,6 @@ subpackages:
           with:
             files: /usr/lib/libzstd.so.1
 
-
 update:
   enabled: true
   github:


### PR DESCRIPTION
In https://github.com/wolfi-dev/os/pull/36708 an ldd check test pipeline was added to wolfi. Let's use it for more packages.