### PR TITLE
conda: fix failure to plan

### DIFF
--- a/conda-base.yaml
+++ b/conda-base.yaml
@@ -1,7 +1,7 @@
 package:
   name: conda-base
   version: 24.11.1
-  epoch: 0
+  epoch: 1
   description: "Base environment for conda."
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
Not sure what is happening, or why 2 different Origins need to have the same version number.

Let's see if bumping conda-base epoch to match conda epoch, will fix this plan failure:

```
╷
│ Error: Multiple packages match
│
│   with module.conda.module.latest["conda"].data.apko_tags.tags[0],
│   on tflib/publisher/main.tf line 132, in data "apko_tags" "tags":
│  132: data "apko_tags" "tags" {
│
│ Multiple packages match with different versions: conda-init (24.11.1-r1) and conda-base (24.11.1-r0)
╵
```


Added this build to image build like this:

```diff
diff --git a/main.tf b/main.tf
index c54ceade2..919bbba9b 100644
--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ provider "apko" {
     "https://packages.wolfi.dev/os",
     "https://packages.cgr.dev/extras",
   ], var.extra_repositories)
-  build_repositories = ["https://apk.cgr.dev/chainguard-private"]
+  build_repositories = ["https://apk.cgr.dev/chainguard-private", "https://apk.cgr.dev/wolfi-presubmit/9788cea0132e7691e5d46465b624b1f56a1450f5"]
   extra_keyring = concat([
     "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
     "https://packages.cgr.dev/extras/chainguard-extras.rsa.pub",
```

And plan now works:

```
Apply complete! Resources: 17 added, 0 changed, 0 destroyed.

Outputs:

summary_conda = {
  "tags" = {
    "registry.localhost:5005/conda@sha256:2db9fefdff9dfc903f3bd096e59213afacfc2d8bb7d59dc7e780ef23b8249632" = tolist([
      "24",
      "24.11",
      "24.11.1",
      "24.11.1-r1",
      "latest",
    ])
    "registry.localhost:5005/conda@sha256:6ada266b91dce78457bf15d2139ecf19f730eab7df2357e4616ae7e4fe12fcb1" = tolist([
      "24-dev",
      "24.11-dev",
      "24.11.1-dev",
      "24.11.1-r1-dev",
      "latest-dev",
    ])
  }
}
```