### PR TITLE
nodejs-*: Use more generic -march for rosetta2 compatibility

### DIFF
--- a/nodejs-16.yaml
+++ b/nodejs-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-16
   version: 16.20.2
-  epoch: 8
+  epoch: 9
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -47,7 +47,14 @@ pipeline:
   - name: Configure and build
     runs: |
       # Add defines recommended in libuv readme.
-      common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+      case "${{build.arch}}" in
+      "aarch64")
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+         ;;
+      "x86_64")
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -march=x86-64"
+         ;;
+      esac
 
       # Fix the standard to work with newer code
       sed s/gnu++14/gnu++17/g -i ./common.gypi
@@ -74,8 +81,6 @@ pipeline:
         --without-corepack
 
         make BUILDTYPE=Release -j$(nproc)
-
-  - uses: autoconf/make
 
   - uses: autoconf/make-install
 

--- a/nodejs-18.yaml
+++ b/nodejs-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-18
   version: 18.20.5
-  epoch: 1
+  epoch: 2
   description: "JavaScript runtime built on V8 engine - LTS version"
   copyright:
     - license: MIT
@@ -47,8 +47,14 @@ pipeline:
   - name: Configure and build
     runs: |
       # Add defines recommended in libuv readme.
-      common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
-
+      case "${{build.arch}}" in
+      "aarch64")
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+         ;;
+      "x86_64")
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -march=x86-64"
+         ;;
+      esac
       # Compiling with O2 instead of Os increases binary size by ~10%
       # (53.1 MiB -> 58.6 MiB), but also increases performance by ~20%
       # according to v8/web-tooling-benchmark. Node.js is quite huge anyway;
@@ -71,8 +77,6 @@ pipeline:
         --without-corepack
 
         make BUILDTYPE=Release -j$(nproc)
-
-  - uses: autoconf/make
 
   - uses: autoconf/make-install
 

--- a/nodejs-20.yaml
+++ b/nodejs-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-20
   version: 20.18.1
-  epoch: 1
+  epoch: 2
   description: "JavaScript runtime built on V8 engine - LTS version"
   dependencies:
     provides:
@@ -47,8 +47,14 @@ pipeline:
   - name: Configure and build
     runs: |
       # Add defines recommended in libuv readme.
-      common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
-
+      case "${{build.arch}}" in
+      "aarch64")
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+         ;;
+      "x86_64")
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -march=x86-64"
+         ;;
+      esac
       # Compiling with O2 instead of Os increases binary size by ~10%
       # (53.1 MiB -> 58.6 MiB), but also increases performance by ~20%
       # according to v8/web-tooling-benchmark. Node.js is quite huge anyway;
@@ -71,8 +77,6 @@ pipeline:
         --without-corepack
 
         make BUILDTYPE=Release -j$(nproc)
-
-  - uses: autoconf/make
 
   - uses: autoconf/make-install
 

--- a/nodejs-21.yaml
+++ b/nodejs-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-21
   version: 21.7.3
-  epoch: 5
+  epoch: 6
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -46,8 +46,14 @@ pipeline:
   - name: Configure and build
     runs: |
       # Add defines recommended in libuv readme.
-      common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
-
+      case "${{build.arch}}" in
+      "aarch64")
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+         ;;
+      "x86_64")
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -march=x86-64"
+         ;;
+      esac
       # Compiling with O2 instead of Os increases binary size by ~10%
       # (53.1 MiB -> 58.6 MiB), but also increases performance by ~20%
       # according to v8/web-tooling-benchmark. Node.js is quite huge anyway;
@@ -70,8 +76,6 @@ pipeline:
         --without-corepack
 
         make BUILDTYPE=Release -j$(nproc)
-
-  - uses: autoconf/make
 
   - uses: autoconf/make-install
 

--- a/nodejs-22.yaml
+++ b/nodejs-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-22
   version: 22.12.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -47,7 +47,14 @@ pipeline:
   - name: Configure and build
     runs: |
       # Add defines recommended in libuv readme.
-      common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+      case "${{build.arch}}" in
+      "aarch64")
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+         ;;
+      "x86_64")
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -march=x86-64"
+         ;;
+      esac
 
       # Compiling with O2 instead of Os increases binary size by ~10%
       # (53.1 MiB -> 58.6 MiB), but also increases performance by ~20%
@@ -71,8 +78,6 @@ pipeline:
         --without-corepack
 
         make BUILDTYPE=Release -j$(nproc)
-
-  - uses: autoconf/make
 
   - uses: autoconf/make-install
 

--- a/nodejs-23.yaml
+++ b/nodejs-23.yaml
@@ -1,7 +1,7 @@
 package:
   name: nodejs-23
   version: 23.5.0
-  epoch: 0
+  epoch: 1
   description: "JavaScript runtime built on V8 engine"
   dependencies:
     provides:
@@ -47,7 +47,14 @@ pipeline:
   - name: Configure and build
     runs: |
       # Add defines recommended in libuv readme.
-      common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+      case "${{build.arch}}" in
+      "aarch64")
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+         ;;
+      "x86_64")
+         common_flags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -march=x86-64"
+         ;;
+      esac
 
       # Compiling with O2 instead of Os increases binary size by ~10%
       # (53.1 MiB -> 58.6 MiB), but also increases performance by ~20%
@@ -71,8 +78,6 @@ pipeline:
         --without-corepack
 
         make BUILDTYPE=Release -j$(nproc)
-
-  - uses: autoconf/make
 
   - uses: autoconf/make-install
 


### PR DESCRIPTION
Building node with `-march=x86_64-v2` is causing our nodejs to hang on
rosetta2.   Setting `-march=x86_64` seems to fix this issue.

Also remove the extra `autoconfg/make` directive.  Nodes build system doesn't carry over the flags from configure from what I can tell so the build that matters is the one at the end of Configure and Build.

19 is currently failing to build so not included.

Fixes: https://github.com/wolfi-dev/os/issues/37196
Related: https://github.com/chainguard-dev/customer-issues/issues/1866