### PR TITLE
gitlab-cng-17.7 enable auto package update

### DIFF
--- a/gitlab-cng-17.7.yaml
+++ b/gitlab-cng-17.7.yaml
@@ -484,8 +484,6 @@ subpackages:
 
 update:
   enabled: true
-  # Requires manual steps when updating
-  manual: true
   git:
     strip-prefix: v
     tag-filter-prefix: v17.7


### PR DESCRIPTION
The package update was set to manual because sometimes it requires manual intervention to update the VARS, but it is only needed manual update of VARS when there is a new minor version update and we have a version stream PR. But for other smaller version change we not need to do anything and the automation can update the version.

in my opinion the package update should not be false in the first place. so that the automation will work for minor package updates and only need manual intervention when there is a new version stream.

> Epoch bump is not required as it will not effect the package build in any way.