### PR TITLE
glibc: test 2.40.9000, but with openssf.

### DIFF
--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
-  version: 2.40
-  epoch: 3
+  version: 2.40.9000
+  epoch: 1
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -44,6 +44,7 @@ environment:
       - flex
       - gawk
       - grep
+      - openssf-compiler-options
       - python3
       - rdfind
       - texinfo
@@ -54,10 +55,10 @@ environment:
     CPPFLAGS: ""
 
 pipeline:
-  - uses: fetch
+  # glibc has no real tag or branch we can use for the 2.41 pre-release
+  - uses: git-checkout
     with:
-      uri: https://ftp.gnu.org/gnu/libc/glibc-${{package.version}}.tar.xz
-      expected-sha256: 19a890175e9263d748f627993de6f4b1af9cd21e03f080e4bfb3a1fac10205a2
+      repository: https://sourceware.org/git/glibc.git
 
   - uses: patch
     with:


### PR DESCRIPTION
Just testing if everything now builds fine with openssf-build-options re-enabled.