### PR TITLE
systemd - make systemd-init package provide /sbin/init rather than /init

### DIFF
--- a/systemd.yaml
+++ b/systemd.yaml
@@ -1,7 +1,7 @@
 package:
   name: systemd
   version: "257.2"
-  epoch: 5
+  epoch: 6
   description: The systemd System and Service Manager
   copyright:
     - license: LGPL-2.1-or-later AND GPL-2.0-or-later
@@ -371,9 +371,14 @@ subpackages:
         - mount
     pipeline:
       - runs: |
-          mkdir -p ${{targets.subpkgdir}}/etc
-          ln -s /usr/lib/systemd/systemd ${{targets.subpkgdir}}/init
-          ln -sf /usr/share/zoneinfo/UTC ${{targets.subpkgdir}}/etc/localtime
+          mkdir -p ${{targets.subpkgdir}}/etc ${{targets.subpkgdir}}/sbin
+          ln -s ../usr/lib/systemd/systemd ${{targets.subpkgdir}}/sbin/init
+          ln -sf ../usr/share/zoneinfo/UTC ${{targets.subpkgdir}}/etc/localtime
+    test:
+      pipeline:
+        - runs: |
+            [ -f /sbin/init -a -x /sbin/init ]
+            [ -f /etc/localtime ]
 
   - name: "systemd-default-network"
     description: "Configure network to DHCP on default interfaces"


### PR DESCRIPTION
Also here, make the symlinks relative rather than absolute.
