### PR TITLE
UpdateBot - Switch to use git poller for updates

### DIFF
--- a/enchant2.yaml
+++ b/enchant2.yaml
@@ -59,8 +59,7 @@ subpackages:
 
 update:
   enabled: true
-  github:
-    identifier: AbiWord/enchant
+  git:
     strip-prefix: v
 
 test:

--- a/exiftool.yaml
+++ b/exiftool.yaml
@@ -39,8 +39,7 @@ pipeline:
 
 update:
   enabled: true
-  github:
-    identifier: exiftool/exiftool
+  git: {}
 
 test:
   pipeline:

--- a/exiftool.yaml
+++ b/exiftool.yaml
@@ -39,7 +39,8 @@ pipeline:
 
 update:
   enabled: true
-  git: {}
+  github:
+    identifier: exiftool/exiftool
 
 test:
   pipeline:


### PR DESCRIPTION
UpdateBot - Was not able to poll this repo for updates. Switch to use git poller. Epoch bump not required.