### PR TITLE
 protobuf-c: rebuild with latest protobuf

### DIFF
--- a/protobuf-c.yaml
+++ b/protobuf-c.yaml
@@ -1,7 +1,7 @@
 package:
   name: protobuf-c
   version: 1.5.0
-  epoch: 11
+  epoch: 12
   description: Protocol Buffers implementation in C
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
Rodman builds are failing because of the dependency resolution failing 

```
"packages: error getting package dependencies: solving "protobuf-c-compiler=1.5.0-r11" constraint: resolving "protobuf-c-compiler-1.5.0-r11.apk" deps:
solving "so:libprotobuf.so.29.1.0" constraint:   libprotobuf-3.29.1-r0.apk disqualified because "3.29.1-r0" does not satisfy "libprotobuf=3.29.2-r0""
```