### PR TITLE
grafana-mimir add subpkgs metaconvert, mimirtool, query-tee

### DIFF
--- a/grafana-mimir.yaml
+++ b/grafana-mimir.yaml
@@ -6,6 +6,13 @@ package:
   copyright:
     - license: AGPL-3.0-or-later
 
+data:
+  - name: grafana-mimir-packages
+    items:
+      metaconvert: metaconvert
+      mimirtool: mimirtool
+      query-tee: query-tee
+
 environment:
   contents:
     packages:
@@ -29,6 +36,23 @@ pipeline:
       modroot: .
       packages: ./cmd/mimir
       output: grafana-mimir
+
+subpackages:
+  - range: grafana-mimir-packages
+    name: grafana-mimir-${{range.key}}
+    pipeline:
+      - uses: go/build
+        with:
+          modroot: .
+          packages: ./cmd/${{range.key}}
+          ldflags: |
+            -X github.com/grafana/mimir/pkg/util/version.Version=${{package.version}}
+          output: ${{range.key}}
+    test:
+      pipeline:
+        - name: Test the ${{range.key}} binary
+          runs: |
+            ${{range.key}} version
 
 update:
   enabled: true

--- a/grafana-mimir.yaml
+++ b/grafana-mimir.yaml
@@ -36,6 +36,8 @@ pipeline:
       modroot: .
       packages: ./cmd/mimir
       ldflags: |
+        -X github.com/grafana/mimir/pkg/util/version.Branch=$(git rev-parse --abbrev-ref HEAD)
+        -X github.com/grafana/mimir/pkg/util/version.Revision=$(git rev-parse --short HEAD)
         -X github.com/grafana/mimir/pkg/util/version.Version=${{package.version}}
       output: grafana-mimir
 
@@ -48,6 +50,8 @@ subpackages:
           modroot: .
           packages: ./cmd/${{range.key}}
           ldflags: |
+            -X github.com/grafana/mimir/pkg/util/version.Branch=$(git rev-parse --abbrev-ref HEAD)
+            -X github.com/grafana/mimir/pkg/util/version.Revision=$(git rev-parse --short HEAD)
             -X github.com/grafana/mimir/pkg/util/version.Version=${{package.version}}
           output: ${{range.key}}
     test:

--- a/grafana-mimir.yaml
+++ b/grafana-mimir.yaml
@@ -63,7 +63,7 @@ update:
 
 test:
   pipeline:
-    - runs: |
+    - runs: |-
         grafana-mimir -version  | grep ${{package.version}}
         grafana-mimir --version | grep ${{package.version}}
         metaconvert --help

--- a/grafana-mimir.yaml
+++ b/grafana-mimir.yaml
@@ -7,7 +7,7 @@ package:
     - license: AGPL-3.0-or-later
 
 data:
-  - name: grafana-mimir-packages
+  - name: grafana-mimir-subpackages
     items:
       metaconvert: metaconvert --help
       mimirtool: mimirtool version | grep ${{package.version}}
@@ -42,8 +42,8 @@ pipeline:
       output: grafana-mimir
 
 subpackages:
-  - range: grafana-mimir-packages
-    name: grafana-mimir-${{range.key}}
+  - range: grafana-mimir-subpackages
+    name: ${{package.name}}-${{range.key}}
     pipeline:
       - uses: go/build
         with:
@@ -74,4 +74,3 @@ test:
     - runs: |-
         grafana-mimir -version  | grep ${{package.version}}
         grafana-mimir --version | grep ${{package.version}}
-

--- a/grafana-mimir.yaml
+++ b/grafana-mimir.yaml
@@ -1,7 +1,7 @@
 package:
   name: grafana-mimir
   version: 2.15.0
-  epoch: 0
+  epoch: 1
   description: Grafana Mimir provides horizontally scalable, highly available, multi-tenant, long-term storage for Prometheus.
   copyright:
     - license: AGPL-3.0-or-later
@@ -35,6 +35,8 @@ pipeline:
     with:
       modroot: .
       packages: ./cmd/mimir
+      ldflags: |
+        -X github.com/grafana/mimir/pkg/util/version.Version=${{package.version}}
       output: grafana-mimir
 
 subpackages:
@@ -48,11 +50,6 @@ subpackages:
           ldflags: |
             -X github.com/grafana/mimir/pkg/util/version.Version=${{package.version}}
           output: ${{range.key}}
-    test:
-      pipeline:
-        - name: Test the ${{range.key}} binary
-          runs: |
-            ${{range.key}} version
 
 update:
   enabled: true
@@ -67,5 +64,8 @@ update:
 test:
   pipeline:
     - runs: |
-        grafana-mimir -version
-        grafana-mimir --version
+        grafana-mimir -version  | grep ${{package.version}}
+        grafana-mimir --version | grep ${{package.version}}
+        metaconvert --help
+        mimirtool version | ${{package.version}}
+        query-tee --help

--- a/grafana-mimir.yaml
+++ b/grafana-mimir.yaml
@@ -9,9 +9,9 @@ package:
 data:
   - name: grafana-mimir-packages
     items:
-      metaconvert: metaconvert
-      mimirtool: mimirtool
-      query-tee: query-tee
+      metaconvert: metaconvert --help
+      mimirtool: mimirtool version | grep ${{package.version}}
+      query-tee: query-tee --help
 
 environment:
   contents:
@@ -50,6 +50,10 @@ subpackages:
           ldflags: |
             -X github.com/grafana/mimir/pkg/util/version.Version=${{package.version}}
           output: ${{range.key}}
+    test:
+      pipeline:
+        - runs: |-
+            ${{range.value}}
 
 update:
   enabled: true
@@ -66,6 +70,4 @@ test:
     - runs: |-
         grafana-mimir -version  | grep ${{package.version}}
         grafana-mimir --version | grep ${{package.version}}
-        metaconvert --help
-        mimirtool version | ${{package.version}}
-        query-tee --help
+


### PR DESCRIPTION
<!---
update grafana-mimir to build additional subpkgs like metaconvert, mimirtool, query-tee

<!--
Issue [#39230](https://github.com/wolfi-dev/os/issues/39230)
 -->

Fixes:

Related: [#39230](https://github.com/wolfi-dev/os/issues/39230)

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [x] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [x] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
