### PR TITLE
gobject-introspection: rebuild against 3.13

### DIFF
--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -43,9 +43,9 @@ environment:
       - meson
       - openssf-compiler-options
       - posix-libc-utils
+      - py${{vars.py-version}}-build-base
       - py${{vars.py-version}}-packaging
       - py${{vars.py-version}}-setuptools
-      - py${{vars.py-version}}-build-base
       - python3
       - python3-dev
 

--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobject-introspection
   version: 1.82.0
-  epoch: 1
+  epoch: 2
   description: Introspection system for GObject-based libraries
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT
@@ -9,7 +9,10 @@ package:
   # build it. This is a drop in replacement to make things work.
   dependencies:
     runtime:
-      - py3-setuptools
+      - py${{vars.py-version}}-setuptools
+
+vars:
+  py-version: 3.13
 
 # creates a new var that contains only the major and minor version to be used in the fetch URL
 # e.g. 1.74.0 will create a new var mangled-package-version=1.74
@@ -40,8 +43,9 @@ environment:
       - meson
       - openssf-compiler-options
       - posix-libc-utils
-      - py3-packaging
-      - py3-setuptools
+      - py${{vars.py-version}}-packaging
+      - py${{vars.py-version}}-setuptools
+      - py${{vars.py-version}}-build-base
       - python3
       - python3-dev
 
@@ -76,7 +80,7 @@ subpackages:
         - gobject-introspection
         - libtool
         - posix-libc-utils
-        - py3-setuptools
+        - py${{vars.py-version}}-setuptools
         - python3
     description: gobject-introspection dev
     test:

--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -44,10 +44,9 @@ environment:
       - openssf-compiler-options
       - posix-libc-utils
       - py${{vars.py-version}}-build-base
+      - py${{vars.py-version}}-build-base-dev
       - py${{vars.py-version}}-packaging
       - py${{vars.py-version}}-setuptools
-      - python3
-      - python3-dev
 
 pipeline:
   - uses: fetch
@@ -65,6 +64,11 @@ pipeline:
 
   - uses: strip
 
+  # Until https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/510 is landed and released
+  - name: "Use correct Python interpreter"
+    runs: |
+      sed -i '1s|^#!/usr/bin/env python3$|#!/usr/bin/env python${{vars.py-version}}|' ${{targets.destdir}}/usr/bin/*
+
 subpackages:
   - name: gobject-introspection-doc
     pipeline:
@@ -81,7 +85,6 @@ subpackages:
         - libtool
         - posix-libc-utils
         - py${{vars.py-version}}-setuptools
-        - python3
     description: gobject-introspection dev
     test:
       pipeline:


### PR DESCRIPTION
We see a FTBFS of `at-spi2-core`. The main reason is that `gobject-introspection` was built against 3.12, and the build can't work with 3.13. Rebuild it and also switch to using the py-versioned versions of packages.

Fixes: https://github.com/wolfi-dev/os/issues/37369

Related: https://github.com/wolfi-dev/os/issues/37197

