### PR TITLE
apache-tika version stream and cve fix

### DIFF
--- a/apache-tika-3.0.yaml
+++ b/apache-tika-3.0.yaml
@@ -1,5 +1,5 @@
 package:
-  name: apache-tika
+  name: apache-tika-3.0
   version: 3.0.0
   epoch: 0
   description: The Apache Tika toolkit detects and extracts metadata and text from over a thousand different file types (such as PPT, XLS, and PDF).
@@ -31,6 +31,11 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 9bcb38d6734ed9d5dcff617f316c535e844c68d1
 
+  - uses: maven/pombump
+    with:
+      patch-file: patches.yaml
+      pom: tika-parent/pom.xml
+
   - runs: |
       mvn clean install -am -DskipTests -Dossindex.skip
       mkdir -p "${{targets.contextdir}}"/usr/share/java/
@@ -49,6 +54,7 @@ update:
   github:
     identifier: apache/tika
     use-tag: true
+    tag-filter: v3.0.
 
 test:
   environment:

--- a/apache-tika-3.0/patches.yaml
+++ b/apache-tika-3.0/patches.yaml
@@ -1,0 +1,5 @@
+patches:
+# CVE-2024-6763
+- groupId: org.eclipse.jetty
+  artifactId: jetty-http
+  version: 12.0.12


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [x] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))
