### PR TITLE
use var-transforms to construct the right version and tag. Update git…

### DIFF
--- a/kpt.yaml
+++ b/kpt.yaml
@@ -15,11 +15,18 @@ environment:
       - go
       - make
 
+var-transforms:
+  # Transform 1.0.0_beta55 -> 1.0.0-beta.55
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+\.\d+)_beta(\d+)$
+    replace: $1-beta.$2
+    to: mangled-package-version
+
 pipeline:
   - uses: git-checkout
     with:
-      repository: https://github.com/GoogleContainerTools/kpt
-      tag: v1.0.0-beta.55
+      repository: https://github.com/kptdev/kpt
+      tag: v${{vars.mangled-package-version}}
       expected-commit: 1f295b3219a3f809fdb5a14d3cffc84422affb3b
 
   - uses: go/bump
@@ -31,10 +38,42 @@ pipeline:
       make GOBIN="${{targets.destdir}}"/usr/bin build
 
 update:
-  enabled: false
-  manual: true # The beta versioning here breaks our automation
-  github:
-    identifier: GoogleContainerTools/kpt
+  enabled: true
+  git:
     strip-prefix: v
-    tag-filter: v
-    use-tag: true
+    tag-filter-prefix: v
+  version-transform:
+    # Transform v1.0.0-beta.55 -> 1.0.0_beta55
+    - match: ^(\d+\.\d+\.\d+)-beta\.(\d+)$
+      replace: $1_beta$2
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+        - git
+  pipeline:
+    - name: Binary verification
+      runs: |
+        test -f /usr/bin/kpt
+        test -x /usr/bin/kpt
+        kpt version
+    - name: Basic functionality test
+      runs: |
+        # Create and initialize test package
+        mkdir -p /tmp/test-pkg
+        kpt pkg init /tmp/test-pkg
+        cd /tmp/test-pkg
+
+        # Verify package structure
+        test -f Kptfile
+
+        # Test basic package commands
+        kpt pkg tree
+
+        # Test function rendering capability
+        kpt fn render --help
+
+        # Test package documentation
+        kpt pkg describe

--- a/kpt.yaml
+++ b/kpt.yaml
@@ -1,7 +1,7 @@
 package:
   name: kpt
   version: 1.0.0_beta55
-  epoch: 0
+  epoch: 1
   description: Automate Kubernetes Configuration Editing
   copyright:
     - license: Apache-2.0

--- a/kpt.yaml
+++ b/kpt.yaml
@@ -51,7 +51,6 @@ test:
   environment:
     contents:
       packages:
-        - busybox
         - git
   pipeline:
     - name: Binary verification


### PR DESCRIPTION
- Use var-transforms to construct the right version and tag
- Update git repo which looks to have been re-named
- Add some basic test coverage

This was an existing package building a beta release. We may need to tweak the var-transforms if and when they drop beta