### PR TITLE
k3s/GHSA-xr7q-jx4m-x55m fix

### DIFF
--- a/k3s.yaml
+++ b/k3s.yaml
@@ -1,7 +1,7 @@
 package:
   name: k3s
   version: 1.31.4.1
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0
@@ -70,7 +70,7 @@ pipeline:
       ./scripts/download
   - uses: go/bump
     with:
-      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.54.0 github.com/opencontainers/runc@v1.1.14 github.com/quic-go/quic-go@v0.48.2 github.com/libp2p/go-libp2p@v0.37.2 golang.org/x/crypto@v0.31.0
+      deps: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.54.0 github.com/opencontainers/runc@v1.1.14 github.com/quic-go/quic-go@v0.48.2 github.com/libp2p/go-libp2p@v0.37.2 golang.org/x/crypto@v0.31.0 golang.org/x/net@v0.33.0 google.golang.org/grpc@v1.68.0
   - runs: |
       # Override the go version check at runtime to always match the go version at build time
       # Ref: https://github.com/k3s-io/k3s/pull/9054


### PR DESCRIPTION
Updated the version of grpc and golang.org/x/net, unable to fix all net version CVEs as there is one introduced via containerd-shim-runc-v2, [there is an upstream fix merged in main](https://github.com/containerd/containerd/pull/11181/commits/7f3599f09396bf69496e1cf189b999acc0db13a5) but this applies to the v2.0 branch and due to the PR including several method changes directly impacting the use of golang.org/x/net and not just a version bump, the fact that there is a [golang.org/x/net version bump to 0.25.0](https://github.com/containerd/containerd/pull/11178) merged into the v1.7.x branch **after**  golang.org/x/net@v.0.30.0 was merged into main, this will need backporting to v1.7.x branch. 