### PR TITLE
fix: bump epoch of all packages that were affected by recent jdk/jvm change

### DIFF
--- a/R.yaml
+++ b/R.yaml
@@ -2,7 +2,7 @@
 package:
   name: R
   version: 4.4.2
-  epoch: 0
+  epoch: 1
   description: Language and environment for statistical computing
   copyright:
     - license: ( GPL-2.0-only OR GPL-3.0-only ) AND LGPL-2.1-or-later

--- a/akhq.yaml
+++ b/akhq.yaml
@@ -1,7 +1,7 @@
 package:
   name: akhq
   version: 0.25.1
-  epoch: 1
+  epoch: 2
   description: "Kafka GUI for Apache Kafka to manage topics, topics data, consumers group, schema registry, connect and more"
   copyright:
     - license: Apache-2.0

--- a/apicurio-registry.yaml
+++ b/apicurio-registry.yaml
@@ -1,7 +1,7 @@
 package:
   name: apicurio-registry
   version: 3.0.6
-  epoch: 0
+  epoch: 1
   description: An API/Schema registry - stores APIs and Schemas
   copyright:
     - license: Apache-2.0

--- a/async-profiler.yaml
+++ b/async-profiler.yaml
@@ -1,7 +1,7 @@
 package:
   name: async-profiler
   version: 3.0
-  epoch: 1
+  epoch: 2
   description: A low overhead sampling profiler for Java
   copyright:
     - license: Apache-2.0

--- a/byteman.yaml
+++ b/byteman.yaml
@@ -1,7 +1,7 @@
 package:
   name: byteman
   version: 4.0.24
-  epoch: 0
+  epoch: 1
   description: Simplify Java tracing, monitoring and testing with Byteman
   copyright:
     - license: GPL-2.0-or-later AND BSD-3-Clause

--- a/cass-config-builder.yaml
+++ b/cass-config-builder.yaml
@@ -1,7 +1,7 @@
 package:
   name: cass-config-builder
   version: 1.0.10
-  epoch: 0
+  epoch: 1
   description: |
     Configuration builder for Apache Cassandra based on definitions at datastax/cass-config-definitions
   copyright:

--- a/cassandra-5.0.yaml
+++ b/cassandra-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-5.0
   version: 5.0.2
-  epoch: 1
+  epoch: 2
   description: Open Source NoSQL Database
   copyright:
     - license: Apache-2.0

--- a/cassandra-reaper.yaml
+++ b/cassandra-reaper.yaml
@@ -1,7 +1,7 @@
 package:
   name: cassandra-reaper
   version: 3.7.1
-  epoch: 0
+  epoch: 1
   description: Automated Repair Awesomeness for Apache Cassandra
   copyright:
     - license: Apache-2.0

--- a/cloudwatch-exporter.yaml
+++ b/cloudwatch-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: cloudwatch-exporter
   version: 0.16.0 # Check if the version bump in the mvn command is still needed next time this package is updated
-  epoch: 2
+  epoch: 3
   description: Metrics exporter for Amazon AWS CloudWatch
   copyright:
     - license: Apache-2.0

--- a/confluent-common-docker.yaml
+++ b/confluent-common-docker.yaml
@@ -1,7 +1,7 @@
 package:
   name: confluent-common-docker
   version: 7.6.0
-  epoch: 9
+  epoch: 10
   description: Confluent Commons with support for building and testing Docker images.
   copyright:
     - license: Apache-2.0

--- a/datadog-jmxfetch.yaml
+++ b/datadog-jmxfetch.yaml
@@ -1,7 +1,7 @@
 package:
   name: datadog-jmxfetch
   version: 0.49.6
-  epoch: 0
+  epoch: 1
   description: Export JMX metrics
   copyright:
     - license: Apache-2.0

--- a/debezium-3.0.yaml
+++ b/debezium-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-3.0
   version: 3.0.6
-  epoch: 0
+  epoch: 1
   description: Debezium is a change data capture (CDC) platform that achieves its durability, reliability, and fault tolerance qualities by reusing Kafka and Kafka Connect.
   copyright:
     - license: Apache-2.0

