### PR TITLE
Switch some packages from using the ldd-check with specific files to the package

### DIFF
--- a/aws-c-auth.yaml
+++ b/aws-c-auth.yaml
@@ -66,7 +66,7 @@ test:
   pipeline:
     - uses: test/ldd-check
       with:
-        files: /usr/lib/libaws-c-auth.so.1.0.0
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/aws-c-cal.yaml
+++ b/aws-c-cal.yaml
@@ -60,7 +60,7 @@ test:
   pipeline:
     - uses: test/ldd-check
       with:
-        files: /usr/lib/libaws-c-cal.so.1.0.0
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/aws-c-common.yaml
+++ b/aws-c-common.yaml
@@ -58,7 +58,7 @@ test:
   pipeline:
     - uses: test/ldd-check
       with:
-        files: /usr/lib/libaws-c-common.so.1.0.0
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/aws-c-compression.yaml
+++ b/aws-c-compression.yaml
@@ -56,7 +56,7 @@ test:
   pipeline:
     - uses: test/ldd-check
       with:
-        files: /usr/lib/libaws-c-compression.so.1.0.0
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/aws-c-event-stream.yaml
+++ b/aws-c-event-stream.yaml
@@ -64,7 +64,7 @@ test:
   pipeline:
     - uses: test/ldd-check
       with:
-        files: /usr/lib/libaws-c-event-stream.so.1.0.0
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/aws-c-http.yaml
+++ b/aws-c-http.yaml
@@ -63,7 +63,7 @@ test:
   pipeline:
     - uses: test/ldd-check
       with:
-        files: /usr/lib/libaws-c-http.so.1.0.0
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/aws-c-mqtt.yaml
+++ b/aws-c-mqtt.yaml
@@ -82,7 +82,7 @@ test:
   pipeline:
     - uses: test/ldd-check
       with:
-        files: /usr/lib/libaws-c-mqtt.so.1.0.0
+        packages: ${{package.name}}
     - name: "Compile simple MQTT test program"
       runs: |
         cat << 'EOF' > test.c

--- a/aws-c-s3.yaml
+++ b/aws-c-s3.yaml
@@ -76,7 +76,7 @@ test:
   pipeline:
     - uses: test/ldd-check
       with:
-        files: /usr/lib/libaws-c-s3.so.1.0.0
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/aws-c-sdkutils.yaml
+++ b/aws-c-sdkutils.yaml
@@ -59,7 +59,7 @@ test:
   pipeline:
     - uses: test/ldd-check
       with:
-        files: /usr/lib/libaws-c-sdkutils.so.1.0.0
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/aws-checksums.yaml
+++ b/aws-checksums.yaml
@@ -59,7 +59,7 @@ test:
   pipeline:
     - uses: test/ldd-check
       with:
-        files: /usr/lib/libaws-checksums.so.1.0.0
+        packages: ${{package.name}}
 
 update:
   enabled: true

--- a/expat.yaml
+++ b/expat.yaml
@@ -1,7 +1,7 @@
 package:
   name: expat
   version: 2.6.4
-  epoch: 0
+  epoch: 1
   description: "XML SAX Parser library written in C"
   copyright:
     - license: MIT
@@ -48,6 +48,11 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr
           mv "${{targets.destdir}}"/usr/lib "${{targets.subpkgdir}}"/usr/
+
+  - name: expat-doc
+    description: expat docs
+    pipeline:
+      - uses: split/manpages
 
 update:
   enabled: true
@@ -98,7 +103,7 @@ test:
         ./test
     - uses: test/ldd-check
       with:
-        files: /usr/lib/libexpat.so.1
+        packages: ${{package.name}}
     - name: "Verify XML parsing functionality"
       runs: |
         cat > test.xml << EOF

--- a/rtmpdump.yaml
+++ b/rtmpdump.yaml
@@ -80,7 +80,7 @@ test:
       runs: rtmpdump --help
     - uses: test/ldd-check
       with:
-        files: /usr/lib/librtmp.so.1
+        packages: ${{package.name}}
     - name: Compile and link a simple C program
       runs: |
         cat <<EOF > test_rtmp.c

--- a/s2n-tls.yaml
+++ b/s2n-tls.yaml
@@ -65,7 +65,7 @@ test:
   pipeline:
     - uses: test/ldd-check
       with:
-        files: /usr/lib/libs2n.so.1.0.0
+        packages: ${{package.name}}
 
 update:
   enabled: true


### PR DESCRIPTION
Only checking specific files with the ldd-check test pipeline is not sustainable as its possible for packages to build new files worth checking subsequently it would be more efficient to test the whole package.

Additionally, this PR splits out expat's docs to a separate package.