### PR TITLE
ruby3.0-bundler: pin to v2.5

### DIFF
--- a/ruby3.0-bundler.yaml
+++ b/ruby3.0-bundler.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.0-bundler
   version: 2.5.23
-  epoch: 0
+  epoch: 1
   description: "Manage an application's gem dependencies"
   copyright:
     - license: MIT
@@ -64,7 +64,8 @@ update:
   github:
     identifier: rubygems/rubygems
     strip-prefix: bundler-v
-    tag-filter: bundler-v
+    # Starting from v2.6.x, upstream drops support for Ruby 3.0.
+    tag-filter: bundler-v2.5.
 
 test:
   pipeline:


### PR DESCRIPTION
See: https://github.com/rubygems/rubygems/releases/tag/bundler-v2.6.0

Closes https://github.com/wolfi-dev/os/pull/38259