### PR TITLE
dbus: add systemd build depends

### DIFF
--- a/dbus.yaml
+++ b/dbus.yaml
@@ -1,7 +1,7 @@
 package:
   name: dbus
   version: 1.16.0
-  epoch: 0
+  epoch: 1
   description: Freedesktop.org message bus system
   copyright:
     - license: AFL-2.1 OR GPL-2.0-or-later
@@ -22,6 +22,7 @@ environment:
       - libx11-dev
       - meson
       - python3-dev
+      - systemd-dev
       - xmlto
 
 pipeline:


### PR DESCRIPTION
This activates upstream build system to install systemd related units
and configuration files, such that dbus can work in a system
container.
