### PR TITLE
openssf-compiler-options: include melange spec files

### DIFF
--- a/openssf-compiler-options.yaml
+++ b/openssf-compiler-options.yaml
@@ -1,7 +1,7 @@
 package:
   name: openssf-compiler-options
   version: 20240627
-  epoch: 10
+  epoch: 11
   description: "Compiler Options Hardening Guide for C and C++"
   url: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
   copyright:

--- a/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/14/openssf-melange.spec
+++ b/openssf-compiler-options/usr/lib/gcc/aarch64-unknown-linux-gnu/14/openssf-melange.spec
@@ -1,0 +1,4 @@
+*self_spec:
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -mbranch-protection=standard -Wl,--as-needed,-O1,--sort-common,-z,noexecstack,-z,relro,-z,now %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+
+%include_noerr </home/build/.melange.gcc.spec>

--- a/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/openssf-melange.spec
+++ b/openssf-compiler-options/usr/lib/gcc/x86_64-pc-linux-gnu/14/openssf-melange.spec
@@ -1,0 +1,4 @@
+*self_spec:
++ %{!O:%{!O1:%{!O2:%{!O3:%{!O0:%{!Os:%{!0fast:%{!0g:%{!0z:-O2}}}}}}}}} -fhardened -Wno-error=hardened -Wno-hardened -Wl,--as-needed,-O1,--sort-common,-z,noexecstack,-z,relro,-z,now %{!fdelete-null-pointer-checks:-fno-delete-null-pointer-checks} -fno-strict-overflow -fno-strict-aliasing -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+
+%include_noerr </home/build/.melange.gcc.spec>


### PR DESCRIPTION
This is part 1 / pre-requisite to land:
- https://github.com/wolfi-dev/os/pull/39152

If exist, include melange generated spec file from workspace.
No errors produced if the melange generated spec file is missing.

Potentially worth exploring to also always load $HOME/.gcc.spec, which
may make it easier to customize gcc spec files on per-package basis.
