### PR TITLE
feat(emissary.yaml): Bump jinja2 version to remediate two jinja2 CVEs

### DIFF
--- a/emissary.yaml
+++ b/emissary.yaml
@@ -1,7 +1,7 @@
 package:
   name: emissary
   version: 3.9.1
-  epoch: 7
+  epoch: 8
   description: "open source Kubernetes-native API gateway for microservices built on the Envoy Proxy"
   copyright:
     - license: Apache-2.0
@@ -89,7 +89,7 @@ subpackages:
 
           # Bump the dependencies in the targetdir.
           python${{range.key}} -m pip install --no-cache-dir --prefix=/usr --root=${{targets.contextdir}} --upgrade \
-            Jinja2==3.1.4 \
+            Jinja2==3.1.5 \
             certifi==2024.07.04 \
             gunicorn==22.0.0 \
             idna==3.7 \


### PR DESCRIPTION
GHSA-q2x7-8rv6-6q7h [1] and GHSA-gmj6-6f8f-6699 [2] are both present in the current version of emissary sub package py3.13-ambassador due to the dependency on jinja2.

The jinja2 dependency was defined as `Jinja2==3.1.4` and as GHSA-q2x7-8rv6-6q7h and GHSA-gmj6-6f8f-6699 are both addressed in the
3.1.5 release on jinja2 - we need to bump that version to Jinja2==3.1.5

[1] https://github.com/advisories/GHSA-q2x7-8rv6-6q7h
[2] https://github.com/advisories/GHSA-gmj6-6f8f-6699

Signed-off-by: philroche <phil.roche@chainguard.dev>
