### PR TITLE
Jenkins-2: GHSA-76h9-2vwh-w278 fix

### DIFF
--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-2
   version: "2.491"
-  epoch: 1
+  epoch: 2
   description: Open-source CI/CD application.
   copyright:
     - license: MIT
@@ -49,6 +49,8 @@ pipeline:
       repository: https://github.com/jenkinsci/jenkins
       tag: jenkins-${{package.version}}
       expected-commit: 6a7b2eb81b66359e6b3933e61baea692108b076c
+      cherry-picks: |
+        master/efae3ca4559e6dc526a37d99e5a9f51050259d5c: Resolves GHSA-76h9-2vwh-w278 by bumping mina-sshd-api version
 
   - uses: patch
     with:


### PR DESCRIPTION
The following [commit merged into main upstream](https://github.com/jenkinsci/jenkins/commit/efae3ca4559e6dc526a37d99e5a9f51050259d5c) resolves the CVE GHSA-76h9-2vwh-w27 as this dependency contains the offending transitive dependency