### PR TITLE
Update conda and conda-build

### DIFF
--- a/conda-build.yaml
+++ b/conda-build.yaml
@@ -2,16 +2,23 @@
 package:
   name: conda-build
   version: 24.11.2
-  epoch: 0
+  epoch: 1
   description: tools for building conda packages
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - conda
-      - py3-filelock
-      - py3-requests
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: conda-build
+  import: conda_build
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
 
 environment:
   contents:
@@ -19,18 +26,10 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - conda
-      - py3-hatch
-      - py3-hatchling
-      - py3-installer
-      - py3-pip
-      - py3-setuptools
-      - py3-wheel
-      - python-3
+      - py3-supported-build-base
+      - py3-supported-hatch
+      - py3-supported-hatch-vcs
       - wolfi-base
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
 
 pipeline:
   - uses: git-checkout
@@ -39,9 +38,83 @@ pipeline:
       repository: https://github.com/conda/conda-build
       tag: ${{package.version}}
 
-  - runs: |
-      hatch build
-      python3 -m installer -d "${{targets.destdir}}" dist/conda_build*.whl
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      runtime:
+        - py${{range.key}}-beautifulsoup4
+        - py${{range.key}}-conda
+        - py${{range.key}}-conda-index
+        - py${{range.key}}-filelock
+        - py${{range.key}}-frozendict
+        - py${{range.key}}-jinja2
+        - py${{range.key}}-libarchive-c
+        - py${{range.key}}-more-itertools
+        - py${{range.key}}-pkginfo
+        - py${{range.key}}-pyyaml
+        - py${{range.key}}-requests
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+          prevent-inclusion: melange-out
+      - name: move usr/bin executables for -bin
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - conda-build
+        - py3-${{vars.pypi-package}}
+        - py3-${{vars.pypi-package}}-bin
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      pipeline:
+        - runs: |
+            conda-build --help
+            conda-convert --help
+            conda-debug --help
+            conda-develop --help
+            conda-inspect --help
+            conda-metapackage --help
+            conda-render --help
+            conda-skeleton --help
+
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/conda.yaml
+++ b/conda.yaml
@@ -2,8 +2,8 @@
 # instead you may use the conda-base package in wolfi-dev
 package:
   name: conda
-  version: 24.11.1
-  epoch: 2
+  version: 24.11.2
+  epoch: 0
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause
@@ -58,7 +58,7 @@ pipeline:
     with:
       repository: https://github.com/conda/conda
       tag: ${{package.version}}
-      expected-commit: 1e025e1ac47914e470e140253f0ec69849535ca6
+      expected-commit: 1b4ab45de0602162508428331d34909e72c84e1b
 
 subpackages:
   - range: py-versions

--- a/conda.yaml
+++ b/conda.yaml
@@ -3,13 +3,10 @@
 package:
   name: conda
   version: 24.11.1
-  epoch: 1
+  epoch: 2
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause
-  options:
-    no-provides: true
-    no-depends: true
   dependencies:
     provider-priority: 0
 
@@ -53,7 +50,6 @@ environment:
       - py3-supported-urllib3
       - py3-supported-wheel
       - py3-supported-zstandard
-      - python3
       - wget
       - wolfi-base
 
@@ -87,6 +83,7 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+          prevent-inclusion: melange-out
       - name: "move usr/bin executables for -bin"
         runs: |
           mkdir -p ./cleanup/${{range.key}}/
@@ -105,9 +102,12 @@ subpackages:
     dependencies:
       runtime:
         - py${{range.key}}-${{vars.pypi-package}}
+        # running 'conda init' as is done in the test will rewrite /usr/bin/conda
+        # and do so with a shbang of '/usr/bin/python'.
         - python-${{range.key}}
       provides:
         - conda
+        - py-${{vars.pypi-package}}
       provider-priority: ${{range.value}}
     pipeline:
       - runs: |

--- a/py3-conda-index.yaml
+++ b/py3-conda-index.yaml
@@ -1,0 +1,81 @@
+package:
+  name: py3-conda-index
+  version: 0.5.0
+  epoch: 0
+  description: An efficient library to read from new and old format .conda and .tar.bz2 conda packages.
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    provider-priority: 0
+
+vars:
+  # this is not named pypi-package because it is not on pypi
+  package: conda-index
+  import: conda_index
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+      - py3-supported-flit-core
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/conda/conda-index
+      tag: ${{package.version}}
+      expected-commit: f6f80d9bd6c8ae6cfb0fff83f2d73049e7bf3b79
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.package}}
+    description: python${{range.key}} version of ${{vars.package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - ${{package.name}}
+        - py3-${{vars.package}}
+      runtime:
+        - py${{range.key}}-requests
+        - py${{range.key}}-zstandard
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
+
+  - name: py3-supported-${{vars.package}}
+    description: meta package providing ${{vars.package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.package}}
+        - py3.11-${{vars.package}}
+        - py3.12-${{vars.package}}
+        - py3.13-${{vars.package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
+
+update:
+  enabled: true
+  github:
+    identifier: conda/conda-index

--- a/py3-frozendict.yaml
+++ b/py3-frozendict.yaml
@@ -1,0 +1,70 @@
+# Generated from https://pypi.org/project/frozendict/
+package:
+  name: py3-frozendict
+  version: 2.4.6
+  epoch: 0
+  description: A simple immutable dictionary
+  copyright:
+    - license: LGPL-3.0-or-later
+  dependencies:
+    provider-priority: "0"
+
+vars:
+  import: frozendict
+  pypi-package: frozendict
+
+data:
+  - name: py-versions
+    items:
+      "3.10": "310"
+      "3.11": "311"
+      "3.12": "312"
+      "3.13": "300"
+
+environment:
+  contents:
+    packages:
+      - py3-supported-build-base
+      - wolfi-base
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: bccc52db5aa317a3c428b1a977dfa57be0c70bc2
+      repository: https://github.com/Marco-Sulla/python-frozendict
+      tag: v${{package.version}}
+
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    pipeline:
+      - name: Python Build
+        uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    test:
+      environment: {}
+      pipeline:
+        - name: Import Test
+          uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
+
+update:
+  enabled: true
+  manual: false
+  github:
+    identifier: Marco-Sulla/python-frozendict
+    strip-prefix: v
+
+test:
+  pipeline:
+    - name: Import Test
+      uses: python/import
+      with:
+        import: ${{vars.import}}


### PR DESCRIPTION
* conda - update for some 3.13 things.
  
   * Enable depends and provides
     - fixed an issue where depends were being added on python3.10
       because melange-out was being recursively collected into each
       package.
  
   * drop python3 from build - not needed
  
   * make py3.XX-conda-bin (which provides 'conda') to depend
     on python-3.XX so that you get /usr/bin/python .
     That is to address the fact that 'conda init' replaces
     /usr/bin/conda with one that has a '/usr/bin/python' shbang
     The test exercises this path, whether or not its legit,
     I do not know.

* conda-build - make multi-version so that it can pair with conda.
  
  This is necessary to ensure that we end up with the py3-package
  versioned with the same python version of conda-build.

* add py3-frozendict.yaml - dep for conda-build

* add py3-conda-index.yaml - dep for conda-build

