### PR TITLE
Add the ldd-check test pipeline to zfs

### DIFF
--- a/zfs.yaml
+++ b/zfs.yaml
@@ -117,3 +117,12 @@ test:
         zed version
         zed help
         zstreamdump -v
+    - uses: test/ldd-check
+      with:
+        files: |
+          /usr/lib/libnvpair.so.3
+          /usr/lib/libuutil.so.3
+          /usr/lib/libzfs.so.4
+          /usr/lib/libzfs_core.so.3
+          /usr/lib/libzfsbootenv.so.1
+          /usr/lib/libzpool.so.5


### PR DESCRIPTION
It passes:

```
2024/12/13 13:03:23 INFO running step "test/ldd-check"
2024/12/13 13:03:23 WARN + '[' -d /home/build ]
2024/12/13 13:03:23 WARN + cd /home/build
2024/12/13 13:03:23 WARN + exit 0
2024/12/13 13:03:23 INFO running step "run ldd on provided files"
2024/12/13 13:03:23 WARN + '[' -d /home/build ]
2024/12/13 13:03:23 WARN + cd /home/build
2024/12/13 13:03:23 WARN + set +x
2024/12/13 13:03:23 INFO PASS[ldd-check]: /usr/lib/libnvpair.so.3
2024/12/13 13:03:23 INFO PASS[ldd-check]: /usr/lib/libuutil.so.3
2024/12/13 13:03:23 INFO PASS[ldd-check]: /usr/lib/libzfs.so.4
2024/12/13 13:03:23 INFO PASS[ldd-check]: /usr/lib/libzfs_core.so.3
2024/12/13 13:03:23 INFO PASS[ldd-check]: /usr/lib/libzfsbootenv.so.1
2024/12/13 13:03:23 INFO PASS[ldd-check]: /usr/lib/libzpool.so.5
2024/12/13 13:03:23 INFO tested 6 files with ldd. 6 passes. 0 fails.
```