### PR TITLE
k8s-device-plugin: Restore non-problematic openssf-compiler-options

### DIFF
--- a/k8s-device-plugin.yaml
+++ b/k8s-device-plugin.yaml
@@ -1,7 +1,7 @@
 package:
   name: k8s-device-plugin
   version: 0.17.0
-  epoch: 2
+  epoch: 3
   description: meta package providing all NVIDIA device plugins for Kubernetes
   copyright:
     - license: Apache-2.0
@@ -20,7 +20,7 @@ environment:
       - go
   environment:
     # See https://github.com/wolfi-dev/os/issues/34568
-    GCC_SPEC_FILE: "/dev/null"
+    GCC_SPEC_FILE: /home/build/openssf.spec
 
 pipeline:
   - uses: git-checkout
@@ -28,6 +28,10 @@ pipeline:
       repository: https://github.com/NVIDIA/k8s-device-plugin
       tag: v${{package.version}}
       expected-commit: d475b2cfcf12b983a4975d4fc59d91af432cf28e
+
+  - runs: |
+      gccdir="$(GCC_SPEC_FILE=/dev/null gcc --print-search-dirs | grep ^install: | cut -d' ' -f2)"
+      sed -r 's/,?-z,now//' < "$gccdir/openssf.spec" > /home/build/openssf.spec
 
   - uses: go/bump
     with:

--- a/k8s-device-plugin.yaml
+++ b/k8s-device-plugin.yaml
@@ -25,9 +25,9 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: d475b2cfcf12b983a4975d4fc59d91af432cf28e
       repository: https://github.com/NVIDIA/k8s-device-plugin
       tag: v${{package.version}}
+      expected-commit: d475b2cfcf12b983a4975d4fc59d91af432cf28e
 
   - uses: go/bump
     with:


### PR DESCRIPTION
Continue the (admittedly ugly) pattern of copy+modifying openssf.spec
to remove -Wl,-z,now so we can reenable the remaining hardening.

Here's the diff in hardening-check output this produces:

```diff
--- before 2025-01-08 10:50:31.373533578 -0700
+++ after  2025-01-08 10:50:42.569543846 -0700
@@ -1,7 +1,7 @@
 /usr/bin/gpu-feature-discovery:
 Position Independent Executable: no, normal executable!
 Stack protected: no, not found!
-Fortify Source functions: no, only unprotected functions found!
+Fortify Source functions: yes
 Read-only relocations: yes
 Immediate binding: no, not found!
 Stack clash protection: unknown, no -fstack-clash-protection instructions found
@@ -9,7 +9,7 @@
 /usr/bin/mps-control-daemon:
 Position Independent Executable: no, normal executable!
 Stack protected: yes
-Fortify Source functions: no, only unprotected functions found!
+Fortify Source functions: yes (some protected functions found)
 Read-only relocations: yes
 Immediate binding: no, not found!
 Stack clash protection: unknown, no -fstack-clash-protection instructions found
@@ -17,7 +17,7 @@
 /usr/bin/nvidia-device-plugin:
 Position Independent Executable: no, normal executable!
 Stack protected: yes
-Fortify Source functions: no, only unprotected functions found!
+Fortify Source functions: yes (some protected functions found)
 Read-only relocations: yes
 Immediate binding: no, not found!
 Stack clash protection: unknown, no -fstack-clash-protection instructions found
```