### PR TITLE
fix(sbt): Drop default-jdk

### DIFF
--- a/sbt-stage0.yaml
+++ b/sbt-stage0.yaml
@@ -1,14 +1,14 @@
 package:
   name: sbt-stage0
   version: 1.8.2
-  epoch: 1
+  epoch: 2
   description: A scala build tool
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - bash
-      - openjdk-11-default-jdk
+      - openjdk-11
     provides:
       - sbt=1.8.2
 

--- a/sbt.yaml
+++ b/sbt.yaml
@@ -1,14 +1,14 @@
 package:
   name: sbt
   version: 1.10.7
-  epoch: 1
+  epoch: 2
   description: A scala build tool
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - bash
-      - openjdk-11-default-jdk
+      - openjdk-11
 
 environment:
   contents:


### PR DESCRIPTION
Depend directly on OpenJDK 11 and allow other variants to be installed