### PR TITLE
fix(ingress-nginx-otel-plugin): Drop controller from runtime deps

### DIFF
--- a/ingress-nginx-controller-1.12.yaml
+++ b/ingress-nginx-controller-1.12.yaml
@@ -3,7 +3,7 @@ package:
   name: ingress-nginx-controller-1.12
   version: 1.12.0
   # There are manual changes to review between each package update. See 'vars:' section.
-  epoch: 1
+  epoch: 2
   description: "Ingress-NGINX Controller for Kubernetes"
   copyright:
     - license: Apache-2.0
@@ -551,8 +551,6 @@ subpackages:
     dependencies:
       provides:
         - ingress-nginx-opentelemetry-plugin=${{package.full-version}}
-      runtime:
-        - ingress-nginx-controller-${{vars.nginx-ingress-major-minor}}
     pipeline:
       - uses: git-checkout
         with:


### PR DESCRIPTION
Allows us to drop in the FIPS variant of ingress nginx