--- a/debezium-3.0.yaml
+++ b/debezium-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-3.0
   version: 3.0.6
-  epoch: 1
+  epoch: 0
   description: Debezium is a change data capture (CDC) platform that achieves its durability, reliability, and fault tolerance qualities by reusing Kafka and Kafka Connect.
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-db2-3.0.yaml
+++ b/debezium-connector-db2-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-db2-3.0
   version: 3.0.6
-  epoch: 0
+  epoch: 1
   description: An incubating Debezium connector for Db2
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-db2-3.0.yaml
+++ b/debezium-connector-db2-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-db2-3.0
   version: 3.0.6
-  epoch: 1
+  epoch: 0
   description: An incubating Debezium connector for Db2
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-ibmi-3.0.yaml
+++ b/debezium-connector-ibmi-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-ibmi-3.0
   version: 3.0.6
-  epoch: 1
+  epoch: 0
   description: Debezium Connector for IBM i (AS/400)
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-ibmi-3.0.yaml
+++ b/debezium-connector-ibmi-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-ibmi-3.0
   version: 3.0.6
-  epoch: 0
+  epoch: 1
   description: Debezium Connector for IBM i (AS/400)
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-informix-3.0.yaml
+++ b/debezium-connector-informix-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-informix-3.0
   version: 3.0.6
-  epoch: 1
+  epoch: 0
   description: An incubating Debezium CDC connector for IBM Informix database
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-informix-3.0.yaml
+++ b/debezium-connector-informix-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-informix-3.0
   version: 3.0.6
-  epoch: 0
+  epoch: 1
   description: An incubating Debezium CDC connector for IBM Informix database
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-spanner-3.0.yaml
+++ b/debezium-connector-spanner-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-spanner-3.0
   version: 3.0.6
-  epoch: 1
+  epoch: 0
   description: An incubating Debezium CDC connector for Google Spanner
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-spanner-3.0.yaml
+++ b/debezium-connector-spanner-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-spanner-3.0
   version: 3.0.6
-  epoch: 0
+  epoch: 1
   description: An incubating Debezium CDC connector for Google Spanner
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-vitess-3.0.yaml
+++ b/debezium-connector-vitess-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-vitess-3.0
   version: 3.0.6
-  epoch: 0
+  epoch: 1
   description: An incubating Debezium CDC connector for Vitess
   copyright:
     - license: Apache-2.0

--- a/debezium-connector-vitess-3.0.yaml
+++ b/debezium-connector-vitess-3.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: debezium-connector-vitess-3.0
   version: 3.0.6
-  epoch: 1
+  epoch: 0
   description: An incubating Debezium CDC connector for Vitess
   copyright:
     - license: Apache-2.0

--- a/dependency-track.yaml
+++ b/dependency-track.yaml
@@ -1,7 +1,7 @@
 package:
   name: dependency-track
   version: 4.12.2
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: Apache-2.0

--- a/docker-selenium.yaml
+++ b/docker-selenium.yaml
@@ -5,7 +5,7 @@ package:
   # 'package format error' when trying to install the package. The workaround is
   # to replace '-' with '.', then mangling the version to replace back.
   version: 4.27.0.20250101
-  epoch: 0
+  epoch: 1
   description: Provides a simple way to run Selenium Grid with Chrome, Firefox, and Edge using Docker, making it easier to perform browser automation
   copyright:
     - license: Apache-2.0

--- a/dotty.yaml
+++ b/dotty.yaml
@@ -1,7 +1,7 @@
 package:
   name: dotty
   version: 3.6.2
-  epoch: 0
+  epoch: 1
   description: The Scala 3 compiler, also known as Dotty.
   copyright:
     - license: Apache-2.0

--- a/druid.yaml
+++ b/druid.yaml
@@ -1,7 +1,7 @@
 package:
   name: druid
   version: 31.0.1
-  epoch: 0
+  epoch: 1
   description: Apache Druid is a high performance real-time analytics database.
   copyright:
     - license: Apache-2.0

