### PR TITLE
fix: image test issues with haproxy-ingress

### DIFF
--- a/haproxy-ingress.yaml
+++ b/haproxy-ingress.yaml
@@ -1,7 +1,7 @@
 package:
   name: haproxy-ingress
   version: 0.14.7
-  epoch: 4
+  epoch: 5
   description: HAProxy Ingress
   copyright:
     - license: Apache-2.0
@@ -31,6 +31,7 @@ pipeline:
   - uses: go/bump
     with:
       deps: golang.org/x/crypto@v0.31.0
+      tidy: false # changes to the dependencies broke this service after bumping crypto. https://github.com/chainguard-dev/image-release-stats/issues/3326
 
   - runs: |
       make GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) linux-build


### PR DESCRIPTION
related to these issues: https://github.com/chainguard-dev/image-release-stats/issues/3326