### PR TITLE
jupyter-server{-terminals} python multiversion support

### DIFF
--- a/py3-jupyter-server-terminals.yaml
+++ b/py3-jupyter-server-terminals.yaml
@@ -1,15 +1,12 @@
-# Generated from https://pypi.org/project/jupyter-server-terminals/
 package:
   name: py3-jupyter-server-terminals
   version: 0.5.3
-  epoch: 0
+  epoch: 1
   description: A Jupyter Server Extension Providing Terminals.
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-terminado
-      - python-3
+    provider-priority: 0
 
 environment:
   contents:
@@ -18,8 +15,21 @@ environment:
       - busybox
       - ca-certificates-bundle
       - py3-setuptools
-      - python-3
+      - py3-supported-build-base
+      - py3-supported-hatchling
       - wolfi-base
+
+vars:
+  import: jupyter_server_terminals
+  pypi-package: jupyter-server-terminals
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 pipeline:
   - uses: fetch
@@ -27,10 +37,40 @@ pipeline:
       expected-sha256: 5ae0295167220e9ace0edcfdb212afd2b01ee8d179fe6f23c899590e9b8a5269
       uri: https://files.pythonhosted.org/packages/source/j/jupyter-server-terminals/jupyter_server_terminals-${{package.version}}.tar.gz
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-terminado
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      environment:
+        contents:
+          packages:
+            - py${{range.key}}-jupyter-server
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true

--- a/py3-jupyter-server.yaml
+++ b/py3-jupyter-server.yaml
@@ -67,8 +67,6 @@ subpackages:
         - py${{range.key}}-tornado
         - py${{range.key}}-traitlets
         - py${{range.key}}-websocket-client
-      provides:
-        - py3-${{vars.pypi-package}}
       provider-priority: ${{range.value}}
     pipeline:
       - uses: py/pip-build-install

--- a/py3-jupyter-server.yaml
+++ b/py3-jupyter-server.yaml
@@ -74,6 +74,10 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
       - uses: strip
     test:
       pipeline:
@@ -81,6 +85,26 @@ subpackages:
           with:
             python: python${{range.key}}
             import: ${{vars.import}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      pipeline:
+        - runs: |
+            jupyter-server --version
+            jupyter-server --help
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.
@@ -97,9 +121,3 @@ update:
   github:
     identifier: jupyter-server/jupyter_server
     strip-prefix: v
-
-test:
-  pipeline:
-    - runs: |
-        jupyter-server --version
-        jupyter-server --help

--- a/py3-jupyter-server.yaml
+++ b/py3-jupyter-server.yaml
@@ -1,32 +1,12 @@
-# Generated from https://pypi.org/project/jupyter-server/
 package:
   name: py3-jupyter-server
   version: 2.14.2
-  epoch: 0
+  epoch: 1
   description: The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications.
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-anyio
-      - py3-argon2-cffi
-      - py3-jinja2
-      - py3-jupyter-client
-      - py3-jupyter-core
-      - py3-jupyter-events
-      - py3-jupyter-server-terminals
-      - py3-nbconvert
-      - py3-nbformat
-      - py3-overrides
-      - py3-packaging
-      - py3-prometheus-client
-      - py3-pyzmq
-      - py3-send2trash
-      - py3-terminado
-      - py3-tornado
-      - py3-traitlets
-      - py3-websocket-client
-      - python-3
+    provider-priority: 0
 
 environment:
   contents:
@@ -36,12 +16,25 @@ environment:
       - ca-certificates-bundle
       - nodejs
       - npm
-      - py3-setuptools
-      - python-3
+      - py3-supported-build-base
+      - py3-supported-hatch-jupyter-builder
+      - py3-supported-hatchling
       - wolfi-base
   environment:
     # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
     SOURCE_DATE_EPOCH: 315532800
+
+vars:
+  pypi-package: jupyter-server
+  import: jupyter_server
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 pipeline:
   - uses: git-checkout
@@ -50,10 +43,53 @@ pipeline:
       repository: https://github.com/jupyter-server/jupyter_server
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-anyio
+        - py${{range.key}}-argon2-cffi
+        - py${{range.key}}-jinja2
+        - py${{range.key}}-jupyter-client
+        - py${{range.key}}-jupyter-core
+        - py${{range.key}}-jupyter-events
+        - py${{range.key}}-jupyter-server-terminals
+        - py${{range.key}}-nbconvert
+        - py${{range.key}}-nbformat
+        - py${{range.key}}-overrides
+        - py${{range.key}}-packaging
+        - py${{range.key}}-prometheus-client
+        - py${{range.key}}-pyzmq
+        - py${{range.key}}-send2trash
+        - py${{range.key}}-terminado
+        - py${{range.key}}-tornado
+        - py${{range.key}}-traitlets
+        - py${{range.key}}-websocket-client
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true


### PR DESCRIPTION
Both are dependent on each other. `jupyter-server` required for tests of `jupyter-server-terminals` during import. 

```bash
$ uv pip show jupyter-server-terminals
Name: jupyter-server-terminals
Version: 0.5.3
Location: /home/user/tmp/hacky_esJK2D/.venv/lib/python3.13/site-packages
Requires: terminado
Required-by: jupyter-server
$ uv pip show jupyter-server
Name: jupyter-server
Version: 2.14.2
Location: /home/user/tmp/hacky_esJK2D/.venv/lib/python3.13/site-packages
Requires: anyio, argon2-cffi, jinja2, jupyter-client, jupyter-core, jupyter-events, jupyter-server-terminals, nbconvert, nbformat, overrides, packaging, prometheus-client, pyzmq, sen
d2trash, terminado, tornado, traitlets, websocket-client
Required-by:

```