### PR TITLE
airflow: pin to python3.12, due to FTBFS with python3.13

### DIFF
--- a/airflow.yaml
+++ b/airflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow
   version: 2.10.3
-  epoch: 1
+  epoch: 2
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it
@@ -10,13 +10,14 @@ package:
     no-depends: true
   dependencies:
     runtime:
-      - python3
+      - python-3.12
   copyright:
     - license: Apache-2.0
 
 environment:
   contents:
     packages:
+      - cargo-auditable
       - gcc
       - glibc-dev
       - mariadb-connector-c-dev
@@ -27,8 +28,10 @@ environment:
       - postgresql-dev
       - py3-pip
       - py3-xmlsec
-      - python3
-      - python3-dev
+      # Airflow requires pytonn<3.13
+      - python-3.12
+      - python-3.12-dev
+      - rust
       - wolfi-base
       - xmlsec-dev
       - xmlsec-openssl


### PR DESCRIPTION
Currently airflow is failing to build from source in post-submit, due to python3 changing from 3.12 to 3.13.

This change happened after successful pre-submit and prior to successful build in post-submit. This race is possible as we do not require "up to date" PR prior to merging, which would be impractical to enforce.

In the future, prior to flipping default, we should detect FTBFS and pin packages to 3.12 prior to upgrading the default.