### PR TITLE
Set an owner for the Makefile

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,10 @@
 # Require review by repo owners of changes to CODEOWNERS
 CODEOWNERS @wolfi-dev/wolfi-owners
 
-# These packages require approval from the Foundations squad.
-openssh.yaml @wolfi-dev/foundations-squad
-ca-certificates.yaml @wolfi-dev/foundations-squad
-
-# Pipeline changes require approval of the Guarded OS squad.
+# Makefile and pipeline changes require approval of the Guarded OS squad.
+Makefile   @wolfi-dev/foundations-squad
 pipelines/ @wolfi-dev/foundations-squad
+
+# These packages require approval from the Foundations squad.
+openssh.yaml         @wolfi-dev/foundations-squad
+ca-certificates.yaml @wolfi-dev/foundations-squad


### PR DESCRIPTION
The foundations-squad / Guarded OS should also be a codeowner of the Makefile. I also reorganized the file so that packages are at the bottom of it.