### PR TITLE
Enable ARM branch protection in gcc + restore OpenSSF hardening in glibc

### DIFF
--- a/gcc-11.yaml
+++ b/gcc-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-11
   version: 11.5.0
-  epoch: 1
+  epoch: 2
   description: "the GNU compiler collection - version 11"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -66,12 +66,16 @@ pipeline:
             "aarch64")
               march=armv8-a+crc+crypto
               mtune=neoverse-v2
+              CFLAGS="-mbranch-protection=standard"
+              CXXFLAGS="-mbranch-protection=standard"
               ;;
             "x86_64")
               march=x86-64-v2
               mtune=sapphirerapids
               ;;
           esac
+          CFLAGS="$CFLAGS" \
+          CXXFLAGS="$CXXFLAGS" \
           ../configure \
             --prefix=/usr \
             --program-suffix="-11" \

--- a/gcc-12.yaml
+++ b/gcc-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-12
   version: 12.4.0
-  epoch: 7
+  epoch: 8
   description: "the GNU compiler collection - version 12"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -66,12 +66,16 @@ pipeline:
             "aarch64")
               march=armv8-a+crc+crypto
               mtune=neoverse-v2
+              CFLAGS="-mbranch-protection=standard"
+              CXXFLAGS="-mbranch-protection=standard"
               ;;
             "x86_64")
               march=x86-64-v2
               mtune=sapphirerapids
               ;;
           esac
+          CFLAGS="$CFLAGS" \
+          CXXFLAGS="$CXXFLAGS" \
           ../configure \
             --prefix=/usr \
             --program-suffix="-12" \

--- a/gcc-13.yaml
+++ b/gcc-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc-13
   version: 13.3.0
-  epoch: 6
+  epoch: 7
   description: "the GNU compiler collection - version 13"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -60,12 +60,16 @@ pipeline:
             "aarch64")
               march=armv8-a+crc+crypto
               mtune=neoverse-v2
+              CFLAGS="-mbranch-protection=standard"
+              CXXFLAGS="-mbranch-protection=standard"
               ;;
             "x86_64")
               march=x86-64-v2
               mtune=sapphirerapids
               ;;
           esac
+          CFLAGS="$CFLAGS" \
+          CXXFLAGS="$CXXFLAGS" \
           ../configure \
             --prefix=/usr \
             --program-suffix="-13" \

--- a/gcc.yaml
+++ b/gcc.yaml
@@ -1,7 +1,7 @@
 package:
   name: gcc
   version: 14.2.0
-  epoch: 7
+  epoch: 8
   description: "the GNU compiler collection"
   copyright:
     - license: GPL-3.0-or-later WITH GCC-exception-3.1
@@ -69,6 +69,8 @@ pipeline:
         "aarch64")
           march=armv8-a+crc+crypto
           mtune=neoverse-v2
+          CFLAGS="-mbranch-protection=standard"
+          CXXFLAGS="-mbranch-protection=standard"
           ;;
         "x86_64")
           march=x86-64-v2
@@ -76,6 +78,9 @@ pipeline:
           ;;
       esac
       cd build
+
+      CFLAGS="$CFLAGS" \
+      CXXFLAGS="$CXXFLAGS" \
       ../configure \
         --prefix=/usr \
         --disable-nls \

--- a/glibc.yaml
+++ b/glibc.yaml
@@ -1,7 +1,7 @@
 package:
   name: glibc
   version: 2.40
-  epoch: 6
+  epoch: 7
   description: "the GNU C library"
   copyright:
     - license: LGPL-2.1-or-later
@@ -53,8 +53,6 @@ environment:
   # glibc manages FORTIFY_SOURCE on per-file basis
   environment:
     CPPFLAGS: ""
-    # https://github.com/chainguard-dev/internal-dev/issues/7756
-    GCC_SPEC_FILE: /dev/null
 
 pipeline:
   - uses: git-checkout

--- a/hardening-check.yaml
+++ b/hardening-check.yaml
@@ -1,7 +1,7 @@
 package:
   name: hardening-check
   version: "2.25.1"
-  epoch: 0
+  epoch: 1
   description: "Debian devscripts hardening-check"
   copyright:
     - license: GPL-2.0-or-later
@@ -20,6 +20,8 @@ pipeline:
       repository: https://salsa.debian.org/debian/devscripts.git
       tag: v${{package.version}}
       expected-commit: 0c91555a03783ba268fa0b0d781a3085b0edd990
+      cherry-picks: |
+        main/7bfe255e81877587b21c68323029ceca00944a0d: scripts/hardening-check.pl: Detect branch protection in ARM binaries
 
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin

--- a/pipelines/test/compiler-hardening-check.yaml
+++ b/pipelines/test/compiler-hardening-check.yaml
@@ -55,6 +55,8 @@ pipeline:
       # full cfprotection is x86 only for now
       if [ "${{build.arch}}" = "aarch64" ]; then
           arch_skip=--nocfprotection
+          # Disabled until glibc has been rebuilt to support it.
+          arch_skip="$arch_skip --nobranchprotection"
       fi
 
       # the branch protection check is ARM only for now

--- a/pipelines/test/compiler-hardening-check.yaml
+++ b/pipelines/test/compiler-hardening-check.yaml
@@ -57,6 +57,9 @@ pipeline:
           arch_skip=--nocfprotection
       fi
 
+      # the branch protection check is ARM only for now
+      [ "${{build.arch}}" = "aarch64" ] || arch_skip=--nobranchprotection
+
       # Test disabling hardening flags
       hardening-check --nostackprotector $arch_skip ${{inputs.args}} --color hello-disabled && exit 1
 


### PR DESCRIPTION
Fixes: https://github.com/chainguard-dev/internal-dev/issues/7940