### PR TITLE
lint.sh: support passing package names.

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -2,7 +2,16 @@
 
 set -euo pipefail
 
-for fn in *.yaml; do
+# If arguments are passed to the command, only lint the files listed.
+if [ "$#" == 0 ]; then
+  list="*.yaml"
+else
+  list=$*
+fi
+
+for fn in $list; do
+  case $fn in *.yaml) ;; *) echo "--- $fn not a yaml file, skipping"; continue ;; esac
+
   p=$(yq -r '.package.name' ${fn})
   echo "--- package" $p
 


### PR DESCRIPTION
A proposed small tweak to the ./lint.sh command. Sometimes you just want to run it against a single package, or a set of yaml files.