### PR TITLE
feat(mlflow.yaml): Bump epoch to force rebuild to remediate two jinja2 CVEs

### DIFF
--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -1,7 +1,7 @@
 package:
   name: mlflow
   version: 2.19.0
-  epoch: 0
+  epoch: 1
   description: Open source platform for the machine learning lifecycle
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
GHSA-q2x7-8rv6-6q7h [1] and GHSA-gmj6-6f8f-6699 [2] are both present in the current version of mlflow due to the dependency on jinja2.

The jinja2 dependency is defined as `Jinja2<4,>=2.11` and as GHSA-q2x7-8rv6-6q7h and GHSA-gmj6-6f8f-6699 are both addressed in the
3.1.5 release on jinja2 - all that is required is a rebuild of mlflow which will update the jinja2 dependency from the
vulnerable 3.1.4 to the non vulnerable 3.1.5.

[1] https://github.com/advisories/GHSA-q2x7-8rv6-6q7h
[2] https://github.com/advisories/GHSA-gmj6-6f8f-6699
[3] https://github.com/mlflow/mlflow/blob/v2.19.0/pyproject.toml#L26

Signed-off-by: philroche <phil.roche@chainguard.dev>
