### PR TITLE
openssl: provide stock config for ca & req apps

### DIFF
--- a/openssl.yaml
+++ b/openssl.yaml
@@ -98,8 +98,10 @@ pipeline:
       rm ${{targets.destdir}}/etc/ssl/openssl.cnf
       # Second identical copy of the above
       rm ${{targets.destdir}}/etc/ssl/openssl.cnf.dist
-      # Provide our hardened configuration for ca & req apps
-      cp openssl.cnf ca.cnf ${{targets.destdir}}/etc/ssl/
+      # Provide our hardened configuration for ca & req apps, note
+      # ca.cnf is shipped with libraries to be reusable without
+      # openssl tool
+      cp openssl.cnf ${{targets.destdir}}/etc/ssl/
       # Empty CT log
       rm ${{targets.destdir}}/etc/ssl/ct_log_list.cnf
       # Second copy of CT log
@@ -136,6 +138,10 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libcrypto.so.3 "${{targets.subpkgdir}}"/usr/lib
+          # Provide our hardened configuration for ca & req apps, note
+          # ca.cnf is shipped here to be reusable without the openssl tool
+          mkdir -p "${{targets.subpkgdir}}"/etc/ssl
+          cp ca.cnf ${{targets.subpkgdir}}/etc/ssl/
 
   - name: "libssl3"
     description: "OpenSSL libssl library"

--- a/openssl.yaml
+++ b/openssl.yaml
@@ -2,10 +2,15 @@
 package:
   name: openssl
   version: 3.4.0
-  epoch: 4
+  epoch: 5
   description: "the OpenSSL cryptography suite"
   copyright:
     - license: Apache-2.0
+  dependencies:
+    # For apk upgrades
+    replaces:
+      - openssl-config<3.4.0
+    replaces-priority: 5
   resources:
     cpu: 16
     memory: 16Gi
@@ -93,6 +98,8 @@ pipeline:
       rm ${{targets.destdir}}/etc/ssl/openssl.cnf
       # Second identical copy of the above
       rm ${{targets.destdir}}/etc/ssl/openssl.cnf.dist
+      # Provide our hardened configuration for ca & req apps
+      cp openssl.cnf ca.cnf ${{targets.destdir}}/etc/ssl/
       # Empty CT log
       rm ${{targets.destdir}}/etc/ssl/ct_log_list.cnf
       # Second copy of CT log
@@ -271,6 +278,34 @@ test:
         grep -q 'Breakpoint 1,' jitter.log || exit 1
         # Assert that getrandom syscall wrapper was used
         grep -q 'Breakpoint 2,' jitter.log && exit 1
+    - name: docker-dind certificate generation
+      runs: |
+        # Distilled from dockerd-entrypoint.sh
+        set -x
+        tmpdir="$(mktemp -d)"
+        trap "rm -rf "$tmpdir"" EXIT
+        rm -rf "$tmpdir/certs/"
+        mkdir -p "$tmpdir/certs/ca"
+        openssl genrsa -out "$tmpdir/certs/ca/key.pem" 4096
+        openssl req -new -key "$tmpdir/certs/ca/key.pem" \
+          -out "$tmpdir/certs/ca/cert.pem" -subj '/CN=docker:dind CA' \
+          -x509 -days 825
+        mkdir -p "$tmpdir/certs/server"
+        openssl genrsa -out "$tmpdir/certs/server/key.pem" 4096
+        openssl req -new -key "$tmpdir/certs/server/key.pem" \
+          -out "$tmpdir/certs/server/csr.pem" -subj '/CN=docker:dind server'
+        cat << EOF >"$tmpdir/certs/server/openssl.cnf"
+        [ x509_exts ]
+        subjectAltName = DNS:b51ddd7b8dcd,DNS:docker,DNS:localhost,IP:127.0.0.1,IP:172.17.0.4,IP:::1
+        EOF
+        openssl x509 -req -in "$tmpdir/certs/server/csr.pem"\
+          -CA "$tmpdir/certs/ca/cert.pem" -CAkey "$tmpdir/certs/ca/key.pem" \
+          -CAcreateserial -out "$tmpdir/certs/server/cert.pem" \
+          -days 825 -extfile "$tmpdir/certs/server/openssl.cnf" \
+          -extensions x509_exts
+        cp "$tmpdir/certs/ca/cert.pem" "$tmpdir/certs/server/ca.pem"
+        openssl verify -CAfile "$tmpdir/certs/server/ca.pem" \
+          "$tmpdir/certs/server/cert.pem"
 
 update:
   enabled: true

