### PR TITLE
fix(world): Correctly use default-jvm and default-jdk

### DIFF
--- a/R.yaml
+++ b/R.yaml
@@ -65,8 +65,7 @@ environment:
       - libxmu-dev
       - make
       - openblas-dev
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - pango-dev
       - pcre2-dev
       - perl

--- a/akhq.yaml
+++ b/akhq.yaml
@@ -14,8 +14,7 @@ environment:
       - curl
       - gradle
       - npm
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
   environment:
     LANG: en_US.UTF-8
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk
@@ -61,7 +60,6 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-17
         - openjdk-17-default-jvm
   pipeline:
     - name: "start daemon on localhost"

--- a/apicurio-registry.yaml
+++ b/apicurio-registry.yaml
@@ -21,8 +21,7 @@ environment:
       - maven
       - nodejs-20
       - npm
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk
 
@@ -89,7 +88,6 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-17
         - openjdk-17-default-jvm
         - bash
         - curl

--- a/async-profiler.yaml
+++ b/async-profiler.yaml
@@ -11,8 +11,7 @@ environment:
     packages:
       - bash
       - build-base
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
       - wolfi-base
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk

--- a/byteman.yaml
+++ b/byteman.yaml
@@ -54,7 +54,6 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-11
         - openjdk-11-default-jvm
   pipeline:
     - name: jar listing

--- a/cass-config-builder.yaml
+++ b/cass-config-builder.yaml
@@ -13,7 +13,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - openjdk-8-default-jvm
+      - openjdk-8-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/java-1.8-openjdk
 

--- a/cassandra-5.0.yaml
+++ b/cassandra-5.0.yaml
@@ -28,7 +28,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
       - py${{vars.pyver}}-build
       - py${{vars.pyver}}-cython-bin
       - py${{vars.pyver}}-pip

--- a/cassandra-reaper.yaml
+++ b/cassandra-reaper.yaml
@@ -20,8 +20,7 @@ environment:
       - build-base
       - maven
       - nvm
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
       - openssl-dev
       - py3-setuptools
       - python3

--- a/cloudwatch-exporter.yaml
+++ b/cloudwatch-exporter.yaml
@@ -15,8 +15,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-21
-      - openjdk-21-default-jvm
+      - openjdk-21-default-jdk
 
 pipeline:
   - uses: git-checkout

--- a/confluent-common-docker.yaml
+++ b/confluent-common-docker.yaml
@@ -13,8 +13,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-21-default-jdk
 
 pipeline:
   - uses: git-checkout

--- a/datadog-jmxfetch.yaml
+++ b/datadog-jmxfetch.yaml
@@ -13,8 +13,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
   environment:
     LANG: en_US.UTF-8
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk

--- a/debezium-3.0.yaml
+++ b/debezium-3.0.yaml
@@ -18,8 +18,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-21
-      - openjdk-21-default-jvm
+      - openjdk-21-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/java-21-openjdk
 
@@ -96,7 +95,6 @@ subpackages:
       environment:
         contents:
           packages:
-            - openjdk-21
             - openjdk-21-default-jvm
       pipeline:
         - name: Verify JAR presence
@@ -168,7 +166,6 @@ subpackages:
       environment:
         contents:
           packages:
-            - openjdk-21
             - openjdk-21-default-jvm
       pipeline:
         - name: Verify JAR presence

--- a/debezium-connector-db2-3.0.yaml
+++ b/debezium-connector-db2-3.0.yaml
@@ -18,8 +18,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-21
-      - openjdk-21-default-jvm
+      - openjdk-21-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/java-21-openjdk
 
@@ -69,7 +68,6 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-21
         - openjdk-21-default-jvm
   pipeline:
     - name: Verify JAR presence

--- a/debezium-connector-ibmi-3.0.yaml
+++ b/debezium-connector-ibmi-3.0.yaml
@@ -18,8 +18,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-21
-      - openjdk-21-default-jvm
+      - openjdk-21-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/java-21-openjdk
 
