### PR TITLE
fix the jar directory of the neo4j

### DIFF
--- a/neo4j-5.26.yaml
+++ b/neo4j-5.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: neo4j-5.26
   version: 5.26.0
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-3.0-or-later
@@ -30,7 +30,7 @@ pipeline:
     with:
       repository: https://github.com/neo4j/neo4j
       tag: ${{package.version}}
-      expected-commit: 17dc7f7e1787c451938b97666a06afd3695987ca
+      expected-commit: c68156edf24164435ab1ac257ec633134c2887f7
 
   - runs: |
       export LANG=en_US.UTF-8
@@ -39,7 +39,7 @@ pipeline:
       mvn package -DskipTests=true -T$(nproc)C -q -Doverwrite=true
 
       mkdir -p ${{targets.destdir}}/usr/share/java/neo4j
-      tar --strip-components=1 -xf private/packaging/standalone/target/neo4j-*.tar.gz -C ${{targets.destdir}}/usr/share/java/neo4j
+      tar --strip-components=1 -xf packaging/standalone/target/neo4j-*.tar.gz -C ${{targets.destdir}}/usr/share/java/neo4j
 
       mkdir -p ${{targets.destdir}}/usr/bin
       for i in neo4j neo4j-admin cypher-shell; do


### PR DESCRIPTION
What I don't understand is how this was successful in the previous build, because there is no “private/” folder in the neo4j codebase, so this PR aims to solve the problem of giving the correct location for neo4j jar files.