### PR TITLE
apache-pulsar: fix CVE-2024-53990

### DIFF
--- a/apache-pulsar.yaml
+++ b/apache-pulsar.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-pulsar
   version: 4.0.1
-  epoch: 0
+  epoch: 1
   description: Pulsar is a distributed pub-sub messaging platform with a very flexible messaging model and an intuitive client API.
   copyright:
     - license: Apache-2.0
@@ -24,9 +24,11 @@ pipeline:
       repository: https://github.com/apache/pulsar
       tag: v${{package.version}}
       expected-commit: 3ea527bf6b720dcfe074c4476257cce96ebc068a
+  
+  - uses: maven/pombump
 
   - name: Build
-    runs: ./mvnw package -DskipTests -Pcore-modules,-main
+    runs: ./mvnw package -DskipTests
 
   - name: Install
     runs: |

--- a/apache-pulsar.yaml
+++ b/apache-pulsar.yaml
@@ -24,7 +24,7 @@ pipeline:
       repository: https://github.com/apache/pulsar
       tag: v${{package.version}}
       expected-commit: 3ea527bf6b720dcfe074c4476257cce96ebc068a
-  
+
   - uses: maven/pombump
 
   - name: Build

--- a/apache-pulsar/pombump-deps.yaml
+++ b/apache-pulsar/pombump-deps.yaml
@@ -1,0 +1,4 @@
+patches:
+  - groupId: org.asynchttpclient
+    artifactId: async-http-client
+    version: 2.12.4


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: CVE-2024-53990

Related: https://github.com/chainguard-dev/image-requests/issues/1654

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

Bumping version for async-http-client fixes CVE-2024-53990

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo
