### PR TITLE
feat(couchdb): add entrypoint and container specific files ; pin Python 3.12

### DIFF
--- a/couchdb-3.3.yaml
+++ b/couchdb-3.3.yaml
@@ -68,6 +68,8 @@ subpackages:
       provides:
         - couchdb-compat=${{package.full-version}}
         - ${{package.name}}-entrypoint=${{package.full-version}}
+      replaces:
+        - ${{package.name}}
     pipeline:
       - runs: |
           # link /usr/share/couchdb to /opt/couchdb

--- a/couchdb-3.3.yaml
+++ b/couchdb-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: couchdb-3.3
   version: 3.3.3
-  epoch: 5
+  epoch: 6
   description: Seamless multi-master syncing database with an intuitive HTTP/JSON API, designed for reliability
   copyright:
     - license: Apache-2.0
@@ -27,7 +27,7 @@ environment:
       - npm
       - openssf-compiler-options
       - openssl-dev
-      - python3
+      - python-3.12 # pinning due to imghdr ; see https://peps.python.org/pep-0594/#imghdr
 
 pipeline:
   - uses: git-checkout
@@ -59,12 +59,31 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: couchdb-compat
+  - name: ${{package.name}}-compat
+    dependencies:
+      runtime:
+        - busybox
+        - curl
+        - su-exec
+      provides:
+        - couchdb-compat=${{package.full-version}}
+        - ${{package.name}}-entrypoint=${{package.full-version}}
     pipeline:
       - runs: |
           # link /usr/share/couchdb to /opt/couchdb
           mkdir -p ${{targets.subpkgdir}}/opt
           ln -sf /usr/share/couchdb ${{targets.subpkgdir}}/opt/couchdb
+
+          # copy docker default settings
+          mkdir -p ${{targets.subpkgdir}}/usr/share/couchdb/etc/default.d
+          install -m644 ./10-docker-default.ini ${{targets.subpkgdir}}/usr/share/couchdb/etc/default.d/
+          install -m644 ./vm.args ${{targets.subpkgdir}}/usr/share/couchdb/etc/
+
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          install -m755 ./docker-entrypoint.sh "${{targets.subpkgdir}}/usr/bin/docker-entrypoint.sh"
+
+          mkdir -p "${{targets.subpkgdir}}/usr/local/bin"
+          ln -s /usr/bin/docker-entrypoint.sh "${{targets.subpkgdir}}/usr/local/bin/docker-entrypoint.sh"
 
   - name: couchdb-doc
     pipeline:

--- a/couchdb-3.3/10-docker-default.ini
+++ b/couchdb-3.3/10-docker-default.ini
@@ -1,0 +1,8 @@
+; CouchDB Configuration Settings
+
+; Custom settings should be made in this file. They will override settings
+; in default.ini, but unlike changes made to default.ini, this file won't be
+; overwritten on server upgrade.
+
+[chttpd]
+bind_address = any

--- a/couchdb-3.3/docker-entrypoint.sh
+++ b/couchdb-3.3/docker-entrypoint.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+set -e
+
+# first arg is `-something` or `+something`
+if [ "${1#-}" != "$1" ] || [ "${1#+}" != "$1" ]; then
+	set -- /opt/couchdb/bin/couchdb "$@"
+fi
+
+# first arg is the bare word `couchdb`
+if [ "$1" = 'couchdb' ]; then
+	shift
+	set -- /opt/couchdb/bin/couchdb "$@"
+fi
+
+if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
+	# Check that we own everything in /opt/couchdb and fix if necessary. We also
+	# add the `-f` flag in all the following invocations because there may be
+	# cases where some of these ownership and permissions issues are non-fatal
+	# (e.g. a config file owned by root with o+r is actually fine), and we don't
+	# to be too aggressive about crashing here ...
+	find /opt/couchdb \! \( -user couchdb -group couchdb \) -exec chown -f couchdb:couchdb '{}' +
+
+	# Ensure that data files have the correct permissions. We were previously
+	# preventing any access to these files outside of couchdb:couchdb, but it
+	# turns out that CouchDB itself does not set such restrictive permissions
+	# when it creates the files. The approach taken here ensures that the
+	# contents of the datadir have the same permissions as they had when they
+	# were initially created. This should minimize any startup delay.
+	find /opt/couchdb/data -type d ! -perm 0755 -exec chmod -f 0755 '{}' +
+	find /opt/couchdb/data -type f ! -perm 0644 -exec chmod -f 0644 '{}' +
+
+	# Do the same thing for configuration files and directories. Technically
+	# CouchDB only needs read access to the configuration files as all online
+	# changes will be applied to the "docker.ini" file below, but we set 644
+	# for the sake of consistency.
+	find /opt/couchdb/etc -type d ! -perm 0755 -exec chmod -f 0755 '{}' +
+	find /opt/couchdb/etc -type f ! -perm 0644 -exec chmod -f 0644 '{}' +
+
+	if [ ! -z "$NODENAME" ] && ! grep "couchdb@" /opt/couchdb/etc/vm.args; then
+		echo "-name couchdb@$NODENAME" >> /opt/couchdb/etc/vm.args
+	fi
+
+	# Ensure that CouchDB will write custom settings in this file
+	touch /opt/couchdb/etc/local.d/docker.ini
+
+	if [ "$COUCHDB_USER" ] && [ "$COUCHDB_PASSWORD" ]; then
+		# Create admin only if not already present
+		if ! grep "^$COUCHDB_USER =" /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
+			printf "\n[admins]\n%s = %s\n" "$COUCHDB_USER" "$COUCHDB_PASSWORD" >> /opt/couchdb/etc/local.d/docker.ini
+		fi
+	fi
+
+	if [ "$COUCHDB_SECRET" ]; then
+		# Set secret only if not already present
+		if ! grep "^secret =" /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
+			printf "\n[chttpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> /opt/couchdb/etc/local.d/docker.ini
+		fi
+	fi
+
+	if [ "$COUCHDB_ERLANG_COOKIE" ]; then
+		cookieFile='/opt/couchdb/.erlang.cookie'
+		if [ -e "$cookieFile" ]; then
+			if [ "$(cat "$cookieFile" 2>/dev/null)" != "$COUCHDB_ERLANG_COOKIE" ]; then
+				echo >&2
+				echo >&2 "warning: $cookieFile contents do not match COUCHDB_ERLANG_COOKIE"
+				echo >&2
+			fi
+		else
+			echo "$COUCHDB_ERLANG_COOKIE" > "$cookieFile"
+		fi
+		chown couchdb:couchdb "$cookieFile"
+		chmod 600 "$cookieFile"
+	fi
+
+	chown -f couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini || true
+
+	# TODO: enable check
+	# if we don't find an [admins] section followed by a non-comment, display a warning
+#         if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/default.d/*.ini /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
+# 		# The - option suppresses leading tabs but *not* spaces. :)
+# 		cat >&2 <<-'EOWARN'
+# *************************************************************
+# ERROR: CouchDB 3.0+ will no longer run in "Admin Party"
+#        mode. You *MUST* specify an admin user and
+#        password, either via your own .ini file mapped
+#        into the container at /opt/couchdb/etc/local.ini
+#        or inside /opt/couchdb/etc/local.d, or with
+#        "-e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password"
+#        to set it via "docker run".
+# *************************************************************
+# EOWARN
+# 		exit 1
+# 	fi
+
+	export HOME=$(echo ~couchdb)
+	set -- su-exec couchdb "$@"
+fi
+
+exec "$@"

