### PR TITLE
py3-jupyterhub- multiversion

### DIFF
--- a/py3-jupyterhub-firstuseauthenticator.yaml
+++ b/py3-jupyterhub-firstuseauthenticator.yaml
@@ -2,25 +2,30 @@
 package:
   name: py3-jupyterhub-firstuseauthenticator
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   description: JupyterHub Authenticator that lets users set passwords on first use
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-bcrypt
-      - py3-jupyterhub
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: jupyterhub-firstuseauthenticator
+  import: firstuseauthenticator
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -29,10 +34,45 @@ pipeline:
       repository: https://github.com/jupyterhub/firstuseauthenticator
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-bcrypt
+        - py${{range.key}}-jupyterhub
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-jupyterhub-hmacauthenticator.yaml
+++ b/py3-jupyterhub-hmacauthenticator.yaml
@@ -2,23 +2,30 @@
 package:
   name: py3-jupyterhub-hmacauthenticator
   version: 1.0
-  epoch: 1
+  epoch: 2
   description: Dummy Authenticator for JupyterHub
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: jupyterhub-hmacauthenticator
+  import: hmacauthenticator
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: fetch
@@ -26,10 +33,44 @@ pipeline:
       expected-sha256: b2b220a5d3762dd43beb6e29ed1bd0e414b3de8ef8b2d1835b9986260a19c374
       uri: https://files.pythonhosted.org/packages/source/j/jupyterhub-hmacauthenticator/jupyterhub-hmacauthenticator-${{package.version}}.tar.gz
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-jupyterhub
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-jupyterhub-idle-culler.yaml
+++ b/py3-jupyterhub-idle-culler.yaml
@@ -49,6 +49,10 @@ subpackages:
       - uses: py/pip-build-install
         with:
           python: python${{range.key}}
+      - name: "move usr/bin executables for -bin"
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
       - uses: strip
     test:
       pipeline:
@@ -57,6 +61,25 @@ subpackages:
             python: python${{range.key}}
             imports: |
               import ${{vars.import}}