--- a/flink-1.20.yaml
+++ b/flink-1.20.yaml
@@ -1,7 +1,7 @@
 package:
   name: flink-1.20
   version: 1.20.0
-  epoch: 1
+  epoch: 2
   description: Apache Flink is an open source stream processing framework with powerful stream- and batch-processing capabilities.
   copyright:
     - license: Apache-2.0

--- a/jackson-json.yaml
+++ b/jackson-json.yaml
@@ -1,7 +1,7 @@
 package:
   name: jackson-json
   version: 1.9.14
-  epoch: 0
+  epoch: 1
   description: Jackson JSON processor 1.9 maintenance package
   copyright:
     - license: Apache-2.0

--- a/jenkins-plugin-manager.yaml
+++ b/jenkins-plugin-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: jenkins-plugin-manager
   version: 2.13.2
-  epoch: 0
+  epoch: 1
   description: Plugin Manager CLI tool for Jenkins
   copyright:
     - license: MIT

--- a/jvmkill.yaml
+++ b/jvmkill.yaml
@@ -2,7 +2,7 @@
 package:
   name: jvmkill
   version: 0.0.1
-  epoch: 0
+  epoch: 1
   description: Terminate the JVM when resources are exhausted
   copyright:
     - license: Apache-2.0

--- a/kafka-3.9.yaml
+++ b/kafka-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: kafka-3.9
   version: 3.9.0
-  epoch: 1
+  epoch: 2
   description: Apache Kafka is a distributed event streaming platform
   copyright:
     - license: Apache-2.0

--- a/keycloak-operator.yaml
+++ b/keycloak-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: keycloak-operator
   version: "26.1.0"
-  epoch: 0
+  epoch: 1
   description: A Kubernetes Operator based on the Operator SDK for installing and managing Keycloak.
   copyright:
     - license: Apache-2.0

--- a/logstash-8.yaml
+++ b/logstash-8.yaml
@@ -17,7 +17,7 @@
 package:
   name: logstash-8
   version: 8.17.0
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0

--- a/logstash-filter-xml.yaml
+++ b/logstash-filter-xml.yaml
@@ -9,7 +9,7 @@
 package:
   name: logstash-filter-xml
   version: 4.2.1
-  epoch: 0
+  epoch: 1
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0

--- a/logstash-integration-jdbc.yaml
+++ b/logstash-integration-jdbc.yaml
@@ -9,7 +9,7 @@
 package:
   name: logstash-integration-jdbc
   version: 5.5.2
-  epoch: 0
+  epoch: 1
   description: Logstash Integration Plugin for JDBC, including Logstash Input and Filter Plugins
   copyright:
     - license: Apache-2.0

--- a/logstash-output-opensearch.yaml
+++ b/logstash-output-opensearch.yaml
@@ -9,7 +9,7 @@
 package:
   name: logstash-output-opensearch
   version: 2.0.3
-  epoch: 1
+  epoch: 2
   description: Logstash - transport and process your logs, events, or other data
   copyright:
     - license: Apache-2.0

--- a/management-api-for-apache-cassandra-5.0.yaml
+++ b/management-api-for-apache-cassandra-5.0.yaml
@@ -1,7 +1,7 @@
 package:
   name: management-api-for-apache-cassandra-5.0
   version: "0.1.91"
-  epoch: 3
+  epoch: 4
   description: RESTful / Secure Management Sidecar for Apache Cassandra
   copyright:
     - license: Apache-2.0

--- a/maven-3.9.yaml
+++ b/maven-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: maven-3.9
   version: 3.9.9
-  epoch: 0
+  epoch: 1
   description: A Java project management and project comprehension tool.
   copyright:
     - license: Apache-2.0

--- a/metric-collector-for-apache-cassandra-4.1.yaml
+++ b/metric-collector-for-apache-cassandra-4.1.yaml
@@ -1,7 +1,7 @@
 package:
   name: metric-collector-for-apache-cassandra-4.1
   version: 0.3.5
-  epoch: 5
+  epoch: 6
   description: Drop-in metrics collection and dashboards for Apache Cassandra
   copyright:
     - license: Apache-2.0

