### PR TITLE
remove unnecessary .pem files under examples folder

### DIFF
--- a/erlang-26.yaml
+++ b/erlang-26.yaml
@@ -1,7 +1,7 @@
 package:
   name: erlang-26
   version: 26.2.5.6
-  epoch: 0
+  epoch: 1
   description: General-purpose programming language and runtime environment
   copyright:
     - license: Apache-2.0
@@ -52,6 +52,10 @@ pipeline:
   - uses: autoconf/make
 
   - uses: autoconf/make-install
+
+  - runs: |
+      # Remove examples and test certificates to avoid false positives in security scans
+      find "${{targets.contextdir}}"/usr/lib/erlang -path "*/examples/*" -name "*.pem" -type f -exec rm -rf {} +
 
   - uses: strip
 


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: This PR helps erlang to avoid having unnecessary *.pem files that cause false-positives during image scanning process.

Related:

### Pre-review Checklist

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)