@@ -69,7 +68,6 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-21
         - openjdk-21-default-jvm
   pipeline:
     - name: Verify JAR presence

--- a/debezium-connector-informix-3.0.yaml
+++ b/debezium-connector-informix-3.0.yaml
@@ -18,8 +18,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-21
-      - openjdk-21-default-jvm
+      - openjdk-21-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/java-21-openjdk
 
@@ -69,7 +68,6 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-21
         - openjdk-21-default-jvm
   pipeline:
     - name: Verify JAR presence

--- a/debezium-connector-spanner-3.0.yaml
+++ b/debezium-connector-spanner-3.0.yaml
@@ -18,8 +18,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-21
-      - openjdk-21-default-jvm
+      - openjdk-21-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/java-21-openjdk
 
@@ -71,7 +70,6 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-21
         - openjdk-21-default-jvm
   pipeline:
     - name: Verify JAR presence

--- a/debezium-connector-vitess-3.0.yaml
+++ b/debezium-connector-vitess-3.0.yaml
@@ -18,8 +18,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-21
-      - openjdk-21-default-jvm
+      - openjdk-21-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/java-21-openjdk
 
@@ -71,7 +70,6 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-21
         - openjdk-21-default-jvm
   pipeline:
     - name: Verify JAR presence

--- a/dependency-track.yaml
+++ b/dependency-track.yaml
@@ -16,8 +16,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-21
-      - openjdk-21-default-jvm
+      - openjdk-21-default-jdk
       - wolfi-base
       - wolfi-baselayout
 

--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -32,9 +32,7 @@ environment:
       - git
       - gnupg
       - jq
-      - openjdk-17
-      - openjdk-17-default-jvm
-      - openjdk-17-jre
+      - openjdk-17-default-jdk
       - openssl
       - x11vnc
       - yq

--- a/dotty.yaml
+++ b/dotty.yaml
@@ -17,8 +17,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - openjdk-11-default-jvm
-      - openjdk-11-jre
+      - openjdk-11-default-jdk
       - sbt
       - unzip
 
@@ -60,7 +59,6 @@ test:
     contents:
       packages:
         - openjdk-11-default-jvm
-        - openjdk-11-jre
   pipeline:
     - name: Verify that the binaries are installed and executable
       runs: |

--- a/druid.yaml
+++ b/druid.yaml
@@ -17,8 +17,7 @@ environment:
       - bash
       - busybox
       - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - py3-pyyaml
       - python3
 

--- a/flink-1.20.yaml
+++ b/flink-1.20.yaml
@@ -30,8 +30,7 @@ environment:
       - curl
       - maven
       - npm
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
       - python3
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk

--- a/jackson-json.yaml
+++ b/jackson-json.yaml
@@ -13,8 +13,7 @@ environment:
       - bash
       - busybox
       - ca-certificates-bundle
-      - openjdk-8
-      - openjdk-8-default-jvm
+      - openjdk-8-default-jdk
       - wolfi-base
 
 pipeline:

--- a/jenkins-2.yaml
+++ b/jenkins-2.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-2
   version: "2.492"
-  epoch: 0
+  epoch: 1
   description: Open-source CI/CD application.
   copyright:
     - license: MIT
@@ -16,8 +16,7 @@ package:
       - glibc-locale-en
       # The entrypoint script is pulled from a separate repo, which we'e packaged.
       - jenkins-entrypoint
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - ttf-dejavu
       - tzdata
 
@@ -35,8 +34,7 @@ environment:
       - glibc-locale-en
       - libxml2-utils
       - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - openssh-client
       - patch
       - tini
@@ -150,8 +148,6 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-17
-        - openjdk-17-default-jvm
         - jenkins-compat
         - jenkins-entrypoint
   pipeline:

--- a/jenkins-plugin-manager.yaml
+++ b/jenkins-plugin-manager.yaml
@@ -10,8 +10,7 @@ environment:
   contents:
     packages:
       - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - wolfi-base
       - wolfi-baselayout
   environment:
