### PR TITLE
meson: python multiversioning

### DIFF
--- a/meson.yaml
+++ b/meson.yaml
@@ -1,13 +1,48 @@
 package:
   name: meson
   version: 1.6.0
-  epoch: 1
+  epoch: 2
   description: Fast and user friendly build system
   copyright:
     - license: Apache-2.0
   dependencies:
-    runtime:
-      - samurai
+    provider-priority: 0
+
+vars:
+  pypi-package: meson
+  import: mesonbuild
+  test-version-help: |
+    meson --help
+  test-demo: |
+    tmpdir=$(mktemp -d)
+    trap "rm -rf $tmpdir" EXIT
+    cd "$tmpdir"
+
+    cat <<'EOF' > main.c
+    #include <stdio.h>
+    int main(int argc, char **argv) {
+      printf("Hello Wolfi.\n");
+      return 0;
+    }
+    EOF
+
+    cat <<'EOF' > "meson.build"
+    project('tutorial', 'c')
+    executable('demo', 'main.c')
+    EOF
+
+    CC=gcc meson setup builddir
+    cd builddir
+    meson compile
+    ./demo
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
+      3.12: "312"
+      3.13: "313"
 
 environment:
   contents:
@@ -15,9 +50,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - openssf-compiler-options
-      - py3-pip
-      - py3-setuptools
-      - python3
+      - py3-supported-build-base
       - samurai
 
 pipeline:
@@ -26,9 +59,81 @@ pipeline:
       expected-sha256: 999b65f21c03541cf11365489c1fad22e2418bb0c3d50ca61139f2eec09d5496
       uri: https://github.com/mesonbuild/meson/releases/download/${{package.version}}/meson-${{package.version}}.tar.gz
 
-  - uses: py/pip-build-install
-
 subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: "move usr/bin executables for -bin"
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+        - samurai
+      provides:
+        - meson
+        - py3-${{vars.pypi-package}}-bin
+      provider-priority: ${{range.value}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      environment:
+        contents:
+          packages:
+            - build-base
+      pipeline:
+        - runs: ${{vars.test-version-help}}
+        - runs: ${{vars.test-demo}}
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.12
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.13
+            import: ${{vars.import}}
+
   - name: meson-doc
     pipeline:
       - uses: split/manpages
@@ -45,30 +150,5 @@ test:
       packages:
         - build-base
   pipeline:
-    - runs: |
-        meson --version | grep ${{package.version}}
-        meson --help
-    - runs: |
-        mkdir -p /tmp
-        cd /tmp
-        cat <<'EOF' >> /tmp/main.c
-        #include <stdio.h>
-
-        //
-        // main is where all program execution starts
-        //
-        int main(int argc, char **argv) {
-        printf("Hello Wolfi.\n");
-        return 0;
-        }
-
-        EOF
-        cat <<'EOF'>> /tmp/meson.build
-        project('tutorial', 'c')
-        executable('demo', 'main.c')
-        EOF
-
-        CC=gcc meson setup builddir
-        cd builddir
-        meson compile
-        ./demo
+    - runs: ${{vars.test-version-help}}
+    - runs: ${{vars.test-demo}}


### PR DESCRIPTION
Related: https://github.com/chainguard-dev/internal-dev/issues/5334

I also tweaked the demo test a bit to use a temporary directory instead of hardcoded paths in /tmp, and to truncate files instead of appending to them in HERE documents, which I imagine would break tests if ran multiple times.