### PR TITLE
Fix docs package and drop go from buildtime deps as this is pre-loaded by go/build

### DIFF
--- a/splunk-otel-collector.yaml
+++ b/splunk-otel-collector.yaml
@@ -1,18 +1,13 @@
 package:
   name: splunk-otel-collector
   version: 0.115.0
-  epoch: 2
+  epoch: 3
   description: Splunk OpenTelemetry Collector is a distribution of the OpenTelemetry Collector. It provides a unified way to receive, process, and export metric, trace, and log data for Splunk Observability Cloud
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - systemd
-
-environment:
-  contents:
-    packages:
-      - go
 
 pipeline:
   - uses: git-checkout
@@ -54,7 +49,16 @@ subpackages:
     description: Documentation for Splunk OTel Collector
     pipeline:
       - name: install-docs
-        runs: mkdir -p ${{targets.contextdir}}/usr/share mv docs "${{targets.contextdir}}/usr/share"
+        runs: |
+          mkdir -p ${{targets.contextdir}}/usr/share
+          mv docs ${{targets.contextdir}}/usr/share
+    test:
+      environment:
+        contents:
+          packages:
+            - ${{package.name}}-doc
+      pipeline:
+        - runs: ls /usr/share/docs/README.md
 
   - name: ${{package.name}}-migratecheckpoint
     description: migrate checkpoint package


### PR DESCRIPTION
Docs package had multiple commands on the same line, splitting out to separate lines. Also dropped go from buildtime deps as go/build loads these for us 