### PR TITLE
kubeflow-pipelines-visualization-server: bump to use Python 3.11

### DIFF
--- a/kubeflow-pipelines-visualization-server.yaml
+++ b/kubeflow-pipelines-visualization-server.yaml
@@ -9,18 +9,21 @@ package:
     - x86_64 # Since tensorflow-data-validation is not available for aaarch64 yet
   dependencies:
     runtime:
-      - py3.11-google-cloud-sdk
-      - py3.11-typing-extensions
-      - python-3.11
+      - py${{vars.py-version}}-google-cloud-sdk
+      - py${{vars.py-version}}-typing-extensions
+      - python-${{vars.py-version}}
+
+vars:
+  py-version: 3.11
 
 environment:
   contents:
     packages:
       - build-base
       - ca-certificates-bundle
-      - py3.11-build-base-dev
-      - py3.11-crcmod
-      - py3.11-pip
+      - py${{vars.py-version}}-build-base-dev
+      - py${{vars.py-version}}-crcmod
+      - py${{vars.py-version}}-pip
 
 pipeline:
   - uses: git-checkout
@@ -42,9 +45,6 @@ pipeline:
 
       pip install --root=${{targets.destdir}} --prefix=/usr -r requirements.txt
       find ${{targets.destdir}} -name "*.pyc" -exec rm -rf '{}' +
-
-      # "collections" is deprecated in Python 3.10+, use "collections.abc" instead
-      sed -i 's/collections/collections.abc/g' ${{targets.destdir}}/usr/lib/python3.11/site-packages/gcsfs/mapping.py
 
       # CVE-2023-47248, GHSA-5wvp-7f3h-6wmm
       pip install pyarrow-hotfix

--- a/kubeflow-pipelines-visualization-server.yaml
+++ b/kubeflow-pipelines-visualization-server.yaml
@@ -1,7 +1,7 @@
 package:
   name: kubeflow-pipelines-visualization-server
   version: 2.3.0
-  epoch: 4
+  epoch: 5
   description: Machine Learning Pipelines for Kubeflow
   copyright:
     - license: Apache-2.0
@@ -9,19 +9,18 @@ package:
     - x86_64 # Since tensorflow-data-validation is not available for aaarch64 yet
   dependencies:
     runtime:
-      - py3.10-google-cloud-sdk
-      - python-3.10
+      - py3.11-google-cloud-sdk
+      - py3.11-typing-extensions
+      - python-3.11
 
 environment:
   contents:
     packages:
       - build-base
-      - busybox
       - ca-certificates-bundle
-      - py3.10-crcmod
-      - py3.10-pip
-      - python-3.10
-      - python-3.10-dev
+      - py3.11-build-base-dev
+      - py3.11-crcmod
+      - py3.11-pip
 
 pipeline:
   - uses: git-checkout
@@ -35,7 +34,6 @@ pipeline:
       patches: 0001-Bump-dependencies.patch
 
   - runs: |
