### PR TITLE
chore(argo-workflows): Disable cgo

### DIFF
--- a/argo-workflows.yaml
+++ b/argo-workflows.yaml
@@ -1,7 +1,7 @@
 package:
   name: argo-workflows
   version: 3.6.2
-  epoch: 1
+  epoch: 2
   description: Workflow engine for Kubernetes.
   copyright:
     - license: Apache-2.0
@@ -16,6 +16,8 @@ environment:
       - nodejs-20
       - openssl
       - yarn
+  environment:
+    CGO_ENABLED: 0
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
From 3.5.2 to 3.6.0, we began using cgo. Disable cgo to match prior behavior