### PR TITLE
aws-cli provide full-version

### DIFF
--- a/aws-cli-2.yaml
+++ b/aws-cli-2.yaml
@@ -3,7 +3,7 @@
 package:
   name: aws-cli-2
   version: 2.22.17
-  epoch: 1
+  epoch: 2
   description: "Universal Command Line Interface for Amazon Web Services (v2)"
   copyright:
     - license: Apache-2.0
@@ -13,7 +13,7 @@ package:
     no-provides: true
   dependencies:
     provides:
-      - aws-cli
+      - aws-cli=${{package.full-version}}
     runtime:
       - groff
 


### PR DESCRIPTION
pinning to aws-cli only was still giving v1 of aws-cli 