### PR TITLE
rebuild ruby3.4-bundler

### DIFF
--- a/ruby3.4-bundler.yaml
+++ b/ruby3.4-bundler.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-bundler
   version: 2.6.2
-  epoch: 0
+  epoch: 1
   description: "Manage an application's gem dependencies"
   copyright:
     - license: MIT


### PR DESCRIPTION
Package has been broken, so let's rebuild for the fix.

```
41bcbe72d1d3:/work/packages# apk update
41bcbe72d1d3:/work/packages# apk add ruby3.4-bundler
41bcbe72d1d3:/work/packages# bundler
/usr/lib/ruby/3.4.0/rubygems.rb:262:in 'Gem.find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundler (Gem::GemNotFoundException)
	from /usr/lib/ruby/3.4.0/rubygems.rb:281:in 'Gem.activate_bin_path'
	from /usr/bin/bundler:25:in '<main>'
```

Fixed:

```
f07b3c84ad19:/work/packages# apk add aarch64/ruby3.4-bundler-2.6.2-r0.apk 
f07b3c84ad19:/work/packages# bundler
Don't run Bundler as root. Installing your bundle as root will break this application for all non-root users on this machine.
Could not locate Gemfile
```