### PR TITLE
rebuild ruby3.4-fluentd-kubernetes-daemonset-1.17

### DIFF
--- a/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.4-fluentd-kubernetes-daemonset-1.17
   version: 1.17.1.1.2
-  epoch: 0
+  epoch: 1
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Rebuild the `ruby3.4-fluentd-kubernetes-daemonset-1.17` since it's built with corrupted ruby-3.4.