### PR TITLE
openjdk: Use JRE build for JRE subpackage

### DIFF
--- a/java-common.yaml
+++ b/java-common.yaml
@@ -1,10 +1,13 @@
 package:
   name: java-common
-  version: 0.1
-  epoch: 3
-  description: "Compatibility infrastructure for JVM runtimes"
+  version: 0.2
+  epoch: 0
+  description: "Compatibility infrastructure for JVM runtimes (JDK)"
   copyright:
     - license: GPL-2.0-or-later
+  dependencies:
+    runtime:
+      - ${{package.name}}-jre
 
 environment:
   contents:
@@ -14,9 +17,24 @@ environment:
 pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"/usr/bin
-      for exe in jaotc jar jarsigner java javac javadoc javap jcmd jdb jdeprscan jdeps jexec jexec-binfmt jfr jhsdb jimage jinfo jjs jlink jmap jmod jps jrunscript jshell jstack jstat jstatd keytool pack200 rmic rmid rmiregistry serialver unpack200; do
+      for exe in jaotc jar jarsigner javac javadoc javap jcmd jdb jdeprscan jdeps jexec jexec-binfmt jhsdb jimage jinfo jjs jlink jmap jmod jps jshell jstack jstat jstatd pack200 rmic rmid serialver unpack200; do
         ln -sf ../lib/jvm/default-jvm/bin/$exe "${{targets.destdir}}"/usr/bin
       done
+
+subpackages:
+  - name: "${{package.name}}-jre"
+    description: "Compatibility infrastructure for JVM runtimes (JRE)"
+    pipeline:
+    - runs: |
+        mkdir -p "${{targets.contextdir}}"/usr/bin
+        for exe in java \
+                   jfr \
+                   jrunscript \
+                   jwebserver \
+                   keytool \
+                   rmiregistry; do
+          ln -sf ../lib/jvm/default-jvm/bin/$exe "${{targets.contextdir}}"/usr/bin
+        done
 
 update:
   enabled: false

--- a/java-common.yaml
+++ b/java-common.yaml
@@ -25,16 +25,16 @@ subpackages:
   - name: "${{package.name}}-jre"
     description: "Compatibility infrastructure for JVM runtimes (JRE)"
     pipeline:
-    - runs: |
-        mkdir -p "${{targets.contextdir}}"/usr/bin
-        for exe in java \
-                   jfr \
-                   jrunscript \
-                   jwebserver \
-                   keytool \
-                   rmiregistry; do
-          ln -sf ../lib/jvm/default-jvm/bin/$exe "${{targets.contextdir}}"/usr/bin
-        done
+      - runs: |
+          mkdir -p "${{targets.contextdir}}"/usr/bin
+          for exe in java \
+                     jfr \
+                     jrunscript \
+                     jwebserver \
+                     keytool \
+                     rmiregistry; do
+            ln -sf ../lib/jvm/default-jvm/bin/$exe "${{targets.contextdir}}"/usr/bin
+          done
 
 update:
   enabled: false

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,13 +1,14 @@
 package:
   name: openjdk-11
   version: 11.0.25 # TODO(jason): on version bump, ensure to update downstream projects that are pinned to a specific prerelease version. See: https://github.com/wolfi-dev/os/pull/7958
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: GPL-2.0-only
   dependencies:
     runtime:
-      - openjdk-11-jre
+      - java-cacerts
+      - zlib
 
 environment:
   contents:
@@ -80,7 +81,7 @@ pipeline:
   # NOTE: Disable flakey tests for now as we're seeing builds hang on aarch64
   # # run the gtest unittest suites
   # make test-hotspot-gtest
-  - runs: make jdk-image
+  - runs: make jdk-image legacy-jre-image
 
   - runs: |
       _java_home="usr/lib/jvm/java-11-openjdk"
