### PR TITLE
add localstack

### DIFF
--- a/localstack.yaml
+++ b/localstack.yaml
@@ -31,8 +31,8 @@ environment:
       - nodejs-18
       - npm
       - openssf-compiler-options
-      - py${{vars.py-version}}-pip
       - py${{vars.py-version}}-build
+      - py${{vars.py-version}}-pip
       - py${{vars.py-version}}-pytest
       - py${{vars.py-version}}-tz
       - python-${{vars.py-version}}

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -32,10 +32,12 @@ environment:
       - npm
       - openssf-compiler-options
       - py${{vars.py-version}}-pip
+      - py${{vars.py-version}}-build
       - py${{vars.py-version}}-pytest
       - py${{vars.py-version}}-tz
       - python-${{vars.py-version}}
       - tzdata
+      - uv
 
 pipeline:
   - uses: git-checkout
@@ -46,19 +48,18 @@ pipeline:
 
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/share/localstack
-      mkdir -p ${{targets.destdir}}/usr/share/localstack-core
       mkdir -p ${{targets.destdir}}/tmp/localstack
 
   - name: Build
     runs: |
-      make VENV_BIN="python%{{vars.py-version}} -m venv"
-      make install-runtime
-      make dist
+      python${{vars.py-version}} -m build
 
   - runs: |
+      # We use uv here as pip backtracks in resolution
+      uv venv -p python${{vars.py-version}} --seed
+      # Install the wheel from file with the runtime extras
+      uv pip install ./dist/localstack_core-${{package.version}}-py3-none-any.whl[runtime]
       mv .venv ${{targets.destdir}}/usr/share/localstack/
