### PR TITLE
kubernetes-csi-node-driver-registrar: bump epoch

### DIFF
--- a/kubernetes-csi-node-driver-registrar-2.13.yaml
+++ b/kubernetes-csi-node-driver-registrar-2.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubernetes-csi-node-driver-registrar-2.13
   version: 2.13.0
-  epoch: 1
+  epoch: 2
   description: Sidecar container that registers a CSI driver with the kubelet using the kubelet plugin registration mechanism.
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
force image rebuild

See https://github.com/chainguard-dev/image-release-stats/issues/3914