@@ -47,7 +46,6 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-17
         - openjdk-17-default-jvm
   pipeline:
     - name: "Check jenkins-plugin-manager Installation"

--- a/jvmkill.yaml
+++ b/jvmkill.yaml
@@ -15,8 +15,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - make
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
 
 pipeline:
   - uses: git-checkout

--- a/kafka-3.9.yaml
+++ b/kafka-3.9.yaml
@@ -25,8 +25,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - gradle
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
   environment:
     LANG: en_US.UTF-8
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk

--- a/keycloak-operator.yaml
+++ b/keycloak-operator.yaml
@@ -1,13 +1,14 @@
 package:
   name: keycloak-operator
   version: "26.0.8"
-  epoch: 0
+  epoch: 1
   description: A Kubernetes Operator based on the Operator SDK for installing and managing Keycloak.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
-      - openjdk-17-default-jvm
+      # The operator depends on Keycloak which currently depends on the full JDK
+      - openjdk-17-default-jdk # TODO: Switch to JRE
 
 environment:
   contents:
@@ -15,8 +16,7 @@ environment:
       - bash
       - busybox
       - ca-certificates-bundle
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - wolfi-base
       - wolfi-baselayout
   environment:

--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -1,14 +1,14 @@
 package:
   name: keycloak
   version: "26.0.8"
-  epoch: 0
+  epoch: 1
   description: Open Source Identity and Access Management For Modern Applications and Services
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - bash # Keycloak helper scripts require bash, aren't compatible with busybox.
-      - openjdk-21-default-jvm
+      - openjdk-21-default-jdk # TODO: Change to JRE
 
 # Create a new major-version variable that contains only the major version
 # to use in the bitnami/compat pipeline to find out the correct folder for the image.
@@ -27,8 +27,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - gcc-13-default
-      - openjdk-21
-      - openjdk-21-default-jvm
+      - openjdk-21-default-jdk
       - wolfi-base
       - wolfi-baselayout
   environment:

--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -28,7 +28,6 @@ package:
     runtime:
       - bash # some helper scripts use bash and busybox utilities
       - busybox
-      - openjdk-17-jre
       - openjdk-17-default-jvm
 
 # Create a new major-version variable that contains only the major version
@@ -50,13 +49,10 @@ environment:
       - gradle
       - jq
       - jruby-9.4
-      # logstash plugins to load at build-time
       - logstash-filter-xml
       - logstash-integration-jdbc
       - logstash-output-opensearch
-      # end logstash plugins to load at build-time
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
   environment:
     OSS: "true"
     LOGSTASH_SOURCE: "1"
@@ -261,7 +257,6 @@ subpackages:
             - bash
             - curl
             - busybox
-            - openjdk-17-jre
             - openjdk-17-default-jvm
         accounts:
           groups:
@@ -334,7 +329,6 @@ subpackages:
       runtime:
         - bash # some helper scripts use bash and busybox utilities
         - busybox
-        - openjdk-17-jre
         - openjdk-17-default-jvm
     pipeline:
       - name: Re-inject default plugins that have been patched

--- a/logstash-filter-xml.yaml
+++ b/logstash-filter-xml.yaml
@@ -22,8 +22,7 @@ environment:
       - ca-certificates-bundle
       - jruby-9.4
       - jruby-9.4-default-ruby
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/default-jvm
 

--- a/logstash-integration-jdbc.yaml
+++ b/logstash-integration-jdbc.yaml
@@ -22,8 +22,7 @@ environment:
       - ca-certificates-bundle
       - jruby-9.4
       - jruby-9.4-default-ruby
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
 
 # Do not run ruby/clean as logstash needs the cached gem file to install
 pipeline:

--- a/logstash-output-opensearch.yaml
+++ b/logstash-output-opensearch.yaml
@@ -24,8 +24,7 @@ environment:
       - ca-certificates-bundle
       - jruby-9.4
       - jruby-9.4-default-ruby
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/default-jvm
     JRUBY_OPTS: "-J-Xmx8g"

