### PR TITLE
nri-mssql: adding the run command for sed godebug

### DIFF
--- a/nri-mssql.yaml
+++ b/nri-mssql.yaml
@@ -21,6 +21,9 @@ pipeline:
       expected-commit: 56dedb7e06e94dc78660834e070e767ecfb49ed0
       tag: v${{package.version}}
 
+  - runs: |
+      sed -i '/^godebug/d' go.mod
+
   - uses: go/bump
     with:
       deps: golang.org/x/crypto@v0.31.0


### PR DESCRIPTION
Adding `sed -i '/^godebug/d' go.mod` to help resolve failure from https://github.com/wolfi-dev/os/pull/36906

> Error: Failed to running update. Error: unable to parse the go mod file with error: go.mod:31: unknown directive: godebug 
