### PR TITLE
apache-pulsar: adding missed runtime dependencies / upgrade bouncycastle

### DIFF
--- a/apache-pulsar.yaml
+++ b/apache-pulsar.yaml
@@ -9,7 +9,7 @@ package:
     runtime:
       - bash
       - libstdc++
-      - openjdk-17-jre
+      - openjdk-21-jre
       - openssl
       - procps
 
@@ -18,7 +18,7 @@ environment:
     packages:
       - busybox
       - maven
-      - openjdk-17-default-jdk
+      - openjdk-21-default-jdk
 
 pipeline:
   - uses: git-checkout
@@ -27,10 +27,14 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 3ea527bf6b720dcfe074c4476257cce96ebc068a
 
+  - uses: patch
+    with:
+      patches: bouncy-castle-bcfips.patch
+
   - uses: maven/pombump
 
   - name: Build
-    runs: ./mvnw package -DskipTests
+    runs: ./mvnw package -DskipTests -Pcore-modules,-main
 
   - name: Install
     runs: |
@@ -64,9 +68,10 @@ test:
         - ${{package.name}}-compat
         - bash
         - libstdc++
+        - procps
     environment:
-      JAVA_HOME: /usr/lib/jvm/java-17-openjdk
-      PATH: /usr/lib/jvm/java-17-openjdk/bin:$PATH
+      JAVA_HOME: /usr/lib/jvm/java-21-openjdk
+      PATH: /usr/lib/jvm/java-21-openjdk/bin:$PATH
   pipeline:
     - name: Test that all CLI tools are at least installed
       runs: |

--- a/apache-pulsar.yaml
+++ b/apache-pulsar.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-pulsar
   version: 4.0.1
-  epoch: 1
+  epoch: 2
   description: Pulsar is a distributed pub-sub messaging platform with a very flexible messaging model and an intuitive client API.
   copyright:
     - license: Apache-2.0
@@ -10,6 +10,8 @@ package:
       - bash
       - libstdc++
       - openjdk-17-jre
+      - openssl
+      - procps
 
 environment:
   contents:

--- a/apache-pulsar.yaml
+++ b/apache-pulsar.yaml
@@ -34,7 +34,7 @@ pipeline:
   - uses: maven/pombump
 
   - name: Build
-    runs: ./mvnw package -DskipTests -Pcore-modules,-main
+    runs: ./mvnw package -DskipTests
 
   - name: Install
     runs: |

--- a/apache-pulsar/bouncy-castle-bcfips.patch
+++ b/apache-pulsar/bouncy-castle-bcfips.patch
@@ -1,0 +1,15 @@
+diff --git a/pom.xml b/pom.xml
+index 2a91978af8..dfee3a3b77 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -159,8 +159,8 @@ flexible messaging model and an intuitive client API.</description>
+     <commons.collections4.version>4.4</commons.collections4.version>
+     <log4j2.version>2.23.1</log4j2.version>
+     <bouncycastle.version>1.78.1</bouncycastle.version>
+-    <bouncycastle.bcpkix-fips.version>1.0.7</bouncycastle.bcpkix-fips.version>
+-    <bouncycastle.bc-fips.version>1.0.2.5</bouncycastle.bc-fips.version>
++    <bouncycastle.bcpkix-fips.version>2.0.7</bouncycastle.bcpkix-fips.version>
++    <bouncycastle.bc-fips.version>2.0.0</bouncycastle.bc-fips.version>
+     <jackson.version>2.17.2</jackson.version>
+     <fastutil.version>8.5.14</fastutil.version>
+     <reflections.version>0.10.2</reflections.version>


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

- Adds `openssl` and `procps` as runtime dependencies
- Builds with `openjdk-21` - external counterpart image uses 21
- Upgrades bouncycastle-bcfips to 2.x

Related: https://github.com/chainguard-dev/image-requests/issues/1654

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For PRs that add patches
<!-- remove if unrelated -->
- [x] Patch source is documented
