### PR TITLE
Split docs to its own package

### DIFF
--- a/lsb-release-minimal.yaml
+++ b/lsb-release-minimal.yaml
@@ -1,7 +1,7 @@
 package:
   name: lsb-release-minimal
   version: "12.1"
-  epoch: 0
+  epoch: 1
   description: Minimal fake lsb-release that uses os-release
   copyright:
     - license: MIT
@@ -28,6 +28,12 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: lsb-release-minimal-doc
+    description: lsb-release-minimal docs
+    pipeline:
+      - uses: split/manpages
 
 update:
   enabled: true


### PR DESCRIPTION
Dustin did some work to split the documentation for packages into their own separate packages but it was a large PR modifying hundreds of packages so has not been merged. This PR includes that change and also will fix the issue using `apk fetch` with this package failing due invalid metadata see https://github.com/wolfi-dev/os/issues/30234 for details.