--- a/neo4j-5.26.yaml
+++ b/neo4j-5.26.yaml
@@ -1,7 +1,7 @@
 package:
   name: neo4j-5.26
   version: "5.26.1"
-  epoch: 0
+  epoch: 1
   description:
   copyright:
     - license: GPL-3.0-or-later

--- a/neuvector-manager.yaml
+++ b/neuvector-manager.yaml
@@ -1,7 +1,7 @@
 package:
   name: neuvector-manager
   version: "5.4.2"
-  epoch: 0
+  epoch: 1
   description: NeuVector Security Center Admin Console.
   copyright:
     - license: Apache-2.0

--- a/nrjmx.yaml
+++ b/nrjmx.yaml
@@ -1,7 +1,7 @@
 package:
   name: nrjmx
   version: 2.6.0
-  epoch: 0
+  epoch: 1
   description: Command line tool to connect to a JMX server and retrieve the MBeans it exposes
   copyright:
     - license: Apache-2.0

--- a/openjdk-10.yaml
+++ b/openjdk-10.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-10
   version: 10.0.2
-  epoch: 6
+  epoch: 7
   description: "Oracle OpenJDK 10"
   copyright:
     - license: GPL-2.0-with-classpath-exception

--- a/openjdk-11.yaml
+++ b/openjdk-11.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-11
   version: 11.0.25 # TODO(jason): on version bump, ensure to update downstream projects that are pinned to a specific prerelease version. See: https://github.com/wolfi-dev/os/pull/7958
-  epoch: 3
+  epoch: 4
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-12.yaml
+++ b/openjdk-12.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-12
   version: 12.0.2.10
-  epoch: 5
+  epoch: 6
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-13.yaml
+++ b/openjdk-13.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-13
   version: 13.0.14.5
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-14.yaml
+++ b/openjdk-14.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-14
   version: 14.0.2.12
-  epoch: 7
+  epoch: 8
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-15.yaml
+++ b/openjdk-15.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-15
   version: 15.0.10.5
-  epoch: 7
+  epoch: 8
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-16.yaml
+++ b/openjdk-16.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-16
   version: 16.0.2.7
-  epoch: 7
+  epoch: 8
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-17.yaml
+++ b/openjdk-17.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-17
   version: 17.0.13 # TODO(jason): on version bump ensure to update downstream projects that are pinned to a specific prerelease version, i.e. https://github.com/chainguard-images/images/tree/main/images
-  epoch: 4
+  epoch: 5
   description:
   copyright:
     - license: GPL-2.0-only

--- a/openjdk-18.yaml
+++ b/openjdk-18.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-18
   version: 18.0.2.1.0
-  epoch: 6
+  epoch: 7
   description:
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-19.yaml
+++ b/openjdk-19.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-19
   version: 19.0.2.7
-  epoch: 6
+  epoch: 7
   description:
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-20.yaml
+++ b/openjdk-20.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-20
   version: 20.0.2.9
-  epoch: 5
+  epoch: 6
   description:
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-21.yaml
+++ b/openjdk-21.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-21
   version: 21.0.5
-  epoch: 2
+  epoch: 3
   description:
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-22.yaml
+++ b/openjdk-22.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-22
   version: 22.0.2
-  epoch: 2
+  epoch: 3
   description: OpenJDK 22
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-23.yaml
+++ b/openjdk-23.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-23
   version: 23.0.1
-  epoch: 2
+  epoch: 3
   description: OpenJDK 23
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-24.yaml
+++ b/openjdk-24.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-24
   version: 24
-  epoch: 2
+  epoch: 3
   description: OpenJDK 24 Early Access Package
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-8.yaml
+++ b/openjdk-8.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-8
   version: 8.432.06 # this corresponds to same release as jdk8u432-ga / jdk8u432-b06
-  epoch: 0
+  epoch: 1
   description: "IcedTea distribution of OpenJDK 8"
   copyright:
     - license: GPL-2.0-or-later

