### PR TITLE
tensorflow-core: Remove build-dep on cython

### DIFF
--- a/tensorflow-core.yaml
+++ b/tensorflow-core.yaml
@@ -2,7 +2,7 @@ package:
   name: tensorflow-core
   description: Framework for data-graph oriented computing (core libraries, oneDNN build)
   version: "2.19.0"
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   resources:
@@ -34,7 +34,6 @@ environment:
       - clang-16-dev
       - coreutils
       - curl-dev
-      - cython~0
       - gcc-12-default
       - giflib-dev
       - hdf5
@@ -84,7 +83,7 @@ environment:
     TF_NEED_NGRAPH: 0
     TF_NEED_IGNITE: 0
     TF_NEED_ROCM: 0
-    TF_SYSTEM_LIBS: "boringssl,curl,gif,icu,libjpeg_turbo,nasm,png,zlib,cython"
+    TF_SYSTEM_LIBS: "boringssl,curl,gif,icu,libjpeg_turbo,nasm,png,zlib"
     TF_SET_ANDROID_WORKSPACE: 0
     TF_DOWNLOAD_CLANG: 0
     TF_NEED_CUDA: 0


### PR DESCRIPTION
tensorflow-core is the last remaining package that uses cython~0, so I checked to see if it was compatible with current cython. But, as far as I could tell, cython is simply never used.

To confirm, I did a build of tensorflow-core where I touched a reference file after the build-deps (including cython) had been installed and then, after each (sub-)package build, ran:

``` 
find $(apk info -L cython | grep -v ^cython | grep -v '^$' | sed 's/^/\//') -anewer /tmp/reference | sed 's/^/DANNF: /'
```

I found no 'DANNF:' lines in the output. This tells me that nothing in the build accessed any files provided by the cython package.

See: https://github.com/wolfi-dev/os/issues/37272