### PR TITLE
docker-credential-ecr-login: fetch2checkout and build with hashes

### DIFF
--- a/docker-credential-ecr-login.yaml
+++ b/docker-credential-ecr-login.yaml
@@ -1,7 +1,7 @@
 package:
   name: docker-credential-ecr-login
   version: 0.9.0
-  epoch: 1
+  epoch: 2
   description: Credential helper for Docker to use the AWS Elastic Container Registry
   copyright:
     - license: Apache-2.0
@@ -9,18 +9,24 @@ package:
 environment:
   contents:
     packages:
+      - bash
       - busybox
-      - ca-certificates-bundle
       - go
 
 pipeline:
-  - uses: fetch
+  - uses: git-checkout
     with:
-      uri: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${{package.version}}/release.tar.gz
-      expected-sha512: 9d8d53c8f3b206db0db5ea4c834a0cd30077cf692eee0a5a35ce8dc1d61cc7503db1f58f8798438c89cb33d1ccf8714686ecf3dc9b34a558ec4e930913cb1b0a
+      expected-commit: bef5bd9384b752e5c645659165746d5af23a098a
+      repository: https://github.com/awslabs/amazon-ecr-credential-helper
+      tag: v${{package.version}}
+
+  - runs: |
+      # Build without vendored code, such that buildinfo has h1: hashes
+      rm -rf ecr-login/vendor/
 
   - uses: go/build
     with:
+      modroot: ecr-login
       packages: ./cli/docker-credential-ecr-login
       ldflags: -X github.com/awslabs/amazon-ecr-credential-helper/ecr-login/version.Version=${{package.version}}
       output: docker-credential-ecr-login


### PR DESCRIPTION
Convert docker-credential-ecr-login to build from git, rather than
from a tarball.

Also purge vendored modules (they are unmodified), such that they are
not used during build. This ensures that binary includes vendored
modules h1 hashes, and is thus indicates it was built with auditable
checksums from https://sum.golang.org/

Previously:
```
go version -m /usr/bin/docker-credential-ecr-login
/usr/bin/docker-credential-ecr-login: go1.23.4
	path	github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
	mod	github.com/awslabs/amazon-ecr-credential-helper/ecr-login	(devel)
	dep	github.com/aws/aws-sdk-go-v2	v1.30.5
	dep	github.com/aws/aws-sdk-go-v2/config	v1.27.33
	dep	github.com/aws/aws-sdk-go-v2/credentials	v1.17.32
	dep	github.com/aws/aws-sdk-go-v2/feature/ec2/imds	v1.16.13
	dep	github.com/aws/aws-sdk-go-v2/internal/configsources	v1.3.17
	dep	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2	v2.6.17
	dep	github.com/aws/aws-sdk-go-v2/internal/ini	v1.8.1
	dep	github.com/aws/aws-sdk-go-v2/service/ecr	v1.32.4
	dep	github.com/aws/aws-sdk-go-v2/service/ecrpublic	v1.25.6
	dep	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding	v1.11.4
	dep	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url	v1.11.19
	dep	github.com/aws/aws-sdk-go-v2/service/sso	v1.22.7
	dep	github.com/aws/aws-sdk-go-v2/service/ssooidc	v1.26.7
	dep	github.com/aws/aws-sdk-go-v2/service/sts	v1.30.7
	dep	github.com/aws/smithy-go	v1.20.4
	dep	github.com/docker/docker-credential-helpers	v0.8.2
	dep	github.com/jmespath/go-jmespath	v0.4.0
	dep	github.com/mitchellh/go-homedir	v1.1.0
	dep	github.com/sirupsen/logrus	v1.9.3
	dep	golang.org/x/sys	v0.15.0
...
```

And now:

```
go version -m /usr/bin/docker-credential-ecr-login
/usr/bin/docker-credential-ecr-login: go1.23.4
	path	github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
	mod	github.com/awslabs/amazon-ecr-credential-helper/ecr-login	(devel)
	dep	github.com/aws/aws-sdk-go-v2	v1.30.5	h1:mWSRTwQAb0aLE17dSzztCVJWI9+cRMgqebndjwDyK0g=
	dep	github.com/aws/aws-sdk-go-v2/config	v1.27.33	h1:Nof9o/MsmH4oa0s2q9a0k7tMz5x/Yj5k06lDODWz3BU=
	dep	github.com/aws/aws-sdk-go-v2/credentials	v1.17.32	h1:7Cxhp/BnT2RcGy4VisJ9miUPecY+lyE9I8JvcZofn9I=
	dep	github.com/aws/aws-sdk-go-v2/feature/ec2/imds	v1.16.13	h1:pfQ2sqNpMVK6xz2RbqLEL0GH87JOwSxPV2rzm8Zsb74=
	dep	github.com/aws/aws-sdk-go-v2/internal/configsources	v1.3.17	h1:pI7Bzt0BJtYA0N/JEC6B8fJ4RBrEMi1LBrkMdFYNSnQ=
	dep	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2	v2.6.17	h1:Mqr/V5gvrhA2gvgnF42Zh5iMiQNcOYthFYwCyrnuWlc=
	dep	github.com/aws/aws-sdk-go-v2/internal/ini	v1.8.1	h1:VaRN3TlFdd6KxX1x3ILT5ynH6HvKgqdiXoTxAF4HQcQ=
	dep	github.com/aws/aws-sdk-go-v2/service/ecr	v1.32.4	h1:nQAU2Yr+afkAvIV39mg7LrNYFNQP7ShwbmiJqx2fUKA=
	dep	github.com/aws/aws-sdk-go-v2/service/ecrpublic	v1.25.6	h1:D9C5XIIciGM6mRZTi7zDdFsBsPsgzbsPwwN0wLCymnc=
	dep	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding	v1.11.4	h1:KypMCbLPPHEmf9DgMGw51jMj77VfGPAN2Kv4cfhlfgI=
	dep	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url	v1.11.19	h1:rfprUlsdzgl7ZL2KlXiUAoJnI/VxfHCvDFr2QDFj6u4=
	dep	github.com/aws/aws-sdk-go-v2/service/sso	v1.22.7	h1:pIaGg+08llrP7Q5aiz9ICWbY8cqhTkyy+0SHvfzQpTc=
	dep	github.com/aws/aws-sdk-go-v2/service/ssooidc	v1.26.7	h1:/Cfdu0XV3mONYKaOt1Gr0k1KvQzkzPyiKUdlWJqy+J4=
	dep	github.com/aws/aws-sdk-go-v2/service/sts	v1.30.7	h1:NKTa1eqZYw8tiHSRGpP0VtTdub/8KNk8sDkNPFaOKDE=
	dep	github.com/aws/smithy-go	v1.20.4	h1:2HK1zBdPgRbjFOHlfeQZfpC4r72MOb9bZkiFwggKO+4=
	dep	github.com/docker/docker-credential-helpers	v0.8.2	h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
	dep	github.com/jmespath/go-jmespath	v0.4.0	h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
	dep	github.com/mitchellh/go-homedir	v1.1.0	h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
	dep	github.com/sirupsen/logrus	v1.9.3	h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
	dep	golang.org/x/sys	v0.15.0	h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
...
```
