### PR TITLE
bind: Upgrade from 9.18 to 9.20 series

### DIFF
--- a/bind.yaml
+++ b/bind.yaml
@@ -1,6 +1,6 @@
 package:
   name: bind
-  version: 9.18.32
+  version: 9.20.4
   epoch: 0
   description: The ISC DNS server
   copyright:
@@ -38,7 +38,7 @@ pipeline:
     with:
       repository: https://gitlab.isc.org/isc-projects/bind9.git
       tag: v${{package.version}}
-      expected-commit: d1f139270ce2d764d90ad0b8724cf0265792136c
+      expected-commit: 283ac230b9277cad7ea509cafcd404573a7270ab
 
   - runs: |
       autoreconf -fi

--- a/bind.yaml
+++ b/bind.yaml
@@ -227,4 +227,4 @@ subpackages:
 update:
   enabled: true
   release-monitor:
-    identifier: 242117
+    identifier: 374094


### PR DESCRIPTION
Bind uses even/odd series for stable/devel releases, with 9.20.x being
the latest stable and 9.21.x being the latest devel. Ideally we would
have "no-odd" semver flag in our update monitors; or jut a regexp
support for tag filtering.

Noticed via [OSS Security post](https://www.openwall.com/lists/oss-security/2024/12/21/1) about 9.20.4 critical issue.

With this update, a new PR should be opened by the bot to upgrade to v9.20.x series:

```
$ GITHUB_TOKEN=$(gh auth token) ~/chainguard-dev/mono/cg/cg check update bind.yaml 
2024/12/21 11:06:32 WARN using GITHUB_TOKEN for token exchange
2024/12/21 11:06:32 INFO found 1 packages

2024/12/21 11:06:32 INFO checking package bind: bind
2024/12/21 11:06:32 INFO [1/1] bind: checking release monitor using id 374094

2024/12/21 11:06:33 INFO found dereferenced tag v9.20.4 for package with commit 283ac230b9277cad7ea509cafcd404573a7270ab
2024/12/21 11:06:33 INFO commit SHA for package bind: 283ac230b9277cad7ea509cafcd404573a7270ab
2024/12/21 11:06:33 INFO attempting to bump version to 9.20.4
2024/12/21 11:06:33 INFO processing git-checkout node
2024/12/21 11:06:33 INFO   expected-commit: 283ac230b9277cad7ea509cafcd404573a7270ab
2024/12/21 11:06:34 INFO git-checkout was successful package=bind
2024/12/21 11:06:34 INFO update config passed validation for packages bind.yaml
```
