### PR TITLE
mysql-9.1: create default runtime directories during build

### DIFF
--- a/mysql-9.1.yaml
+++ b/mysql-9.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: mysql-9.1
   version: 9.1.0
-  epoch: 0
+  epoch: 1
   description: "The MySQL open source relational database"
   copyright:
     - license: GPL-2.0-only # https://downloads.mysql.com/docs/licenses/mysqld-9.0-gpl-en.pdf
@@ -37,6 +37,9 @@ environment:
       - wolfi-baselayout
       - xz-dev
       - zlib-dev
+  environment:
+    DATADIR: /var/lib/mysql
+    SOCKDIR: /run/mysqld
 
 pipeline:
   - working-directory: /home/build/mysql
@@ -52,8 +55,8 @@ pipeline:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=/usr \
             -DSYSCONFDIR=/etc \
-            -DMYSQL_DATADIR=/var/lib/mysql \
-            -DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock \
+            -DMYSQL_DATADIR=$DATADIR \
+            -DMYSQL_UNIX_ADDR=$SOCKDIR/mysqld.sock \
             -DDEFAULT_CHARSET=utf8mb4 \
             -DDEFAULT_COLLATION=utf8mb4_general_ci \
             -DENABLED_LOCAL_INFILE=ON \
@@ -77,6 +80,9 @@ pipeline:
       - name: "Remove extras"
         runs: |
           rm -r "${{targets.destdir}}"/usr/mysql-test/
+      - name: "Create runtime directories"
+        runs: |
+          mkdir -p "${{targets.destdir}}"$DATADIR "${{targets.destdir}}"$SOCKDIR
 
   - uses: strip
 
@@ -137,8 +143,6 @@ test:
       packages:
         - ${{package.name}}
         - ${{package.name}}-client
-    environment:
-      DBDATA: /var/lib/mysql
   pipeline:
     - name: Check versions
       runs: |
@@ -148,9 +152,9 @@ test:
       uses: test/daemon-check-output
       with:
         setup: |
-          mkdir -p "$DBDATA" /var/tmp /var/log/mysql /run/mysqld
-          mysqld --initialize-insecure --datadir="$DBDATA"
-        start: mysqld --user=root --datadir="$DBDATA"
+          mkdir -p /var/tmp /var/log/mysql
+          mysqld --initialize-insecure
+        start: mysqld --user=root
         post: |
           mysqladmin --user=root ping --wait=5
         timeout: 60


### PR DESCRIPTION
`mysqld` won't start in the default configuration which we ship without these directories being present; this commit avoids users having to discover the issue and create them themselves.

To validate this change, this commit also updates the test pipeline to run with the default value for --datadir (which is the same as what we were passing anyway), and not to create the directories which the package now ships.
