### PR TITLE
openscap - update for python3.13

### DIFF
--- a/openscap.yaml
+++ b/openscap.yaml
@@ -1,10 +1,13 @@
 package:
   name: openscap
   version: 1.4.0
-  epoch: 2
+  epoch: 3
   description: NIST Certified SCAP 1.2 toolkit
   copyright:
     - license: LGPL-2.1-or-later
+
+vars:
+  py-version: 3.13
 
 environment:
   contents:
@@ -35,15 +38,14 @@ environment:
       - perl-xml-parser
       - popt-dev
       - procps
-      - py3-gv
-      - py3-setuptools
+      - py${{vars.py-version}}-setuptools
+      - python-${{vars.py-version}}-dev
       # TODO: Needed for rpm/apt scanning
       # - perl-xml-xpath
       # - opendbx-dev
       # - rpm-dev
       # - apt-dev
       # - libselinux
-      - python3-dev
       - samurai
       - swig
       - systemd-dev
@@ -71,6 +73,14 @@ pipeline:
 
   - uses: cmake/install
 
+  - name: fix python shbang
+    runs: |
+      # change /usr/bin/python3 to /usr/bin/python3.XX
+      for f in ${{targets.destdir}}/usr/bin/*; do
+        [ -f "$f" ] || continue
+        sed -i '1s,^#!/usr/bin/python3$,#!/usr/bin/python${{vars.py-version}},' "$f"
+      done
+
   - uses: strip
 
 subpackages:
@@ -79,8 +89,18 @@ subpackages:
     dependencies:
       runtime:
         - openscap
-        - py3-docker
+        - py${{vars.py-version}}-docker
         - docker-cli
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{vars.py-version}}
+            imports: |
+              import openscap_py
+              import oscap_docker_python
+        - runs: |
+            oscap-docker --help
 
 # TODO: Requires some additional graphviz/xml packages
 # - name: ${{package.name}}-doc


### PR DESCRIPTION
drop the py3-gv build dependency.  It appears not needed. That is nice, because py3-gv is not currently multi-versioned. so picking a specific version would mean keeping the 2 in sync.

Add a test for oscap-docker to validate it can at least run help and import some python modules.
