### PR TITLE
Build yara-x with increased memory, --target-dir for cargo-c, and optimizations

### DIFF
--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -17,6 +17,8 @@ environment:
       - perl
       - rust
       - wolfi-base
+  environment:
+    RUSTFLAGS: "-C opt-level=3"
 
 pipeline:
   - uses: git-checkout
@@ -27,7 +29,7 @@ pipeline:
 
   - runs: cargo install cargo-c --features=vendored-openssl --root $HOME/.cargo --target-dir $HOME/.cargo
 
-  - runs: RUSTFLAGS="-C opt-level=3" cargo cinstall -p yara-x-capi --release --prefix=/usr --pkgconfigdir=/usr/lib/pkgconfig --includedir=/usr/include --libdir=/usr/lib
+  - runs: cargo cinstall -p yara-x-capi --release --prefix=/usr --pkgconfigdir=/usr/lib/pkgconfig --includedir=/usr/include --libdir=/usr/lib
 
 subpackages:
   - name: yara-x-compat

--- a/yara-x.yaml
+++ b/yara-x.yaml
@@ -1,10 +1,12 @@
 package:
   name: yara-x
   version: 0.12.0
-  epoch: 1
+  epoch: 2
   description: "A rewrite of YARA in Rust."
   copyright:
     - license: BSD-3-Clause
+  resources:
+    memory: 6Gi
 
 environment:
   contents:
@@ -23,9 +25,9 @@ pipeline:
       expected-commit: d2b8358879c009f41f0e14847681f2f8dbe624cf
       tag: v${{package.version}}
 
-  - runs: cargo install cargo-c --features=vendored-openssl --root $HOME/.cargo
+  - runs: cargo install cargo-c --features=vendored-openssl --root $HOME/.cargo --target-dir $HOME/.cargo
 
-  - runs: cargo cinstall -p yara-x-capi --release --prefix=/usr --pkgconfigdir=/usr/lib/pkgconfig --includedir=/usr/include --libdir=/usr/lib
+  - runs: RUSTFLAGS="-C opt-level=3" cargo cinstall -p yara-x-capi --release --prefix=/usr --pkgconfigdir=/usr/lib/pkgconfig --includedir=/usr/include --libdir=/usr/lib
 
 subpackages:
   - name: yara-x-compat


### PR DESCRIPTION
I had some local Melange changes that made #38328 appear valid when in fact the build artifacts for `cargo-c` were still landing in `/tmp`.

This PR specifies `--target-dir` to redirect `cargo-c`'s build artifacts to a non-`/tmp` directory to avoid running in to QEMU's `noexec` tmpfs. 

Once this was fixed, the `cargo-c` install was OOM'ing with the default `-m 4000000k` configuration so I added a memory requirement of `6Gi` which allowed the build to succeed.  Finally, I added `opt-level=3` to build the `yara-x-capi` with all available optimizations.