### PR TITLE
ruby3.x-mini_portile2

### DIFF
--- a/ruby3.2-mini_portile2.yaml
+++ b/ruby3.2-mini_portile2.yaml
@@ -1,5 +1,5 @@
 package:
-  name: ruby3.4-mini_portile2
+  name: ruby3.2-mini_portile2
   version: 2.8.8
   epoch: 0
   description: Simple autoconf and cmake builder for developers

--- a/ruby3.2-mini_portile2.yaml
+++ b/ruby3.2-mini_portile2.yaml
@@ -53,7 +53,10 @@ test:
         require "mini_portile2"
 
         recipe = MiniPortile.new("libiconv", "1.17.0")
-        recipe.files = ["https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"]
+        recipe.files << {
+          url: "https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz",
+          sha256: "8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313"
+        }
         recipe.cook
         recipe.activate
         EOT

--- a/ruby3.2-mini_portile2.yaml
+++ b/ruby3.2-mini_portile2.yaml
@@ -1,5 +1,5 @@
 package:
-  name: ruby3.2-mini_portile2
+  name: ruby3.4-mini_portile2
   version: 2.8.8
   epoch: 0
   description: Simple autoconf and cmake builder for developers
@@ -8,6 +8,7 @@ package:
   dependencies:
     runtime:
       - build-base
+      - cmake
       - ruby-${{vars.rubyMM}}
 
 environment:
@@ -42,16 +43,35 @@ test:
     contents:
       packages:
         - build-base
+        - cmake
   pipeline:
     - name: Validate import
       runs: ruby -e "require 'mini_portile2'"
-    - name: Test example recipe in docs
+    - name: Test example recipe from docs
       runs: |
         cat > test.rb <<EOT
         require "mini_portile2"
 
         recipe = MiniPortile.new("libiconv", "1.17.0")
         recipe.files = ["https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"]
+        recipe.cook
+        recipe.activate
+        EOT
+
+        ruby test.rb
+    - name: Test CMake recipe
+      runs: |
+        # Needed for the corrosion package
+        apk add rust
+
+        cat > test.rb <<EOT
+        require "mini_portile2"
+
+        recipe = MiniPortileCMake.new("corrosion", "0.5.1")
+        recipe.files << {
+          url: "https://github.com/corrosion-rs/corrosion/archive/refs/tags/v0.5.1.tar.gz",
+          sha256: "843334a9f0f5efbc225dccfa88031fe0f2ec6fd787ca1e7d55ed27b2c25d9c97"
+        }
         recipe.cook
         recipe.activate
         EOT

--- a/ruby3.3-mini_portile2.yaml
+++ b/ruby3.3-mini_portile2.yaml
@@ -1,5 +1,5 @@
 package:
-  name: ruby3.4-mini_portile2
+  name: ruby3.3-mini_portile2
   version: 2.8.8
   epoch: 0
   description: Simple autoconf and cmake builder for developers

--- a/ruby3.3-mini_portile2.yaml
+++ b/ruby3.3-mini_portile2.yaml
@@ -1,5 +1,5 @@
 package:
-  name: ruby3.3-mini_portile2
+  name: ruby3.4-mini_portile2
   version: 2.8.8
   epoch: 0
   description: Simple autoconf and cmake builder for developers
@@ -8,6 +8,7 @@ package:
   dependencies:
     runtime:
       - build-base
+      - cmake
       - ruby-${{vars.rubyMM}}
 
 environment:
@@ -42,10 +43,11 @@ test:
     contents:
       packages:
         - build-base
+        - cmake
   pipeline:
     - name: Validate import
       runs: ruby -e "require 'mini_portile2'"
-    - name: Test example recipe in docs
+    - name: Test example recipe from docs
       runs: |
         cat > test.rb <<EOT
         require "mini_portile2"
@@ -57,18 +59,24 @@ test:
         EOT
 
         ruby test.rb
-    # - name: Test CMake recipe
-    #   runs: |
-    #     cat > test.rb <<EOT
-    #     require "mini_portile2"
+    - name: Test CMake recipe
+      runs: |
+        # Needed for the corrosion package
+        apk add rust
 
-    #     recipe = MiniPortile.new("libiconv", "1.17.0")
-    #     recipe.files = ["https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"]
-    #     recipe.cook
-    #     recipe.activate
-    #     EOT
+        cat > test.rb <<EOT
+        require "mini_portile2"
 
-    #     ruby test.rb
+        recipe = MiniPortileCMake.new("corrosion", "0.5.1")
+        recipe.files << {
+          url: "https://github.com/corrosion-rs/corrosion/archive/refs/tags/v0.5.1.tar.gz",
+          sha256: "843334a9f0f5efbc225dccfa88031fe0f2ec6fd787ca1e7d55ed27b2c25d9c97"
+        }
+        recipe.cook
+        recipe.activate
+        EOT
+
+        ruby test.rb
 
 update:
   enabled: true

--- a/ruby3.3-mini_portile2.yaml
+++ b/ruby3.3-mini_portile2.yaml
@@ -53,7 +53,10 @@ test:
         require "mini_portile2"
 
         recipe = MiniPortile.new("libiconv", "1.17.0")
