### PR TITLE
gcc-11: modernize based on gcc-12 packaging

### DIFF
--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -1,19 +1,18 @@
 package:
   name: gcc-11
   version: 11.5.0
-  epoch: 0
+  epoch: 1
   description: "the GNU compiler collection - version 11"
   copyright:
-    - license: GPL-3.0-or-later
+    - license: GPL-3.0-or-later WITH GCC-exception-3.1
   resources:
     cpu: 16
     memory: 16Gi
-  options:
-    no-provides: true
   dependencies:
     runtime:
       - binutils
       - libstdc++-11-dev
+      - openssf-compiler-options
       - posix-cc-wrappers
 
 environment:
@@ -31,32 +30,54 @@ environment:
       - make
       - mpc-dev
       - mpfr-dev
+      - openssf-compiler-options
       - texinfo
       - wolfi-baselayout
       - zip
       - zlib-dev
 
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+).*
+    replace: $1
+    to: major-version
+
 pipeline:
   - uses: fetch
     with:
       uri: https://ftp.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
-      expected-sha256: a6e21868ead545cf87f0c01f84276e4b5281d672098591c1c896241f09363478
+      expected-sha512: 88f17d5a5e69eeb53aaf0a9bc9daab1c4e501d145b388c5485ebeb2cc36178fbb2d3e49ebef4a8c007a05e88471a06b97cf9b08870478249f77fbfa3d4abd9a8
+
+  - name: Fix false invalid march extension crc on arm64
+    uses: patch
+    with:
+      patches: 1be715f31605976d8e4336973d3b81c5b7cea79f.patch
 
   - working-directory: /home/build/build
     pipeline:
       - name: 'Configure GCC'
         runs: |
-          # We use generic CFLAGS, because GCC 6 is older than the CFLAGS we normally use.
-          CFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
-          CXXFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
-          CPPFLAGS="-O2 -Wall -pipe -Wno-error=format-security"
-          export CFLAGS CXXFLAGS CPPFLAGS
-
+          # Check https://aws.amazon.com/ec2/instance-types/ and
+          # https://cloud.google.com/compute/docs/general-purpose-machines
+          # for most current CPU types on arm64 and x86 to set mtune to
+          # the current generation of CPUs. Other clouds are typically
+          # roughly at the same level (Azure, Oracle, IBM, Linode, etc).
+          case "${{build.arch}}" in
+            "aarch64")
+              march=armv8-a+crc+crypto
+              mtune=neoverse-v2
+              ;;
+            "x86_64")
+              march=x86-64-v2
+              mtune=sapphirerapids
+              ;;
+          esac
           ../configure \
             --prefix=/usr \
             --program-suffix="-11" \
             --disable-nls \
             --disable-werror \
+            --with-pkgversion='Wolfi ${{package.full-version}}' \
             --with-glibc-version=2.35 \
             --enable-initfini-array \
             --disable-nls \
@@ -70,11 +91,16 @@ pipeline:
             --enable-default-pie \
             --enable-default-ssp \
             --with-system-zlib \
+            --with-arch=$march \
+            --with-tune=$mtune \
             --enable-languages=c,c++ \
             --enable-bootstrap \
             --enable-gnu-indirect-function \
             --enable-gnu-unique-object \
+            --enable-cet=auto \
+            --enable-link-mutex \
             --enable-version-specific-runtime-libs \
+            --with-gcc-major-version-only \
             --with-linker-hash-style=gnu \
             --disable-libcc1
 
@@ -90,6 +116,20 @@ pipeline:
       rm -f "${{targets.destdir}}"/usr/lib/libffi* "${{targets.destdir}}"/usr/share/man/man3/ffi*
       find "${{targets.destdir}}" -name 'ffi*.h' | xargs rm -f
 
