### PR TITLE
Bump the version of ncurses fixing a FTBFS

### DIFF
--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
   version: 6.5_p20241228
-  epoch: 5
+  epoch: 0
   description: "console display library"
   copyright:
     - license: MIT

--- a/ncurses.yaml
+++ b/ncurses.yaml
@@ -1,7 +1,7 @@
 package:
   name: ncurses
-  version: 6.5_p20241006
-  epoch: 4
+  version: 6.5_p20241228
+  epoch: 5
   description: "console display library"
   copyright:
     - license: MIT
@@ -29,7 +29,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://invisible-mirror.net/archives/ncurses/current/ncurses-${{vars.mangled-package-version}}.tgz
-      expected-sha512: 60ca1c6e1797feade55306f7c9be57e546ddbdad36fa09a914f8884c628fbd8683660f895899a419172518b78e3edd49257c0fb7b6d4d83705f494f4766aa066
+      expected-sha512: 4ca73f46f598647dea24cbd89a5704eccdf7e52626f15f8271b08bf3bd2221f5bfb327c9b40532a6ebcc4cf1cd58e33bf4c149de9f8abaaafe1e2b0ce4cdf4d8
 
   - name: Configure
     runs: |


### PR DESCRIPTION
The old tarball of ncurses is no longer available which is causing the package to FTBFS as seen in https://github.com/wolfi-dev/os/issues/38653.  This bumps the version and passes testing on amd64.

```
2025/01/02 20:24:39 WARN + ncursesw6-config --version
2025/01/02 20:24:39 INFO 6.5.20241228
2025/01/02 20:24:39 WARN + ncursesw6-config --help
2025/01/02 20:24:39 INFO Usage: ncursesw6-config [options]
2025/01/02 20:24:39 INFO
2025/01/02 20:24:39 INFO Options:
2025/01/02 20:24:39 INFO   --prefix            echos the package-prefix of ncursesw
2025/01/02 20:24:39 INFO   --exec-prefix       echos the executable-prefix of ncursesw
2025/01/02 20:24:39 INFO
2025/01/02 20:24:39 INFO   --cflags            echos the C compiler flags needed to compile for ncursesw
2025/01/02 20:24:39 INFO   --cflags-only-I     echos only -I C compiler flags needed with ncursesw
2025/01/02 20:24:39 INFO   --cflags-only-other echos only C compiler flags other than -I for ncursesw
2025/01/02 20:24:39 INFO   --libs              echos the libraries needed to link with ncursesw
2025/01/02 20:24:39 INFO
2025/01/02 20:24:39 INFO   --libs-only-L       echos -L linker options (search path) for ncursesw
2025/01/02 20:24:39 INFO   --libs-only-l       echos -l linker options (libraries) for ncursesw
2025/01/02 20:24:39 INFO   --libs-only-other   echos linker options other than -L/-l
2025/01/02 20:24:39 INFO
2025/01/02 20:24:39 INFO   --version           echos the release+patchdate version of ncursesw
2025/01/02 20:24:39 INFO   --abi-version       echos the ABI version of ncursesw
2025/01/02 20:24:39 INFO   --mouse-version     echos the mouse-interface version of ncursesw
2025/01/02 20:24:39 INFO
2025/01/02 20:24:39 INFO   --bindir            echos the directory containing ncursesw programs
2025/01/02 20:24:39 INFO   --datadir           echos the directory containing ncursesw data
2025/01/02 20:24:39 INFO   --includedir        echos the directory containing ncursesw header files
2025/01/02 20:24:39 INFO   --libdir            echos the directory containing ncursesw libraries
2025/01/02 20:24:39 INFO   --mandir            echos the directory containing ncursesw manpages
2025/01/02 20:24:39 INFO   --terminfo          echos the $TERMINFO terminfo database path
2025/01/02 20:24:39 INFO   --terminfo-dirs     echos the $TERMINFO_DIRS directory list
2025/01/02 20:24:39 INFO   --termpath          echos the $TERMPATH termcap list
2025/01/02 20:24:39 INFO
2025/01/02 20:24:39 INFO   --help              prints this message
2025/01/02 20:24:39 WARN + exit 0
```