### PR TITLE
Fix updates by migrating to git poller and git clone

### DIFF
--- a/py3-async-timeout.yaml
+++ b/py3-async-timeout.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-async-timeout
-  version: 4.0.3
-  epoch: 7
+  version: 5.0.1
+  epoch: 0
   description: Timeout context manager for asyncio programs
   copyright:
     - license: Apache-2.0
@@ -30,10 +30,11 @@ environment:
       - wolfi-base
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: 4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f
-      uri: https://files.pythonhosted.org/packages/source/a/async-timeout/async-timeout-${{package.version}}.tar.gz
+      repository: https://github.com/aio-libs/async-timeout.git
+      expected-commit: cc52d410e733b302873e6e52db9a9b6578d053a4
+      tag: v${{package.version}}
 
 subpackages:
   - range: py-versions
@@ -72,5 +73,8 @@ subpackages:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 37104
+  git:
+    strip-prefix: v
+    tag-filter-prefix: v
+  ignore-regex-patterns:
+    - ".*a.*"


### PR DESCRIPTION
Migrate to git poller and also pull the source from GitHub. The download URL had changed using the previous approach.

Also bumps to latest version.