### PR TITLE
trust-manager: enable GODEBUG=x509negativeserial=1

### DIFF
--- a/trust-manager.yaml
+++ b/trust-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: trust-manager
   version: 0.14.0
-  epoch: 1
+  epoch: 2
   description: trust-manager is an operator for distributing trust bundles across a Kubernetes cluster.
   copyright:
     - license: Apache-2.0
@@ -36,6 +36,18 @@ pipeline:
   - runs: |
       cd trust-manager
       mkdir ./bin
+
+      # In the cert bundle that current version of trust-manager used, there
+      # is a cert that will produce a negative serial number, which is disallowed
+      # on Go 1.23. According to https://pkg.go.dev/crypto/x509#ParseCertificate,
+      # the Go 1.22 behavior can be restored using GODEBUG=x509negativeserial=1.
+      #
+      # See https://github.com/cert-manager/trust-manager/pull/515/files
+      # and https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1734105432142589
+      #
+      # We should revert this change when upstream fixes their cert bundle.
+      export GODEBUG="x509negativeserial=1"
+
       go build -o ./bin/trust-manager ./cmd/trust-manager
       mkdir -p ${{targets.destdir}}/usr/bin
       install -Dm755 ./bin/trust-manager ${{targets.destdir}}/usr/bin/trust-manager


### PR DESCRIPTION
* trust-manager: In the cert bundle that current version of trust-manager used, there is a cert that will produce a negative serial number, which is disallowed on Go 1.23. According to https://pkg.go.dev/crypto/x509#ParseCertificate, the Go 1.22 behavior can be restored using `GODEBUG="x509negativeserial=1"`. 

See https://github.com/cert-manager/trust-manager/pull/515/files and https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1734105432142589. 

We should revert this change when upstream fixes their cert bundle.