+  # For some reason libgcc_s.1 is installed into /lib64/ subdir, which
+  # is not in `gcc -print-search-dirs` libraries location, and thus
+  # link tests fail to find libgcc_s.so linker script. Compiled
+  # binaries at runtime use public libgcc.
+  - name: 'Fix libgcc_s.so location'
+    runs: |
+      cd "${{targets.destdir}}"/usr/lib/gcc/${{host.triplet.gnu}}
+      mv lib64/libgcc_s.* ${{vars.major-version}}/
+      rmdir lib64/
+
+  # Remove stray gcc-tmp (which used to be gcc-M.N.P)
+  - runs: |
+      rm ${{targets.destdir}}/usr/bin/${{host.triplet.gnu}}-gcc-tmp
+
   - name: 'Clean up documentation'
     runs: |
       rm -rf ${{targets.destdir}}/usr/share/info
@@ -104,7 +144,7 @@ subpackages:
   - name: 'libstdc++-11'
     pipeline:
       - runs: |
-          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
 
           mkdir -p "${{targets.subpkgdir}}"/$gcclibdir
           mv "${{targets.destdir}}"/$gcclibdir/*++.so.* "${{targets.subpkgdir}}"/$gcclibdir
@@ -112,18 +152,22 @@ subpackages:
       no-provides: true
 
   - name: 'libstdc++-11-dev'
+    dependencies:
+      runtime:
+        # cargo-culted from gcc-12.yaml
+        - libstdc++-11
     pipeline:
       - runs: |
-          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{package.version}}
+          gcclibdir=/usr/lib/gcc/${{host.triplet.gnu}}/${{vars.major-version}}
 
           mkdir -p "${{targets.subpkgdir}}"/$gcclibdir
           mkdir -p "${{targets.subpkgdir}}"/$gcclibdir/include
-          mkdir -p "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx
+          mkdir -p "${{targets.subpkgdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx
           mv "${{targets.destdir}}"/$gcclibdir/*++.a "${{targets.subpkgdir}}"/$gcclibdir/
           mv "${{targets.destdir}}"/$gcclibdir/libstdc++.so* "${{targets.subpkgdir}}"/$gcclibdir/
           mv "${{targets.destdir}}"/$gcclibdir/include/*++* "${{targets.subpkgdir}}"/$gcclibdir/include/
-          mv "${{targets.destdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/* \
-            "${{targets.subpkgdir}}"/usr/share/gcc-${{package.version}}/python/libstdcxx/
+          mv "${{targets.destdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/* \
+            "${{targets.subpkgdir}}"/usr/share/gcc-${{vars.major-version}}/python/libstdcxx/
 
   - name: 'gcc-11-default'
     description: 'Use GCC 11 as system gcc'
@@ -143,9 +187,100 @@ subpackages:
           for i in c++ g++ cpp gcc gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do
             ln -sf $i"-11" "${{targets.subpkgdir}}"/usr/bin/$i
           done
+    test:
+      pipeline:
+        - runs: |
+            c++ --version
+            c++ --help
+            cpp --version
+            cpp --help
+            g++ --version
+            g++ --help
+            gcc --version
+            gcc --help
+            gcc-ar --version
+            gcc-ar --help
+            gcc-nm --version
+            gcc-nm --help
+            gcc-ranlib --version
+            gcc-ranlib --help
+            gcov --version
+            gcov --help
+            gcov-dump --version
+            gcov-dump --help
+            gcov-tool --version
+            gcov-tool --help
+            lto-dump --version
+            lto-dump --help
 
-          mkdir -p "${{targets.subpkgdir}}"/usr/lib
-          ln -sf libgcc_s.so.1 "${{targets.subpkgdir}}"/usr/lib/libgcc_s.so
+test:
+  environment:
+    contents:
+      packages:
+        - glibc-dev
+  pipeline:
+    - name: Check basic usage of top level & libexec binaries
+      runs: |
+        # Check C frontend compiler
+        gcc-11 --version | grep ${{package.version}}
+        # Check C++ frontend compiler
+        g++-11 --version | grep ${{package.version}}
+        # Check C empty translation unit compilation
+        : > empty.c
+        gcc-11 -c empty.c
+
+        # Check C++ empty translation unit compilation
+        : > empty.cpp
+        g++-11 -c empty.cpp
+        c++-11 --version
+        c++-11 --help
+        cpp-11 --version
+        cpp-11 --help
+        g++-11 --help
+        gcc-11 --help
+        gcc-ar-11 --version
+        gcc-ar-11 --help
+        gcc-nm-11 --version
+        gcc-nm-11 --help
+        gcc-ranlib-11 --version
+        gcc-ranlib-11 --help
+        gcov-11 --version
+        gcov-11 --help
+        gcov-dump-11 --version
+        gcov-dump-11 --help
+        gcov-tool-11 --version
+        gcov-tool-11 --help
+        lto-dump-11 --version
+        lto-dump-11 --help
+    - name: hello world c
+      runs: |
+        cat >hello.c <<"EOF"
+        #include <stdio.h>
+        int main(int argc, char* argv[]) {
+            printf("hello-c");
+            return 0;
+        }
+        EOF
+
+        gcc-11 -o hello-c hello.c
+        out=$(./hello-c)
+        [ "$out" = "hello-c" ]
+    - name: hello world c++
+      runs: |
+        cat >hello.cpp <<"EOF"
+        #include <iostream>
+        int main() {
+            std::cout << "hello-c++";
+            return 0;
+        }
+        EOF
+
+        g++-11 -o hello-c++ hello.cpp
+        out=$(./hello-c++)
+        [ "$out" = "hello-c++" ]
+    - uses: test/compiler-hardening-check
+      with:
+        cc: gcc-11
 
 update:
   enabled: false

--- a/gcc-11/1be715f31605976d8e4336973d3b81c5b7cea79f.patch
+++ b/gcc-11/1be715f31605976d8e4336973d3b81c5b7cea79f.patch
@@ -1,0 +1,323 @@
+From 301f5d91c17b25c9b091587e8c551551f761bb52 Mon Sep 17 00:00:00 2001
+From: Wilco Dijkstra <wilco.dijkstra@arm.com>
+Date: Wed, 18 May 2022 16:02:12 +0100
+Subject: [PATCH] AArch64: Cleanup CPU option processing code
+
+The --with-cpu/--with-arch configure option processing not only checks valid
+arguments but also sets TARGET_CPU_DEFAULT with a CPU and extension bitmask.
+This isn't used however since a --with-cpu is translated into a -mcpu option
+which is processed as if written on the command-line (so TARGET_CPU_DEFAULT
+is never accessed).
+
+So remove all the complex processing and bitmask, and just validate the
+option. Fix a bug that always reports valid architecture extensions as invalid.
+As a result the CPU processing in aarch64.c can be simplified.
+
+gcc/
+	* config.gcc (aarch64*-*-*): Simplify --with-cpu and --with-arch
+	processing.  Add support for architectural extensions.
+	* config/aarch64/aarch64.h (TARGET_CPU_DEFAULT): Remove
+	AARCH64_CPU_DEFAULT_FLAGS.
+	(TARGET_CPU_NBITS): Remove.
+	(TARGET_CPU_MASK): Remove.
+	* config/aarch64/aarch64.cc (AARCH64_CPU_DEFAULT_FLAGS): Remove define.
+	(get_tune_cpu): Assert CPU is always valid.
+	(get_arch): Assert architecture is always valid.
+	(aarch64_override_options): Cleanup CPU selection code and simplify logic.
+	(aarch64_option_restore): Remove unnecessary checks on tune.
+
+[dannf: backported to gcc-11]
+---
+ gcc/config.gcc               |  43 +-------------
+ gcc/config/aarch64/aarch64.c | 111 ++++++++++-------------------------
+ gcc/config/aarch64/aarch64.h |   3 +-
+ 3 files changed, 32 insertions(+), 125 deletions(-)
+
+diff --git a/gcc/config.gcc b/gcc/config.gcc
+index 6e6ce881d89..9f31f170115 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -4208,8 +4208,6 @@ case "${target}" in
+ 			  pattern=AARCH64_CORE
+ 			fi
+ 
+-			ext_mask=AARCH64_CPU_DEFAULT_FLAGS
+-
+ 			# Find the base CPU or ARCH id in aarch64-cores.def or
+ 			# aarch64-arches.def
+ 			if [ x"$base_val" = x ] \
+@@ -4217,23 +4215,6 @@ case "${target}" in
+ 				    ${srcdir}/config/aarch64/$def \
+ 				    > /dev/null; then
+ 
+-			  if [ $which = arch ]; then
+-				base_id=`grep "^$pattern(\"$base_val\"," \
+-				  ${srcdir}/config/aarch64/$def | \
+-				  sed -e 's/^[^,]*,[ 	]*//' | \
+-				  sed -e 's/,.*$//'`
+-				# Extract the architecture flags from aarch64-arches.def
+-				ext_mask=`grep "^$pattern(\"$base_val\"," \
+-				   ${srcdir}/config/aarch64/$def | \
+-				   sed -e 's/)$//' | \
+-				   sed -e 's/^.*,//'`
+-			  else
+-				base_id=`grep "^$pattern(\"$base_val\"," \
+-				  ${srcdir}/config/aarch64/$def | \
+-				  sed -e 's/^[^,]*,[ 	]*//' | \
+-				  sed -e 's/,.*$//'`
+-			  fi
+-
+ 			  # Disallow extensions in --with-tune=cortex-a53+crc.
+ 			  if [ $which = tune ] && [ x"$ext_val" != x ]; then
+ 			    echo "Architecture extensions not supported in --with-$which=$val" 1>&2
+@@ -4264,25 +4245,7 @@ case "${target}" in
+ 					grep "^\"$base_ext\""`
+ 
+ 				if [ x"$base_ext" = x ] \
+-				    || [[ -n $opt_line ]]; then
+-
+-				  # These regexp extract the elements based on
+-				  # their group match index in the regexp.
+-				  ext_canon=`echo -e "$opt_line" | \
+-					sed -e "s/$sed_patt/\2/"`
+-				  ext_on=`echo -e "$opt_line" | \
+-					sed -e "s/$sed_patt/\3/"`
+-				  ext_off=`echo -e "$opt_line" | \
+-					sed -e "s/$sed_patt/\4/"`
+-
+-				  if [ $ext = $base_ext ]; then
+-					# Adding extension
+-					ext_mask="("$ext_mask") | ("$ext_on" | "$ext_canon")"
+-				  else
+-					# Removing extension
+-					ext_mask="("$ext_mask") & ~("$ext_off" | "$ext_canon")"
+-				  fi
+-
++				    || [ x"$opt_line" != x ]; then
+ 				  true
+ 				else
+ 				  echo "Unknown extension used in --with-$which=$val" 1>&2
+@@ -4291,10 +4254,6 @@ case "${target}" in
+ 				ext_val=`echo $ext_val | sed -e 's/[a-z0-9]\+//'`
+ 			  done
+ 
+-			  ext_mask="(("$ext_mask") << 6)"
+-			  if [ x"$base_id" != x ]; then
+-				target_cpu_cname="TARGET_CPU_$base_id | $ext_mask"
+-			  fi
+ 			  true
+ 			else
+ 			  # Allow --with-$which=native.
+diff --git a/gcc/config/aarch64/aarch64.c b/gcc/config/aarch64/aarch64.c
+index 9ec09d94100..aa6dd2e0b4c 100644
+--- a/gcc/config/aarch64/aarch64.c
++++ b/gcc/config/aarch64/aarch64.c
+@@ -2245,8 +2245,6 @@ static const struct attribute_spec aarch64_attribute_table[] =
+   { NULL,                 0, 0, false, false, false, false, NULL, NULL }
+ };
+ 
+-#define AARCH64_CPU_DEFAULT_FLAGS ((selected_cpu) ? selected_cpu->flags : 0)
+-
+ /* An ISA extension in the co-processor and main instruction set space.  */
+ struct aarch64_option_extension
+ {
+@@ -17155,35 +17153,24 @@ aarch64_validate_mtune (const char *str, const struct processor **res)
+   return false;
+ }
+ 
+-/* Return the CPU corresponding to the enum CPU.
+-   If it doesn't specify a cpu, return the default.  */
++/* Return the CPU corresponding to the enum CPU.  */
+ 
+ static const struct processor *
+ aarch64_get_tune_cpu (enum aarch64_processor cpu)
+ {
+-  if (cpu != aarch64_none)
+-    return &all_cores[cpu];
++  gcc_assert (cpu != aarch64_none);
+ 
+-  /* The & 0x3f is to extract the bottom 6 bits that encode the
+-     default cpu as selected by the --with-cpu GCC configure option
+-     in config.gcc.
+-     ???: The whole TARGET_CPU_DEFAULT and AARCH64_CPU_DEFAULT_FLAGS
+-     flags mechanism should be reworked to make it more sane.  */
+-  return &all_cores[TARGET_CPU_DEFAULT & 0x3f];
++  return &all_cores[cpu];
+ }
+ 
+-/* Return the architecture corresponding to the enum ARCH.
+-   If it doesn't specify a valid architecture, return the default.  */
++/* Return the architecture corresponding to the enum ARCH.  */
+ 
+ static const struct processor *
+ aarch64_get_arch (enum aarch64_arch arch)
+ {
+-  if (arch != aarch64_no_arch)
+-    return &all_architectures[arch];
+-
+-  const struct processor *cpu = &all_cores[TARGET_CPU_DEFAULT & 0x3f];
++  gcc_assert (arch != aarch64_no_arch);
+ 
+-  return &all_architectures[cpu->arch];
++  return &all_architectures[arch];
+ }
+ 
+ /* Return the VG value associated with -msve-vector-bits= value VALUE.  */
+@@ -17221,10 +17208,6 @@ aarch64_override_options (void)
+   uint64_t arch_isa = 0;
+   aarch64_isa_flags = 0;
+ 
+-  bool valid_cpu = true;
+-  bool valid_tune = true;
+-  bool valid_arch = true;
+-
+   selected_cpu = NULL;
+   selected_arch = NULL;
+   selected_tune = NULL;
+@@ -17239,77 +17222,56 @@ aarch64_override_options (void)
+      If either of -march or -mtune is given, they override their
+      respective component of -mcpu.  */
+   if (aarch64_cpu_string)
+-    valid_cpu = aarch64_validate_mcpu (aarch64_cpu_string, &selected_cpu,
+-					&cpu_isa);
++    aarch64_validate_mcpu (aarch64_cpu_string, &selected_cpu, &cpu_isa);
+ 
+   if (aarch64_arch_string)
+-    valid_arch = aarch64_validate_march (aarch64_arch_string, &selected_arch,
+-					  &arch_isa);
++    aarch64_validate_march (aarch64_arch_string, &selected_arch, &arch_isa);
+ 
+   if (aarch64_tune_string)
+-    valid_tune = aarch64_validate_mtune (aarch64_tune_string, &selected_tune);
++    aarch64_validate_mtune (aarch64_tune_string, &selected_tune);
+ 
+ #ifdef SUBTARGET_OVERRIDE_OPTIONS
+   SUBTARGET_OVERRIDE_OPTIONS;
+ #endif
+ 
+-  /* If the user did not specify a processor, choose the default
+-     one for them.  This will be the CPU set during configuration using
+-     --with-cpu, otherwise it is "generic".  */
+-  if (!selected_cpu)
+-    {
+-      if (selected_arch)
+-	{
+-	  selected_cpu = &all_cores[selected_arch->ident];
+-	  aarch64_isa_flags = arch_isa;
+-	  explicit_arch = selected_arch->arch;
+-	}
+-      else
+-	{
+-	  /* Get default configure-time CPU.  */
+-	  selected_cpu = aarch64_get_tune_cpu (aarch64_none);
+-	  aarch64_isa_flags = TARGET_CPU_DEFAULT >> 6;
+-	}
+-
+-      if (selected_tune)
+-	explicit_tune_core = selected_tune->ident;
+-    }
+-  /* If both -mcpu and -march are specified check that they are architecturally
+-     compatible, warn if they're not and prefer the -march ISA flags.  */
+-  else if (selected_arch)
++  if (selected_cpu && selected_arch)
+     {
++      /* If both -mcpu and -march are specified, warn if they are not
++	 architecturally compatible and prefer the -march ISA flags.  */
+       if (selected_arch->arch != selected_cpu->arch)
+ 	{
+ 	  warning (0, "switch %<-mcpu=%s%> conflicts with %<-march=%s%> switch",
+ 		       aarch64_cpu_string,
+ 		       aarch64_arch_string);
+ 	}
++
+       aarch64_isa_flags = arch_isa;
+-      explicit_arch = selected_arch->arch;
+-      explicit_tune_core = selected_tune ? selected_tune->ident
+-					  : selected_cpu->ident;
+     }
+-  else
++  else if (selected_cpu)
+     {
+-      /* -mcpu but no -march.  */
+-      aarch64_isa_flags = cpu_isa;
+-      explicit_tune_core = selected_tune ? selected_tune->ident
+-					  : selected_cpu->ident;
+-      gcc_assert (selected_cpu);
+       selected_arch = &all_architectures[selected_cpu->arch];
+-      explicit_arch = selected_arch->arch;
++      aarch64_isa_flags = cpu_isa;
+     }
+-
+-  /* Set the arch as well as we will need it when outputing
+-     the .arch directive in assembly.  */
+-  if (!selected_arch)
++  else if (selected_arch)
++    {
++      selected_cpu = &all_cores[selected_arch->ident];
++      aarch64_isa_flags = arch_isa;
++    }
++  else
+     {
+-      gcc_assert (selected_cpu);
++      /* No -mcpu or -march specified, so use the default CPU.  */
++      selected_cpu = &all_cores[TARGET_CPU_DEFAULT];
+       selected_arch = &all_architectures[selected_cpu->arch];
++      aarch64_isa_flags = selected_cpu->flags;
+     }
+ 
++  explicit_arch = selected_arch->arch;
+   if (!selected_tune)
+     selected_tune = selected_cpu;
++  explicit_tune_core = selected_tune->ident;
++
++  gcc_assert (explicit_tune_core != aarch64_none);
++  gcc_assert (explicit_arch != aarch64_no_arch);
+ 
+   if (aarch64_enable_bti == 2)
+     {
+@@ -17345,15 +17307,6 @@ aarch64_override_options (void)
+   if (aarch64_ra_sign_scope != AARCH64_FUNCTION_NONE && TARGET_ILP32)
+     sorry ("return address signing is only supported for %<-mabi=lp64%>");
+ 
+-  /* Make sure we properly set up the explicit options.  */
+-  if ((aarch64_cpu_string && valid_cpu)
+-       || (aarch64_tune_string && valid_tune))
+-    gcc_assert (explicit_tune_core != aarch64_none);
+-
+-  if ((aarch64_cpu_string && valid_cpu)
+-       || (aarch64_arch_string && valid_arch))
+-    gcc_assert (explicit_arch != aarch64_no_arch);
+-
+   /* The pass to insert speculation tracking runs before
+      shrink-wrapping and the latter does not know how to update the
+      tracking status.  So disable it in this case.  */
+@@ -17459,11 +17412,7 @@ aarch64_option_restore (struct gcc_options *opts,
+   opts->x_explicit_arch = ptr->x_explicit_arch;
+   selected_arch = aarch64_get_arch (ptr->x_explicit_arch);
+   opts->x_explicit_tune_core = ptr->x_explicit_tune_core;
+-  if (opts->x_explicit_tune_core == aarch64_none
+-      && opts->x_explicit_arch != aarch64_no_arch)
+-    selected_tune = &all_cores[selected_arch->ident];
+-  else
+-    selected_tune = aarch64_get_tune_cpu (ptr->x_explicit_tune_core);
++  selected_tune = aarch64_get_tune_cpu (ptr->x_explicit_tune_core);
+   opts->x_aarch64_override_tune_string = ptr->x_aarch64_override_tune_string;
+   opts->x_aarch64_branch_protection_string
+     = ptr->x_aarch64_branch_protection_string;
+diff --git a/gcc/config/aarch64/aarch64.h b/gcc/config/aarch64/aarch64.h
+index 9084b1cfb9d..ca5f13c0ee6 100644
+--- a/gcc/config/aarch64/aarch64.h
++++ b/gcc/config/aarch64/aarch64.h
+@@ -785,8 +785,7 @@ enum target_cpus
+ 
+ /* If there is no CPU defined at configure, use generic as default.  */
+ #ifndef TARGET_CPU_DEFAULT
+-#define TARGET_CPU_DEFAULT \
+-  (TARGET_CPU_generic | (AARCH64_CPU_DEFAULT_FLAGS << 6))
++# define TARGET_CPU_DEFAULT TARGET_CPU_generic
+ #endif
+ 
+ /* If inserting NOP before a mult-accumulate insn remember to adjust the
+-- 
+2.45.2
+

--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,11 +1,15 @@
 package:
   name: openssf-compiler-options
   version: 20240627
-  epoch: 7
+  epoch: 8
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:
     - license: CC-BY-4.0
+
+vars:
+  clang-major-versions: 15 16 17 18 19
+  gcc-major-versions: 11 12 13 14
 
 environment:
   contents:
@@ -17,19 +21,19 @@ pipeline:
     runs: |
       mkdir -p "${{targets.destdir}}"
       cp -r etc usr "${{targets.destdir}}"
-      for i in 15 16 17 18 19; do
+      for i in ${{vars.clang-major-versions}}; do
         ln -s clang "${{targets.destdir}}"/etc/clang-$i
       done
       cd ${{targets.destdir}}/usr/local/bin
       ln -s gcc-wrapper cc
       ln -s gcc-wrapper cpp
-      for suffix in 11 12 13 14; do
+      for suffix in ${{vars.gcc-major-versions}}; do
         ln -s gcc-wrapper cpp-$suffix
       done
       for app in c++ g++ gcc; do
         ln -s gcc-wrapper $app
         ln -s gcc-wrapper ${{host.triplet.gnu}}-$app
-        for suffix in 12 13 14; do
+        for suffix in ${{vars.gcc-major-versions}}; do
           ln -s gcc-wrapper $app-$suffix
           ln -s gcc-wrapper ${{host.triplet.gnu}}-$app-$suffix
         done

--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -23,7 +23,7 @@ pipeline:
       cd ${{targets.destdir}}/usr/local/bin
       ln -s gcc-wrapper cc
       ln -s gcc-wrapper cpp
-      for suffix in 12 13 14; do
+      for suffix in 11 12 13 14; do
         ln -s gcc-wrapper cpp-$suffix
       done
       for app in c++ g++ gcc; do
@@ -41,6 +41,7 @@ test:
       packages:
         - clang-18
         - gcc
+        - gcc-11
         - gcc-12
   pipeline:
     - uses: test/compiler-hardening-check
@@ -49,6 +50,9 @@ test:
     - uses: test/compiler-hardening-check
       with:
         cc: gcc
+    - uses: test/compiler-hardening-check
+      with:
+        cc: gcc-11
     - uses: test/compiler-hardening-check
       with:
         cc: gcc-12

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/11/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/11/openssf.spec
@@ -1,0 +1,2 @@
+*self_spec:
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -Wl,--as-needed,-O1,--sort-common -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fno-delete-null-pointer-checks -fno-strict-overflow -fno-strict-aliasing -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -mbranch-protection=standard -fstack-clash-protection -fstack-protector-strong

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/11/openssf.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/11/openssf.spec
@@ -1,0 +1,2 @@
+*self_spec:
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -Wl,--as-needed,-O1,--sort-common -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fno-delete-null-pointer-checks -fno-strict-overflow -fno-strict-aliasing -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -fcf-protection=full -fstack-clash-protection -fstack-protector-strong


### PR DESCRIPTION
```bash
dann-frazier@dann-frazier-laptop:~/git/os$ cp gcc-11.yaml /tmp
dann-frazier@dann-frazier-laptop:~/git/os$ cp gcc-12.yaml /tmp
dann-frazier@dann-frazier-laptop:~/git/os$ sed -i 's/11/XX/' /tmp/gcc-11.yaml 
dann-frazier@dann-frazier-laptop:~/git/os$ sed -i 's/12/XX/' /tmp/gcc-12.yaml 
dann-frazier@dann-frazier-laptop:~/git/os$ diff -u /tmp/gcc-11.yaml /tmp/gcc-12.yaml 
```
```diff
--- /tmp/gcc-11.yaml	2025-01-07 12:17:50.785632866 -0700
+++ /tmp/gcc-12.yaml	2025-01-07 12:17:55.874625149 -0700
@@ -1,7 +1,7 @@
 package:
   name: gcc-XX
