### PR TITLE
openfga: add openfga-compat subpackage

### DIFF
--- a/openfga.yaml
+++ b/openfga.yaml
@@ -60,7 +60,7 @@ test:
       packages:
         - ${{package.name}}-compat
         - curl
-        - go-1.23
+        - go
         - jq
     environment:
       STORES_URL: localhost:8080/stores

--- a/openfga.yaml
+++ b/openfga.yaml
@@ -23,8 +23,6 @@ pipeline:
       output: openfga
       packages: ./cmd/openfga
 
-  - uses: strip
-
 subpackages:
   - name: ${{package.name}}-compat
     pipeline:

--- a/openfga.yaml
+++ b/openfga.yaml
@@ -1,7 +1,7 @@
 package:
   name: openfga
   version: 1.8.3
-  epoch: 2
+  epoch: 3
   description: A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar
   copyright:
     - license: Apache-2.0
@@ -19,12 +19,21 @@ pipeline:
         -X github.com/openfga/openfga/internal/build.Version=v${{package.version}}
         -X github.com/openfga/openfga/internal/build.Commit=$(git rev-parse HEAD)
         -X github.com/openfga/openfga/internal/build.Date=$(TZ="UTC" date +"%Y-%m-%dT%TZ")
+        -X github.com/openfga/openfga/internal/build.ProjectName=${{package.name}}
       output: openfga
       packages: ./cmd/openfga
 
   - uses: strip
 
 subpackages:
+  - name: ${{package.name}}-compat
+    pipeline:
+      - runs: |
+          ln -sf /usr/bin/openfga ${{targets.subpkgdir}}/openfga
+    test:
+      pipeline:
+        - runs: stat /openfga
+
   - name: ${{package.name}}-healthcheck-compat
     pipeline:
       - runs: |
@@ -49,6 +58,7 @@ test:
   environment:
     contents:
       packages:
+        - ${{package.name}}-compat
         - curl
         - go-1.23
         - jq
@@ -61,7 +71,7 @@ test:
     - name: Test server startup and hitting some endpoints
       uses: test/daemon-check-output
       with:
-        start: openfga run
+        start: /openfga run
         expected_output: |
           starting openfga service...
           starting prometheus metrics server
@@ -92,7 +102,7 @@ test:
     - name: Test profiler
       uses: test/daemon-check-output
       with:
-        start: openfga run --profiler-enabled --playground-enabled=false
+        start: /openfga run --profiler-enabled --playground-enabled=false
         expected_output: |
           starting openfga service...
           starting pprof profiler


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes: missed the need for this, but the `openfga` image expects the executable in `/`: https://github.com/openfga/openfga/blob/main/Dockerfile#L31

Related: https://github.com/chainguard-dev/image-requests/issues/5204
