### PR TITLE
py3-jupyterhub-idle-culler: only the -bin package should provide the original

### DIFF
--- a/py3-jupyterhub-idle-culler.yaml
+++ b/py3-jupyterhub-idle-culler.yaml
@@ -2,7 +2,7 @@
 package:
   name: py3-jupyterhub-idle-culler
   version: 1.4.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-3-Clause
   dependencies:
@@ -39,8 +39,6 @@ subpackages:
     description: python${{range.key}} version of ${{vars.pypi-package}}
     dependencies:
       provider-priority: ${{range.value}}
-      provides:
-        - py3-${{vars.pypi-package}}
       runtime:
         - py${{range.key}}-tornado
         - py${{range.key}}-packaging


### PR DESCRIPTION
When doing the multiversioning changes, I had to split idle-culler into a -bin package. But while doing the split, even though the -bin package correctly provides the original py3-jupyterhub-idle-culler package, I forgot to remove the same provides: from the versioned py<version>-jupyterhub-idle-culler one.