### PR TITLE
nodejs - be explicit about which python is used in build environment.

### DIFF
--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-16
   version: 16.20.2
-  epoch: 7
+  epoch: 8
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -12,6 +12,9 @@ package:
   resources:
     cpu: 33
     memory: 64Gi
+
+vars:
+  py-version: 3.12
 
 environment:
   contents:
@@ -27,9 +30,9 @@ environment:
       - nghttp2-dev
       - openssf-compiler-options
       - openssl-dev
-      - py3-jinja2
-      - py3-setuptools
-      - python3
+      - py${{vars.py-version}}-jinja2
+      - py${{vars.py-version}}-setuptools
+      - python-${{vars.py-version}}-base
       - samurai
       - wolfi-base
       - zlib-dev
@@ -56,7 +59,7 @@ pipeline:
       export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
       export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
       export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-      python3 configure.py --prefix=/usr \
+      python${{vars.py-version}} configure.py --prefix=/usr \
         --shared-brotli \
         --shared-zlib \
         --shared-openssl \

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-18
   version: 18.20.5
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT
@@ -12,6 +12,9 @@ package:
   resources:
     cpu: 33
     memory: 64Gi
+
+vars:
+  py-version: 3.12
 
 environment:
   contents:
@@ -27,9 +30,9 @@ environment:
       - nghttp2-dev
       - openssf-compiler-options
       - openssl-dev
-      - py3-jinja2
-      - py3-setuptools
-      - python3
+      - py${{vars.py-version}}-jinja2
+      - py${{vars.py-version}}-setuptools
+      - python-${{vars.py-version}}-base
       - samurai
       - wolfi-base
       - zlib-dev
@@ -53,7 +56,7 @@ pipeline:
       export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
       export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
       export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-      python3 configure.py --prefix=/usr \
+      python${{vars.py-version}} configure.py --prefix=/usr \
         --shared-brotli \
         --shared-zlib \
         --shared-openssl \

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-20
   version: 20.18.1
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine - LTS version"
   dependencies:
     provides:
@@ -12,6 +12,9 @@ package:
   resources:
     cpu: 33
     memory: 64Gi
+
+vars:
+  py-version: 3.12
 
 environment:
   contents:
@@ -27,9 +30,9 @@ environment:
       - nghttp2-dev
       - openssf-compiler-options
       - openssl-dev
-      - py3-jinja2
-      - py3-setuptools
-      - python3
+      - py${{vars.py-version}}-jinja2
+      - py${{vars.py-version}}-setuptools
+      - python-${{vars.py-version}}-base
       - samurai
       - wolfi-base
       - zlib-dev
@@ -53,7 +56,7 @@ pipeline:
       export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
       export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
       export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-      python3 configure.py --prefix=/usr \
+      python${{vars.py-version}} configure.py --prefix=/usr \
         --shared-brotli \
         --shared-zlib \
         --shared-openssl \

--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-21
   version: 21.7.3
-  epoch: 4
+  epoch: 5
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -11,6 +11,9 @@ package:
   resources:
     cpu: 33
     memory: 64Gi
+
+vars:
+  py-version: 3.12
 
 environment:
   contents:
@@ -26,9 +29,9 @@ environment:
       - nghttp2-dev
       - openssf-compiler-options
       - openssl-dev
-      - py3-jinja2
-      - py3-setuptools
-      - python3
+      - py${{vars.py-version}}-jinja2
+      - py${{vars.py-version}}-setuptools
+      - python-${{vars.py-version}}-base
       - samurai
       - wolfi-base
       - zlib-dev
@@ -52,7 +55,7 @@ pipeline:
       export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
       export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
       export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-      python3 configure.py --prefix=/usr \
+      python${{vars.py-version}} configure.py --prefix=/usr \
         --shared-brotli \
         --shared-zlib \
         --shared-openssl \

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-22
   version: 22.11.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -11,6 +11,9 @@ package:
   resources:
     cpu: 33
     memory: 64Gi
+
+vars:
+  py-version: 3.13
 
 environment:
   contents:
@@ -25,12 +28,14 @@ environment:
       - linux-headers
       - nghttp2-dev
       - openssl-dev
-      - py3-jinja2
-      - py3-setuptools
-      - python3
+      - py${{vars.py-version}}-jinja2
+      - py${{vars.py-version}}-setuptools
+      - python-${{vars.py-version}}-base
       - samurai
       - wolfi-base
       - zlib-dev
+  environment:
+    GCC_SPEC_FILE: /dev/null # https://github.com/wolfi-dev/os/issues/34075
 
 pipeline:
   - uses: git-checkout
@@ -51,7 +56,7 @@ pipeline:
       export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
       export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
       export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-      python3 configure.py --prefix=/usr \
+      python${{vars.py-version}} configure.py --prefix=/usr \
         --shared-brotli \
         --shared-zlib \
         --shared-openssl \

--- a/nodejs-23.yaml
+++ b/nodejs-23.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-23
   version: 23.4.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -11,6 +11,9 @@ package:
   resources:
     cpu: 33
     memory: 64Gi
+
+vars:
+  py-version: 3.13
 
 environment:
   contents:
@@ -25,9 +28,9 @@ environment:
       - linux-headers
       - nghttp2-dev
       - openssl-dev
-      - py3-jinja2
-      - py3-setuptools
-      - python3
+      - py${{vars.py-version}}-jinja2
+      - py${{vars.py-version}}-setuptools
+      - python-${{vars.py-version}}-base
       - samurai
       - wolfi-base
       - zlib-dev
@@ -53,7 +56,7 @@ pipeline:
       export CFLAGS="${CFLAGS/-Os/-O2} $common_flags"
       export CXXFLAGS="${CXXFLAGS/-Os/-O2} $common_flags"
       export CPPFLAGS="${CPPFLAGS/-Os/-O2} $common_flags"
-      python3 configure.py --prefix=/usr \
+      python${{vars.py-version}} configure.py --prefix=/usr \
         --shared-brotli \
         --shared-zlib \
         --shared-openssl \


### PR DESCRIPTION
When 'python3' and 'py3-jinja2' are installed in the build environment, there is not currently a way to guarantee that the 'python3' (a virtual package provided by python3.12, python3.13...) will be the same python version that fulfills the virtual package 'py3-jinja2'.

The easiest way to guarantee this is to pin the python version as done here.

python-3.12 (eol 2028) will outlive any of the currently available nodejs versions. So it would be sufficient for the 'py-version' value in all of these changes.  Moving the last node lts (22) to 3.13 will give us a neweer python moving forward.
