### PR TITLE
malcontent/GHSA-w32m-9786-jp63 fix 

### DIFF
--- a/malcontent.yaml
+++ b/malcontent.yaml
@@ -1,7 +1,7 @@
 package:
   name: malcontent
   version: 1.7.1
-  epoch: 0
+  epoch: 1
   description: enumerate file capabilities, including malicious behaviors
   copyright:
     - license: Apache-2.0
@@ -23,6 +23,10 @@ pipeline:
       repository: https://github.com/chainguard-dev/malcontent
       tag: v${{package.version}}
       expected-commit: 6e326a4a9d69a995aedeff4514dc9a8c2c8620c7
+
+  - uses: go/bump
+    with:
+      deps: golang.org/x/net@v0.33.0
 
   - uses: go/build
     with:


### PR DESCRIPTION
adding go/bump with relevant module and version fix