### PR TITLE
pipelines: test: ldd-check: Add "packages" input parameter

### DIFF
--- a/gcc.yaml
+++ b/gcc.yaml
@@ -352,37 +352,7 @@ test:
         cc: gcc
     - uses: test/ldd-check
       with:
-        files: |-
-          /usr/lib/gcc/x86_64-pc-linux-gnu/14/plugin/libcc1plugin.so
-          /usr/lib/gcc/x86_64-pc-linux-gnu/14/plugin/libcc1plugin.so.0
-          /usr/lib/gcc/x86_64-pc-linux-gnu/14/plugin/libcc1plugin.so.0.0.0
-          /usr/lib/gcc/x86_64-pc-linux-gnu/14/plugin/libcp1plugin.so
-          /usr/lib/gcc/x86_64-pc-linux-gnu/14/plugin/libcp1plugin.so.0
-          /usr/lib/gcc/x86_64-pc-linux-gnu/14/plugin/libcp1plugin.so.0.0.0
-          /usr/lib/libasan.so
-          /usr/lib/libasan.so.8
-          /usr/lib/libasan.so.8.0.0
-          /usr/lib/libatomic.so
-          /usr/lib/libcc1.so
-          /usr/lib/libcc1.so.0
-          /usr/lib/libcc1.so.0.0.0
-          /usr/lib/libgomp.so
-          /usr/lib/libhwasan.so
-          /usr/lib/libhwasan.so.0
-          /usr/lib/libhwasan.so.0.0.0
-          /usr/lib/libitm.so
-          /usr/lib/libitm.so.1
-          /usr/lib/libitm.so.1.0.0
-          /usr/lib/liblsan.so
-          /usr/lib/liblsan.so.0
-          /usr/lib/liblsan.so.0.0.0
-          /usr/lib/libquadmath.so
-          /usr/lib/libtsan.so
-          /usr/lib/libtsan.so.2
-          /usr/lib/libtsan.so.2.0.0
-          /usr/lib/libubsan.so
-          /usr/lib/libubsan.so.1
-          /usr/lib/libubsan.so.1.0.0
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/pipelines/test/ldd-check.yaml
+++ b/pipelines/test/ldd-check.yaml
@@ -2,6 +2,7 @@ name: ldd-check
 
 needs:
   packages:
+    - apk-tools
     - busybox
     - posix-libc-utils
 
@@ -9,7 +10,11 @@ inputs:
   files:
     description: |
       The files to run `ldd` on and check for missing deps.
-    required: true
+    required: false
+  packages:
+    description: |
+      Check all binaries in these installed packages
+    required: false
   verbose:
     description: |
       Should the full ldd output be shown
@@ -32,16 +37,17 @@ pipeline:
       fails=0
       passes=0
       files="${{inputs.files}}"
+      packages="${{inputs.packages}}"
       verbose="${{inputs.verbose}}"
       case "$verbose" in
         true|false) :;;
         *) error "verbose must be 'true' or 'false'. found '$verbose'";;
       esac
+      [ -n "${files}${packages}" ] || error "No files or packages specified"
 
       export LANG=C
-      set -- $files
-      outf="$tmpd/out"
-      for f in "$@"; do
+      test_file() {
+        outf="$tmpd/out"
         [ -e "$f" ] || { fail "$f: does not exist"; continue; }
         [ -f "$f" ] || { fail "$f: not a file"; continue; }
         ldd "$f" > "$outf" || { fail "$f: ldd exited $?"; continue; }
@@ -54,6 +60,23 @@ pipeline:
         fi
         [ -z "$missing" ] && { pass "$f"; continue; }
         fail "$f: missing ${missing# }"
+      }
+      set -- $files
+      for f in "$@"; do
+        test_file "$f"
+      done
+      set -- $packages
+      for pkg in "$@"; do
+        echo "[ldd-check] Testing binaries in package $pkg"
+        apk info -eq "$pkg" > /dev/null || \
+          { fail "Package $pkg is not installed"; continue; }
+        apk info -Lq "$pkg" | while read f; do
+          [ -n "$f" ] || continue
+          f="/$f"
+          [ -f "$f" ] || continue
+          ldd "$f" > /dev/null 2>&1 || continue
+          test_file "$f"
+        done
       done
       echo "tested $((passes+fails)) files with ldd. $passes passes. $fails fails."
       exit $fails


### PR DESCRIPTION
`gcc` currently fails to test on ARM because some of the filenames we provide to `test/ldd-check` are architecture-specific.

This should unblock https://github.com/wolfi-dev/os/pull/35302