### PR TITLE
powershell upgrade

### DIFF
--- a/dotnet-8.0.404.yaml
+++ b/dotnet-8.0.404.yaml
@@ -1,0 +1,99 @@
+package:
+  name: dotnet-8.0.404
+  version: 8.0.404
+  epoch: 1
+  description: ".NET SDK"
+  copyright:
+    - license: MIT
+  resources:
+    cpu: 2
+    memory: 32Gi
+  dependencies:
+    runtime:
+      - dotnet-8-sdk-default
+      - icu
+
+environment:
+  environment:
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    DISABLE_CROSSGEN: true
+    DisableArcade: 1
+  contents:
+    packages:
+      - bash-binsh
+      - brotli-dev
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - clang-15
+      - clang-15-default
+      - cmake
+      - curl
+      - dotnet-bootstrap-8
+      - glibc-locale-en
+      - icu-dev
+      - krb5-dev
+      - libunwind
+      - libunwind-dev
+      - llvm15
+      - llvm15-cmake-default
+      - llvm15-dev
+      - llvm15-tools
+      - lttng-ust-dev
+      - ncurses-dev
+      - nodejs-22
+      - openssl-dev
+      - posix-libc-utils
+      - python3
+      - rapidjson-dev
+      - samurai
+      - wolfi-base
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/dotnet/sdk
+      tag: v${{package.version}}
+      expected-commit: 5dd80ae4b107027f86bda68ce91542cad72b2868
+      destination: /home/build/src
+
+  - working-directory: /home/build/src
+    pipeline:
+      - runs: |
+          ln -sf /usr/share/dotnet-bootstrap-8/dotnet .dotnet
+          mkdir -p prereqs/packages/archive/
+          ln -sf /usr/share/dotnet-bootstrap-8/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz
+          mkdir -p prereqs/packages/previously-source-built
+          tar -xzvf prereqs/packages/archive/Private.SourceBuilt.Artifacts.Bootstrap.tar.gz -C prereqs/packages/previously-source-built/
+      - runs: |
+          ./build.sh --configuration Release --build /p:CustomPrebuiltSourceBuiltPackagesPath=$(realpath prereqs/packages/previously-source-built) -- \
+            /v:n \
+            /p:ContinueOnPrebuiltBaselineError=true \
+            /p:MinimalConsoleLogOutput=false \
+            /p:SkipPortableRuntimeBuild=true \
+            /p:BuildWithOnlineSources=false \
+            /p:CustomPrebuiltSourceBuiltPackagesPath=$(realpath prereqs/packages/previously-source-built)
+      - runs: |
+          mkdir -p "${{targets.destdir}}"/usr/share/dotnet/sdk-manifests
+
+          cp -R artifacts/bin/redist/Release/dotnet/sdk "${{targets.destdir}}"/usr/share/dotnet
+          # Do not copy duplicated 8.0.100
+          cp -R artifacts/bin/redist/Release/dotnet/sdk-manifests/8.0.400 "${{targets.destdir}}"/usr/share/dotnet/sdk-manifests/
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: dotnet/sdk
+    strip-prefix: v
+    use-tag: true
+    tag-filter: "v8.0.404"
+
+test:
+  pipeline:
+    - name: Basic .NET command test
+      runs: |
+        dotnet --info
+        dotnet --list-sdks | grep ${{package.version}}

--- a/powershell.yaml
+++ b/powershell.yaml
@@ -1,6 +1,6 @@
 package:
   name: powershell
-  version: 7.4.1
+  version: 7.4.6
   epoch: 2
   description: 'cross-platform automation and configuration tool/framework'
   copyright:
@@ -18,7 +18,7 @@ environment:
       - aspnet-8-runtime
       - aspnet-8-targeting-pack
       - build-base
-      - dotnet-8-sdk
+      - dotnet-8.0.404
       - icu-dev
       - krb5-dev
       - libpsl-native
@@ -32,7 +32,7 @@ pipeline:
     with:
       repository: https://github.com/powershell/powershell
       tag: v${{package.version}}
-      expected-commit: 5668713d3c906d63cd68e37d415206a95ac061d0
+      expected-commit: 81930547a20205e5bfed32c66ab6fed50d6e2008
       destination: powershell
 
   - working-directory: /home/build/powershell
@@ -61,7 +61,6 @@ pipeline:
           dotnet publish --configuration Linux "src/powershell-unix/" \
                 --output bin \
                 --no-self-contained \
-                --runtime "$(dotnet --info | awk '$1=="RID:"{print $2}')" \
                 -p:NuGetAudit=false \
                 -p:PublishReadyToRun=true /v:n \
                 /consoleLoggerParameters:ShowTimestamp
@@ -69,12 +68,21 @@ pipeline:
           # directory creation
           install -dm 755 "${{targets.destdir}}"/usr/lib "${{targets.destdir}}"/usr/bin
 
+          case "${{build.arch}}" in
+            "aarch64")
+              rid=linux-arm64
+              ;;
+            "x86_64")
+              rid=linux-x64
+              ;;
+          esac
+
           # library copy
-          cp -ar /home/build/powershell/src/powershell-unix/bin/Linux/*/wolfi* "${{targets.destdir}}"/usr/lib/${{package.name}}
+          cp -ar /home/build/powershell/src/powershell-unix/bin/Linux/*/$rid "${{targets.destdir}}"/usr/lib/${{package.name}}
 
           # already provided by 'libpsl-native' aport
-          rm -f "${{targets.destdir}}"/usr/lib/$pkgname/libpsl-native.so
-          rm -f "${{targets.destdir}}"/usr/lib/$pkgname/libSystem.IO.Ports.Native.so
+          rm -f "${{targets.destdir}}"/usr/lib/${{package.name}}/libpsl-native.so
+          rm -f "${{targets.destdir}}"/usr/lib/${{package.name}}/libSystem.IO.Ports.Native.so
 
           # binary link
           ln -s "/usr/lib/${{package.name}}/pwsh" "${{targets.destdir}}"/usr/bin/pwsh


### PR DESCRIPTION
- **New package dotnet-8.0.404**
  Packaging of optional SDK version of .net 8 tagged 8.0.404. Note this
  is sdk only, for package build-time only for now. Runtime versions
  unaffected.
  

- **powershell: upgrade to 7.4.6 built with 8.0.404 sdk**
  Based on work by @ader1990.
  
  This PR demonstates that dotnet-8.0.404 sdk packaging works and
  produced upgrade of powershell to latest.
  
  Based on:
  - https://github.com/wolfi-dev/os/pull/37439
  