### PR TITLE
procps: fix tests by using absolute path for kill

### DIFF
--- a/procps.yaml
+++ b/procps.yaml
@@ -71,9 +71,10 @@ test:
         ps --version || exit 1
         free --version
         free --help
-        kill --help
+        # Use full path as kill is always preferred via the shell builtin
+        /usr/bin/kill --help
         sleep 9999 &
-        kill -9 $$
+        /usr/bin/kill -9 $!
         pgrep --version
         pgrep --help
         pidof --version


### PR DESCRIPTION
No epoch bump needed as this is just a test fix. The tests are failing as executions of `kill` always prioritize the builtin implementation. From what I know this is not only the case for busybox, but also bash - where for bash a `enable -n kill` is needed to disable this behavior. Since we want to test the procps implementation, one way of doing it is just using the absolute path for the kill binary.