### PR TITLE
pylint - specify a python version

### DIFF
--- a/pylint.yaml
+++ b/pylint.yaml
@@ -1,18 +1,20 @@
 package:
   name: pylint
   version: 3.3.2
-  epoch: 0
+  epoch: 1
   description: A static code analyser for Python 2 and 3
   copyright:
     - license: GPL-2.0-only
   dependencies:
     runtime:
-      - py3-astroid
-      - py3-dill
-      - py3-isort
-      - py3-platformdirs
-      - py3-tomlkit
-      - python3
+      - py${{vars.py-version}}-astroid
+      - py${{vars.py-version}}-dill
+      - py${{vars.py-version}}-isort
+      - py${{vars.py-version}}-platformdirs
+      - py${{vars.py-version}}-tomlkit
+
+vars:
+  py-version: 3.13
 
 environment:
   contents:
@@ -20,11 +22,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-build
-      - py3-installer
-      - py3-pip
-      - py3-setuptools
-      - python3
+      - py${{vars.py-version}}-build-base
       - wolfi-base
 
 pipeline:
@@ -34,11 +32,7 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: a5a1bc3a9602d08f15ac90ad12f5b25bde375613
 
-  - name: Python Build
-    runs: python -m build
-
-  - name: Python Install
-    runs: python -m installer -d "${{targets.destdir}}/" dist/*.whl
+  - uses: py/pip-build-install
 
   - uses: strip
 
@@ -51,7 +45,7 @@ update:
 test:
   pipeline:
     - runs: |
-        pylint --version |grep ${{package.version}}
+        pylint --version | grep ${{package.version}}
         pylint --help
         pylint-config --version
         pyreverse --version


### PR DESCRIPTION
When building a python package, it will install into a specific usr/lib/python3.XX/site-packages.  Thus, there is a runtime dependency
on that specific python version.   Melange identifies and records
that correctly.

However, for python runtime dependencies melange does not record any dependencies.  The solution in the past was to record those dependencies as 'py3-<pkgname>'.  The problem with that solution is that py3-pkgname is a virtual package that will move versions over time (ie, from 3.12 to 3.13).

The result was that pylint had a python3.12 dependency, but py-astroid (and others) would install 3.13.  We'd have 2 installed pythons and no working pylint.
