### PR TITLE
Add python3 as a dep so g-ir-scanner can run

### DIFF
--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobject-introspection
   version: 1.82.0
-  epoch: 1
+  epoch: 2
   description: Introspection system for GObject-based libraries
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT
@@ -9,6 +9,7 @@ package:
   # build it. This is a drop in replacement to make things work.
   dependencies:
     runtime:
+      - python3
       - py3-setuptools
 
 # creates a new var that contains only the major and minor version to be used in the fetch URL
@@ -99,3 +100,4 @@ test:
         g-ir-inspect --help
         g-ir-compiler --help
         g-ir-generate --help
+        g-ir-scanner --help


### PR DESCRIPTION
g-ir-scanner would previously fail to run because python3 was not available.