### PR TITLE
supervisor: rebuild for Python 3.13

### DIFF
--- a/supervisor.yaml
+++ b/supervisor.yaml
@@ -11,7 +11,7 @@ package:
       - supervisor-config
 
 vars:
-  py-version: 3.12
+  py-version: 3.13
 
 environment:
   contents:

--- a/supervisor.yaml
+++ b/supervisor.yaml
@@ -16,9 +16,7 @@ vars:
 environment:
   contents:
     packages:
-      - busybox
-      - py${{vars.py-version}}-pip
-      - python-${{vars.py-version}}
+      - py${{vars.py-version}}-build-base
 
 pipeline:
   - uses: git-checkout

--- a/supervisor.yaml
+++ b/supervisor.yaml
@@ -49,7 +49,7 @@ pipeline:
       mkdir -p "${{targets.destdir}}/etc/logrotate.d"
       mkdir -p "${{targets.destdir}}/usr/bin/"
 
-      pip install supervisor
+      pip${{vars.py-version}} install supervisor
 
       /usr/bin/echo_supervisord_conf > "${{targets.destdir}}/etc/supervisord.conf"
       cat "${{targets.destdir}}/etc/supervisord.conf"

--- a/supervisor.yaml
+++ b/supervisor.yaml
@@ -1,7 +1,7 @@
 package:
   name: supervisor
   version: 4.2.5
-  epoch: 7
+  epoch: 8
   description: Supervisor process control system for Unix (supervisord)
   copyright:
     - license: BSD-3-Clause


### PR DESCRIPTION
The `supervisor` package was still built with Python 3.12, causing some issues on certain images. Let's use the explicit setuptools packages while at it.

