### PR TITLE
grpc-health-probe: add compat-openfga subpackage

### DIFF
--- a/grpc-health-probe.yaml
+++ b/grpc-health-probe.yaml
@@ -37,7 +37,7 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: grpc-health-probe-compat
+  - name: ${{package.name}}-compat
     pipeline:
       - runs: |
           # Symlink the binary from usr/bin to /bin
@@ -45,7 +45,17 @@ subpackages:
           ln -sf /usr/bin/grpc-health-probe ${{targets.subpkgdir}}/bin/grpc-health-probe
     dependencies:
       runtime:
-        - grpc-health-probe
+        - ${{package.name}}
+
+  - name: ${{package.name}}-compat-openfga
+    pipeline:
+      - runs: |
+          # openfga image has a unique path to this binary
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
+          ln -sf /usr/bin/grpc-health-probe ${{targets.subpkgdir}}/usr/local/bin/grpc_health_probe
+    dependencies:
+      runtime:
+        - ${{package.name}}
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: `openfga` image / helm chart expect the `grpc-health-probe` binary at a unique location

Related: https://github.com/chainguard-dev/image-requests/issues/5204