### PR TITLE
fix(cert-manager): Force rebuild of packages and images following image fix

### DIFF
--- a/cert-manager-1.16.yaml
+++ b/cert-manager-1.16.yaml
@@ -2,7 +2,7 @@ package:
   name: cert-manager-1.16
   # See https://cert-manager.io/docs/installation/supported-releases/ for upstream-supported versions
   version: 1.16.2
-  epoch: 3
+  epoch: 4
   description: Automatically provision and manage TLS certificates in Kubernetes
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
PR https://github.com/wolfi-dev/os/pull/34777 introduced a package rename from cert-manager-1.16-acmesolver -> cert-manager-acmesolver-1.16

This rename was not reflected in the image defintion causing the image to continue to pull in the older packages -
these older packages are now vulnerable to CVEs.

This commit bumps the epoch to force a new package version and thus a new image build.

Signed-off-by: philroche <phil.roche@chainguard.dev>