--- a/openssl/ca.cnf
+++ b/openssl/ca.cnf
@@ -1,0 +1,243 @@
+# Include upstream ca & req apps configuration
+# Changes from upstream:
+# - default_days increase to 825 - maximum allowed on Mac OS X
+# - default_bits increase to 3072 for NIST SP 800-131A Rev. 3
+# - countryName_default set to US (Chainguard Inc)
+# - sateOrProvinceName_default set to Washington (Chainguard Inc)
+# - organizationName_default set to Chainguard Images
+#
+# Configuration for TSA & CMP apps is not provided for now
+#
+# These defaults are more feature-proof, and provide better
+# tracebility, and prevent accidental privacy leaks to the CMP demo
+# server.
+
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
+[ ca ]
+default_ca	= CA_default		# The default ca section
+
+[ CA_default ]
+
+dir		= ./demoCA		# Where everything is kept
+certs		= $dir/certs		# Where the issued certs are kept
+crl_dir		= $dir/crl		# Where the issued crl are kept
+database	= $dir/index.txt	# database index file.
+#unique_subject	= no			# Set to 'no' to allow creation of
+					# several certs with same subject.
+new_certs_dir	= $dir/newcerts		# default place for new certs.
+
+certificate	= $dir/cacert.pem 	# The CA certificate
+serial		= $dir/serial 		# The current serial number
+crlnumber	= $dir/crlnumber	# the current crl number
+					# must be commented out to leave a V1 CRL
+crl		= $dir/crl.pem 		# The current CRL
+private_key	= $dir/private/cakey.pem # The private key
+
+x509_extensions	= usr_cert		# The extensions to add to the cert
+
+# Comment out the following two lines for the "traditional"
+# (and highly broken) format.
+name_opt 	= ca_default		# Subject Name options
+cert_opt 	= ca_default		# Certificate field options
+
+# Extension copying option: use with caution.
+# copy_extensions = copy
+
+# Extensions to add to a CRL. Note: Netscape communicator chokes on V2 CRLs
+# so this is commented out by default to leave a V1 CRL.
+# crlnumber must also be commented out to leave a V1 CRL.
+# crl_extensions	= crl_ext
+
+default_days	= 825			# how long to certify for
+default_crl_days= 30			# how long before next CRL
+default_md	= default		# use public key default MD
+preserve	= no			# keep passed DN ordering
+
+# A few difference way of specifying how similar the request should look
+# For type CA, the listed attributes must be the same, and the optional
+# and supplied fields are just that :-)
+policy		= policy_match
+
+# For the CA policy
+[ policy_match ]
+countryName		= match
+stateOrProvinceName	= match
+organizationName	= match
+organizationalUnitName	= optional
+commonName		= supplied
+emailAddress		= optional
+
+# For the 'anything' policy
+# At this point in time, you must list all acceptable 'object'
+# types.
+[ policy_anything ]
+countryName		= optional
+stateOrProvinceName	= optional
+localityName		= optional
+organizationName	= optional
+organizationalUnitName	= optional
+commonName		= supplied
+emailAddress		= optional
+
+####################################################################
+[ req ]
+default_bits		= 3072
+default_keyfile 	= privkey.pem
+distinguished_name	= req_distinguished_name
+attributes		= req_attributes
+x509_extensions	= v3_ca	# The extensions to add to the self signed cert
+
+# Passwords for private keys if not present they will be prompted for
+# input_password = secret
+# output_password = secret
+
+# This sets a mask for permitted string types. There are several options.
+# default: PrintableString, T61String, BMPString.
+# pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
+# utf8only: only UTF8Strings (PKIX recommendation after 2004).
+# nombstr : PrintableString, T61String (no BMPStrings or UTF8Strings).
+# MASK:XXXX a literal mask value.
+# WARNING: ancient versions of Netscape crash on BMPStrings or UTF8Strings.
+string_mask = utf8only
+
+# req_extensions = v3_req # The extensions to add to a certificate request
+
+[ req_distinguished_name ]
+countryName			= Country Name (2 letter code)
+countryName_default		= US
+countryName_min			= 2
+countryName_max			= 2
+
+stateOrProvinceName		= State or Province Name (full name)
+stateOrProvinceName_default	= Washington
+
+localityName			= Locality Name (eg, city)
+
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= Chainguard Images
+
+# we can do this but it is not needed normally :-)
+#1.organizationName		= Second Organization Name (eg, company)
+#1.organizationName_default	= World Wide Web Pty Ltd
+
+organizationalUnitName		= Organizational Unit Name (eg, section)
+#organizationalUnitName_default	=
+
+commonName			= Common Name (e.g. server FQDN or YOUR name)
+commonName_max			= 64
+
+emailAddress			= Email Address
+emailAddress_max		= 64
+
+# SET-ex3			= SET extension number 3
+
+[ req_attributes ]
+challengePassword		= A challenge password
+challengePassword_min		= 8
+challengePassword_max		= 20
+
+unstructuredName		= An optional company name
+
+[ usr_cert ]
+
+# These extensions are added when 'ca' signs a request.
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+# This is required for TSA certificates.
+# extendedKeyUsage = critical,timeStamping
+
+[ v3_req ]
+
+# Extensions to add to a certificate request
+
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[ v3_ca ]
+
+
+# Extensions for a typical CA
+
+
+# PKIX recommendation.
+
+subjectKeyIdentifier=hash
+
+authorityKeyIdentifier=keyid:always,issuer
+
+basicConstraints = critical,CA:true
+
+# Key usage: this is typical for a CA certificate. However since it will
+# prevent it being used as an test self-signed certificate it is best
+# left out by default.
+# keyUsage = cRLSign, keyCertSign
+
+# Include email address in subject alt name: another PKIX recommendation
+# subjectAltName=email:copy
+# Copy issuer details
+# issuerAltName=issuer:copy
+
+# DER hex encoding of an extension: beware experts only!
+# obj=DER:02:03
+# Where 'obj' is a standard or added object
+# You can even override a supported extension:
+# basicConstraints= critical, DER:30:03:01:01:FF
+
+[ crl_ext ]
+
+# CRL extensions.
+# Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
+
+# issuerAltName=issuer:copy
+authorityKeyIdentifier=keyid:always
+
+[ proxy_cert_ext ]
+# These extensions should be added when creating a proxy certificate
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+# This really needs to be in place for it to be a proxy certificate.
+proxyCertInfo=critical,language:id-ppl-anyLanguage,pathlen:3,policy:foo

--- a/openssl/openssl.cnf
+++ b/openssl/openssl.cnf
@@ -1,0 +1,5 @@
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
+# Include hardened configuration for ca & req apps
+.include /etc/ssl/ca.cnf


### PR DESCRIPTION
Ship openssl.cnf in openssl package, replace old openssl-config
package (just in case), include a separate (hardened) ca.cnf.

Set replaces priority, just in case.