--- a/openjdk-9.yaml
+++ b/openjdk-9.yaml
@@ -1,7 +1,7 @@
 package:
   name: openjdk-9
   version: 9.0.4
-  epoch: 5
+  epoch: 6
   description: "Oracle OpenJDK 9"
   copyright:
     - license: GPL-2.0-with-classpath-exception

--- a/opensearch-2.yaml
+++ b/opensearch-2.yaml
@@ -5,7 +5,7 @@
 package:
   name: opensearch-2
   version: 2.18.0
-  epoch: 0
+  epoch: 1
   description: Open source distributed and RESTful search engine.
   copyright:
     - license: Apache-2.0

--- a/pdftk.yaml
+++ b/pdftk.yaml
@@ -2,7 +2,7 @@
 package:
   name: pdftk
   version: 3.3.3
-  epoch: 1
+  epoch: 2
   description: Command-line tool for working with PDFs
   copyright:
     - license: GPL-2.0-or-later

--- a/prometheus-jmx-exporter.yaml
+++ b/prometheus-jmx-exporter.yaml
@@ -1,7 +1,7 @@
 package:
   name: prometheus-jmx-exporter
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   url: https://github.com/prometheus/jmx_exporter
   description: JMX to Prometheus exporter javaagent
   copyright:

--- a/ruby3.2-concurrent-ruby.yaml
+++ b/ruby3.2-concurrent-ruby.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.2-concurrent-ruby
   version: "1.3.5"
-  epoch: 0
+  epoch: 1
   description: Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more. Inspired by Erlang, Clojure, Go, JavaScript, actors, and classic concurrency patterns.
   copyright:
     - license: MIT

--- a/ruby3.2-logstash-core-plugin-api.yaml
+++ b/ruby3.2-logstash-core-plugin-api.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-logstash-core-plugin-api
   version: 8.17.0
-  epoch: 0
+  epoch: 1
   description: Logstash plugin API
   copyright:
     - license: Apache-2.0

--- a/ruby3.2-logstash-core.yaml
+++ b/ruby3.2-logstash-core.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.2-logstash-core
   version: 8.17.0
-  epoch: 0
+  epoch: 1
   description: The core components of logstash, the scalable log and event management tool
   copyright:
     - license: Apache-2.0

--- a/ruby3.3-concurrent-ruby.yaml
+++ b/ruby3.3-concurrent-ruby.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.3-concurrent-ruby
   version: "1.3.5"
-  epoch: 0
+  epoch: 1
   description: Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more. Inspired by Erlang, Clojure, Go, JavaScript, actors, and classic concurrency patterns.
   copyright:
     - license: MIT

--- a/ruby3.3-logstash-core-plugin-api.yaml
+++ b/ruby3.3-logstash-core-plugin-api.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.3-logstash-core-plugin-api
   version: 8.17.0
-  epoch: 0
+  epoch: 1
   description: Logstash plugin API
   copyright:
     - license: Apache-2.0

--- a/ruby3.3-logstash-core.yaml
+++ b/ruby3.3-logstash-core.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.3-logstash-core
   version: 8.17.0
-  epoch: 0
+  epoch: 1
   description: The core components of logstash, the scalable log and event management tool
   copyright:
     - license: Apache-2.0

--- a/ruby3.4-concurrent-ruby.yaml
+++ b/ruby3.4-concurrent-ruby.yaml
@@ -1,7 +1,7 @@
 package:
   name: ruby3.4-concurrent-ruby
   version: "1.3.5"
-  epoch: 0
+  epoch: 1
   description: Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more. Inspired by Erlang, Clojure, Go, JavaScript, actors, and classic concurrency patterns.
   copyright:
     - license: MIT

--- a/ruby3.4-logstash-core-plugin-api.yaml
+++ b/ruby3.4-logstash-core-plugin-api.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.4-logstash-core-plugin-api
   version: 8.17.0
-  epoch: 1
+  epoch: 2
   description: Logstash plugin API
   copyright:
     - license: Apache-2.0