-        recipe.files = ["https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"]
+        recipe.files << {
+          url: "https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz",
+          sha256: "8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313"
+        }
         recipe.cook
         recipe.activate
         EOT

--- a/ruby3.3-mini_portile2.yaml
+++ b/ruby3.3-mini_portile2.yaml
@@ -1,5 +1,5 @@
 package:
-  name: ruby3.4-mini_portile2
+  name: ruby3.3-mini_portile2
   version: 2.8.8
   epoch: 0
   description: Simple autoconf and cmake builder for developers
@@ -57,6 +57,18 @@ test:
         EOT
 
         ruby test.rb
+    # - name: Test CMake recipe
+    #   runs: |
+    #     cat > test.rb <<EOT
+    #     require "mini_portile2"
+
+    #     recipe = MiniPortile.new("libiconv", "1.17.0")
+    #     recipe.files = ["https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"]
+    #     recipe.cook
+    #     recipe.activate
+    #     EOT
+
+    #     ruby test.rb
 
 update:
   enabled: true

--- a/ruby3.4-mini_portile2.yaml
+++ b/ruby3.4-mini_portile2.yaml
@@ -8,6 +8,7 @@ package:
   dependencies:
     runtime:
       - build-base
+      - cmake
       - ruby-${{vars.rubyMM}}
 
 environment:
@@ -42,16 +43,35 @@ test:
     contents:
       packages:
         - build-base
+        - cmake
   pipeline:
     - name: Validate import
       runs: ruby -e "require 'mini_portile2'"
-    - name: Test example recipe in docs
+    - name: Test example recipe from docs
       runs: |
         cat > test.rb <<EOT
         require "mini_portile2"
 
         recipe = MiniPortile.new("libiconv", "1.17.0")
         recipe.files = ["https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"]
+        recipe.cook
+        recipe.activate
+        EOT
+
+        ruby test.rb
+    - name: Test CMake recipe
+      runs: |
+        # Needed for the corrosion package
+        apk add rust
+
+        cat > test.rb <<EOT
+        require "mini_portile2"
+
+        recipe = MiniPortileCMake.new("corrosion", "0.5.1")
+        recipe.files << {
+          url: "https://github.com/corrosion-rs/corrosion/archive/refs/tags/v0.5.1.tar.gz",
+          sha256: "843334a9f0f5efbc225dccfa88031fe0f2ec6fd787ca1e7d55ed27b2c25d9c97"
+        }
         recipe.cook
         recipe.activate
         EOT

--- a/ruby3.4-mini_portile2.yaml
+++ b/ruby3.4-mini_portile2.yaml
@@ -1,0 +1,76 @@
+package:
+  name: ruby3.4-mini_portile2
+  version: 2.8.8
+  epoch: 0
+  description: Simple autoconf and cmake builder for developers
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - ruby-${{vars.rubyMM}}
+
+environment:
+  contents:
+    packages:
+      - ruby-${{vars.rubyMM}}
+      - ruby-${{vars.rubyMM}}-dev
+
+vars:
+  gem: mini_portile2
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/flavorjones/mini_portile
+      tag: v${{package.version}}
+      expected-commit: 17cd199e99daf84f80b2d144eff5bc699aa21a9c
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+
+test:
+  environment:
+    contents:
+      packages:
+        - autoconf
+        - automake
+        - build-base
+        - cmake
+        - gcc
+        - make
+  pipeline:
+    - name: Validate import
+      runs: ruby -e "require 'mini_portile2'"
+    - name: Test example recipe in docs
+      runs: |
+        cat > test.rb <<EOT
+        require "mini_portile2"
+
+        recipe = MiniPortile.new("libiconv", "1.13.1")
+        recipe.files = ["http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.13.1.tar.gz"]
+        recipe.cook
+        recipe.activate
+        EOT
+
+        ruby test.rb
+
+update:
+  enabled: true
+  github:
+    identifier: flavorjones/mini_portile
+    strip-prefix: v
+    tag-filter: v
+
+var-transforms:
+  - from: ${{package.name}}
+    match: ^ruby(\d\.\d+)-.*
+    replace: $1
+    to: rubyMM

--- a/ruby3.4-mini_portile2.yaml
+++ b/ruby3.4-mini_portile2.yaml
@@ -43,8 +43,10 @@ test:
         - autoconf
         - automake
         - build-base
+        - busybox
         - cmake
         - gcc
+        - libtool
         - make
   pipeline:
     - name: Validate import

--- a/ruby3.4-mini_portile2.yaml
+++ b/ruby3.4-mini_portile2.yaml
@@ -53,7 +53,10 @@ test:
         require "mini_portile2"
 
         recipe = MiniPortile.new("libiconv", "1.17.0")
-        recipe.files = ["https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"]
+        recipe.files << {
+          url: "https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz",
+          sha256: "8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313"
+        }
         recipe.cook
         recipe.activate
         EOT


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Adding the `mini_portile2` Ruby gem: https://rubygems.org/gems/mini_portile2

Related: https://github.com/chainguard-dev/image-requests/issues/5160