+
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+      provides:
+        - py3-${{vars.pypi-package}}-bin
+        - py3-${{vars.pypi-package}}
+      provider-priority: ${{range.value}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      pipeline:
+        - runs: |
+            jupyterhub-idle-culler --help
 
   - name: py3-supported-${{vars.pypi-package}}
     description: meta package providing ${{vars.pypi-package}} for supported python versions.

--- a/py3-jupyterhub-idle-culler.yaml
+++ b/py3-jupyterhub-idle-culler.yaml
@@ -2,27 +2,29 @@
 package:
   name: py3-jupyterhub-idle-culler
   version: 1.4.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-tornado
-      - py3-python-dateutil
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: jupyterhub-idle-culler
+  import: jupyterhub_idle_culler
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 environment:
-  environment:
-    # This is needed to work around the error "ValueError: ZIP does not support timestamps before 1980"
-    SOURCE_DATE_EPOCH: 315532800
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -31,10 +33,46 @@ pipeline:
       repository: https://github.com/jupyterhub/jupyterhub-idle-culler
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-tornado
+        - py${{range.key}}-packaging
+        - py${{range.key}}-python-dateutil
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-jupyterhub-ldapauthenticator.yaml
+++ b/py3-jupyterhub-ldapauthenticator.yaml
@@ -2,27 +2,29 @@
 package:
   name: py3-jupyterhub-ldapauthenticator
   version: 2.0.2
-  epoch: 0
+  epoch: 1
   description: LDAP Authenticator for JupyterHub
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-jupyterhub
-      - py3-ldap3
-      - py3-tornado
-      - py3-traitlets
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: jupyterhub-ldapauthenticator
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -31,22 +33,47 @@ pipeline:
       repository: https://github.com/jupyterhub/ldapauthenticator
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-jupyterhub
+        - py${{range.key}}-ldap3
+        - py${{range.key}}-tornado
+        - py${{range.key}}-traitlets
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              from ldapauthenticator import LDAPAuthenticator
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
 
 test:
-  environment:
-    contents:
-      packages:
-        - openssl
-        - py3-jupyterhub
-        - py3-pip
   pipeline:
     - uses: python/import
       with:
-        imports: from ldapauthenticator import LDAPAuthenticator
+        imports: |
+          from ldapauthenticator import LDAPAuthenticator
 
 update:
   enabled: true

--- a/py3-jupyterhub-ldapauthenticator.yaml
+++ b/py3-jupyterhub-ldapauthenticator.yaml
@@ -44,7 +44,6 @@ subpackages:
       runtime:
         - py${{range.key}}-jupyterhub
         - py${{range.key}}-ldap3
-        - py${{range.key}}-tornado
         - py${{range.key}}-traitlets
     pipeline:
       - uses: py/pip-build-install

--- a/py3-jupyterhub-ltiauthenticator.yaml
+++ b/py3-jupyterhub-ltiauthenticator.yaml
@@ -2,28 +2,30 @@
 package:
   name: py3-jupyterhub-ltiauthenticator
   version: 1.6.2
-  epoch: 0
+  epoch: 1
   description: JupyterHub authenticator implementing LTI v1.1 and LTI v1.3
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-escapism
-      - py3-jupyterhub
-      - py3-oauthlib
-      - py3-pyjwt
-      - py3-traitlets
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: jupyterhub-ltiauthenticator
+  import: ltiauthenticator
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -32,10 +34,48 @@ pipeline:
       repository: https://github.com/jupyterhub/ltiauthenticator
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-escapism
+        - py${{range.key}}-jupyterhub
+        - py${{range.key}}-oauthlib
+        - py${{range.key}}-pyjwt
+        - py${{range.key}}-traitlets
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-jupyterhub-nativeauthenticator.yaml
+++ b/py3-jupyterhub-nativeauthenticator.yaml
@@ -2,26 +2,30 @@
 package:
   name: py3-jupyterhub-nativeauthenticator
   version: 1.3.0
-  epoch: 0
+  epoch: 1
   description: JupyterHub Native Authenticator
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - py3-jupyterhub
-      - py3-bcrypt
-      - py3-onetimepass
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: jupyterhub-nativeauthenticator
+  import: nativeauthenticator
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -30,10 +34,46 @@ pipeline:
       repository: https://github.com/jupyterhub/nativeauthenticator
       tag: ${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-jupyterhub
+        - py${{range.key}}-bcrypt
+        - py${{range.key}}-onetimepass
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true

--- a/py3-jupyterhub-tmpauthenticator.yaml
+++ b/py3-jupyterhub-tmpauthenticator.yaml
@@ -2,23 +2,30 @@
 package:
   name: py3-jupyterhub-tmpauthenticator
   version: 1.0.0
-  epoch: 0
+  epoch: 1
   description: JupyterHub authenticator that hands out temporary accounts for everyone
   copyright:
     - license: BSD-3-Clause
   dependencies:
-    runtime:
-      - python-3
+    provider-priority: 0
+
+vars:
+  pypi-package: jupyterhub-tmpauthenticator
+  import: tmpauthenticator
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 environment:
   contents:
     packages:
-      - build-base
-      - busybox
-      - ca-certificates-bundle
-      - py3-setuptools
-      - python-3
-      - wolfi-base
+      - py3-supported-build-base
+      - py3-supported-hatchling
 
 pipeline:
   - uses: git-checkout
@@ -27,10 +34,44 @@ pipeline:
       repository: https://github.com/jupyterhub/tmpauthenticator
       tag: v${{package.version}}
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      provides:
+        - py3-${{vars.pypi-package}}
+      runtime:
+        - py${{range.key}}-jupyterhub
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            imports: |
+              import ${{vars.import}}
 
-  - uses: strip
+  - name: py3-supported-${{vars.pypi-package}}
+    description: meta package providing ${{vars.pypi-package}} for supported python versions.
+    dependencies:
+      runtime:
+        - py3.10-${{vars.pypi-package}}
+        - py3.11-${{vars.pypi-package}}
+        - py3.12-${{vars.pypi-package}}
+        - py3.13-${{vars.pypi-package}}
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          import ${{vars.import}}
 
 update:
   enabled: true


### PR DESCRIPTION
Some of the py3-jupyterhub-* packages have not been multiversioned. This causes certain images that use them to ship multiple Python bases.

Related: https://github.com/wolfi-dev/os/issues/37197
