### PR TITLE
fix(aws-ebs-csi-driver): Add missing dependencies, create needed symlink

### DIFF
--- a/aws-ebs-csi-driver.yaml
+++ b/aws-ebs-csi-driver.yaml
@@ -1,7 +1,7 @@
 package:
   name: aws-ebs-csi-driver
   version: 1.38.1
-  epoch: 0
+  epoch: 1
   description: CSI driver for Amazon EBS.
   copyright:
     - license: Apache-2.0
@@ -9,10 +9,15 @@ package:
     runtime:
       - blkid
       - blockdev
+      - ca-certificates
+      - ca-certificates-bundle
       - e2fsprogs
       - e2fsprogs-extra
       - lsblk
       - mount
+      - umount
+      - util-linux
+      - util-linux-misc
       - xfsprogs
 
 environment:
@@ -20,9 +25,6 @@ environment:
     packages:
       - build-base
       - busybox
-      - ca-certificates-bundle
-      - go
-      - wolfi-baselayout
 
 pipeline:
   # We can't use go/install because this requires specific ldflags to set the version
@@ -41,6 +43,10 @@ pipeline:
         -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.gitCommit=$(git rev-parse HEAD)
         -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.buildDate=$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%Y-%m-%dT%H:%M:%SZ")
       output: aws-ebs-csi-driver
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/bin
+      ln -s /usr/bin/aws-ebs-csi-driver ${{targets.destdir}}/bin/aws-ebs-csi-driver
 
 update:
   enabled: true


### PR DESCRIPTION
The AWS EBS CSI driver depends on various utilities that weren't provided. Add them as runtime dependencies

Also symlink the driver to /bin so that it's found (this is where upstream places it and where the chart expects it). This package isn't useful without this link so don't relegate to a compat package