--- a/management-api-for-apache-cassandra-5.0.yaml
+++ b/management-api-for-apache-cassandra-5.0.yaml
@@ -17,8 +17,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - maven
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
 
@@ -83,7 +82,6 @@ test:
     contents:
       packages:
         - management-api-for-apache-cassandra-compat
-        - openjdk-11
         - openjdk-11-default-jvm
   pipeline:
     - runs: |

--- a/maven-3.9.yaml
+++ b/maven-3.9.yaml
@@ -15,12 +15,8 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      # The first time this is built, it depends on maven-stage0.yaml being built first,
-      # using pre-built maven binaries, which `provides` a maven package at an earlier version.
-      # Afterwards it depends on previous versions of this package built from source.
       - maven
-      - openjdk-11-default-jvm
-      - openjdk-11-jre
+      - openjdk-11-default-jdk
 
 pipeline:
   - uses: git-checkout
@@ -71,7 +67,6 @@ test:
     contents:
       packages:
         - openjdk-11-default-jvm
-        - openjdk-11-jre
     environment:
       JAVA_HOME: /usr/lib/jvm/java-11-openjdk
   pipeline:

--- a/metric-collector-for-apache-cassandra-4.1.yaml
+++ b/metric-collector-for-apache-cassandra-4.1.yaml
@@ -20,8 +20,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - maven
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
   environment:
     CASSANDRA_VERSION: 4.1.5
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
@@ -64,7 +63,6 @@ test:
     contents:
       packages:
         - bash
-        - openjdk-11
         - openjdk-11-default-jvm
   pipeline:
     - name: Check JAR integrity

--- a/neo4j-5.26.yaml
+++ b/neo4j-5.26.yaml
@@ -20,8 +20,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - wolfi-base
       - wolfi-baselayout
 
@@ -96,7 +95,6 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-17
         - openjdk-17-default-jvm
         - wait-for-it
   pipeline:

--- a/neuvector-manager.yaml
+++ b/neuvector-manager.yaml
@@ -21,10 +21,9 @@ environment:
     packages:
       - build-base
       - busybox
-      - nodejs-22 # Lock to (current) latest LTS as recommended during build process.
+      - nodejs-22
       - npm
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - py3-pip
       - python3
       - sbt

--- a/newrelic-infrastructure-bundle.yaml
+++ b/newrelic-infrastructure-bundle.yaml
@@ -1,7 +1,7 @@
 package:
   name: newrelic-infrastructure-bundle
   version: 3.2.62
-  epoch: 1
+  epoch: 2
   description: New Relic Infrastructure containerised agent bundle
   copyright:
     - license: Apache-2.0
@@ -46,7 +46,7 @@ package:
       - nri-redis
       - nri-redis-compat
       - nrjmx
-      - openjdk-8-jre
+      - openjdk-8 # TODO: Switch to JRE
 
 environment:
   contents:

--- a/nrjmx.yaml
+++ b/nrjmx.yaml
@@ -17,8 +17,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - wolfi-base
       - wolfi-baselayout
   environment:

--- a/openjdk-10.yaml
+++ b/openjdk-10.yaml
@@ -35,8 +35,7 @@ environment:
       - libxt-dev
       - libxtst-dev
       - linux-headers
-      - openjdk-9
-      - openjdk-9-default-jvm
+      - openjdk-9-default-jdk
       - wolfi-base
       - zip
       - zlib-dev

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -34,8 +34,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-10
-      - openjdk-10-default-jvm
+      - openjdk-10-default-jdk
       - zip
 
 pipeline:

--- a/openjdk-12.yaml
+++ b/openjdk-12.yaml
@@ -36,8 +36,7 @@ environment:
       - libxt-dev
       - libxtst-dev
       - linux-headers
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
       - zip
       - zlib-dev
   environment:

--- a/openjdk-13.yaml
+++ b/openjdk-13.yaml
@@ -34,8 +34,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-12
-      - openjdk-12-default-jvm
+      - openjdk-12-default-jdk
       - zip
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL

