### PR TITLE
provide gitlab through gitlab-cng for versioning

### DIFF
--- a/gitlab-cng-17.7.yaml
+++ b/gitlab-cng-17.7.yaml
@@ -34,13 +34,14 @@ package:
   name: gitlab-cng-17.7
   # ---Additional updates required--- Review 'vars' section (above), when reviewing version bumps.
   version: 17.7.1
-  epoch: 0
+  epoch: 1
   description: Cloud Native container images per component of GitLab
   copyright:
     - license: MIT
   dependencies:
     provides:
       - gitlab-cng=${{package.full-version}}
+      - gitlab=${{package.full-version}}
 
 environment:
   contents:


### PR DESCRIPTION
allow for unifying version information solely from `gitlab`