### PR TITLE
Implement Package Metadata ELF notes by including melange generated gcc specs for C, C++, Rust, Go.

### DIFF
--- a/gops.yaml
+++ b/gops.yaml
@@ -1,7 +1,7 @@
 package:
   name: gops
   version: 0.3.28
-  epoch: 15
+  epoch: 16
   description: gops is a command to list and diagnose Go processes currently running on your system.
   copyright:
     - license: BSD-3-Clause
@@ -11,6 +11,8 @@ environment:
     packages:
       - build-base
       - git
+  environment:
+    GCC_SPEC_FILE: openssf-melange.spec
 
 pipeline:
   - uses: git-checkout
@@ -28,6 +30,7 @@ pipeline:
   - uses: go/build
     with:
       packages: .
+      ldflags: -linkmode external
       output: gops
 
 update:

--- a/pax-utils.yaml
+++ b/pax-utils.yaml
@@ -1,7 +1,7 @@
 package:
   name: pax-utils
   version: 1.3.8
-  epoch: 1
+  epoch: 2
   description: "ELF related utilities for 32-bit and 64-bit binaries"
   copyright:
     - license: GPL-2.0-only
@@ -24,6 +24,8 @@ environment:
       - py3-pyelftools
       - wolfi-baselayout
       - xz
+  environment:
+    GCC_SPEC_FILE: openssf-melange.spec
 
 pipeline:
   - uses: git-checkout

--- a/rust-audit-info.yaml
+++ b/rust-audit-info.yaml
@@ -1,7 +1,7 @@
 package:
   name: rust-audit-info
   version: 0.5.4
-  epoch: 0
+  epoch: 1
   description: Read audit information from rust binaries
   copyright:
     - license: MIT OR Apache-2.0
@@ -13,6 +13,8 @@ environment:
       - busybox
       - cargo-auditable
       - rust
+  environment:
+    GCC_SPEC_FILE: openssf-melange.spec
 
 pipeline:
   - uses: git-checkout


### PR DESCRIPTION
Cannot land this PR in one go, thus split openssf-compiler-options (first commit) into separate PR to land first:
- https://github.com/wolfi-dev/os/pull/39242

- **openssf-compiler-options: include melange spec files**
  If exist, include melange generated spec file from workspace.
  No errors produced if the melange generated spec file is missing.
  
  Potentially worth exploring to also always load $HOME/.gcc.spec, which
  may make it easier to customize gcc spec files on per-package basis.
  

- **Use new spec file with optional include**
  As an e2e test for three packages (written in C/Go/Rust). This enables
  using the future spec file with melange generated spec file include.
  
  When these land in images, and SBOM/Vulnerability/Console all look
  good we can roll this out by default.
  

NB! This PR needs melange that generates the dynamic gcc spec file which is being optionally included.

Once this lands for three packages in question, images are tested, and any bugs/issues resolved, we can remove the opt-in, and make the ELF notes the default.