### PR TITLE
systemd: Add container package for container related tools and daemons

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "257.2"
-  epoch: 1
+  epoch: 2
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -148,6 +148,7 @@ subpackages:
     dependencies:
       runtime:
         - systemd
+        - systemd-container
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}/usr/lib/systemd
@@ -176,7 +177,6 @@ subpackages:
             # test-path-util - failed at src/test/test-path-util.c:385, function test_find_executable_full(). Aborting.
             # test-label - Error occurred while opening directory =>: Read-only file system
             # test-dns-domain - Assertion 'r >= expected' failed at src/test/test-dns-domain.c:782, function test_dns_name_apply_idna_one(). Aborting.
-            # test-cryptolib - no error printed
             # test-compress-benchmark - failed at src/test/test-compress-benchmark.c:105, function test_compress_decompress(). Aborting.
             # test-capability - but got error: Protocol error
             # test-bcd - >= 0' failed at src/boot/test-bcd.c:19, function load_bcd().
@@ -188,13 +188,73 @@ subpackages:
             -s test-path-util \
             -s test-label \
             -s test-dns-domain \
-            -s test-cyrptolib \
             -s test-compress-benchmark \
             -s test-capability \
             -s test-bcd \
             -s test-tpm2 \
             -s test-fd-util \
             -s test-fstab-generator.sh
+
+  - name: "systemd-container"
+    description: "systemd container tools"
+    dependencies:
+      runtime:
+        - systemd
+    pipeline:
+      - runs: |
+          # Move machine, vm/nspawn, import, export and portable components
+          cd ${{targets.destdir}}/
+          find . -name '*machine*' \
+          -not -name 'systemd-machine-id*' \
+          -not -name 'sysinit.target.wants' \
+          -not -name 'sysinit.target.wants/' \
+          -not -name 'systemd-pcr*.service' \
+          -exec cp -l -v --parents -r '{}' ${{targets.subpkgdir}} \;
+          find . -name '*nspawn*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+          find . -name '*vmspawn*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+          find . -name '*import*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+          find . -name '*export*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+          find . -name '*portable*' -exec cp -v --parents -r '{}' ${{targets.subpkgdir}} \;
+
+          # Remove those files from the main package
+          find . -name '*machine*' -not -name 'systemd-machine-id*' -exec rm -f '{}' \;
+          find . -name '*nspawn*' -exec rm -f '{}' \;
+          find . -name '*vmspawn*' -exec rm -f '{}' \;
+          find . -name '*import*' -exec rm -f '{}' \;
+          find . -name '*export*' -exec rm -f '{}' \;
+          find . -name '*portable*' -type f -exec rm -f '{}' \;
+          find . -name '*portable*' -type d -exec rmdir '{}' \;
+
+          # Misc utilties
+          mv usr/lib/systemd/systemd-pull ${{targets.subpkgdir}}/usr/lib/systemd/
+          mv usr/bin/systemd-dissect ${{targets.subpkgdir}}/usr/bin/
+    test:
+      pipeline:
+        - runs: |
+            machinectl --help
+            machinectl --version
+            portablectl --version
+            portablectl --help
+            systemd-dissect --help
+            systemd-dissect --version
+            systemd-nspawn --help
+            systemd-nspawn --version
+            systemd-vmspawn --help
+            systemd-vmspawn --version
+            /usr/lib/systemd/systemd-export --help
+            /usr/lib/systemd/systemd-export --version
+            /usr/lib/systemd/systemd-import --help
+            /usr/lib/systemd/systemd-import --version
+            /usr/lib/systemd/systemd-import-fs --help
+            /usr/lib/systemd/systemd-import-fs --version
+            /usr/lib/systemd/systemd-importd --help
+            /usr/lib/systemd/systemd-importd --version
+            /usr/lib/systemd/systemd-machined --help
+            /usr/lib/systemd/systemd-machined --version
+            /usr/lib/systemd/systemd-portabled --help
+            /usr/lib/systemd/systemd-portabled --version
+            /usr/lib/systemd/systemd-pull --help
+            /usr/lib/systemd/systemd-pull --version
 
   - name: "systemd-init"
     description: "Configure systemd for use as an init system"
