### PR TITLE
pups: add pups gem package

### DIFF
--- a/pups.yaml
+++ b/pups.yaml
@@ -1,0 +1,56 @@
+package:
+  name: pups
+  version: 1.2.1
+  epoch: 0
+  description: "Simple YAML--based bootstrapper"
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby-3.3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - ruby-3.3-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/discourse/pups
+      tag: v${{package.version}}
+      expected-commit: 5436aec99ea3cd55eb9a0962b7a8cc7c2220d26e
+
+  - uses: ruby/build
+    with:
+      gem: ${{package.name}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{package.name}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+update:
+  enabled: true
+  github:
+    identifier: discourse/pups
+    strip-prefix: v
+    use-tag: true
+    tag-filter: v
+
+test:
+  pipeline:
+    - name: Test a basic parsing and execution
+      runs: |
+        cat <<EOF >test.yaml
+        params:
+          hello: 'hello world'
+        run:
+          - exec: sh -c 'echo \$hello >hello.txt'
+        EOF
+        pups test.yaml
+        test -f test.yaml
+        grep -q "hello world" hello.txt


### PR DESCRIPTION
#### For new package PRs only
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
Notes:
Despite last version of October 23, the gem doesn't have CVEs.