@@ -88,6 +89,11 @@ pipeline:
       mkdir -p "${{targets.destdir}}"/$_java_home
       cp -r build/*-normal-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
       rm "${{targets.destdir}}"/$_java_home/lib/src.zip
+
+      # copy to shared java cacerts store
+      rm -f "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
+      cp /etc/ssl/certs/java/cacerts \
+        "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
 
 subpackages:
   - name: "openjdk-11-dbg"
@@ -98,13 +104,14 @@ subpackages:
       runtime:
         - openjdk-11
 
-  - name: "openjdk-11-jre"
+  - name: "${{package.name}}-jre"
     description: "OpenJDK 11 Java Runtime Environment"
     dependencies:
       runtime:
         - alsa-lib
         - freetype
         - giflib
+        - java-cacerts
         - lcms2
         - libfontconfig1
         - libjpeg-turbo
@@ -113,63 +120,17 @@ subpackages:
         - libxi
         - libxrender
         - libxtst
-        - openjdk-11-jre-base
         - ttf-dejavu
     pipeline:
       - runs: |
           _java_home="usr/lib/jvm/java-11-openjdk"
 
-          mkdir -p "${{targets.subpkgdir}}"/$_java_home/lib
-          mv "${{targets.destdir}}"/$_java_home/lib/libawt_xawt.so \
-              "${{targets.destdir}}"/$_java_home/lib/libfontmanager.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjavajpeg.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjawt.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjsound.so \
-              "${{targets.destdir}}"/$_java_home/lib/liblcms.so \
-              "${{targets.destdir}}"/$_java_home/lib/libsplashscreen.so \
-              "${{targets.subpkgdir}}"/$_java_home/lib
-
-  - name: "openjdk-11-jre-base"
-    description: "OpenJDK 11 Java Runtime Environment (headless)"
-    dependencies:
-      runtime:
-        - java-common
-        - java-cacerts
-    pipeline:
-      - runs: |
-          _java_home="usr/lib/jvm/java-11-openjdk"
-
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/lib \
-             "${{targets.subpkgdir}}"/$_java_home
+          cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
-          mkdir -p "${{targets.subpkgdir}}"/$_java_home/bin
-          for i in java \
-                    jfr \
-                    jjs \
-                    jrunscript \
-                    keytool \
-                    pack200 \
-                    rmid \
-                    rmiregistry \
-                    unpack200; do
-            mv "${{targets.destdir}}"/$_java_home/bin/$i "${{targets.subpkgdir}}"/$_java_home/bin/$i
-          done
-
-          [ "${{build.arch}}" = "x86_64" ] && \
-            mv "${{targets.destdir}}"/$_java_home/bin/jaotc "${{targets.subpkgdir}}"/$_java_home/bin/jaotc
-
-          mv "${{targets.destdir}}"/$_java_home/legal "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/conf "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/release "${{targets.subpkgdir}}"/$_java_home
-          cp ASSEMBLY_EXCEPTION \
-              LICENSE \
-              README.md \
-             "${{targets.subpkgdir}}"/$_java_home
-
-          # symlink to shared java cacerts store
+          # copy to shared java cacerts store
           rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-          ln -sf /etc/ssl/certs/java/cacerts \
+          cp /etc/ssl/certs/java/cacerts \
             "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
@@ -206,6 +167,7 @@ subpackages:
     description: "Use the openjdk-11 JVM as the default JVM"
     dependencies:
       runtime:
+        - java-common-jre
         - openjdk-11-jre
       provides:
         - default-jvm=1.11
@@ -219,7 +181,7 @@ subpackages:
     description: "Use the openjdk-11 JVM as the default JVM with the JDK installed"
     dependencies:
       runtime:
-        - openjdk-11-default-jvm
+        - java-common
         - openjdk-11
       provides:
         - default-jdk=1.11

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -186,6 +186,10 @@ subpackages:
       provides:
         - default-jdk=1.11
         - default-jdk-lts=1.11
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-11-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
 
 # OpenJDK versions use an interesting versioning approach.  You can read the Timeline section https://wiki.openjdk.org/display/JDKUpdates/JDK11u
 # The OpenJDK repo uses tags for prereleases and GA releases https://github.com/openjdk/jdk11u/tags

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,13 +1,14 @@
 package:
   name: openjdk-17
   version: 17.0.13 # TODO(jason): on version bump ensure to update downstream projects that are pinned to a specific prerelease version, i.e. https://github.com/chainguard-images/images/tree/main/images
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: GPL-2.0-only
   dependencies:
     runtime:
-      - openjdk-17-jre
+      - java-cacerts
+      - zlib
 
 environment:
   contents:
@@ -88,7 +89,7 @@ pipeline:
         --with-gtest="/home/build/googletest" \
         --with-version-string=""
 
-  - runs: make jdk-image
+  - runs: make jdk-image legacy-jre-image
 
   # Check we built something valid
   - runs: |
@@ -108,6 +109,11 @@ pipeline:
       cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
       rm "${{targets.destdir}}"/$_java_home/lib/src.zip
 
+      # copy to shared java cacerts store
+      rm -f "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
+      cp /etc/ssl/certs/java/cacerts \
+        "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
+
 subpackages:
   - name: "openjdk-17-dbg"
     description: "OpenJDK 17 Java Debug Symbols"
@@ -117,7 +123,7 @@ subpackages:
       runtime:
         - openjdk-17
 
-  - name: "openjdk-17-jre"
+  - name: "${{package.name}}-jre"
     description: "OpenJDK 17 Java Runtime Environment"
     dependencies:
       runtime:
@@ -125,6 +131,7 @@ subpackages:
         - freetype
         - giflib
         - lcms2
+        - java-cacerts
         - libfontconfig1
         - libjpeg-turbo
         - libx11
@@ -132,56 +139,17 @@ subpackages:
         - libxi
         - libxrender
         - libxtst
-        - openjdk-17-jre-base
         - ttf-dejavu
     pipeline:
       - runs: |
-          _java_home="usr/lib/jvm/java-17-openjdk"
-
-          mkdir -p "${{targets.subpkgdir}}"/$_java_home/lib
-          mv "${{targets.destdir}}"/$_java_home/lib/libawt_xawt.so \
-              "${{targets.destdir}}"/$_java_home/lib/libfontmanager.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjavajpeg.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjawt.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjsound.so \
-              "${{targets.destdir}}"/$_java_home/lib/liblcms.so \
-              "${{targets.destdir}}"/$_java_home/lib/libsplashscreen.so \
-              "${{targets.subpkgdir}}"/$_java_home/lib
-
-  - name: "openjdk-17-jre-base"
-    description: "OpenJDK 17 Java Runtime Environment (headless)"
-    dependencies:
-      runtime:
-        - java-common
-        - java-cacerts
-    pipeline:
-      - runs: |
-          _java_home="usr/lib/jvm/java-17-openjdk"
+          _java_home="usr/lib/jvm/java-22-openjdk"
 
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/lib \
-             "${{targets.subpkgdir}}"/$_java_home
+          cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
-          mkdir -p "${{targets.subpkgdir}}"/$_java_home/bin
-          for i in java \
-                    jfr \
-                    jrunscript \
-                    keytool \
-                    rmiregistry; do
-            mv "${{targets.destdir}}"/$_java_home/bin/$i "${{targets.subpkgdir}}"/$_java_home/bin/$i
-          done
-
-          mv "${{targets.destdir}}"/$_java_home/legal "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/conf "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/release "${{targets.subpkgdir}}"/$_java_home
-          cp ASSEMBLY_EXCEPTION \
-              LICENSE \
-              README.md \
-             "${{targets.subpkgdir}}"/$_java_home
-
-          # symlink to shared java cacerts store
+          # copy to shared java cacerts store
           rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-          ln -sf /etc/ssl/certs/java/cacerts \
+          cp /etc/ssl/certs/java/cacerts \
             "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
@@ -218,6 +186,7 @@ subpackages:
     description: "Use the openjdk-17 JVM as the default JVM"
     dependencies:
       runtime:
+        - java-common-jre
         - openjdk-17-jre
       provides:
         - default-jvm=1.17
@@ -231,7 +200,7 @@ subpackages:
     description: "Use the openjdk-17 JVM as the default JVM with the JDK installed"
     dependencies:
       runtime:
-        - openjdk-17-default-jvm
+        - java-common
         - openjdk-17
       provides:
         - default-jdk=1.17

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -205,6 +205,10 @@ subpackages:
       provides:
         - default-jdk=1.17
         - default-jdk-lts=1.17
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-17-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
 
 # OpenJDK versions use an interesting versioning approach.  You can read the Timeline section https://wiki.openjdk.org/display/JDKUpdates/JDK17u
 # The OpenJDK repo uses tags for prereleases and GA releases https://github.com/openjdk/jdk17u/tags

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -210,6 +210,10 @@ subpackages:
       provides:
         - default-jdk=1.21
         - default-jdk-lts=1.21
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-21-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
 
 # OpenJDK versions use an interesting versioning approach.  You can read the Timeline section https://wiki.openjdk.org/display/JDKUpdates/JDK+21u
 # The OpenJDK repo uses tags for prereleases and GA releases https://github.com/openjdk/jdk21u/tags

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -1,13 +1,14 @@
 package:
   name: openjdk-21
   version: 21.0.5
-  epoch: 1
+  epoch: 2
   description:
   copyright:
     - license: GPL-2.0-or-later
   dependencies:
     runtime:
-      - openjdk-21-jre
+      - java-cacerts
+      - zlib
 
 environment:
   contents:
@@ -94,7 +95,7 @@ pipeline:
         --with-version-pre="no" \
         --with-version-string=""
 
-  - runs: make jdk-image
+  - runs: make jdk-image legacy-jre-image
 
   # Check we built something valid
   - runs: |
@@ -114,6 +115,11 @@ pipeline:
       cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
       rm "${{targets.destdir}}"/$_java_home/lib/src.zip
 
+      # copy to shared java cacerts store
+      rm -f "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
+      cp /etc/ssl/certs/java/cacerts \
+        "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
+
 subpackages:
   - name: "openjdk-21-dbg"
     description: "OpenJDK 21 Java Debug Symbols"
@@ -123,13 +129,14 @@ subpackages:
       runtime:
         - openjdk-21
 
-  - name: "openjdk-21-jre"
+  - name: "${{package.name}}-jre"
     description: "OpenJDK 21 Java Runtime Environment"
     dependencies:
       runtime:
         - alsa-lib
         - freetype
         - giflib
+        - java-cacerts
         - libfontconfig1
         - libjpeg-turbo
         - libx11
@@ -137,57 +144,17 @@ subpackages:
         - libxi
         - libxrender
         - libxtst
-        - openjdk-21-jre-base
         - ttf-dejavu
     pipeline:
       - runs: |
           _java_home="usr/lib/jvm/java-21-openjdk"
 
-          mkdir -p "${{targets.subpkgdir}}"/$_java_home/lib
-          mv "${{targets.destdir}}"/$_java_home/lib/libawt_xawt.so \
-              "${{targets.destdir}}"/$_java_home/lib/libfontmanager.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjavajpeg.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjawt.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjsound.so \
-              "${{targets.destdir}}"/$_java_home/lib/liblcms.so \
-              "${{targets.destdir}}"/$_java_home/lib/libsplashscreen.so \
-              "${{targets.subpkgdir}}"/$_java_home/lib
-
-  - name: "openjdk-21-jre-base"
-    description: "OpenJDK 21 Java Runtime Environment (headless)"
-    dependencies:
-      runtime:
-        - java-common
-        - java-cacerts
-    pipeline:
-      - runs: |
-          _java_home="usr/lib/jvm/java-21-openjdk"
-
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/lib \
-             "${{targets.subpkgdir}}"/$_java_home
+          cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
-          mkdir -p "${{targets.subpkgdir}}"/$_java_home/bin
-          for i in java \
-                    jfr \
-                    jrunscript \
-                    jwebserver \
-                    keytool \
-                    rmiregistry; do
-            mv "${{targets.destdir}}"/$_java_home/bin/$i "${{targets.subpkgdir}}"/$_java_home/bin/$i
-          done
-
-          mv "${{targets.destdir}}"/$_java_home/legal "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/conf "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/release "${{targets.subpkgdir}}"/$_java_home
-          cp ASSEMBLY_EXCEPTION \
-              LICENSE \
-              README.md \
-             "${{targets.subpkgdir}}"/$_java_home
-
-          # symlink to shared java cacerts store
+          # copy to shared java cacerts store
           rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-          ln -sf /etc/ssl/certs/java/cacerts \
+          cp /etc/ssl/certs/java/cacerts \
             "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)
@@ -224,6 +191,7 @@ subpackages:
     description: "Use the openjdk-21 JVM as the default JVM"
     dependencies:
       runtime:
+        - java-common-jre
         - openjdk-21-jre
       provides:
         - default-jvm=1.21
@@ -237,7 +205,7 @@ subpackages:
     description: "Use the openjdk-21 JVM as the default JVM with the JDK installed"
     dependencies:
       runtime:
-        - openjdk-21-default-jvm
+        - java-common
         - openjdk-21
       provides:
         - default-jdk=1.21

--- a/openjdk-22.yaml
+++ b/openjdk-22.yaml
@@ -152,9 +152,9 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
           cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
-          # symlink to shared java cacerts store
+          # copy to shared java cacerts store
           rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-          ln -sf /etc/ssl/certs/java/cacerts \
+          cp /etc/ssl/certs/java/cacerts \
             "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)

--- a/openjdk-22.yaml
+++ b/openjdk-22.yaml
@@ -1,13 +1,14 @@
 package:
   name: openjdk-22
   version: 22.0.2
-  epoch: 1
+  epoch: 2
   description: OpenJDK 22
   copyright:
     - license: GPL-2.0-or-later
   dependencies:
     runtime:
-      - openjdk-22-jre
+      - java-cacerts
+      - zlib
 
 environment:
   contents:
@@ -94,7 +95,7 @@ pipeline:
         --with-version-pre="no" \
         --with-version-string=""
 
-  - runs: make jdk-image
+  - runs: make jdk-image legacy-jre-image
 
   # Check we built something valid
   - runs: |
@@ -114,6 +115,12 @@ pipeline:
       cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
       rm "${{targets.destdir}}"/$_java_home/lib/src.zip
 
+      # copy to shared java cacerts store
+      rm -f "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
+      cp /etc/ssl/certs/java/cacerts \
+        "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
+
+
 subpackages:
   - name: "${{package.name}}-dbg"
     description: "OpenJDK 22 Java Debug Symbols"
@@ -127,10 +134,10 @@ subpackages:
     description: "OpenJDK 22 Java Runtime Environment"
     dependencies:
       runtime:
-        - ${{package.name}}-jre-base
         - alsa-lib
         - freetype
         - giflib
+        - java-cacerts
         - libfontconfig1
         - libjpeg-turbo
         - libx11
@@ -143,47 +150,8 @@ subpackages:
       - runs: |
           _java_home="usr/lib/jvm/java-22-openjdk"
 
-          mkdir -p "${{targets.subpkgdir}}"/$_java_home/lib
-          mv "${{targets.destdir}}"/$_java_home/lib/libawt_xawt.so \
-              "${{targets.destdir}}"/$_java_home/lib/libfontmanager.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjavajpeg.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjawt.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjsound.so \
-              "${{targets.destdir}}"/$_java_home/lib/liblcms.so \
-              "${{targets.destdir}}"/$_java_home/lib/libsplashscreen.so \
-              "${{targets.subpkgdir}}"/$_java_home/lib
-
-  - name: "${{package.name}}-jre-base"
-    description: "OpenJDK 22 Java Runtime Environment (headless)"
-    dependencies:
-      runtime:
-        - java-common
-        - java-cacerts
-    pipeline:
-      - runs: |
-          _java_home="usr/lib/jvm/java-22-openjdk"
-
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/lib \
-             "${{targets.subpkgdir}}"/$_java_home
-
-          mkdir -p "${{targets.subpkgdir}}"/$_java_home/bin
-          for i in java \
-                    jfr \
-                    jrunscript \
-                    jwebserver \
-                    keytool \
-                    rmiregistry; do
-            mv "${{targets.destdir}}"/$_java_home/bin/$i "${{targets.subpkgdir}}"/$_java_home/bin/$i
-          done
-
-          mv "${{targets.destdir}}"/$_java_home/legal "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/conf "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/release "${{targets.subpkgdir}}"/$_java_home
-          cp ASSEMBLY_EXCEPTION \
-              LICENSE \
-              README.md \
-             "${{targets.subpkgdir}}"/$_java_home
+          cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
           # symlink to shared java cacerts store
           rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
@@ -224,6 +192,7 @@ subpackages:
     description: "Use the openjdk-22 JVM as the default JVM"
     dependencies:
       runtime:
+        - java-common-jre
         - ${{package.name}}-jre
       provides:
         - default-jvm=1.22
@@ -236,7 +205,7 @@ subpackages:
     description: "Use the openjdk-22 JVM as the default JVM with the JDK installed"
     dependencies:
       runtime:
-        - ${{package.name}}-default-jvm
+        - java-common
         - ${{package.name}}
       provides:
         - default-jdk=1.22

--- a/openjdk-22.yaml
+++ b/openjdk-22.yaml
@@ -120,7 +120,6 @@ pipeline:
       cp /etc/ssl/certs/java/cacerts \
         "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
 
-
 subpackages:
   - name: "${{package.name}}-dbg"
     description: "OpenJDK 22 Java Debug Symbols"

--- a/openjdk-22.yaml
+++ b/openjdk-22.yaml
@@ -208,6 +208,10 @@ subpackages:
         - ${{package.name}}
       provides:
         - default-jdk=1.22
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-22-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
 
 update:
   enabled: true

--- a/openjdk-23.yaml
+++ b/openjdk-23.yaml
@@ -1,13 +1,14 @@
 package:
   name: openjdk-23
   version: 23.0.1
-  epoch: 1
+  epoch: 2
   description: OpenJDK 23
   copyright:
     - license: GPL-2.0-or-later
   dependencies:
     runtime:
-      - openjdk-23-jre
+      - java-cacerts
+      - zlib
 
 environment:
   contents:
@@ -108,6 +109,11 @@ pipeline:
       cp -r build/*-server-release/images/jdk/* "${{targets.destdir}}"/$_java_home
       rm "${{targets.destdir}}"/$_java_home/lib/src.zip
 
+      # copy to shared java cacerts store
+      rm -f "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
+      cp /etc/ssl/certs/java/cacerts \
+        "${{targets.contextdir}}"/$_java_home/lib/security/cacerts
+
 subpackages:
   - name: "${{package.name}}-dbg"
     description: "OpenJDK 23 Java Debug Symbols"
@@ -121,10 +127,10 @@ subpackages:
     description: "OpenJDK 23 Java Runtime Environment"
     dependencies:
       runtime:
-        - ${{package.name}}-jre-base
         - alsa-lib
         - freetype
         - giflib
+        - java-cacerts
         - libfontconfig1
         - libjpeg-turbo
         - libx11
@@ -137,47 +143,8 @@ subpackages:
       - runs: |
           _java_home="usr/lib/jvm/java-23-openjdk"
 
-          mkdir -p "${{targets.subpkgdir}}"/$_java_home/lib
-          mv "${{targets.destdir}}"/$_java_home/lib/libawt_xawt.so \
-              "${{targets.destdir}}"/$_java_home/lib/libfontmanager.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjavajpeg.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjawt.so \
-              "${{targets.destdir}}"/$_java_home/lib/libjsound.so \
-              "${{targets.destdir}}"/$_java_home/lib/liblcms.so \
-              "${{targets.destdir}}"/$_java_home/lib/libsplashscreen.so \
-              "${{targets.subpkgdir}}"/$_java_home/lib
-
-  - name: "${{package.name}}-jre-base"
-    description: "OpenJDK 23 Java Runtime Environment (headless)"
-    dependencies:
-      runtime:
-        - java-common
-        - java-cacerts
-    pipeline:
-      - runs: |
-          _java_home="usr/lib/jvm/java-23-openjdk"
-
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/lib \
-             "${{targets.subpkgdir}}"/$_java_home
-
-          mkdir -p "${{targets.subpkgdir}}"/$_java_home/bin
-          for i in java \
-                    jfr \
-                    jrunscript \
-                    jwebserver \
-                    keytool \
-                    rmiregistry; do
-            mv "${{targets.destdir}}"/$_java_home/bin/$i "${{targets.subpkgdir}}"/$_java_home/bin/$i
-          done
-
-          mv "${{targets.destdir}}"/$_java_home/legal "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/conf "${{targets.subpkgdir}}"/$_java_home
-          mv "${{targets.destdir}}"/$_java_home/release "${{targets.subpkgdir}}"/$_java_home
-          cp ASSEMBLY_EXCEPTION \
-              LICENSE \
-              README.md \
-             "${{targets.subpkgdir}}"/$_java_home
+          cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
           # symlink to shared java cacerts store
           rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
@@ -215,9 +182,10 @@ subpackages:
              "${{targets.subpkgdir}}"/usr/lib/jvm/java-23-openjdk
 
   - name: "${{package.name}}-default-jvm"
-    description: "Use the openjdk-23 JVM as the default JVM"
+    description: "Use the openjdk-23 JVM (JRE) as the default JVM"
     dependencies:
       runtime:
+        - java-common-jre
         - ${{package.name}}-jre
       provides:
         - default-jvm=1.23
@@ -230,10 +198,14 @@ subpackages:
     description: "Use the openjdk-23 JVM as the default JVM with the JDK installed"
     dependencies:
       runtime:
-        - ${{package.name}}-default-jvm
+        - java-common
         - ${{package.name}}
       provides:
         - default-jdk=1.23
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib/jvm
+          ln -sf java-23-openjdk "${{targets.subpkgdir}}"/usr/lib/jvm/default-jvm
 
 update:
   enabled: true

--- a/openjdk-23.yaml
+++ b/openjdk-23.yaml
@@ -146,9 +146,9 @@ subpackages:
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
           cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home
 
-          # symlink to shared java cacerts store
+          # copy to shared java cacerts store
           rm -f "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
-          ln -sf /etc/ssl/certs/java/cacerts \
+          cp /etc/ssl/certs/java/cacerts \
             "${{targets.subpkgdir}}"/$_java_home/lib/security/cacerts
 
           # symlink for `java-common` to work (which expects jre in $_java_home/jre)


### PR DESCRIPTION
Adds a new java-common-jre subpackage to reduce dangling symlinks if only JRE present

This removes some unnecessary java modules installed when just using a JRE

Signed-off-by: Pris Nasrat <pris.nasrat@chainguard.dev>
