### PR TITLE
chore(icu): Update to 76.1

### DIFF
--- a/R.yaml
+++ b/R.yaml
@@ -2,7 +2,7 @@
 package:
   name: R
   version: 4.4.2
-  epoch: 0
+  epoch: 1
   description: Language and environment for statistical computing
   copyright:
     - license: ( GPL-2.0-only OR GPL-3.0-only ) AND LGPL-2.1-or-later

--- a/apache-arrow.yaml
+++ b/apache-arrow.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-arrow
   version: 18.1.0
-  epoch: 1
+  epoch: 2
   description: "multi-language toolbox for accelerated data interchange and in-memory processing"
   copyright:
     - license: Apache-2.0

--- a/couchdb-3.3.yaml
+++ b/couchdb-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: couchdb-3.3
   version: 3.3.3
-  epoch: 5
+  epoch: 6
   description: Seamless multi-master syncing database with an intuitive HTTP/JSON API, designed for reliability
   copyright:
     - license: Apache-2.0

--- a/falco.yaml
+++ b/falco.yaml
@@ -1,7 +1,7 @@
 package:
   name: falco
   version: 0.39.2 # on update check if we can remove the 'Patch falcosecurity-libs' pipeline below if https://github.com/falcosecurity/libs/pull/2079 is merged
-  epoch: 2
+  epoch: 3
   description: Cloud Native Runtime Security
   copyright:
     - license: Apache-2.0

--- a/freerdp-3.yaml
+++ b/freerdp-3.yaml
@@ -1,7 +1,7 @@
 package:
   name: freerdp-3
   version: 3.10.0
-  epoch: 0
+  epoch: 1
   description: FreeRDP client
   copyright:
     - license: Apache-2.0

--- a/gitlab-cng-17.6.yaml
+++ b/gitlab-cng-17.6.yaml
@@ -34,7 +34,7 @@ package:
   name: gitlab-cng-17.6
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
   version: 17.6.0
-  epoch: 1
+  epoch: 2
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT

--- a/grpc-1.66.yaml
+++ b/grpc-1.66.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.66
   version: 1.66.2
-  epoch: 2
+  epoch: 3
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.67.yaml
+++ b/grpc-1.67.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.67
   version: 1.67.1
-  epoch: 4
+  epoch: 5
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/grpc-1.68.yaml
+++ b/grpc-1.68.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.68
   version: 1.68.2
-  epoch: 2
+  epoch: 3
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT

--- a/harfbuzz.yaml
+++ b/harfbuzz.yaml
@@ -1,7 +1,7 @@
 package:
   name: harfbuzz
   version: 10.1.0
-  epoch: 0
+  epoch: 1
   description: Text shaping library
   copyright:
     - license: MIT

--- a/icu.yaml
+++ b/icu.yaml
@@ -1,7 +1,7 @@
 package:
   name: icu
-  version: "75.1"
-  epoch: 5
+  version: "76.1"
+  epoch: 1
   description: "International Components for Unicode library"
   copyright:
     - license: MIT
@@ -37,7 +37,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/unicode-org/icu/releases/download/release-${{vars.dash-package-version}}/icu4c-${{vars.underscore-package-version}}-src.tgz
-      expected-sha256: cb968df3e4d2e87e8b11c49a5d01c787bd13b9545280fc6642f826527618caef
+      expected-sha256: dfacb46bfe4747410472ce3e1144bf28a102feeaa4e3875bac9b4c6cf30f4f3e
       strip-components: 0
 
   - runs: |
@@ -104,7 +104,6 @@ subpackages:
 #   strip-prefix: release-
 update:
   enabled: true
-  manual: true # ICU updates contain ABI breaking changes which require manual intervention
   version-transform:
     - match: \-
       replace: .

--- a/libical.yaml
+++ b/libical.yaml
@@ -2,7 +2,7 @@
 package:
   name: libical
   version: 3.0.16
-  epoch: 5
+  epoch: 6
   description: Reference implementation of the iCalendar format
   copyright:
     - license: LGPL-2.1-only OR MPL-2.0

--- a/mozjs91.yaml
+++ b/mozjs91.yaml
@@ -1,7 +1,7 @@
 package:
   name: mozjs91
   version: 91.13.0
-  epoch: 6
+  epoch: 7
   description:
   copyright:
     - license: MPL-2.0

--- a/neon.yaml
+++ b/neon.yaml
@@ -1,7 +1,7 @@
 package:
   name: neon
   version: "7336"
-  epoch: 0
+  epoch: 1
   description: "Serverless Postgres. We separated storage and compute to offer autoscaling, branching, and bottomless storage."
   copyright:
     - license: Apache-2.0

--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-16
   version: 16.20.2
