### PR TITLE
Fix a FTBFS with libxcb due to a missing dep

### DIFF
--- a/libxcb.yaml
+++ b/libxcb.yaml
@@ -1,7 +1,7 @@
 package:
   name: libxcb
   version: 1.17.0
-  epoch: 3
+  epoch: 4
   description: X11 client-side library
   copyright:
     - license: MIT
@@ -20,6 +20,7 @@ environment:
       - libxdmcp-dev
       - libxslt
       - pkgconf-dev
+      - py3-xcbgen
       - python3
       - util-macros
       - xcb-proto


### PR DESCRIPTION
This fixes the FTBFS seen in https://github.com/wolfi-dev/os/issues/38652.  Here's a log of the success:

```
2025/01/03 14:09:36 INFO wrote packages/x86_64/libxcb-dev-1.17.0-r4.apk
2025/01/03 14:09:36 INFO cleaning Workspace by removing 85 file/directories in /home/build
2025/01/03 14:09:37 INFO generating apk index from packages in packages/x86_64
2025/01/03 14:09:37 INFO processing package packages/x86_64/libxcb-dev-1.17.0-r4.apk
2025/01/03 14:09:37 INFO processing package packages/x86_64/libxcb-static-1.17.0-r4.apk
2025/01/03 14:09:37 INFO processing package packages/x86_64/libxcb-doc-1.17.0-r4.apk
2025/01/03 14:09:37 INFO processing package packages/x86_64/libxcb-1.17.0-r4.apk
2025/01/03 14:09:37 INFO loaded 38/38 packages from index packages/x86_64/APKINDEX.tar.gz
2025/01/03 14:09:37 INFO updating index at packages/x86_64/APKINDEX.tar.gz with new packages: [libxcb-1.17.0-r4 libxcb-static-1.17.0-r4 libxcb-doc-1.17.0-r4 libxcb-dev-1.17.0-r4]
2025/01/03 14:09:37 INFO signing apk index at packages/x86_64/APKINDEX.tar.gz
2025/01/03 14:09:37 INFO signing index packages/x86_64/APKINDEX.tar.gz with key local-melange.rsa
2025/01/03 14:09:37 INFO appending signature RSA to index packages/x86_64/APKINDEX.tar.gz
2025/01/03 14:09:37 INFO writing signed index to packages/x86_64/APKINDEX.tar.gz
2025/01/03 14:09:37 INFO signed index packages/x86_64/APKINDEX.tar.gz with key local-melange.rsa
2025/01/03 14:09:37 INFO deleting guest dir /tmp/melange-guest-4188430222
2025/01/03 14:09:37 INFO deleting workspace dir /tmp/melange-workspace-4097013464
2025/01/03 14:09:37 INFO removing image path /tmp/melange-guest-3384410133
```