### PR TITLE
yamllint - specify python version

### DIFF
--- a/yamllint.yaml
+++ b/yamllint.yaml
@@ -1,14 +1,17 @@
 package:
   name: yamllint
   version: 1.35.1
-  epoch: 1
+  epoch: 2
   description: "A linter for YAML"
   copyright:
     - license: GPL-3.0-or-later
   dependencies:
     runtime:
-      - py3-pathspec
-      - py3-pyyaml
+      - py${{vars.py-version}}-pathspec
+      - py${{vars.py-version}}-pyyaml
+
+vars:
+  py-version: 3.13
 
 environment:
   contents:
@@ -16,9 +19,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-pip
-      - py3-setuptools
-      - python3
+      - py${{vars.py-version}}-build-base
       - wolfi-base
 
 pipeline:
@@ -28,9 +29,7 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 81e9f98ffd059efe8aa9c1b1a42e5cce61b640c6
 
-  - uses: python/build
-
-  - uses: python/install
+  - uses: py/pip-build-install
 
   - uses: strip
 


### PR DESCRIPTION
When building a python apckage, it will install into a specific usr/lib/python3.XX/site-packages thus rendering the dependency on build-time of that specific python interpreter.

The runtime dependencies are resolved at install time, and at that point they may have moved.

This dependency is thus correct and required to keep the package running.