@@ -270,14 +330,10 @@ test:
         localectl --help
         loginctl --version
         loginctl --help
-        machinectl --version
-        machinectl --help
         networkctl --version
         networkctl --help
         oomctl --version
         oomctl --help
-        portablectl --version
-        portablectl --help
         resolvectl --version
         resolvectl --help
         run0 --version
@@ -301,8 +357,6 @@ test:
         systemd-delta --version
         systemd-delta --help
         systemd-detect-virt --help
-        systemd-dissect --version
-        systemd-dissect --help
         systemd-escape --version
         systemd-escape --help
         systemd-firstboot --version
@@ -319,8 +373,6 @@ test:
         systemd-mount --help
         systemd-notify --version
         systemd-notify --help
-        systemd-nspawn --version
-        systemd-nspawn --help
         systemd-path --version
         systemd-path --help
         systemd-repart --version
@@ -343,8 +395,6 @@ test:
         systemd-tty-ask-password-agent --help
         systemd-umount --version
         systemd-umount --help
-        systemd-vmspawn --version
-        systemd-vmspawn --help
         systemd-vpick --version
         systemd-vpick --help
         timedatectl --version
@@ -363,12 +413,6 @@ test:
         runlevel --help
         shutdown --help
         telinit --help
-    - name: "Verify key binaries"
-      runs: |
-        systemctl --version
-        systemd-analyze --version
-        udevadm --version
-        systemd-detect-virt --version
     - name: "Check libsystemd"
       runs: |
         ldconfig -p | grep libsystemd.so

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -231,6 +231,12 @@ subpackages:
           mv usr/lib/systemd/systemd-pull ${{targets.subpkgdir}}/usr/lib/systemd/
           mv usr/bin/systemd-dissect ${{targets.subpkgdir}}/usr/bin/
     test:
+      environment:
+        contents:
+          # without openssl-provider-legacy import errors referencing CRYPTOGRAPHY_OPENSSL_NO_LEGACY
+          packages:
+            - curl
+            - gnutar
       pipeline:
         - runs: |
             machinectl --help
@@ -257,6 +263,14 @@ subpackages:
             /usr/lib/systemd/systemd-portabled --version
             /usr/lib/systemd/systemd-pull --help
             /usr/lib/systemd/systemd-pull --version
+        - runs: |
+            # Run a pull command
+            SYSTEMD_LOG_LEVEL=debug /usr/lib/systemd/systemd-pull tar https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/x86_64/alpine-minirootfs-3.21.2-x86_64.tar.gz test --verify=checksum --verify=checksum --direct --force
+
+            # ensure it exists
+            #
+            # # test if it works
+            ls -la /var/lib/machines/test
 
   - name: "systemd-init"
     description: "Configure systemd for use as an init system"

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -204,6 +204,8 @@ subpackages:
       - runs: |
           # Move machine, vm/nspawn, import, export and portable components
           cd ${{targets.destdir}}/
+          mkdir -p  ${{targets.subpkgdir}}
+
           find . -name '*machine*' \
           -not -name 'systemd-machine-id*' \
           -not -name 'sysinit.target.wants' \

--- a/systemd.yaml
+++ b/systemd.yaml
@@ -200,6 +200,7 @@ subpackages:
     dependencies:
       runtime:
         - systemd
+        - gnutar
     pipeline:
       - runs: |
           # Move machine, vm/nspawn, import, export and portable components


### PR DESCRIPTION
This new package contains the follow pieces used for container and image management which are not needed for most systems.

Notably sysext and context are being left in the main systemd package but portablectl is being included here. Debian puts it in their system-container package but fedora doesn't. I think it fits well here so that's where I put it.

machine
portable
systemd-disect
vm/nspawn
import/export