--- a/openjdk-14.yaml
+++ b/openjdk-14.yaml
@@ -34,8 +34,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-13
-      - openjdk-13-default-jvm
+      - openjdk-13-default-jdk
       - zip
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -34,8 +34,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-14
-      - openjdk-14-default-jvm
+      - openjdk-14-default-jdk
       - zip
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -34,8 +34,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-15
-      - openjdk-15-default-jvm
+      - openjdk-15-default-jdk
       - zip
 
 # transform melange version to contain "+" rather than third "." so we can use a var in the fetch URL

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -34,8 +34,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-16
-      - openjdk-16-default-jvm
+      - openjdk-16-default-jdk
       - zip
 
 pipeline:

--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -34,8 +34,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - zip
   environment:
     # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -34,8 +34,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-18
-      - openjdk-18-default-jvm
+      - openjdk-18-default-jdk
       - zip
   environment:
     # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -34,8 +34,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-19
-      - openjdk-19-default-jvm
+      - openjdk-19-default-jdk
       - zip
   environment:
     # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -34,8 +34,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-20
-      - openjdk-20-default-jvm
+      - openjdk-20-default-jdk
       - zip
   environment:
     # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z

--- a/openjdk-22.yaml
+++ b/openjdk-22.yaml
@@ -34,8 +34,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-21
-      - openjdk-21-default-jvm
+      - openjdk-21-default-jdk
       - zip
   environment:
     # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z

--- a/openjdk-23.yaml
+++ b/openjdk-23.yaml
@@ -34,8 +34,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-22
-      - openjdk-22-default-jvm
+      - openjdk-22-default-jdk
       - zip
   environment:
     # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z

--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -36,8 +36,7 @@ environment:
       - libxrender-dev
       - libxt-dev
       - libxtst-dev
-      - openjdk-23
-      - openjdk-23-default-jvm
+      - openjdk-23-default-jdk
       - zip
   environment:
     # This is needed to work around the error date 1970-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z

--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -54,8 +54,7 @@ environment:
       - libxt-dev
       - libxtst-dev
       - linux-headers
-      - openjdk-7
-      - openjdk-7-default-jvm
+      - openjdk-7-default-jdk
       - pango-dev
       - patch
       - pkgconf-dev

--- a/openjdk-9.yaml
+++ b/openjdk-9.yaml
@@ -35,8 +35,7 @@ environment:
       - libxt-dev
       - libxtst-dev
       - linux-headers
-      - openjdk-8
-      - openjdk-8-default-jvm
+      - openjdk-8-default-jdk
       - wolfi-base
       - zip
       - zlib-dev

--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -26,8 +26,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - gradle
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - patch
       - unzip
   environment:

--- a/pdftk.yaml
+++ b/pdftk.yaml
@@ -17,8 +17,7 @@ environment:
       - build-base
       - busybox
       - gradle-8
-      - openjdk-8
-      - openjdk-8-default-jvm
+      - openjdk-8-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/java-1.8-openjdk
 

--- a/prometheus-jmx-exporter.yaml
+++ b/prometheus-jmx-exporter.yaml
@@ -14,8 +14,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - maven
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
   environment:
     LANG: en_US.UTF-8
     JAVA_HOME: /usr/lib/jvm/default-jvm
@@ -46,7 +45,6 @@ test:
   environment:
     contents:
       packages:
-        - openjdk-11
         - openjdk-11-default-jvm
         - ${{package.name}}-httpserver
         - curl

--- a/ruby3.2-concurrent-ruby.yaml
+++ b/ruby3.2-concurrent-ruby.yaml
@@ -17,8 +17,7 @@ environment:
       - ca-certificates-bundle
       - git
       - jruby-9.4
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
       - ruby${{vars.rubyMM}}-bundler
       - ruby-${{vars.rubyMM}}
       - ruby-${{vars.rubyMM}}-dev