-  epoch: 7
+  epoch: 8
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-18
   version: 18.20.5
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-20
   version: 20.18.1
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   dependencies:
     provides:

--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-21
   version: 21.7.3
-  epoch: 4
+  epoch: 5
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-22
   version: 22.11.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/nodejs-23.yaml
+++ b/nodejs-23.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-23
   version: 23.4.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:

--- a/percona-server-9.0.yaml
+++ b/percona-server-9.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-server-9.0
   version: 9.0.1.1
-  epoch: 0
+  epoch: 1
   description: "Percona Server for MySQL is a free, fully compatible, enhanced, and open source drop-in replacement for any MySQL database. It provides superior performance, scalability, and instrumentation."
   copyright:
     - license: GPL-3.0-or-later

--- a/percona-xtrabackup-8.4.yaml
+++ b/percona-xtrabackup-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-xtrabackup-8.4
   version: 8.4.0.1
-  epoch: 2
+  epoch: 3
   description: Open source hot backup tool for InnoDB and XtraDB databases
   copyright:
     - license: Apache-2.0

--- a/php-8.1-pecl-http.yaml
+++ b/php-8.1-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1-pecl-http
   version: 4.2.6
-  epoch: 0
+  epoch: 1
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause

--- a/php-8.1.yaml
+++ b/php-8.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.1
   version: 8.1.31
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/php-8.2-pecl-http.yaml
+++ b/php-8.2-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2-pecl-http
   version: 4.2.6
-  epoch: 0
+  epoch: 1
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause

--- a/php-8.2.yaml
+++ b/php-8.2.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.2
   version: 8.2.26
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/php-8.3-pecl-http.yaml
+++ b/php-8.3-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3-pecl-http
   version: 4.2.6
-  epoch: 0
+  epoch: 1
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause

--- a/php-8.3.yaml
+++ b/php-8.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.3
   version: 8.3.14
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/php-8.4-pecl-http.yaml
+++ b/php-8.4-pecl-http.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4-pecl-http
   version: 4.2.6
-  epoch: 0
+  epoch: 1
   description: "Provides PHP ${{vars.phpMM}} HTTP module for PHP Extended HTTP Support- PECL"
   copyright:
     - license: BSD-2-Clause

--- a/php-8.4.yaml
+++ b/php-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: php-8.4
   version: 8.4.1
-  epoch: 0
+  epoch: 1
   description: "the PHP programming language"
   copyright:
     - license: PHP-3.01

--- a/postfix.yaml
+++ b/postfix.yaml
@@ -1,7 +1,7 @@
 package:
   name: postfix
   version: 3.9.1
-  epoch: 0
+  epoch: 1
   description: Secure and fast drop-in replacement for Sendmail (MTA)
   copyright:
     - license: IPL-1.0 OR EPL-2.0

--- a/postgresql-16.yaml
+++ b/postgresql-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-16
   version: "16.6"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/postgresql-17.yaml
+++ b/postgresql-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: postgresql-17
   version: "17.2"
-  epoch: 0
+  epoch: 1
   description: A sophisticated object-relational DBMS
   copyright:
     - license: BSD-3-Clause

--- a/qt5-qtbase.yaml
+++ b/qt5-qtbase.yaml
@@ -2,7 +2,7 @@
 package:
   name: qt5-qtbase
   version: 5.15.16
-  epoch: 0
+  epoch: 1
   description: Qt5 - QtBase components
   copyright:
     - license: LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0

--- a/re2.yaml
+++ b/re2.yaml
@@ -1,7 +1,7 @@
 package:
   name: re2
   version: "2024.02.01"
-  epoch: 2
+  epoch: 3
   description: Efficient, principled regular expression library
   copyright:
     - license: BSD-3-Clause

--- a/ruby3.2-charlock_holmes.yaml
+++ b/ruby3.2-charlock_holmes.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-charlock_holmes
   version: 0.7.9
-  epoch: 2
+  epoch: 3
   description: charlock_holmes provides binary and text detection as well as text transcoding using libicu
   copyright:
     - license: MIT

--- a/ruby3.3-charlock_holmes.yaml
+++ b/ruby3.3-charlock_holmes.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.3-charlock_holmes
   version: 0.7.9
-  epoch: 0
+  epoch: 1
   description: charlock_holmes provides binary and text detection as well as text transcoding using libicu
   copyright:
     - license: MIT

--- a/tesseract.yaml
+++ b/tesseract.yaml
@@ -1,7 +1,7 @@
 package:
   name: tesseract
   version: 5.5.0
-  epoch: 2
+  epoch: 3
   description: Tesseract Open Source OCR Engine
   copyright:
     - license: Apache-2.0

--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: 5.0.0
-  epoch: 4
+  epoch: 5
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
