### PR TITLE
loki-3.0: withdraw package from os

### DIFF
--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -1,1 +1,1 @@
-speexdsp-1.2.1-r0.apk
+loki-3.0-3.1.0-r0.apk


### PR DESCRIPTION
It seems we published on July a loki-3.0 package with version v3.1, look at https://apk.dag.dev/https/packages.wolfi.dev/os/aarch64/loki-3.0-3.1.0-r0.apk@sha1:c7afdeba9ce7481fd4021441f02c202543295690/. However we still have a loki-3.0 package definition available on enterprise-packages.

Note that this package also uses a wrong version `v3.1..`.