### PR TITLE
Fix yara-x build in QEMU

### DIFF
--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -1,7 +1,7 @@
 package:
   name: yara-x
   version: 0.12.0
-  epoch: 0
+  epoch: 1
   description: "A rewrite of YARA in Rust."
   copyright:
     - license: BSD-3-Clause
@@ -23,7 +23,7 @@ pipeline:
       expected-commit: d2b8358879c009f41f0e14847681f2f8dbe624cf
       tag: v${{package.version}}
 
-  - runs: cargo install cargo-c --features=vendored-openssl
+  - runs: cargo install cargo-c --features=vendored-openssl --root $HOME/.cargo
 
   - runs: cargo cinstall -p yara-x-capi --release --prefix=/usr --pkgconfigdir=/usr/lib/pkgconfig --includedir=/usr/include --libdir=/usr/lib
 


### PR DESCRIPTION
I noticed that running `make package/yara-x` would fail when using the QEMU runner.

This is due to `cargo install cargo-c` leveraging `/tmp` which is mounted as `noexec` in the QEMU runner: https://github.com/wolfi-dev/os/blob/2825e0b3c582679cef961cd97b6b7cc47cb50516/melange/init#L10

To comply with this restriction, this PR sets the installation root for `cargo-c` to `$HOME/.cargo` rather than `/tmp`.