### PR TITLE
Drop unused python or python deps from build environment.

### DIFF
--- a/clamav-1.4.yaml
+++ b/clamav-1.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav-1.4
   version: 1.4.1
-  epoch: 1
+  epoch: 2
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only
@@ -30,7 +30,6 @@ environment:
       - openssf-compiler-options
       - openssl-dev
       - pcre2-dev
-      - python3
       - rust
       - samurai
       - zlib-dev

--- a/clamav.yaml
+++ b/clamav.yaml
@@ -1,7 +1,7 @@
 package:
   name: clamav
   version: 1.4.1
-  epoch: 0
+  epoch: 1
   description: An anti-virus toolkit for UNIX eis-ng backport
   copyright:
     - license: GPL-2.0-only
@@ -26,7 +26,6 @@ environment:
       - ncurses-dev
       - openssl-dev
       - pcre2-dev
-      - python3
       - rust
       - samurai
       - zlib-dev

--- a/configurable-http-proxy.yaml
+++ b/configurable-http-proxy.yaml
@@ -17,7 +17,6 @@ environment:
       - ca-certificates-bundle
       - nodejs-18
       - npm
-      - python3
       - wolfi-base
 
 pipeline:

--- a/fatrace.yaml
+++ b/fatrace.yaml
@@ -2,7 +2,7 @@
 package:
   name: fatrace
   version: 0.17.0
-  epoch: 2
+  epoch: 3
   description: Report system wide file access events
   copyright:
     - license: GPL-3.0-or-later
@@ -16,7 +16,6 @@ environment:
       - busybox
       - ca-certificates-bundle
       - openssf-compiler-options
-      - python3
 
 pipeline:
   - uses: fetch

--- a/fish.yaml
+++ b/fish.yaml
@@ -2,7 +2,7 @@
 package:
   name: fish
   version: 3.7.1
-  epoch: 2
+  epoch: 3
   description: Modern interactive commandline shell
   copyright:
     - license: GPL-2.0-only
@@ -24,22 +24,7 @@ environment:
       - ncurses-dev
       - openssf-compiler-options
       - pcre2-dev
-      - py3-alabaster
-      - py3-babel
-      - py3-docutils
-      - py3-imagesize
-      - py3-jinja2
-      - py3-packaging
-      - py3-pygments
-      - py3-requests
-      - py3-snowballstemmer
-      - py3-sphinx
-      - py3-sphinxcontrib-applehelp
-      - py3-sphinxcontrib-devhelp
-      - py3-sphinxcontrib-htmlhelp
-      - py3-sphinxcontrib-packages
-      - py3-sphinxcontrib-qthelp
-      - py3-sphinxcontrib-serializinghtml
+      - py3-sphinx-bin
       - samurai
 
 pipeline:


### PR DESCRIPTION
 *  fish - simplify build-deps on python in order to run sphinx.
    the build just used sphinx-build. no reason to specify its deps.
 *  fattrace - drop unused python3 from build
 *  clamav-1.4 - drop unused python3 from build env
 *  clamav - drop unused python3 from build env
 *  configurable-http-proxy - drop unused python build-time dep.