--- a/ruby3.2-logstash-core-plugin-api.yaml
+++ b/ruby3.2-logstash-core-plugin-api.yaml
@@ -19,8 +19,7 @@ environment:
       - git
       - jruby-9.4
       - jruby-9.4-default-ruby
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
     # TODO: Ideally, we should read the version from the ../versions.yml file. But

--- a/ruby3.2-logstash-core.yaml
+++ b/ruby3.2-logstash-core.yaml
@@ -37,8 +37,7 @@ environment:
       - git
       - jruby-9.4
       - jruby-9.4-default-ruby
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
 
 pipeline:
   - uses: git-checkout

--- a/ruby3.3-concurrent-ruby.yaml
+++ b/ruby3.3-concurrent-ruby.yaml
@@ -17,8 +17,7 @@ environment:
       - ca-certificates-bundle
       - git
       - jruby-9.4
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
       - ruby${{vars.rubyMM}}-bundler
       - ruby-${{vars.rubyMM}}
       - ruby-${{vars.rubyMM}}-dev

--- a/ruby3.3-logstash-core-plugin-api.yaml
+++ b/ruby3.3-logstash-core-plugin-api.yaml
@@ -19,8 +19,7 @@ environment:
       - git
       - jruby-9.4
       - jruby-9.4-default-ruby
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
     # TODO: Ideally, we should read the version from the ../versions.yml file. But

--- a/ruby3.3-logstash-core.yaml
+++ b/ruby3.3-logstash-core.yaml
@@ -37,8 +37,7 @@ environment:
       - git
       - jruby-9.4
       - jruby-9.4-default-ruby
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
 
 pipeline:
   - uses: git-checkout

--- a/ruby3.4-concurrent-ruby.yaml
+++ b/ruby3.4-concurrent-ruby.yaml
@@ -17,8 +17,7 @@ environment:
       - ca-certificates-bundle
       - git
       - jruby-9.4
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
       - ruby${{vars.rubyMM}}-bundler
       - ruby-${{vars.rubyMM}}
       - ruby-${{vars.rubyMM}}-dev

--- a/ruby3.4-logstash-core-plugin-api.yaml
+++ b/ruby3.4-logstash-core-plugin-api.yaml
@@ -19,8 +19,7 @@ environment:
       - git
       - jruby-9.4
       - jruby-9.4-default-ruby
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11-openjdk
     # TODO: Ideally, we should read the version from the ../versions.yml file. But

--- a/ruby3.4-logstash-core.yaml
+++ b/ruby3.4-logstash-core.yaml
@@ -37,8 +37,7 @@ environment:
       - git
       - jruby-9.4
       - jruby-9.4-default-ruby
-      - openjdk-11
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
 
 pipeline:
   - uses: git-checkout

--- a/sbt-stage0.yaml
+++ b/sbt-stage0.yaml
@@ -8,7 +8,7 @@ package:
   dependencies:
     runtime:
       - bash
-      - openjdk-11-jre
+      - openjdk-11-default-jdk
     provides:
       - sbt=1.8.2
 

--- a/sbt.yaml
+++ b/sbt.yaml
@@ -1,14 +1,14 @@
 package:
   name: sbt
   version: 1.10.7
-  epoch: 0
+  epoch: 1
   description: A scala build tool
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - bash
-      - openjdk-11-jre
+      - openjdk-11-default-jdk
 
 environment:
   contents:
@@ -16,11 +16,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      # The first time this is built, it depends on sbt-stage0.yaml being built first,
-      # using pre-built sbt binaries, which `provides` a sbt package at an earlier version.
-      # Afterwards it depends on previous versions of this package built from source.
-      - openjdk-11-default-jvm
-      - openjdk-11-jre
+      - openjdk-11-default-jdk
       - sbt
 
 pipeline:

--- a/scala-2.13.yaml
+++ b/scala-2.13.yaml
@@ -15,8 +15,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
-      - openjdk-11-default-jvm
-      - openjdk-11-jre
+      - openjdk-11-default-jdk
       - sbt
 
 pipeline:
