### PR TITLE
libb64-1.2: New package

### DIFF
--- a/libb64-1.2.yaml
+++ b/libb64-1.2.yaml
@@ -1,0 +1,52 @@
+package:
+  name: libb64-1.2
+  version: 1.2.1
+  epoch: 0
+  description: Fast Base64 encoding/decoding routines
+  dependencies:
+    provides:
+      - ${{package.name}}-dev=${{package.full-version}}
+  copyright:
+    - license: CC-PDDC
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: git-checkout
+    with:
+      # 1.2.1 is last release on sourceforge verified tag in this fork matches manually.
+      expected-commit: "c1e3323498e1b5512e509716c5720029853846bc"
+      repository: https://github.com/libb64/libb64
+      tag: v${{package.version}}
+
+  - runs: |
+      # Remove CFLAGS to use wolfi defaults.
+      sed -i '/-O3/ d' src/Makefile
+      sed -i '/pedantic/ d' src/Makefile
+      make all_base64
+
+  - runs: |
+      install -Dm 0644 src/libb64.a -t ${{targets.contextdir}}/usr/lib
+      install -Dm 0644 include/b64/*.h -t ${{targets.contextdir}}/usr/include/b64
+
+  - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-doc
+    description: libb64 docs
+    pipeline:
+      - runs: |
+          install -Dm 0644 README LICENSE -t ${{targets.contextdir}}/usr/share/doc/libb64
+          cp -rf examples ${{targets.contextdir}}/usr/share/doc/libb64/
+
+update:
+  enabled: true
+  github:
+    identifier: libb64/libb64
+    strip-prefix: v
+    tag-filter: v1.2.


### PR DESCRIPTION
Package virtually provides libb64-1.2-dev for last sf release of libb64

Signed-off-by: Pris Nasrat <pris.nasrat@chainguard.dev>
