### PR TITLE
py3-cassandra-medusa: re-remove the grpc-health-probe dep

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: 0.22.3
-  epoch: 2
+  epoch: 3
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0
@@ -93,7 +93,6 @@ subpackages:
         # The entrypoint script fails to start without bash and sleep (which comes from busybox)
         - bash
         - busybox
-        - grpc-health-probe
     pipeline:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}/home/cassandra/"


### PR DESCRIPTION
Possibly added by mistake. The symlink seems to be 'fine' when it's dangling. This also fixes some incompatibilities when fips versions are involved in images.