### PR TITLE
py3-cassandra-medusa: pin to python3.11, use wolfi deps where possible, restoring & multiversioning ssh python libs

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -28,6 +28,7 @@ package:
       - py${{vars.py-version}}-grpcio
       - py${{vars.py-version}}-grpcio-health-checking
       - py${{vars.py-version}}-idna
+      - py${{vars.py-version}}-parallel-ssh
       - py${{vars.py-version}}-psutil
       - py${{vars.py-version}}-pyopenssl
       - py${{vars.py-version}}-requests
@@ -65,12 +66,6 @@ pipeline:
 
   - name: Install deps from PyPI that aren't currently packaged in wolfi
     runs: |
-      .venv/bin/pip${{vars.py-version}} install -I parallel-ssh --no-compile --no-deps
-      .venv/bin/pip${{vars.py-version}} install -I ssh2-python --no-compile --no-deps
-      .venv/bin/pip${{vars.py-version}} install -I ssh-python --no-compile --no-deps
-      .venv/bin/pip${{vars.py-version}} install -I .wheels/${{vars.py-version}}/*.whl --no-compile --no-deps
-
-  - runs: |
       # python-snappy is required to run medusa using $MEDUSA_MODE=GRPC.
       .venv/bin/pip${{vars.py-version}} install -I python-snappy --no-compile --no-deps
 

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -25,7 +25,7 @@ environment:
       - ca-certificates-bundle
       - py${{vars.py-version}}-installer
       - py${{vars.py-version}}-pip
-      - python-${{vars.py-version}}
+      - python-${{vars.py-version}}-base
       - wolfi-base
 
 pipeline:
@@ -37,8 +37,8 @@ pipeline:
 
   - name: Python Build
     runs: |
-      pip install wheel
-      pip install poetry
+      pip${{vars.py-version}} install wheel
+      pip${{vars.py-version}} install poetry
       poetry add "aiohttp==3.10.11"
       poetry add "certifi==2024.7.4"
       poetry add "dnspython==2.6.1"
@@ -57,17 +57,17 @@ pipeline:
 
   - runs: |
       # Setup the virtualenv
-      python -m venv .venv --system-site-packages
+      python${{vars.py-version}} -m venv .venv --system-site-packages
       # Bump pip to patch a CVE
-      .venv/bin/pip install --upgrade pip==24.0 setuptools==70.0.0
+      .venv/bin/pip${{vars.py-version}} install --upgrade pip==24.0 setuptools==70.0.0
 
   - runs: |
-      .venv/bin/pip install -I -r requirements.txt --no-compile
-      .venv/bin/pip install -I --no-compile dist/*.whl
+      .venv/bin/pip${{vars.py-version}} install -I -r requirements.txt --no-compile
+      .venv/bin/pip${{vars.py-version}} install -I --no-compile dist/*.whl
 
   - runs: |
       # python-snappy is required to run medusa using $MEDUSA_MODE=GRPC.
-      .venv/bin/pip install -I python-snappy --no-compile
+      .venv/bin/pip${{vars.py-version}} install -I python-snappy --no-compile
 
   - runs: |
       mkdir -p ${{targets.destdir}}/home/cassandra
@@ -115,14 +115,13 @@ test:
   environment:
     contents:
       packages:
-        - python-${{vars.py-version}}
         - grpc-health-probe
   pipeline:
     - runs: medusa --version
     - runs: |
         set +e
         fail() { echo "$@" 1>&2; exit 1; }
-        out=$(/home/cassandra/.venv/bin/python3 -m medusa.service.grpc.server 2>&1)
+        out=$(/home/cassandra/.venv/bin/python${{vars.py-version}} -m medusa.service.grpc.server 2>&1)
         status=$?
         echo "$out" | grep -q '/etc/medusa/medusa.ini' || fail "medusa.service.grpc.server output did not contain expected 'medusa.ini' message. Exit status $status: $out"
         echo "medusa.service.grpc.server exited with expected error message"

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -11,7 +11,29 @@ package:
     no-depends: true
   dependencies:
     runtime:
-      - py${{vars.py-version}}-poetry
+      - py${{vars.py-version}}-aiohttp
+      - py${{vars.py-version}}-azure-identity
+      - py${{vars.py-version}}-azure-storage-blob
+      - py${{vars.py-version}}-boto3
+      - py${{vars.py-version}}-cassandra-driver
+      - py${{vars.py-version}}-click
+      - py${{vars.py-version}}-click-aliases
+      - py${{vars.py-version}}-certifi
+      - py${{vars.py-version}}-cryptography
+      - py${{vars.py-version}}-datadog
+      - py${{vars.py-version}}-dnspython
+      - py${{vars.py-version}}-ffwd
+      - py${{vars.py-version}}-gcloud-aio-storage
+      - py${{vars.py-version}}-gevent
+      - py${{vars.py-version}}-grpcio
+      - py${{vars.py-version}}-grpcio-health-checking
+      - py${{vars.py-version}}-idna
+      - py${{vars.py-version}}-psutil
+      - py${{vars.py-version}}-pyopenssl
+      - py${{vars.py-version}}-requests
+      - py${{vars.py-version}}-retrying
+      - py${{vars.py-version}}-urllib3
+      - py${{vars.py-version}}-pyyaml
 
 vars:
   py-version: 3.11
@@ -22,7 +44,7 @@ environment:
       - build-base
       - ca-certificates-bundle
       - py${{vars.py-version}}-build-base-dev
-      - py${{vars.py-version}}-poetry-bin
+      - py${{vars.py-version}}-poetry
       - wolfi-base
 
 pipeline:
@@ -32,37 +54,25 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 6202aca6e4c2859d2ad601571571a774df7bebc8
 
-  - name: Python Build
-    runs: |
-      poetry add "aiohttp==3.10.11"
-      poetry add "certifi==2024.7.4"
-      poetry add "dnspython==2.6.1"
-      poetry add "idna==3.7"
-      poetry add "pyOpenSSL@^24.0.0"
-      poetry add "cryptography@^43.0.1"
-      # CVE-2024-35195: requests
-      poetry add "requests@^2.23.0"
-      # GHSA-m5vv-6r4h-3vj9: azure-identity
-      poetry add "azure-identity==1.16.1"
-      # GHSA-34jh-p97f-mpxf: urllib3
-      poetry add "urllib3==1.26.19"
-      poetry run pip freeze | grep -v cassandra-medusa > requirements.txt
-      POETRY_VIRTUALENVS_IN_PROJECT=true poetry install
-      poetry build
-
   - runs: |
       # Setup the virtualenv
       python${{vars.py-version}} -m venv .venv --system-site-packages
-      # Bump pip to patch a CVE
-      .venv/bin/pip${{vars.py-version}} install --upgrade pip==24.0 setuptools==70.0.0
 
-  - runs: |
-      .venv/bin/pip${{vars.py-version}} install -I -r requirements.txt --no-compile
-      .venv/bin/pip${{vars.py-version}} install -I --no-compile dist/*.whl
+  - name: Python Build
+    uses: py/pip-build-install
+    with:
+      python: .venv/bin/python${{vars.py-version}}
+
+  - name: Install deps from PyPI that aren't currently packaged in wolfi
+    runs: |
+      .venv/bin/pip${{vars.py-version}} install -I parallel-ssh --no-compile --no-deps
+      .venv/bin/pip${{vars.py-version}} install -I ssh2-python --no-compile --no-deps
+      .venv/bin/pip${{vars.py-version}} install -I ssh-python --no-compile --no-deps
+      .venv/bin/pip${{vars.py-version}} install -I .wheels/${{vars.py-version}}/*.whl --no-compile --no-deps
 
   - runs: |
       # python-snappy is required to run medusa using $MEDUSA_MODE=GRPC.
-      .venv/bin/pip${{vars.py-version}} install -I python-snappy --no-compile
+      .venv/bin/pip${{vars.py-version}} install -I python-snappy --no-compile --no-deps
 
   - runs: |
       mkdir -p ${{targets.destdir}}/home/cassandra

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -12,7 +12,6 @@ package:
   dependencies:
     runtime:
       - py${{vars.py-version}}-poetry
-      - python-${{vars.py-version}}-base
 
 vars:
   py-version: 3.11

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -11,7 +11,7 @@ package:
     no-depends: true
   dependencies:
     runtime:
-      - poetry
+      - py${{vars.py-version}}-poetry
       - python-${{vars.py-version}}-base
 
 vars:
@@ -34,7 +34,6 @@ pipeline:
 
   - name: Python Build
     runs: |
-      pip${{vars.py-version}} install wheel
       pip${{vars.py-version}} install poetry
       poetry add "aiohttp==3.10.11"
       poetry add "certifi==2024.7.4"

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -69,7 +69,8 @@ pipeline:
       mv .venv ${{targets.destdir}}/home/cassandra/
 
       # edit the venv paths
-      sed -i "s|/home/build|${{targets.destdir}}/home/cassandra|g" ${{targets.destdir}}/home/cassandra/.venv/bin/*
+      find '${{targets.destdir}}/home/cassandra/.venv/bin/' -type f | \
+        xargs sed -i "s|/home/build|${{targets.destdir}}/home/cassandra|g"
 
       # allow site-packages
       sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/home/cassandra/.venv/pyvenv.cfg

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -22,6 +22,7 @@ environment:
       - build-base
       - ca-certificates-bundle
       - py${{vars.py-version}}-build-base-dev
+      - py${{vars.py-version}}-poetry-bin
       - wolfi-base
 
 pipeline:
@@ -33,7 +34,6 @@ pipeline:
 
   - name: Python Build
     runs: |
-      pip${{vars.py-version}} install poetry
       poetry add "aiohttp==3.10.11"
       poetry add "certifi==2024.7.4"
       poetry add "dnspython==2.6.1"

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -21,11 +21,8 @@ environment:
   contents:
     packages:
       - build-base
-      - busybox
       - ca-certificates-bundle
-      - py${{vars.py-version}}-installer
-      - py${{vars.py-version}}-pip
-      - python-${{vars.py-version}}-base
+      - py${{vars.py-version}}-build-base
       - wolfi-base
 
 pipeline:

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -12,7 +12,10 @@ package:
   dependencies:
     runtime:
       - poetry
-      - python-3.11-base
+      - python-${{vars.py-version}}-base
+
+vars:
+  py-version: 3.11
 
 environment:
   contents:
@@ -20,10 +23,10 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3.11-installer
-      - py3.11-pip
-      - python-3.11
-      - python-3.11-dev
+      - py${{vars.py-version}}-installer
+      - py${{vars.py-version}}-pip
+      - python-${{vars.py-version}}
+      - python-${{vars.py-version}}-dev
       - wolfi-base
 
 pipeline:
@@ -113,8 +116,8 @@ test:
   environment:
     contents:
       packages:
-        - python-3.11
-        - python-3.11-dev
+        - python-${{vars.py-version}}
+        - python-${{vars.py-version}}-dev
         - grpc-health-probe
   pipeline:
     - runs: medusa --version

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: 0.22.3
-  epoch: 1
+  epoch: 2
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -93,6 +93,7 @@ subpackages:
         # The entrypoint script fails to start without bash and sleep (which comes from busybox)
         - bash
         - busybox
+        - grpc-health-probe
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/home/cassandra/"

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -26,7 +26,6 @@ environment:
       - py${{vars.py-version}}-installer
       - py${{vars.py-version}}-pip
       - python-${{vars.py-version}}
-      - python-${{vars.py-version}}-dev
       - wolfi-base
 
 pipeline:
@@ -117,7 +116,6 @@ test:
     contents:
       packages:
         - python-${{vars.py-version}}
-        - python-${{vars.py-version}}-dev
         - grpc-health-probe
   pipeline:
     - runs: medusa --version

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -21,7 +21,7 @@ environment:
     packages:
       - build-base
       - ca-certificates-bundle
-      - py${{vars.py-version}}-build-base
+      - py${{vars.py-version}}-build-base-dev
       - wolfi-base
 
 pipeline:

--- a/py3-parallel-ssh.yaml
+++ b/py3-parallel-ssh.yaml
@@ -1,17 +1,22 @@
-# Generated from https://pypi.org/project/parallel-ssh/
 package:
   name: py3-parallel-ssh
   version: 2.12.0
-  epoch: 1
+  epoch: 2
   description: Asynchronous parallel SSH library
   copyright:
     - license: LGPL-2.1-or-later
   dependencies:
-    runtime:
-      - py3-gevent
-      - py3-ssh2-python
-      - py3-ssh-python
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: parallel-ssh
+  import: pssh
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
 
 environment:
   contents:
@@ -19,6 +24,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - py3-supported-build-base
       - wolfi-base
 
 pipeline:
@@ -31,10 +37,46 @@ pipeline:
     with:
       patches: config-parser.patch
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+      runtime:
+        - py${{range.key}}-gevent
+        - py${{range.key}}-ssh2-python
+        - py${{range.key}}-ssh-python
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-parallel-ssh.yaml
+++ b/py3-parallel-ssh.yaml
@@ -1,0 +1,42 @@
+# Generated from https://pypi.org/project/parallel-ssh/
+package:
+  name: py3-parallel-ssh
+  version: 2.12.0
+  epoch: 1
+  description: Asynchronous parallel SSH library
+  copyright:
+    - license: LGPL-2.1-or-later
+  dependencies:
+    runtime:
+      - py3-gevent
+      - py3-ssh2-python
+      - py3-ssh-python
+      - python3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - wolfi-base
+
+pipeline:
+  - uses: fetch
+    with:
+      expected-sha256: be2c06ee8765273d204e00f82afae2dace5eebaefc5343d1dfc64513642161e0
+      uri: https://files.pythonhosted.org/packages/source/p/parallel-ssh/parallel-ssh-${{package.version}}.tar.gz
+
+  - uses: patch
+    with:
+      patches: config-parser.patch
+
+  - name: Python Build
+    uses: python/build-wheel
+
+  - uses: strip
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 7890

--- a/py3-parallel-ssh/config-parser.patch
+++ b/py3-parallel-ssh/config-parser.patch
@@ -1,0 +1,16 @@
+diff --git a/versioneer.py b/versioneer.py
+index a287060..eafcdac 100644
+--- a/versioneer.py
++++ b/versioneer.py
+@@ -339,9 +339,9 @@ def get_config_from_root(root):
+     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
+     # the top of versioneer.py for instructions on writing your setup.cfg .
+     setup_cfg = os.path.join(root, "setup.cfg")
+-    parser = configparser.SafeConfigParser()
++    parser = configparser.ConfigParser()
+     with open(setup_cfg, "r") as f:
+-        parser.readfp(f)
++        parser.read_file(f)
+     VCS = parser.get("versioneer", "VCS")  # mandatory
+ 
+     def get(parser, name):

--- a/py3-ssh-python.yaml
+++ b/py3-ssh-python.yaml
@@ -1,20 +1,27 @@
-# Generated from https://pypi.org/project/ssh-python/
 package:
   name: py3-ssh-python
   version: 1.0.0
-  epoch: 1
+  epoch: 2
   description: libssh C library bindings for Python.
   copyright:
     - license: LGPL-2.1-only
   dependencies:
-    runtime:
-      - python3
+    provider-priority: 0
+
+vars:
+  pypi-package: ssh-python
+  import: ssh
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
 
 environment:
   contents:
     packages:
       - build-base
-      - busybox
       - ca-certificates-bundle
       - cmake
       - libssh2
@@ -22,10 +29,7 @@ environment:
       - libssl3
       - openssl
       - openssl-dev
-      - py3.11-installer
-      - py3.11-pip
-      - python-3.11
-      - python-3.11-dev
+      - py3-supported-build-base-dev
       - zlib
       - zlib-dev
 
@@ -40,31 +44,43 @@ pipeline:
     with:
       patches: config-parser.patch
 
-  - name: Python Build
-    runs: |
-      pip install wheel
-      python setup.py bdist_wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
-  - runs: |
-      # Setup the virtualenv
-      python -m venv .venv --system-site-packages
-      # Bump pip to patch a CVE
-      .venv/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
-
-  - runs: |
-      .venv/bin/pip install -I --no-compile dist/*.whl
-
-  - runs: |
-      mkdir -p ${{targets.destdir}}/usr/share/py3-ssh
-      mv .venv ${{targets.destdir}}/usr/share/py3-ssh/
-
-      # edit the venv paths
-      sed -i "s|/home/build|/usr/share/py3-ssh|g" ${{targets.destdir}}/usr/share/py3-ssh/.venv/bin/*
-
-      # allow site-packages
-      sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/py3-ssh/.venv/pyvenv.cfg
-
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.import}}
+        - uses: strip
 
 update:
   enabled: true

--- a/py3-ssh-python.yaml
+++ b/py3-ssh-python.yaml
@@ -1,0 +1,75 @@
+# Generated from https://pypi.org/project/ssh-python/
+package:
+  name: py3-ssh-python
+  version: 1.0.0
+  epoch: 1
+  description: libssh C library bindings for Python.
+  copyright:
+    - license: LGPL-2.1-only
+  dependencies:
+    runtime:
+      - python3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - libssh2
+      - libssh2-dev
+      - libssl3
+      - openssl
+      - openssl-dev
+      - py3.11-installer
+      - py3.11-pip
+      - python-3.11
+      - python-3.11-dev
+      - zlib
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: a62aaf26aa18b861242364ddf3c18bc5d8343ae6
+      repository: https://github.com/ParallelSSH/ssh-python
+      tag: ${{package.version}}
+
+  - uses: patch
+    with:
+      patches: config-parser.patch
+
+  - name: Python Build
+    runs: |
+      pip install wheel
+      python setup.py bdist_wheel
+
+  - runs: |
+      # Setup the virtualenv
+      python -m venv .venv --system-site-packages
+      # Bump pip to patch a CVE
+      .venv/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
+
+  - runs: |
+      .venv/bin/pip install -I --no-compile dist/*.whl
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/py3-ssh
+      mv .venv ${{targets.destdir}}/usr/share/py3-ssh/
+
+      # edit the venv paths
+      sed -i "s|/home/build|/usr/share/py3-ssh|g" ${{targets.destdir}}/usr/share/py3-ssh/.venv/bin/*
+
+      # allow site-packages
+      sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/py3-ssh/.venv/pyvenv.cfg
+
+  - uses: strip
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - (.*).post(.*)
+    - 03.0
+  github:
+    identifier: ParallelSSH/ssh-python

--- a/py3-ssh-python/config-parser.patch
+++ b/py3-ssh-python/config-parser.patch
@@ -1,0 +1,16 @@
+diff --git a/versioneer.py b/versioneer.py
+index a287060..eafcdac 100644
+--- a/versioneer.py
++++ b/versioneer.py
+@@ -339,9 +339,9 @@ def get_config_from_root(root):
+     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
+     # the top of versioneer.py for instructions on writing your setup.cfg .
+     setup_cfg = os.path.join(root, "setup.cfg")
+-    parser = configparser.SafeConfigParser()
++    parser = configparser.ConfigParser()
+     with open(setup_cfg, "r") as f:
+-        parser.readfp(f)
++        parser.read_file(f)
+     VCS = parser.get("versioneer", "VCS")  # mandatory
+ 
+     def get(parser, name):

--- a/py3-ssh2-python.yaml
+++ b/py3-ssh2-python.yaml
@@ -2,19 +2,27 @@
 package:
   name: py3-ssh2-python
   version: 1.0.0
-  epoch: 1
+  epoch: 2
   description: Bindings for libssh2 C library
   copyright:
     - license: LGPL-2.1-only
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: ssh2-python
+  import: ssh2
+
+data:
+  - name: py-versions
+    items:
+      3.10: "310"
+      3.11: "311"
 
 environment:
   contents:
     packages:
       - build-base
-      - busybox
       - ca-certificates-bundle
       - cmake
       - libssh2
@@ -22,10 +30,7 @@ environment:
       - libssl3
       - openssl
       - openssl-dev
-      - py3.11-installer
-      - py3.11-pip
-      - python-3.11
-      - python-3.11-dev
+      - py3-supported-build-base-dev
       - zlib
       - zlib-dev
 
@@ -40,31 +45,42 @@ pipeline:
     with:
       patches: config-parser.patch
 
-  - name: Python Build
-    runs: |
-      pip install wheel
-      python setup.py bdist_wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provides:
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
-  - runs: |
-      # Setup the virtualenv
-      python -m venv .venv --system-site-packages
-      # Bump pip to patch a CVE
-      .venv/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
-
-  - runs: |
-      .venv/bin/pip install -I --no-compile dist/*.whl
-
-  - runs: |
-      mkdir -p ${{targets.destdir}}/usr/share/py3-ssh2
-      mv .venv ${{targets.destdir}}/usr/share/py3-ssh2/
-
-      # edit the venv paths
-      sed -i "s|/home/build|/usr/share/py3-ssh2|g" ${{targets.destdir}}/usr/share/py3-ssh2/.venv/bin/*
-
-      # allow site-packages
-      sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/py3-ssh2/.venv/pyvenv.cfg
-
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python3.10
+            import: ${{vars.import}}
+        - uses: python/import
+          with:
+            python: python3.11
+            import: ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-ssh2-python.yaml
+++ b/py3-ssh2-python.yaml
@@ -1,0 +1,74 @@
+# Generated from https://pypi.org/project/ssh2-python/
+package:
+  name: py3-ssh2-python
+  version: 1.0.0
+  epoch: 1
+  description: Bindings for libssh2 C library
+  copyright:
+    - license: LGPL-2.1-only
+  dependencies:
+    runtime:
+      - python-3
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - cmake
+      - libssh2
+      - libssh2-dev
+      - libssl3
+      - openssl
+      - openssl-dev
+      - py3.11-installer
+      - py3.11-pip
+      - python-3.11
+      - python-3.11-dev
+      - zlib
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      expected-commit: 018fd695ebadad7eed102ec3a00dcfa70cf44e83
+      repository: https://github.com/ParallelSSH/ssh2-python
+      tag: ${{package.version}}
+
+  - uses: patch
+    with:
+      patches: config-parser.patch
+
+  - name: Python Build
+    runs: |
+      pip install wheel
+      python setup.py bdist_wheel
+
+  - runs: |
+      # Setup the virtualenv
+      python -m venv .venv --system-site-packages
+      # Bump pip to patch a CVE
+      .venv/bin/pip install --upgrade pip==23.3.2 setuptools==65.5.1
+
+  - runs: |
+      .venv/bin/pip install -I --no-compile dist/*.whl
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/py3-ssh2
+      mv .venv ${{targets.destdir}}/usr/share/py3-ssh2/
+
+      # edit the venv paths
+      sed -i "s|/home/build|/usr/share/py3-ssh2|g" ${{targets.destdir}}/usr/share/py3-ssh2/.venv/bin/*
+
+      # allow site-packages
+      sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/py3-ssh2/.venv/pyvenv.cfg
+
+  - uses: strip
+
+update:
+  enabled: true
+  ignore-regex-patterns:
+    - (.*).post(.*)
+  github:
+    identifier: ParallelSSH/ssh2-python

--- a/py3-ssh2-python/config-parser.patch
+++ b/py3-ssh2-python/config-parser.patch
@@ -1,0 +1,16 @@
+diff --git a/versioneer.py b/versioneer.py
+index a287060..eafcdac 100644
+--- a/versioneer.py
++++ b/versioneer.py
+@@ -339,9 +339,9 @@ def get_config_from_root(root):
+     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
+     # the top of versioneer.py for instructions on writing your setup.cfg .
+     setup_cfg = os.path.join(root, "setup.cfg")
+-    parser = configparser.SafeConfigParser()
++    parser = configparser.ConfigParser()
+     with open(setup_cfg, "r") as f:
+-        parser.readfp(f)
++        parser.read_file(f)
+     VCS = parser.get("versioneer", "VCS")  # mandatory
+ 
+     def get(parser, name):


### PR DESCRIPTION
My goal here was initially just to fix up the python dependencies to make sure the package uses the correct python interpreter version, and avoid dragging in additional python version stacks. But the vulnerability scan in CI [detected a number of issues](https://github.com/wolfi-dev/os/pull/38175/checks?check_run_id=34747801205) caused by pulling in pinned versions of packages from PyPI, so about half of these changes are switching back over to wolfi deps where possible.

Note that this resurrects various python ssh packages that were previously removed. I believe that their removal predated the multi-versioning technique when there wasn't a clean way to only build for older/supported Python versions. I've gone ahead and multi-versioned them here.

More details as always in the individual commits.