### PR TITLE
audit - update prefix for install to /usr rather than /usr/local

### DIFF
--- a/audit.yaml
+++ b/audit.yaml
@@ -1,7 +1,7 @@
 package:
   name: audit
   version: 4.0.2
-  epoch: 2
+  epoch: 3
   description: User space tools for kernel auditing
   copyright:
     - license: LGPL-2.1-or-later
@@ -56,21 +56,19 @@ pipeline:
   - runs: |
       # Base flags
       _flags="
-          --disable-zos-remote \
-          --enable-shared=audit \
-          --with-python3=yes \
-          --enable-gssapi-krb5=yes \
-          --with-libcap-ng=yes \
-          --without-golang \
-          --with-io_uring \
+          --prefix=/usr
+          --disable-zos-remote
+          --enable-shared=audit
+          --with-python3=yes
+          --enable-gssapi-krb5=yes
+          --with-libcap-ng=yes
+          --without-golang
+          --with-io_uring
       "
 
       # Append architecture-specific flag if needed
       if [ "${build_arch}" = "aarch64" ]; then
           _flags="$_flags --with_aarch64=yes"
-      else
-          # Remove the trailing backslash
-          _flags=$(echo "$_flags" | sed 's/\\ $//')
       fi
 
       # Configure with the joined flags
@@ -130,3 +128,6 @@ test:
         audisp-remote --help
         aureport --help
         ausearch --help
+    - uses: python/import
+      with:
+        import: audit


### PR DESCRIPTION
The change here simplifies flags setting in configure and also sets the --prefix to /usr.

Setting to /usr means that audit's python package is installed into /usr/lib/python3.XX/site-packages where it is then picked up as a melange SCA depends.

This _does_ mean that the python that is built rolls with forward with whatever 'python3-dev' happens to install.  For now that seems fine.
