### PR TITLE
gitlab-cng-17.7: update registry-commit

### DIFF
--- a/gitlab-cng-17.7.yaml
+++ b/gitlab-cng-17.7.yaml
@@ -6,8 +6,8 @@
 # # Additionally, the latest 'gitaly-backup' package (part of gitlab-cng), must be built first.
 vars:
   # Container registry tags: https://gitlab.com/gitlab-org/container-registry/-/tags
-  registry-commit: 9d471de66ad21e6df01cdbf3bde4c2eb1d242a91
-  registry-tag: 4.13.0
+  registry-commit: 056306100582da8facddcacbc0c2e743ff0ffd89
+  registry-tag: 4.14.0
   # ElasticSearch indexer tags: https://gitlab.com/gitlab-org/gitlab-elasticsearch-indexer/-/tags
   indexer-commit: 7a0d81c7be6022c36902736fb83261b478f95d9f
   indexer-tag: 5.4.0
@@ -34,7 +34,7 @@ package:
   name: gitlab-cng-17.7
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
   version: 17.7.0
-  epoch: 0
+  epoch: 1
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT


### PR DESCRIPTION
This was missed during the last upgrade through 17.7.

All the other versions are unchanged since 17.6