### PR TITLE
bump to 17.7.1

### DIFF
--- a/gitlab-cng-17.7.yaml
+++ b/gitlab-cng-17.7.yaml
@@ -33,8 +33,8 @@ var-transforms:
 package:
   name: gitlab-cng-17.7
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
-  version: 17.7.0
-  epoch: 1
+  version: 17.7.1
+  epoch: 0
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
@@ -64,7 +64,7 @@ pipeline:
     with:
       repository: https://gitlab.com/gitlab-org/build/CNG.git
       tag: v${{package.version}}
-      expected-commit: 057923e87a074d9ae72af6a3569755f580d4640c
+      expected-commit: 84d7f760388323fdab87e7be9f5070a3a1f13e99
 
 data:
   # Used to create all of the *-scripts subpackages from the CNG repo.


### PR DESCRIPTION
I checked against the [upstream components](https://gitlab.com/gitlab-org/build/CNG/-/blob/v17.7.1/ci_files/variables.yml) and they all appear to be the same for this version bump.

https://github.com/chainguard-dev/internal-dev/issues/7389