### PR TITLE
cython-0 - fix ftbfs after python3.13 transition

### DIFF
--- a/cython-0.yaml
+++ b/cython-0.yaml
@@ -1,15 +1,16 @@
 package:
   name: cython-0
   version: 0.29.37.1
-  epoch: 1
+  epoch: 2
   description: Cython is an optimising static compiler for both the Python & the extended Cython programming languages.
   copyright:
     - license: Apache-2.0
   dependencies:
     provides:
       - cython=${{package.version}}-r${{package.epoch}}
-    runtime:
-      - python3
+
+vars:
+  py-version: 3.12
 
 environment:
   contents:
@@ -18,9 +19,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - openssf-compiler-options
-      - py3-setuptools
-      - python3
-      - python3-dev
+      - py${{vars.py-version}}-build-base-dev
 
 pipeline:
   - uses: git-checkout
@@ -29,9 +28,7 @@ pipeline:
       repository: https://github.com/cython/cython
       tag: ${{package.version}}
 
-  - runs: |
-      python3 setup.py build
-      python3 setup.py install --prefix=/usr --root="${{targets.destdir}}"
+  - uses: py/pip-build-install
 
   - uses: strip
 


### PR DESCRIPTION
cython-0 would not build with python3 as python3.13. Pin it to python-3.12.
