### PR TITLE
Fix a FTBFS with poppler due to a missing dep

### DIFF
--- a/poppler.yaml
+++ b/poppler.yaml
@@ -1,7 +1,7 @@
 package:
   name: poppler
   version: 24.12.0
-  epoch: 0
+  epoch: 1
   description: Poppler is a PDF rendering library based on the xpdf-3.0 code base.
   copyright:
     - license: GPL-2.0-or-later
@@ -36,6 +36,7 @@ environment:
       - openjpeg-dev
       - openjpeg-tools
       - pango-dev
+      - python3
       - samurai
       - tiff-dev
       - zlib-dev


### PR DESCRIPTION
This fixes the FTBFS identified in https://github.com/wolfi-dev/os/issues/38655.  Here's an excerpt of the successful build:

```
2025/01/03 22:53:07 INFO wrote packages/x86_64/poppler-utils-24.12.0-r1.apk
2025/01/03 22:53:07 INFO cleaning Workspace by removing 43 file/directories in /home/build
2025/01/03 22:53:08 INFO generating apk index from packages in packages/x86_64
2025/01/03 22:53:08 INFO processing package packages/x86_64/poppler-glib-24.12.0-r1.apk
2025/01/03 22:53:08 INFO processing package packages/x86_64/poppler-dev-24.12.0-r1.apk
2025/01/03 22:53:08 INFO processing package packages/x86_64/poppler-24.12.0-r1.apk
2025/01/03 22:53:08 INFO processing package packages/x86_64/poppler-doc-24.12.0-r1.apk
2025/01/03 22:53:08 INFO processing package packages/x86_64/poppler-utils-24.12.0-r1.apk
2025/01/03 22:53:08 INFO loaded 445/445 packages from index packages/x86_64/APKINDEX.tar.gz
2025/01/03 22:53:08 INFO updating index at packages/x86_64/APKINDEX.tar.gz with new packages: [poppler-24.12.0-r1 poppler-dev-24.12.0-r1 poppler-doc-24.12.0-r1 poppler-glib-24.12.0-r1 poppler-utils-24.12.0-r1]
2025/01/03 22:53:08 INFO signing apk index at packages/x86_64/APKINDEX.tar.gz
2025/01/03 22:53:08 INFO signing index packages/x86_64/APKINDEX.tar.gz with key local-melange.rsa
2025/01/03 22:53:08 INFO appending signature RSA256 to index packages/x86_64/APKINDEX.tar.gz
2025/01/03 22:53:08 INFO writing signed index to packages/x86_64/APKINDEX.tar.gz
2025/01/03 22:53:08 INFO signed index packages/x86_64/APKINDEX.tar.gz with key local-melange.rsa
2025/01/03 22:53:08 INFO deleting guest dir /home/user/tmp/melange-guest-2285671965
2025/01/03 22:53:08 INFO deleting workspace dir /home/user/tmp/melange-workspace-3578389386
2025/01/03 22:53:08 INFO removing image path /home/user/tmp/melange-guest-3685571777
```