### PR TITLE
add linkerd-extension-init

### DIFF
--- a/linkerd-extension-init.yaml
+++ b/linkerd-extension-init.yaml
@@ -1,0 +1,72 @@
+package:
+  name: linkerd-extension-init
+  version: 0.1.2
+  epoch: 0
+  description: "A utility for initializing Linkerd extension namespaces after installation"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - openssf-compiler-options
+      - perl
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/linkerd/linkerd-extension-init
+      tag: release/v${{package.version}}
+      expected-commit: 3e898e7601149daf028024b15111d0b15bd12625
+
+  - uses: cargo/build
+    with:
+      modroot: .
+      output: linkerd-extension-init
+
+  - uses: strip
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream helm charts"
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/bin
+          ln -sf /usr/bin/linkerd-extension-init ${{targets.contextdir}}/bin/linkerd-extension-init
+    test:
+      pipeline:
+        - runs: |
+            test -L /bin/linkerd-extension-init
+
+update:
+  enabled: true
+  github:
+    identifier: linkerd/linkerd-extension-init
+    strip-prefix: release/v
+
+test:
+  environment:
+    contents:
+      packages:
+        - linkerd2-cli
+        - yq
+  pipeline:
+    - runs: |
+        /usr/bin/linkerd-extension-init --help
+    - uses: test/kwok/cluster
+    - name: Install linkerd
+      runs: |
+        linkerd install --crds | kubectl apply -f -
+        linkerd install | kubectl apply -f -
+        linkerd check
+    - name: "Integration test"
+      uses: test/daemon-check-output
+      with:
+        setup: kubectl create namespace linkerd-extension-init-test
+        start: linkerd-extension-init -n linkerd-extension-init-test --linkerd-namespace linkerd --extension extname --prometheus-url promurl
+        timeout: 30
+        expected_output: successfully patched namespace
+        post: |
+          kubectl get namespace linkerd-extension-init-test -o yaml | grep "viz.linkerd.io/external-prometheus: promurl"
+          kubectl get namespace linkerd-extension-init-test -o yaml | grep "linkerd.io/extension: extname"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
