### PR TITLE
btrfs-progs - set py-version, fix installation path of python module.

### DIFF
--- a/btrfs-progs.yaml
+++ b/btrfs-progs.yaml
@@ -1,10 +1,13 @@
 package:
   name: btrfs-progs
   version: "6.12"
-  epoch: 0
+  epoch: 1
   description: BTRFS filesystem utilities
   copyright:
     - license: GPL-2.0-or-later
+
+vars:
+  py-version: 3.13
 
 environment:
   contents:
@@ -21,14 +24,9 @@ environment:
       - lzo-dev
       - openssf-compiler-options
       - pkgconf-dev
-      - py3-babel
-      - py3-docutils
-      - py3-jinja2
-      - py3-packaging
-      - py3-pygments
-      - py3-setuptools
-      - py3-sphinx
-      - python3-dev
+      - py${{vars.py-version}}-setuptools
+      - py3-build-base-dev
+      - python-${{vars.py-version}}-dev
       - systemd-dev
       - zlib-dev
       - zstd-dev
@@ -71,7 +69,12 @@ subpackages:
         - btrfs-progs
     pipeline:
       - runs: |
-          make install_python DESTDIR="${{targets.subpkgdir}}"/usr/lib/python3 V=1
+          make install_python DESTDIR="${{targets.subpkgdir}}"
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            import: btrfsutil
 
   - name: btrfs-progs-bash-completion
     description: btrfs-progs bash completion


### PR DESCRIPTION
The python module was being installed into
/usr/lib/python3/usr/lib/python3.XX so it would not actually work.

The change here fixes that and tests it now.
