### PR TITLE
fluentd: stream for python 3.1

### DIFF
--- a/ruby3.1-fluentd-1.17.yaml
+++ b/ruby3.1-fluentd-1.17.yaml
@@ -1,0 +1,183 @@
+package:
+  # fluentd supported versions: https://github.com/fluent/fluentd/blob/master/SECURITY.md
+  name: ruby3.1-fluentd-1.17
+  version: 1.17.1
+  epoch: 0
+  description: Fluentd is an open source data collector designed to scale and simplify log management. It can collect, process and ship many kinds of data in near real-time.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - ruby${{vars.rubyMM}}-base64
+      - ruby${{vars.rubyMM}}-bundler
+      - ruby${{vars.rubyMM}}-cool.io
+      - ruby${{vars.rubyMM}}-csv
+      - ruby${{vars.rubyMM}}-drb
+      - ruby${{vars.rubyMM}}-http_parser.rb
+      - ruby${{vars.rubyMM}}-logger
+      - ruby${{vars.rubyMM}}-msgpack
+      - ruby${{vars.rubyMM}}-serverengine
+      - ruby${{vars.rubyMM}}-sigdump
+      - ruby${{vars.rubyMM}}-strptime
+      - ruby${{vars.rubyMM}}-tzinfo
+      - ruby${{vars.rubyMM}}-tzinfo-data
+      - ruby${{vars.rubyMM}}-webrick
+      - ruby${{vars.rubyMM}}-yajl-ruby
+      - ruby-${{vars.rubyMM}}
+    provides:
+      - ruby${{vars.rubyMM}}-fluentd=${{package.full-version}}
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
+
+vars:
+  gem: fluentd
+
+pipeline:
+  # This package makes use of `git ls-files` in its gemspec so the git repo
+  # must be checked out in order for the gem to build with all files.
+  - uses: git-checkout
+    with:
+      destination: ${{vars.gem}}
+      expected-commit: 78a7972bfe6b421f08472701f04f00515ed24bee
+      repository: https://github.com/fluent/fluentd.git
+      tag: v${{package.version}}
+
+  - working-directory: ${{vars.gem}}
+    pipeline:
+      - uses: ruby/build
+        with:
+          gem: ${{vars.gem}}
+      - uses: ruby/install
+        with:
+          gem: ${{vars.gem}}
+          version: ${{package.version}}
+
+  - uses: ruby/clean
+
+  - runs: |
+      GEM_DIR=${{targets.destdir}}$(ruby -e 'puts Gem.default_dir')/gems/${{vars.gem}}-${{package.version}}
+      rm -rf ${GEM_DIR}/test \
+             ${GEM_DIR}/docs \
+             ${GEM_DIR}/*.md \
+             ${GEM_DIR}/.github
+
+subpackages:
+  - name: ${{package.name}}-logging-operator-compat
+    description: Entrypoint used by the logging operator image
+    dependencies:
+      runtime:
+        - busybox
+    pipeline:
+      - runs: |
+          git clone https://github.com/kube-logging/fluentd-images.git
+          cd fluentd-images
+          git checkout 773503fd12bcdb75f042ea3deb712ccb86a31d61
+          install -Dm755 ./v1.16/entrypoint.sh "${{targets.subpkgdir}}/bin/entrypoint.sh"
+          install -Dm755 ./v1.16/healthy.sh "${{targets.subpkgdir}}/bin/healthy.sh"
+          install -Dm644 ./v1.16/fluent.conf "${{targets.subpkgdir}}/fluentd/etc/fluent.conf"
+
+update:
+  enabled: true
+  github:
+    identifier: fluent/fluentd
+    strip-prefix: v
+    tag-filter: v1.17.
+
+test:
+  pipeline:
+    # Keep existing daemon test
+    - name: Daemon test
+      uses: test/daemon-check-output
+      with:
+        start: /usr/bin/fluentd
+        setup: |
+          mkdir -p /etc/fluent/
+          touch /etc/fluent/fluent.conf
+        expected_output: fluentd worker is now running
+    # Keep command line tests
+    - name: Command line tests
+      runs: |
+        fluent-binlog-reader --version
+        fluent-ca-generate --version
+        fluent-ca-generate --help
+        fluent-cat --version
+        fluent-cat --help
+        fluent-ctl --version
+        fluent-ctl --help
+        fluent-debug --help
+        fluent-gem --version
+        fluent-gem --help
+        fluent-plugin-config-format --version
+        fluent-plugin-config-format --help
+        fluent-plugin-generate --version
+        fluent-plugin-generate --help
+        fluentd --version
+        fluentd --help
+    - name: Basic IO test
+      runs: |
+        # Create minimal config
+        cat > test.conf <<EOF
+        <system>
+          log_level debug
+        </system>
+
+        <source>
+          @type forward
+          port 24224
+        </source>
+
+        <match test.**>
+          @type file
+          path /tmp/fluentd_test
+          append true
+          <buffer>
+            flush_mode immediate
+          </buffer>
+        </match>
+        EOF
+
+        # Start fluentd with logs
+        fluentd -c test.conf -d /tmp/fluentd.pid --log /tmp/fluentd.log
+
+        # Wait for start
+        sleep 5
+
+        # Send test message with specific content
+        echo '{"message":"test_message_content"}' | fluent-cat test.tag
+
+        # Wait for processing
+        sleep 5
+
+        # Check output files and content
+        if ls /tmp/fluentd_test.*.log > /dev/null 2>&1; then
+          OUTPUT=$(cat /tmp/fluentd_test.*.log)
+          echo "Output file contents: $OUTPUT"
+
+          if echo "$OUTPUT" | grep -q "test_message_content"; then
+            echo "Test passed: Message content verified"
+          else
+            echo "Test failed: Expected message content not found"
+            exit 1
+          fi
+        else
+          echo "Test failed: No output file"
+          echo "Fluentd logs:"
+          cat /tmp/fluentd.log
+          exit 1
+        fi
+
+        # Cleanup
+        kill $(cat /tmp/fluentd.pid)
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
