### PR TITLE
fluentd-kubernetes-daemonset: mitigate cves

### DIFF
--- a/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.1-fluentd-kubernetes-daemonset-1.17.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.1-fluentd-kubernetes-daemonset-1.17
   version: 1.17.1.1.2
-  epoch: 0
+  epoch: 1
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -64,6 +64,9 @@ subpackages:
     pipeline:
       - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
         runs: |
+          # Mitigates CVE-2024-49761, CVE-2024-39908, CVE-2024-41946, CVE-2024-41123, CVE-2024-43398
+          sed -i 's/rexml (3\.2\.9)/rexml (3.3.9)/' Gemfile.lock
+
           # Install bundle
           mkdir -p ${{targets.contextdir}}/fluentd/vendor/bundle
           bundle config silence_root_warning true

--- a/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.2-fluentd-kubernetes-daemonset-1.17.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.2-fluentd-kubernetes-daemonset-1.17
   version: 1.17.1.1.2
-  epoch: 0
+  epoch: 1
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -64,6 +64,9 @@ subpackages:
     pipeline:
       - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
         runs: |
+          # Mitigates CVE-2024-49761, CVE-2024-39908, CVE-2024-41946, CVE-2024-41123, CVE-2024-43398
+          sed -i 's/rexml (3\.2\.9)/rexml (3.3.9)/' Gemfile.lock
+
           # Install bundle
           mkdir -p ${{targets.contextdir}}/fluentd/vendor/bundle
           bundle config silence_root_warning true

--- a/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.3-fluentd-kubernetes-daemonset-1.17.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.3-fluentd-kubernetes-daemonset-1.17
   version: 1.17.1.1.2
-  epoch: 0
+  epoch: 1
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -64,6 +64,9 @@ subpackages:
     pipeline:
       - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
         runs: |
+          # Mitigates CVE-2024-49761, CVE-2024-39908, CVE-2024-41946, CVE-2024-41123, CVE-2024-43398
+          sed -i 's/rexml (3\.2\.9)/rexml (3.3.9)/' Gemfile.lock
+
           # Install bundle
           mkdir -p ${{targets.contextdir}}/fluentd/vendor/bundle
           bundle config silence_root_warning true

--- a/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
+++ b/ruby3.4-fluentd-kubernetes-daemonset-1.17.yaml
@@ -3,7 +3,7 @@ package:
   # The kubernetes daemonset trails fluentd releases by a bit
   name: ruby3.4-fluentd-kubernetes-daemonset-1.17
   version: 1.17.1.1.2
-  epoch: 1
+  epoch: 2
   description: Fluentd ${{vars.fluentdMM}} daemonset for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -64,6 +64,9 @@ subpackages:
     pipeline:
       - working-directory: ./docker-image/v${{vars.fluentdMM}}/debian-${{range.key}}
         runs: |
+          # Mitigates CVE-2024-49761, CVE-2024-39908, CVE-2024-41946, CVE-2024-41123, CVE-2024-43398
+          sed -i 's/rexml (3\.2\.9)/rexml (3.3.9)/' Gemfile.lock
+
           # Install bundle
           mkdir -p ${{targets.contextdir}}/fluentd/vendor/bundle
           bundle config silence_root_warning true


### PR DESCRIPTION
Mitigates CVE-2024-49761, CVE-2024-39908, CVE-2024-41946, CVE-2024-41123, CVE-2024-43398 for `fluentd-kubernetes-daemonset` packages.
