### PR TITLE
Add pipelines to codeowners for Foundations Squad

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,3 +4,6 @@ CODEOWNERS @wolfi-dev/wolfi-owners
 # These packages require approval from the Foundations squad.
 openssh.yaml @wolfi-dev/foundations-squad
 ca-certificates.yaml @wolfi-dev/foundations-squad
+
+# Pipeline changes require approval of the Guarded OS squad.
+pipelines/ @wolfi-dev/foundations-squad


### PR DESCRIPTION
We'd like the Guarded OS team to be the codeowners of the pipelines but there isn't a Github team for that yet. But the Foundations Squad includes most members (not me!) of Guarded OS so let's use that in the meantime.