-      cp -avR localstack-core/* ${{targets.destdir}}/usr/share/localstack-core/
-      install -Dm644 pyproject.toml ${{targets.destdir}}/usr/share/localstack/pyproject.toml
 
   - runs: |
       # Fix venv paths
@@ -103,8 +104,6 @@ subpackages:
           for f in localstack localstack-supervisor localstack.bat; do
             ln -sf /usr/bin/$f "${{targets.contextdir}}"/opt/code/localstack/bin/$f
           done
-          ln -sf /usr/share/localstack-core "${{targets.contextdir}}"/opt/code/localstack/localstack-core
-          ln -sf /usr/share/localstack/pyproject.toml "${{targets.contextdir}}"/opt/code/localstack/pyproject.toml
       - name: Symlink Java 11
         runs: |
           mkdir -p "${{targets.contextdir}}"/var/lib/localstack/lib/java/11

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -1,0 +1,133 @@
+package:
+  name: localstack
+  version: 4.0.3
+  epoch: 0
+  description: A fully functional local AWS cloud stack. Develop and test your cloud & Serverless apps offline
+  copyright:
+    - license: Apache-2.0
+    - license: LicenseRef-LICENSE
+      license-path: LICENSE.txt
+    - license: LicenseRef-EULA
+      license-path: docs/end_user_license_agreement/README.md
+  dependencies:
+    runtime:
+      - corepack
+      - nodejs-18
+      - npm
+      - openjdk-11-default-jvm
+
+vars:
+  py-version: 3.11
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - git
+      - nodejs-18
+      - npm
+      - openssf-compiler-options
+      - py${{vars.py-version}}-pip
+      - py3-supported-pytest
+      - py3-supported-tz
+      - python-${{vars.py-version}}
+      - tzdata
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/localstack/localstack
+      tag: v${{package.version}}
+      expected-commit: aa795ed1c04a8285c01c96aa7ab79c17489f5766
+
+  - runs: |
+      mkdir -p ${{targets.destdir}}/usr/share/localstack
+      mkdir -p ${{targets.destdir}}/usr/share/localstack-core
+      mkdir -p ${{targets.destdir}}/tmp/localstack
+
+  - name: Build
+    runs: |
+      make install-runtime
+      make dist
+
+  - runs: |
+      mv .venv ${{targets.destdir}}/usr/share/localstack/
+      cp -avR localstack-core/* ${{targets.destdir}}/usr/share/localstack-core/
+      install -Dm644 pyproject.toml ${{targets.destdir}}/usr/share/localstack/pyproject.toml
+
+  - runs: |
+      # Fix venv paths
+      find ${{targets.destdir}}/usr/share/${{package.name}}/.venv/bin/ -type f | xargs sed -i "s|/home/build|/usr/share|g"
+      # Include system site-packages
+      sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/${{package.name}}/.venv/pyvenv.cfg
+
+  # pip3 install --upgrade awscli awscli-local requests
+  - name: Cleanup
+    runs: |
+      find ${{targets.destdir}}/usr/share/${{package.name}}/.venv -name "*.pyc" -delete
+      find ${{targets.destdir}}/usr/share/${{package.name}}/.venv -name "__pycache__" -exec rm -rf {} +
+      find ${{targets.destdir}}/usr/share/${{package.name}}/.venv/lib/python${{vars.py-version}}/site-packages/ -type d -name "tests" -exec rm -rf {} +
+
+  - name: Install scripts
+    working-directory: bin
+    runs: |
+      mkdir -p "${{targets.contextdir}}"/usr/bin
+      for f in docker-entrypoint.sh docker-helper.sh localstack localstack-supervisor localstack.bat; do
+        install -Dm755 $f ${{targets.contextdir}}/usr/bin/$f
+      done
+
+  - name: Mark community version
+    runs: |
+      mkdir -p "${{targets.contextdir}}"/usr/lib/localstack
+      echo "${{package.version}} (Built by Chainguard)" > ${{targets.contextdir}}/usr/lib/localstack/.community-version
+
+subpackages:
+  - name: "${{package.name}}-compat"
+    description: "Compatibility package to place binaries in the location expected by upstream Dockerfile"
+    pipeline:
+      - name: Symlink scripts
+        runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/local/bin
+          for f in docker-entrypoint.sh docker-helper.sh localstack localstack-supervisor localstack.bat; do
+            ln -sf /usr/bin/$f "${{targets.contextdir}}"/usr/local/bin/$f
+          done
+      - name: Symlink binaries and libraries
+        runs: |
+          mkdir -p "${{targets.contextdir}}"/opt/code/localstack/bin
+          ln -sf /usr/share/localstack/.venv "${{targets.contextdir}}"/opt/code/localstack/.venv
+          for f in localstack localstack-supervisor localstack.bat; do
+            ln -sf /usr/bin/$f "${{targets.contextdir}}"/opt/code/localstack/bin/$f
+          done
+          ln -sf /usr/share/localstack-core "${{targets.contextdir}}"/opt/code/localstack/localstack-core
+          ln -sf /usr/share/localstack/pyproject.toml "${{targets.contextdir}}"/opt/code/localstack/pyproject.toml
+      - name: Symlink Java 11
+        runs: |
+          mkdir -p "${{targets.contextdir}}"/var/lib/localstack/lib/java/11
+          for f in bin conf legal lib release; do
+            ln -sf /usr/lib/jvm/java-11-openjdk/$f "${{targets.contextdir}}"/var/lib/localstack/lib/java/11/$f
+          done
+      - name: Symlink Python ${{vars.py-version}}
+        runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/local/lib
+          ln -sf /usr/lib/python${{vars.py-version}} "${{targets.contextdir}}"/usr/local/lib/python${{vars.py-version}}
+      - name: Symlink Node
+        runs: |
+          ln -sf /usr/bin/node "${{targets.contextdir}}"/usr/local/bin/node
+          ln -sf /usr/bin/node "${{targets.contextdir}}"/usr/local/bin/nodejs
+          ln -sf /usr/bin/npm "${{targets.contextdir}}"/usr/local/bin/npm
+          ln -sf /usr/bin/npx "${{targets.contextdir}}"/usr/local/bin/npx
+          ln -sf /usr/bin/corepack "${{targets.contextdir}}"/usr/local/bin/corepack
+          mkdir -p "${{targets.contextdir}}"/usr/local/include
+          mkdir -p "${{targets.contextdir}}"/usr/local/lib/node_modules
+          ln -sf /usr/include/node "${{targets.contextdir}}"/usr/local/include/node
+          ln -sf /usr/lib/node_modules/npm "${{targets.contextdir}}"/usr/local/lib/node_modules/npm
+          ln -sf /usr/share/node_modules/corepack "${{targets.contextdir}}"/usr/local/lib/node_modules/corepack
+
+update:
+  enabled: true
+  github:
+    identifier: localstack/localstack
+    strip-prefix: v

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -11,11 +11,30 @@ package:
       license-path: docs/end_user_license_agreement/README.md
   dependencies:
     runtime:
+      - binutils
+      - ca-certificates-bundle
       - corepack
+      - coreutils
+      - curl
+      - git
+      - gnupg
+      - gnutar
+      - groff
+      - iproute2
+      - iputils
+      - libatomic
+      - libexpat1
+      # pixz
+      - make
       - nodejs #-18
       - npm
+      - nss-passwords
       - openjdk-11-default-jvm
-      - python-${{vars.py-version}}
+      - openssl
+      - procps
+      - unzip
+      - xz
+      - zip
 
 vars:
   py-version: 3.11
@@ -53,6 +72,7 @@ pipeline:
   - name: Build
     runs: |
       python${{vars.py-version}} -m build
+      make install-runtime
 
   - runs: |
       # We use uv here as pip backtracks in resolution
@@ -63,11 +83,14 @@ pipeline:
 
   - runs: |
       # Fix venv paths
-      find ${{targets.destdir}}/usr/share/${{package.name}}/.venv/bin/ -type f | xargs sed -i "s|/home/build|/usr/share|g"
+      find ${{targets.destdir}}/usr/share/${{package.name}}/.venv/bin/ -type f | xargs sed -i "s|/home/build|/usr/share/${{package.name}}|g"
       # Include system site-packages
       sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/usr/share/${{package.name}}/.venv/pyvenv.cfg
 
-  # pip3 install --upgrade awscli awscli-local requests
+  # - name: Install dependencies
+  #   runs: |
+  #     ${{targets.destdir}}/usr/share/localstack/.venv/bin/python3 -m pip install --upgrade awscli awscli-local requests
+
   - name: Cleanup
     runs: |
       find ${{targets.destdir}}/usr/share/${{package.name}}/.venv -name "*.pyc" -delete
@@ -139,6 +162,10 @@ test:
       packages:
         - localstack-compat
   pipeline:
-    - runs: |
+    - name: Check if Python venv properly installed
+      runs: |
         source /opt/code/localstack/.venv/bin/activate
         python3 -m localstack.runtime.init BOOT
+    - name: Test entrypoint
+      runs: |
+        DEBUG=1 docker-entrypoint.sh

--- a/localstack.yaml
+++ b/localstack.yaml
@@ -12,9 +12,10 @@ package:
   dependencies:
     runtime:
       - corepack
-      - nodejs-18
+      - nodejs #-18
       - npm
       - openjdk-11-default-jvm
+      - python-${{vars.py-version}}
 
 vars:
   py-version: 3.11
@@ -31,8 +32,8 @@ environment:
       - npm
       - openssf-compiler-options
       - py${{vars.py-version}}-pip
-      - py3-supported-pytest
-      - py3-supported-tz
+      - py${{vars.py-version}}-pytest
+      - py${{vars.py-version}}-tz
       - python-${{vars.py-version}}
       - tzdata
 
@@ -50,6 +51,7 @@ pipeline:
 
   - name: Build
     runs: |
+      make VENV_BIN="python%{{vars.py-version}} -m venv"
       make install-runtime
       make dist
 
@@ -131,3 +133,13 @@ update:
   github:
     identifier: localstack/localstack
     strip-prefix: v
+
+test:
+  environment:
+    contents:
+      packages:
+        - localstack-compat
+  pipeline:
+    - runs: |
+        source /opt/code/localstack/.venv/bin/activate
+        python3 -m localstack.runtime.init BOOT


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [X] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [X] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