-  version: XX.5.0
-  epoch: 1
+  version: XX.4.0
+  epoch: 7
   description: "the GNU compiler collection - version XX"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -24,13 +24,13 @@
       - ca-certificates-bundle
       - flex-dev
       - gawk
-      - gcc-12-default
       - gmp-dev
       - isl-dev
       - make
       - mpc-dev
       - mpfr-dev
       - openssf-compiler-options
+      - patch
       - texinfo
       - wolfi-baselayout
       - zip
@@ -46,7 +46,7 @@
   - uses: fetch
     with:
       uri: https://ftp.gnu.org/gnu/gcc/gcc-${{package.version}}/gcc-${{package.version}}.tar.xz
-      expected-sha512: 88f17d5a5e69eeb53aaf0a9bc9daab1c4e501d145b388c5485ebeb2cc36178fbb2d3e49ebef4a8c007a05e88471a06b97cf9b08870478249f77fbfa3d4abd9a8
+      expected-sha5XX: 5bd29402cad2deb5d9388d0236c7146414d77e5b8d5f1c6c941c7a1f47691c3389f08656d5f6e8e2d6717bf2c81f018d326f632fb468f42925b40bd217fc4853
 
   - name: Fix false invalid march extension crc on arm64
     uses: patch
@@ -154,7 +154,10 @@
   - name: 'libstdc++-XX-dev'
     dependencies:
       runtime:
-        # cargo-culted from gcc-12.yaml
+        # libstdc++-XX-dev is no longer compatible at link time with
+        # libstdc++ 13, despite being runtime compatible Ensure any
+        # users of libstdc++-XX-dev have access to link against
+        # libstsdc++-XX
         - libstdc++-XX
     pipeline:
       - runs: |
@@ -173,7 +176,7 @@
     description: 'Use GCC XX as system gcc'
     dependencies:
       provides:
-        - gcc=${{package.version}}
+        - gcc=XX.3.1
       runtime:
         - gcc-XX
     pipeline:
```