### PR TITLE
grpc-1.66: move to mainline cython

### DIFF
--- a/grpc-1.66.yaml
+++ b/grpc-1.66.yaml
@@ -1,7 +1,7 @@
 package:
   name: grpc-1.66
   version: 1.66.2
-  epoch: 2
+  epoch: 3
   description: The C based gRPC
   copyright:
     - license: Apache-2.0 AND BSD-3-Clause AND MIT
@@ -32,7 +32,7 @@ environment:
       - chrpath
       - cmake
       - curl
-      - cython~0
+      - cython
       - icu-dev
       - libstdc++-dev
       - libsystemd


### PR DESCRIPTION
The cython~0 pin was added back in 1.59.1 (see commit dce154cd7ef0). 1.66 builds fine w/ mainline cython, so remove the pin.

See: https://github.com/wolfi-dev/os/issues/37272