### PR TITLE
Updatebot w3m package

### DIFF
--- a/w3m.yaml
+++ b/w3m.yaml
@@ -2,7 +2,7 @@
 package:
   name: w3m
   version: 0.5.3.20230121
-  epoch: 3
+  epoch: 0
   description: text-based web & gopher browser, as well as pager
   copyright:
     - license: MIT

--- a/w3m.yaml
+++ b/w3m.yaml
@@ -29,7 +29,6 @@ var-transforms:
     match: (\d+\.\d+\.\d+)\.\d+
     replace: $1
     to: package-version
-
   - from: ${{package.version}}
     match: \d+\.\d+\.\d+\.(\d+)
     replace: $1
@@ -66,7 +65,6 @@ update:
     # Transform v0.5.3+git20230121 -> 0.5.3.20230121
     - match: ^(\d+\.\d+\.\d+)\+git(\d+)$
       replace: $1.$2
-
 
 # Basic test, requires newtork access, to dump https://example.com to stdout
 test:

--- a/w3m.yaml
+++ b/w3m.yaml
@@ -1,7 +1,7 @@
 #nolint:git-checkout-must-use-github-updates,valid-pipeline-git-checkout-tag
 package:
   name: w3m
-  version: 0.5.3.20230718
+  version: 0.5.3.20230121
   epoch: 3
   description: text-based web & gopher browser, as well as pager
   copyright:
@@ -24,11 +24,23 @@ environment:
       - ncurses-dev
       - openssl-dev
 
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d+\.\d+\.\d+)\.\d+
+    replace: $1
+    to: package-version
+
+  - from: ${{package.version}}
+    match: \d+\.\d+\.\d+\.(\d+)
+    replace: $1
+    to: package-version-datestamp
+
 pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/tats/w3m
-      expected-commit: ee66aabc3987000c2851bce6ade4dcbb0b037d81
+      expected-commit: c8223fed7cc631ad85d8e5665e509e7988bedbab
+      tag: v${{vars.package-version}}+git${{vars.package-version-datestamp}}
 
   - uses: autoconf/configure
 
@@ -46,8 +58,15 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 5115
+  git:
+    strip-prefix: v
+  ignore-regex-patterns:
+    - .*deb.*
+  version-transform:
+    # Transform v0.5.3+git20230121 -> 0.5.3.20230121
+    - match: ^(\d+\.\d+\.\d+)\+git(\d+)$
+      replace: $1.$2
+
 
 # Basic test, requires newtork access, to dump https://example.com to stdout
 test:

--- a/withdrawn-packages.txt
+++ b/withdrawn-packages.txt
@@ -54,3 +54,5 @@ neo4j-5.26-oci-entrypoint-5.26.0-r0.apk
 neo4j-5.26-5.26.0-r0.apk
 neo4j-5.26-oci-entrypoint-5.26.0-r1.apk
 neo4j-5.26-5.26.0-r1.apk
+w3m-0.5.3.20230718-r3.apk
+w3m-doc-0.5.3.20230718-r3.apk


### PR DESCRIPTION
The w3m package was relying on release monitor for update alerts, which is now returning a version that not exist upstream. It's possible that the tag / release was removed.

Wiring up to poll Git for updates, and also withdrawing package version built previously for the non-existant version.

There are no other packages or images dependent on this package.