-      ln -sf /usr/bin/python3.10 /usr/bin/python3
       mkdir -p ${{targets.destdir}}/usr/share/app
       cp -r backend/src/apiserver/visualization/* ${{targets.destdir}}/usr/share/app/
       cd ${{targets.destdir}}/usr/share/app/
@@ -45,8 +43,8 @@ pipeline:
       pip install --root=${{targets.destdir}} --prefix=/usr -r requirements.txt
       find ${{targets.destdir}} -name "*.pyc" -exec rm -rf '{}' +
 
-      # "collections" is deprecated in Python 3.10, use "collections.abc" instead
-      sed -i 's/collections/collections.abc/g' ${{targets.destdir}}/usr/lib/python3.10/site-packages/gcsfs/mapping.py
+      # "collections" is deprecated in Python 3.10+, use "collections.abc" instead
+      sed -i 's/collections/collections.abc/g' ${{targets.destdir}}/usr/lib/python3.11/site-packages/gcsfs/mapping.py
 
       # CVE-2023-47248, GHSA-5wvp-7f3h-6wmm
       pip install pyarrow-hotfix

--- a/kubeflow-pipelines-visualization-server/0001-Bump-dependencies.patch
+++ b/kubeflow-pipelines-visualization-server/0001-Bump-dependencies.patch
@@ -19,7 +19,7 @@ index 61ebd737b..d4ff15c82 100644
 -tensorflow-serving-api==2.10.1
 +nbformat==5.5.0
 +scikit-learn==1.5.0
-+tensorflow==2.15.0
++tensorflow==2.16.2
 +tensorflow-metadata==1.14.*
 +tensorflow-model-analysis==0.47.*
 +tensorflow-data-validation==1.16.1

--- a/kubeflow-pipelines-visualization-server/0001-Bump-dependencies.patch
+++ b/kubeflow-pipelines-visualization-server/0001-Bump-dependencies.patch
@@ -21,8 +21,8 @@ index 61ebd737b..d4ff15c82 100644
 +scikit-learn==1.5.0
 +tensorflow==2.15.0
 +tensorflow-metadata==1.14.*
-+tensorflow-model-analysis==0.45.*
-+tensorflow-data-validation==1.14.0
++tensorflow-model-analysis==0.47.*
++tensorflow-data-validation==1.16.1
 +tensorflow-serving-api==2.14.1
  tornado==6.*
 -mistune<2.0.0
@@ -43,7 +43,7 @@ index 00cc9a82e..8f69cbc48 100644
  #
  absl-py==1.4.0
      # via
-@@ -12,40 +12,48 @@ absl-py==1.4.0
+@@ -12,40 +12,48 @@
      #   tensorflow-metadata
      #   tensorflow-model-analysis
      #   tfx-bsl
@@ -102,7 +102,7 @@ index 00cc9a82e..8f69cbc48 100644
      # via ipywidgets
  crcmod==1.7
      # via apache-beam
-@@ -57,24 +65,34 @@ defusedxml==0.7.1
+@@ -57,24 +65,34 @@
      # via nbconvert
  dill==0.3.1.1
      # via apache-beam
@@ -141,7 +141,7 @@ index 00cc9a82e..8f69cbc48 100644
      #   google-cloud-bigquery
      #   google-cloud-bigquery-storage
      #   google-cloud-bigtable
-@@ -85,7 +103,9 @@ google-api-core[grpc]==2.11.1
+@@ -85,7 +103,9 @@
      #   google-cloud-pubsub
      #   google-cloud-pubsublite
      #   google-cloud-recommendations-ai
@@ -151,7 +151,7 @@ index 00cc9a82e..8f69cbc48 100644
      #   google-cloud-videointelligence
      #   google-cloud-vision
  google-api-python-client==1.7.12
-@@ -94,7 +114,7 @@ google-api-python-client==1.7.12
+@@ -94,7 +114,7 @@
      #   tfx-bsl
  google-apitools==0.5.31
      # via apache-beam
@@ -160,7 +160,7 @@ index 00cc9a82e..8f69cbc48 100644
      # via
      #   apache-beam
      #   gcsfs
-@@ -102,75 +122,106 @@ google-auth==2.23.0
+@@ -102,106 +122,134 @@
      #   google-api-python-client
      #   google-auth-httplib2
      #   google-auth-oauthlib
@@ -290,7 +290,10 @@ index 00cc9a82e..8f69cbc48 100644
      #   grpcio-status
      #   tensorboard
      #   tensorflow
-@@ -180,28 +231,25 @@ grpcio-status==1.48.2
+     #   tensorflow-serving-api
+-grpcio-status==1.48.2
++grpcio-status==1.49.1
+     # via
      #   google-api-core
      #   google-cloud-pubsub
      #   google-cloud-pubsublite
@@ -326,7 +329,7 @@ index 00cc9a82e..8f69cbc48 100644
      #   notebook
  ipython==7.12.0
      # via
-@@ -212,48 +260,55 @@ ipython==7.12.0
+@@ -212,48 +260,55 @@
  ipython-genutils==0.2.0
      # via
      #   ipywidgets
@@ -388,7 +391,7 @@ index 00cc9a82e..8f69cbc48 100644
 -keras==2.10.0
 -    # via tensorflow
 -keras-preprocessing==1.1.2
-+keras==2.15.0
++keras==3.8.0
      # via tensorflow
 -libclang==16.0.6
 +libclang==18.1.1
@@ -398,11 +401,11 @@ index 00cc9a82e..8f69cbc48 100644
      # via tensorboard
  markupsafe==2.0.1
      # via
-@@ -263,30 +318,43 @@ mistune==0.8.4
+@@ -263,30 +318,43 @@
      # via
      #   -r requirements.in
      #   nbconvert
-+ml-dtypes==0.2.0
++ml-dtypes==0.3.1
 +    # via tensorflow
 +nbclassic==1.1.0
 +    # via notebook
@@ -448,7 +451,7 @@ index 00cc9a82e..8f69cbc48 100644
      #   tensorboard
      #   tensorflow
      #   tensorflow-data-validation
-@@ -296,18 +364,21 @@ oauth2client==4.1.3
+@@ -296,18 +364,21 @@
      # via google-apitools
  oauthlib==3.2.2
      # via requests-oauthlib
@@ -474,7 +477,7 @@ index 00cc9a82e..8f69cbc48 100644
      #   tensorflow
  pandas==1.5.3
      # via
-@@ -315,39 +386,47 @@ pandas==1.5.3
+@@ -315,39 +386,47 @@
      #   tensorflow-data-validation
      #   tensorflow-model-analysis
      #   tfx-bsl
@@ -528,7 +531,7 @@ index 00cc9a82e..8f69cbc48 100644
 +    #   google-cloud-videointelligence
      #   google-cloud-vision
 -protobuf==3.19.6
-+protobuf==3.20.3
++protobuf
      # via
      #   apache-beam
      #   google-api-core
@@ -537,7 +540,7 @@ index 00cc9a82e..8f69cbc48 100644
      #   google-cloud-bigquery-storage
      #   google-cloud-bigtable
      #   google-cloud-datastore
-@@ -355,6 +434,7 @@ protobuf==3.19.6
+@@ -355,6 +434,7 @@
      #   google-cloud-language
      #   google-cloud-pubsub
      #   google-cloud-recommendations-ai
@@ -545,7 +548,7 @@ index 00cc9a82e..8f69cbc48 100644
      #   google-cloud-spanner
      #   google-cloud-videointelligence
      #   google-cloud-vision
-@@ -373,87 +453,97 @@ ptyprocess==0.7.0
+@@ -373,87 +453,97 @@
      # via
      #   pexpect
      #   terminado
@@ -669,7 +672,7 @@ index 00cc9a82e..8f69cbc48 100644
  six==1.16.0
      # via
      #   astunparse
-@@ -463,66 +553,70 @@ six==1.16.0
+@@ -463,66 +553,70 @@
      #   google-apitools
      #   google-pasta
      #   hdfs
@@ -687,7 +690,7 @@ index 00cc9a82e..8f69cbc48 100644
 +sqlparse==0.5.1
      # via google-cloud-spanner
 -tensorboard==2.10.1
-+tensorboard==2.15.2
++tensorboard==2.16.2
      # via tensorflow
 -tensorboard-data-server==0.6.1
 +tensorboard-data-server==0.7.2
@@ -695,7 +698,7 @@ index 00cc9a82e..8f69cbc48 100644
 -tensorboard-plugin-wit==1.8.1
 -    # via tensorboard
 -tensorflow==2.10.1
-+tensorflow==2.15.0
++tensorflow==2.16.2
      # via
      #   -r requirements.in
      #   tensorflow-data-validation
@@ -703,7 +706,7 @@ index 00cc9a82e..8f69cbc48 100644
      #   tensorflow-serving-api
      #   tfx-bsl
 -tensorflow-data-validation==1.9.0
-+tensorflow-data-validation==1.14.0
++tensorflow-data-validation==1.16.1
      # via -r requirements.in
 -tensorflow-estimator==2.10.0
 +tensorflow-estimator==2.15.0
@@ -712,14 +715,14 @@ index 00cc9a82e..8f69cbc48 100644
 +tensorflow-io-gcs-filesystem==0.37.1
      # via tensorflow
 -tensorflow-metadata==1.9.0
-+tensorflow-metadata==1.14.0
++tensorflow-metadata==1.16.1
      # via
      #   -r requirements.in
      #   tensorflow-data-validation
      #   tensorflow-model-analysis
      #   tfx-bsl
 -tensorflow-model-analysis==0.40.0
-+tensorflow-model-analysis==0.45.0
++tensorflow-model-analysis==0.47.1
      # via -r requirements.in
 -tensorflow-serving-api==2.10.1
 +tensorflow-serving-api==2.14.1
@@ -738,7 +741,7 @@ index 00cc9a82e..8f69cbc48 100644
  testpath==0.6.0
      # via nbconvert
 -tfx-bsl==1.9.0
-+tfx-bsl==1.14.0
++tfx-bsl==1.16.1
      # via
      #   tensorflow-data-validation
      #   tensorflow-model-analysis
@@ -760,7 +763,7 @@ index 00cc9a82e..8f69cbc48 100644
      # via
      #   comm
      #   ipykernel
-@@ -530,38 +624,38 @@ traitlets==5.10.0
+@@ -530,38 +624,38 @@
      #   ipywidgets
      #   jupyter-client
      #   jupyter-core


### PR DESCRIPTION
Another package that was causing some images to pull in multiple Python bases.

This only bumps the used Python version to 3.11 as this is the max that google-cloud-sdk seems to support for now (see google-cloud-sdk.yaml). This also required bumping some pip dependencies.
