### PR TITLE
Split docs to its own package

### DIFF
--- a/pwgen.yaml
+++ b/pwgen.yaml
@@ -1,7 +1,7 @@
 package:
   name: pwgen
   version: "2.08"
-  epoch: 5
+  epoch: 6
   description: "A Password Generator"
   copyright:
     - license: GPL-2.0-or-later
@@ -32,6 +32,12 @@ pipeline:
   - uses: autoconf/make-install
 
   - uses: strip
+
+subpackages:
+  - name: pwgen-doc
+    description: pwgen docs
+    pipeline:
+      - uses: split/manpages
 
 update:
   enabled: true


### PR DESCRIPTION
Dustin did some work to split the documentation for packages into their own separate packages but it was a large PR modifying hundreds of packages so has not been merged. This PR includes that change and also will fix the issue using `apk fetch` with this package failing due invalid metadata see https://github.com/wolfi-dev/os/issues/30234 for details.
