### PR TITLE
percona-xtrabackup: bump epoch to rebuild with new procps

### DIFF
--- a/percona-xtrabackup-8.4.yaml
+++ b/percona-xtrabackup-8.4.yaml
@@ -1,7 +1,7 @@
 package:
   name: percona-xtrabackup-8.4
   version: 8.4.0.2
-  epoch: 1
+  epoch: 2
   description: Open source hot backup tool for InnoDB and XtraDB databases
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
https://github.com/wolfi-dev/os/pull/37498 updated procps and changed its `.so` dep version, but when it ran in postsubmit it rebuilt percona first, then procps, so percona didn't get the new dep.

Bumping here should fix that.

This indicates an error with elastic build ordering, since the intention of bumping percona in that PR was to ensure it was built _after_ procps was updated.