### PR TITLE
ruby3.* add activemode/support update warning

### DIFF
--- a/ruby3.2-activemodel.yaml
+++ b/ruby3.2-activemodel.yaml
@@ -1,6 +1,6 @@
 package:
   name: ruby3.2-activemodel
-  version: 8.0.1
+  version: 8.0.1 # !! Update activesupport at the same time
   epoch: 0
   description: A toolkit for building modeling frameworks like Active Record. Rich support for attributes, callbacks, validations, serialization, internationalization, and testing.
   copyright:

--- a/ruby3.2-activesupport.yaml
+++ b/ruby3.2-activesupport.yaml
@@ -1,6 +1,6 @@
 package:
   name: ruby3.2-activesupport
-  version: 8.0.1
+  version: 8.0.1 # !!! Update activemodel at the same time
   epoch: 0
   description: A toolkit of support libraries and Ruby core extensions extracted from the Rails framework. Rich support for multibyte strings, internationalization, time zones, and testing.
   copyright:

--- a/ruby3.3-activemodel.yaml
+++ b/ruby3.3-activemodel.yaml
@@ -1,6 +1,6 @@
 package:
   name: ruby3.3-activemodel
-  version: 8.0.1
+  version: 8.0.1 # !!! Update activesupport at the same time
   epoch: 0
   description: A toolkit for building modeling frameworks like Active Record. Rich support for attributes, callbacks, validations, serialization, internationalization, and testing.
   copyright:

--- a/ruby3.3-activesupport.yaml
+++ b/ruby3.3-activesupport.yaml
@@ -1,6 +1,6 @@
 package:
   name: ruby3.3-activesupport
-  version: 8.0.1
+  version: 8.0.1 # !!! Update activemodel at the same time
   epoch: 0
   description: A toolkit of support libraries and Ruby core extensions extracted from the Rails framework. Rich support for multibyte strings, internationalization, time zones, and testing.
   copyright:

--- a/ruby3.4-activemodel.yaml
+++ b/ruby3.4-activemodel.yaml
@@ -1,6 +1,6 @@
 package:
   name: ruby3.4-activemodel
-  version: 8.0.1
+  version: 8.0.1 # !!! Update activesupport at the same time
   epoch: 0
   description: A toolkit for building modeling frameworks like Active Record. Rich support for attributes, callbacks, validations, serialization, internationalization, and testing.
   copyright:

--- a/ruby3.4-activesupport.yaml
+++ b/ruby3.4-activesupport.yaml
@@ -1,6 +1,6 @@
 package:
   name: ruby3.4-activesupport
-  version: 8.0.1
+  version: 8.0.1 # !!! Update activesupport at the same time
   epoch: 1
   description: A toolkit of support libraries and Ruby core extensions extracted from the Rails framework. Rich support for multibyte strings, internationalization, time zones, and testing.
   copyright:


### PR DESCRIPTION
activemodel requires a matching version of active support and should be updated at the same time ideally in the same PR. Upstream will release them at the same time but we have two update PRs from our infra and occasionally one is missed. I'm adding a note to remind people.  Our packages will install fine but not be able to import.  This will show up as a runtime failure for testing activemodel but not when testing activesupport.

https://github.com/rails/rails/blob/be9aa73dd72f1097be5d45a58d7912447a266bd1/activemodel/activemodel.gemspec#L35