### PR TITLE
fixing several cves in vitess-20.0

### DIFF
--- a/vitess-20.0.yaml
+++ b/vitess-20.0.yaml
@@ -65,13 +65,13 @@ pipeline:
     with:
       packages: ./go/...
       output: " " # Workaround: set to non-empty string to build all binaries at once
-      ldflags: |
+      ldflags
+      # Add a step to enforce secure versions of dependencies via overrides: |
         -w
         -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=$(git rev-parse --short HEAD)'
         -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=$(git rev-parse --abbrev-ref HEAD)'
         -X 'vitess.io/vitess/go/vt/servenv.buildTime=$(date +"%a %b %d %T %Z %Y")'
-    
-    # Add a step to enforce secure versions of dependencies via overrides
+
   - name: Add dependency overrides
     working-directory: web/vtadmin
     runs: |

--- a/vitess-20.0.yaml
+++ b/vitess-20.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: vitess-20.0
   version: 20.0.4
-  epoch: 2
+  epoch: 3
   description: Autoscaling components for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -70,6 +70,16 @@ pipeline:
         -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=$(git rev-parse --short HEAD)'
         -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=$(git rev-parse --abbrev-ref HEAD)'
         -X 'vitess.io/vitess/go/vt/servenv.buildTime=$(date +"%a %b %d %T %Z %Y")'
+    
+    # Add a step to enforce secure versions of dependencies via overrides
+  - name: Add dependency overrides
+    working-directory: web/vtadmin
+    runs: |
+      npm pkg set overrides.cookie=0.7.0
+      npm pkg set overrides['get-func-name']=2.0.1
+      npm pkg set overrides.nanoid=3.3.8
+      npm pkg set overrides.ip=2.0.1
+      npm pkg set overrides.tar=6.2.1
 
   - name: Build web UI
     working-directory: web/vtadmin
@@ -77,7 +87,7 @@ pipeline:
       npm install --omit=dev
 
       # CVE GHSA-3xgq-45jj-v275
-      npm install cross-spawn@7.0.5
+      npm install cross-spawn@7.0.6
 
       npm prune --production
       npm install vite --save-dev

--- a/vitess-20.0.yaml
+++ b/vitess-20.0.yaml
@@ -65,13 +65,13 @@ pipeline:
     with:
       packages: ./go/...
       output: " " # Workaround: set to non-empty string to build all binaries at once
-      ldflags
-      # Add a step to enforce secure versions of dependencies via overrides: |
+      ldflags: |
         -w
         -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=$(git rev-parse --short HEAD)'
         -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=$(git rev-parse --abbrev-ref HEAD)'
         -X 'vitess.io/vitess/go/vt/servenv.buildTime=$(date +"%a %b %d %T %Z %Y")'
 
+  # Add a step to enforce secure versions of dependencies via overrides
   - name: Add dependency overrides
     working-directory: web/vtadmin
     runs: |


### PR DESCRIPTION
Remedated the following CVEs by overriding the required version of transitive dependencies as long as it was within a minor version bump of the currently installed value;

1. CVE-2022-25883
2. CVE-2024-29415
3. CVE-2023-42282
4. CVE-2024-28863