### PR TITLE
feat(kubeflow-volumes-web-app.yaml.yaml): Bump epoch to force rebuild to remediate two jinja2 CVEs

### DIFF
--- a/kubeflow-volumes-web-app.yaml
+++ b/kubeflow-volumes-web-app.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-volumes-web-app
   version: 1.9.2
-  epoch: 2
+  epoch: 3
   description: Kubeflow volumes web app component
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
GHSA-q2x7-8rv6-6q7h [1] and GHSA-gmj6-6f8f-6699 [2] are both present in the current version of kubeflow-volumes-web-app due to the dependency on jinja2.

The jinja2 dependency is defined as `jinja2>=3.0.0` and as GHSA-q2x7-8rv6-6q7h and GHSA-gmj6-6f8f-6699 are both addressed in the
3.1.5 release on jinja2 - all that is required is a rebuild of kubeflow-volumes-web-app which will update the jinja2 dependency from the
vulnerable 3.1.4 to the non vulnerable 3.1.5.

[1] https://github.com/advisories/GHSA-q2x7-8rv6-6q7h
[2] https://github.com/advisories/GHSA-gmj6-6f8f-6699

Signed-off-by: philroche <phil.roche@chainguard.dev>
