### PR TITLE
Add a disabled test of g-ir-scanner

### DIFF
--- a/gobject-introspection.yaml
+++ b/gobject-introspection.yaml
@@ -114,3 +114,6 @@ test:
         g-ir-scanner --version | grep -F "${{package.version}}"
         g-ir-annotation-tool --help
         g-ir-annotation-tool --version | grep -F "${{package.version}}"
+        # This fails because the package has a build-time config for the python interpreter
+        # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/510
+        # g-ir-scanner --help


### PR DESCRIPTION
The test currently fails as detailed in https://github.com/wolfi-dev/os/pull/37393#issuecomment-2552811148 but we don't want to lose track of the fact that we should be testing g-ir-scanner so let's add it as a comment.