### PR TITLE
pipelines: test: ldd-check: Fix pass/fail/total counts

### DIFF
--- a/pipelines/test/ldd-check.yaml
+++ b/pipelines/test/ldd-check.yaml
@@ -61,22 +61,29 @@ pipeline:
         [ -z "$missing" ] && { pass "$f"; continue; }
         fail "$f: missing ${missing# }"
       }
+
+      test_files_in() {
+        echo "[ldd-check] Testing binaries in package $pkg"
+        apk info -eq "$pkg" > /dev/null || \
+          { fail "Package $pkg is not installed"; continue; }
+        apk info -Lq "$pkg" > "$tmpd/$pkg.list"
+        while read f; do
+          echo "file: $f"
+          [ -n "$f" ] || continue
+          f="/$f"
+          [ -f "$f" ] || continue
+          ldd "$f" > /dev/null 2>&1 || continue
+          test_file "$f"
+        done < "$tmpd/$pkg.list"
+      }
+
       set -- $files
       for f in "$@"; do
         test_file "$f"
       done
       set -- $packages
       for pkg in "$@"; do
-        echo "[ldd-check] Testing binaries in package $pkg"
-        apk info -eq "$pkg" > /dev/null || \
-          { fail "Package $pkg is not installed"; continue; }
-        apk info -Lq "$pkg" | while read f; do
-          [ -n "$f" ] || continue
-          f="/$f"
-          [ -f "$f" ] || continue
-          ldd "$f" > /dev/null 2>&1 || continue
-          test_file "$f"
-        done
+        test_files_in "$pkg"
       done
       echo "tested $((passes+fails)) files with ldd. $passes passes. $fails fails."
       exit $fails


### PR DESCRIPTION
Piping to `while` was creating a subshell that placed the counter variables out of scope, so they always reported 0 for packages.
