### PR TITLE
fix the tests by adding java also remove the patches

### DIFF
--- a/apache-tika-3.0.yaml
+++ b/apache-tika-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: apache-tika-3.0
   version: 3.0.0
-  epoch: 1
+  epoch: 2
   description: The Apache Tika toolkit detects and extracts metadata and text from over a thousand different file types (such as PPT, XLS, and PDF).
   copyright:
     - license: Apache-2.0
@@ -33,11 +33,6 @@ pipeline:
       tag: ${{package.version}}
       expected-commit: 9bcb38d6734ed9d5dcff617f316c535e844c68d1
 
-  - uses: maven/pombump
-    with:
-      patch-file: patches.yaml
-      pom: tika-parent/pom.xml
-
   - runs: |
       mvn clean install -am -DskipTests -Dossindex.skip
       mkdir -p "${{targets.contextdir}}"/usr/share/java/
@@ -64,6 +59,7 @@ test:
       packages:
         - curl
         - ${{package.name}}-compat
+        - openjdk-17-default-jvm
   pipeline:
     - name: "start server and verify endpoint"
       runs: |


### PR DESCRIPTION
First of all, the test should have failed with non-zero code because I saw in the logs that there was a `java not found` error log, but somehow the tests passed even if the java command was not present.

This caused another problem, when we applied the patch I saw other error logs like `java.lang.UnsupportedClassVersionError:org/eclipse/jetty/http/BadMessageException`, but because the tests passed I didn't even realize that the project wasn't working as intended.

So this PR aims to fix the issue but we should create an advisory for the CVE for sure.