### PR TITLE
fix(couchdb): remove set -x from compat package

### DIFF
--- a/couchdb-3.3.yaml
+++ b/couchdb-3.3.yaml
@@ -1,7 +1,7 @@
 package:
   name: couchdb-3.3
   version: 3.3.3
-  epoch: 6
+  epoch: 7
   description: Seamless multi-master syncing database with an intuitive HTTP/JSON API, designed for reliability
   copyright:
     - license: Apache-2.0

--- a/couchdb-3.3/docker-entrypoint.sh
+++ b/couchdb-3.3/docker-entrypoint.sh
@@ -13,9 +13,6 @@
 
 set -e
 
-# TODO: remove
-set -x
-
 # first arg is `-something` or `+something`
 if [ "${1#-}" != "$1" ] || [ "${1#+}" != "$1" ]; then
 	set -- /opt/couchdb/bin/couchdb "$@"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
Removes `set -x` added for debugging
