### PR TITLE
drop python3 from build environment where not needed.

### DIFF
--- a/aom.yaml
+++ b/aom.yaml
@@ -23,7 +23,6 @@ environment:
       - gcc~13
       - openssf-compiler-options
       - perl
-      - python3
       - samurai
       - tree
       - yasm

--- a/argo-cd-2.13.yaml
+++ b/argo-cd-2.13.yaml
@@ -16,7 +16,6 @@ environment:
       - ca-certificates-bundle
       - go
       - nodejs-20
-      - python3
       - yarn
 
 pipeline:

--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -15,7 +15,6 @@ environment:
       - node-gyp
       - nodejs-20
       - openssl
-      - python3
       - yarn
 
 pipeline:

--- a/aws-c-common.yaml
+++ b/aws-c-common.yaml
@@ -14,7 +14,6 @@ environment:
       - ca-certificates-bundle
       - cmake
       - openssf-compiler-options
-      - python3-dev
       - samurai
 
 pipeline:

--- a/bun.yaml
+++ b/bun.yaml
@@ -39,7 +39,6 @@ environment:
       - perl
       - pkgconf
       - pkgconf-dev
-      - python3-dev
       - ruby-3.3
       - rust
       - samurai

--- a/gtest.yaml
+++ b/gtest.yaml
@@ -11,7 +11,7 @@ environment:
     packages:
       - build-base
       - openssf-compiler-options
-      - python3-dev
+      - python3
       - wolfi-base
 
 pipeline:

--- a/libdwarf.yaml
+++ b/libdwarf.yaml
@@ -16,7 +16,6 @@ environment:
       - libtool
       - meson
       - pkgconf-dev
-      - python3
       - zlib-dev
       - zstd-dev
 

--- a/wasmedge.yaml
+++ b/wasmedge.yaml
@@ -28,7 +28,6 @@ environment:
       - llvm-lld-${{vars.llvm-vers}}-dev
       - llvm-lld-${{vars.llvm-vers}}-static
       - openssf-compiler-options
-      - python3
       - rapidjson-dev
       - samurai
       - zlib-dev


### PR DESCRIPTION
libdwarf had python3 likely only because of meson. meson handles that dep correctly now.
gtest uses 'python3' in its build environment, it doesn't need -dev. "latest" should suffice for it.

The others, I believe python3 was just copy/pasta'd in.
