### PR TITLE
Fix Druid pombump configuration

### DIFF
--- a/druid.yaml
+++ b/druid.yaml
@@ -1,7 +1,7 @@
 package:
   name: druid
   version: 31.0.0
-  epoch: 2
+  epoch: 3
   description: Apache Druid is a high performance real-time analytics database.
   copyright:
     - license: Apache-2.0

--- a/druid/pombump-deps.yaml
+++ b/druid/pombump-deps.yaml
@@ -2,6 +2,3 @@ patches:
     - groupId: org.apache.kafka
       artifactId: kafka-clients
       version: 3.7.1
-    - groupId: io.netty
-      artifactId: netty-common
-      version: 4.1.115.Final

--- a/druid/pombump-properties.yaml
+++ b/druid/pombump-properties.yaml
@@ -3,3 +3,5 @@ properties:
     value: "9.4.56.v20240826"
   - property: apache.kafka.version
     value: "3.7.1"
+  - property: netty4.version
+    value: 4.1.115.Final


### PR DESCRIPTION
After analyzing the druid pom structure, and the stacktrace linked in the stale druid
issue, realized that we were getting a class compatibility issue with netty-common,
specifically the Timer class. This is because every other netty dependency was a
different version that netty-common. By setting the netty4.version property, we guarantee
that all netty libs are on the same version and are therefore compatible. And the reason
we added the pombump dependency in the first place (probably to solve a CVE) is preserved.

The class compatiblity issue was causing the imagetest for druid to fail, because services could not correctly come up with that issue, which is part of the Druid startup process.

Fixes https://github.com/chainguard-dev/image-release-stats/issues/3075