### PR TITLE
Add missing deps to kserve-storage-controller

### DIFF
--- a/kserve.yaml
+++ b/kserve.yaml
@@ -73,13 +73,20 @@ subpackages:
         runs: |
           # Install dependencies and build the package using poetry
           poetry install --no-interaction --no-root --extras "storage ray"
-          poetry add "certifi==2024.7.4"
-          poetry add "idna==3.7"
+          # CVE-2024-47554 GHSA-78wr-2p64-hpwj
+          poetry add "ray=^2.24.0"
+          # CVE-2024-52304 GHSA-8495-4g3g-x7pr
+          poetry add "aiohttp=^3.10.11"
+          # CVE-2024-6345 GHSA-cx63-2mw6-8hw5
+          poetry add "setuptools=^70.0.0"
+          poetry add "certifi"
+          poetry add "idna"
           # CVE-2024-35195: requests
           poetry add "requests@^2.23.0"
           poetry add "packaging"
-          poetry add "typing-extensions"
           poetry add "google.cloud"
+          poetry add "typing-extensions"
+          poetry add "starlette=^0.40.0"
           poetry run pip freeze | grep -v kserve > requirements.txt
 
           poetry build
@@ -106,25 +113,10 @@ subpackages:
         contents:
           packages:
             - busybox
-            - py3.11-poetry
-            - python-3.11
       pipeline:
         - name: "test entrypoint usage"
           runs: |
             /storage-initializer/scripts/initializer-entrypoint --help
-            dotenv --help
-            f2py  --help
-            pyrsa-decrypt --help
-            pyrsa-encrypt --help
-            pyrsa-keygen --help
-            pyrsa-priv2pub --help
-            pyrsa-sign --help
-            pyrsa-verify --help
-            tabulate --help
-            uvicorn --version
-            uvicorn --help
-            watchfiles --help
-            wsdump --help
 
 update:
   enabled: true

--- a/kserve.yaml
+++ b/kserve.yaml
@@ -1,7 +1,7 @@
 package:
   name: kserve
   version: 0.14.0
-  epoch: 1
+  epoch: 2
   description: "Standardized Serverless ML Inference Platform on Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -65,9 +65,6 @@ subpackages:
             [ -x /${{range.key}} -a -f /${{range.key}} ]
 
   - name: kserve-storage-controller
-    dependencies:
-      runtime:
-        - py3.11-packaging
     options:
       no-commands: true
     pipeline:
@@ -76,9 +73,18 @@ subpackages:
         runs: |
           # Install dependencies and build the package using poetry
           poetry install --no-interaction --no-root --extras "storage ray"
-          poetry build
+          poetry add "certifi==2024.7.4"
+          poetry add "idna==3.7"
+          # CVE-2024-35195: requests
+          poetry add "requests@^2.23.0"
+          poetry add "packaging"
+          poetry add "typing-extensions"
+          poetry add "google.cloud"
+          poetry run pip freeze | grep -v kserve > requirements.txt
 
+          poetry build
           # Install the wheel file with the root directory set to ${{targets.contextdir}}
+          pip install --root ${{targets.contextdir}} -I -r requirements.txt --no-compile
           python3 -m pip install --verbose --prefix=/usr --root=${{targets.contextdir}} dist/*.whl
       - name: install storage-initializer entrypoint
         working-directory: ./python/storage-initializer


### PR DESCRIPTION
Because the current deps are `pip install`ed, we can't just add runtime deps from `py3.11-${pkg}` because that would result in conflicting files.

So we just do `pip freeze` (similar to https://github.com/wolfi-dev/os/blob/main/py3-cassandra-medusa.yaml#L52)

Because `pip install`ed dep conflicts with the `python3.11` package itself, the test env needs to update, and tests not specific to this package (`dotenv`, ...) need to be removed.