### PR TITLE
lychee: bump to 0.18.0

### DIFF
--- a/lychee.yaml
+++ b/lychee.yaml
@@ -1,10 +1,11 @@
 package:
   name: lychee
-  version: 0.15.1
-  epoch: 3
+  version: 0.18.0
+  epoch: 0
   description: "Fast, async, stream-based link checker written in Rust"
   copyright:
-    - license: Apache-2.0 AND MIT
+    - license: Apache-2.0
+    - license: MIT
 
 environment:
   contents:
@@ -21,8 +22,8 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/lycheeverse/lychee
-      tag: v${{package.version}}
-      expected-commit: 0a54079d01ba9a4ff9850d8e46d3ba64743d2c8d
+      tag: lychee-v${{package.version}}
+      expected-commit: 1780aa0daa70462e296f9811e06178f13fd945db
 
   - uses: rust/cargobump
 
@@ -36,7 +37,8 @@ update:
   enabled: true
   github:
     identifier: lycheeverse/lychee
-    strip-prefix: v
+    strip-prefix: lychee-v
+    tag-filter: lychee-v
 
 test:
   environment:

--- a/lychee/cargobump-deps.yaml
+++ b/lychee/cargobump-deps.yaml
@@ -1,3 +1,5 @@
 packages:
-    - name: openssl
-      version: 0.10.66
+  - name: rustls
+    version: 0.23.18
+  - name: publicsuffix
+    version: 2.3.0


### PR DESCRIPTION
Upstream has been changed its tag naming, so it has `lychee-v` prefix now.

We can't get omit the `idna@0.2.3`, as `trust-dns-proto` hard depend on it:

```
cargo update -p trust-dns-proto --precise 0.23.2
    Updating crates.io index
error: failed to select a version for the requirement `trust-dns-proto = "^0.21.2"`
candidate versions found which didn't match: 0.23.2
location searched: crates.io index
required by package `check-if-email-exists v0.9.1`
    ... which satisfies dependency `check-if-email-exists = "^0.9.1"` (locked to 0.9.1) of package `lychee-lib v0.18.0 (/home/user/lychee/lychee-lib)`
    ... which satisfies path dependency `lychee-lib` (locked to 0.18.0) of package `lychee v0.18.0 (/home/user/lychee/lychee-bin)`
```

Advisory will be submitted.