### PR TITLE
remove tag usage from lean4 package update

### DIFF
--- a/lean4.yaml
+++ b/lean4.yaml
@@ -58,7 +58,6 @@ update:
   enabled: true
   github:
     identifier: leanprover/lean4
-    use-tag: true
     strip-prefix: v
     tag-filter: v
 


### PR DESCRIPTION
related to https://github.com/wolfi-dev/os/pull/38687/ bot update 
    
    remove tag usage from lean4 package update
    
    this is required because upstream project cuts rc releases and bot was
    creating new patches even on rc releases.
    
    We can use regex to ignore rc releases but upstream project also does
    regular releases so we can directly use releases and this way bot will
    not create PRs when upstream project does a pre-release.