### PR TITLE
Fix for update-bot failing to poll repo - also flips from fork to main source repo

### DIFF
--- a/py3-escapism.yaml
+++ b/py3-escapism.yaml
@@ -71,4 +71,4 @@ test:
 
 update:
   enabled: true
-  git:
+  git: {}

--- a/py3-escapism.yaml
+++ b/py3-escapism.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-escapism
   version: 1.0.1
-  epoch: 2
+  epoch: 3
   description: Simple, generic API for escaping strings.
   copyright:
     - license: MIT
@@ -29,7 +29,7 @@ pipeline:
   - uses: git-checkout
     with:
       expected-commit: 29e4604e1419d1b347ec1ada5d8a84af865953b0
-      repository: https://github.com/minrk/escapism
+      repository: https://github.com/jupyterhub/escapism
       tag: ${{package.version}}
 
 subpackages:
@@ -71,7 +71,4 @@ test:
 
 update:
   enabled: true
-  manual: false
-  github:
-    identifier: minrk/escapism
-    use-tag: true
+  git:


### PR DESCRIPTION
Fix for update-bot failing to poll repo - by migrating to git poller.

This package was also referencing a fork, and that fork does not contain any additional changes vs original upstream repo, not does it contain any release tags. This seems... incorrect? Perhaps not intended originally. I bumped the epoch to trigger a build given we flipped the source repo.