### PR TITLE
fix(openjdk-17-jre): Use correct Java home

### DIFF
--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
   version: 17.0.13 # TODO(jason): on version bump ensure to update downstream projects that are pinned to a specific prerelease version, i.e. https://github.com/chainguard-images/images/tree/main/images
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-only
@@ -142,7 +142,7 @@ subpackages:
         - ttf-dejavu
     pipeline:
       - runs: |
-          _java_home="usr/lib/jvm/java-22-openjdk"
+          _java_home="usr/lib/jvm/java-17-openjdk"
 
           mkdir -p "${{targets.subpkgdir}}"/$_java_home
           cp -r build/*-server-release/images/jre/* "${{targets.subpkgdir}}"/$_java_home


### PR DESCRIPTION
This was pointing to OpenJDK 22, correctly point to 17