### PR TITLE
py3-alembic: bump and fix automatic updates

### DIFF
--- a/py3-alembic.yaml
+++ b/py3-alembic.yaml
@@ -1,18 +1,12 @@
 package:
   name: py3-alembic
-  version: 1.11.3
-  epoch: 7
+  version: 1.14.0
+  epoch: 0
   description: A database migration tool for SQLAlchemy.
   copyright:
     - license: MIT
   dependencies:
     provider-priority: 0
-
-var-transforms:
-  - from: ${{package.version}}
-    match: \.
-    replace: _
-    to: mangled-package-version
 
 vars:
   pypi-package: alembic
@@ -35,7 +29,7 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/sqlalchemy/alembic
-      expected-commit: 47850ab7dbc88905db8abf7abab6a48699d4a50a
+      expected-commit: 0c70a0bb3f64aff5c6c729497f17b2bf63d882fa
       tag: rel_${{vars.mangled-package-version}}
 
 subpackages:
@@ -109,8 +103,16 @@ test:
           import ${{vars.import}}
 
 update:
-  enabled: false
-  manual: true
-  exclude-reason: This requires manual updates because of the strange tagging scheme.
+  enabled: true
+  version-transform:
+    - match: rel_(\d+)_(\d+)_(\d+)
+      replace: $1.$2.$3
   github:
     identifier: sqlalchemy/alembic
+    tag-filter: rel_
+
+var-transforms:
+  - from: ${{package.version}}
+    match: \.
+    replace: _
+    to: mangled-package-version


### PR DESCRIPTION
alembic is owned by the sqlalchemy org which has an "odd" label naming format.  this has been resolved for sqlalchemy itself but alembic did not get this fix leading it to be out of date.

Bump py3-alembic and fix automatic updates to solve this issue.

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For version bump PRs
<!-- remove if unrelated -->
- [X] The `epoch` field is reset to 0
