### PR TITLE
websockify: multiversion support

### DIFF
--- a/websockify.yaml
+++ b/websockify.yaml
@@ -1,28 +1,34 @@
 package:
   name: websockify
   version: 0.12.0
-  epoch: 2
+  epoch: 3
   description: WebSockets support for any application/server
   copyright:
     - license: LGPL-3.0-or-later
   dependencies:
-    runtime:
-      - numpy
-      - py3-jwcrypto
-      - py3-requests
-      - py3-simplejson
+    provider-priority: 0
+
+vars:
+  pypi-package: websockify
+  import: websockify
+
+data:
+  - name: py-versions
+    items:
+      3.10: '310'
+      3.11: '311'
+      3.12: '312'
+      3.13: '313'
 
 environment:
   contents:
     packages:
-      - autoconf
-      - automake
       - build-base
       - busybox
       - ca-certificates-bundle
-      - py3-gpep517
-      - py3-setuptools
-      - py3-wheel
+      - py3-supported-gpep517
+      - py3-supported-pip
+      - py3-supported-python-dev
 
 pipeline:
   - uses: git-checkout
@@ -31,18 +37,55 @@ pipeline:
       tag: v${{package.version}}
       expected-commit: 99f83ca08390dc876b1b3580c210abea5b9f4edd
 
-  - name: Python Build
-    uses: python/build-wheel
+subpackages:
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}
+    description: python${{range.key}} version of ${{vars.pypi-package}}
+    dependencies:
+      provider-priority: ${{range.value}}
+      runtime:
+        - py${{range.key}}-numpy
+        - py${{range.key}}-jwcrypto
+        - py${{range.key}}-requests
+        - py${{range.key}}-simplejson
+    pipeline:
+      - uses: py/pip-build-install
+        with:
+          python: python${{range.key}}
+      - name: "move usr/bin executables for -bin"
+        runs: |
+          mkdir -p ./cleanup/${{range.key}}/
+          mv ${{targets.contextdir}}/usr/bin ./cleanup/${{range.key}}/
+      - uses: strip
+    test:
+      pipeline:
+        - uses: python/import
+          with:
+            python: python${{range.key}}
+            import: ${{vars.import}}
 
-  - uses: strip
+  - range: py-versions
+    name: py${{range.key}}-${{vars.pypi-package}}-bin
+    description: Executable binaries for ${{vars.pypi-package}} installed for python${{range.key}}
+    dependencies:
+      runtime:
+        - py${{range.key}}-${{vars.pypi-package}}
+      provides:
+        - py3-${{vars.pypi-package}}-bin
+        - websockify
+      provider-priority: ${{range.value}}
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/usr/
+          mv ./cleanup/${{range.key}}/bin ${{targets.contextdir}}/usr/
+    test:
+      pipeline:
+        - runs: |
+            websockify --help
 
 test:
   pipeline:
-    - uses: python/import
-      with:
-        imports: |
-          import websockify
-      runs: |
+    - runs: |
         websockify --help
 
 update:

--- a/websockify.yaml
+++ b/websockify.yaml
@@ -72,6 +72,7 @@ subpackages:
         - py${{range.key}}-${{vars.pypi-package}}
       provides:
         - py3-${{vars.pypi-package}}-bin
+        - py3-${{vars.pypi-package}}
         - websockify
       provider-priority: ${{range.value}}
     pipeline:


### PR DESCRIPTION
Currently pulls in 3.12 because the `/usr/bin/websockify` script tries to use the python3.12 interpreter (build time defined). Move to multiversion + split off to -bin (with provides).