### PR TITLE
ca-certs: require approval from Foundations squad

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,4 @@ CODEOWNERS @wolfi-dev/wolfi-owners
 
 # These packages require approval from the Foundations squad.
 openssh.yaml @wolfi-dev/foundations-squad
+ca-certificates.yaml @wolfi-dev/foundations-squad


### PR DESCRIPTION
Without this, PRs to update this core package can be approved and auto-merged without human intervention, which is probably not what we want. For example, https://github.com/wolfi-dev/os/pull/38723