### PR TITLE
multiversion py3-notebook-shim package

### DIFF
--- a/py3-notebook-shim.yaml
+++ b/py3-notebook-shim.yaml
@@ -1,15 +1,12 @@
-# Generated from https://pypi.org/project/notebook-shim/
 package:
   name: py3-notebook-shim
   version: 0.2.4
-  epoch: 1
+  epoch: 2
   description: A shim layer for notebook traits and config
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-jupyter-server
-      - python-3
+    provider-priority: 0
 
 environment:
   contents:
@@ -17,9 +14,21 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
+      - py3-supported-build-base
+      - py3-supported-hatchling
       - wolfi-base
+
+vars:
+  pypi-package: notebook-shim
+  import: notebook_shim
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 pipeline:
   - uses: fetch
@@ -27,10 +36,34 @@ pipeline:
       expected-sha256: b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb
       uri: https://files.pythonhosted.org/packages/source/n/notebook-shim/notebook_shim-${{package.version}}.tar.gz
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-jupyter-server
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 update:
   enabled: true


### PR DESCRIPTION
```bash
$ uv pip show notebook-shim
Name: notebook-shim
Version: 0.2.4
Location: /home/user/tmp/hacky_o64q1g/.venv/lib/python3.12/site-packages
Requires: jupyter-server
Required-by:
```

