### PR TITLE
Add pre-commit with check to forbid submodules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: forbid-submodules


### PR DESCRIPTION
With this in place

```
$ pre-commit install

$ git commit
forbid submodules........................................................Failed
- hook id: forbid-submodules
- exit code: 1

submodules are not allowed in this repository:

mono
```

adding submodules fails the commit.


hallarious

```
Build ID: b98a1180-c583-4595-b4f0-ab97084804e1
Error: unable to decode configuration file ".pre-commit-config.yaml": yaml: unmarshal errors:
line 1: field repos not found in type config.Configuration
```