### PR TITLE
xcb-proto - split python package out

### DIFF
--- a/xcb-proto.yaml
+++ b/xcb-proto.yaml
@@ -1,7 +1,7 @@
 package:
   name: xcb-proto
   version: 1.17.0
-  epoch: 2
+  epoch: 3
   description: XML-XCB protocol descriptions
   copyright:
     - license: MIT
@@ -28,6 +28,19 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+subpackages:
+  - name: py3-xcbgen
+    description: the xcbgen python module from xcb-proto
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/lib
+          mv ${{targets.destdir}}/usr/lib/python* ${{targets.contextdir}}/usr/lib/
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            import: xcbgen
 
 update:
   enabled: true


### PR DESCRIPTION
this was pulling in python in a lot of places where it probably was not necessary.
