### PR TITLE
Corrects file structure within kong-entrypoint

### DIFF
--- a/kong-entrypoint.yaml
+++ b/kong-entrypoint.yaml
@@ -1,7 +1,7 @@
 package:
   name: kong-entrypoint
   version: 3.9.0
-  epoch: 0
+  epoch: 1
   description: "Provides entrypoint for kong"
   copyright:
     - license: Apache-2.0
@@ -22,7 +22,7 @@ pipeline:
       expected-commit: d46098c09b6198efb71682fe7209bd6467bf3f67
 
   - runs: |
-      install -Dm755 ./docker-entrypoint.sh  -t ${{targets.destdir}}/docker-entrypoint.sh
+      install -Dm755 ./docker-entrypoint.sh  -t ${{targets.destdir}}/
 
 test:
   pipeline:


### PR DESCRIPTION
The entrypoint script was placed  within a duplicate folder named after itself. 

Epoch has been bumped.
