### PR TITLE
dask-gateway: Use python 3.13 and other cleanups

### DIFF
--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -57,7 +57,8 @@ pipeline:
       mv .venv ${{targets.destdir}}/usr/share/${{package.name}}/
 
       # Fix venv paths
-      sed -i "s|/home/build|/usr/share|g" ${{targets.destdir}}/usr/share/${{package.name}}/.venv/bin/*
+      find ${{targets.destdir}}/usr/share/${{package.name}}/.venv/bin/ -type f | \
+        xargs sed -i "s|/home/build|/usr/share|g"
 
       # Include system site-packages
       sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/${{package.name}}/.venv/pyvenv.cfg
@@ -94,7 +95,8 @@ subpackages:
           mv .venv ${{targets.subpkgdir}}/usr/share/${{package.name}}-server/
 
           # Fix venv paths
-          sed -i "s|/home/build|/usr/share|g" ${{targets.subpkgdir}}/usr/share/${{package.name}}-server/.venv/bin/*
+          find ${{targets.subpkgdir}}/usr/share/${{package.name}}-server/.venv/bin/ -type f | \
+            xargs sed -i "s|/home/build|/usr/share|g"
 
           # Include system site-packages
           sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.subpkgdir}}/usr/share/${{package.name}}-server/.venv/pyvenv.cfg

--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -13,7 +13,10 @@ package:
     no-depends: true
   dependencies:
     runtime:
-      - python3
+      - python-${{vars.py-version}}-base
+
+vars:
+  py-version: 3.13
 
 environment:
   contents:
@@ -22,13 +25,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - go
-      - py3-gpep517
-      - py3-installer
-      - py3-pip
-      - py3-setuptools
-      - py3-wheel
-      - python3
-      - python3-dev
+      - py${{vars.py-version}}-build-base-dev
+      - py${{vars.py-version}}-gpep517
       - wolfi-base
 
 pipeline:
@@ -46,10 +44,10 @@ pipeline:
       sed -i 's|aiohttp|aiohttp>=3.10.11|g' requirements.txt
 
       # Build package
-      python -m gpep517 build-wheel --wheel-dir dist --output-fd 1
+      python${{vars.py-version}} -m gpep517 build-wheel --wheel-dir dist --output-fd 1
 
       # Setup venv and install package
-      python -m venv .venv --system-site-packages
+      python${{vars.py-version}} -m venv .venv --system-site-packages
       .venv/bin/pip install -I --no-compile dist/*.whl
 
       mkdir -p ${{targets.destdir}}/usr/share/${{package.name}}
@@ -75,7 +73,9 @@ subpackages:
       no-depends: true
     dependencies:
       runtime:
-        - python3
+        # sqlalchemy needs typing-extensions
+        - py${{vars.py-version}}-typing-extensions
+        - python-${{vars.py-version}}-base
     pipeline:
       - name: Python Build
         runs: |
@@ -84,10 +84,10 @@ subpackages:
           sed -i 's|aiohttp|aiohttp>=3.10.2|g' requirements.txt
 
           # Build package
-          python -m gpep517 build-wheel --wheel-dir dist --output-fd 1
+          python${{vars.py-version}} -m gpep517 build-wheel --wheel-dir dist --output-fd 1
 
           # Setup venv and install package
-          python -m venv .venv --system-site-packages
+          python${{vars.py-version}} -m venv .venv --system-site-packages
           .venv/bin/pip install -I --no-compile dist/*.whl
 
           # Install kubernetes asyncio, sqlalchemy, and typing extensions
@@ -118,10 +118,10 @@ subpackages:
 
             # Test imports in virtual environment
             source /usr/share/${{package.name}}-server/.venv/bin/activate
-            python -c "import dask_gateway_server"
-            python -c "import kubernetes_asyncio"
-            python -c "import sqlalchemy"
-            python -c "import typing_extensions"
+            python${{vars.py-version}} -c "import dask_gateway_server"
+            python${{vars.py-version}} -c "import kubernetes_asyncio"
+            python${{vars.py-version}} -c "import sqlalchemy"
+            python${{vars.py-version}} -c "import typing_extensions"
             dask-gateway-jobqueue-launcher --version
             dask-gateway-jobqueue-launcher --help
             dask-gateway-server --help
@@ -143,8 +143,8 @@ test:
 
         # Test imports in virtual environment
         source /usr/share/${{package.name}}/.venv/bin/activate
-        python -c "import dask_gateway"
-        python -c "from dask_gateway import Gateway"
+        python${{vars.py-version}} -c "import dask_gateway"
+        python${{vars.py-version}} -c "from dask_gateway import Gateway"
         dask --help
         dask-scheduler --help
         dask-ssh --help

--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -5,15 +5,6 @@ package:
   description: "A multi-tenant server for securely deploying and managing Dask clusters."
   copyright:
     - license: BSD-3-Clause
-  options:
-    # We create a dependency on libpython even though we provide
-    # libpython in the virtual environment. This prevents python
-    # versions on the host from being swapped out. Enabling no-
-    # depends works around this
-    no-depends: true
-  dependencies:
-    runtime:
-      - python-${{vars.py-version}}-base
 
 vars:
   py-version: 3.13
@@ -69,13 +60,10 @@ pipeline:
 subpackages:
   - name: dask-gateway-server
     description: A multi-tenant server for securely deploying and managing Dask clusters
-    options:
-      no-depends: true
     dependencies:
       runtime:
         # sqlalchemy needs typing-extensions
         - py${{vars.py-version}}-typing-extensions
-        - python-${{vars.py-version}}-base
     pipeline:
       - name: Python Build
         runs: |

--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -5,6 +5,17 @@ package:
   description: "A multi-tenant server for securely deploying and managing Dask clusters."
   copyright:
     - license: BSD-3-Clause
+  dependencies:
+    runtime:
+      - py${{vars.py-version}}-aiohttp
+      - py${{vars.py-version}}-click
+      - py${{vars.py-version}}-cloudpickle
+      - py${{vars.py-version}}-msgpack
+      - py${{vars.py-version}}-packaging
+      - py${{vars.py-version}}-psutil
+      - py${{vars.py-version}}-pyyaml
+      - py${{vars.py-version}}-sortedcontainers
+      - py${{vars.py-version}}-tornado
 
 vars:
   py-version: 3.13
@@ -29,18 +40,19 @@ pipeline:
 
   - runs: |
       cd ${{package.name}}
-      # Mitigate GHSA-753j-mpmx-qq6g, GHSA-w235-7p84-xx57
-      sed -i 's|tornado|tornado==6.4.2|g' requirements.txt
-      # Mitigate GHSA-jwhx-xcg6-8xhj, GHSA-8495-4g3g-x7pr
-      sed -i 's|aiohttp|aiohttp>=3.10.11|g' requirements.txt
 
       # Build package
       python${{vars.py-version}} -m gpep517 build-wheel --wheel-dir dist --output-fd 1
 
       # Setup venv and install package
       python${{vars.py-version}} -m venv .venv --system-site-packages
-      .venv/bin/pip install -I --no-compile dist/*.whl
-
+      .venv/bin/pip install -I --no-deps --no-compile dist/*.whl
+      .venv/bin/pip install -I --no-deps --no-compile dask
+      .venv/bin/pip install -I --no-deps --no-compile distributed
+      .venv/bin/pip install -I --no-deps --no-compile locket
+      .venv/bin/pip install -I --no-deps --no-compile tblib
+      .venv/bin/pip install -I --no-deps --no-compile toolz
+      .venv/bin/pip install -I --no-deps --no-compile zict
       mkdir -p ${{targets.destdir}}/usr/share/${{package.name}}
       mv .venv ${{targets.destdir}}/usr/share/${{package.name}}/
 
@@ -62,24 +74,21 @@ subpackages:
     description: A multi-tenant server for securely deploying and managing Dask clusters
     dependencies:
       runtime:
-        # sqlalchemy needs typing-extensions
-        - py${{vars.py-version}}-typing-extensions
+        - py${{vars.py-version}}-kubernetes-asyncio
+        - py${{vars.py-version}}-colorlog
+        - py${{vars.py-version}}-sqlalchemy
+        - py${{vars.py-version}}-traitlets
     pipeline:
       - name: Python Build
         runs: |
           cd ${{package.name}}-server
-          # Mitigate GHSA-jwhx-xcg6-8xhj
-          sed -i 's|aiohttp|aiohttp>=3.10.2|g' requirements.txt
 
           # Build package
           python${{vars.py-version}} -m gpep517 build-wheel --wheel-dir dist --output-fd 1
 
           # Setup venv and install package
           python${{vars.py-version}} -m venv .venv --system-site-packages
-          .venv/bin/pip install -I --no-compile dist/*.whl
-
-          # Install kubernetes asyncio, sqlalchemy, and typing extensions
-          .venv/bin/pip install kubernetes-asyncio sqlalchemy typing_extensions --no-compile
+          .venv/bin/pip install -I --no-deps --no-compile dist/*.whl
 
           mkdir -p ${{targets.subpkgdir}}/usr/share/${{package.name}}-server
           mv .venv ${{targets.subpkgdir}}/usr/share/${{package.name}}-server/

--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -1,7 +1,7 @@
 package:
   name: dask-gateway
   version: 2024.1.0
-  epoch: 12
+  epoch: 13
   description: "A multi-tenant server for securely deploying and managing Dask clusters."
   copyright:
     - license: BSD-3-Clause

--- a/dask-gateway.yaml
+++ b/dask-gateway.yaml
@@ -118,9 +118,6 @@ subpackages:
             # Test imports in virtual environment
             source /usr/share/${{package.name}}-server/.venv/bin/activate
             python${{vars.py-version}} -c "import dask_gateway_server"
-            python${{vars.py-version}} -c "import kubernetes_asyncio"
-            python${{vars.py-version}} -c "import sqlalchemy"
-            python${{vars.py-version}} -c "import typing_extensions"
             dask-gateway-jobqueue-launcher --version
             dask-gateway-jobqueue-launcher --help
             dask-gateway-server --help


### PR DESCRIPTION
dask-gateway is broken because it was built against python 3.12, but depends on python3 which now defaults to python 3.13.

Fixes: https://github.com/chainguard-dev/image-release-stats/issues/3316

It uses venvs, and I noticed that it has multiple copies of the python interpreter included. I've switched those to symlinks. It also installs dependencies from PyPI. For any of the ones that wolfi provides, I've switched it over to those instead. But there are a handful that are not in wolfi, so those continue to come from PyPI for now.

Longterm we should package the remaining dependencies, split dask's own python libraries out into multiversioned py3.x packages and switch to building them with the py/pip-build-install pipeline. But let's get our dask images working again first.