### PR TITLE
Make the ldd-check less verbose

### DIFF
--- a/pipelines/test/ldd-check.yaml
+++ b/pipelines/test/ldd-check.yaml
@@ -68,7 +68,6 @@ pipeline:
           { fail "Package $pkg is not installed"; continue; }
         apk info -Lq "$pkg" > "$tmpd/$pkg.list"
         while read f; do
-          echo "file: $f"
           [ -n "$f" ] || continue
           f="/$f"
           [ -f "$f" ] || continue


### PR DESCRIPTION
The `echo` makes the ldd-check test more verbose for no gain e.g. nobody wants to know all the files installed by a package.