### PR TITLE
Update glib and gobject-introspection for specific python version 3.13

### DIFF
--- a/glib.yaml
+++ b/glib.yaml
@@ -1,10 +1,15 @@
 package:
   name: glib
   version: 2.83.2
-  epoch: 0
+  epoch: 1
   description: Common C routines used by Gtk+ and other libs
   copyright:
     - license: LGPL-2.1-or-later
+
+vars:
+  # build uses rst2man from py3-docutils and also invokes 'python3'
+  # installed /usr/bin/gtester-report gets correct shbang (/usr/bin/python3.XX)
+  py-version: 3.13
 
 environment:
   contents:
@@ -25,11 +30,8 @@ environment:
       - meson
       - openssf-compiler-options
       - pcre2-dev
-      - py3-docutils
-      - py3-packaging
-      - py3-setuptools
-      - python3
-      - python3-dev
+      - py${{vars.py-version}}-docutils-bin
+      - python-${{vars.py-version}}
       - util-linux-dev
       - zlib-dev
 
@@ -92,7 +94,6 @@ subpackages:
         - gettext-dev
         - libxml2-utils
         - libxslt
-        - python3
         - libffi-dev # needed by gobject-2.0 when building gobject-introspection
         - pcre2-dev # needed by glib-2.0 when building gobject-introspection
         - util-linux-dev # needed by gio-2.0 when building gobject-introspection

--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -1,7 +1,7 @@
 package:
   name: gobject-introspection
   version: 1.82.0
-  epoch: 1
+  epoch: 2
   description: Introspection system for GObject-based libraries
   copyright:
     - license: LGPL-2.0-or-later AND GPL-2.0-or-later AND MIT
@@ -9,7 +9,10 @@ package:
   # build it. This is a drop in replacement to make things work.
   dependencies:
     runtime:
-      - py3-setuptools
+      - py${{vars.py-version}}-setuptools
+
+vars:
+  py-version: 3.13
 
 # creates a new var that contains only the major and minor version to be used in the fetch URL
 # e.g. 1.74.0 will create a new var mangled-package-version=1.74
@@ -40,10 +43,8 @@ environment:
       - meson
       - openssf-compiler-options
       - posix-libc-utils
-      - py3-packaging
-      - py3-setuptools
-      - python3
-      - python3-dev
+      - py${{vars.py-version}}-build-base-dev
+      - python-${{vars.py-version}}
 
 pipeline:
   - uses: fetch
@@ -58,6 +59,17 @@ pipeline:
   - uses: meson/compile
 
   - uses: meson/install
+
+  - name: update shbang
+    runs: |
+      # replace usr/bin/env python3
+      d=${{targets.destdir}}/usr/bin
+      # change '/usr/bin/env python3' or '/usr/bin/python3' to /usr/bin/python3.XX
+      op='1s,^#!/usr/bin/\(env python3\|python3\)$,#!/usr/bin/python${{vars.py-version}},'
+      for f in "$d"/*; do
+         [ -f "$f" ] || continue
+         sed -i -e "$op" "$f";
+      done
 
   - uses: strip
 
@@ -76,8 +88,7 @@ subpackages:
         - gobject-introspection
         - libtool
         - posix-libc-utils
-        - py3-setuptools
-        - python3
+        - py${{vars.py-version}}-setuptools
     description: gobject-introspection dev
     test:
       pipeline:
@@ -99,3 +110,7 @@ test:
         g-ir-inspect --help
         g-ir-compiler --help
         g-ir-generate --help
+        g-ir-scanner --help
+        g-ir-scanner --version | grep -F "${{package.version}}"
+        g-ir-annotation-tool --help
+        g-ir-annotation-tool --version | grep -F "${{package.version}}"


### PR DESCRIPTION
 * gobject-introspection - use specific python version, test g-ir-scanner
   
   gobject-introspection build writes programs in /usr/bin/
   g-ir-scanner and g-ir-annotation-tool that used '#!/usr/bin/env python3'
   
   It installs python files and modules into /usr/lib/gobject-introspection
   and successfully finds that at runtime.  However, it built a c extension
   _giscanner.cpython-312-x86_64-linux-gnu.so which will only load with
   a specific python (the one that it was built against).
   
   So, update the shbang on g-ir-scanner and g-ir-annotation-tool to
   reference the specific python it was built against.

 * glib - use a specific python in build, drop runtime dep on python3
   
   the build system installs /usr/bin/gtester-report with
   /usr/bin/python3.XX shbang (based on the build version). This is good,
   but in this case it does appear not strictly necessary.
   
   The package installs a pure python, standard-lib-only module into
   usr/share/glib-2.0 and finds it correctly.  It _could_ work with "any
   old python".

