### PR TITLE
feat(airflow.yaml): Bump epoch to force rebuild to remediate two jinja2 CVEs

### DIFF
--- a/airflow.yaml
+++ b/airflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: airflow
   version: 2.10.4
-  epoch: 1
+  epoch: 2
   description: Platform to programmatically author, schedule, and monitor workflows
   options:
     #  There is a dependency on libarrow.so although it


### PR DESCRIPTION
GHSA-q2x7-8rv6-6q7h [1] and GHSA-gmj6-6f8f-6699 [2] are both present in the current version of airflow due to the dependency on jinja2.

The jinja2 dependency is defined as `jinja2>=3.0.0` [3] and as GHSA-q2x7-8rv6-6q7h and GHSA-gmj6-6f8f-6699 are both addressed in the
3.1.5 release on jinja2 - all that is required is a rebuild of airflow which will update the jinja2 dependency from the
vulnerable 3.1.4 to the non vulnerable 3.1.5.

[1] https://github.com/advisories/GHSA-q2x7-8rv6-6q7h
[2] https://github.com/advisories/GHSA-gmj6-6f8f-6699
[3] https://github.com/apache/airflow/blob/2.10.4/hatch_build.py#L462

Signed-off-by: philroche <phil.roche@chainguard.dev>
