### PR TITLE
add *.apk to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dag.svg
 .melange.k8s.yaml
 packages.log
 *.iml
+*.apk
 APKINDEX.tar.gz
 
 # macOS


### PR DESCRIPTION
    add *.apk to gitignore
    
    in the current context, if we invoke `eval $(make fetch-kernel)` then
    it's pulling in `linux-virt.apk` at the root of the repository.
    
    This commit appends `*.apk` to gitignore so that we avoid accidently
    including *.apk in our commit.
    
    Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>