### PR TITLE
Set manual update flag, unfortunately we can't enable auto-updates fo…

### DIFF
--- a/chrpath.yaml
+++ b/chrpath.yaml
@@ -35,7 +35,8 @@ subpackages:
       - uses: split/manpages
 
 update:
-  enabled: true
+  enabled: false
+  exclude-reason: v16 is the latest stable at time of writing. v18 is unstable and returned by release-monitor project. Code is not in a SCM for us to use git poller.
   release-monitor:
     identifier: 13891
 


### PR DESCRIPTION
release-monitor project returns v18:
 - https://release-monitoring.org/project/13891/
 
 But there is no stable v18, so the download link will fail:
 
```bash
ERRO chrpath: package chrpath: failed to validate update config, melange bump: got 404 Not Found when fetching https://alioth-archive.debian.org/releases/chrpath/chrpath/0.18/chrpath-0.18.tar.gz
```

Latest stable is v16. v18 is shown to be unstable. We can't use git poller here as the source is not hosted on a SCM. I couldn't see a better way to handle this in a new release-monitor project either.

Setting manual update flag - it'll appear on our list of manual packages to review.