### PR TITLE
Split docs to its own package

### DIFF
--- a/mailcap.yaml
+++ b/mailcap.yaml
@@ -1,7 +1,7 @@
 package:
   name: mailcap
   version: 2.1.54
-  epoch: 1
+  epoch: 2
   description: "Helper application and MIME type associations for file types"
   copyright:
     - license: CC-PDDC AND MIT
@@ -21,6 +21,12 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: mailcap-doc
+    description: mailcap docs
+    pipeline:
+      - uses: split/manpages
 
 update:
   enabled: true


### PR DESCRIPTION
Dustin did some work to split the documentation for packages into their own separate packages but it was a large PR modifying hundreds of packages so has not been merged. This PR includes that change and also will fix the issue using `apk fetch` with this package failing due invalid metadata see https://github.com/wolfi-dev/os/issues/30234 for details.