### PR TITLE
conda: avoid py3.x-conda cross-contamination

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -3,7 +3,7 @@
 package:
   name: conda
   version: 24.11.2
-  epoch: 0
+  epoch: 1
   description: "A system-level, binary package and environment manager running on all major operating systems and platforms."
   copyright:
     - license: BSD-3-Clause
@@ -80,10 +80,14 @@ subpackages:
         - py${{range.key}}-ruamel-yaml
         - py${{range.key}}-tqdm
     pipeline:
+      - runs: |
+          # We don't use this dir until further down, but py/pip-build-install
+          # will fail if a parameter to its `prevent-inclusion:` does not exist
+          mkdir -p ./cleanup
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
-          prevent-inclusion: melange-out
+          prevent-inclusion: cleanup melange-out
       - name: "move usr/bin executables for -bin"
         runs: |
           mkdir -p ./cleanup/${{range.key}}/


### PR DESCRIPTION
Anything in the top-level directory of this package will end up getting installed into each version of the python module. We already use the `prevent-inclusion` parameter to prevent those files from being copied in. Now that we're using "cleanup" as a holding area, we need to include that as well.

This was causing the usr/bin/* files from all previously built modules to be included in subsequent ones:

```
  # apk info -L py3.12-conda | grep cleanup
  WARNING: opening /work/packages: No such file or directory
  usr/lib/python3.12/site-packages/cleanup/3.10/bin/conda
  usr/lib/python3.12/site-packages/cleanup/3.11/bin/conda
  usr/lib/python3.12/site-packages/melange-out/py3.11-conda/usr/lib/python3.11/site-packages/cleanup/3.10/bin/conda
```

And, because melange adds dependencies for paths in the shebangs, we were getting dependencies on additional python versions.
