### PR TITLE
kafka: add missing symlinks as upstream image has already

### DIFF
--- a/kafka-3.9.yaml
+++ b/kafka-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: kafka-3.9
   version: 3.9.0
-  epoch: 0
+  epoch: 1
   description: Apache Kafka is a distributed event streaming platform
   copyright:
     - license: Apache-2.0
@@ -74,6 +74,16 @@ subpackages:
           ln -s /usr/lib/kafka/libs ${{targets.subpkgdir}}/opt/bitnami/kafka/libs
           ln -s /usr/lib/kafka/config ${{targets.subpkgdir}}/opt/bitnami/kafka/config
           ln -s /usr/lib/kafka/logs ${{targets.subpkgdir}}/opt/bitnami/kafka/logs
+          ln -sf /opt/bitnami/scripts/kafka/entrypoint.sh ${{targets.subpkgdir}}/entrypoint.sh
+          ln -sf /opt/bitnami/scripts/kafka/run.sh ${{targets.subpkgdir}}/run.sh
+    test:
+      pipeline:
+        - name: "Test compatibility with bitnami/kafka image"
+          runs: |
+            test -L /entrypoint.sh
+            test -L /run.sh
+            test "$(readlink /entrypoint.sh)" = "/opt/bitnami/scripts/kafka/entrypoint.sh"
+            test "$(readlink /run.sh)" = "/opt/bitnami/scripts/kafka/run.sh"
 
 test:
   environment:


### PR DESCRIPTION
```
docker container run -it --entrypoint=sh bitnami/kafka:latest

I have no name!@f7f8b91690e2:/$ readlink /entrypoint.sh
/opt/bitnami/scripts/kafka/entrypoint.sh
I have no name!@f7f8b91690e2:/$ readlink /run.sh
/opt/bitnami/scripts/kafka/run.sh
```