--- a/couchdb-3.3/docker-entrypoint.sh
+++ b/couchdb-3.3/docker-entrypoint.sh
@@ -86,23 +86,22 @@ if [ "$1" = '/opt/couchdb/bin/couchdb' ]; then
 
 	chown -f couchdb:couchdb /opt/couchdb/etc/local.d/docker.ini || true
 
-	# TODO: enable check
 	# if we don't find an [admins] section followed by a non-comment, display a warning
-#         if ! grep -Pzoqr '\[admins\]\n[^;]\w+' /opt/couchdb/etc/default.d/*.ini /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini; then
-# 		# The - option suppresses leading tabs but *not* spaces. :)
-# 		cat >&2 <<-'EOWARN'
-# *************************************************************
-# ERROR: CouchDB 3.0+ will no longer run in "Admin Party"
-#        mode. You *MUST* specify an admin user and
-#        password, either via your own .ini file mapped
-#        into the container at /opt/couchdb/etc/local.ini
-#        or inside /opt/couchdb/etc/local.d, or with
-#        "-e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password"
-#        to set it via "docker run".
-# *************************************************************
-# EOWARN
-# 		exit 1
-# 	fi
+    if ! (grep -B0 -A1 -h -E '^\[admins\]' /opt/couchdb/etc/default.d/*.ini /opt/couchdb/etc/local.d/*.ini /opt/couchdb/etc/local.ini | grep -v -E '^(\[admins\]|[[:space:]]*(;|#))' | grep '=' >/dev/null); then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOWARN'
+*************************************************************
+ERROR: CouchDB 3.0+ will no longer run in "Admin Party"
+       mode. You *MUST* specify an admin user and
+       password, either via your own .ini file mapped
+       into the container at /opt/couchdb/etc/local.ini
+       or inside /opt/couchdb/etc/local.d, or with
+       "-e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password"
+       to set it via "docker run".
+*************************************************************
+EOWARN
+		exit 1
+	fi
 
 	export HOME=$(echo ~couchdb)
 	set -- su-exec couchdb "$@"

--- a/couchdb-3.3/vm.args
+++ b/couchdb-3.3/vm.args
@@ -1,0 +1,47 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Ensure that the Erlang VM listens on a known port
+-kernel inet_dist_listen_min 9100
+-kernel inet_dist_listen_max 9100
+
+# Tell kernel and SASL not to log anything
+-kernel error_logger silent
+-sasl sasl_error_logger false
+
+# This will toggle to true in Erlang 25+. However since we don't use global
+# any longer, and have our own auto-connection module, we can keep the
+# existing global behavior to avoid surprises. See
+# https://github.com/erlang/otp/issues/6470#issuecomment-1337421210 for more
+# information about possible increased coordination and messages being sent on
+# disconnections when this setting is enabled.
+#
+-kernel prevent_overlapping_partitions false
+
+# Increase the pool of dirty IO schedulers from 10 to 16
+# Dirty IO schedulers are used for file IO.
++SDio 16
+
+# Increase distribution buffer size from default of 1MB to 32MB. The default is
+# usually a bit low on busy clusters. Has no effect for single-node setups.
+# The unit is in kilobytes.
++zdbbl 32768
+
+# When running on Docker, Kubernetes or an OS using CFS (Completely Fair
+# Scheduler) with CPU quota limits set, disable busy waiting for schedulers to
+# avoid busy waiting consuming too much of Erlang VM's CPU time-slice shares.
++sbwt none
++sbwtdcpu none
++sbwtdio none
+
+# Comment this line out to enable the interactive Erlang shell on startup
++Bd -noinput


### PR DESCRIPTION
Add entrypoint needed for container as well as files for running couchdb in container

Pin Python to version 3.12 to avoid build errors with Python 3.13 and up

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
