### PR TITLE
add argocd-image-updater package

### DIFF
--- a/argocd-image-updater.yaml
+++ b/argocd-image-updater.yaml
@@ -1,0 +1,60 @@
+package:
+  name: argocd-image-updater
+  version: 0.15.1
+  epoch: 0
+  description: Automatic container image update for Argo CD
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - aws-cli-2
+      - ca-certificates
+      - git
+      - gpg
+      - openssh-client
+      - tini
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/argoproj-labs/argocd-image-updater
+      tag: v${{package.version}}
+      expected-commit: 3a2c074a8fc2730c95f16c3a806ec031a72387d9
+
+  - uses: go/bump
+    with:
+      deps: github.com/golang-jwt/jwt/v4@v4.5.1 golang.org/x/crypto@v0.31.0
+
+  - uses: go/build
+    with:
+      packages: ./cmd/
+      output: argocd-image-updater
+      ldflags: |
+        -X github.com/argoproj-labs/argocd-image-updater/pkg/version.version=${{package.version}}
+        -X github.com/argoproj-labs/argocd-image-updater/pkg/version.gitCommit=$(git rev-parse HEAD)
+        -X github.com/argoproj-labs/argocd-image-updater/pkg/version.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+subpackages:
+  - name: ${{package.name}}-compat
+    description: argocd-image-updater compat to put binary at expected place by stream
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/local/bin
+          ln -sf /usr/bin/argocd-image-updater ${{targets.subpkgdir}}/usr/local/bin/argocd-image-updater
+
+update:
+  enabled: true
+  github:
+    identifier: argoproj-labs/argocd-image-updater
+    strip-prefix: v
+    tag-filter: v
+
+test:
+  pipeline:
+    - name: Check version
+      runs: |
+        argocd-image-updater version | grep -q ${{package.version}}
+    - uses: test/kwok/cluster
+    - name: more tests
+      runs: |
+        argocd-image-updater test nginx


### PR DESCRIPTION
the CVEs require upstream fix without bringing in big patch. will file advisories for the same.