### PR TITLE
Fix(CVE): GHSA-rhh4-rh7c-7r5v for mattermost-10.3

### DIFF
--- a/mattermost-10.3.yaml
+++ b/mattermost-10.3.yaml
@@ -3,7 +3,7 @@ package:
   # Note the npm version has been pinned to 10.8.3 to avoid the error:
   # "npm error notsup Required: {"node":">=18.10.0","npm":"^9.0.0 || ^10.0.0"}"
   version: 10.3.1
-  epoch: 0
+  epoch: 1
   description: "Mattermost is an open source platform for secure collaboration across the entire software development lifecycle."
   copyright:
     - license: MIT
@@ -46,6 +46,13 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: af1560dea70d1e5575932ee07093fb40ad37d925
 
+  - uses: go/bump
+    with:
+      deps: golang.org/x/crypto@v0.31.0 golang.org/x/net@v0.33.0
+      replaces: github.com/mholt/archiver/v3=github.com/anchore/archiver/v3@v3.5.2
+      modroot: ./server
+      tidy: false # https://github.com/mattermost/mattermost/issues/26221
+
   - runs: |
       mkdir -p ${{targets.contextdir}}/usr/bin
       for dir in bin data logs config plugins fonts i18n templates client test; do
@@ -54,11 +61,6 @@ pipeline:
 
   - working-directory: server
     pipeline:
-      - uses: go/bump
-        with:
-          deps: golang.org/x/crypto@v0.31.0 golang.org/x/net@v0.33.0
-          modroot: .
-          tidy: false # https://github.com/mattermost/mattermost/issues/26221
       - runs: make modules-tidy
       - runs: |
           # Our global LDFLAGS conflict with a Makefile parameter: `flag provided but not defined: -Wl,--as-needed,-O1,--sort-common`


### PR DESCRIPTION
The fork we are using is a drop in replacement which includes one extra commit and have released a tag
[`github.com/anchore/archiver`](https://github.com/anchore/archiver/)

Until the version 4.x.x gets released for [`github.com/mholt/archiver`](https://github.com/mholt/archiver) we can use this fork temporary for these CVE