### PR TITLE
libvips: configure using `auto_features`, make sure we enable svg support + add tests

### DIFF
--- a/libvips.yaml
+++ b/libvips.yaml
@@ -28,7 +28,6 @@ environment:
       - openexr-dev
       - openssf-compiler-options
       - orc-dev
-      - poppler-dev # TODO: libvips required poppler-glib but the files we need is in poppler-dev. This is different with other distro.
 
 pipeline:
   - uses: git-checkout
@@ -51,6 +50,7 @@ pipeline:
         -Dheif=disabled \
         -Djpeg-xl=disabled \
         -Dnifti=disabled \
+        -Dpoppler=disabled \
         -Dintrospection=disabled
 
   - uses: meson/compile
@@ -92,3 +92,4 @@ test:
         vipsheader --help
         vipsthumbnail --help
         vips --vips-config | grep svg
+        vips --vips-config | grep png

--- a/libvips.yaml
+++ b/libvips.yaml
@@ -1,7 +1,7 @@
 package:
   name: libvips
   version: 8.16.0
-  epoch: 0
+  epoch: 1
   description: "A fast image processing library with low memory needs"
   copyright:
     - license: LGPL-2.1-or-later
@@ -29,6 +29,9 @@ pipeline:
       tag: v${{package.version}}
 
   - uses: meson/configure
+    with:
+      opts: |
+        -D rsvg=enabled
 
   - uses: meson/compile
 
@@ -68,3 +71,4 @@ test:
         vips --help
         vipsheader --help
         vipsthumbnail --help
+        vips --vips-config | grep svg

--- a/libvips.yaml
+++ b/libvips.yaml
@@ -14,12 +14,21 @@ environment:
       - busybox
       - cmake
       - expat-dev
+      - fftw-dev
       - glib-dev
+      - highway-dev
+      - imagemagick-7-dev
+      - lcms2-dev
+      - libarchive-dev
       - libexif-dev
+      - libimagequant-dev
       - libjpeg-turbo-dev
       - librsvg-dev
       - meson
+      - openexr-dev
       - openssf-compiler-options
+      - orc-dev
+      - poppler-dev # TODO: libvips required poppler-glib but the files we need is in poppler-dev. This is different with other distro.
 
 pipeline:
   - uses: git-checkout
@@ -31,7 +40,18 @@ pipeline:
   - uses: meson/configure
     with:
       opts: |
-        -D rsvg=enabled
+        -Dauto_features=enabled \
+        -Dcfitsio=disabled \
+        -Dcgif=disabled \
+        -Dspng=disabled \
+        -Dopenslide=disabled \
+        -Dmatio=disabled \
+        -Dopenjpeg=disabled \
+        -Dpdfium=disabled \
+        -Dheif=disabled \
+        -Djpeg-xl=disabled \
+        -Dnifti=disabled \
+        -Dintrospection=disabled
 
   - uses: meson/compile
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

- use `auto_features` to enable feats for those we already have deps packaged. list of auto_features is listed [here upstream](https://github.com/libvips/libvips/blob/master/meson_options.txt)
- disable those that we do not currenty package yet.

TODO: need to take a look at poppler-glib. It doesn't have deps required for this but poppler-dev does. My guess is that we somehow split everything in -dev pkg. cc @kauabh 

Fixes: https://github.com/wolfi-dev/os/issues/37054 https://github.com/wolfi-dev/os/issues/37929

![image](https://github.com/user-attachments/assets/6bc0e491-fdf2-4740-9f16-a314bb344f7b)


Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
