### PR TITLE
update mlflow to 2.19.0, rebuild with new python 3.13

### DIFF
--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: mlflow
-  version: 2.18.0
-  epoch: 1
+  version: 2.19.0
+  epoch: 0
   description: Open source platform for the machine learning lifecycle
   copyright:
     - license: Apache-2.0
@@ -35,7 +35,7 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: 65d4042cedaf26c992531a3c84326677b8ddce46
+      expected-commit: ad1710112c3ff0e05f12833ea3b477a933438940
       repository: https://github.com/mlflow/mlflow
       tag: v${{package.version}}
 

--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: mlflow
   version: 2.18.0
-  epoch: 0
+  epoch: 1
   description: Open source platform for the machine learning lifecycle
   copyright:
     - license: Apache-2.0

--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -119,7 +119,8 @@ subpackages:
 
           # Create auth symlink expected in Bitnami Helm chart
           mkdir -p ${{targets.contextdir}}/bitnami
-          ln -sf /usr/share/mlflow/lib/python3.12/site-packages/mlflow/server/auth ${{targets.contextdir}}/bitnami/mlflow-basic-auth
+          find / -path "/usr/share/mlflow/lib/python*/mlflow/server/auth" -type d -exec \
+            ln -sf {} ${{targets.contextdir}}/bitnami/mlflow-basic-auth +; 
     test:
       pipeline:
         - runs: |

--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -119,8 +119,8 @@ subpackages:
 
           # Create auth symlink expected in Bitnami Helm chart
           mkdir -p ${{targets.contextdir}}/bitnami
-          find / -path "/usr/share/mlflow/lib/python*/mlflow/server/auth" -type d -exec \
-            ln -sf {} ${{targets.contextdir}}/bitnami/mlflow-basic-auth +;
+          PY_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+          ln -sf "/usr/share/mlflow/lib/python${PY_VERSION}/site-packages/mlflow/server/auth" ${{targets.contextdir}}/bitnami/mlflow-basic-auth
     test:
       pipeline:
         - runs: |

--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -120,7 +120,7 @@ subpackages:
           # Create auth symlink expected in Bitnami Helm chart
           mkdir -p ${{targets.contextdir}}/bitnami
           find / -path "/usr/share/mlflow/lib/python*/mlflow/server/auth" -type d -exec \
-            ln -sf {} ${{targets.contextdir}}/bitnami/mlflow-basic-auth +; 
+            ln -sf {} ${{targets.contextdir}}/bitnami/mlflow-basic-auth +;
     test:
       pipeline:
         - runs: |


### PR DESCRIPTION
The existing mlflow package is built with python 3.12. This epoch bump forces a rebuild using 3.13.

fixes https://github.com/wolfi-dev/os/pull/36360