### PR TITLE
py3-pamela - fix FTBFS by updating repository url

### DIFF
--- a/py3-pamela.yaml
+++ b/py3-pamela.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-pamela
   version: 1.2.0
-  epoch: 2
+  epoch: 3
   description: PAM interface using ctypes
   copyright:
     - license: MIT
@@ -29,7 +29,7 @@ pipeline:
   - uses: git-checkout
     with:
       expected-commit: 8b55885855c57ed510d2c45143864fcfac5840b3
-      repository: https://github.com/minrk/pamela
+      repository: https://github.com/jupyterhub/pamela
       tag: ${{package.version}}
 
 subpackages:
@@ -76,5 +76,5 @@ update:
   enabled: true
   manual: false
   github:
-    identifier: minrk/pamela
+    identifier: jupyterhub/pamela
     use-tag: true


### PR DESCRIPTION
https://github.com/jupyterhub/pamela is upstream for pamela, https://github.com/minrk/pamela is an individual developer's fork.

Fixes #38659
