### PR TITLE
prometheus-exporter-plugin-for-opensearch: declare compat with opensearch 2.18

### DIFF
--- a/prometheus-exporter-plugin-for-opensearch.yaml
+++ b/prometheus-exporter-plugin-for-opensearch.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-exporter-plugin-for-opensearch
   version: 2.17.1.0
-  epoch: 0
+  epoch: 1
   description: |
     Prometheus exporter plugin for OpenSearch & OpenSearch Mixin
   copyright:
@@ -29,13 +29,17 @@ pipeline:
       tag: ${{package.version}}
       recurse-submodules: true
 
+  - name: Support OpenSearch 2.18.0.0, see https://github.com/Aiven-Open/prometheus-exporter-plugin-for-opensearch/pull/316/files
+    runs: |
+      sed 's|^version = 2.17.1.0$|version = 2.18.0.0|' -i gradle.properties
+
   - runs: |
       #ignoring test as it requires to run opensearch as non-root
       ./gradlew build test -x integTest -x yamlRestTest
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/share/opensearch/plugins/prometheus-exporter-plugin-for-opensearch
-      unzip "build/distributions/prometheus-exporter-${{package.version}}.zip" -d "${{targets.destdir}}/usr/share/opensearch/plugins/prometheus-exporter-plugin-for-opensearch"
+      unzip build/distributions/prometheus-exporter-*.zip -d "${{targets.destdir}}/usr/share/opensearch/plugins/prometheus-exporter-plugin-for-opensearch"
 
 update:
   enabled: true


### PR DESCRIPTION
Upstream release of this plugging is lagging. Bump the compat version
of it by hand. Also see:
- https://github.com/Aiven-Open/prometheus-exporter-plugin-for-opensearch/issues/317
- https://github.com/Aiven-Open/prometheus-exporter-plugin-for-opensearch/pull/316

With this change, opensearch 2.18 with this plugin works again; and deploys in a helm chart.