### PR TITLE
systemd: Add misc dependencies for additional functionality

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "257.2"
-  epoch: 0
+  epoch: 1
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -12,28 +12,52 @@ vars:
 environment:
   contents:
     packages:
+      - acl-dev
+      - audit-dev
+      - bpftool
       - build-base
       - busybox-full
       - ca-certificates-bundle
       - clang-${{vars.llvm-vers}}
       - cmake
       - coreutils
+      - cryptsetup-dev
+      - curl-dev
+      - dbus-dev
+      - findutils
       - gperf
+      - iptables-dev
+      - kmod
       - kmod-dev
+      - libarchive-dev
       - libbpf
       - libbpf-dev
       - libcap-dev
+      - libgcrypt-dev
+      - libgpg-error-dev
+      - libidn2-dev
+      - libmicrohttpd-dev
       - libmount
+      - libseccomp-dev
       - libuuid
+      - libxslt
+      - linux-headers
+      - linux-pam-dev
       - llvm-${{vars.llvm-vers}}
       - meson
       - ninja
       - openssf-compiler-options
+      - pcre2-dev
       - posix-libc-utils
       - py3-jinja2
       - py3-pyelftools
       - python3
+      - quota-tools
+      - rsync
+      - tpm2-tss
       - util-linux-dev
+      - valgrind-dev
+      - xz-dev
 
 pipeline:
   - uses: git-checkout
@@ -43,6 +67,11 @@ pipeline:
       expected-commit: 7fa3b5018bfffa176c77a2a5794dce792eebadcb
 
   - uses: meson/configure
+    with:
+      opts: |
+        -Dmode=release \
+        -Dvmspawn=enabled \
+        -Dinstall-tests=true
 
   - uses: meson/compile
 
@@ -113,6 +142,59 @@ subpackages:
             bootctl --help
             kernel-install --version
             kernel-install --help
+
+  - name: "systemd-test"
+    description: "Installable systemd-tests"
+    dependencies:
+      runtime:
+        - systemd
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd
+          mv ${{targets.destdir}}/usr/lib/systemd/tests ${{targets.subpkgdir}}/usr/lib/systemd
+    test:
+      environment:
+        contents:
+          packages:
+            - bash
+            - coreutils
+            - findutils
+            - python3
+            - tzdata
+            - busybox
+            - tpm2-tss
+            - libidn2 # There's a lot of dlopen tests
+            - libbpf
+            - libzstd1
+            - libarchive
+            - kmod-libs
+      pipeline:
+        - runs: |
+            mkdir -p /var/tmp/
+            # Skipping tests:
+            # test-sd-device - but got the following error: No such device
+            # test-path-util - failed at src/test/test-path-util.c:385, function test_find_executable_full(). Aborting.
+            # test-label - Error occurred while opening directory =>: Read-only file system
+            # test-dns-domain - Assertion 'r >= expected' failed at src/test/test-dns-domain.c:782, function test_dns_name_apply_idna_one(). Aborting.
+            # test-cryptolib - no error printed
+            # test-compress-benchmark - failed at src/test/test-compress-benchmark.c:105, function test_compress_decompress(). Aborting.
+            # test-capability - but got error: Protocol error
+            # test-bcd - >= 0' failed at src/boot/test-bcd.c:19, function load_bcd().
+            # test-tpm2 - none setup in the test env.
+            # test-fd-util - Failed to fork off '(caf-noproc)': Operation not permitted
+            # test-fstab-generator - lots of set -x seems to fail messing with mounts?
+            /usr/lib/systemd/tests/run-unit-tests.py -u \
+            -s test-sd-device \
+            -s test-path-util \
+            -s test-label \
+            -s test-dns-domain \
+            -s test-cyrptolib \
+            -s test-compress-benchmark \
+            -s test-capability \
+            -s test-bcd \
+            -s test-tpm2 \
+            -s test-fd-util \
+            -s test-fstab-generator.sh
 
   - name: "systemd-init"
     description: "Configure systemd for use as an init system"

--- a/tpm2-tss.yaml
+++ b/tpm2-tss.yaml
@@ -1,0 +1,45 @@
+package:
+  name: tpm2-tss
+  version: "4.1.3"
+  epoch: 0
+  description: "Implementation of the TCG Trusted Platform Module 2.0 Software Stack (TSS2)"
+  copyright:
+    - license: BSD-2-Clause
+
+environment:
+  contents:
+    packages:
+      - autoconf
+      - autoconf-archive
+      - automake
+      - build-base
+      - busybox-full
+      - curl-dev
+      - json-c-dev
+      - libltdl
+      - libtool
+      - openssl-dev
+      - pkgconf
+      - pkgconf-dev
+  environment:
+    PKG_CONFIG_PATH: /usr/lib/pkgconfig
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/tpm2-software/tpm2-tss
+      tag: ${{package.version}}
+      expected-commit: 30e6057722058cb85c292dcb7b77760ad6410d4e
+
+  - runs: |
+      ./bootstrap
+      ./configure
+
+  - uses: autoconf/make
+
+  - uses: autoconf/make-install
+
+update:
+  enabled: true
+  github:
+    identifier: tpm2-software/tpm2-tss


### PR DESCRIPTION
Also runs the upstream tests with some skips that don't work primarily due to the runtime env and explicitly build for release.

Also add tpm2-tss to build the systemd related pieces.