### PR TITLE
py3-cassandra-medusa: pin poetry version during build

### DIFF
--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -43,7 +43,6 @@ pipeline:
       #   https://github.com/thelastpickle/cassandra-medusa/commit/b873fdbc51c2f542f80520d54f8006d8662fd6d2
       # but that fails to cleanly cherry-pick. Drop this when we bump to > 0.22.3
       poetry add "aiohttp==3.10.11"
-      poetry add "idna==3.7"
       poetry add "pyOpenSSL@^24.0.0"
       poetry add "cryptography@^43.0.1"
       # CVE-2024-35195: requests

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -43,7 +43,6 @@ pipeline:
       #   https://github.com/thelastpickle/cassandra-medusa/commit/b873fdbc51c2f542f80520d54f8006d8662fd6d2
       # but that fails to cleanly cherry-pick. Drop this when we bump to > 0.22.3
       poetry add "aiohttp==3.10.11"
-      poetry add "dnspython==2.6.1"
       poetry add "idna==3.7"
       poetry add "pyOpenSSL@^24.0.0"
       poetry add "cryptography@^43.0.1"

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -46,7 +46,10 @@ pipeline:
       poetry add "pyOpenSSL@^24.0.0"
       poetry add "cryptography@^43.0.1"
       # CVE-2024-35195: requests
-      poetry add "requests@^2.23.0"
+      # Upstream bumped requests to 2.32.3 in:
+      #   https://github.com/thelastpickle/cassandra-medusa/commit/f1013d8e6dbdc05496095d69b36b3210448d20b3,
+      # which doesn't cleanly cherry-pick. Drop this when we bump to > 0.22.3
+      poetry add "requests@^2.32.0"
       # GHSA-34jh-p97f-mpxf: urllib3
       poetry add "urllib3==1.26.19"
       poetry run pip freeze | grep -v cassandra-medusa > requirements.txt

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -30,14 +30,19 @@ pipeline:
       repository: https://github.com/thelastpickle/cassandra-medusa
       tag: v${{package.version}}
       expected-commit: 6202aca6e4c2859d2ad601571571a774df7bebc8
+      cherry-picks: |
+        master/fd044f92d9a5ea245c61d1df9c58462de51496e4: Bump certifi from 2024.2.2 to 2024.7.4 (#788)
+        master/69fd085a307340feb01214679b171a8da2a14fec: Bump setuptools from 69.5.1 to 70.0.0 (#792)
 
   - name: Python Build
     runs: |
       # As of 0.22.3, this package is incompatible with poetry 2.0.
       # See: https://github.com/thelastpickle/cassandra-medusa/commit/fd044f92d9a5ea245c61d1df9c58462de51496e4
       pip${{vars.py-version}} install 'poetry>=1.0.0,<2.0.0'
+      # Upstream has bumped aiohttp in:
+      #   https://github.com/thelastpickle/cassandra-medusa/commit/b873fdbc51c2f542f80520d54f8006d8662fd6d2
+      # but that fails to cleanly cherry-pick. Drop this when we bump to > 0.22.3
       poetry add "aiohttp==3.10.11"
-      poetry add "certifi==2024.7.4"
       poetry add "dnspython==2.6.1"
       poetry add "idna==3.7"
       poetry add "pyOpenSSL@^24.0.0"
@@ -56,7 +61,7 @@ pipeline:
       # Setup the virtualenv
       python${{vars.py-version}} -m venv .venv --system-site-packages
       # Bump pip to patch a CVE
-      .venv/bin/pip${{vars.py-version}} install --upgrade pip==24.0 setuptools==70.0.0
+      .venv/bin/pip${{vars.py-version}} install --upgrade pip==24.0
 
   - runs: |
       .venv/bin/pip${{vars.py-version}} install -I -r requirements.txt --no-compile

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -50,8 +50,6 @@ pipeline:
       #   https://github.com/thelastpickle/cassandra-medusa/commit/f1013d8e6dbdc05496095d69b36b3210448d20b3,
       # which doesn't cleanly cherry-pick. Drop this when we bump to > 0.22.3
       poetry add "requests@^2.32.0"
-      # GHSA-34jh-p97f-mpxf: urllib3
-      poetry add "urllib3==1.26.19"
       poetry run pip freeze | grep -v cassandra-medusa > requirements.txt
       POETRY_VIRTUALENVS_IN_PROJECT=true poetry install
       poetry build

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -33,7 +33,9 @@ pipeline:
 
   - name: Python Build
     runs: |
-      pip${{vars.py-version}} install poetry
+      # As of 0.22.3, this package is incompatible with poetry 2.0.
+      # See: https://github.com/thelastpickle/cassandra-medusa/commit/fd044f92d9a5ea245c61d1df9c58462de51496e4
+      pip${{vars.py-version}} install 'poetry>=1.0.0,<2.0.0'
       poetry add "aiohttp==3.10.11"
       poetry add "certifi==2024.7.4"
       poetry add "dnspython==2.6.1"

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -47,8 +47,6 @@ pipeline:
       poetry add "cryptography@^43.0.1"
       # CVE-2024-35195: requests
       poetry add "requests@^2.23.0"
-      # GHSA-m5vv-6r4h-3vj9: azure-identity
-      poetry add "azure-identity==1.16.1"
       # GHSA-34jh-p97f-mpxf: urllib3
       poetry add "urllib3==1.26.19"
       poetry run pip freeze | grep -v cassandra-medusa > requirements.txt

--- a/py3-cassandra-medusa.yaml
+++ b/py3-cassandra-medusa.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-cassandra-medusa
   version: 0.22.3
-  epoch: 3
+  epoch: 4
   description: Apache Cassandra backup and restore tool
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Fixes a ftbfs introduced by poetry 2.0's recent release.

Note: `ci-cve-scan` issues are being discussed in https://github.com/chainguard-dev/internal-dev/issues/7891 and shouldn't block this fix IMHO.