### PR TITLE
Update Git checkout URL

### DIFF
--- a/sqlite.yaml
+++ b/sqlite.yaml
@@ -28,7 +28,7 @@ var-transforms:
 pipeline:
   - uses: fetch
     with:
-      uri: https://www.sqlite.org/2024/sqlite-autoconf-${{vars.sqlite-download-version}}.tar.gz
+      uri: https://www.sqlite.org/2025/sqlite-autoconf-${{vars.sqlite-download-version}}.tar.gz
       expected-sha256: f1b2ee412c28d7472bc95ba996368d6f0cdcf00362affdadb27ed286c179540b
 
   - name: Configure

--- a/sqlite.yaml
+++ b/sqlite.yaml
@@ -1,6 +1,6 @@
 package:
   name: sqlite
-  version: 3.47.2
+  version: 3.48.0
   epoch: 0
   description: "C library which implements an SQL database engine"
   copyright:
@@ -29,7 +29,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://www.sqlite.org/2025/sqlite-autoconf-${{vars.sqlite-download-version}}.tar.gz
-      expected-sha256: f1b2ee412c28d7472bc95ba996368d6f0cdcf00362affdadb27ed286c179540b
+      expected-sha256: ac992f7fca3989de7ed1fe99c16363f848794c8c32a158dafd4eb927a2e02fd5
 
   - name: Configure
     runs: |


### PR DESCRIPTION
This package currently leverages release-monitor and fetch to pull down the source code. The URL has the year hard-coded, which needs to be updated.

Longer term we might consider moving this to a git clone, but the reasons for not doing so originally would need to be understood. It's sometimes intentional for larger projects.

Additionally, upgrades to latest package version.