### PR TITLE
spdlog: cherry pick fix for compat with fmt >= 11.1

### DIFF
--- a/spdlog.yaml
+++ b/spdlog.yaml
@@ -1,7 +1,7 @@
 package:
   name: spdlog
   version: 1.15.0
-  epoch: 0
+  epoch: 1
   description: Fast C++ logging library.
   copyright:
     - license: MIT
@@ -22,6 +22,8 @@ pipeline:
       expected-commit: 8e5613379f5140fefb0b60412fbf1f5406e7c7f8
       repository: https://github.com/gabime/spdlog
       tag: v${{package.version}}
+      cherry-picks: |
+        v1.x/276ee5f5c0eb13626bd367b006ace5eae9526d8a: fix: update to_string_view function for fmt 11.1 (#3301)
 
   - uses: cmake/configure
     with:


### PR DESCRIPTION
Fixes a FTBFS with `libmamba`.