### PR TITLE
daemon-check-output: add new 'command not found' case

### DIFF
--- a/pipelines/test/daemon-check-output.yaml
+++ b/pipelines/test/daemon-check-output.yaml
@@ -41,6 +41,7 @@ inputs:
       java.lang.NullPointerException
       java.lang.RuntimeException
       Gem::MissingSpecError
+      command not found
 
 pipeline:
   - name: "start daemon on localhost"


### PR DESCRIPTION
Noticed some tests prints out `command not found` error but still continues and exists with success. But we were silently ignore not-exist commands.