### PR TITLE
Symlink PG binaries to /usr/local

### DIFF
--- a/pgadmin4-17.yaml
+++ b/pgadmin4-17.yaml
@@ -145,16 +145,12 @@ test:
         sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start
         createdb testdb
         psql -lqt | cut -d \| -f 1 | grep -qw testdb
-    - name: "Verify PostgreSQL binaries"
+    - name: "stat symlink"
       runs: |
-        BINARIES=(pg_dump pg_dumpall pg_restore psql)
-        for BIN in "${BINARIES[@]}"; do
-          if [ ! -L "/usr/local/pgsql-${{vars.pg-version}}/$BIN" ]; then
-            echo "Binary $BIN is missing or not linked correctly"
-            exit 1
-          fi
-        done
-        echo "All PostgreSQL binaries are installed and linked correctly."
+        stat /usr/local/pgsql-${{vars.pg-version}}/pg_dump
+        stat /usr/local/pgsql-${{vars.pg-version}}/pg_dumpall
+        stat /usr/local/pgsql-${{vars.pg-version}}/pg_restore
+        stat /usr/local/pgsql-${{vars.pg-version}}/psql
     - name: "Start pgAdmin4 Server"
       uses: test/daemon-check-output
       working-directory: /pgadmin4

--- a/pgadmin4-17.yaml
+++ b/pgadmin4-17.yaml
@@ -3,7 +3,7 @@
 package:
   name: pgadmin4-17
   version: "8.14"
-  epoch: 0
+  epoch: 1
   description: "pgAdmin is the most popular and feature rich Open Source administration and development platform for PostgreSQL, the most advanced Open Source database in the world."
   copyright:
     - license: PostgreSQL
@@ -113,6 +113,13 @@ pipeline:
       # allow site-packages
       sed -i "s|include-system-site-packages = false|include-system-site-packages = true|g" ${{targets.destdir}}/pgadmin4/venv/pyvenv.cfg
 
+      # Copy the PG binaries
+      mkdir  -p ${{targets.destdir}}/usr/local/pgsql-${{vars.pg-version}}
+      ln -sf  /usr/libexec/postgresql${{vars.pg-version}}/pg_dump ${{targets.destdir}}/usr/local/pgsql-${{vars.pg-version}}/
+      ln -sf  /usr/libexec/postgresql${{vars.pg-version}}/pg_dumpall ${{targets.destdir}}/usr/local/pgsql-${{vars.pg-version}}/
+      ln -sf  /usr/libexec/postgresql${{vars.pg-version}}/pg_restore ${{targets.destdir}}/usr/local/pgsql-${{vars.pg-version}}/
+      ln -sf  /usr/libexec/postgresql${{vars.pg-version}}/psql ${{targets.destdir}}/usr/local/pgsql-${{vars.pg-version}}/
+
 test:
   environment:
     contents:
@@ -138,6 +145,16 @@ test:
         sudo -u $PGUSER pg_ctl -D /tmp/test_db -l /tmp/logfile start
         createdb testdb
         psql -lqt | cut -d \| -f 1 | grep -qw testdb
+    - name: "Verify PostgreSQL binaries"
+      runs: |
+        BINARIES=(pg_dump pg_dumpall pg_restore psql)
+        for BIN in "${BINARIES[@]}"; do
+          if [ ! -L "/usr/local/pgsql-${{vars.pg-version}}/$BIN" ]; then
+            echo "Binary $BIN is missing or not linked correctly"
+            exit 1
+          fi
+        done
+        echo "All PostgreSQL binaries are installed and linked correctly."
     - name: "Start pgAdmin4 Server"
       uses: test/daemon-check-output
       working-directory: /pgadmin4


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
