### PR TITLE
py3-click/8.1.8 package update with build fix

### DIFF
--- a/py3-click.yaml
+++ b/py3-click.yaml
@@ -1,8 +1,8 @@
 # Generated from https://pypi.org/project/click/
 package:
   name: py3-click
-  version: 8.1.7
-  epoch: 7
+  version: 8.1.8
+  epoch: 0
   description: Composable command line interface toolkit
   copyright:
     - license: BSD-3-Clause
@@ -27,6 +27,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - py3-supported-pip
+      - py3-supported-flit-core
       - wolfi-base
 
 pipeline:
@@ -34,7 +35,7 @@ pipeline:
     with:
       repository: https://github.com/pallets/click
       tag: ${{package.version}}
-      expected-commit: 874ca2bc1c30d93a4ac6e36a15ed685eafe89097
+      expected-commit: 934813e4d421071a1b3db3973c02fe2721359a6e
 
 subpackages:
   - range: py-versions

--- a/py3-click.yaml
+++ b/py3-click.yaml
@@ -26,8 +26,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-supported-pip
       - py3-supported-flit-core
+      - py3-supported-pip
       - wolfi-base
 
 pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:
Adding py-3-supported-flit core to the packages which installed each supported version rather than exclusively 3.10, and solved the build failure.


Related:
https://github.com/wolfi-dev/os/pull/38181

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For version bump PRs
<!-- remove if unrelated -->
- [x] The `epoch` field is reset to 0
