### PR TITLE
tileserver-gl: rebuilding with latest libpng-dev

### DIFF
--- a/tileserver-gl.yaml
+++ b/tileserver-gl.yaml
@@ -1,7 +1,7 @@
 package:
   name: tileserver-gl
   version: 5.0.0
-  epoch: 5
+  epoch: 6
   description: Vector and raster maps with GL styles. Server side rendering by MapLibre GL Native. Map tile server for MapLibre GL JS, Android, iOS, Leaflet, OpenLayers, GIS via WMTS, etc.
   copyright:
     - license: BSD-2-Clause


### PR DESCRIPTION
* tileserver-gl: rebuilding with latest libpng-dev. The binary requires that the header `libpng-dev` (last compiled with 1.6.44) to have the same version of `libpng`, which has since been advanced to 1.6.45.

### Pre-review Checklist
