### PR TITLE
New package dotnet-8.0.404

### DIFF
--- a/dotnet-8.0.404.yaml
+++ b/dotnet-8.0.404.yaml
@@ -1,0 +1,99 @@
+package:
+  name: dotnet-8.0.404
+  version: 8.0.404
+  epoch: 1
+  description: ".NET SDK"
+  copyright:
+    - license: MIT
+  resources:
+    cpu: 2
+    memory: 32Gi
+  dependencies:
+    runtime:
+      - dotnet-8-sdk-default
+      - icu
+
+environment:
+  environment:
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    DISABLE_CROSSGEN: true
+    DisableArcade: 1
+  contents:
+    packages:
+      - bash-binsh
+      - brotli-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang-15
+      - clang-15-default
+      - cmake
+      - curl
+      - dotnet-bootstrap-8
+      - glibc-locale-en
+      - icu-dev
+      - krb5-dev
+      - libunwind
+      - libunwind-dev
+      - llvm15
+      - llvm15-cmake-default
+      - llvm15-dev
+      - llvm15-tools
+      - lttng-ust-dev
+      - ncurses-dev
+      - nodejs-22
+      - openssl-dev
+      - posix-libc-utils
+      - python3
+      - rapidjson-dev
+      - samurai
+      - wolfi-base
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/dotnet/sdk
+      tag: v${{package.version}}
+      expected-commit: 5dd80ae4b107027f86bda68ce91542cad72b2868
+      destination: /home/build/src
+
+  - working-directory: /home/build/src
+    pipeline:
+      - runs: |
+          ln -sf /usr/share/dotnet-bootstrap-8/dotnet .dotnet
+          mkdir -p prereqs/packages/archive/
+          ln -sf /usr/share/dotnet-bootstrap-8/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz
+          mkdir -p prereqs/packages/previously-source-built
+          tar -xzvf prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz -C prereqs/packages/previously-source-built/
+      - runs: |
+          ./build.sh --configuration Release --build /p:CustomPrebuiltSourceBuiltPackagesPath=$(realpath prereqs/packages/previously-source-built) -- \
+            /v:n \
+            /p:ContinueOnPrebuiltBaselineError=true \
+            /p:MinimalConsoleLogOutput=false \
+            /p:SkipPortableRuntimeBuild=true \
+            /p:BuildWithOnlineSources=false \
+            /p:CustomPrebuiltSourceBuiltPackagesPath=$(realpath prereqs/packages/previously-source-built)
+      - runs: |
+          mkdir -p "${{targets.destdir}}"/usr/share/dotnet/sdk-manifests
+
+          cp -R artifacts/bin/redist/Release/dotnet/sdk "${{targets.destdir}}"/usr/share/dotnet
+          # Do not copy duplicated 8.0.100
+          cp -R artifacts/bin/redist/Release/dotnet/sdk-manifests/8.0.400 "${{targets.destdir}}"/usr/share/dotnet/sdk-manifests/
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: dotnet/sdk
+    strip-prefix: v
+    use-tag: true
+    tag-filter: "v8.0.404"
+
+test:
+  pipeline:
+    - name: Basic .NET command test
+      runs: |
+        dotnet --info
+        dotnet --list-sdks | grep ${{package.version}}


### PR DESCRIPTION
Packaging of optional SDK version of .net 8 tagged 8.0.404. Note this
is sdk only, for package build-time only for now. Runtime versions
unaffected.
