### PR TITLE
python 3.13 changes to gpsd kubeflow-jupyter-web-app py3-ml-metadata scons

### DIFF
--- a/gpsd.yaml
+++ b/gpsd.yaml
@@ -1,10 +1,13 @@
 package:
   name: gpsd
   version: "3.25"
-  epoch: 3
+  epoch: 4
   description: GPS daemon
   copyright:
     - license: BSD-2-Clause
+
+vars:
+  py-version: 3.13
 
 environment:
   contents:
@@ -18,9 +21,7 @@ environment:
       - libcap-dev
       - ncurses-dev
       - openssf-compiler-options
-      - py3.12-setuptools
-      - python3
-      - python3-dev
+      - py${{vars.py-version}}-build-base-dev
       - scons
 
 pipeline:
@@ -37,8 +38,8 @@ pipeline:
       CPPFLAGS="$CPPFLAGS -I./pps-tools/ -DHAVE_SYS_TIMEPPS_H"
       scons -j${JOBS:-1} \
       	prefix=/usr \
-      	target_python=python3 \
-      	python_shebang=/usr/bin/python3.12 \
+      	target_python=python${{vars.py-version}} \
+      	python_shebang=/usr/bin/python${{vars.py-version}} \
       	dbus_export=no \
       	systemd=no
 
@@ -66,7 +67,10 @@ subpackages:
       - uses: split/manpages
     description: gpsd manpages
 
-  - name: py3-gpsd
+  - name: py${{vars.py-version}}-gpsd
+    dependencies:
+      provides:
+        - py3-gpsd
     pipeline:
       - runs: |
           mkdir -p  "${{targets.subpkgdir}}"/usr/bin

--- a/kubeflow-jupyter-web-app.yaml
+++ b/kubeflow-jupyter-web-app.yaml
@@ -8,8 +8,10 @@ package:
   dependencies:
     runtime:
       - bash
-      - py3-gunicorn
-      - python3
+      - py${{vars.py-version}}-gunicorn
+
+vars:
+  py-version: 3.13
 
 environment:
   contents:
@@ -23,12 +25,8 @@ environment:
       - openssf-compiler-options
       - openssl
       - openssl-provider-legacy
-      - py3-pip
-      - py3-setuptools
-      - py3-urllib3
-      - py3-wheel
-      - python3
-      - python3-dev
+      - py${{vars.py-version}}-build-base-dev
+      - py${{vars.py-version}}-urllib3
       - wolfi-base
 
 pipeline:
@@ -39,21 +37,24 @@ pipeline:
       expected-commit: 315ee7e305e8b7485c975283fb7e5751d21f267d
 
   - runs: |
+      python3=python${{vars.py-version}}
+      pip=pip${{vars.py-version}}
+
       # Build the backend common libs into a wheel
       cd components/crud-web-apps/common/backend
       # Remove the version requirement on gevent. This was introduced in this PR: https://github.com/kubeflow/kubeflow/pull/7231/files
       # The dependency was pinned due to a build issue on ppc64le: https://github.com/kubeflow/kubeflow/issues/7226
       sed -i -E 's/gevent[^"]+/gevent/g' setup.py
       # Setup the virtualenv
-      python -m venv venv --system-site-packages
+      $python3 -m venv venv --system-site-packages
       source venv/bin/activate
-      python3 ./setup.py bdist_wheel
+      $python3 ./setup.py bdist_wheel
       ls -latr dist
-      pip install -I --no-compile dist/*.whl --prefix=/usr --root="${{targets.destdir}}"
-      pip install . --prefix=/usr --root="${{targets.destdir}}"
+      $pip install -I --no-compile dist/*.whl --prefix=/usr --root="${{targets.destdir}}"
+      $pip install . --prefix=/usr --root="${{targets.destdir}}"
       # Mitigate GHSA-34jh-p97f-mpxf
-      pip install urllib3==2.2.2 --prefix=/usr --root="${{targets.destdir}}"
-      ls -latr /usr/lib/python3.12/site-packages
+      $pip install urllib3==2.2.2 --prefix=/usr --root="${{targets.destdir}}"
+      ls -latr /usr/lib/python${{vars.py-version}}/site-packages
 
       cd ../../jupyter/backend
       # pip install -r requirements.txt --prefix=/usr --root="${{targets.destdir}}"

--- a/py3-ml-metadata.yaml
+++ b/py3-ml-metadata.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-ml-metadata
   version: 1.16.0
-  epoch: 4
+  epoch: 5
   description: For recording and retrieving metadata associated with ML developer and data scientist workflows.
   copyright:
     - license: MIT
@@ -21,7 +21,7 @@ data:
       3.10: '310'
       3.11: '311'
       3.12: '312'
-      3.13: '300'
+      3.13: '313'
 
 environment:
   contents:

--- a/scons.yaml
+++ b/scons.yaml
@@ -1,10 +1,17 @@
 package:
   name: scons
   version: 4.8.1
-  epoch: 0
+  epoch: 1
   description: Software construction system
   copyright:
     - license: MIT
+  dependencies:
+    runtime:
+      # needs setuptools for distuils use
+      - py${{vars.py-version}}-setuptools
+
+vars:
+  py-version: 3.13
 
 environment:
   contents:
@@ -15,10 +22,8 @@ environment:
       - busybox
       - ca-certificates-bundle
       - curl
-      - py3-gpep517
-      - py3-setuptools
-      - py3-wheel
-      - python3
+      - py${{vars.py-version}}-build-base
+      - py${{vars.py-version}}-gpep517
 
 pipeline:
   - uses: git-checkout
@@ -35,12 +40,13 @@ pipeline:
       extract: false
 
   - runs: |
+      python3=python${{vars.py-version}}
       tar -xzf SCons-${{package.version}}.tar.gz
 
-      python3 -m gpep517 build-wheel --wheel-dir .dist --output-fd 3 3>&1 >&2
+      $python3 -m gpep517 build-wheel --wheel-dir .dist --output-fd 3 3>&1 >&2
       install -vDm 644 ./scons-${{package.version}}/*.1 -t "${{targets.destdir}}/usr/share/man/man1/"
 
-      python3 -m installer -d "${{targets.destdir}}" .dist/*.whl
+      $python3 -m installer -d "${{targets.destdir}}" .dist/*.whl
       # remove docbook dirs
       find "${{targets.destdir}}" -name 'docbook' -type d -exec rm -rf {} +
 


### PR DESCRIPTION
 * py3-gpsd - pin python version to 3.13
 * py3-ml-metadata - bump python 3.13 provider priority to be highest
 * kubeflow-jupyter-web-app - pin python version to 3.13
 * scons - pin python version to 3.13
   
   I'm not actually sure how important this is, as I think
   scons creates a build tool that supports working with
   other pythons.

