### PR TITLE
openfga: healthcheck compat package

### DIFF
--- a/openfga.yaml
+++ b/openfga.yaml
@@ -5,9 +5,6 @@ package:
   description: A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar
   copyright:
     - license: Apache-2.0
-  dependencies:
-    runtime:
-      - grpc-health-probe
 
 pipeline:
   - uses: git-checkout
@@ -37,6 +34,9 @@ subpackages:
     dependencies:
       runtime:
         - grpc-health-probe
+    test:
+      pipeline:
+        - runs: stat /usr/local/bin/grpc_health_probe
 
 update:
   enabled: true

--- a/openfga.yaml
+++ b/openfga.yaml
@@ -1,10 +1,13 @@
 package:
   name: openfga
   version: 1.8.3
-  epoch: 1
+  epoch: 2
   description: A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar
   copyright:
     - license: Apache-2.0
+  dependencies:
+    runtime:
+      - grpc-health-probe
 
 pipeline:
   - uses: git-checkout
@@ -23,6 +26,17 @@ pipeline:
       packages: ./cmd/openfga
 
   - uses: strip
+
+subpackages:
+  - name: ${{package.name}}-healthcheck-compat
+    pipeline:
+      - runs: |
+          # openfga image has a unique path to its grpc-health-probe binary
+          mkdir -p "${{targets.subpkgdir}}"/usr/local/bin
+          ln -sf /usr/bin/grpc-health-probe ${{targets.subpkgdir}}/usr/local/bin/grpc_health_probe
+    dependencies:
+      runtime:
+        - grpc-health-probe
 
 update:
   enabled: true


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Puts the `openfga` compat package for its healthcheck in the right spot.

Related: https://github.com/chainguard-dev/image-requests/issues/5204
