### PR TITLE
openfga - fix ldflags for version/commit/timestamp

### DIFF
--- a/openfga.yaml
+++ b/openfga.yaml
@@ -43,7 +43,7 @@ test:
   pipeline:
     - name: Test build with right version
       runs: |
-        openfga version
+        openfga version 2>&1 >/dev/null | grep "${{package.version}}"
     - name: Test server startup and hitting some endpoints
       uses: test/daemon-check-output
       with:

--- a/openfga.yaml
+++ b/openfga.yaml
@@ -1,7 +1,7 @@
 package:
   name: openfga
   version: 1.8.3
-  epoch: 0
+  epoch: 1
   description: A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar
   copyright:
     - license: Apache-2.0
@@ -15,6 +15,10 @@ pipeline:
 
   - uses: go/build
     with:
+      ldflags: |
+        -X github.com/openfga/openfga/internal/build.Version=v${{package.version}}
+        -X github.com/openfga/openfga/internal/build.Commit=$(git rev-parse HEAD)
+        -X github.com/openfga/openfga/internal/build.Date=$(TZ="UTC" date +"%Y-%m-%dT%TZ")
       output: openfga
       packages: ./cmd/openfga
 
@@ -37,6 +41,9 @@ test:
     environment:
       STORES_URL: localhost:8080/stores
   pipeline:
+    - name: Test build with right version
+      runs: |
+        openfga version
     - name: Test server startup and hitting some endpoints
       uses: test/daemon-check-output
       with:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: Without `ldflags` the `openfga version` command outputs `version 'dev' from 'none' on 'unknown'` - adding flags to build the package with the proper version tags.

Related: https://github.com/chainguard-dev/image-requests/issues/5204

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->