@@ -58,7 +57,6 @@ test:
       packages:
         - bash
         - openjdk-11-default-jvm
-        - openjdk-11-jre
   pipeline:
     - name: "Verify Scala version"
       runs: |

--- a/selenium.yaml
+++ b/selenium.yaml
@@ -26,8 +26,7 @@ environment:
       - libbz2-1
       - liblz4-1
       - libzstd1
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - python3
       - ruby-3.3
       - tzdata

--- a/snappy-java.yaml
+++ b/snappy-java.yaml
@@ -15,8 +15,7 @@ environment:
       - ca-certificates-bundle
       - cmake
       - curl
-      - openjdk-8
-      - openjdk-8-default-jvm
+      - openjdk-8-default-jdk
       - samurai
   environment:
     LANG: en_US.UTF-8

--- a/solr.yaml
+++ b/solr.yaml
@@ -18,7 +18,7 @@ environment:
     packages:
       - build-base
       - busybox
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - perl
 
 pipeline:

--- a/sonar-scanner-cli.yaml
+++ b/sonar-scanner-cli.yaml
@@ -13,8 +13,7 @@ environment:
   contents:
     packages:
       - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - wolfi-base
       - wolfi-baselayout
   environment:
@@ -64,7 +63,6 @@ test:
     contents:
       packages:
         - openjdk-17-default-jvm
-        - openjdk-17
   pipeline:
     - runs: |
         sonar-scanner-cli --version

--- a/sonarqube-10.yaml
+++ b/sonarqube-10.yaml
@@ -24,7 +24,7 @@ environment:
       - ca-certificates-bundle
       - nodejs~18
       - npm
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - yarn
       - zstd-dev
   environment:

--- a/spdx-tools-java.yaml
+++ b/spdx-tools-java.yaml
@@ -1,22 +1,20 @@
 package:
   name: spdx-tools-java
   version: 1.1.8
-  epoch: 1
+  epoch: 2
   description: SPDX Command Line Tools using the Spdx-Java-Library
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - openjdk-17-default-jvm
-      - openjdk-17-jre
 
 environment:
   contents:
     packages:
       - busybox
       - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - ttf-dejavu
   environment:
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk

--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -20,13 +20,12 @@ environment:
       - ca-certificates-bundle
       - coreutils
       - curl
-      - docker # not gonna be needed but their script requires docker to be installed
+      - docker
       - findutils
       - helm
       - make
       - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - perl-utils
       - tini
       - tini-compat

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -19,8 +19,7 @@ environment:
       - lcms2
       - maven
       - nodejs-16
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - ttf-dejavu
       - xz
       - yarn

--- a/wavefront-proxy.yaml
+++ b/wavefront-proxy.yaml
@@ -1,14 +1,13 @@
 package:
   name: wavefront-proxy
   version: "13.7" # When version is bumped, check if patches are still needed to address CVE-2023-1428
-  epoch: 3
+  epoch: 4
   description: Wavefront Proxy Project
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - openjdk-11-default-jvm
-      - openjdk-11-jre
 
 environment:
   contents:
@@ -17,7 +16,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - maven
-      - openjdk-11-default-jvm
+      - openjdk-11-default-jdk
       - wolfi-baselayout
 
 pipeline:

--- a/zetasql.yaml
+++ b/zetasql.yaml
@@ -20,8 +20,7 @@ environment:
       - ca-certificates-bundle
       - gcc-12
       - git
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
       - patch
       - python3
       - tzdata

--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -30,8 +30,7 @@ environment:
       - ca-certificates-bundle
       - curl
       - maven
-      - openjdk-17
-      - openjdk-17-default-jvm
+      - openjdk-17-default-jdk
   environment:
     LANG: en_US.UTF-8
     JAVA_HOME: /usr/lib/jvm/java-17-openjdk


### PR DESCRIPTION
default-jvm is meant for exclusive use for the JRE and default-jdk is for exclusive use with the JDK

Only rebuild packages where runtime dependencies have changed