### PR TITLE
cargobump: expose cargo update flag

### DIFF
--- a/pipelines/rust/cargobump.yaml
+++ b/pipelines/rust/cargobump.yaml
@@ -20,6 +20,9 @@ inputs:
   show-dependency-graph:
     default: false
     description: Display a tree visualization of a dependency graph
+  update:
+    default: false
+    description: Run 'cargo update' command before the bump
 
 pipeline:
   - runs: |
@@ -39,4 +42,4 @@ pipeline:
         cargo tree
       fi
 
-      cargobump $PACKAGES_FLAG $BUMP_FILE_FLAG
+      cargobump --run-update=${{inputs.update}} $PACKAGES_FLAG $BUMP_FILE_FLAG


### PR DESCRIPTION
This requires an upgrade to cargobump package prior merging it.