### PR TITLE
new package: k8s-wait-for

### DIFF
--- a/k8s-wait-for.yaml
+++ b/k8s-wait-for.yaml
@@ -12,15 +12,25 @@ package:
       - jq
       - kubectl
 
+environment:
+  contents:
+    packages:
+      - busybox
+
 pipeline:
   - uses: git-checkout
     with:
-      uri: https://github.com/groundnuty/k8s-wait-for
-      expected-commit: 79b1f15b3e139e2d1a031e164f0003bc6e0df65b
+      repository: https://github.com/groundnuty/k8s-wait-for
       tag: v${{package.version}}
+      expected-commit: 79b1f15b3e139e2d1a031e164f0003bc6e0df65b
 
   - runs: |
       install -Dm755 wait_for.sh ${{targets.destdir}}/usr/bin/wait_for.sh
+
+test:
+  pipeline:
+    - runs: |
+        wait_for.sh | grep -q "This script waits until a job"
 
 update:
   enabled: true

--- a/k8s-wait-for.yaml
+++ b/k8s-wait-for.yaml
@@ -1,0 +1,29 @@
+package:
+  name: k8s-wait-for
+  version: 2.0
+  epoch: 0
+  description: A simple script that allows to wait for a k8s service, job or pods to enter a desired state
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - bash
+      - curl
+      - jq
+      - kubectl
+
+pipeline:
+  - uses: git-checkout
+    with:
+      uri: https://github.com/groundnuty/k8s-wait-for
+      expected-commit: 79b1f15b3e139e2d1a031e164f0003bc6e0df65b
+      tag: v${{package.version}}
+
+  - runs: |
+      install -Dm755 wait_for.sh ${{targets.destdir}}/usr/bin/wait_for.sh
+
+update:
+  enabled: true
+  github:
+    identifier: groundnuty/k8s-wait-for
+    strip-prefix: v


### PR DESCRIPTION
https://github.com/groundnuty/k8s-wait-for/blob/79b1f15b3e139e2d1a031e164f0003bc6e0df65b/wait_for.sh

This is used by jitsucom's helm chart, and the image should become configurable after https://github.com/stafftastic/jitsu-chart/issues/53