--- a/ruby3.4-logstash-core.yaml
+++ b/ruby3.4-logstash-core.yaml
@@ -2,7 +2,7 @@
 package:
   name: ruby3.4-logstash-core
   version: 8.17.0
-  epoch: 1
+  epoch: 2
   description: The core components of logstash, the scalable log and event management tool
   copyright:
     - license: Apache-2.0

--- a/sbt-stage0.yaml
+++ b/sbt-stage0.yaml
@@ -1,7 +1,7 @@
 package:
   name: sbt-stage0
   version: 1.8.2
-  epoch: 2
+  epoch: 3
   description: A scala build tool
   copyright:
     - license: Apache-2.0

--- a/scala-2.13.yaml
+++ b/scala-2.13.yaml
@@ -1,7 +1,7 @@
 package:
   name: scala-2.13
   version: "2.13.16"
-  epoch: 0
+  epoch: 1
   description: Scala 2 compiler and standard library.
   copyright:
     - license: Apache-2.0

--- a/selenium.yaml
+++ b/selenium.yaml
@@ -1,7 +1,7 @@
 package:
   name: selenium
   version: 4.27.0
-  epoch: 0
+  epoch: 1
   description: A browser automation framework and ecosystem.
   copyright:
     - license: Apache-2.0

--- a/snappy-java.yaml
+++ b/snappy-java.yaml
@@ -1,7 +1,7 @@
 package:
   name: snappy-java
   version: 1.1.10.7
-  epoch: 0
+  epoch: 1
   description: Snappy compressor/decompressor for Java
   copyright:
     - license: Apache-2.0

--- a/solr.yaml
+++ b/solr.yaml
@@ -1,7 +1,7 @@
 package:
   name: solr
   version: 9.7.0
-  epoch: 1
+  epoch: 2
   description: Apache Solr open-source search software
   copyright:
     - license: Apache-2.0

--- a/sonar-scanner-cli.yaml
+++ b/sonar-scanner-cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: sonar-scanner-cli
   version: 6.2.1.4610
-  epoch: 0
+  epoch: 1
   description: Scanner CLI for SonarQube and SonarCloud
   copyright:
     - license: LGPL-3.0-or-later

--- a/sonarqube-10.yaml
+++ b/sonarqube-10.yaml
@@ -1,7 +1,7 @@
 package:
   name: sonarqube-10
   version: 25.1.0.102122
-  epoch: 0
+  epoch: 1
   description: SonarQube is an open source platform for continuous inspection of code quality
   copyright:
     - license: LGPL-3.0-or-later

--- a/strimzi-kafka-operator.yaml
+++ b/strimzi-kafka-operator.yaml
@@ -1,7 +1,7 @@
 package:
   name: strimzi-kafka-operator
   version: 0.45.0
-  epoch: 0
+  epoch: 1
   description: Apache Kafka® running on Kubernetes
   copyright:
     - license: Apache-2.0

--- a/thingsboard.yaml
+++ b/thingsboard.yaml
@@ -1,7 +1,7 @@
 package:
   name: thingsboard
   version: "3.9"
-  epoch: 0
+  epoch: 1
   description: "Open-source IoT Platform - Device management, data collection, processing and visualization."
   copyright:
     - license: Apache-2.0

--- a/zetasql.yaml
+++ b/zetasql.yaml
@@ -1,7 +1,7 @@
 package:
   name: zetasql
   version: 2024.06.1
-  epoch: 2
+  epoch: 3
   description: ZetaSQL - Analyzer Framework for SQL
   copyright:
     - license: Apache-2.0

--- a/zookeeper-3.9.yaml
+++ b/zookeeper-3.9.yaml
@@ -1,7 +1,7 @@
 package:
   name: zookeeper-3.9
   version: 3.9.3.2
-  epoch: 1
+  epoch: 2
   description: Distributed, highly available, robust, fault-tolerant system for distributed coordination
   copyright:
     - license: Apache-2.0


### PR DESCRIPTION
This change https://github.com/wolfi-dev/os/pull/39462 brought the recent jdk/jvm correct usage but missed the epoch bump of most packages and that led or could lead to failures in images. This PR handles that. 


<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
