### PR TITLE
pull code from git and use git poller. update to latest version. Add …

### DIFF
--- a/py3-python-crfsuite.yaml
+++ b/py3-python-crfsuite.yaml
@@ -1,7 +1,7 @@
 package:
   name: py3-python-crfsuite
-  version: 0.9.10
-  epoch: 2
+  version: 0.9.11
+  epoch: 0
   description: Python binding for CRFsuite
   copyright:
     - license: MIT
@@ -28,12 +28,15 @@ environment:
       - libarchive-tools
       - liblbfgs
       - py3-supported-build-base-dev
+      - py3-supported-cython
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      expected-sha256: f38524631e2b533341f10f2c77689270dc6ecd5985495dccf7aa37b1045bc2e5
-      uri: https://files.pythonhosted.org/packages/source/p/python-crfsuite/python-crfsuite-${{package.version}}.tar.gz
+      repository: https://github.com/scrapinghub/python-crfsuite.git
+      expected-commit: e81d4fa33ecfc39053085abe0f1dcb754e13cd70
+      tag: ${{package.version}}
+      recurse-submodules: true
 
 subpackages:
   - range: py-versions
@@ -74,5 +77,6 @@ test:
 
 update:
   enabled: true
-  release-monitor:
-    identifier: 85558
+  git: {}
+  ignore-regex-patterns:
+    - ".*bumped.*"

--- a/py3-python-crfsuite.yaml
+++ b/py3-python-crfsuite.yaml
@@ -80,3 +80,5 @@ update:
   git: {}
   ignore-regex-patterns:
     - ".*bumped.*"
+    # Upstream cut a once-off 0.99 bad tag, which takes presence over 0.9.x format used.
+    - ".*0.99.*"


### PR DESCRIPTION
UpdateBot was failing. Switches to using git poller and git clone for source. Adds cpython as buildtime dep which was needed to resolve a build failure.