### PR TITLE
trino logback-core fix GHSA-6v67-2wr5-gvf4, GHSA-pr98-23f8-jwxv

### DIFF
--- a/trino.yaml
+++ b/trino.yaml
@@ -36,8 +36,6 @@ pipeline:
       expected-commit: cb7a9cc1cf4e9ea26ccaa966e8a421a76c273954
 
   - uses: maven/pombump
-    with:
-      properties-file: pombump-deps.yaml
 
   - runs: |
       set -x

--- a/trino.yaml
+++ b/trino.yaml
@@ -1,7 +1,7 @@
 package:
   name: trino
   version: "468"
-  epoch: 0
+  epoch: 1
   description: The distributed SQL query engine for big data, formerly known as PrestoSQL
   copyright:
     - license: Apache-2.0
@@ -36,6 +36,8 @@ pipeline:
       expected-commit: cb7a9cc1cf4e9ea26ccaa966e8a421a76c273954
 
   - uses: maven/pombump
+    with:
+      properties-file: pombump-deps.yaml
 
   - runs: |
       set -x

--- a/trino/pombump-deps.yaml
+++ b/trino/pombump-deps.yaml
@@ -1,7 +1,12 @@
 patches:
     - groupId: io.netty
       artifactId: netty-common
-      version: 4.1.115.Final
-    - groupId: net.snowflake.client.jdbc.SnowflakeDriver
-      artifactId: snowflake_snowflake-jdbc
-      version: 3.20.0
+      version: 4.1.116.Final
+    - groupId: io.airlift
+      artifactId: airbase
+      version: 211
+    - groupId: ch.qos.logback
+      artifactId: logback-core
+      version: 1.5.15
+      scope: import
+      type: jar

--- a/trino/pombump-deps.yaml
+++ b/trino/pombump-deps.yaml
@@ -2,9 +2,6 @@ patches:
     - groupId: io.netty
       artifactId: netty-common
       version: 4.1.116.Final
-    - groupId: io.airlift
-      artifactId: airbase
-      version: 211
     - groupId: ch.qos.logback
       artifactId: logback-core
       version: 1.5.15


### PR DESCRIPTION
Simple update to logback-core version upgrade from 1.5.12 -> 1.5.15 to remediate the above CVEs.