### PR TITLE
Add compat package to create root level symlink, required by helm chart

### DIFF
--- a/splunk-otel-collector.yaml
+++ b/splunk-otel-collector.yaml
@@ -1,7 +1,7 @@
 package:
   name: splunk-otel-collector
   version: 0.115.0
-  epoch: 1
+  epoch: 2
   description: Splunk OpenTelemetry Collector is a distribution of the OpenTelemetry Collector. It provides a unified way to receive, process, and export metric, trace, and log data for Splunk Observability Cloud
   copyright:
     - license: Apache-2.0

--- a/splunk-otel-collector.yaml
+++ b/splunk-otel-collector.yaml
@@ -66,8 +66,19 @@ subpackages:
           ldflags: -X github.com/signalfx/splunk-otel-collector/internal/version.Version=v${{package.version}} -X go.opentelemetry.io/collector/internal/version.Version=${{package.version}}
           output: migratecheckpoint
     test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}-migratecheckpoint-compat
       pipeline:
         - runs: migratecheckpoint --help
+        - runs: /migratecheckpoint --help
+
+  - name: ${{package.name}}-migratecheckpoint-compat
+    description: Symlink for the migratecheckpoint binary in the root folder
+    pipeline:
+      - runs: |
+          ln -sf /usr/bin/migratecheckpoint ${{targets.contextdir}}/
 
 update:
   enabled: true
@@ -77,5 +88,6 @@ update:
 
 test:
   pipeline:
-    - runs: otelcol --help
-    - runs: otelcol --version | grep ${{package.version}}
+    - runs: |
+        otelcol --help
+        otelcol --version | grep ${{package.version}}


### PR DESCRIPTION
The helm chart for deploying this package/image expects a root-level binary to be present. This creates a compat package to satisfy the helm chart. Example:
 - https://github.com/search?q=repo%3Asignalfx%2Fsplunk-otel-collector-chart%20migratecheckpoint&type=code