### PR TITLE
add provides to compat package

### DIFF
--- a/gatekeeper-3.17.yaml
+++ b/gatekeeper-3.17.yaml
@@ -77,6 +77,9 @@ subpackages:
   # https://github.com/open-policy-agent/gatekeeper/blob/master/crd.Dockerfile#L11
   # https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/templates/upgrade-crds-hook.yaml#L112-L115
   - name: ${{package.name}}-crds-compat
+    dependencies:
+      provides:
+        - gatekeeper-crds-compat=${{package.full-version}}
     pipeline:
       - runs: |
           mkdir -p ${{targets.subpkgdir}}

--- a/gatekeeper-3.17.yaml
+++ b/gatekeeper-3.17.yaml
@@ -1,7 +1,7 @@
 package:
   name: gatekeeper-3.17
   version: 3.17.1
-  epoch: 6
+  epoch: 7
   description: Gatekeeper - Policy Controller for Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
Following on from previous commit: https://github.com/wolfi-dev/os/pull/39220

Need to add a 'provides' to the compat package, as we have other image versions referring to the latest version of subpackages from here,