### PR TITLE
refactor jupyter-docker-stacks package

### DIFF
--- a/jupyter-docker-stacks.yaml
+++ b/jupyter-docker-stacks.yaml
@@ -1,8 +1,8 @@
 #nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: jupyter-docker-stacks
-  version: 7.3.2
-  epoch: 1
+  version: 0.0.0_git20250107
+  epoch: 2
   description: Ready-to-run images containing Jupyter applications
   copyright:
     - license: BSD-3-Clause
@@ -11,12 +11,10 @@ environment:
   contents:
     packages:
       - busybox
-      - py3.12-pip
 
 pipeline:
   - uses: git-checkout
     with:
-      # we want to package things from main branch on every release of jupyter/notebook
       repository: https://github.com/jupyter/docker-stacks
       branch: main
 
@@ -43,90 +41,25 @@ subpackages:
             stat /usr/local/bin/start.sh
             stat /usr/local/bin/run-hooks.sh
 
-  - name: ${{package.name}}-base-notebook
-    dependencies:
-      runtime:
-        - font-liberation
-        - python-3.12
-        - run-one
+  - name: jupyter-docker-notebook-oci-entrypoint
     pipeline:
       - working-directory: images/base-notebook
         pipeline:
           - runs: |
               mkdir -p ${{targets.contextdir}}/usr/local/bin
-              mkdir -p ${{targets.contextdir}}/home/jovyan/.jupyter
               # copy entrypoint scripts
               cp start-notebook.py start-singleuser.py start-notebook.sh start-singleuser.sh ${{targets.contextdir}}/usr/local/bin
-              # install jupyterlab, nbclassic and notebook
-              pip install jupyterlab --prefix=/usr --root=${{targets.contextdir}}
-              pip install nbclassic --prefix=/usr --root=${{targets.contextdir}}
-              pip install notebook --prefix=/usr --root=${{targets.contextdir}}
-              # https://github.com/jupyter/docker-stacks/blob/9ffeb238dc8e363b5bddd779442b4f32d06aff0d/images/base-notebook/Dockerfile#L50 (else browser is not detected)
-              pip install jupyterlab
-              jupyter server --generate-config
-              cp /home/build/.jupyter/jupyter_server_config.py ${{targets.contextdir}}/home/jovyan/.jupyter/jupyter_server_config.py
-              jupyter lab clean
     test:
-      environment:
-        contents:
-          packages:
-            - jq
-            - py3.12-pip
       pipeline:
         - runs: |
-            pip list | grep jupyterlab
-            pip list | grep nbclassic
-            pip list | grep notebook
-            jupyter --version
-            cat <<EOF > notebook.ipynb
-            {
-             "cells": [
-              {
-               "cell_type": "code",
-               "execution_count": 0,
-               "metadata":{},
-               "outputs": [],
-               "source": [
-                "import sys\n",
-                "print(sys.version_info)\n"
-               ]
-              }
-             ],
-             "metadata": {
-              "kernelspec": {
-               "display_name": "Python 3 (ipykernel)",
-               "language": "python",
-               "name": "python3"
-              },
-              "language_info": {
-               "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-               },
-               "file_extension": ".py",
-               "mimetype": "text/x-python",
-               "name": "python"
-              }
-             },
-             "nbformat": 4,
-             "nbformat_minor": 4
-            }
-            EOF
-            jupyter-execute --inplace notebook.ipynb
-            export PYVERSION=$(python -c 'import sys; print(sys.version_info)')
-            cat notebook.ipynb | jq '.cells [] .outputs [] .text []' | grep -F "$PYVERSION"
-        - name: Run and test jupyter server
-          uses: test/daemon-check-output
-          with:
-            start: jupyter server
-            timeout: 30
-            expected_output: |
-              extension was successfully linked
-              extension was successfully loaded
+            stat /usr/local/bin/start-notebook.py
+            stat /usr/local/bin/start-singleuser.py
+            stat /usr/local/bin/start-notebook.sh
+            stat /usr/local/bin/start-singleuser.sh
 
 update:
   enabled: true
-  github:
-    identifier: jupyter/notebook
-    strip-prefix: v
-    tag-filter: v
+  git: {}
+  schedule:
+    period: weekly
+    reason: Upstream does not maintain tags or releases

--- a/jupyter-docker-stacks.yaml
+++ b/jupyter-docker-stacks.yaml
@@ -41,7 +41,11 @@ subpackages:
             stat /usr/local/bin/start.sh
             stat /usr/local/bin/run-hooks.sh
 
-  - name: jupyter-docker-notebook-oci-entrypoint
+  - name: jupyter-base-notebook-oci-entrypoint
+    dependencies:
+      runtime:
+        - bash
+        - busybox
     pipeline:
       - working-directory: images/base-notebook
         pipeline:

--- a/jupyter-docker-stacks.yaml
+++ b/jupyter-docker-stacks.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-commit,valid-pipeline-git-checkout-tag
 package:
   name: jupyter-docker-stacks
-  version: 0.0.0_git20250107
+  version: 0.0.0_git20250108
   epoch: 2
   description: Ready-to-run images containing Jupyter applications
   copyright:


### PR DESCRIPTION
refactor jupyter-docker-stacks package

we splitted the pip install jupyter into a separate package called
jupyter-docker-notebook.

this package only contains scripts from jupyter/docker-stacks
repository.

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>