### PR TITLE
tensorflow-cpu: match upstream release version

### DIFF
--- a/tensorflow-cpu.yaml
+++ b/tensorflow-cpu.yaml
@@ -1,7 +1,7 @@
 #nolint:valid-pipeline-git-checkout-tag
 package:
   name: tensorflow-cpu
-  version: 0_git20250108
+  version: 2.18.0
   epoch: 0
   description: tensorflow-cpu
   copyright:
@@ -43,14 +43,17 @@ environment:
 pipeline:
   - uses: git-checkout
     with:
-      expected-commit: e23ae5591020ef3cb2917293ed92af7ea70bcdb1
-      repository: https://github.com/tensorflow/build
-      branch: master
+      repository: https://github.com/tensorflow/tensorflow
+      tag: v${{package.version}}
+      expected-commit: 6550e4bd80223cdb8be6c3afd1f81e86a4d433c3
 
-  - working-directory: tensorflow_runtime_dockerfiles
+  - runs: |
+      git clone --depth=1 https://github.com/tensorflow/build tensorflow-build
+
+  - working-directory: tensorflow-build/tensorflow_runtime_dockerfiles
     pipeline:
       - name: Check latest supported Python version
-      - runs: |
+        runs: |
           PYTHON_VERSION=$(grep -E "^ARG PYTHON_VERSION" cpu.Dockerfile | cut -d '=' -f2 | sed 's|python||g')
           test "${{vars.py-version}}" == "${PYTHON_VERSION}" || \
             { echo "error: Python version does not match the latest supported version: want: ${{vars.py-version}} got: ${PYTHON_VERSION} from $(grep -H -n -E '^ARG PYTHON_VERSION' cpu.Dockerfile)" && exit 1; }
@@ -84,7 +87,7 @@ pipeline:
         runs: |
           mkdir -p ${{targets.contextdir}}/${{vars.shared}}
           mv .venv/* ${{targets.contextdir}}/${{vars.shared}}
-          sed -i "s|/home/build/tensorflow_runtime_dockerfiles/.venv|${{vars.shared}}|g" ${{targets.contextdir}}/${{vars.shared}}/bin/*
+          sed -i "s|/home/build/tensorflow-build/tensorflow_runtime_dockerfiles/.venv|${{vars.shared}}|g" ${{targets.contextdir}}/${{vars.shared}}/bin/*
       - name: Install bashrc
         runs: |
           mkdir -p ${{targets.contextdir}}/etc
@@ -102,6 +105,11 @@ test:
     environment:
       PYTHONPATH: ${{vars.shared}}/lib/python${{vars.py-version}}/site-packages
   pipeline:
+    - name: Test Tensorflow version
+      runs: |
+        python -c 'import tensorflow as tf; print("TensorFlow version:", tf.__version__)' 2>/dev/null | \
+          cut -d ':' -f2 | sed 's|\ ||g' | \
+          grep -q -E "^${{package.version}}$"
     - name: Test import of IPython kernel for Jupyter
       uses: python/import
       with:
@@ -140,7 +148,8 @@ test:
 
 update:
   enabled: true
-  git: {}
-  schedule:
-    period: daily
-    reason: Upstream does not maintain tags or releases
+  github:
+    identifier: tensorflow/tensorflow
+    use-tag: true
+    strip-prefix: v
+    tag-filter: v


### PR DESCRIPTION
This PR wil make the package versioning to match the upstream release version, by changing update configuration to be based on the Git tags that are published to the main repository.

The change should be safe because the Python requirements declared in the SIG build repository that are referred to satisfy dependencies, do not pin any version.